### PR TITLE
[hotfix][table-common] Simplify formatted exceptions

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableException.java
@@ -21,19 +21,65 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.PublicEvolving;
 
 /**
-  * General Exception for all errors during table handling.
-  *
-  * <p>This exception indicates that an internal error occurred or that a feature is not supported
-  * yet. Usually, this exception does not indicate a fault of the user.
-  */
+ * General Exception for all errors during table handling.
+ *
+ * <p>This exception indicates that an internal error occurred or that a feature is not supported
+ * yet. Usually, this exception does not indicate a fault of the user.
+ *
+ * @see ValidationException
+ */
 @PublicEvolving
-public class TableException extends RuntimeException {
+public final class TableException extends RuntimeException {
 
+	/**
+	 * Unformatted exception with cause.
+	 *
+	 * @see TableException#TableException(Throwable, String, Object...)
+	 */
 	public TableException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Unformatted exception.
+	 *
+	 * @see TableException#TableException(String, Object...)
+	 */
 	public TableException(String message) {
 		super(message);
+	}
+
+	/**
+	 * Creates a formatted exception for a unified exception experience.
+	 *
+	 * <p>Please use the following convention:
+	 *
+	 * <p><ul>
+	 * <li>Start with a capital letter.
+	 * <li>Surround strings with single quotes. Numbers must not be surrounded.
+	 * <li>End message sentences with a period.
+	 * </ul>
+	 *
+	 * <p>E.g.: {@code new TableException("Function class '%s' is not supported yet.", clazz.getName())}
+	 */
+	public TableException(String format, Object... args) {
+		this(String.format(format, args));
+	}
+
+	/**
+	 * Creates a formatted exception with cause for a unified exception experience.
+	 *
+	 * <p>Please use the following convention:
+	 *
+	 * <p><ul>
+	 * <li>Start with a capital letter.
+	 * <li>Surround strings with single quotes. Numbers must not be surrounded.
+	 * <li>End message sentences with a period.
+	 * </ul>
+	 *
+	 * <p>E.g.: {@code new TableException(t, "Function class '%s' is not supported yet.", clazz.getName())}
+	 */
+	public TableException(Throwable cause, String format, Object... args) {
+		this(String.format(format, args), cause);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ValidationException.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/ValidationException.java
@@ -21,18 +21,64 @@ package org.apache.flink.table.api;
 import org.apache.flink.annotation.PublicEvolving;
 
 /**
-  * Exception for all errors occurring during validation phase.
-  *
-  * <p>This exception indicates that the user did something wrong.
-  */
+ * Exception for all errors occurring during validation phase.
+ *
+ * <p>This exception indicates that the user did something wrong.
+ *
+ * @see TableException
+ */
 @PublicEvolving
-public class ValidationException extends RuntimeException {
+public final class ValidationException extends RuntimeException {
 
+	/**
+	 * Unformatted exception with cause.
+	 *
+	 * @see ValidationException#ValidationException(Throwable, String, Object...)
+	 */
 	public ValidationException(String message, Throwable cause) {
 		super(message, cause);
 	}
 
+	/**
+	 * Unformatted exception.
+	 *
+	 * @see ValidationException#ValidationException(String, Object...)
+	 */
 	public ValidationException(String message) {
 		super(message);
+	}
+
+	/**
+	 * Creates a formatted exception for a unified exception experience.
+	 *
+	 * <p>Please use the following convention:
+	 *
+	 * <p><ul>
+	 * <li>Start with a capital letter.
+	 * <li>Surround strings with single quotes. Numbers must not be surrounded.
+	 * <li>End message sentences with a period.
+	 * </ul>
+	 *
+	 * <p>E.g.: {@code new ValidationException("Function class '%s' at position %d is invalid.", clazz.getName(), pos)}
+	 */
+	public ValidationException(String format, Object ... args) {
+		this(String.format(format, args));
+	}
+
+	/**
+	 * Creates a formatted exception with cause for a unified exception experience.
+	 *
+	 * <p>Please use the following convention:
+	 *
+	 * <p><ul>
+	 * <li>Start with a capital letter.
+	 * <li>Surround strings with single quotes. Numbers must not be surrounded.
+	 * <li>End message sentences with a period.
+	 * </ul>
+	 *
+	 * <p>E.g.: {@code new ValidationException(t, "Function class '%s' at position %d is invalid.", clazz.getName(), pos)}
+	 */
+	public ValidationException(Throwable cause, String format, Object... args) {
+		this(String.format(format, args), cause);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Makes formatted exceptions easier and helps by providing some simple coding guidelines in the JavaDocs.

## Brief change log

- New constructors for `TableException` and `ValidationException`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
