### PR TITLE
[FLINK-14853][docs] Use higher granularity units in generated docs for Duration & MemorySize if possible

### DIFF
--- a/docs/_includes/generated/execution_checkpointing_configuration.html
+++ b/docs/_includes/generated/execution_checkpointing_configuration.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>execution.checkpointing.min-pause</h5></td>
-            <td style="word-wrap: break-word;">0ms</td>
+            <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
             <td>The minimal pause between checkpointing attempts. This setting defines how soon thecheckpoint coordinator may trigger another checkpoint after it becomes possible to triggeranother checkpoint with respect to the maximum number of concurrent checkpoints(see <span markdown="span">`execution.checkpointing.max-concurrent-checkpoints`</span>).<br /><br />If the maximum number of concurrent checkpoints is set to one, this setting makes effectively sure that a minimum amount of time passes where no checkpoint is in progress at all.</td>
         </tr>
@@ -46,7 +46,7 @@
         </tr>
         <tr>
             <td><h5>execution.checkpointing.timeout</h5></td>
-            <td style="word-wrap: break-word;">600000ms</td>
+            <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>
             <td>The maximum time that a checkpoint may take before being discarded.</td>
         </tr>

--- a/docs/_includes/generated/execution_configuration.html
+++ b/docs/_includes/generated/execution_configuration.html
@@ -10,7 +10,7 @@
     <tbody>
         <tr>
             <td><h5>execution.buffer-timeout</h5></td>
-            <td style="word-wrap: break-word;">100ms</td>
+            <td style="word-wrap: break-word;">100 ms</td>
             <td>Duration</td>
             <td>The maximum time frequency (milliseconds) for the flushing of the output buffers. By default the output buffers flush frequently to provide low latency and to aid smooth developer experience. Setting the parameter can result in three logical modes:<ul><li>A positive value triggers flushing periodically by that interval</li><li>0 triggers flushing after every record thus minimizing latency</li><li>-1 ms triggers flushing only when the output buffer is full thus maximizing throughput</li></ul></td>
         </tr>

--- a/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
+++ b/docs/_includes/generated/failure_rate_restart_strategy_configuration.html
@@ -10,13 +10,13 @@
     <tbody>
         <tr>
             <td><h5>restart-strategy.failure-rate.delay</h5></td>
-            <td style="word-wrap: break-word;">1000ms</td>
+            <td style="word-wrap: break-word;">1 s</td>
             <td>Duration</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>
         <tr>
             <td><h5>restart-strategy.failure-rate.failure-rate-interval</h5></td>
-            <td style="word-wrap: break-word;">60000ms</td>
+            <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
             <td>Time interval for measuring failure rate if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`failure-rate`</span>. It can be specified using notation: "1 min", "20 s"</td>
         </tr>

--- a/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
+++ b/docs/_includes/generated/fixed_delay_restart_strategy_configuration.html
@@ -16,7 +16,7 @@
         </tr>
         <tr>
             <td><h5>restart-strategy.fixed-delay.delay</h5></td>
-            <td style="word-wrap: break-word;">1000ms</td>
+            <td style="word-wrap: break-word;">1 s</td>
             <td>Duration</td>
             <td>Delay between two consecutive restart attempts if <span markdown="span">`restart-strategy`</span> has been set to <span markdown="span">`fixed-delay`</span>. Delaying the retries can be helpful when the program interacts with external systems where for example connections or pending transactions should reach a timeout before re-execution is attempted. It can be specified using notation: "1 min", "20 s"</td>
         </tr>

--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td><h5>pipeline.auto-watermark-interval</h5></td>
-            <td style="word-wrap: break-word;">0ms</td>
+            <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
             <td>The interval of the automatic watermark emission. Watermarks are used throughout the streaming system to keep track of the progress of time. They are used, for example, for time based windowing.</td>
         </tr>

--- a/docs/_includes/generated/rocks_db_configurable_configuration.html
+++ b/docs/_includes/generated/rocks_db_configurable_configuration.html
@@ -58,7 +58,7 @@
         </tr>
         <tr>
             <td><h5>state.backend.rocksdb.write-batch-size</h5></td>
