### PR TITLE
[FLINK-15434][Tests]Fix unstable tests in JobMasterTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -708,7 +708,8 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices);
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -769,7 +770,8 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraphWithNewOperator,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices);
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -820,7 +822,8 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices);
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -960,7 +963,8 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices);
 
 		final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
@@ -1002,7 +1006,8 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build());
+			new TestingJobManagerSharedServicesBuilder().build(),
+			heartbeatServices);
 
 		CompletableFuture<Acknowledge> startFuture = jobMaster.start(jobMasterId);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -708,8 +708,7 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+			new TestingJobManagerSharedServicesBuilder().build());
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -770,8 +769,7 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraphWithNewOperator,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+			new TestingJobManagerSharedServicesBuilder().build());
 
 		try {
 			// starting the JobMaster should have read the savepoint
@@ -822,8 +820,7 @@ public class JobMasterTest extends TestLogger {
 			configuration,
 			jobGraph,
 			haServices,
-			new TestingJobManagerSharedServicesBuilder().build(),
-			heartbeatServices);
+			new TestingJobManagerSharedServicesBuilder().build());
 
 		try {
 			// starting the JobMaster should have read the savepoint


### PR DESCRIPTION
## What is the purpose of the change

Fix unstable tests in JobMasterTest

## Brief change log

Create the jobmaster with heartbeatServices instead of fastHeartbeatServices for some tests.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
