### PR TITLE
[FLINK-14255][WIP][table] Introduce FileSystemStreamingSink

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -45,4 +45,10 @@ public class HiveOptions {
 			key("table.exec.hive.infer-source-parallelism.max")
 					.defaultValue(1000)
 					.withDescription("Sets max infer parallelism for source operator.");
+
+	public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_STREAMING_SINK =
+			key("table.exec.hive.streaming-sink")
+					.defaultValue(false)
+					.withDescription(
+							"Using streaming mode in sink to write to hive.\n");
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -45,10 +45,4 @@ public class HiveOptions {
 			key("table.exec.hive.infer-source-parallelism.max")
 					.defaultValue(1000)
 					.withDescription("Sets max infer parallelism for source operator.");
-
-	public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_STREAMING_SINK =
-			key("table.exec.hive.streaming-sink")
-					.defaultValue(false)
-					.withDescription(
-							"Using streaming mode in sink to write to hive.\n");
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -20,13 +20,11 @@ package org.apache.flink.connectors.hive;
 
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.config.CatalogConfig;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
-import org.apache.flink.table.sinks.OutputFormatTableSink;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.types.Row;
@@ -88,16 +86,12 @@ public class HiveTableFactory
 		boolean isGeneric = Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
 
 		if (!isGeneric) {
-			return createOutputFormatTableSink(context.getObjectIdentifier().toObjectPath(), table);
+			return new HiveTableSink(
+					new JobConf(hiveConf),
+					context.getObjectIdentifier().toObjectPath(),
+					table);
 		} else {
 			return TableFactoryUtil.findAndCreateTableSink(context);
 		}
-	}
-
-	/**
-	 * Creates and configures a {@link org.apache.flink.table.sinks.OutputFormatTableSink} using the given {@link CatalogTable}.
-	 */
-	private OutputFormatTableSink<Row> createOutputFormatTableSink(ObjectPath tablePath, CatalogTable table) {
-		return new HiveTableSink(new JobConf(hiveConf), tablePath, table);
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.connectors.hive;
 
-import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -30,8 +31,11 @@ import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.descriptors.HiveCatalogValidator;
 import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
+import org.apache.flink.table.descriptors.FileSystemValidator;
 import org.apache.flink.table.filesystem.FileSystemOutputFormat;
-import org.apache.flink.table.sinks.OutputFormatTableSink;
+import org.apache.flink.table.filesystem.streaming.FileSystemStreamingSink;
+import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.OverwritableTableSink;
 import org.apache.flink.table.sinks.PartitionableTableSink;
 import org.apache.flink.table.sinks.TableSink;
@@ -58,7 +62,7 @@ import java.util.Map;
 /**
  * Table sink to write to Hive tables.
  */
-public class HiveTableSink extends OutputFormatTableSink<Row> implements PartitionableTableSink, OverwritableTableSink {
+public class HiveTableSink implements AppendStreamTableSink<Row>, PartitionableTableSink, OverwritableTableSink {
 
 	private final JobConf jobConf;
 	private final CatalogTable catalogTable;
@@ -83,7 +87,14 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 	}
 
 	@Override
-	public OutputFormat<Row> getOutputFormat() {
+	public final DataStreamSink<Row> consumeDataStream(DataStream<Row> dataStream) {
+		int parallelism = dataStream.getParallelism();
+		String sinkParallelism = catalogTable.getProperties()
+				.get(ConnectorDescriptorValidator.CONNECTOR_SINK_PARALLELISM);
+		if (sinkParallelism != null) {
+			parallelism = Integer.parseInt(sinkParallelism);
+		}
+
 		String[] partitionColumns = getPartitionFieldNames().toArray(new String[0]);
 		String dbName = tablePath.getDatabaseName();
 		String tableName = tablePath.getObjectName();
@@ -92,34 +103,67 @@ public class HiveTableSink extends OutputFormatTableSink<Row> implements Partiti
 			Table table = client.getTable(dbName, tableName);
 			StorageDescriptor sd = table.getSd();
 
-			FileSystemOutputFormat.Builder<Row> builder = new FileSystemOutputFormat.Builder<>();
-			builder.setPartitionComputer(new HivePartitionComputer(
+			HivePartitionComputer partitionComputer = new HivePartitionComputer(
 					hiveShim,
 					jobConf.get(
 							HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
 							HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal),
 					tableSchema.getFieldNames(),
 					tableSchema.getFieldDataTypes(),
-					partitionColumns));
-			builder.setDynamicGrouped(dynamicGrouping);
-			builder.setPartitionColumns(partitionColumns);
-			builder.setFileSystemFactory(new HadoopFileSystemFactory(jobConf));
-			builder.setFormatFactory(new HiveOutputFormatFactory(
+					partitionColumns);
+			HadoopFileSystemFactory fsFactory = new HadoopFileSystemFactory(
+					jobConf,
+					catalogTable.getProperties()
+							.get(FileSystemValidator.CONNECTOR_HADOOP_USERNAME));
+			HiveOutputFormatFactory outputFormatFactory = new HiveOutputFormatFactory(
 					jobConf,
 					sd.getOutputFormat(),
 					sd.getSerdeInfo(),
 					tableSchema,
 					partitionColumns,
 					HiveReflectionUtils.getTableMetadata(hiveShim, table),
-					hiveShim));
-			builder.setMetaStoreFactory(
-					new HiveTableMetaStoreFactory(jobConf, hiveVersion, dbName, tableName));
-			builder.setOverwrite(overwrite);
-			builder.setStaticPartitions(staticPartitionSpec);
-			builder.setTempPath(new org.apache.flink.core.fs.Path(
-					toStagingDir(sd.getLocation(), jobConf)));
+					hiveShim);
+			HiveTableMetaStoreFactory msFactory = new HiveTableMetaStoreFactory(
+					jobConf, hiveVersion, dbName, tableName);
+			org.apache.flink.core.fs.Path tmpPath = new org.apache.flink.core.fs.Path(
+					toStagingDir(sd.getLocation(), jobConf));
 
-			return builder.build();
+			if (Boolean.parseBoolean(catalogTable.getProperties()
+					.get(FileSystemValidator.CONNECTOR_SINK_STREAMING_ENABLE))) {
+				if (overwrite) {
+					throw new IllegalStateException("Streaming mode not support overwrite.");
+				}
+
+				FileSystemStreamingSink.Builder<Row> builder = new FileSystemStreamingSink.Builder<>();
+				builder.setPartitionComputer(partitionComputer);
+				builder.setPartitionColumns(partitionColumns);
+				builder.setFileSystemFactory(fsFactory);
+				builder.setFormatFactory(outputFormatFactory);
+				builder.setMetaStoreFactory(msFactory);
+				builder.setStaticPartitions(staticPartitionSpec);
+				builder.setTempPath(tmpPath);
+				builder.setLocationPath(new org.apache.flink.core.fs.Path(sd.getLocation()));
+				builder.setProperties(catalogTable.getProperties());
+
+				return dataStream
+						.addSink(builder.build())
+						.setParallelism(parallelism);
+			} else {
+				FileSystemOutputFormat.Builder<Row> builder = new FileSystemOutputFormat.Builder<>();
+				builder.setPartitionComputer(partitionComputer);
+				builder.setDynamicGrouped(dynamicGrouping);
+				builder.setPartitionColumns(partitionColumns);
+				builder.setFileSystemFactory(fsFactory);
+				builder.setFormatFactory(outputFormatFactory);
+				builder.setMetaStoreFactory(msFactory);
+				builder.setOverwrite(overwrite);
+				builder.setStaticPartitions(staticPartitionSpec);
+				builder.setTempPath(tmpPath);
+
+				return dataStream
+						.writeUsingOutputFormat(builder.build())
+						.setParallelism(parallelism);
+			}
 		} catch (TException e) {
 			throw new CatalogException("Failed to query Hive metaStore", e);
 		} catch (IOException e) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/ConnectorDescriptorValidator.java
@@ -48,6 +48,11 @@ public abstract class ConnectorDescriptorValidator implements DescriptorValidato
 	 */
 	public static final String CONNECTOR_VERSION = "connector.version";
 
+	/**
+	 * Key for describing the parallelism of the sink.
+	 */
+	public static final String CONNECTOR_SINK_PARALLELISM = "connector.sink.parallelism";
+
 	@Override
 	public void validate(DescriptorProperties properties) {
 		properties.validateString(CONNECTOR_TYPE, false, 1);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FileSystemValidator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FileSystemValidator.java
@@ -28,6 +28,19 @@ public class FileSystemValidator extends ConnectorDescriptorValidator {
 
 	public static final String CONNECTOR_TYPE_VALUE = "filesystem";
 	public static final String CONNECTOR_PATH = "connector.path";
+	public static final String CONNECTOR_SINK_SHUFFLE_ENABLE =
+			"connector.sink.shuffle-by-partition.enable";
+	public static final String CONNECTOR_SINK_STREAMING_ENABLE =
+			"connector.sink.streaming-mode.enable";
+	public static final String CONNECTOR_HADOOP_USERNAME = "connector.hadoop.username";
+	public static final String CONNECTOR_SINK_PARTITION_COMMIT_POLICY =
+			"connector.sink.partition-commit.policy";
+	public static final String CONNECTOR_SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
+			"connector.sink.partition-commit.success-file.name";
+	public static final String CONNECTOR_SINK_PARTITION_COMMIT_TRIGGER =
+			"connector.sink.partition-commit.trigger";
+	public static final String CONNECTOR_SINK_PARTITION_COMMIT_TRIGGER_CLASS =
+			"connector.sink.partition-commit.trigger.class";
 
 	@Override
 	public void validate(DescriptorProperties properties) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DynamicPartitionWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DynamicPartitionWriter.java
@@ -48,7 +48,7 @@ public class DynamicPartitionWriter<T> implements PartitionWriter<T> {
 	}
 
 	@Override
-	public void write(T in) throws Exception {
+	public String write(T in) throws Exception {
 		String partition = generatePartitionPath(computer.generatePartValues(in));
 		OutputFormat<T> format = formats.get(partition);
 
@@ -58,6 +58,7 @@ public class DynamicPartitionWriter<T> implements PartitionWriter<T> {
 			formats.put(partition, format);
 		}
 		format.writeRecord(computer.projectColumnsToWrite(in));
+		return partition;
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemCommitter.java
@@ -21,27 +21,26 @@ package org.apache.flink.table.filesystem;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory.TableMetaStore;
 
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import static org.apache.flink.table.filesystem.PartitionPathUtils.generatePartitionPath;
 import static org.apache.flink.table.filesystem.PartitionTempFileManager.collectPartSpecToPaths;
-import static org.apache.flink.table.filesystem.PartitionTempFileManager.deleteCheckpoint;
-import static org.apache.flink.table.filesystem.PartitionTempFileManager.headCheckpoints;
 import static org.apache.flink.table.filesystem.PartitionTempFileManager.listTaskTemporaryPaths;
 
 /**
  * File system file committer implementation. It move all files to output path from temporary path.
  *
- * <p>In a checkpoint:
+ * <p>For a batch job:
  *  1.Every task will create a {@link PartitionTempFileManager} to initialization, it generate path
  *  for task writing. And clean the temporary path of task.
- *  2.After writing done for this checkpoint, need invoke {@link #commitUpToCheckpoint(long)},
- *  will move the temporary files to real output path.
- *
- * <p>Batch is a special case of Streaming, which has only one checkpoint.
+ *  2.After writing done, need invoke {@link #commitJob}, will move the temporary files to real
+ *  output path.
  *
  * <p>Data consistency:
  * 1.For task failure: will launch a new task and create a {@link PartitionTempFileManager},
@@ -63,6 +62,7 @@ import static org.apache.flink.table.filesystem.PartitionTempFileManager.listTas
 class FileSystemCommitter implements Serializable {
 
 	private static final long serialVersionUID = 1L;
+	static final long CHECKPOINT_ID = 0;
 
 	private final FileSystemFactory factory;
 	private final TableMetaStoreFactory metaStoreFactory;
@@ -84,37 +84,31 @@ class FileSystemCommitter implements Serializable {
 	}
 
 	/**
-	 * For committing job's output after successful batch job completion or one checkpoint finish
-	 * for streaming job. Should move all files to final output paths.
-	 *
-	 * <p>NOTE: According to checkpoint notify mechanism of Flink, checkpoint may fail and be
-	 * abandoned, so this method should commit all checkpoint ids that less than current
-	 * checkpoint id (Includes failure checkpoints).
+	 * For committing job's output after successful batch job completion. Move all files
+	 * to final output paths.
 	 */
-	public void commitUpToCheckpoint(long toCpId) throws Exception {
+	void commitJob() throws Exception {
 		FileSystem fs = factory.create(tmpPath.toUri());
-
-		try (PartitionLoader loader = new PartitionLoader(overwrite, fs, metaStoreFactory)) {
-			for (long cp : headCheckpoints(fs, tmpPath, toCpId)) {
-				commitSingleCheckpoint(fs, loader, cp);
-			}
-		}
-	}
-
-	private void commitSingleCheckpoint(
-			FileSystem fs, PartitionLoader loader, long checkpointId) throws Exception {
-		try {
-			List<Path> taskPaths = listTaskTemporaryPaths(fs, tmpPath, checkpointId);
+		try (TableMetaStore metaStore = metaStoreFactory.createTableMetaStore()) {
+			PartitionLoader loader = new PartitionLoader(overwrite, fs);
+			List<Path> taskPaths = listTaskTemporaryPaths(fs, tmpPath, CHECKPOINT_ID);
 			if (partitionColumnSize > 0) {
 				for (Map.Entry<LinkedHashMap<String, String>, List<Path>> entry :
 						collectPartSpecToPaths(fs, taskPaths, partitionColumnSize).entrySet()) {
-					loader.loadPartition(entry.getKey(), entry.getValue());
+					Optional<Path> pathFromMeta = metaStore.getPartition(entry.getKey());
+					Path path = pathFromMeta.orElseGet(() ->
+							new Path(metaStore.getLocationPath(), generatePartitionPath(entry.getKey())));
+					loader.loadPath(entry.getValue(), path);
+					if (!pathFromMeta.isPresent()) {
+						metaStore.createPartition(entry.getKey(), path);
+					}
 				}
 			} else {
-				loader.loadNonPartition(taskPaths);
+				Path tableLocation = metaStore.getLocationPath();
+				loader.loadPath(taskPaths, tableLocation);
 			}
 		} finally {
-			deleteCheckpoint(fs, tmpPath, checkpointId);
+			fs.delete(tmpPath, true);
 		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOutputFormat.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 
+import static org.apache.flink.table.filesystem.FileSystemCommitter.CHECKPOINT_ID;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -41,8 +42,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class FileSystemOutputFormat<T> implements OutputFormat<T>, FinalizeOnMaster, Serializable {
 
 	private static final long serialVersionUID = 1L;
-
-	private static final long CHECKPOINT_ID = 0;
 
 	private final FileSystemFactory fsFactory;
 	private final TableMetaStoreFactory msFactory;
@@ -87,7 +86,7 @@ public class FileSystemOutputFormat<T> implements OutputFormat<T>, FinalizeOnMas
 					overwrite,
 					tmpPath,
 					partitionColumns.length);
-			committer.commitUpToCheckpoint(CHECKPOINT_ID);
+			committer.commitJob();
 		} catch (Exception e) {
 			throw new TableException("Exception in finalizeGlobal", e);
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/GroupedPartitionWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/GroupedPartitionWriter.java
@@ -49,7 +49,7 @@ public class GroupedPartitionWriter<T> implements PartitionWriter<T> {
 	}
 
 	@Override
-	public void write(T in) throws Exception {
+	public String write(T in) throws Exception {
 		String partition = generatePartitionPath(computer.generatePartValues(in));
 		if (!partition.equals(currentPartition)) {
 			if (currentFormat != null) {
@@ -60,6 +60,7 @@ public class GroupedPartitionWriter<T> implements PartitionWriter<T> {
 			currentPartition = partition;
 		}
 		currentFormat.writeRecord(computer.projectColumnsToWrite(in));
+		return partition;
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionWriter.java
@@ -38,9 +38,9 @@ import java.io.IOException;
 public interface PartitionWriter<T> {
 
 	/**
-	 * Write a record.
+	 * Write a record, return partition.
 	 */
-	void write(T in) throws Exception;
+	String write(T in) throws Exception;
 
 	/**
 	 * End a transaction.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SingleDirectoryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SingleDirectoryWriter.java
@@ -35,6 +35,7 @@ public class SingleDirectoryWriter<T> implements PartitionWriter<T> {
 
 	private final PartitionComputer<T> computer;
 	private final OutputFormat<T> format;
+	private final String partition;
 
 	public SingleDirectoryWriter(
 			Context<T> context,
@@ -42,14 +43,16 @@ public class SingleDirectoryWriter<T> implements PartitionWriter<T> {
 			PartitionComputer<T> computer,
 			LinkedHashMap<String, String> staticPartitions) throws Exception {
 		this.computer = computer;
+		this.partition = staticPartitions.size() == 0 ? "" : generatePartitionPath(staticPartitions);
 		this.format = context.createNewOutputFormat(staticPartitions.size() == 0 ?
 				manager.createPartitionDir() :
-				manager.createPartitionDir(generatePartitionPath(staticPartitions)));
+				manager.createPartitionDir(partition));
 	}
 
 	@Override
-	public void write(T in) throws Exception {
+	public String write(T in) throws Exception {
 		format.writeRecord(computer.projectColumnsToWrite(in));
+		return partition;
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamCommitter.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.filesystem.FileSystemFactory;
+import org.apache.flink.table.filesystem.PartitionLoader;
+import org.apache.flink.table.filesystem.PartitionTempFileManager;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
+import org.apache.flink.table.filesystem.streaming.policy.PartitionCommitPolicy;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.table.filesystem.PartitionPathUtils.extractPartitionSpecFromPath;
+import static org.apache.flink.table.filesystem.PartitionPathUtils.generatePartitionPath;
+import static org.apache.flink.table.filesystem.PartitionPathUtils.searchPartSpecAndPaths;
+import static org.apache.flink.table.filesystem.PartitionTempFileManager.deleteCheckpoint;
+import static org.apache.flink.table.filesystem.PartitionTempFileManager.getTaskTempDir;
+import static org.apache.flink.table.filesystem.PartitionTempFileManager.headCheckpoints;
+
+/**
+ * Streaming File system file committer implementation. It move all files to output path from temporary path.
+ *
+ * <p>In a checkpoint:
+ *  1.Every task will create a {@link PartitionTempFileManager} to initialization, it generate path
+ *  for task writing. And clean the temporary path of task.
+ *  2.Every task will invoke {@link #commitTaskUpToCheckpoint} to move files to location path.
+ *  3.After task commit finish, invoke {@link #commitJobPartitions(Set)} to add partitions to meta store,
+ *  meta store related operations should be finish in a single point, meta store can not be touched by tasks.
+ *
+ * <p>Data consistency:
+ * 1.For task failure: will launch a new task and create a {@link PartitionTempFileManager},
+ *   this will clean previous temporary files (This simple design can make it easy to delete the
+ *   invalid temporary directory of the task, but it also causes that our directory does not
+ *   support the same task to start multiple backups to run).
+ * 2.For notify checkpoint complete commit failure when append: This can lead to inconsistent data.
+ *   But, considering that the commit action is a quick execution, and only moves files and updates
+ *   metadata, it will be faster, so the probability of inconsistency is relatively small.
+ *
+ * <p>See:
+ * {@link PartitionTempFileManager}.
+ * {@link PartitionLoader}.
+ */
+class FileSystemStreamCommitter implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final FileSystemFactory factory;
+	private final TableMetaStoreFactory metaStoreFactory;
+	private final List<PartitionCommitPolicy> policies;
+	private final Path tmpPath;
+	private final Path locationPath;
+	private final int partitionColumnSize;
+
+	FileSystemStreamCommitter(
+			FileSystemFactory factory,
+			TableMetaStoreFactory metaStoreFactory,
+			List<PartitionCommitPolicy> policies,
+			Path tmpPath,
+			Path locationPath,
+			int partitionColumnSize) {
+		this.factory = factory;
+		this.metaStoreFactory = metaStoreFactory;
+		this.policies = policies;
+		this.tmpPath = tmpPath;
+		this.locationPath = locationPath;
+		this.partitionColumnSize = partitionColumnSize;
+	}
+
+	/**
+	 * For committing job's output after one checkpoint finish for streaming job.
+	 * Move all files to final output paths.
+	 *
+	 * <p>NOTE: According to checkpoint notify mechanism of Flink, checkpoint may fail and be
+	 * abandoned, so this method should commit all checkpoint ids that less than current
+	 * checkpoint id (Includes failure checkpoints).
+	 */
+	void commitTaskUpToCheckpoint(long toCpId, int taskId) throws Exception {
+		FileSystem fs = factory.create(tmpPath.toUri());
+
+		PartitionLoader pathLoader = new PartitionLoader(false, fs);
+		for (long cp : headCheckpoints(fs, tmpPath, toCpId)) {
+			try {
+				Path taskTmpDir = getTaskTempDir(tmpPath, cp, taskId);
+				if (partitionColumnSize > 0) {
+					for (Tuple2<LinkedHashMap<String, String>, Path> entry :
+							searchPartSpecAndPaths(fs, taskTmpDir, partitionColumnSize)) {
+						pathLoader.loadPath(
+								Collections.singletonList(entry.f1),
+								new Path(locationPath, generatePartitionPath(entry.f0)));
+					}
+				} else {
+					pathLoader.loadPath(Collections.singletonList(taskTmpDir), locationPath);
+				}
+			} finally {
+				deleteCheckpoint(fs, tmpPath, cp);
+			}
+		}
+	}
+
+	/**
+	 * Commit give pending partitions to meta store.
+	 */
+	void commitJobPartitions(Set<String> pendingPartitions) throws Exception {
+		FileSystem fs = factory.create(tmpPath.toUri());
+		try (TableMetaStoreFactory.TableMetaStore metaStore = metaStoreFactory.createTableMetaStore()) {
+			for (String partition : pendingPartitions) {
+				LinkedHashMap<String, String> partSpec = extractPartitionSpecFromPath(new Path(partition));
+				Path path = new Path(metaStore.getLocationPath(), generatePartitionPath(partSpec));
+				for (PartitionCommitPolicy policy : policies) {
+					policy.commit(partSpec, path, fs, metaStore);
+				}
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSink.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.table.filesystem.FileSystemFactory;
+import org.apache.flink.table.filesystem.FileSystemOutputFormat;
+import org.apache.flink.table.filesystem.OutputFormatFactory;
+import org.apache.flink.table.filesystem.PartitionComputer;
+import org.apache.flink.table.filesystem.PartitionTempFileManager;
+import org.apache.flink.table.filesystem.PartitionWriter;
+import org.apache.flink.table.filesystem.PartitionWriterFactory;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
+import org.apache.flink.table.filesystem.streaming.policy.PartitionCommitPolicy;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.filesystem.PartitionTempFileManager.cleanTaskTempFiles;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * File system sink for streaming jobs.
+ */
+public class FileSystemStreamingSink<T> extends RichSinkFunction<T>
+		implements CheckpointedFunction, CheckpointListener {
+
+	private static final long FIRST_CHECKPOINT_ID = 1L;
+	private static final ListStateDescriptor<Long> CP_ID_STATE_DESC =
+			new ListStateDescriptor<>("checkpoint-id", LongSerializer.INSTANCE);
+
+	private final FileSystemFactory fsFactory;
+	private final TableMetaStoreFactory msFactory;
+	private final Path tmpPath;
+	private final Path locationPath;
+	private final String[] partitionColumns;
+	private final LinkedHashMap<String, String> staticPartitions;
+	private final PartitionComputer<T> computer;
+	private final OutputFormatFactory<T> formatFactory;
+	private final Map<String, String> properties;
+
+	private transient PartitionWriter<T> writer;
+	private transient Configuration parameters;
+	private transient int taskId;
+	private transient ListState<Long> cpIdState;
+	private transient PartitionWriterFactory<T> partitionWriterFactory;
+	private transient FileSystemStreamCommitter committer;
+
+	private transient boolean hasPartCommitter;
+	private transient TaskPartitionManager partManager;
+	private transient GlobalPartitionCommitter partitionCommitter;
+
+	private FileSystemStreamingSink(
+			FileSystemFactory fsFactory,
+			TableMetaStoreFactory msFactory,
+			Path tmpPath,
+			Path locationPath,
+			String[] partitionColumns,
+			LinkedHashMap<String, String> staticPartitions,
+			OutputFormatFactory<T> formatFactory,
+			PartitionComputer<T> computer,
+			Map<String, String> properties) {
+		this.fsFactory = fsFactory;
+		this.msFactory = msFactory;
+		this.tmpPath = tmpPath;
+		this.locationPath = locationPath;
+		this.partitionColumns = partitionColumns;
+		this.staticPartitions = staticPartitions;
+		this.formatFactory = formatFactory;
+		this.computer = computer;
+		this.properties = properties;
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+		this.parameters = parameters;
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		this.taskId = getRuntimeContext().getIndexOfThisSubtask();
+
+		List<PartitionCommitPolicy> commitChain = PartitionCommitPolicy.createCommitChain(properties);
+		this.hasPartCommitter = commitChain.size() > 0;
+		this.committer = new FileSystemStreamCommitter(
+				fsFactory,
+				msFactory,
+				commitChain,
+				tmpPath,
+				locationPath,
+				partitionColumns.length);
+
+		if (hasPartCommitter) {
+			this.partitionCommitter = new GlobalPartitionCommitter(
+					(StreamingRuntimeContext) getRuntimeContext(), committer);
+			this.partManager = new TaskPartitionManager(
+					context, getRuntimeContext(), properties);
+		}
+
+		this.cpIdState = context.getOperatorStateStore().getUnionListState(CP_ID_STATE_DESC);
+		this.partitionWriterFactory = PartitionWriterFactory.get(
+				partitionColumns.length - staticPartitions.size() > 0,
+				false,
+				staticPartitions);
+		createPartitionWriter(context.isRestored() ?
+				cpIdState.get().iterator().next() + 1 : FIRST_CHECKPOINT_ID);
+	}
+
+	private void closePartitionWriter() throws Exception {
+		if (writer != null) {
+			writer.close();
+			writer = null;
+		}
+	}
+
+	private void createPartitionWriter(long checkpointId) throws Exception {
+		PartitionTempFileManager fileManager = new PartitionTempFileManager(
+				fsFactory, tmpPath, taskId, checkpointId);
+		writer = partitionWriterFactory.create(
+				new PartitionWriter.Context<>(parameters, formatFactory),
+				fileManager,
+				computer);
+	}
+
+	@Override
+	public void invoke(T value, Context context) throws Exception {
+		String partition = this.writer.write(value);
+
+		if (this.hasPartCommitter) {
+			this.partManager.invokeForPartition(partition, context.currentWatermark());
+		}
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		long cpId = context.getCheckpointId();
+		this.cpIdState.clear();
+		this.cpIdState.add(cpId);
+
+		if (this.hasPartCommitter) {
+			this.partManager.snapshotState(cpId);
+		}
+
+		closePartitionWriter();
+		createPartitionWriter(cpId + 1);
+	}
+
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		this.committer.commitTaskUpToCheckpoint(checkpointId, taskId);
+		if (hasPartCommitter) {
+			this.partitionCommitter.commit(
+					checkpointId,
+					this.partManager.triggeredPartitions(checkpointId));
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		closePartitionWriter();
+		cleanTaskTempFiles(fsFactory.create(tmpPath.toUri()), tmpPath, taskId);
+	}
+
+	/**
+	 * Builder to build {@link FileSystemOutputFormat}.
+	 */
+	public static class Builder<T> {
+
+		private String[] partitionColumns;
+		private OutputFormatFactory<T> formatFactory;
+		private TableMetaStoreFactory metaStoreFactory;
+		private Path tmpPath;
+		private Path locationPath;
+
+		private LinkedHashMap<String, String> staticPartitions = new LinkedHashMap<>();
+		private FileSystemFactory fileSystemFactory = FileSystem::get;
+
+		private PartitionComputer<T> computer;
+
+		private Map<String, String> properties;
+
+		public Builder<T> setPartitionColumns(String[] partitionColumns) {
+			this.partitionColumns = partitionColumns;
+			return this;
+		}
+
+		public Builder<T> setStaticPartitions(LinkedHashMap<String, String> staticPartitions) {
+			this.staticPartitions = staticPartitions;
+			return this;
+		}
+
+		public Builder<T> setFormatFactory(OutputFormatFactory<T> formatFactory) {
+			this.formatFactory = formatFactory;
+			return this;
+		}
+
+		public Builder<T> setFileSystemFactory(FileSystemFactory fileSystemFactory) {
+			this.fileSystemFactory = fileSystemFactory;
+			return this;
+		}
+
+		public Builder<T> setMetaStoreFactory(TableMetaStoreFactory metaStoreFactory) {
+			this.metaStoreFactory = metaStoreFactory;
+			return this;
+		}
+
+		public Builder<T> setTempPath(Path tmpPath) {
+			this.tmpPath = tmpPath;
+			return this;
+		}
+
+		public Builder<T> setLocationPath(Path locationPath) {
+			this.locationPath = locationPath;
+			return this;
+		}
+
+		public Builder<T> setPartitionComputer(PartitionComputer<T> computer) {
+			this.computer = computer;
+			return this;
+		}
+
+		public Builder<T> setProperties(Map<String, String> properties) {
+			this.properties = properties;
+			return this;
+		}
+
+		public FileSystemStreamingSink<T> build() {
+			checkNotNull(partitionColumns, "partitionColumns should not be null");
+			checkNotNull(formatFactory, "formatFactory should not be null");
+			checkNotNull(metaStoreFactory, "metaStoreFactory should not be null");
+			checkNotNull(tmpPath, "tmpPath should not be null");
+			checkNotNull(computer, "partitionComputer should not be null");
+
+			return new FileSystemStreamingSink<>(
+					fileSystemFactory,
+					metaStoreFactory,
+					tmpPath,
+					locationPath,
+					partitionColumns,
+					staticPartitions,
+					formatFactory,
+					computer,
+					properties);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSink.java
@@ -110,7 +110,7 @@ public class FileSystemStreamingSink<T> extends RichSinkFunction<T>
 		this.taskId = getRuntimeContext().getIndexOfThisSubtask();
 
 		List<PartitionCommitPolicy> commitChain = PartitionCommitPolicy.createCommitChain(properties);
-		this.hasPartCommitter = commitChain.size() > 0;
+		this.hasPartCommitter = commitChain.size() > 0 && partitionColumns.length > 0;
 		this.committer = new FileSystemStreamCommitter(
 				fsFactory,
 				msFactory,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/GlobalPartitionCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/GlobalPartitionCommitter.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.table.api.TableException;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Partition committer to commit partition to success file or metastore.
+ */
+public class GlobalPartitionCommitter {
+
+	private final GlobalAggregateManager aggregateManager;
+	private final GlobalCommitFunction commitFunction;
+	private final int taskId;
+
+	public GlobalPartitionCommitter(
+			StreamingRuntimeContext context,
+			FileSystemStreamCommitter fileSystemCommitter) {
+		this.aggregateManager = context.getGlobalAggregateManager();
+		this.taskId = context.getIndexOfThisSubtask();
+		this.commitFunction = new GlobalCommitFunction(
+				context.getNumberOfParallelSubtasks(),
+				fileSystemCommitter);
+	}
+
+	public void commit(
+			long checkpointId, Collection<String> pendingParts) throws Exception {
+		aggregateManager.updateGlobalAggregate(
+				"commit",
+				new CommitAggregateValue(
+						checkpointId,
+						taskId,
+						pendingParts),
+				commitFunction);
+	}
+
+	private static class GlobalCommitFunction implements
+			AggregateFunction<CommitAggregateValue, TreeMap<Long, CpAccumulator>, Boolean> {
+
+		private final int numberOfTasks;
+		private final FileSystemStreamCommitter committer;
+
+		GlobalCommitFunction(int numberOfTasks, FileSystemStreamCommitter committer) {
+			this.numberOfTasks = numberOfTasks;
+			this.committer = committer;
+		}
+
+		@Override
+		public TreeMap<Long, CpAccumulator> createAccumulator() {
+			return new TreeMap<>();
+		}
+
+		@Override
+		public TreeMap<Long, CpAccumulator> add(CommitAggregateValue value, TreeMap<Long, CpAccumulator> accumulator) {
+			accumulator.compute(value.checkpointId, (cpId, cpAcc) -> {
+				cpAcc = cpAcc == null ? new CpAccumulator() : cpAcc;
+				cpAcc.add(value);
+				return cpAcc;
+			});
+			return accumulator;
+		}
+
+		@Override
+		public Boolean getResult(TreeMap<Long, CpAccumulator> accumulator) {
+			Long commitCpId = null;
+			for (Map.Entry<Long, CpAccumulator> entry : accumulator.descendingMap().entrySet()) {
+				if (entry.getValue().taskIds.size() == numberOfTasks) {
+					commitCpId = entry.getKey();
+					try {
+						committer.commitJobPartitions(entry.getValue().pendingParts);
+					} catch (Exception e) {
+						throw new TableException("Commit failed.", e);
+					}
+					break;
+				}
+			}
+			if (commitCpId != null) {
+				accumulator.headMap(commitCpId, true).clear();
+				return true;
+			} else {
+				return false;
+			}
+		}
+
+		@Override
+		public TreeMap<Long, CpAccumulator> merge(
+				TreeMap<Long, CpAccumulator> accumulator, TreeMap<Long, CpAccumulator> b) {
+			b.forEach((cpId, acc) -> accumulator.compute(cpId, (key, preAcc) -> {
+				preAcc = preAcc == null ? new CpAccumulator() : preAcc;
+				preAcc.merge(acc);
+				return preAcc;
+			}));
+			return accumulator;
+		}
+	}
+
+	private static class CpAccumulator implements Serializable {
+
+		private Set<Integer> taskIds = new HashSet<>();
+		private Set<String> pendingParts = new HashSet<>();
+
+		public void add(CommitAggregateValue value) {
+			taskIds.add(value.taskId);
+			this.pendingParts.addAll(value.pendingParts);
+		}
+
+		public void merge(CpAccumulator acc) {
+			taskIds.addAll(acc.taskIds);
+			this.pendingParts.addAll(acc.pendingParts);
+		}
+	}
+
+	private static class CommitAggregateValue implements Serializable {
+
+		private long checkpointId;
+		private int taskId;
+		private Set<String> pendingParts;
+
+		public CommitAggregateValue() {}
+
+		CommitAggregateValue(long checkpointId, int taskId, Collection<String> pendingParts) {
+			this.checkpointId = checkpointId;
+			this.taskId = taskId;
+			this.pendingParts = new HashSet<>(pendingParts);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/TaskPartitionManager.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/TaskPartitionManager.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.table.descriptors.FileSystemValidator;
+import org.apache.flink.table.filesystem.streaming.trigger.PartitionCommitTrigger;
+import org.apache.flink.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.apache.flink.table.filesystem.PartitionPathUtils.extractPartitionSpecFromPath;
+
+/**
+ * Manage task partition and watermark.
+ */
+public class TaskPartitionManager {
+
+	private static final ListStateDescriptor<Map<Long, Long>> CP_ID_WATERMARK_STATE_DESC =
+			new ListStateDescriptor<>(
+					"checkpoint-id-to-watermark",
+					new MapSerializer<>(LongSerializer.INSTANCE, LongSerializer.INSTANCE));
+	private static final ListStateDescriptor<String> PENDING_PARTITIONS_STATE_DESC =
+			new ListStateDescriptor<>("pending-partitions", StringSerializer.INSTANCE);
+
+	private final ListState<Map<Long, Long>> cpIdToWatermarkState;
+	private final ListState<String> pendingPartitions;
+	private final Set<String> partitions;
+	private final PartitionCommitTrigger partCommitTrigger;
+
+	private long currentWatermark = Long.MIN_VALUE;
+
+	public TaskPartitionManager(
+			FunctionInitializationContext context,
+			RuntimeContext runtimeContext,
+			Map<String, String> properties) throws Exception {
+		this.partCommitTrigger = PartitionCommitTrigger.createTrigger(
+				properties.get(FileSystemValidator.CONNECTOR_SINK_PARTITION_COMMIT_TRIGGER),
+				properties.get(FileSystemValidator.CONNECTOR_SINK_PARTITION_COMMIT_TRIGGER_CLASS),
+				runtimeContext.getUserCodeClassLoader());
+
+		this.cpIdToWatermarkState = context.getOperatorStateStore().getListState(CP_ID_WATERMARK_STATE_DESC);
+		this.pendingPartitions = context.getOperatorStateStore().getListState(PENDING_PARTITIONS_STATE_DESC);
+
+		Map<Long, Long> cpIdToWatermark = new HashMap<>();
+		if (context.isRestored()) {
+			this.cpIdToWatermarkState.get().forEach(element -> {
+				element.forEach((cpId, watermark) ->
+						cpIdToWatermark.compute(
+								cpId,
+								(k, v) -> v == null ? watermark : Math.min(watermark, v)));
+			});
+			this.cpIdToWatermarkState.clear();
+		}
+		this.cpIdToWatermarkState.add(cpIdToWatermark);
+		this.partitions = new HashSet<>();
+	}
+
+	public void invokeForPartition(String partition, long currentWatermark) {
+		this.currentWatermark = currentWatermark;
+		if (!StringUtils.isNullOrWhitespaceOnly(partition)) {
+			partitions.add(partition);
+		}
+	}
+
+	public void snapshotState(long checkpointId) throws Exception {
+		updateCpIdToWatermark(checkpointId);
+		updatePendingPartitions();
+	}
+
+	public List<String> triggeredPartitions(long checkpointId) throws Exception {
+		long watermark = headCpIdToWatermark(checkpointId);
+
+		List<String> parts = new ArrayList<>();
+		List<String> keepPendingParts = new ArrayList<>();
+		for (String part : pendingPartitions.get()) {
+			if (partCommitTrigger.canCommit(
+					extractPartitionSpecFromPath(new Path(part)),
+					watermark)) {
+				parts.add(part);
+			} else {
+				keepPendingParts.add(part);
+			}
+		}
+		pendingPartitions.clear();
+		pendingPartitions.addAll(keepPendingParts);
+		return parts;
+	}
+
+	private long headCpIdToWatermark(long checkpointId) throws Exception {
+		TreeMap<Long, Long> cpIdToWatermark = new TreeMap<>(cpIdToWatermarkState.get().iterator().next());
+		cpIdToWatermarkState.clear();
+		long ret = cpIdToWatermark.get(checkpointId);
+		cpIdToWatermark.headMap(checkpointId, true).clear();
+		cpIdToWatermarkState.add(cpIdToWatermark);
+		return ret;
+	}
+
+	private void updateCpIdToWatermark(long cpId) throws Exception {
+		Map<Long, Long> cpIdToWatermark = cpIdToWatermarkState.get().iterator().next();
+		cpIdToWatermark.put(cpId, currentWatermark);
+		cpIdToWatermarkState.clear();
+		cpIdToWatermarkState.add(cpIdToWatermark);
+	}
+
+	private void updatePendingPartitions() throws Exception {
+		for (String partition : pendingPartitions.get()) {
+			partitions.add(partition);
+		}
+		pendingPartitions.clear();
+		for (String partition : partitions) {
+			pendingPartitions.add(partition);
+		}
+		partitions.clear();
+	}
+
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/MetastoreCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/MetastoreCommitPolicy.java
@@ -16,27 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskexecutor;
+package org.apache.flink.table.filesystem.streaming.policy;
 
-import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
-public class TestGlobalAggregateManager implements GlobalAggregateManager {
+/**
+ * Partition commit policy to update metastore.
+ */
+public class MetastoreCommitPolicy implements PartitionCommitPolicy {
 
-	private Map<String, Object> accumulators = new HashMap<>();
-
-	@SuppressWarnings("unchecked")
 	@Override
-	public <IN, ACC, OUT> OUT updateGlobalAggregate(String aggregateName, Object aggregand,
-		AggregateFunction<IN, ACC, OUT> aggregateFunction) {
-		Object accumulator = accumulators.get(aggregateName);
-		if(null == accumulator) {
-			accumulator = aggregateFunction.createAccumulator();
-		}
-		accumulator = aggregateFunction.add((IN) aggregand, (ACC) accumulator);
-		accumulators.put(aggregateName, accumulator);
-		return aggregateFunction.getResult((ACC) accumulator);
+	public void commit(
+			LinkedHashMap<String, String> partitionSpec,
+			Path partitionPath,
+			FileSystem fileSystem,
+			TableMetaStoreFactory.TableMetaStore metaStore) throws Exception {
+		metaStore.createPartition(partitionSpec, partitionPath);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/PartitionCommitPolicy.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming.policy;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.descriptors.FileSystemValidator;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Policy for partition commit.
+ */
+public interface PartitionCommitPolicy extends Serializable {
+
+	/**
+	 * Commit partition by partitionSpec and path.
+	 */
+	void commit(
+			LinkedHashMap<String, String> partitionSpec,
+			Path partitionPath,
+			FileSystem fileSystem,
+			TableMetaStoreFactory.TableMetaStore metaStore) throws Exception;
+
+	static List<PartitionCommitPolicy> createCommitChain(Map<String, String> properties) {
+		String policy = properties.get(FileSystemValidator.CONNECTOR_SINK_PARTITION_COMMIT_POLICY);
+		if (policy == null) {
+			return Collections.emptyList();
+		}
+		String[] policyStrings = policy.split(",");
+		return Arrays.stream(policyStrings).map(name -> {
+			switch (name) {
+				case "metastore":
+					return new MetastoreCommitPolicy();
+				case "success-file":
+					String fileName = properties.get(
+							FileSystemValidator.CONNECTOR_SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
+					return new SuccessFileCommitPolicy(fileName == null ? "_SUCCESS" : fileName);
+				default:
+					throw new UnsupportedOperationException("Unsupported policy: " + name);
+			}
+		}).collect(Collectors.toList());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/SuccessFileCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/policy/SuccessFileCommitPolicy.java
@@ -16,27 +16,31 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.taskexecutor;
+package org.apache.flink.table.filesystem.streaming.policy;
 
-import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
-public class TestGlobalAggregateManager implements GlobalAggregateManager {
+/**
+ * Partition commit policy to update metastore.
+ */
+public class SuccessFileCommitPolicy implements PartitionCommitPolicy {
 
-	private Map<String, Object> accumulators = new HashMap<>();
+	private final String fileName;
 
-	@SuppressWarnings("unchecked")
+	public SuccessFileCommitPolicy(String fileName) {
+		this.fileName = fileName;
+	}
+
 	@Override
-	public <IN, ACC, OUT> OUT updateGlobalAggregate(String aggregateName, Object aggregand,
-		AggregateFunction<IN, ACC, OUT> aggregateFunction) {
-		Object accumulator = accumulators.get(aggregateName);
-		if(null == accumulator) {
-			accumulator = aggregateFunction.createAccumulator();
-		}
-		accumulator = aggregateFunction.add((IN) aggregand, (ACC) accumulator);
-		accumulators.put(aggregateName, accumulator);
-		return aggregateFunction.getResult((ACC) accumulator);
+	public void commit(
+			LinkedHashMap<String, String> partitionSpec,
+			Path partitionPath,
+			FileSystem fileSystem,
+			TableMetaStoreFactory.TableMetaStore metaStore) throws Exception {
+		fileSystem.create(new Path(partitionPath, fileName), FileSystem.WriteMode.OVERWRITE);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayHourPartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayHourPartitionCommitTrigger.java
@@ -34,7 +34,7 @@ public class DayHourPartitionCommitTrigger extends DayPartitionCommitTrigger {
 		Iterator<String> iter = partitionSpec.values().iterator();
 		String day = iter.hasNext() ? iter.next() : null;
 		String hour = iter.hasNext() ? iter.next() : null;
-		return watermark > dayToMillisecond(day) +
+		return watermark >= dayToMillisecond(day) +
 				hourToMillisecond(hour) +
 				SqlDateTimeUtils.MILLIS_PER_HOUR;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayHourPartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayHourPartitionCommitTrigger.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming.trigger;
+
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+/**
+ * Day-hour trigger: day-hour: two partition columns. The first partition field like
+ * {@link DayPartitionCommitTrigger}, represents day. The second format is ‘HH’ represents hour.
+ */
+public class DayHourPartitionCommitTrigger extends DayPartitionCommitTrigger {
+
+	@Override
+	public boolean canCommit(LinkedHashMap<String, String> partitionSpec, long watermark) {
+		Iterator<String> iter = partitionSpec.values().iterator();
+		String day = iter.hasNext() ? iter.next() : null;
+		String hour = iter.hasNext() ? iter.next() : null;
+		return watermark > dayToMillisecond(day) +
+				hourToMillisecond(hour) +
+				SqlDateTimeUtils.MILLIS_PER_HOUR;
+	}
+
+	private long hourToMillisecond(String hourField) {
+		int hour = Integer.parseInt(hourField);
+		if (hour > 23) {
+			throw new IllegalArgumentException(
+					String.format("Hour %s can not bigger than 23.", hourField));
+		}
+		return hour * SqlDateTimeUtils.MILLIS_PER_HOUR;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayPartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayPartitionCommitTrigger.java
@@ -33,7 +33,7 @@ public class DayPartitionCommitTrigger implements PartitionCommitTrigger {
 	public boolean canCommit(LinkedHashMap<String, String> partitionSpec, long watermark) {
 		Iterator<String> iter = partitionSpec.values().iterator();
 		String day = iter.hasNext() ? iter.next() : null;
-		return watermark > dayToMillisecond(day) + SqlDateTimeUtils.MILLIS_PER_DAY;
+		return watermark >= dayToMillisecond(day) + SqlDateTimeUtils.MILLIS_PER_DAY;
 	}
 
 	protected long dayToMillisecond(String dayField) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayPartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/DayPartitionCommitTrigger.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming.trigger;
+
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+/**
+ * Day trigger: one partition column, format is ‘yyyy-MM-dd’. Extract and parse
+ * the first partition field and check whether it should be committed.
+ */
+public class DayPartitionCommitTrigger implements PartitionCommitTrigger {
+
+	@Override
+	public boolean canCommit(LinkedHashMap<String, String> partitionSpec, long watermark) {
+		Iterator<String> iter = partitionSpec.values().iterator();
+		String day = iter.hasNext() ? iter.next() : null;
+		return watermark > dayToMillisecond(day) + SqlDateTimeUtils.MILLIS_PER_DAY;
+	}
+
+	protected long dayToMillisecond(String dayField) {
+		Integer date = SqlDateTimeUtils.dateStringToUnixDate(dayField);
+		if (date == null) {
+			throw new RuntimeException(String.format("Can not parse %s to date.", dayField));
+		}
+		return date * SqlDateTimeUtils.MILLIS_PER_DAY;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/PartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/streaming/trigger/PartitionCommitTrigger.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming.trigger;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Partition trigger strategy for committing.
+ */
+public interface PartitionCommitTrigger {
+
+	/**
+	 * Can commit this partition.
+	 */
+	boolean canCommit(LinkedHashMap<String, String> partitionSpec, long watermark);
+
+	static PartitionCommitTrigger createTrigger(
+			String type, String customClass, ClassLoader userClassLoader) {
+		type = type == null ? "custom" : type;
+		switch (type.toLowerCase()) {
+			case "day":
+				return new DayPartitionCommitTrigger();
+			case "day-hour":
+				return new DayHourPartitionCommitTrigger();
+			case "custom":
+				if (customClass == null) {
+					return null;
+				}
+				try {
+					return (PartitionCommitTrigger) userClassLoader.loadClass(customClass).newInstance();
+				} catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+					throw new RuntimeException(
+							"Can not new instance for custom class from " + customClass, e);
+				}
+			default:
+				throw new UnsupportedOperationException("Unsupported type: " + type);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -73,7 +73,7 @@ public class SqlDateTimeUtils {
 	/**
 	 * The number of milliseconds in an hour.
 	 */
-	private static final long MILLIS_PER_HOUR = 3600000L; // = 60 * 60 * 1000
+	public static final long MILLIS_PER_HOUR = 3600000L; // = 60 * 60 * 1000
 
 	/**
 	 * The number of milliseconds in a day.
@@ -81,7 +81,7 @@ public class SqlDateTimeUtils {
 	 * <p>This is the modulo 'mask' used when converting
 	 * TIMESTAMP values to DATE and TIME values.
 	 */
-	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+	public static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
 
 	/** The SimpleDateFormat string for ISO dates, "yyyy-MM-dd". */
 	private static final String DATE_FORMAT_STRING = "yyyy-MM-dd";

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSinkTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/filesystem/streaming/FileSystemStreamingSinkTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.streaming;
+
+import org.apache.flink.api.java.io.TextOutputFormat;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.filesystem.FileSystemCommitterTest;
+import org.apache.flink.table.filesystem.RowPartitionComputer;
+import org.apache.flink.types.Row;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Test for {@link FileSystemStreamingSink}.
+ */
+public class FileSystemStreamingSinkTest {
+
+	@ClassRule
+	public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+	private File tmpFile;
+	private File outputFile;
+	private FileSystemCommitterTest.TestMetaStoreFactory msFactory;
+
+	@Before
+	public void before() throws IOException {
+		tmpFile = TEMP_FOLDER.newFolder();
+		outputFile = TEMP_FOLDER.newFolder();
+	}
+
+	@Test
+	public void testClosingWithoutInput() throws Exception {
+		try (OneInputStreamOperatorTestHarness<Row, Object> testHarness = createSink(
+				false, new LinkedHashMap<>(), new AtomicReference<>())) {
+			testHarness.setup();
+			testHarness.open();
+		}
+	}
+
+	@Test
+	public void testRecoveryWithPartition() throws Exception {
+		OperatorSubtaskState snapshot;
+
+		try (OneInputStreamOperatorTestHarness<Row, Object> testHarness = createSink(true)) {
+
+			testHarness.setup();
+			testHarness.open();
+
+			testHarness.processElement(new StreamRecord<>(Row.of("a1", 1, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a3", 3, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p2"), 1L));
+
+			testHarness.snapshot(1L, 1L);
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 3, "p1"), 1L));
+
+			snapshot = testHarness.snapshot(2L, 1L);
+
+			Assert.assertEquals(2, getFileContentByPath(new File(tmpFile, "cp-1")).size());
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-2")).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 3, "p1"), 1L));
+
+			testHarness.notifyOfCompletedCheckpoint(2);
+
+			LinkedHashMap<String, String> part1 = new LinkedHashMap<>();
+			part1.put("c", "p1");
+			LinkedHashMap<String, String> part2 = new LinkedHashMap<>();
+			part2.put("c", "p2");
+			Set<LinkedHashMap<String, String>> partitionCreated = new HashSet<>();
+			partitionCreated.add(part1);
+			partitionCreated.add(part2);
+			Assert.assertEquals(partitionCreated, msFactory.partitionCreated);
+
+			testHarness.snapshot(3L, 1L);
+
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-3")).size());
+			Assert.assertEquals(3, getFileContentByPath(outputFile).size());
+		}
+
+		try (OneInputStreamOperatorTestHarness<Row, Object> testHarness = createSink(true)) {
+
+			testHarness.setup();
+			testHarness.initializeState(snapshot);
+			testHarness.open();
+
+			// check clean tmp dir
+			Assert.assertEquals(0, getFileContentByPath(new File(tmpFile, "cp-1")).size());
+			Assert.assertEquals(0, getFileContentByPath(new File(tmpFile, "cp-2")).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("a4", 1, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a5", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a6", 3, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a4", 2, "p3"), 1L));
+
+			testHarness.snapshot(3L, 1L);
+
+			Assert.assertEquals(2, getFileContentByPath(new File(tmpFile, "cp-3")).size());
+			Assert.assertEquals(3, getFileContentByPath(outputFile).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test7", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test8", 3, "p1"), 1L));
+
+			testHarness.snapshot(4L, 1L);
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test7", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test8", 3, "p1"), 1L));
+
+			testHarness.notifyOfCompletedCheckpoint(4);
+
+			LinkedHashMap<String, String> part1 = new LinkedHashMap<>();
+			part1.put("c", "p1");
+			LinkedHashMap<String, String> part2 = new LinkedHashMap<>();
+			part2.put("c", "p2");
+			LinkedHashMap<String, String> part3 = new LinkedHashMap<>();
+			part3.put("c", "p3");
+			Set<LinkedHashMap<String, String>> partitionCreated = new HashSet<>();
+			partitionCreated.add(part1);
+			partitionCreated.add(part2);
+			partitionCreated.add(part3);
+			Assert.assertEquals(partitionCreated, msFactory.partitionCreated);
+
+			Assert.assertEquals(6, getFileContentByPath(outputFile).size());
+		}
+	}
+
+	@Test
+	public void testRecoveryWithoutPatition() throws Exception {
+		OperatorSubtaskState snapshot;
+
+		try (OneInputStreamOperatorTestHarness<Row, Object> testHarness = createSink(false)) {
+
+			testHarness.setup();
+			testHarness.open();
+
+			testHarness.processElement(new StreamRecord<>(Row.of("a1", 1, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a3", 3, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a2", 2, "p2"), 1L));
+
+			testHarness.snapshot(1L, 1L);
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 3, "p1"), 1L));
+
+			snapshot = testHarness.snapshot(2L, 1L);
+
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-1")).size());
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-2")).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test1", 3, "p1"), 1L));
+
+			testHarness.notifyOfCompletedCheckpoint(2);
+			testHarness.snapshot(3L, 1L);
+
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-3")).size());
+			Assert.assertEquals(2, getFileContentByPath(outputFile).size());
+		}
+
+		try (OneInputStreamOperatorTestHarness<Row, Object> testHarness = createSink(false)) {
+
+			testHarness.setup();
+			testHarness.initializeState(snapshot);
+			testHarness.open();
+
+			// check clean tmp dir
+			Assert.assertEquals(0, getFileContentByPath(new File(tmpFile, "cp-1")).size());
+			Assert.assertEquals(0, getFileContentByPath(new File(tmpFile, "cp-2")).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("a4", 1, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a5", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a6", 3, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("a4", 2, "p3"), 1L));
+
+			testHarness.snapshot(3L, 1L);
+
+			Assert.assertEquals(1, getFileContentByPath(new File(tmpFile, "cp-3")).size());
+			Assert.assertEquals(2, getFileContentByPath(outputFile).size());
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test7", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test8", 3, "p1"), 1L));
+
+			testHarness.snapshot(4L, 1L);
+
+			testHarness.processElement(new StreamRecord<>(Row.of("test7", 2, "p1"), 1L));
+			testHarness.processElement(new StreamRecord<>(Row.of("test8", 3, "p1"), 1L));
+
+			testHarness.notifyOfCompletedCheckpoint(4);
+
+			Assert.assertEquals(4, getFileContentByPath(outputFile).size());
+		}
+	}
+
+	private OneInputStreamOperatorTestHarness<Row, Object> createSink(
+			boolean partition) throws Exception {
+		return createSink(partition, new LinkedHashMap<>(), new AtomicReference<>());
+	}
+
+	private OneInputStreamOperatorTestHarness<Row, Object> createSink(
+			boolean partition,
+			LinkedHashMap<String, String> staticPartitions,
+			AtomicReference<FileSystemStreamingSink<Row>> sinkRef) throws Exception {
+		String[] columnNames = new String[]{"a", "b", "c"};
+		String[] partitionColumns = partition ? new String[]{"c"} : new String[0];
+
+		Path locationPath = new Path(outputFile.getPath());
+		msFactory = new FileSystemCommitterTest.TestMetaStoreFactory(locationPath);
+		FileSystemStreamingSink<Row> sink = new FileSystemStreamingSink.Builder<Row>()
+				.setMetaStoreFactory(msFactory)
+				.setTempPath(new Path(tmpFile.getPath()))
+				.setLocationPath(locationPath)
+				.setPartitionColumns(partitionColumns)
+				.setPartitionComputer(
+						new RowPartitionComputer("default", columnNames, partitionColumns))
+				.setFormatFactory(TextOutputFormat::new)
+				.setStaticPartitions(staticPartitions)
+				.build();
+
+		sinkRef.set(sink);
+
+		return new OneInputStreamOperatorTestHarness<>(
+				new StreamSink<>(sink),
+				// test parallelism
+				1, 1, 0);
+	}
+
+	private static Map<File, String> getFileContentByPath(File directory) throws IOException {
+		Map<File, String> contents = new HashMap<>(4);
+
+		if (!directory.exists() || !directory.isDirectory()) {
+			return contents;
+		}
+
+		final Collection<File> filesInBucket = FileUtils.listFiles(directory, null, true);
+		for (File file : filesInBucket) {
+			contents.put(file, FileUtils.readFileToString(file));
+		}
+		return contents;
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Streaming version of FileSystemOutputFormat.
Deal with exactly-once processing.
This is basic implementation of FileSystemStreamingSink. Eagerly add partition to metastore.

NOTE: Work in progress, for testing.

## Brief change log

- Introduce FileSystemStreamingSink
- Integrate hive to FileSystemStreamingSink

## Verifying this change

FileSystemStreamingSinkTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
