### PR TITLE
[FLINK-15541] Fix unstable case FlinkKinesisConsumerTest

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -1012,10 +1012,10 @@ public class FlinkKinesisConsumerTest extends TestLogger {
 		assertThat(results, org.hamcrest.Matchers.contains(expectedResults.toArray()));
 
 		// verify exception propagation
+		Assert.assertNull(sourceThreadError.get());
 		throwOnCollect.set(true);
 		shard1.put(Long.toString(record2 + 1));
 
-		Assert.assertNull(sourceThreadError.get());
 		deadline  = Deadline.fromNow(Duration.ofSeconds(10));
 		while (deadline.hasTimeLeft() && sourceThreadError.get() == null) {
 			Thread.sleep(10);


### PR DESCRIPTION
## What is the purpose of the change

* It's a quick fix for `FlinkKinesisConsumerTest#testSourceSynchronization`. This checking should happen before `throwOnCollect` is set.

## Brief change log

* Fix the bug of wrong checking introduced by FLINK-15301

## Verifying this change

* This is a fixing of test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
