### PR TITLE
[FLINK-13465][legal] Update javassist licensing

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -22,7 +22,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-compress:1.18
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
-- org.javassist:javassist:3.19.0-GA
+- org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.5.0
 - org.objenesis:objenesis:2.1
 - org.xerial.snappy:snappy-java:1.1.4


### PR DESCRIPTION
Javassist was bumped in FLINK-13465 but I forgot to update the NOTICE file of flink-dist.