### PR TITLE
[FLINK-15522][runtime] JobResult takes ExecutionGraph failure cause as its failure cause only if job is FAILED

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Similar to {@link org.apache.flink.api.common.JobExecutionResult} but with an optional
@@ -234,10 +235,9 @@ public class JobResult implements Serializable {
 
 		if (jobStatus == JobStatus.FAILED) {
 			final ErrorInfo errorInfo = accessExecutionGraph.getFailureInfo();
+			checkNotNull(errorInfo, "No root cause is found for the job failure.");
 
-			if (errorInfo != null) {
-				builder.serializedThrowable(errorInfo.getException());
-			}
+			builder.serializedThrowable(errorInfo.getException());
 		}
 
 		return builder.build();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobResult.java
@@ -232,7 +232,7 @@ public class JobResult implements Serializable {
 		builder.netRuntime(guardedNetRuntime);
 		builder.accumulatorResults(accessExecutionGraph.getAccumulatorsSerialized());
 
-		if (jobStatus != JobStatus.FINISHED) {
+		if (jobStatus == JobStatus.FAILED) {
 			final ErrorInfo errorInfo = accessExecutionGraph.getFailureInfo();
 
 			if (errorInfo != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobResultTest.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -110,7 +111,8 @@ public class JobResultTest extends TestLogger {
 			jobResult.toJobExecutionResult(getClass().getClassLoader());
 			fail("Job should fail with an JobCancellationException.");
 		} catch (JobCancellationException expected) {
-			assertThat(expected.getCause(), is(equalTo(cause)));
+			// the failure cause in the execution graph should not be the cause of the canceled job result
+			assertThat(expected.getCause(), is(nullValue()));
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobResultTest.java
@@ -133,4 +133,13 @@ public class JobResultTest extends TestLogger {
 			assertThat(expected.getCause(), is(equalTo(cause)));
 		}
 	}
+
+	@Test(expected = NullPointerException.class)
+	public void testFailureResultRequiresFailureCause() {
+		JobResult.createFrom(
+			new ArchivedExecutionGraphBuilder()
+				.setJobID(new JobID())
+				.setState(JobStatus.FAILED)
+				.build());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

In JobResult#createFrom it sets the latest global failure cause of the ExecutionGraph to be the cause of the JobResult if the job is terminated but not FINISHED.
So if the job is CANCELED and any global failure had ever happened, the latest global failure cause would be shown as the root cause of the canceling. This results in a misleading root cause exception when a user cancels the job.

## Brief change log

  - *Changed JobResult to take ExecutionGraph failure cause as its failure cause only if the job is FAILED*
 - *also checked the failure cause to be not null if a job is FAILED*


## Verifying this change

This change added tests and can be verified as follows:
  - *Fixed testCancelledJobThrowsJobCancellationException*
  - *Added testFailureResultRequiresFailureCause*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
