### PR TITLE
[FLINK-15533] Fix parallelism setting propagation during graph instantiation.

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -165,6 +165,16 @@ public class ExecutionEnvironment {
 		this.executorServiceLoader = checkNotNull(executorServiceLoader);
 		this.configuration = checkNotNull(configuration);
 		this.userClassloader = userClassloader == null ? getClass().getClassLoader() : userClassloader;
+
+		// the parallelism of a job or an operator can only be specified at the following places:
+		//     i) at the operator level using the SingleOutputStreamOperator.setParallelism().
+		//     ii) programmatically by using the env.setParallelism() method
+		//
+		// if specified in multiple places, the priority order is the above.
+		//
+		// Given this, it is safe to overwrite the execution config default value here because all other ways assume
+		// that the env is already instantiated so they will overwrite the value passed here.
+		this.config.setParallelism(configuration.get(CoreOptions.DEFAULT_PARALLELISM));
 	}
 
 	/**
@@ -214,7 +224,6 @@ public class ExecutionEnvironment {
 	 *         returns {@link ExecutionConfig#PARALLELISM_DEFAULT}, if the environment's default parallelism should be used.
 	 */
 	public int getParallelism() {
-		consolidateParallelismDefinitionsInConfiguration();
 		return config.getParallelism();
 	}
 
