### PR TITLE
[FLINK-15355][plugins] Added parent first patterns for plugins.

### DIFF
--- a/docs/_includes/generated/core_configuration.html
+++ b/docs/_includes/generated/core_configuration.html
@@ -38,5 +38,17 @@
             <td>Integer</td>
             <td>Default parallelism for jobs.</td>
         </tr>
+        <tr>
+            <td><h5>plugin.classloader.parent-first-patterns.additional</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked  against the fully qualified class name. These patterns are appended to "plugin.classloader.parent-first-patterns.default".</td>
+        </tr>
+        <tr>
+            <td><h5>plugin.classloader.parent-first-patterns.default</h5></td>
+            <td style="word-wrap: break-word;">"java.;<wbr>scala.;<wbr>org.apache.flink.;<wbr>javax.annotation.;<wbr>org.slf4j;<wbr>org.apache.log4j;<wbr>org.apache.logging;<wbr>org.apache.commons.logging;<wbr>ch.qos.logback"</td>
+            <td>String</td>
+            <td>A (semicolon-separated) list of patterns that specifies which classes should always be resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked  against the fully qualified class name. This setting should generally not be modified. To add another  pattern we recommend to use "plugin.classloader.parent-first-patterns.additional" instead.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -121,6 +121,36 @@ public class CoreOptions {
 		}
 	}
 
+	/**
+	 * Plugin-specific option of {@link #ALWAYS_PARENT_FIRST_LOADER_PATTERNS}. Plugins use this parent first list
+	 * instead of the global version.
+	 */
+	public static final ConfigOption<String> PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS = ConfigOptions
+		.key("plugin.classloader.parent-first-patterns.default")
+		.stringType()
+		.defaultValue("java.;scala.;org.apache.flink.;javax.annotation.;org.slf4j;org.apache.log4j;org.apache" +
+			".logging;org.apache.commons.logging;ch.qos.logback")
+		.withDescription("A (semicolon-separated) list of patterns that specifies which classes should always be" +
+			" resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked " +
+			" against the fully qualified class name. This setting should generally not be modified. To add another " +
+			" pattern we recommend to use \"plugin.classloader.parent-first-patterns.additional\" instead.");
+
+	public static final ConfigOption<String> PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL = ConfigOptions
+		.key("plugin.classloader.parent-first-patterns.additional")
+		.stringType()
+		.defaultValue("")
+		.withDescription("A (semicolon-separated) list of patterns that specifies which classes should always be" +
+			" resolved through the plugin parent ClassLoader first. A pattern is a simple prefix that is checked " +
+			" against the fully qualified class name. These patterns are appended to \"" +
+			PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS.key() + "\".");
+
+	public static String[] getPluginParentFirstLoaderPatterns(Configuration config) {
+		String base = config.getString(PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS);
+		String append = config.getString(PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);
+
+		return ArrayUtils.concat(base.split(";"), append.split(";"));
+	}
+
 	// ------------------------------------------------------------------------
 	//  process parameters
 	// ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginConfig.java
@@ -56,7 +56,7 @@ public class PluginConfig {
 	public static PluginConfig fromConfiguration(Configuration configuration) {
 		return new PluginConfig(
 			getPluginsDir().map(File::toPath),
-			CoreOptions.getParentFirstLoaderPatterns(configuration));
+			CoreOptions.getPluginParentFirstLoaderPatterns(configuration));
 	}
 
 	public static Optional<File> getPluginsDir() {


### PR DESCRIPTION
Forwards port of https://github.com/apache/flink/pull/10778 . Main commit untouched and only the commit that reenables tests is dropped as they were never disabled on master.