### PR TITLE
[FLINK-15172][table-blink] Optimize the operator algorithm to lazily allocate memory

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/SortCodeGeneratorTest.java
@@ -47,6 +47,7 @@ import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.generated.NormalizedKeyComputer;
 import org.apache.flink.table.runtime.generated.RecordComparator;
 import org.apache.flink.table.runtime.operators.sort.BinaryInMemorySortBuffer;
+import org.apache.flink.table.runtime.operators.sort.ListMemorySegmentPool;
 import org.apache.flink.table.runtime.types.InternalSerializers;
 import org.apache.flink.table.runtime.typeutils.AbstractRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
@@ -455,7 +456,7 @@ public class SortCodeGeneratorTest {
 
 		BinaryInMemorySortBuffer sortBuffer = BinaryInMemorySortBuffer.createBuffer(
 				tuple2.f0, (AbstractRowSerializer) serializer, serializer,
-				tuple2.f1, segments);
+				tuple2.f1, new ListMemorySegmentPool(segments));
 
 		BinaryRow[] dataArray = getTestData();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -348,6 +348,11 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	}
 
 	@Override
+	public int freePages() {
+		throw new UnsupportedOperationException("Contains spill memories, it is hard to estimate free pages.");
+	}
+
+	@Override
 	public int pageSize() {
 		return segmentSize;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.runtime.hashtable;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.memory.MemorySegment;
@@ -28,10 +27,10 @@ import org.apache.flink.runtime.io.disk.iomanager.BlockChannelReader;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.HeaderlessChannelReaderInputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.runtime.util.MemorySegmentPool;
 import org.apache.flink.util.MathUtils;
 
@@ -81,12 +80,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 */
 	protected final int totalNumBuffers;
 
-	private final MemoryManager memManager;
-
-	/**
-	 * The free memory segments currently available to the hash join.
-	 */
-	public final ArrayList<MemorySegment> availableMemory;
+	protected final LazyMemorySegmentPool internalPool;
 
 	/**
 	 * The I/O manager used to instantiate writers for the spilled partitions.
@@ -179,16 +173,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 		this.totalNumBuffers = (int) (reservedMemorySize / memManager.getPageSize());
 		// some sanity checks first
 		checkArgument(totalNumBuffers >= MIN_NUM_MEMORY_SEGMENTS);
-		this.availableMemory = new ArrayList<>(this.totalNumBuffers);
-		try {
-			List<MemorySegment> allocates = memManager.allocatePages(owner, totalNumBuffers);
-			this.availableMemory.addAll(allocates);
-			allocates.clear();
-		} catch (MemoryAllocationException e) {
-			LOG.error("Out of memory", e);
-			throw new RuntimeException(e);
-		}
-		this.memManager = memManager;
+		this.internalPool = new LazyMemorySegmentPool(owner, memManager, totalNumBuffers);
 		this.ioManager = ioManager;
 
 		this.segmentSize = memManager.getPageSize();
@@ -220,7 +205,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * can be used because two Buffers are needed to read the data.
 	 */
 	protected int maxNumPartition() {
-		return (availableMemory.size() + buildSpillRetBufferNumbers) / 2;
+		return (internalPool.freePages() + buildSpillRetBufferNumbers) / 2;
 	}
 
 	/**
@@ -266,10 +251,10 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * @return The next buffer to be used by the hash-table, or null, if no buffer remains.
 	 */
 	public MemorySegment getNextBuffer() {
-		// check if the list directly offers memory
-		int s = this.availableMemory.size();
-		if (s > 0) {
-			return this.availableMemory.remove(s - 1);
+		// check if the pool directly offers memory
+		MemorySegment segment = this.internalPool.nextSegment();
+		if (segment != null) {
+			return segment;
 		}
 
 		// check if there are write behind buffers that actually are to be used for the hash table
@@ -286,7 +271,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 			// grab as many more buffers as are available directly
 			MemorySegment currBuff;
 			while (this.buildSpillRetBufferNumbers > 0 && (currBuff = this.buildSpillReturnBuffers.poll()) != null) {
-				this.availableMemory.add(currBuff);
+				returnPage(currBuff);
 				this.buildSpillRetBufferNumbers--;
 			}
 			return toReturn;
@@ -361,7 +346,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	public void returnAll(List<MemorySegment> memory) {
 		for (MemorySegment segment : memory) {
 			if (segment != null) {
-				availableMemory.add(segment);
+				returnPage(segment);
 			}
 		}
 	}
@@ -380,13 +365,13 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * @param minRequiredAvailable The minimum number of buffers that needs to be reclaimed.
 	 */
 	public void ensureNumBuffersReturned(final int minRequiredAvailable) {
-		if (minRequiredAvailable > this.availableMemory.size() + this.buildSpillRetBufferNumbers) {
+		if (minRequiredAvailable > internalPool.freePages() + this.buildSpillRetBufferNumbers) {
 			throw new IllegalArgumentException("More buffers requested available than totally available.");
 		}
 
 		try {
-			while (this.availableMemory.size() < minRequiredAvailable) {
-				this.availableMemory.add(this.buildSpillReturnBuffers.take());
+			while (internalPool.freePages() < minRequiredAvailable) {
+				returnPage(this.buildSpillReturnBuffers.take());
 				this.buildSpillRetBufferNumbers--;
 			}
 		} catch (InterruptedException iex) {
@@ -421,7 +406,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 		// return the write-behind buffers
 		for (int i = 0; i < this.buildSpillRetBufferNumbers; i++) {
 			try {
-				this.availableMemory.add(this.buildSpillReturnBuffers.take());
+				returnPage(this.buildSpillReturnBuffers.take());
 			} catch (InterruptedException iex) {
 				throw new RuntimeException("Hashtable closing was interrupted");
 			}
@@ -433,7 +418,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 
 	public void free() {
 		if (this.closed.get()) {
-			memManager.release(availableMemory);
+			freeCurrent();
 		} else {
 			throw new IllegalStateException("Cannot release memory until BinaryHashTable is closed!");
 		}
@@ -443,24 +428,23 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 	 * Free the memory not used.
 	 */
 	public void freeCurrent() {
-		memManager.release(availableMemory);
+		internalPool.cleanCache();
 	}
 
-	@VisibleForTesting
-	public List<MemorySegment> getFreedMemory() {
-		return this.availableMemory;
+	LazyMemorySegmentPool getInternalPool() {
+		return this.internalPool;
 	}
 
-	public void free(MemorySegment segment) {
-		this.availableMemory.add(segment);
+	public void returnPage(MemorySegment segment) {
+		internalPool.returnPage(segment);
 	}
 
 	public int remainBuffers() {
-		return availableMemory.size() + buildSpillRetBufferNumbers;
+		return internalPool.freePages() + buildSpillRetBufferNumbers;
 	}
 
 	public long getUsedMemoryInBytes() {
-		return (totalNumBuffers - availableMemory.size()) * ((long) memManager.getPageSize());
+		return (totalNumBuffers - internalPool.freePages()) * ((long) internalPool.pageSize());
 	}
 
 	public long getNumSpillFiles() {
@@ -487,7 +471,7 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
 				ioManager, id, retSegments,
 				compressionEnable, compressionCodecFactory, compressionBlockSize, segmentSize);
 		for (int i = 0; i < blockCount; i++) {
-			reader.readBlock(availableMemory.remove(availableMemory.size() - 1));
+			reader.readBlock(internalPool.nextSegment());
 		}
 		reader.closeAndDelete();
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.memory.AbstractPagedOutputView;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
 import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.runtime.util.MemorySegmentPool;
 import org.apache.flink.table.runtime.util.RowIterator;
 import org.apache.flink.util.MathUtils;
@@ -41,7 +42,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -356,13 +356,13 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
 	 *                                      requests will be retained; used for build-side outer
 	 *                                      joins.
 	 */
-	void finalizeProbePhase(List<MemorySegment> freeMemory, List<BinaryHashPartition> spilledPartitions,
+	void finalizeProbePhase(LazyMemorySegmentPool pool, List<BinaryHashPartition> spilledPartitions,
 							boolean keepUnprobedSpilledPartitions) throws IOException {
 		if (isInMemory()) {
-			this.bucketArea.returnMemory(freeMemory);
+			this.bucketArea.returnMemory(pool);
 			this.bucketArea = null;
 			// return the partition buffers
-			Collections.addAll(freeMemory, this.partitionBuffers);
+			pool.returnAll(Arrays.asList(partitionBuffers));
 			this.partitionBuffers = null;
 		} else {
 			if (bloomFilter != null) {
@@ -381,20 +381,20 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
 		}
 	}
 
-	void clearAllMemory(List<MemorySegment> target) {
+	void clearAllMemory(LazyMemorySegmentPool pool) {
 		// return current buffers from build side and probe side
 		if (this.buildSideWriteBuffer != null) {
 			if (this.buildSideWriteBuffer.getCurrentSegment() != null) {
-				target.add(this.buildSideWriteBuffer.getCurrentSegment());
+				pool.returnPage(this.buildSideWriteBuffer.getCurrentSegment());
 			}
-			target.addAll(this.buildSideWriteBuffer.targetList);
+			pool.returnAll(this.buildSideWriteBuffer.targetList);
 			this.buildSideWriteBuffer.targetList.clear();
 			this.buildSideWriteBuffer = null;
 		}
 
 		// return the overflow segments
 		if (this.bucketArea != null) {
-			bucketArea.returnMemory(target);
+			bucketArea.returnMemory(pool);
 		}
 
 		if (bloomFilter != null) {
@@ -403,7 +403,7 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
 
 		// return the partition buffers
 		if (this.partitionBuffers != null) {
-			Collections.addAll(target, this.partitionBuffers);
+			pool.returnAll(Arrays.asList(this.partitionBuffers));
 			this.partitionBuffers = null;
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashTable.java
@@ -364,7 +364,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 	private boolean prepareNextPartition() throws IOException {
 		// finalize and cleanup the partitions of the current table
 		for (final BinaryHashPartition p : this.partitionsBeingBuilt) {
-			p.finalizeProbePhase(this.availableMemory, this.partitionsPending, type.needSetProbed());
+			p.finalizeProbePhase(this.internalPool, this.partitionsPending, type.needSetProbed());
 		}
 
 		this.partitionsBeingBuilt.clear();
@@ -458,11 +458,11 @@ public class BinaryHashTable extends BaseHybridHashTable {
 		//        that single partition.
 		// 2) We can not guarantee that enough memory segments are available and read the partition
 		//    in, distributing its data among newly created partitions.
-		final int totalBuffersAvailable = this.availableMemory.size() + this.buildSpillRetBufferNumbers;
+		final int totalBuffersAvailable = this.internalPool.freePages() + this.buildSpillRetBufferNumbers;
 		if (totalBuffersAvailable != this.totalNumBuffers) {
 			throw new RuntimeException(String.format("Hash Join bug in memory management: Memory buffers leaked." +
 					" availableMemory(%s), buildSpillRetBufferNumbers(%s), reservedNumBuffers(%s)",
-					availableMemory.size(), buildSpillRetBufferNumbers, totalNumBuffers));
+					internalPool.freePages(), buildSpillRetBufferNumbers, totalNumBuffers));
 		}
 
 		long numBuckets = p.getBuildSideRecordCount() / BinaryHashBucketArea.NUM_ENTRIES_PER_BUCKET + 1;
@@ -569,7 +569,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 		for (int i = this.partitionsBeingBuilt.size() - 1; i >= 0; --i) {
 			final BinaryHashPartition p = this.partitionsBeingBuilt.get(i);
 			try {
-				p.clearAllMemory(this.availableMemory);
+				p.clearAllMemory(this.internalPool);
 			} catch (Exception e) {
 				LOG.error("Error during partition cleanup.", e);
 			}
@@ -578,7 +578,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 
 		// clear the partitions that are still to be done (that have files on disk)
 		for (final BinaryHashPartition p : this.partitionsPending) {
-			p.clearAllMemory(this.availableMemory);
+			p.clearAllMemory(this.internalPool);
 		}
 	}
 
@@ -614,7 +614,7 @@ public class BinaryHashTable extends BaseHybridHashTable {
 		// grab as many buffers as are available directly
 		MemorySegment currBuff;
 		while (this.buildSpillRetBufferNumbers > 0 && (currBuff = this.buildSpillReturnBuffers.poll()) != null) {
-			this.availableMemory.add(currBuff);
+			returnPage(currBuff);
 			this.buildSpillRetBufferNumbers--;
 		}
 		numSpillFiles++;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.memory.AbstractPagedOutputView;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
 import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.runtime.util.RowIterator;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.Preconditions;
@@ -43,7 +44,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -770,13 +770,13 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 		}
 	}
 
-	void clearAllMemory(List<MemorySegment> target) {
+	void clearAllMemory(LazyMemorySegmentPool pool) {
 		// return current buffers from build side and probe side
 		if (this.buildSideWriteBuffer != null) {
 			if (this.buildSideWriteBuffer.getCurrentSegment() != null) {
-				target.add(this.buildSideWriteBuffer.getCurrentSegment());
+				pool.returnPage(this.buildSideWriteBuffer.getCurrentSegment());
 			}
-			target.addAll(this.buildSideWriteBuffer.targetList);
+			pool.returnAll(this.buildSideWriteBuffer.targetList);
 			this.buildSideWriteBuffer.targetList.clear();
 			this.buildSideWriteBuffer = null;
 		}
@@ -784,7 +784,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
 
 		// return the partition buffers
 		if (this.partitionBuffers != null) {
-			Collections.addAll(target, this.partitionBuffers);
+			pool.returnAll(Arrays.asList(this.partitionBuffers));
 			this.partitionBuffers = null;
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMap.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMap.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.runtime.operators.aggregate;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
-import org.apache.flink.core.memory.MemorySegmentSource;
 import org.apache.flink.runtime.io.disk.RandomAccessInputView;
 import org.apache.flink.runtime.io.disk.SimpleCollectingOutputView;
 import org.apache.flink.runtime.memory.AbstractPagedInputView;
@@ -29,6 +28,7 @@ import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.MutableObjectIterator;
@@ -109,8 +109,6 @@ public class BytesHashMap {
 	 */
 	private final LookupInfo reuseLookInfo;
 
-	private final MemoryManager memoryManager;
-
 	/**
 	 * Used as a reused object when retrieve the map's value by key and iteration.
 	 */
@@ -120,7 +118,7 @@ public class BytesHashMap {
 	 */
 	private BinaryRow reusedKey;
 
-	private final List<MemorySegment> freeMemorySegments;
+	private final LazyMemorySegmentPool memoryPool;
 	private List<MemorySegment> bucketSegments;
 
 	private long numElements = 0;
@@ -159,12 +157,7 @@ public class BytesHashMap {
 			boolean inferBucketMemory) {
 		this.segmentSize = memoryManager.getPageSize();
 		this.reservedNumBuffers = (int) (memorySize / segmentSize);
-		this.memoryManager = memoryManager;
-		try {
-			this.freeMemorySegments = memoryManager.allocatePages(owner, reservedNumBuffers);
-		} catch (MemoryAllocationException e) {
-			throw new IllegalArgumentException("BytesHashMap can't allocate " + reservedNumBuffers + " pages", e);
-		}
+		this.memoryPool = new LazyMemorySegmentPool(owner, memoryManager, reservedNumBuffers);
 		this.numBucketsPerSegment = segmentSize / BUCKET_SIZE;
 		this.numBucketsPerSegmentBits = MathUtils.log2strict(this.numBucketsPerSegment);
 		this.numBucketsPerSegmentMask = (1 << this.numBucketsPerSegmentBits) - 1;
@@ -359,7 +352,7 @@ public class BytesHashMap {
 		}
 		this.bucketSegments = new ArrayList<>(numBucketSegments);
 		for (int i = 0; i < numBucketSegments; i++) {
-			bucketSegments.add(i, freeMemorySegments.remove(freeMemorySegments.size() - 1));
+			bucketSegments.add(i, memoryPool.nextSegment());
 		}
 
 		resetBucketSegments(this.bucketSegments);
@@ -391,14 +384,13 @@ public class BytesHashMap {
 		List<MemorySegment> newBucketSegments = new ArrayList<>(required);
 
 		try {
-			int freeNumSegments = freeMemorySegments.size();
-			int numAllocatedSegments = required - freeNumSegments;
+			int numAllocatedSegments = required - memoryPool.freePages();
 			if (numAllocatedSegments > 0) {
 				throw new MemoryAllocationException();
 			}
 			int needNumFromFreeSegments = required - newBucketSegments.size();
 			for (int end = needNumFromFreeSegments; end > 0; end--) {
-				newBucketSegments.add(freeMemorySegments.remove(freeMemorySegments.size() - 1));
+				newBucketSegments.add(memoryPool.nextSegment());
 			}
 
 			setBucketVariables(newBucketSegments);
@@ -437,7 +429,7 @@ public class BytesHashMap {
 			}
 		}
 		LOG.info("The rehash take {} ms for {} segments", (System.currentTimeMillis() - reHashStartTime), required);
-		this.freeMemorySegments.addAll(this.bucketSegments);
+		this.memoryPool.returnAll(this.bucketSegments);
 		this.bucketSegments = newBucketSegments;
 	}
 
@@ -491,7 +483,7 @@ public class BytesHashMap {
 		this.bucketSegments.clear();
 		recordArea.release();
 		if (!reservedRecordMemory) {
-			memoryManager.release(freeMemorySegments);
+			memoryPool.close();
 		}
 		numElements = 0;
 		destructiveIterator = null;
@@ -507,12 +499,15 @@ public class BytesHashMap {
 		resetBucketSegments(bucketSegments);
 		numElements = 0;
 		destructiveIterator = null;
-		LOG.info("reset BytesHashMap with record memory segments {}, {} in bytes, init allocating {} for bucket area.",
-				freeMemorySegments.size(), freeMemorySegments.size() * segmentSize, bucketSegments.size());
+		LOG.info(
+				"reset BytesHashMap with record memory segments {}, {} in bytes, init allocating {} for bucket area.",
+				memoryPool.freePages(),
+				memoryPool.freePages() * segmentSize,
+				bucketSegments.size());
 	}
 
 	private void returnSegments(List<MemorySegment> segments) {
-		freeMemorySegments.addAll(segments);
+		memoryPool.returnAll(segments);
 	}
 
 	// ----------------------- Record Area -----------------------
@@ -524,7 +519,7 @@ public class BytesHashMap {
 		private final SimpleCollectingOutputView outView;
 
 		RecordArea() {
-			this.outView = new SimpleCollectingOutputView(segments, new RecordAreaMemorySource(), segmentSize);
+			this.outView = new SimpleCollectingOutputView(segments, memoryPool, segmentSize);
 			this.inView = new RandomAccessInputView(segments, segmentSize);
 		}
 
@@ -539,20 +534,6 @@ public class BytesHashMap {
 			// reset segmentNum and positionInSegment
 			outView.reset();
 			inView.setReadPosition(0);
-		}
-
-		// ----------------------- Memory Management -----------------------
-
-		private final class RecordAreaMemorySource implements MemorySegmentSource {
-			@Override
-			public MemorySegment nextSegment() {
-				int s = freeMemorySegments.size();
-				if (s > 0) {
-					return freeMemorySegments.remove(s - 1);
-				} else {
-					return null;
-				}
-			}
 		}
 
 		// ----------------------- Append -----------------------

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapSpillMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/BytesHashMapSpillMemorySegmentPool.java
@@ -55,6 +55,11 @@ public class BytesHashMapSpillMemorySegmentPool implements MemorySegmentPool {
 	}
 
 	@Override
+	public int freePages() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
 	public int pageSize() {
 		return pageSize;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BinaryExternalSorter.java
@@ -22,12 +22,10 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.AlgorithmOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.compression.BlockCompressionFactory;
 import org.apache.flink.runtime.io.disk.iomanager.AbstractChannelWriterOutputView;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.operators.sort.ExceptionHandler;
 import org.apache.flink.runtime.operators.sort.IndexedSorter;
@@ -43,6 +41,7 @@ import org.apache.flink.table.runtime.io.ChannelWithMeta;
 import org.apache.flink.table.runtime.typeutils.AbstractRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
 import org.apache.flink.table.runtime.util.FileChannelUtil;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.util.MutableObjectIterator;
 
 import org.slf4j.Logger;
@@ -52,7 +51,6 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -111,15 +109,12 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 	 * The memory segments used first for sorting and later for reading/pre-fetching
 	 * during the external merge.
 	 */
-	private final List<List<MemorySegment>> sortReadMemory;
+	private final List<LazyMemorySegmentPool> sortReadMemory;
 
 	/**
 	 * Records all sort buffer.
 	 */
 	private final List<BinaryInMemorySortBuffer> sortBuffers;
-
-	/** The memory manager through which memory is allocated and released. */
-	private final MemoryManager memoryManager;
 
 	// ------------------------------------------------------------------------
 	//                            Miscellaneous Fields
@@ -199,7 +194,7 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 			final Object owner, MemoryManager memoryManager, long reservedMemorySize,
 			IOManager ioManager, AbstractRowSerializer<BaseRow> inputSerializer,
 			BinaryRowSerializer serializer, NormalizedKeyComputer normalizedKeyComputer,
-			RecordComparator comparator, Configuration conf) throws IOException {
+			RecordComparator comparator, Configuration conf) {
 		this(owner, memoryManager, reservedMemorySize, ioManager,
 				inputSerializer, serializer, normalizedKeyComputer, comparator,
 				conf, AlgorithmOptions.SORT_SPILLING_THRESHOLD.defaultValue());
@@ -211,7 +206,7 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 			BinaryRowSerializer serializer,
 			NormalizedKeyComputer normalizedKeyComputer,
 			RecordComparator comparator, Configuration conf,
-			float startSpillingFraction) throws IOException {
+			float startSpillingFraction) {
 		int maxNumFileHandles = conf.getInteger(ExecutionConfigOptions.TABLE_EXEC_SORT_MAX_NUM_FILE_HANDLES);
 		this.compressionEnable = conf.getBoolean(ExecutionConfigOptions.TABLE_EXEC_SPILL_COMPRESSION_ENABLED);
 		this.compressionCodecFactory = this.compressionEnable
@@ -225,8 +220,8 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 		checkArgument(maxNumFileHandles >= 2);
 		checkNotNull(ioManager);
 		checkNotNull(normalizedKeyComputer);
+		checkNotNull(memoryManager);
 		this.serializer = (BinaryRowSerializer) serializer.duplicate();
-		this.memoryManager = checkNotNull(memoryManager);
 		this.memorySegmentSize = memoryManager.getPageSize();
 
 		if (reservedMemorySize < SORTER_MIN_NUM_SORT_MEM) {
@@ -246,19 +241,9 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 		}
 		final int numSegmentsPerSortBuffer = sortMemPages / numSortBuffers;
 		this.sortReadMemory = new ArrayList<>();
-		List<MemorySegment> readMemory;
-		try {
-			readMemory = memoryManager.allocatePages(owner, sortMemPages);
-		} catch (MemoryAllocationException e) {
-			LOG.error("Can't allocate {} pages from fixed memory pool.", sortMemPages, e);
-			throw new RuntimeException(e);
-		}
 
 		// circular circularQueues pass buffers between the threads
 		final CircularQueues circularQueues = new CircularQueues();
-
-		// allocate the sort buffers and fill empty queue with them
-		final Iterator<MemorySegment> segments = readMemory.iterator();
 
 		LOG.info("BinaryExternalSorter with initial memory segments {}, " +
 				"maxNumFileHandles({}), compressionEnable({}), compressionCodecFactory({}), compressionBlockSize({}).",
@@ -266,19 +251,18 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 				compressionEnable ? compressionCodecFactory.getClass() : null, compressionBlockSize);
 
 		this.sortBuffers = new ArrayList<>();
+		int totalBuffers = sortMemPages;
 		for (int i = 0; i < numSortBuffers; i++) {
 			// grab some memory
-			final List<MemorySegment> sortSegments = new ArrayList<>(numSegmentsPerSortBuffer);
-			for (int k = (i == numSortBuffers - 1 ? Integer.MAX_VALUE : numSegmentsPerSortBuffer); k > 0 && segments
-					.hasNext(); k--) {
-				sortSegments.add(segments.next());
-			}
-			this.sortReadMemory.add(sortSegments);
+			int sortSegments = Math.min(i == numSortBuffers - 1 ? Integer.MAX_VALUE : numSegmentsPerSortBuffer, totalBuffers);
+			totalBuffers -= sortSegments;
+			LazyMemorySegmentPool pool = new LazyMemorySegmentPool(owner, memoryManager, sortSegments);
+			this.sortReadMemory.add(pool);
 			final BinaryInMemorySortBuffer buffer = BinaryInMemorySortBuffer.createBuffer(
-					normalizedKeyComputer, inputSerializer, serializer, comparator, sortSegments);
+					normalizedKeyComputer, inputSerializer, serializer, comparator, pool);
 
 			// add to empty queue
-			CircularElement element = new CircularElement(i, buffer, sortSegments);
+			CircularElement element = new CircularElement(i, buffer);
 			circularQueues.empty.add(element);
 			this.sortBuffers.add(buffer);
 		}
@@ -322,7 +306,7 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 
 		// start the thread that handles merging from second storage
 		this.mergeThread = getMergingThread(
-			exceptionHandler, circularQueues, ioManager, maxNumFileHandles, merger);
+				exceptionHandler, circularQueues, maxNumFileHandles, merger);
 
 		// propagate the context class loader to the spawned threads
 		ClassLoader contextLoader = Thread.currentThread().getContextClassLoader();
@@ -453,30 +437,12 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 			// floating segments are released in `dispose()` method
 			this.sortBuffers.forEach(BinaryInMemorySortBuffer::dispose);
 			this.sortBuffers.clear();
-		} catch (Throwable ignored) {
-			LOG.info("error.", ignored);
+		} catch (Throwable e) {
+			LOG.info("error.", e);
 		}
 
-		releaseCoreSegments();
+		sortReadMemory.forEach(LazyMemorySegmentPool::close);
 		sortReadMemory.clear();
-	}
-
-	private void releaseCoreSegments() {
-		// NOTE: This method can only be called after disposing some buffers
-
-		List<MemorySegment> coreSegments = new ArrayList<>();
-		for (List<MemorySegment> segs : sortReadMemory) {
-			coreSegments.addAll(segs);
-		}
-
-		try {
-			if (!coreSegments.isEmpty()) {
-				this.memoryManager.release(coreSegments);
-			}
-			coreSegments.clear();
-		} catch (Throwable ignored) {
-			LOG.info("error.", ignored);
-		}
 	}
 
 	private ThreadBase getSortingThread(ExceptionHandler<IOException> exceptionHandler,
@@ -492,9 +458,10 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 
 	private MergingThread getMergingThread(
 			ExceptionHandler<IOException> exceptionHandler,
-			CircularQueues queues, IOManager ioManager,
-			int maxNumFileHandles, BinaryExternalMerger merger) {
-		return new MergingThread(exceptionHandler, queues, ioManager, maxNumFileHandles, merger);
+			CircularQueues queues,
+			int maxNumFileHandles,
+			BinaryExternalMerger merger) {
+		return new MergingThread(exceptionHandler, queues, maxNumFileHandles, merger);
 	}
 
 	public void write(BaseRow current) throws IOException {
@@ -656,18 +623,15 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 
 		final int id; // just for debug.
 		final BinaryInMemorySortBuffer buffer;
-		final List<MemorySegment> memory; // for release memory
 
-		public CircularElement() {
+		private CircularElement() {
 			this.id = -1;
 			this.buffer = null;
-			this.memory = null;
 		}
 
-		public CircularElement(int id, BinaryInMemorySortBuffer buffer, List<MemorySegment> memory) {
+		private CircularElement(int id, BinaryInMemorySortBuffer buffer) {
 			this.id = id;
 			this.buffer = buffer;
-			this.memory = memory;
 		}
 	}
 
@@ -1054,7 +1018,7 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 					}
 				}
 			}
-			releaseCoreSegments();
+			sortReadMemory.forEach(LazyMemorySegmentPool::cleanCache);
 		}
 	}
 
@@ -1064,18 +1028,16 @@ public class BinaryExternalSorter implements Sorter<BinaryRow> {
 	 */
 	private class MergingThread extends ThreadBase {
 
-		private final IOManager ioManager;                // I/O manager to create channels
-
 		private final int maxFanIn;
 
 		private final BinaryExternalMerger merger;
 
-		public MergingThread(
+		private MergingThread(
 				ExceptionHandler<IOException> exceptionHandler,
-				CircularQueues queues, IOManager ioManager,
-				int maxNumFileHandles, BinaryExternalMerger merger) {
+				CircularQueues queues,
+				int maxNumFileHandles,
+				BinaryExternalMerger merger) {
 			super(exceptionHandler, "SortMerger merging thread", queues);
-			this.ioManager = ioManager;
 			this.maxFanIn = maxNumFileHandles;
 			this.merger = merger;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BinaryIndexedSortable.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/BinaryIndexedSortable.java
@@ -77,7 +77,7 @@ public abstract class BinaryIndexedSortable implements IndexedSortable {
 			BinaryRowSerializer serializer,
 			RecordComparator comparator,
 			ArrayList<MemorySegment> recordBufferSegments,
-			MemorySegmentPool memorySegmentPool) throws IOException {
+			MemorySegmentPool memorySegmentPool) {
 		if (normalizedKeyComputer == null || serializer == null) {
 			throw new NullPointerException();
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/ListMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/ListMemorySegmentPool.java
@@ -55,6 +55,11 @@ public class ListMemorySegmentPool implements MemorySegmentPool {
 		segments.addAll(memory);
 	}
 
+	@Override
+	public int freePages() {
+		return segments.size();
+	}
+
 	public void clear() {
 		segments.clear();
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LazyMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/LazyMemorySegmentPool.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.runtime.memory.MemoryAllocationException;
+import org.apache.flink.runtime.memory.MemoryManager;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * {@link MemorySegmentPool} that lazy allocate memory pages from {@link MemoryManager}.
+ */
+public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
+
+	private static final long PER_REQUEST_MEMORY_SIZE = 16 * 1024 * 1024;
+
+	private final Object owner;
+	private final MemoryManager memoryManager;
+	private final ArrayList<MemorySegment> cachePages;
+	private final int maxPages;
+	private final int perRequestPages;
+
+	private int pageUsage;
+
+	public LazyMemorySegmentPool(Object owner, MemoryManager memoryManager, int maxPages) {
+		this.owner = owner;
+		this.memoryManager = memoryManager;
+		this.cachePages = new ArrayList<>();
+		this.maxPages = maxPages;
+		this.pageUsage = 0;
+		this.perRequestPages = Math.max(1, (int) (PER_REQUEST_MEMORY_SIZE / memoryManager.getPageSize()));
+	}
+
+	@Override
+	public int pageSize() {
+		return this.memoryManager.getPageSize();
+	}
+
+	@Override
+	public void returnAll(List<MemorySegment> memory) {
+		this.pageUsage -= memory.size();
+		if (this.pageUsage < 0) {
+			throw new RuntimeException("Return too more memories.");
+		}
+		this.cachePages.addAll(memory);
+	}
+
+	public void returnPage(MemorySegment segment) {
+		returnAll(Collections.singletonList(segment));
+	}
+
+	@Override
+	public MemorySegment nextSegment() {
+		int freePages = freePages();
+		if (freePages == 0) {
+			return null;
+		}
+
+		if (this.cachePages.isEmpty()) {
+			int numPages = Math.min(freePages, this.perRequestPages);
+			try {
+				this.memoryManager.allocatePages(owner, this.cachePages, numPages);
+			} catch (MemoryAllocationException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		this.pageUsage++;
+		return this.cachePages.remove(this.cachePages.size() - 1);
+	}
+
+	@Override
+	public int freePages() {
+		return this.maxPages - this.pageUsage;
+	}
+
+	@Override
+	public void close() {
+		if (this.pageUsage != 0) {
+			throw new RuntimeException(
+					"Should return all used memory before clean, page used: " + pageUsage);
+		}
+		cleanCache();
+	}
+
+	public void cleanCache() {
+		this.memoryManager.release(this.cachePages);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/MemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/MemorySegmentPool.java
@@ -42,5 +42,9 @@ public interface MemorySegmentPool extends MemorySegmentSource {
 	 */
 	void returnAll(List<MemorySegment> memory);
 
+	/**
+	 * @return Free page number.
+	 */
+	int freePages();
 }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/ResettableExternalBuffer.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.io.disk.iomanager.ChannelReaderInputView;
 import org.apache.flink.runtime.io.disk.iomanager.FileIOChannel;
 import org.apache.flink.runtime.io.disk.iomanager.HeaderlessChannelReaderInputView;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
-import org.apache.flink.runtime.memory.ListMemorySegmentSource;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -73,15 +72,15 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 	// We will only read one spilled file at the same time.
 	private static final int READ_BUFFER = 2;
 
-	private final MemoryManager memoryManager;
 	private final IOManager ioManager;
-	private final List<MemorySegment> memory;
+	private final LazyMemorySegmentPool pool;
 	private final BinaryRowSerializer binaryRowSerializer;
 	private final InMemoryBuffer inMemoryBuffer;
-	private long spillSize;
 
 	// The size of each segment
-	private int segmentSize;
+	private final int segmentSize;
+
+	private long spillSize;
 
 	// The length of each row, if each row is of fixed length
 	private long rowLength;
@@ -101,25 +100,21 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 	private boolean addCompleted;
 
 	public ResettableExternalBuffer(
-		MemoryManager memoryManager,
 		IOManager ioManager,
-		List<MemorySegment> memory,
+		LazyMemorySegmentPool pool,
 		AbstractRowSerializer serializer,
 		boolean isRowAllInFixedPart) {
-		this.memoryManager = memoryManager;
 		this.ioManager = ioManager;
-		this.memory = memory;
+		this.pool = pool;
 
 		this.binaryRowSerializer = serializer instanceof BinaryRowSerializer ?
 				(BinaryRowSerializer) serializer.duplicate() :
 				new BinaryRowSerializer(serializer.getArity());
 
-		this.inMemoryBuffer = new InMemoryBuffer(serializer);
+		this.segmentSize = pool.pageSize();
 
 		this.spilledChannelIDs = new ArrayList<>();
 		this.spillSize = 0;
-
-		this.segmentSize = memory.get(0).size();
 
 		this.spilledChannelRowOffsets = new ArrayList<>();
 		this.numRows = 0;
@@ -130,6 +125,8 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 		this.isRowAllInFixedPart = isRowAllInFixedPart;
 		this.rowLength = isRowAllInFixedPart ? binaryRowSerializer.getSerializedRowFixedPartLength() : -1;
 		this.addCompleted = false;
+
+		this.inMemoryBuffer = new InMemoryBuffer(serializer);
 	}
 
 	@Override
@@ -182,8 +179,8 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 	@Override
 	public void close() {
 		clearChannels();
-		memoryManager.release(memory);
 		inMemoryBuffer.close();
+		pool.close();
 	}
 
 	private void throwTooBigException(BaseRow row) throws IOException {
@@ -225,7 +222,7 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 	}
 
 	private int memorySize() {
-		return memory.size() * segmentSize;
+		return pool.freePages() * segmentSize;
 	}
 
 	public long getUsedMemoryInBytes() {
@@ -567,8 +564,6 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 	 */
 	private class InMemoryBuffer implements Closeable {
 
-		private final int segmentSize;
-		private final ArrayList<MemorySegment> freeMemory;
 		private final AbstractRowSerializer serializer;
 		private final ArrayList<MemorySegment> recordBufferSegments;
 		private final SimpleCollectingOutputView recordCollector;
@@ -581,13 +576,11 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 		private int recordCount;
 
 		private InMemoryBuffer(AbstractRowSerializer serializer) {
-			this.segmentSize = memory.get(0).size();
-			this.freeMemory = new ArrayList<>(memory);
 			// serializer has states, so we must duplicate
 			this.serializer = (AbstractRowSerializer) serializer.duplicate();
-			this.recordBufferSegments = new ArrayList<>(memory.size());
-			this.recordCollector = new SimpleCollectingOutputView(this.recordBufferSegments,
-					new ListMemorySegmentSource(this.freeMemory), this.segmentSize);
+			this.recordBufferSegments = new ArrayList<>();
+			this.recordCollector = new SimpleCollectingOutputView(
+					this.recordBufferSegments, pool, segmentSize);
 			this.recordCount = 0;
 		}
 
@@ -595,16 +588,18 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 			this.currentDataBufferOffset = 0;
 			this.recordCount = 0;
 
-			// reset free and record segments.
-			this.freeMemory.addAll(this.recordBufferSegments);
-			this.recordBufferSegments.clear();
+			returnToSegmentPool();
 
 			this.recordCollector.reset();
 		}
 
 		@Override
 		public void close() {
-			this.freeMemory.clear();
+			returnToSegmentPool();
+		}
+
+		private void returnToSegmentPool() {
+			pool.returnAll(this.recordBufferSegments);
 			this.recordBufferSegments.clear();
 		}
 
@@ -645,7 +640,7 @@ public class ResettableExternalBuffer implements ResettableRowBuffer {
 			checkArgument(offset >= 0, "`offset` can't be negative!");
 
 			RandomAccessInputView recordBuffer = new RandomAccessInputView(
-					this.recordBufferSegments, this.segmentSize, numBytesInLastBuffer);
+					this.recordBufferSegments, segmentSize, numBytesInLastBuffer);
 			return new InMemoryBufferIterator(recordCount, beginRow, offset, recordBuffer);
 		}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinIteratorTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.dataformat.BinaryRowWriter;
 import org.apache.flink.table.runtime.operators.join.Int2HashJoinOperatorTest.MyProjection;
 import org.apache.flink.table.runtime.operators.sort.IntRecordComparator;
 import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
+import org.apache.flink.table.runtime.util.LazyMemorySegmentPool;
 import org.apache.flink.table.runtime.util.ResettableExternalBuffer;
 import org.apache.flink.util.MutableObjectIterator;
 
@@ -180,7 +181,8 @@ public class SortMergeJoinIteratorTest {
 				input1,
 				input2,
 				new ResettableExternalBuffer(
-						memManager, ioManager, memManager.allocatePages(this, BUFFER_MEMORY),
+						ioManager,
+						new LazyMemorySegmentPool(this, memManager, BUFFER_MEMORY),
 						serializer, false), new boolean[]{true})) {
 			int id = 0;
 			while (iterator.nextInnerJoin()) {
@@ -218,7 +220,8 @@ public class SortMergeJoinIteratorTest {
 				input1,
 				input2,
 				new ResettableExternalBuffer(
-						memManager, ioManager, memManager.allocatePages(this, BUFFER_MEMORY),
+						ioManager,
+						new LazyMemorySegmentPool(this, memManager, BUFFER_MEMORY),
 						serializer, false), new boolean[]{true})) {
 			int id = 0;
 			while (iterator.nextOuterJoin()) {
@@ -257,10 +260,12 @@ public class SortMergeJoinIteratorTest {
 				input1,
 				input2,
 				new ResettableExternalBuffer(
-						memManager, ioManager, memManager.allocatePages(this, BUFFER_MEMORY),
+						ioManager,
+						new LazyMemorySegmentPool(this, memManager, BUFFER_MEMORY),
 						serializer, false),
 				new ResettableExternalBuffer(
-						memManager, ioManager, memManager.allocatePages(this, BUFFER_MEMORY),
+						ioManager,
+						new LazyMemorySegmentPool(this, memManager, BUFFER_MEMORY),
 						serializer, false), new boolean[]{true})) {
 			int id = 0;
 			while (iterator.nextOuterJoin()) {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/TestMemorySegmentPool.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/TestMemorySegmentPool.java
@@ -45,6 +45,11 @@ public class TestMemorySegmentPool implements MemorySegmentPool {
 	}
 
 	@Override
+	public int freePages() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
 	public MemorySegment nextSegment() {
 		return MemorySegmentFactory.wrap(new byte[pageSize]);
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/ResettableExternalBufferTest.java
@@ -19,7 +19,6 @@ package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
-import org.apache.flink.runtime.memory.MemoryAllocationException;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -71,15 +70,15 @@ public class ResettableExternalBufferTest {
 		this.multiColumnVariableLengthSerializer = new BinaryRowSerializer(5);
 	}
 
-	private ResettableExternalBuffer newBuffer(long memorySize) throws MemoryAllocationException {
+	private ResettableExternalBuffer newBuffer(long memorySize) {
 		return newBuffer(memorySize, this.serializer, true);
 	}
 
 	private ResettableExternalBuffer newBuffer(long memorySize,
-			BinaryRowSerializer serializer, boolean isRowAllInFixedPart) throws MemoryAllocationException {
+			BinaryRowSerializer serializer, boolean isRowAllInFixedPart) {
 		return new ResettableExternalBuffer(
-				memManager, ioManager,
-				memManager.allocatePages(this, (int) (memorySize / memManager.getPageSize())),
+				ioManager,
+				new LazyMemorySegmentPool(this, memManager, (int) (memorySize / memManager.getPageSize())),
 				serializer, isRowAllInFixedPart);
 	}
 
@@ -178,8 +177,8 @@ public class ResettableExternalBufferTest {
 	public void testHugeRecord() throws Exception {
 		thrown.expect(IOException.class);
 		try (ResettableExternalBuffer buffer = new ResettableExternalBuffer(
-				memManager, ioManager,
-				memManager.allocatePages(this, 3 * DEFAULT_PAGE_SIZE / memManager.getPageSize()),
+				ioManager,
+				new LazyMemorySegmentPool(this, memManager, 3 * DEFAULT_PAGE_SIZE / memManager.getPageSize()),
 				new BinaryRowSerializer(1),
 				false)) {
 			writeHuge(buffer, 10);


### PR DESCRIPTION

## What is the purpose of the change

Now after FLINK-14063 , operators will get all manage memory of TaskManager,  The cost of over allocate memory is very high, lead to performance regression of small batch sql jobs:

Allocate memory will have the cost of memory management algorithm.
Allocate memory will have the cost of memory initialization, will set all memory to zero. And this initialization will require the operating system to actually allocate physical memory.
Over allocate memory will squash the file cache too.
We can optimize the operator algorithm, apply lazy allocation, and avoid meaningless memory allocation.

## Brief change log

- Introduce LazyMemorySegmentPool
- Improve operators to lazily allocate memory

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