@@ -896,8 +905,6 @@ public class ExecutionEnvironment {
 	public JobClient executeAsync(String jobName) throws Exception {
 		checkNotNull(configuration.get(DeploymentOptions.TARGET), "No execution.target specified in your configuration file.");
 
-		consolidateParallelismDefinitionsInConfiguration();
-
 		final Plan plan = createProgramPlan(jobName);
 		final PipelineExecutorFactory executorFactory =
 			executorServiceLoader.getExecutorFactory(configuration);
@@ -921,13 +928,6 @@ public class ExecutionEnvironment {
 
 			// make javac happy, this code path will not be reached
 			return null;
-		}
-	}
-
-	private void consolidateParallelismDefinitionsInConfiguration() {
-		if (config.getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
-			final int parallelism = configuration.get(CoreOptions.DEFAULT_PARALLELISM);
-			this.setParallelism(parallelism);
 		}
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -214,6 +214,7 @@ public class ExecutionEnvironment {
 	 *         returns {@link ExecutionConfig#PARALLELISM_DEFAULT}, if the environment's default parallelism should be used.
 	 */
 	public int getParallelism() {
+		consolidateParallelismDefinitionsInConfiguration();
 		return config.getParallelism();
 	}
 
@@ -924,8 +925,9 @@ public class ExecutionEnvironment {
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {
-		if (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
-			configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).ifPresent(this::setParallelism);
+		if (config.getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
+			final int parallelism = configuration.get(CoreOptions.DEFAULT_PARALLELISM);
+			this.setParallelism(parallelism);
 		}
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.webmonitor.handlers;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -301,7 +302,7 @@ public abstract class JarHandlerParameterTest
 	JobGraph validateDefaultGraph() {
 		JobGraph jobGraph = LAST_SUBMITTED_JOB_GRAPH_REFERENCE.getAndSet(null);
 		Assert.assertEquals(0, ParameterProgram.actualArguments.length);
-		Assert.assertEquals(ExecutionConfig.PARALLELISM_DEFAULT, getExecutionConfig(jobGraph).getParallelism());
+		Assert.assertEquals(CoreOptions.DEFAULT_PARALLELISM.defaultValue().intValue(), getExecutionConfig(jobGraph).getParallelism());
 		return jobGraph;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1062,7 +1062,11 @@ public class DataStream<T> {
 	 *            The path pointing to the location the text file is written to.
 	 *
 	 * @return The closed DataStream.
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public DataStreamSink<T> writeAsText(String path) {
 		return writeUsingOutputFormat(new TextOutputFormat<T>(new Path(path)));
@@ -1081,7 +1085,11 @@ public class DataStream<T> {
 	 *            NO_OVERWRITE and OVERWRITE.
 	 *
 	 * @return The closed DataStream.
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public DataStreamSink<T> writeAsText(String path, WriteMode writeMode) {
 		TextOutputFormat<T> tof = new TextOutputFormat<>(new Path(path));
@@ -1100,7 +1108,11 @@ public class DataStream<T> {
 	 *            the path pointing to the location the text file is written to
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public DataStreamSink<T> writeAsCsv(String path) {
 		return writeAsCsv(path, null, CsvOutputFormat.DEFAULT_LINE_DELIMITER, CsvOutputFormat.DEFAULT_FIELD_DELIMITER);
@@ -1120,7 +1132,11 @@ public class DataStream<T> {
 	 *            NO_OVERWRITE and OVERWRITE.
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public DataStreamSink<T> writeAsCsv(String path, WriteMode writeMode) {
 		return writeAsCsv(path, writeMode, CsvOutputFormat.DEFAULT_LINE_DELIMITER, CsvOutputFormat.DEFAULT_FIELD_DELIMITER);
@@ -1144,8 +1160,12 @@ public class DataStream<T> {
 	 *            the delimiter for two fields
 	 *
 	 * @return the closed DataStream
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
 	@SuppressWarnings("unchecked")
+	@Deprecated
 	@PublicEvolving
 	public <X extends Tuple> DataStreamSink<T> writeAsCsv(
 			String path,
@@ -1197,7 +1217,11 @@ public class DataStream<T> {
 	 *
 	 * @param format The output format
 	 * @return The closed DataStream
+	 *
+	 * @deprecated Please use the {@link org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink} explicitly using the
+	 * {@link #addSink(SinkFunction)} method.
 	 */
+	@Deprecated
 	@PublicEvolving
 	public DataStreamSink<T> writeUsingOutputFormat(OutputFormat<T> format) {
 		return addSink(new OutputFormatSinkFunction<>(format));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -273,6 +273,7 @@ public class StreamExecutionEnvironment {
 	 * value.
 	 */
 	public int getParallelism() {
+		consolidateParallelismDefinitionsInConfiguration();
 		return config.getParallelism();
 	}
 
@@ -1757,8 +1758,9 @@ public class StreamExecutionEnvironment {
 	}
 
 	private void consolidateParallelismDefinitionsInConfiguration() {
-		if (getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
-			configuration.getOptional(CoreOptions.DEFAULT_PARALLELISM).ifPresent(this::setParallelism);
+		if (config.getParallelism() == ExecutionConfig.PARALLELISM_DEFAULT) {
+			final int parallelism = configuration.get(CoreOptions.DEFAULT_PARALLELISM);
+			this.setParallelism(parallelism);
 		}
 	}
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/DataStream.scala
@@ -1006,7 +1006,12 @@ class DataStream[T](stream: JavaStream[T]) {
     *
     * @param path The path pointing to the location the text file is written to
     * @return The closed DataStream
+    *
+    * @deprecated Please use the
+    *             [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+    *             explicitly using the [[addSink()]] method.
     */
+  @Deprecated
   @PublicEvolving
   def writeAsText(path: String): DataStreamSink[T] =
     stream.writeAsText(path)
@@ -1021,7 +1026,12 @@ class DataStream[T](stream: JavaStream[T]) {
     * @param writeMode Controls the behavior for existing files. Options are NO_OVERWRITE and
     *                  OVERWRITE.
     * @return The closed DataStream
+    *
+    * @deprecated Please use the
+    *             [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+    *             explicitly using the [[addSink()]] method.
     */
+  @Deprecated
   @PublicEvolving
   def writeAsText(path: String, writeMode: FileSystem.WriteMode): DataStreamSink[T] = {
     if (writeMode != null) {
@@ -1037,7 +1047,12 @@ class DataStream[T](stream: JavaStream[T]) {
     *
     * @param path Path to the location of the CSV file
     * @return The closed DataStream
+    *
+    * @deprecated Please use the
+    *             [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+    *             explicitly using the [[addSink()]] method.
     */
+  @Deprecated
   @PublicEvolving
   def writeAsCsv(path: String): DataStreamSink[T] = {
     writeAsCsv(
@@ -1054,7 +1069,12 @@ class DataStream[T](stream: JavaStream[T]) {
     * @param path Path to the location of the CSV file
     * @param writeMode Controls whether an existing file is overwritten or not
     * @return The closed DataStream
+    *
+    * @deprecated Please use the
+    *             [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+    *             explicitly using the [[addSink()]] method.
     */
+  @Deprecated
   @PublicEvolving
   def writeAsCsv(path: String, writeMode: FileSystem.WriteMode): DataStreamSink[T] = {
     writeAsCsv(
@@ -1073,7 +1093,12 @@ class DataStream[T](stream: JavaStream[T]) {
     * @param rowDelimiter Delimiter for consecutive rows
     * @param fieldDelimiter Delimiter for consecutive fields
     * @return The closed DataStream
+    *
+    * @deprecated Please use the
+    *             [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+    *             explicitly using the [[addSink()]] method.
     */
+  @Deprecated
   @PublicEvolving
   def writeAsCsv(
       path: String,


### PR DESCRIPTION
## What is the purpose of the change

Before the introduction of the executor (FLIP-73) and the consolidation of the different environments, some environments were overwriting the parallelism setting in their constructor. Now, after the refactoring of the environments we were not always doing it. In addition, the problem now is even more evident as that the user can directly pass a `Configuration` in the `(Stream)ExecutionEnvironment` constructor.

This PR makes sure that we always expose a consistent view of the parallelism when the user calls `env.getParallelism()`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
