### PR TITLE
[FLINK-15444][runtime] Make the component AbstractInvokable in CheckpointBarrierHandler NonNull

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyCheckpointInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyCheckpointInvokable.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.testutils;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+
+/**
+ * An invokable that does nothing with checkpoint.
+ */
+public class DummyCheckpointInvokable extends DummyInvokable {
+
+	public DummyCheckpointInvokable() {
+		super();
+	}
+
+	public void triggerCheckpointOnBarrier(
+		CheckpointMetaData checkpointMetaData,
+		CheckpointOptions checkpointOptions,
+		CheckpointMetrics checkpointMetrics) {
+	}
+
+	public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 
 /**
@@ -71,7 +69,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	CheckpointBarrierAligner(
 			int totalNumberOfInputChannels,
 			String taskName,
-			@Nullable AbstractInvokable toNotifyOnCheckpoint) {
+			AbstractInvokable toNotifyOnCheckpoint) {
 		super(toNotifyOnCheckpoint);
 		this.totalNumberOfInputChannels = totalNumberOfInputChannels;
 		this.taskName = taskName;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
-import javax.annotation.Nullable;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * The {@link CheckpointBarrierHandler} reacts to checkpoint barrier arriving from the input channels.
@@ -36,11 +36,10 @@ import javax.annotation.Nullable;
 public abstract class CheckpointBarrierHandler {
 
 	/** The listener to be notified on complete checkpoints. */
-	@Nullable
 	private final AbstractInvokable toNotifyOnCheckpoint;
 
-	public CheckpointBarrierHandler(@Nullable AbstractInvokable toNotifyOnCheckpoint) {
-		this.toNotifyOnCheckpoint = toNotifyOnCheckpoint;
+	public CheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint) {
+		this.toNotifyOnCheckpoint = checkNotNull(toNotifyOnCheckpoint);
 	}
 
 	public abstract void releaseBlocksAndResetBarriers();
@@ -75,19 +74,17 @@ public abstract class CheckpointBarrierHandler {
 	public abstract void checkpointSizeLimitExceeded(long maxBufferedBytes) throws Exception;
 
 	protected void notifyCheckpoint(CheckpointBarrier checkpointBarrier, long bufferedBytes, long alignmentDurationNanos) throws Exception {
-		if (toNotifyOnCheckpoint != null) {
-			CheckpointMetaData checkpointMetaData =
-				new CheckpointMetaData(checkpointBarrier.getId(), checkpointBarrier.getTimestamp());
+		CheckpointMetaData checkpointMetaData =
+			new CheckpointMetaData(checkpointBarrier.getId(), checkpointBarrier.getTimestamp());
 
-			CheckpointMetrics checkpointMetrics = new CheckpointMetrics()
-				.setBytesBufferedInAlignment(bufferedBytes)
-				.setAlignmentDurationNanos(alignmentDurationNanos);
+		CheckpointMetrics checkpointMetrics = new CheckpointMetrics()
+			.setBytesBufferedInAlignment(bufferedBytes)
+			.setAlignmentDurationNanos(alignmentDurationNanos);
 
-			toNotifyOnCheckpoint.triggerCheckpointOnBarrier(
-				checkpointMetaData,
-				checkpointBarrier.getCheckpointOptions(),
-				checkpointMetrics);
-		}
+		toNotifyOnCheckpoint.triggerCheckpointOnBarrier(
+			checkpointMetaData,
+			checkpointBarrier.getCheckpointOptions(),
+			checkpointMetrics);
 	}
 
 	protected void notifyAbortOnCancellationBarrier(long checkpointId) throws Exception {
@@ -96,8 +93,6 @@ public abstract class CheckpointBarrierHandler {
 	}
 
 	protected void notifyAbort(long checkpointId, CheckpointException cause) throws Exception {
-		if (toNotifyOnCheckpoint != null) {
-			toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId, cause);
-		}
+		toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId, cause);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.util.ArrayDeque;
 
 /**
@@ -71,11 +69,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 	/** The highest checkpoint ID encountered so far. */
 	private long latestPendingCheckpointID = -1;
 
-	public CheckpointBarrierTracker(int totalNumberOfInputChannels) {
-		this(totalNumberOfInputChannels, null);
-	}
-
-	public CheckpointBarrierTracker(int totalNumberOfInputChannels, @Nullable AbstractInvokable toNotifyOnCheckpoint) {
+	public CheckpointBarrierTracker(int totalNumberOfInputChannels, AbstractInvokable toNotifyOnCheckpoint) {
 		super(toNotifyOnCheckpoint);
 		this.totalNumberOfInputChannels = totalNumberOfInputChannels;
 		this.pendingCheckpoints = new ArrayDeque<>();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -29,8 +29,6 @@ import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -66,7 +64,7 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 			InputGate inputGate,
 			BufferStorage bufferStorage,
 			String taskName,
-			@Nullable AbstractInvokable toNotifyOnCheckpoint) {
+			AbstractInvokable toNotifyOnCheckpoint) {
 		this(
 			inputGate,
 			bufferStorage,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 
 import org.junit.Test;
 
@@ -60,7 +61,7 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 					myIG,
 					new CachedBufferStorage(PAGE_SIZE),
 					"Testing: No task associated",
-					null);
+					new DummyCheckpointInvokable());
 
 			for (int i = 0; i < 2000000; i++) {
 				BufferOrEvent boe = checkpointedInputGate.pollNext().get();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -34,14 +34,13 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.After;
 import org.junit.Test;
-
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -76,16 +75,16 @@ public abstract class CheckpointBarrierAlignerTestBase {
 	protected CheckpointedInputGate createBarrierBuffer(
 		int numberOfChannels,
 		BufferOrEvent[] sequence,
-		@Nullable AbstractInvokable toNotify) throws IOException {
+		AbstractInvokable toNotify) throws IOException {
 		MockInputGate gate = new MockInputGate(numberOfChannels, Arrays.asList(sequence));
 		return createBarrierBuffer(gate, toNotify);
 	}
 
 	protected CheckpointedInputGate createBarrierBuffer(int numberOfChannels, BufferOrEvent[] sequence) throws IOException {
-		return createBarrierBuffer(numberOfChannels, sequence, null);
+		return createBarrierBuffer(numberOfChannels, sequence, new DummyCheckpointInvokable());
 	}
 
-	abstract CheckpointedInputGate createBarrierBuffer(InputGate gate, @Nullable AbstractInvokable toNotify) throws IOException;
+	abstract CheckpointedInputGate createBarrierBuffer(InputGate gate, AbstractInvokable toNotify) throws IOException;
 
 	abstract void validateAlignmentBuffered(long actualBytesBuffered, BufferOrEvent... sequence);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerTestBase.java
@@ -85,10 +85,6 @@ public abstract class CheckpointBarrierAlignerTestBase {
 		return createBarrierBuffer(numberOfChannels, sequence, null);
 	}
 
-	protected CheckpointedInputGate createBarrierBuffer(InputGate gate) throws IOException {
-		return createBarrierBuffer(gate, null);
-	}
-
 	abstract CheckpointedInputGate createBarrierBuffer(InputGate gate, @Nullable AbstractInvokable toNotify) throws IOException;
 
 	abstract void validateAlignmentBuffered(long actualBytesBuffered, BufferOrEvent... sequence);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTrackerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTrackerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 
 import org.junit.After;
 import org.junit.Test;
@@ -366,7 +367,7 @@ public class CheckpointBarrierTrackerTest {
 	//  Utils
 	// ------------------------------------------------------------------------
 	private static CheckpointedInputGate createBarrierTracker(int numberOfChannels, BufferOrEvent[] sequence) {
-		return createBarrierTracker(numberOfChannels, sequence, null);
+		return createBarrierTracker(numberOfChannels, sequence, new DummyCheckpointInvokable());
 	}
 
 	private static CheckpointedInputGate createBarrierTracker(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CreditBasedCheckpointBarrierAlignerTest.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 
-import javax.annotation.Nullable;
-
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -32,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 public class CreditBasedCheckpointBarrierAlignerTest extends CheckpointBarrierAlignerTestBase {
 
 	@Override
-	CheckpointedInputGate createBarrierBuffer(InputGate gate, @Nullable AbstractInvokable toNotify) {
+	CheckpointedInputGate createBarrierBuffer(InputGate gate, AbstractInvokable toNotify) {
 		return new CheckpointedInputGate(gate, new CachedBufferStorage(PAGE_SIZE), "Testing", toNotify);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.operators.testutils.DummyCheckpointInvokable;
 import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -86,7 +87,7 @@ public class StreamTaskNetworkInputTest {
 			new CheckpointedInputGate(
 				new MockInputGate(1, buffers, false),
 				new EmptyBufferStorage(),
-				new CheckpointBarrierTracker(1)),
+				new CheckpointBarrierTracker(1, new DummyCheckpointInvokable())),
 			LongSerializer.INSTANCE,
 			ioManager,
 			new StatusWatermarkValve(1, output),
@@ -116,7 +117,7 @@ public class StreamTaskNetworkInputTest {
 			new CheckpointedInputGate(
 				inputGate.getInputGate(),
 				new EmptyBufferStorage(),
-				new CheckpointBarrierTracker(1)),
+				new CheckpointBarrierTracker(1, new DummyCheckpointInvokable())),
 			inSerializer,
 			new StatusWatermarkValve(1, output),
 			0,


### PR DESCRIPTION
## What is the purpose of the change

*The current component `AbstractInvokable` in `CheckpointBarrierHandler` is annotated as `@Nullable`. Actually in real code path it is passed via the constructor and never be null. The nullable annotation is only used for unit test purpose. But this way would mislead the real usage in practice and bring extra troubles, because you have to alway check whether it is null before usage in related processes.*

*We can refactor the related unit tests to implement a dummy `AbstractInvokable` for tests and remove the @Nullable annotation from the related class constructors.*


## Brief change log

  - *Remove `Nullable` annotation from `CheckpointedInputGate`*
  - *Remove `Nullable` annotation from `CheckpointBarrierHandler`*
  - *Introduce `DummyCheckpointInvokable` for tests*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
