### PR TITLE
[FLINK-15518][web]: don not hide web frontend side pane automatically

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app-routing.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app-routing.module.ts
@@ -24,7 +24,7 @@ const routes: Routes = [
   { path: 'submit', loadChildren: './pages/submit/submit.module#SubmitModule' },
   { path: 'job-manager', loadChildren: './pages/job-manager/job-manager.module#JobManagerModule' },
   { path: 'task-manager', loadChildren: './pages/task-manager/task-manager.module#TaskManagerModule' },
-  { path: 'job', loadChildren: './pages/job/job.module#JobModule', data: { collapse: true } },
+  { path: 'job', loadChildren: './pages/job/job.module#JobModule' },
   { path: '**', redirectTo: 'overview', pathMatch: 'full' }
 ];
 

--- a/flink-runtime-web/web-dashboard/src/app/app.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.component.ts
@@ -16,10 +16,9 @@
  * limitations under the License.
  */
 
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { Component } from '@angular/core';
 import { fromEvent, merge } from 'rxjs';
-import { filter, first, map, startWith } from 'rxjs/operators';
+import { map, startWith } from 'rxjs/operators';
 import { StatusService } from 'services';
 import { MonacoEditorService } from 'share/common/monaco-editor/monaco-editor.service';
 
@@ -28,7 +27,7 @@ import { MonacoEditorService } from 'share/common/monaco-editor/monaco-editor.se
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.less']
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   collapsed = false;
   visible = false;
   online$ = merge(
@@ -54,25 +53,5 @@ export class AppComponent implements OnInit {
     this.monacoEditorService.layout();
   }
 
-  constructor(
-    private router: Router,
-    private activatedRoute: ActivatedRoute,
-    public statusService: StatusService,
-    private monacoEditorService: MonacoEditorService
-  ) {}
-
-  /**
-   * Auto collapse sidebar when routing data matched
-   */
-  ngOnInit(): void {
-    this.router.events
-      .pipe(
-        filter(event => event instanceof NavigationEnd),
-        filter(() => this.activatedRoute.firstChild && this.activatedRoute.firstChild.snapshot.data.collapse),
-        first()
-      )
-      .subscribe(() => {
-        this.collapsed = true;
-      });
-  }
+  constructor(public statusService: StatusService, private monacoEditorService: MonacoEditorService) {}
 }


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-15518

## Brief change log

support more metric display at once

## Verifying this change

  - *Go to the job page*
  - *Side tab do not hide automaticlly*


before:

![image](https://user-images.githubusercontent.com/1506722/72031252-d4017480-32c6-11ea-9e31-99176c095097.png)


after:

![image](https://user-images.githubusercontent.com/1506722/72031264-e085cd00-32c6-11ea-8429-7f3439558c77.png)



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
