### PR TITLE
[FLINK-15542][legal] Move NOTICE entry for lz4-java

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -25,6 +25,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.19.0-GA
+- org.lz4:lz4-java:1.5.0
 - org.objenesis:objenesis:2.1
 - org.xerial.snappy:snappy-java:1.1.4
 

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.netty:netty:3.10.6.Final
 - org.apache.zookeeper:zookeeper:3.4.10
 - org.uncommons.maths:uncommons-maths:1.2.2a
-- org.lz4:lz4-java:1.5.0
 
 This project bundles io.netty:netty:3.10.6.Final from which it inherits the following notices:
 


### PR DESCRIPTION
Moves the NOTICE entry for lz4-java from flink-runtime to flink-dist, which is the actual jar bundling this dependency.