### PR TITLE
[hotfix] Fix wrong javadoc of ProcessFunctionTestHarnessesTest

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnessesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/ProcessFunctionTestHarnessesTest.java
@@ -38,7 +38,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link ProcessFunctionTestHarnessesTest}.
+ * Tests for {@link ProcessFunctionTestHarnesses}.
  */
 public class ProcessFunctionTestHarnessesTest extends TestLogger {
 


### PR DESCRIPTION


## What is the purpose of the change

*Fix wrong javadoc of ProcessFunctionTestHarnessesTest*

## Brief change log

  - *Fix wrong javadoc of ProcessFunctionTestHarnessesTest*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
