### PR TITLE
[FLINK-15535][documentation] Add usage of ProcessFunctionTestHarnesses for testing documentation

### DIFF
--- a/docs/dev/stream/testing.md
+++ b/docs/dev/stream/testing.md
@@ -332,10 +332,11 @@ Many more examples for the usage of these test harnesses can be found in the Fli
 
 <span class="label label-info">Note</span> Be aware that `AbstractStreamOperatorTestHarness` and its derived classes are currently not part of the public API and can be subject to change.
 
-### Unit Testing ProcessFunction
+#### Unit Testing ProcessFunction
 
-The `ProcessFunction` is a widely used low-level and powerful stream processing operation, giving access to the basic building blocks of all (acyclic) streaming applications.
-Flink provides a test harness named `ProcessFunctionTestHarnesses` that can be used to test your `ProcessFunction`. Considering this example:
+Given its importance, in addition to the previous test harnesses that can be used directly to test a `ProcessFunction`, Flink provides a test harness factory named `ProcessFunctionTestHarnesses` that allows for easier test harness instantiation. Considering this example:
+
+<span class="label label-info">Note</span> Be aware that to use this test harness, you also need to introduce the dependencies mentioned in the last section.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -412,6 +413,8 @@ class PassThroughProcessFunctionTest extends FlatSpec with Matchers {
 {% endhighlight %}
 </div>
 </div>
+
+For more examples on how to use the `ProcessFunctionTestHarnesses` in order to test the different flavours of the `ProcessFunction`, e.g. `KeyedProcessFunction`, `KeyedCoProcessFunction`, `BroadcastProcessFunction`, etc, the user is encouraged to look at the `ProcessFunctionTestHarnessesTest`.
 
 ## Testing Flink Jobs
 

--- a/docs/dev/stream/testing.zh.md
+++ b/docs/dev/stream/testing.zh.md
@@ -332,10 +332,11 @@ Many more examples for the usage of these test harnesses can be found in the Fli
 
 <span class="label label-info">Note</span> Be aware that `AbstractStreamOperatorTestHarness` and its derived classes are currently not part of the public API and can be subject to change.
 
-### Unit Testing ProcessFunction
+#### Unit Testing ProcessFunction
 
-The `ProcessFunction` is a widely used low-level and powerful stream processing operation, giving access to the basic building blocks of all (acyclic) streaming applications.
-Flink provides a test harness named `ProcessFunctionTestHarnesses` that can be used to test your `ProcessFunction`. Considering this example:
+Given its importance, in addition to the previous test harnesses that can be used directly to test a `ProcessFunction`, Flink provides a test harness factory named `ProcessFunctionTestHarnesses` that allows for easier test harness instantiation. Considering this example:
+
+<span class="label label-info">Note</span> Be aware that to use this test harness, you also need to introduce the dependencies mentioned in the last section.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -412,6 +413,8 @@ class PassThroughProcessFunctionTest extends FlatSpec with Matchers {
 {% endhighlight %}
 </div>
 </div>
+
+For more examples on how to use the `ProcessFunctionTestHarnesses` in order to test the different flavours of the `ProcessFunction`, e.g. `KeyedProcessFunction`, `KeyedCoProcessFunction`, `BroadcastProcessFunction`, etc, the user is encouraged to look at the `ProcessFunctionTestHarnessesTest`.
 
 ## Testing Flink Jobs
 


### PR DESCRIPTION


## What is the purpose of the change

*This pull request adds usage of ProcessFunctionTestHarnesses for testing documentation*

## Brief change log

  - *Add usage of ProcessFunctionTestHarnesses for testing documentation*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
