### PR TITLE
[FLINK-15512][statebackend] Refactor the mechanism to calculate the cache capacity shared among RocksDB instance(s)

### DIFF
--- a/docs/_includes/generated/rocks_db_configuration.html
+++ b/docs/_includes/generated/rocks_db_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>state.backend.rocksdb.memory.high-prio-pool-ratio</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
             <td>Double</td>
-            <td>The fraction of total shared memory that is reserved for high-priority data like index, filter, and compression dictionary blocks. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
+            <td>The fraction of cache memory that is reserved for high-priority data like index, filter, and compression dictionary blocks. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.memory.managed</h5></td>

--- a/docs/_includes/generated/rocks_db_configuration.html
+++ b/docs/_includes/generated/rocks_db_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>state.backend.rocksdb.memory.high-prio-pool-ratio</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
             <td>Double</td>
-            <td>The fraction of cache memory that is reserved for high-priority data like index, filter, and compression dictionary blocks. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
+            <td>The fraction of total shared memory that is reserved for high-priority data like index, filter, and compression dictionary blocks. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.memory.managed</h5></td>
@@ -42,7 +42,7 @@
             <td><h5>state.backend.rocksdb.memory.write-buffer-ratio</h5></td>
             <td style="word-wrap: break-word;">0.5</td>
             <td>Double</td>