-            <td style="word-wrap: break-word;">2097152 bytes</td>
+            <td style="word-wrap: break-word;">2 mb</td>
             <td>MemorySize</td>
             <td>The max size of the consumed memory for RocksDB batch write, will flush just based on item count if this config set to 0.</td>
         </tr>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -71,25 +71,25 @@
         </tr>
         <tr>
             <td><h5>taskmanager.registration.initial-backoff</h5></td>
-            <td style="word-wrap: break-word;">500ms</td>
+            <td style="word-wrap: break-word;">500 ms</td>
             <td>Duration</td>
             <td>The initial registration backoff between two consecutive registration attempts. The backoff is doubled for each new registration attempt until it reaches the maximum registration backoff.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.max-backoff</h5></td>
-            <td style="word-wrap: break-word;">30000ms</td>
+            <td style="word-wrap: break-word;">30 s</td>
             <td>Duration</td>
             <td>The maximum registration backoff between two consecutive registration attempts. The max registration backoff requires a time unit specifier (ms/s/min/h/d).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.refused-backoff</h5></td>
-            <td style="word-wrap: break-word;">10000ms</td>
+            <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>
             <td>The backoff after a registration has been refused by the job manager before retrying to connect.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.registration.timeout</h5></td>
-            <td style="word-wrap: break-word;">300000ms</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -9,20 +9,26 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>taskmanager.memory.flink.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.framework.heap.size</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
             <td>Framework Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for TaskExecutor framework, which will not be allocated to task slots.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
             <td>Framework Off-Heap Memory size for TaskExecutors. This is the size of off-heap memory (JVM direct memory and native memory) reserved for TaskExecutor framework, which will not be allocated to task slots. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>
         </tr>
@@ -34,13 +40,13 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.max</h5></td>
-            <td style="word-wrap: break-word;">1073741824 bytes</td>
+            <td style="word-wrap: break-word;">1 gb</td>
             <td>MemorySize</td>
             <td>Max JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.min</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">128 mb</td>
             <td>MemorySize</td>
             <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
@@ -57,8 +63,14 @@
             <td>Managed Memory size for TaskExecutors. This is the size of off-heap memory managed by the memory manager, reserved for sorting, hash tables, caching of intermediate results and RocksDB state backend. Memory consumers can either allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the memory manager and keep their memory usage within that boundary. If unspecified, it will be derived to make up the configured fraction of the Total Flink Memory.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.process.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>
-            <td style="word-wrap: break-word;">32768 bytes</td>
+            <td style="word-wrap: break-word;">32 kb</td>
             <td>MemorySize</td>
             <td>Size of memory buffers used by the network stack and the memory manager.</td>
         </tr>
@@ -70,13 +82,13 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.max</h5></td>
-            <td style="word-wrap: break-word;">1073741824 bytes</td>
+            <td style="word-wrap: break-word;">1 gb</td>
             <td>MemorySize</td>
             <td>Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.shuffle.min</h5></td>
-            <td style="word-wrap: break-word;">67108864 bytes</td>
+            <td style="word-wrap: break-word;">64 mb</td>
             <td>MemorySize</td>
             <td>Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
@@ -91,18 +103,6 @@
             <td style="word-wrap: break-word;">0 bytes</td>
             <td>MemorySize</td>
             <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for tasks. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.flink.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>MemorySize</td>
-            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.process.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>MemorySize</td>
-            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryTestBase.java
@@ -143,7 +143,7 @@ public abstract class ElasticsearchUpsertTableSinkFactoryTestBase extends TestLo
 		sinkOptions.put(SinkOption.BULK_FLUSH_BACKOFF_RETRIES, "3");
 		sinkOptions.put(SinkOption.BULK_FLUSH_INTERVAL, "100");
 		sinkOptions.put(SinkOption.BULK_FLUSH_MAX_ACTIONS, "1000");
