### PR TITLE
[FLINK-15537][table-planner-blink] Type of keys should be `BinaryRow`…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.codegen.agg
 
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.api.dataview.MapView
-import org.apache.flink.table.dataformat.GenericRow
+import org.apache.flink.table.dataformat.BinaryRow
 import org.apache.flink.table.expressions.Expression
 import org.apache.flink.table.planner.codegen.CodeGenUtils.{newName, _}
 import org.apache.flink.table.planner.codegen.GenerateUtils.{generateFieldAccess, generateInputAccess}
@@ -34,9 +34,7 @@ import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.{LogicalType, RowType}
 import org.apache.flink.util.Preconditions
 import org.apache.flink.util.Preconditions.checkArgument
-
 import org.apache.calcite.tools.RelBuilder
-
 import java.lang.{Long => JLong}
 
 /**
@@ -391,7 +389,7 @@ class DistinctAggCodeGen(
       generator.generateResultExpression(
         fieldExprs,
         valueType,
-        classOf[GenericRow],
+        classOf[BinaryRow],
         outRow = keyTerm,
         reusedOutRow = false)
     } else {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/DistinctAggCodeGen.scala
@@ -382,6 +382,7 @@ class DistinctAggCodeGen(
     // the key expression of MapView
     if (fieldExprs.length > 1) {
       val keyTerm = newName(DISTINCT_KEY_TERM)
+      val outRowWriter = newName(DEFAULT_OUT_RECORD_WRITER_TERM)
       val valueType = RowType.of(
         fieldExprs.map(_.resultType): _*)
 
@@ -391,6 +392,7 @@ class DistinctAggCodeGen(
         valueType,
         classOf[BinaryRow],
         outRow = keyTerm,
+        outRowWriter = Some(outRowWriter),
         reusedOutRow = false)
     } else {
       val fieldExpr = fieldExprs.head

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/functions/aggfunctions/ListAggWsWithRetractAggFunctionTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test case for built-in concatWs with retraction aggregate function.
+ * Test case for built-in ListAggWs with retraction aggregate function.
  */
 public class ListAggWsWithRetractAggFunctionTest
 	extends AggFunctionTestBase<BinaryString, ListAggWsWithRetractAccumulator> {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRuleTest.xml
@@ -169,7 +169,7 @@ FlinkLogicalAggregate(group=[{0}], agg#0=[MIN($3)], agg#1=[MAX($4)], agg#2=[SUM(
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg">
+  <TestCase name="testSingleListAggWithDistinctAgg">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.xml
@@ -675,7 +675,7 @@ GlobalGroupAggregate(groupBy=[c], partialFinalType=[FINAL], select=[c, MIN_RETRA
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg[splitDistinctAggEnabled=false, aggPhaseEnforcer=ONE_PHASE]">
+  <TestCase name="testSingleListAggWithDistinctAgg[splitDistinctAggEnabled=false, aggPhaseEnforcer=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>
@@ -695,7 +695,7 @@ GroupAggregate(groupBy=[a], select=[a, LISTAGG(c) AS EXPR$1, COUNT(DISTINCT b) A
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg[splitDistinctAggEnabled=false, aggPhaseEnforcer=TWO_PHASE]">
+  <TestCase name="testSingleListAggWithDistinctAgg[splitDistinctAggEnabled=false, aggPhaseEnforcer=TWO_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>
@@ -739,7 +739,7 @@ GroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, $SUM0_RETRACT($
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=ONE_PHASE]">
+  <TestCase name="testSingleListAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>
@@ -764,7 +764,7 @@ GroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, LISTAGG_RETRACT
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
+  <TestCase name="testSingleListAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/IncrementalAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/IncrementalAggregateTest.xml
@@ -218,7 +218,7 @@ GlobalGroupAggregate(groupBy=[a], partialFinalType=[FINAL], select=[a, $SUM0(cou
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSingleConcatAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
+  <TestCase name="testSingleListAggWithDistinctAgg[splitDistinctAggEnabled=true, aggPhaseEnforcer=TWO_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRuleTest.scala
@@ -80,7 +80,7 @@ class SplitAggregateRuleTest extends TableTestBase {
   }
 
   @Test
-  def testSingleConcatAggWithDistinctAgg(): Unit = {
+  def testSingleListAggWithDistinctAgg(): Unit = {
     util.verifyPlan("SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/DistinctAggregateTest.scala
@@ -87,7 +87,7 @@ class DistinctAggregateTest(
   }
 
   @Test
-  def testSingleConcatAggWithDistinctAgg(): Unit = {
+  def testSingleListAggWithDistinctAgg(): Unit = {
     util.verifyPlan("SELECT a, LISTAGG(c), COUNT(DISTINCT b) FROM MyTable GROUP BY a")
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/SortAggITCase.scala
@@ -140,7 +140,7 @@ class SortAggITCase
   // NOTE: Spark has agg functions collect_list(), collect_set().
   //       instead, we'll test LISTAGG() here
   @Test
-  def testConcatAgg(): Unit = {
+  def testListAgg(): Unit = {
     checkResult(
       "SELECT LISTAGG(c, '-'), LISTAGG(c) FROM SmallTable3",
       Seq(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -544,7 +544,7 @@ class AggregateITCase(
   }
 
   @Test
-  def testConcatAggWithNullData(): Unit = {
+  def testListAggWithNullData(): Unit = {
     val dataWithNull = List(
       (1, 1, null),
       (2, 1, null),
@@ -568,7 +568,7 @@ class AggregateITCase(
   }
 
   @Test
-  def testConcatAggWithoutDelimiterTreatNull(): Unit = {
+  def testListAggWithoutDelimiterTreatNull(): Unit = {
     val dataWithNull = List(
       (1, 1, null),
       (2, 1, null),
@@ -591,6 +591,28 @@ class AggregateITCase(
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
 
+  @Test
+  def testListAggWithDistinct(): Unit = {
+    val data = new mutable.MutableList[(Int, Long, String)]
+    data.+=((1, 1L, "A"))
+    data.+=((2, 2L, "B"))
+    data.+=((3, 2L, "B"))
+    data.+=((4, 3L, "C"))
+    data.+=((5, 3L, "C"))
+    data.+=((6, 3L, "A"))
+    data.+=((7, 4L, "EF"))
+    data.+=((1, 1L, "A"))
+    data.+=((8, 4L, "EF"))
+    data.+=((8, 4L, null))
+    val sqlQuery = "SELECT b, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY b"
+    tEnv.registerTable("MyTable",
+      failingDataSource(data).toTable(tEnv).as('a, 'b, 'c))
+    val sink = new TestingRetractSink
+    tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
+    env.execute()
+    val expected = List("1,A", "2,B", "3,C#A", "4,EF")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 
   @Test
   def testUnboundedGroupByCollect(): Unit = {
@@ -1014,7 +1036,7 @@ class AggregateITCase(
 
   /** Test LISTAGG **/
   @Test
-  def testConcatAgg(): Unit = {
+  def testListAgg(): Unit = {
     tEnv.registerFunction("listagg_retract", new ListAggWithRetractAggFunction)
     tEnv.registerFunction("listagg_ws_retract", new ListAggWsWithRetractAggFunction)
     val sqlQuery =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
@@ -95,7 +95,7 @@ class AggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     data.+=((3, 2, "B"))
 
     val testAgg = new WeightedAvg
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
       .groupBy('c)
       .select('c, 'a.count.distinct, 'a.sum.distinct,
         testAgg.distinct('a, 'b), testAgg.distinct('b, 'a), testAgg('a, 'b))


### PR DESCRIPTION
## What is the purpose of the change

Fix bug of distinct aggregate codegen when key type of distinct `MapView` is `BaseRow`.

## Brief change log
  - This PR mainly fix some problems of `DistinctAggCodeGen`.
  - BTW, refine name problems of `ListAgg` aggregate function in tests..

## Verifying this change

This change added tests and can be verified as follows:

  - Added integration tests in `AggregateITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
