### PR TITLE
[FLINK-15523][conf] Japicmp checks ConfigConstants

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -150,7 +150,6 @@ under the License.
 							<exclude>org.apache.flink.api.java.typeutils.AvroTypeInfo</exclude>
 							<!-- Breaking changes between 1.1 and 1.2.
 							We ignore these changes because these are low-level, internal runtime configuration parameters -->
-							<exclude>org.apache.flink.configuration.ConfigConstants</exclude>
 							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_NETWORK_REQUEST_BACKOFF_INITIAL</exclude>
 							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_NETWORK_REQUEST_BACKOFF_MAX</exclude>
 							<exclude>org.apache.flink.configuration.ConfigConstants#DEFAULT_TASK_CANCELLATION_TIMEOUT_MILLIS</exclude>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -247,6 +247,22 @@ public final class ConfigConstants {
 	 */
 	public static final String TASK_MANAGER_LOG_PATH_KEY = "taskmanager.log.path";
 
+	/** @deprecated Use {@link TaskManagerOptions#MANAGED_MEMORY_SIZE} instead */
+	@Deprecated
+	public static final String TASK_MANAGER_MEMORY_SIZE_KEY = "taskmanager.memory.size";
+
+	/** @deprecated has no effect */
+	@Deprecated
+	public static final String TASK_MANAGER_MEMORY_FRACTION_KEY = "taskmanager.memory.fraction";
+
+	/** @deprecated has no effect */
+	@Deprecated
+	public static final String TASK_MANAGER_MEMORY_OFF_HEAP_KEY = "taskmanager.memory.off-heap";
+
+	/** @deprecated has no effect */
+	@Deprecated
+	public static final String TASK_MANAGER_MEMORY_PRE_ALLOCATE_KEY = "taskmanager.memory.preallocate";
+
 	/**
 	 * The config parameter defining the number of buffers used in the network stack. This defines the
 	 * number of possible tasks and shuffles.
@@ -327,6 +343,10 @@ public final class ConfigConstants {
 	 */
 	@Deprecated
 	public static final String TASK_MANAGER_REFUSED_REGISTRATION_PAUSE = "taskmanager.refused-registration-pause";
+
+	/** @deprecated has no effect */
+	@Deprecated
+	public static final boolean DEFAULT_TASK_MANAGER_MEMORY_PRE_ALLOCATE = false;
 
 	/**
 	 * @deprecated Deprecated. Please use {@link TaskManagerOptions#TASK_CANCELLATION_INTERVAL}.
@@ -1391,6 +1411,10 @@ public final class ConfigConstants {
 	 */
 	@Deprecated
 	public static final String DEFAULT_TASK_MANAGER_TMP_PATH = System.getProperty("java.io.tmpdir");
+
+	/** @deprecated has no effect */
+	@Deprecated
+	public static final float DEFAULT_MEMORY_MANAGER_MEMORY_FRACTION = 0.7f;
 
 	/**
 	 * Config key has been deprecated. Therefore, no default value required.


### PR DESCRIPTION
Reverts the removal of several `@Public` fields and re-enables the japicmp checks for `ConfigConstants`.

Both commits sdhould be backported to 1.10, whereas only the latter should be backported to 1.8/1.9 .