### PR TITLE
[hotfix][documentation] Fix wrong time semantics description

### DIFF
--- a/docs/dev/stream/testing.md
+++ b/docs/dev/stream/testing.md
@@ -494,7 +494,7 @@ A few remarks on integration testing with `MiniClusterWithClientResource`:
 Communicating with operators instantiated by a local Flink mini cluster via static variables is one way around this issue.
 Alternatively, you could write the data to files in a temporary directory with your test sink.
 
-* You can implement a custom *parallel* source function for emitting watermarks if your job uses event timer timers.
+* You can implement a custom *parallel* source function for emitting watermarks if your job uses event time timers.
 
 * It is recommended to always test your pipelines locally with a parallelism > 1 to identify bugs which only surface for the pipelines executed in parallel.
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes wrong time semantics description*

## Brief change log

  - *Fix wrong time semantics description*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