-            <td>The maximum amount of memory that write buffers may take, as a fraction of the total cache memory. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
+            <td>The maximum amount of memory that write buffers may take, as a fraction of the total shared memory. This option only has an effect when 'state.backend.rocksdb.memory.managed' or 'state.backend.rocksdb.memory.fixed-per-slot' are configured.</td>
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.options-factory</h5></td>

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.rocksdb.Cache;
+import org.rocksdb.LRUCache;
+import org.rocksdb.WriteBufferManager;
+
+/**
+ * Utils to crate {@link Cache} and {@link WriteBufferManager} which used to control total memory usage of RocksDB.
+ */
+public class RocksDBMemoryControllerUtils {
+
+	/**
+	 * Allocate memory controllable RocksDB shared resources.
+	 *
+	 * @param totalMemorySize The total memory limit size.
+	 * @param writeBufferRatio The ratio of total memory which is occupied by write buffer manager.
+	 * @param highPriorityPoolRatio The high priority pool ratio of cache.
+	 * @return memory controllable RocksDB shared resources.
+	 */
+	public static RocksDBSharedResources allocateRocksDBSharedResources(long totalMemorySize, double writeBufferRatio, double highPriorityPoolRatio) {
+		long calculatedCacheCapacity = RocksDBMemoryControllerUtils.calculateActualCacheCapacity(totalMemorySize, writeBufferRatio);
+		final Cache cache = RocksDBMemoryControllerUtils.createCache(calculatedCacheCapacity, highPriorityPoolRatio);
+
+		long writeBufferManagerCapacity = RocksDBMemoryControllerUtils.calculateWriteBufferManagerCapacity(totalMemorySize, writeBufferRatio);
+		final WriteBufferManager wbm = RocksDBMemoryControllerUtils.createWriteBufferManager(writeBufferManagerCapacity, cache);
+
+		return new RocksDBSharedResources(cache, wbm);
+	}
+
+	/**
+	 * Calculate the actual calculated memory capacity of cache, which would be shared among rocksDB instance(s).
+	 * We introduce this method because:
+	 * a) We cannot create a strict capacity limit cache util FLINK-15532 resolved.
+	 * b) Regardless of the memory usage of blocks pinned by RocksDB iterators,
+	 * which is difficult to calculate and only happened when we iterator entries in RocksDBMapState, the overuse of memory is mainly occupied by at most half of the write buffer usage.
+	 * (see <a href="https://github.com/dataArtisans/frocksdb/blob/958f191d3f7276ae59b270f9db8390034d549ee0/include/rocksdb/write_buffer_manager.h#L51">the flush implementation of write buffer manager</a>).
+	 * Thus, we have four equations below:
+	 *   write_buffer_manager_memory = 1.5 * write_buffer_manager_capacity
+	 *   write_buffer_manager_memory = total_memory_size * write_buffer_ratio
+	 *   write_buffer_manager_memory + other_part = total_memory_size
+	 *   write_buffer_manager_capacity + other_part = cache_capacity
+	 * And we would deduce the formula:
+	 *   cache_capacity =  (3 - write_buffer_ratio) * total_memory_size / 3
+	 *   write_buffer_manager_capacity = 2 * total_memory_size * write_buffer_ratio / 3
+	 *
+	 * @param totalMemorySize  Total off-heap memory size reserved for RocksDB instance(s).
+	 * @param writeBufferRatio The ratio of total memory size which would be reserved for write buffer manager and its over-capacity part.
+	 * @return The actual calculated cache capacity.
+	 */
+	@VisibleForTesting
+	static long calculateActualCacheCapacity(long totalMemorySize, double writeBufferRatio) {
+		return (long) ((3 - writeBufferRatio) * totalMemorySize / 3);
+	}
+
+	/**
+	 * Calculate the actual calculated memory capacity of write buffer manager, which would be shared among rocksDB instance(s).
+	 * The formula to use here could refer to {@link #calculateActualCacheCapacity(long, double)}.
+	 *
+	 * @param totalMemorySize  Total off-heap memory size reserved for RocksDB instance(s).
+	 * @param writeBufferRatio The ratio of total memory size which would be reserved for write buffer manager and its over-capacity part.
+	 * @return The actual calculated write buffer manager capacity.
+	 */
+	@VisibleForTesting
+	static long calculateWriteBufferManagerCapacity(long totalMemorySize, double writeBufferRatio) {
+		return (long) (2 * totalMemorySize * writeBufferRatio / 3);
+	}
+
+	@VisibleForTesting
+	static Cache createCache(long cacheCapacity, double highPriorityPoolRatio) {
+		// TODO use strict capacity limit until FLINK-15532 resolved
+		return new LRUCache(cacheCapacity, -1, false, highPriorityPoolRatio);
+	}
+
+	@VisibleForTesting
+	static WriteBufferManager createWriteBufferManager(long writeBufferManagerCapacity, Cache cache) {
+		return new WriteBufferManager(writeBufferManagerCapacity, cache);
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtils.java
@@ -48,7 +48,7 @@ public class RocksDBMemoryControllerUtils {
 	}
 
 	/**
-	 * Calculate the actual calculated memory capacity of cache, which would be shared among rocksDB instance(s).
+	 * Calculate the actual memory capacity of cache, which would be shared among rocksDB instance(s).
 	 * We introduce this method because:
 	 * a) We cannot create a strict capacity limit cache util FLINK-15532 resolved.
 	 * b) Regardless of the memory usage of blocks pinned by RocksDB iterators,
@@ -73,8 +73,8 @@ public class RocksDBMemoryControllerUtils {
 	}
 
 	/**
-	 * Calculate the actual calculated memory capacity of write buffer manager, which would be shared among rocksDB instance(s).
-	 * The formula to use here could refer to {@link #calculateActualCacheCapacity(long, double)}.
+	 * Calculate the actual memory capacity of write buffer manager, which would be shared among rocksDB instance(s).
+	 * The formula to use here could refer to the doc of {@link #calculateActualCacheCapacity(long, double)}.
 	 *
 	 * @param totalMemorySize  Total off-heap memory size reserved for RocksDB instance(s).
 	 * @param writeBufferRatio The ratio of total memory size which would be reserved for write buffer manager and its over-capacity part.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -111,7 +111,7 @@ public class RocksDBOptions {
 		.doubleType()
 		.defaultValue(0.5)
 		.withDescription(String.format(
-			"The maximum amount of memory that write buffers may take, as a fraction of the total cache memory. " +
+			"The maximum amount of memory that write buffers may take, as a fraction of the total shared memory. " +
 			"This option only has an effect when '%s' or '%s' are configured.",
 			USE_MANAGED_MEMORY.key(),
 			FIX_PER_SLOT_MEMORY_SIZE.key()));
@@ -121,7 +121,7 @@ public class RocksDBOptions {
 		.doubleType()
 		.defaultValue(0.1)
 		.withDescription(String.format(
-				"The fraction of cache memory that is reserved for high-priority data like index, filter, and " +
+				"The fraction of total shared memory that is reserved for high-priority data like index, filter, and " +
 				"compression dictionary blocks. This option only has an effect when '%s' or '%s' are configured.",
 				USE_MANAGED_MEMORY.key(),
 				FIX_PER_SLOT_MEMORY_SIZE.key()));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -121,7 +121,7 @@ public class RocksDBOptions {
 		.doubleType()
 		.defaultValue(0.1)
 		.withDescription(String.format(
-				"The fraction of total shared memory that is reserved for high-priority data like index, filter, and " +
+				"The fraction of cache memory that is reserved for high-priority data like index, filter, and " +
 				"compression dictionary blocks. This option only has an effect when '%s' or '%s' are configured.",
 				USE_MANAGED_MEMORY.key(),
 				FIX_PER_SLOT_MEMORY_SIZE.key()));

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtilsTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBMemoryControllerUtilsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.contrib.streaming.state;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.rocksdb.Cache;
+import org.rocksdb.LRUCache;
+import org.rocksdb.NativeLibraryLoader;
+import org.rocksdb.WriteBufferManager;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Tests to guard {@link RocksDBMemoryControllerUtils}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RocksDBMemoryControllerUtils.class)
+public class RocksDBMemoryControllerUtilsTest {
+
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Before
+	public void ensureRocksDbNativeLibraryLoaded() throws IOException {
+		NativeLibraryLoader.getInstance().loadLibrary(temporaryFolder.newFolder().getAbsolutePath());
+	}
+
+	@Test
+	public void testCreateSharedResourcesWithExpectedCapacity() {
+		PowerMockito.mockStatic(RocksDBMemoryControllerUtils.class);
+		final AtomicLong actualCacheCapacity = new AtomicLong(0L);
+		final AtomicLong actualWbmCapacity = new AtomicLong(0L);
+
+		when(RocksDBMemoryControllerUtils.allocateRocksDBSharedResources(anyLong(), anyDouble(), anyDouble()))
+			.thenCallRealMethod();
+
+		when(RocksDBMemoryControllerUtils.calculateActualCacheCapacity(anyLong(), anyDouble()))
+			.thenCallRealMethod();
+
+		when(RocksDBMemoryControllerUtils.calculateWriteBufferManagerCapacity(anyLong(), anyDouble()))
+			.thenCallRealMethod();
+
+		// because PowerMockito cannot mock on native static method easily,
+		// we introduce `createCache` and `createWriteBufferManager` wrappers here.
+		when(RocksDBMemoryControllerUtils.createCache(anyLong(), anyDouble()))
+			.thenAnswer((Answer<LRUCache>) invocation -> {
+				Object[] arguments = invocation.getArguments();
+				actualCacheCapacity.set((long) arguments[0]);
+				return (LRUCache) invocation.callRealMethod();
+			});
+
+		when(RocksDBMemoryControllerUtils.createWriteBufferManager(anyLong(), any(Cache.class)))
+			.thenAnswer((Answer<WriteBufferManager>) invocation -> {
+				Object[] arguments = invocation.getArguments();
+				actualWbmCapacity.set((long) arguments[0]);
+				return (WriteBufferManager) invocation.callRealMethod();
+			});
+
+		long totalMemorySize = 2048L;
+		double writeBufferRatio = 0.5;
+		double highPriPoolRatio = 0.1;
+		RocksDBMemoryControllerUtils.allocateRocksDBSharedResources(totalMemorySize, writeBufferRatio, highPriPoolRatio);
+		long expectedCacheCapacity = RocksDBMemoryControllerUtils.calculateActualCacheCapacity(totalMemorySize, writeBufferRatio);
+		long expectedWbmCapacity = RocksDBMemoryControllerUtils.calculateWriteBufferManagerCapacity(totalMemorySize, writeBufferRatio);
+		assertThat(actualCacheCapacity.get(), is(expectedCacheCapacity));
+		assertThat(actualWbmCapacity.get(), is(expectedWbmCapacity));
+	}
+}

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -163,12 +163,12 @@ public class RocksDBResourceContainerTest {
 	@Test
 	public void testCreateSharedResourcesWithExpectedCapacity() throws Exception {
 		PowerMockito.spy(RocksDBOperationUtils.class);
-		final AtomicLong actualCacheSize = new AtomicLong(0L);
+		final AtomicLong actualCacheCapacity = new AtomicLong(0L);
 		// the `createCache` wrapper is introduced due to PowerMockito cannot mock on native static method easily.
 		PowerMockito.when(RocksDBOperationUtils.createCache(anyLong(), anyDouble()))
 			.thenAnswer((Answer<LRUCache>) invocation -> {
 				Object[] arguments = invocation.getArguments();
-				actualCacheSize.set((long) arguments[0]);
+				actualCacheCapacity.set((long) arguments[0]);
 				return (LRUCache) invocation.callRealMethod();
 			});
 
@@ -176,8 +176,8 @@ public class RocksDBResourceContainerTest {
 		double writeBufferRatio = 0.5;
 		double highPriPoolRatio = 0.1;
 		createSharedResources(totalMemorySize, writeBufferRatio, highPriPoolRatio);
-		long expectedCacheSize = RocksDBOperationUtils.calculateActualCacheSize(totalMemorySize, writeBufferRatio);
-		assertThat(actualCacheSize.get(), is(expectedCacheSize));
+		long expectedCacheCapacity = RocksDBOperationUtils.calculateActualCacheCapacity(totalMemorySize, writeBufferRatio);
+		assertThat(actualCacheCapacity.get(), is(expectedCacheCapacity));
 	}
 
 	private OpaqueMemoryResource<RocksDBSharedResources> getSharedResources() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBResourceContainerTest.java
@@ -21,10 +21,15 @@ package org.apache.flink.contrib.streaming.state;
 import org.apache.flink.runtime.memory.OpaqueMemoryResource;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyOptions;
@@ -37,22 +42,32 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
 
 /**
  * Tests to guard {@link RocksDBResourceContainer}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(RocksDBOperationUtils.class)
 public class RocksDBResourceContainerTest {
 
-	@ClassRule
-	public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+	private static boolean rocksDBLoaded = false;
 
-	@BeforeClass
-	public static void ensureRocksDbNativeLibraryLoaded() throws IOException {
-		NativeLibraryLoader.getInstance().loadLibrary(TMP_FOLDER.newFolder().getAbsolutePath());
+	@Rule
+	public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	@Before
+	public void ensureRocksDbNativeLibraryLoaded() throws IOException {
+		if (!rocksDBLoaded) {
+			NativeLibraryLoader.getInstance().loadLibrary(temporaryFolder.newFolder().getAbsolutePath());
+			rocksDBLoaded = true;
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -145,12 +160,34 @@ public class RocksDBResourceContainerTest {
 		container.close();
 	}
 
+	@Test
+	public void testCreateSharedResourcesWithExpectedCapacity() throws Exception {
+		PowerMockito.spy(RocksDBOperationUtils.class);
+		final AtomicLong actualCacheSize = new AtomicLong(0L);
+		// the `createCache` wrapper is introduced due to PowerMockito cannot mock on native static method easily.
+		PowerMockito.when(RocksDBOperationUtils.createCache(anyLong(), anyDouble()))
+			.thenAnswer((Answer<LRUCache>) invocation -> {
+				Object[] arguments = invocation.getArguments();
+				actualCacheSize.set((long) arguments[0]);
+				return (LRUCache) invocation.callRealMethod();
+			});
+
+		long totalMemorySize = 2048L;
+		double writeBufferRatio = 0.5;
+		double highPriPoolRatio = 0.1;
+		createSharedResources(totalMemorySize, writeBufferRatio, highPriPoolRatio);
+		long expectedCacheSize = RocksDBOperationUtils.calculateActualCacheSize(totalMemorySize, writeBufferRatio);
+		assertThat(actualCacheSize.get(), is(expectedCacheSize));
+	}
+
 	private OpaqueMemoryResource<RocksDBSharedResources> getSharedResources() {
-		final long cacheSize = 1024L, writeBufferSize = 512L;
-		final LRUCache cache = new LRUCache(cacheSize, -1, false, 0.1);
-		final WriteBufferManager wbm = new WriteBufferManager(writeBufferSize, cache);
-		RocksDBSharedResources rocksDBSharedResources = new RocksDBSharedResources(cache, wbm);
-		return new OpaqueMemoryResource<>(rocksDBSharedResources, cacheSize, rocksDBSharedResources::close);
+		return createSharedResources(1024L, 0.5, 0.1);
+	}
+
+	private OpaqueMemoryResource<RocksDBSharedResources> createSharedResources(long totalMemorySize, double writeBufferRatio, double highPriPoolRatio) {
+		RocksDBSharedResources rocksDBSharedResources = RocksDBOperationUtils
+			.allocateRocksDBSharedResources(totalMemorySize, writeBufferRatio, highPriPoolRatio);
+		return new OpaqueMemoryResource<>(rocksDBSharedResources, totalMemorySize, rocksDBSharedResources::close);
 	}
 
 	private Cache getBlockCache(ColumnFamilyOptions columnOptions) {


### PR DESCRIPTION
## What is the purpose of the change

Due to the implemenation of write buffer manager of RocksDB and the issue cannot create stric capacity limit cache, we need to refactor the mechanism to calculate the cache capacity shared among RocksDB instance(s).

## Brief change log

  - Introduce `RocksDBOperationUtils.java#calculateActualCacheSize` to calculate actual cache size.
  - Add test `testCreateSharedResourcesWithExpectedCapacity` to verify the capacity of cache created is what we want.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testCreateSharedResourcesWithExpectedCapacity` to verify the capacity of cache created is what we want.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
