### PR TITLE
[FLINK-15497][table-planner-blink] Reduce outputs when rank number is not required in Retractable topN

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -260,12 +260,13 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 					}
 				} else {
 					long count = entry.getValue();
-					long tmpRank = curRank + count;
-					if (isInRankEnd(tmpRank)) {
-						curRank = tmpRank;
+					// gets the rank of last record with same sortKey
+					long rankOfLastRecord = curRank + count;
+					// deletes the record if there is a record recently downgrades to Top-(N+1)
+					if (isInRankEnd(rankOfLastRecord)) {
+						curRank = rankOfLastRecord;
 					} else {
 						int index = Long.valueOf(rankEnd - curRank).intValue();
-						// delete retired message
 						toDelete = inputs.get(index);
 						break;
 					}
@@ -380,14 +381,15 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 				}
 			} else if (findsSortKey) {
 				long count = entry.getValue();
-				long tmpRank = curRank + count;
-				if (tmpRank < rankEnd) {
-					curRank = tmpRank;
+				// gets the rank of last record with same sortKey
+				long rankOfLastRecord = curRank + count;
+				// sends the record if there is a record recently upgrades to Top-N
+				if (rankOfLastRecord < rankEnd) {
+					curRank = rankOfLastRecord;
 				} else {
-					int index = Long.valueOf(rankEnd - curRank -1).intValue();
+					int index = Long.valueOf(rankEnd - curRank - 1).intValue();
 					List<BaseRow> inputs = dataState.get(key);
 					BaseRow toAdd = inputs.get(index);
-					// send row which upgrades to TopN
 					collect(out, toAdd);
 					break;
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -135,8 +135,13 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			}
 
 			// emit
-			emitRecordsWithRowNumber(sortedMap, sortKey, input, out);
-
+			if (outputRankNumber || hasOffset()) {
+				// the without-number-algorithm can't handle topN with offset,
+				// so use the with-number-algorithm to handle offset
+				emitRecordsWithRowNumber(sortedMap, sortKey, input, out);
+			} else {
+				emitRecordsWithoutRowNumber(sortedMap, sortKey, input, out);
+			}
 			// update data state
 			List<BaseRow> inputs = dataState.get(sortKey);
 			if (inputs == null) {
@@ -147,7 +152,13 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			dataState.put(sortKey, inputs);
 		} else {
 			// emit updates first
-			retractRecordWithRowNumber(sortedMap, sortKey, input, out);
+			if (outputRankNumber || hasOffset()) {
+				// the without-number-algorithm can't handle topN with offset,
+				// so use the with-number-algorithm to handle offset
+				retractRecordWithRowNumber(sortedMap, sortKey, input, out);
+			} else {
+				retractRecordWithoutRowNumber(sortedMap, sortKey, input, out);
+			}
 
 			// and then update sortedMap
 			if (sortedMap.containsKey(sortKey)) {
@@ -182,6 +193,87 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 	}
 
 	// ------------- ROW_NUMBER-------------------------------
+
+	private void emitRecordsWithRowNumber(
+			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
+			throws Exception {
+		Iterator<Map.Entry<BaseRow, Long>> iterator = sortedMap.entrySet().iterator();
+		long curRank = 0L;
+		boolean findsSortKey = false;
+		while (iterator.hasNext() && isInRankEnd(curRank)) {
+			Map.Entry<BaseRow, Long> entry = iterator.next();
+			BaseRow key = entry.getKey();
+			if (!findsSortKey && key.equals(sortKey)) {
+				curRank += entry.getValue();
+				collect(out, inputRow, curRank);
+				findsSortKey = true;
+			} else if (findsSortKey) {
+				List<BaseRow> inputs = dataState.get(key);
+				if (inputs == null) {
+					// Skip the data if it's state is cleared because of state ttl.
+					if (lenient) {
+						LOG.warn(STATE_CLEARED_WARN_MSG);
+					} else {
+						throw new RuntimeException(STATE_CLEARED_WARN_MSG);
+					}
+				} else {
+					int i = 0;
+					while (i < inputs.size() && isInRankEnd(curRank)) {
+						curRank += 1;
+						BaseRow prevRow = inputs.get(i);
+						retract(out, prevRow, curRank - 1);
+						collect(out, prevRow, curRank);
+						i++;
+					}
+				}
+			} else {
+				curRank += entry.getValue();
+			}
+		}
+	}
+
+	private void emitRecordsWithoutRowNumber(
+			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
+			throws Exception {
+		Iterator<Map.Entry<BaseRow, Long>> iterator = sortedMap.entrySet().iterator();
+		long curRank = 0L;
+		boolean findsSortKey = false;
+		while (iterator.hasNext() && isInRankEnd(curRank)) {
+			Map.Entry<BaseRow, Long> entry = iterator.next();
+			BaseRow key = entry.getKey();
+			if (!findsSortKey && key.equals(sortKey)) {
+				curRank += entry.getValue();
+				if (isInRankRange(curRank)) {
+					collect(out, inputRow);
+				}
+				findsSortKey = true;
+			} else if (findsSortKey) {
+				List<BaseRow> inputs = dataState.get(key);
+				if (inputs == null) {
+					// Skip the data if it's state is cleared because of state ttl.
+					if (lenient) {
+						LOG.warn(STATE_CLEARED_WARN_MSG);
+					} else {
+						throw new RuntimeException(STATE_CLEARED_WARN_MSG);
+					}
+				} else {
+					long count = entry.getValue();
+					long tmpRank = curRank + count;
+					if (isInRankEnd(tmpRank)) {
+						curRank = tmpRank;
+					} else {
+						int index = Long.valueOf(rankEnd - curRank).intValue();
+						BaseRow toDelete = inputs.get(index);
+						// delete retired message
+						delete(out, toDelete);
+						break;
+					}
+				}
+			} else {
+				curRank += entry.getValue();
+			}
+		}
+	}
 
 	private void retractRecordWithRowNumber(
 			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
@@ -238,7 +330,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 		}
 	}
 
-	private void emitRecordsWithRowNumber(
+	private void retractRecordWithoutRowNumber(
 			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
 			throws Exception {
 		Iterator<Map.Entry<BaseRow, Long>> iterator = sortedMap.entrySet().iterator();
@@ -248,10 +340,6 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			Map.Entry<BaseRow, Long> entry = iterator.next();
 			BaseRow key = entry.getKey();
 			if (!findsSortKey && key.equals(sortKey)) {
-				curRank += entry.getValue();
-				collect(out, inputRow, curRank);
-				findsSortKey = true;
-			} else if (findsSortKey) {
 				List<BaseRow> inputs = dataState.get(key);
 				if (inputs == null) {
 					// Skip the data if it's state is cleared because of state ttl.
@@ -261,14 +349,40 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 						throw new RuntimeException(STATE_CLEARED_WARN_MSG);
 					}
 				} else {
-					int i = 0;
-					while (i < inputs.size() && isInRankEnd(curRank)) {
+					Iterator<BaseRow> inputIter = inputs.iterator();
+					while (inputIter.hasNext() && isInRankEnd(curRank)) {
 						curRank += 1;
-						BaseRow prevRow = inputs.get(i);
-						retract(out, prevRow, curRank - 1);
-						collect(out, prevRow, curRank);
-						i++;
+						BaseRow prevRow = inputIter.next();
+						if (!findsSortKey && equaliser.equalsWithoutHeader(prevRow, inputRow)) {
+							delete(out, prevRow, curRank);
+							curRank -= 1;
+							findsSortKey = true;
+							inputIter.remove();
+						} else if (findsSortKey) {
+							if (curRank == rankEnd) {
+								collect(out, prevRow, curRank);
+								break;
+							}
+						}
 					}
+					if (inputs.isEmpty()) {
+						dataState.remove(key);
+					} else {
+						dataState.put(key, inputs);
+					}
+				}
+			} else if (findsSortKey) {
+				long count = entry.getValue();
+				long tmpRank = curRank + count;
+				if (isInRankEnd(tmpRank)) {
+					curRank = tmpRank;
+				} else {
+					int index = Long.valueOf(rankEnd - curRank).intValue();
+					List<BaseRow> inputs = dataState.get(key);
+					BaseRow toAdd = inputs.get(index);
+					// send row which upgrades to TopN
+					collect(out, toAdd);
+					break;
 				}
 			} else {
 				curRank += entry.getValue();

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -55,7 +55,7 @@ import java.util.TreeMap;
  * However, the function only works in some special scenarios:
  * 1. sort field collation is ascending and its mono is decreasing, or sort field collation is descending and its mono
  * is increasing
- * 2. input data has unique keys
+ * 2. input data has unique keys and unique key must contain partition key
  * 3. input stream could not contain delete record or retract record
  */
 public class UpdatableTopNFunction extends AbstractTopNFunction implements CheckpointedFunction {

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -111,10 +111,58 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
-	// TODO RetractRankFunction could be sent less retraction message when does not need to retract row_number
-	@Override
 	@Test
-	public void testConstantRankRangeWithoutOffset() throws Exception {
+	public void testConstantRankRangeWithoutOffsetWithRowNumber() throws Exception {
+		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true,
+				true);
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(record("book", 1L, 12));
+		testHarness.processElement(record("book", 2L, 19));
+		testHarness.processElement(record("book", 4L, 11));
+		testHarness.processElement(record("fruit", 4L, 33));
+		testHarness.processElement(record("fruit", 3L, 44));
+		testHarness.processElement(record("fruit", 5L, 22));
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(record("book", 1L, 12, 1L));
+		expectedOutput.add(record("book", 2L, 19, 2L));
+		expectedOutput.add(retractRecord("book", 1L, 12, 1L));
+		expectedOutput.add(record("book", 1L, 12, 2L));
+		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
+		expectedOutput.add(record("book", 4L, 11, 1L));
+		expectedOutput.add(record("fruit", 4L, 33, 1L));
+		expectedOutput.add(record("fruit", 3L, 44, 2L));
+		expectedOutput.add(retractRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(retractRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(record("fruit", 4L, 33, 2L));
+		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		assertorWithRowNumber
+				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+
+		// do a snapshot, data could be recovered from state
+		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
+		testHarness.close();
+		expectedOutput.clear();
+
+		func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true, true);
+		testHarness = createTestHarness(func);
+		testHarness.setup();
+		testHarness.initializeState(snapshot);
+		testHarness.open();
+		testHarness.processElement(record("book", 1L, 10));
+
+		expectedOutput.add(retractRecord("book", 1L, 12, 2L));
+		expectedOutput.add(retractRecord("book", 4L, 11, 1L));
+		expectedOutput.add(record("book", 4L, 11, 2L));
+		expectedOutput.add(record("book", 1L, 10, 1L));
+		assertorWithRowNumber
+				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
+
+	@Test
+	public void testConstantRankRangeWithoutOffsetWithoutRowNumber() throws Exception {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), true,
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
@@ -129,15 +177,11 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 1L, 12));
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(retractRecord("book", 2L, 19));
+		expectedOutput.add(deleteRecord("book", 2L, 19));
 		expectedOutput.add(record("book", 4L, 11));
 		expectedOutput.add(record("fruit", 4L, 33));
 		expectedOutput.add(record("fruit", 3L, 44));
-		expectedOutput.add(retractRecord("fruit", 4L, 33));
-		expectedOutput.add(retractRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 4L, 33));
+		expectedOutput.add(deleteRecord("fruit", 3L, 44));
 		expectedOutput.add(record("fruit", 5L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
@@ -154,18 +198,42 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.open();
 		testHarness.processElement(record("book", 1L, 10));
 
-		expectedOutput.add(retractRecord("book", 1L, 12));
-		expectedOutput.add(retractRecord("book", 4L, 11));
-		expectedOutput.add(record("book", 4L, 11));
+		expectedOutput.add(deleteRecord("book", 1L, 12));
 		expectedOutput.add(record("book", 1L, 10));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}
 
-	// TODO RetractRankFunction could be sent less retraction message when does not need to retract row_number
 	@Test
-	public void testVariableRankRange() throws Exception {
+	public void testVariableRankRangeWithRowNumber() throws Exception {
+		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(record("book", 2L, 12));
+		testHarness.processElement(record("book", 2L, 19));
+		testHarness.processElement(record("book", 2L, 11));
+		testHarness.processElement(record("fruit", 1L, 33));
+		testHarness.processElement(record("fruit", 1L, 44));
+		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.close();
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(record("book", 2L, 12, 1L));
+		expectedOutput.add(record("book", 2L, 19, 2L));
+		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
+		expectedOutput.add(retractRecord("book", 2L, 12, 1L));
+		expectedOutput.add(record("book", 2L, 12, 2L));
+		expectedOutput.add(record("book", 2L, 11, 1L));
+		expectedOutput.add(record("fruit", 1L, 33, 1L));
+		expectedOutput.add(retractRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(record("fruit", 1L, 22, 1L));
+		assertorWithRowNumber
+				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testVariableRankRangeWithoutRowNumber() throws Exception {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
@@ -180,20 +248,44 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 2L, 12));
 		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 12));
-		expectedOutput.add(record("book", 2L, 12));
+		expectedOutput.add(deleteRecord("book", 2L, 19));
 		expectedOutput.add(record("book", 2L, 11));
 		expectedOutput.add(record("fruit", 1L, 33));
-		expectedOutput.add(retractRecord("fruit", 1L, 33));
+		expectedOutput.add(deleteRecord("fruit", 1L, 33));
 		expectedOutput.add(record("fruit", 1L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
-	// TODO
 	@Test
-	public void testDisableGenerateRetraction() throws Exception {
+	public void testDisableGenerateRetractionWithRowNumber() throws Exception {
+		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false,
+				true);
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(record("book", 1L, 12));
+		testHarness.processElement(record("book", 2L, 19));
+		testHarness.processElement(record("book", 4L, 11));
+		testHarness.processElement(record("fruit", 4L, 33));
+		testHarness.processElement(record("fruit", 3L, 44));
+		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.close();
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(record("book", 1L, 12, 1L));
+		expectedOutput.add(record("book", 2L, 19, 2L));
+		expectedOutput.add(record("book", 1L, 12, 2L));
+		expectedOutput.add(record("book", 4L, 11, 1L));
+		expectedOutput.add(record("fruit", 4L, 33, 1L));
+		expectedOutput.add(record("fruit", 3L, 44, 2L));
+		expectedOutput.add(record("fruit", 4L, 33, 2L));
+		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		assertorWithRowNumber
+				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testDisableGenerateRetractionWithoutRowNumber() throws Exception {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new ConstantRankRange(1, 2), false,
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
@@ -209,12 +301,12 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 4L, 11));
+		expectedOutput.add(deleteRecord("book", 2L, 19));
 		expectedOutput.add(record("fruit", 4L, 33));
 		expectedOutput.add(record("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 4L, 33));
 		expectedOutput.add(record("fruit", 5L, 22));
+		expectedOutput.add(deleteRecord("fruit", 3L, 44));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -184,7 +184,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
 		expectedOutput.add(record("fruit", 5L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
@@ -201,7 +201,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		expectedOutput.add(deleteRecord("book", 1L, 12));
 		expectedOutput.add(record("book", 1L, 10));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}
 
@@ -254,7 +254,7 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		expectedOutput.add(deleteRecord("fruit", 1L, 33));
 		expectedOutput.add(record("fruit", 1L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -301,14 +301,14 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(record("book", 4L, 11));
 		expectedOutput.add(deleteRecord("book", 2L, 19));
+		expectedOutput.add(record("book", 4L, 11));
 		expectedOutput.add(record("fruit", 4L, 33));
 		expectedOutput.add(record("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 5L, 22));
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
+		expectedOutput.add(record("fruit", 5L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

As we described in the doc: https://ci.apache.org/projects/flink/flink-docs-release-1.9/dev/table/sql.html#top-n

When rank number is not required, we can reduce some output, like unnecessary retract messages. 

However the optimization does not work for Retractable topN before, the pr aims to resolve the issue.

## Brief change log

  - Update Retractable TopN function
  - Add UT

## Verifying this change

UT

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
