### PR TITLE
[FLINK-15521][e2e] Follow symbolic link when copying distribution

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -65,4 +65,19 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>default-test</id>
+						<phase>test</phase>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -87,7 +89,7 @@ public enum TestUtils {
 	 * @throws IOException if any IO error happen.
 	 */
 	public static Path copyDirectory(final Path source, final Path destination) throws IOException {
-		Files.walkFileTree(source, new SimpleFileVisitor<Path>() {
+		Files.walkFileTree(source, EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE, new SimpleFileVisitor<Path>() {
 			@Override
 			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes ignored)
 				throws IOException {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
@@ -93,11 +93,11 @@ public enum TestUtils {
 			@Override
 			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes ignored)
 				throws IOException {
-				final Path targetRir = destination.resolve(source.relativize(dir));
+				final Path targetDir = destination.resolve(source.relativize(dir));
 				try {
-					Files.copy(dir, targetRir, StandardCopyOption.COPY_ATTRIBUTES);
+					Files.copy(dir, targetDir, StandardCopyOption.COPY_ATTRIBUTES);
 				} catch (FileAlreadyExistsException e) {
-					if (!Files.isDirectory(targetRir)) {
+					if (!Files.isDirectory(targetDir)) {
 						throw e;
 					}
 				}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/TestUtilsTest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/tests/util/TestUtilsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util;
+
+import org.apache.flink.tests.util.activation.OperatingSystemRestriction;
+import org.apache.flink.util.OperatingSystem;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests for {@link TestUtils}.
+ */
+public class TestUtilsTest extends TestLogger {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@BeforeClass
+	public static void setupClass() {
+		OperatingSystemRestriction.forbid("Symbolic links usually require special permissions on Windows.", OperatingSystem.WINDOWS);
+	}
+
+	@Test
+	public void copyDirectory() throws IOException {
+		Path[] files = {
+			Paths.get("file1"),
+			Paths.get("dir1", "file2"),
+		};
+
+		Path source = temporaryFolder.newFolder("source").toPath();
+		for (Path file : files) {
+			Files.createDirectories(source.resolve(file).getParent());
+			Files.createFile(source.resolve(file));
+		}
+
+		Path symbolicLink = source.getParent().resolve("link");
+		Files.createSymbolicLink(symbolicLink, source);
+
+		Path target = source.getParent().resolve("target");
+		TestUtils.copyDirectory(symbolicLink, target);
+
+		for (Path file: files) {
+			Assert.assertTrue(Files.exists(target.resolve(file)));
+		}
+	}
+}


### PR DESCRIPTION
Fixes an issue where pointing `distDir` to a symbolic link would fail with misleading exceptions.