-		sinkOptions.put(SinkOption.BULK_FLUSH_MAX_SIZE, "1048576 bytes");
+		sinkOptions.put(SinkOption.BULK_FLUSH_MAX_SIZE, "1 mb");
 		sinkOptions.put(SinkOption.REST_MAX_RETRY_TIMEOUT, "100");
 		sinkOptions.put(SinkOption.REST_PATH_PREFIX, "/myapp");
 		return sinkOptions;

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/table/descriptors/ElasticsearchTest.java
@@ -134,7 +134,7 @@ public class ElasticsearchTest extends DescriptorTestBase {
 		maximumDesc.put("connector.bulk-flush.backoff.max-retries", "3");
 		maximumDesc.put("connector.bulk-flush.interval", "100");
 		maximumDesc.put("connector.bulk-flush.max-actions", "1000");
-		maximumDesc.put("connector.bulk-flush.max-size", "12582912 bytes");
+		maximumDesc.put("connector.bulk-flush.max-size", "12 mb");
 		maximumDesc.put("connector.failure-handler", "retry-rejected");
 		maximumDesc.put("connector.connection-max-retry-timeout", "100");
 		maximumDesc.put("connector.connection-path-prefix", "/myapp");

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseDescriptorTest.java
@@ -78,7 +78,7 @@ public class HBaseDescriptorTest extends DescriptorTestBase {
 		prop1.put("connector.property-version", "1");
 		prop1.put("connector.write.buffer-flush.interval", "2s");
 		prop1.put("connector.write.buffer-flush.max-rows", "100");
-		prop1.put("connector.write.buffer-flush.max-size", "1048576 bytes");
+		prop1.put("connector.write.buffer-flush.max-size", "1 mb");
 
 		return Arrays.asList(prop0, prop1);
 	}

--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -21,7 +21,11 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.PublicEvolving;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.BYTES;
 import static org.apache.flink.configuration.MemorySize.MemoryUnit.GIGA_BYTES;
@@ -54,6 +58,9 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
 	/** The memory size, in bytes. */
 	private final long bytes;
+
+	/** The memorized value returned by toString(). */
+	private transient String stringified;
 
 	/**
 	 * Constructs a new MemorySize.
@@ -117,7 +124,38 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 
 	@Override
 	public String toString() {
-		return bytes + " bytes";
+		if (stringified == null) {
+			stringified = formatToString();
+		}
+
+		return stringified;
+	}
+
+	private String formatToString() {
+		List<MemoryUnit> orderedUnits = Arrays.asList(
+			BYTES,
+			KILO_BYTES,
+			MEGA_BYTES,
+			GIGA_BYTES,
+			TERA_BYTES);
+
+		MemoryUnit highestIntegerUnit = IntStream.range(0, orderedUnits.size())
+			.sequential()
+			.filter(idx -> bytes % orderedUnits.get(idx).getMultiplier() != 0)
+			.boxed()
+			.findFirst()
+			.map(idx -> {
+				if (idx == 0) {
+					return orderedUnits.get(0);
+				} else {
+					return orderedUnits.get(idx - 1);
+				}
+			}).orElse(BYTES);
+
+		return String.format(
+			"%d %s",
+			bytes / highestIntegerUnit.getMultiplier(),
+			highestIntegerUnit.getUnits()[1]);
 	}
 
 	@Override
@@ -224,32 +262,7 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 					"' cannot be re represented as 64bit number (numeric overflow).");
 		}
 
-		final long multiplier;
-		if (unit.isEmpty()) {
-			multiplier = 1L;
-		}
-		else {
-			if (matchesAny(unit, BYTES)) {
-				multiplier = 1L;
-			}
-			else if (matchesAny(unit, KILO_BYTES)) {
-				multiplier = 1024L;
-			}
-			else if (matchesAny(unit, MEGA_BYTES)) {
-				multiplier = 1024L * 1024L;
-			}
-			else if (matchesAny(unit, GIGA_BYTES)) {
-				multiplier = 1024L * 1024L * 1024L;
-			}
-			else if (matchesAny(unit, TERA_BYTES)) {
-				multiplier = 1024L * 1024L * 1024L * 1024L;
-			}
-			else {
-				throw new IllegalArgumentException("Memory size unit '" + unit +
-						"' does not match any of the recognized units: " + MemoryUnit.getAllUnits());
-			}
-		}
-
+		final long multiplier = parseUnit(unit).map(MemoryUnit::getMultiplier).orElse(1L);
 		final long result = value * multiplier;
 
 		// check for overflow
@@ -259,6 +272,25 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 		}
 
 		return result;
+	}
+
+	private static Optional<MemoryUnit> parseUnit(String unit) {
+		if (matchesAny(unit, BYTES)) {
+			return Optional.of(BYTES);
+		} else if (matchesAny(unit, KILO_BYTES)) {
+			return Optional.of(KILO_BYTES);
+		} else if (matchesAny(unit, MEGA_BYTES)) {
+			return Optional.of(MEGA_BYTES);
+		} else if (matchesAny(unit, GIGA_BYTES)) {
+			return Optional.of(GIGA_BYTES);
+		} else if (matchesAny(unit, TERA_BYTES)) {
+			return Optional.of(TERA_BYTES);
+		} else if (!unit.isEmpty()) {
+			throw new IllegalArgumentException("Memory size unit '" + unit +
+				"' does not match any of the recognized units: " + MemoryUnit.getAllUnits());
+		}
+
+		return Optional.empty();
 	}
 
 	private static boolean matchesAny(String str, MemoryUnit unit) {
@@ -286,20 +318,27 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 	 */
 	public enum MemoryUnit {
 
-		BYTES(new String[] { "b", "bytes" }),
-		KILO_BYTES(new String[] { "k", "kb", "kibibytes" }),
-		MEGA_BYTES(new String[] { "m", "mb", "mebibytes" }),
-		GIGA_BYTES(new String[] { "g", "gb", "gibibytes" }),
-		TERA_BYTES(new String[] { "t", "tb", "tebibytes" });
+		BYTES(new String[] { "b", "bytes" }, 1L),
+		KILO_BYTES(new String[] { "k", "kb", "kibibytes" }, 1024L),
+		MEGA_BYTES(new String[] { "m", "mb", "mebibytes" }, 1024L * 1024L),
+		GIGA_BYTES(new String[] { "g", "gb", "gibibytes" }, 1024L * 1024L * 1024L),
+		TERA_BYTES(new String[] { "t", "tb", "tebibytes" }, 1024L * 1024L * 1024L * 1024L);
 
-		private String[] units;
+		private final String[] units;
 
-		MemoryUnit(String[] units) {
+		private final long multiplier;
+
+		MemoryUnit(String[] units, long multiplier) {
 			this.units = units;
+			this.multiplier = multiplier;
 		}
 
 		public String[] getUnits() {
 			return units;
+		}
+
+		public long getMultiplier() {
+			return multiplier;
 		}
 
 		public static String getAllUnits() {
@@ -343,6 +382,5 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 			builder.setLength(builder.length() - 3);
 			return builder.toString();
 		}
-
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/MemorySizePrettyPrintingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/MemorySizePrettyPrintingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.configuration.MemorySize.MemoryUnit;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link MemorySize#toString()}.
+ */
+@RunWith(Parameterized.class)
+public class MemorySizePrettyPrintingTest extends TestLogger {
+	@Parameterized.Parameters
+	public static Object[][] parameters() {
+		return new Object[][]{
+			new Object[]{
+				new MemorySize(MemoryUnit.KILO_BYTES.getMultiplier() + 1),
+				"1025 bytes"
+			},
+			new Object[]{
+				new MemorySize(100),
+				"100 bytes"
+			},
+			new Object[]{
+				new MemorySize(1024),
+				"1 kb"
+			},
+			new Object[]{
+				new MemorySize(MemoryUnit.GIGA_BYTES.getMultiplier() + 1),
+				String.format("%d %s", MemoryUnit.GIGA_BYTES.getMultiplier() + 1, "bytes")
+			},
+			new Object[]{
+				new MemorySize(0),
+				"0 bytes"
+			}
+		};
+	}
+
+	@Parameterized.Parameter
+	public MemorySize memorySize;
+
+	@Parameterized.Parameter(1)
+	public String expectedString;
+
+	@Test
+	public void testFormatting() {
+		assertThat(memorySize.toString(), is(expectedString));
+	}
+}

--- a/flink-core/src/test/java/org/apache/flink/util/TimeUtilsPrettyPrintingTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TimeUtilsPrettyPrintingTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.time.Duration;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link TimeUtils#formatWithHighestUnit(Duration)}.
+ */
+@RunWith(Parameterized.class)
+public class TimeUtilsPrettyPrintingTest extends TestLogger {
+	@Parameterized.Parameters
+	public static Object[][] parameters() {
+		return new Object[][]{
+			new Object[]{
+				Duration.ofMinutes(3).plusSeconds(30),
+				"210 s"
+			},
+			new Object[]{
+				Duration.ofNanos(100),
+				"100 ns"
+			},
+			new Object[]{
+				Duration.ofSeconds(120),
+				"2 min"
+			},
+			new Object[]{
+				Duration.ofMillis(200),
+				"200 ms"
+			},
+			new Object[]{
+				Duration.ofHours(1).plusSeconds(3),
+				"3603 s"
+			},
+			new Object[]{
+				Duration.ofSeconds(0),
+				"0 ms"
+			},
+			new Object[]{
+				Duration.ofMillis(60000),
+				"1 min"
+			}
+		};
+	}
+
+	@Parameterized.Parameter
+	public Duration duration;
+
+	@Parameterized.Parameter(1)
+	public String expectedString;
+
+	@Test
+	public void testFormatting() {
+		assertThat(TimeUtils.formatWithHighestUnit(duration), is(expectedString));
+	}
+}

--- a/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/configuration/ConfigOptionsDocGenerator.java
@@ -387,7 +387,7 @@ public class ConfigOptionsDocGenerator {
 			}
 			return "\"" + value + "\"";
 		} else if (value instanceof Duration) {
-			return TimeUtils.getStringInMillis((Duration) value);
+			return TimeUtils.formatWithHighestUnit((Duration) value);
 		} else if (value instanceof List) {
 			return ((List<Object>) value).stream()
 				.map(ConfigOptionsDocGenerator::stringifyObject)

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -159,7 +159,7 @@ public class ConfigOptionsDocGeneratorTest {
 				"        </tr>\n" +
 				"        <tr>\n" +
 				"            <td><h5>option.memory</h5></td>\n" +
-				"            <td style=\"word-wrap: break-word;\">1024 bytes</td>\n" +
+				"            <td style=\"word-wrap: break-word;\">1 kb</td>\n" +
 				"            <td>MemorySize</td>\n" +
 				"            <td>Description</td>\n" +
 				"        </tr>\n" +

--- a/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/configuration/ConfigOptionsDocGeneratorTest.java
@@ -129,7 +129,7 @@ public class ConfigOptionsDocGeneratorTest {
 				"    <tbody>\n" +
 				"        <tr>\n" +
 				"            <td><h5>option.duration</h5></td>\n" +
-				"            <td style=\"word-wrap: break-word;\">60000ms</td>\n" +
+				"            <td style=\"word-wrap: break-word;\">1 min</td>\n" +
 				"            <td>Duration</td>\n" +
 				"            <td>Description</td>\n" +
 				"        </tr>\n" +

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -277,7 +277,7 @@ class ElasticsearchDescriptorTest(PyFlinkTestCase):
         elasticsearch = Elasticsearch().bulk_flush_max_size("42 mb")
 
         properties = elasticsearch.to_properties()
-        expected = {'connector.bulk-flush.max-size': '44040192 bytes',
+        expected = {'connector.bulk-flush.max-size': '42 mb',
                     'connector.type': 'elasticsearch',
                     'connector.property-version': '1'}
         self.assertEqual(expected, properties)


### PR DESCRIPTION
## What is the purpose of the change

Make the formatting of MemorySize and Duration a bit nicer in the documentation.

## Verifying this change

This change added tests:
* TimeUtilsPrettyPrintingTest
* MemorySizePrettyPrintingTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no /** don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no /** don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
