### PR TITLE
[FLINK-15536][configuration] Revert removal of ConfigConstants.YARN_MAX_FAILED_CONTAINERS

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -435,6 +435,17 @@ public final class ConfigConstants {
 	public static final String YARN_REALLOCATE_FAILED_CONTAINERS = "yarn.reallocate-failed";
 
 	/**
+	 * The maximum number of failed YARN containers before entirely stopping
+	 * the YARN session / job on YARN.
+	 *
+	 * <p>By default, we take the number of initially requested containers.
+	 *
+	 * @deprecated in favor of {@code YarnConfigOptions#MAX_FAILED_CONTAINERS}.
+	 */
+	@Deprecated
+	public static final String YARN_MAX_FAILED_CONTAINERS = "yarn.maximum-failed-containers";
+
+	/**
 	 * Set the number of retries for failed YARN ApplicationMasters/JobManagers in high
 	 * availability mode. This value is usually limited by YARN.
 	 *


### PR DESCRIPTION
Revert breaking changes introduced by FLINK-15359 #10658 

cc @tillrohrmann 