### PR TITLE
[Flink-15355] Fixed parsing of plugin parent-first patterns.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -23,7 +23,9 @@ import org.apache.flink.annotation.docs.ConfigGroup;
 import org.apache.flink.annotation.docs.ConfigGroups;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
-import org.apache.flink.util.ArrayUtils;
+
+import org.apache.flink.shaded.guava18.com.google.common.base.Splitter;
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -109,16 +111,7 @@ public class CoreOptions {
 	public static String[] getParentFirstLoaderPatterns(Configuration config) {
 		String base = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS);
 		String append = config.getString(ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);
-
-		String[] basePatterns = base.isEmpty()
-			? new String[0]
-			: base.split(";");
-
-		if (append.isEmpty()) {
-			return basePatterns;
-		} else {
-			return ArrayUtils.concat(basePatterns, append.split(";"));
-		}
+		return parseParentFirstLoaderPatterns(base, append);
 	}
 
 	/**
@@ -147,8 +140,12 @@ public class CoreOptions {
 	public static String[] getPluginParentFirstLoaderPatterns(Configuration config) {
 		String base = config.getString(PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS);
 		String append = config.getString(PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);
+		return parseParentFirstLoaderPatterns(base, append);
+	}
 
-		return ArrayUtils.concat(base.split(";"), append.split(";"));
+	private static String[] parseParentFirstLoaderPatterns(String base, String append) {
+		Splitter splitter = Splitter.on(';').omitEmptyStrings();
+		return Iterables.toArray(Iterables.concat(splitter.split(base), splitter.split(append)), String.class);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/configuration/CoreOptionsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/CoreOptionsTest.java
@@ -21,34 +21,53 @@ package org.apache.flink.configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.function.Function;
+
 /**
  * Tests for {@link CoreOptions}.
  */
 public class CoreOptionsTest {
 	@Test
 	public void testGetParentFirstLoaderPatterns() {
+		testParentFirst(
+			CoreOptions::getParentFirstLoaderPatterns,
+			CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS,
+			CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);
+	}
+
+	@Test
+	public void testGetPluginParentFirstLoaderPatterns() {
+		testParentFirst(
+			CoreOptions::getPluginParentFirstLoaderPatterns,
+			CoreOptions.PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS,
+			CoreOptions.PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL);
+	}
+
+	private void testParentFirst(
+			Function<Configuration, String[]> patternGetter,
+			ConfigOption<String> patternOption,
+			ConfigOption<String> additionalOption) {
 		Configuration config = new Configuration();
+		Assert.assertArrayEquals(patternOption.defaultValue().split(";"),
+			patternGetter.apply(config));
 
-		Assert.assertArrayEquals(
-			CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS.defaultValue().split(";"),
-			CoreOptions.getParentFirstLoaderPatterns(config));
-
-		config.setString(CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS, "hello;world");
+		config.setString(patternOption, "hello;world");
 
 		Assert.assertArrayEquals(
 			"hello;world".split(";"),
-			CoreOptions.getParentFirstLoaderPatterns(config));
+			patternGetter.apply(config));
 
-		config.setString(CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL, "how;are;you");
+		config.setString(additionalOption, "how;are;you");
 
 		Assert.assertArrayEquals(
 			"hello;world;how;are;you".split(";"),
-			CoreOptions.getParentFirstLoaderPatterns(config));
+			patternGetter.apply(config));
 
-		config.setString(CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS, "");
+		config.setString(patternOption, "");
 
 		Assert.assertArrayEquals(
 			"how;are;you".split(";"),
-			CoreOptions.getParentFirstLoaderPatterns(config));
+			patternGetter.apply(config));
 	}
+
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixed parsing of plugin parent-first patterns.

Previously, empty options would result in an empty pattern, which matches everything. Thus, we effectively got parent first for all classes.

## Brief change log

- Fix in CoreOptions for parsing of plugin parent-first patterns.


## Verifying this change

- File Sink e2e tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
