### PR TITLE
[FLINK-15554][azure] Bump jetty-util to 3.1.2

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -36,6 +36,7 @@ under the License.
 	<properties>
 		<fs.azure.sdk.version>1.16.0</fs.azure.sdk.version>
 		<fs.jackson.core.version>2.9.4</fs.jackson.core.version>
+		<jetty.version>9.3.24.v20180605</jetty.version>
 	</properties>
 
 	<dependencies>
@@ -89,6 +90,17 @@ under the License.
 		</dependency>
 
 	</dependencies>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<!-- Pulled in by hadoop-azure; bumps it to the version used by 3.1.2+ for security purposes -->
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-util-ajax</artifactId>
+				<version>${jetty.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -17,5 +17,5 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-azure:3.1.0
 - org.apache.httpcomponents:httpclient:4.5.3
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.eclipse.jetty:jetty-util:9.3.19.v20170502
-- org.eclipse.jetty:jetty-util-ajax:9.3.19.v20170502
+- org.eclipse.jetty:jetty-util:9.3.24.v20180605
+- org.eclipse.jetty:jetty-util-ajax:9.3.24.v20180605


### PR DESCRIPTION
`flink-fs-hadoop-azure` has transitive dependency on jetty-util-ajax:9.3.19, which has a security vulnerability: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7657

This was fixed in `9.3.24.v20180605` ([source](https://bugs.eclipse.org/bugs/show_bug.cgi?id=535668)). Starting from version 3.2.1 `hadoop-azure` is using this version as well, but for a quick resolution I propose bumped this single dependency for the time being.