### PR TITLE
[FLINK-15565][table-planner-blink] Fix error conversion of TinyInt,SmallInt literals between Flink and Calcite

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -115,6 +115,21 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 				RelDataType decType = relBuilder.getTypeFactory().createSqlType(SqlTypeName.DECIMAL,
 						dt.getPrecision(), dt.getScale());
 				return relBuilder.getRexBuilder().makeExactLiteral(bigDecimal, decType);
+			case TINYINT:
+				return relBuilder.getRexBuilder().makeLiteral(
+						extractValue(valueLiteral, Object.class),
+						typeFactory.createSqlType(SqlTypeName.TINYINT),
+						true);
+			case SMALLINT:
+				return relBuilder.getRexBuilder().makeLiteral(
+						extractValue(valueLiteral, Object.class),
+						typeFactory.createSqlType(SqlTypeName.SMALLINT),
+						true);
+			case INTEGER:
+				return relBuilder.getRexBuilder().makeLiteral(
+						extractValue(valueLiteral, Object.class),
+						typeFactory.createSqlType(SqlTypeName.INTEGER),
+						true);
 			case BIGINT:
 				// create BIGINT literals for long type
 				BigDecimal bigint = extractValue(valueLiteral, BigDecimal.class);

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.planner.delegation.PlannerContext;
+import org.apache.flink.table.planner.plan.metadata.MetadataTestUtil;
+import org.apache.flink.table.planner.plan.trait.FlinkRelDistributionTraitDef;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.plan.ConventionTraitDef;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Test for {@link ExpressionConverter}.
+ */
+public class ExpressionConverterTest {
+
+	private final TableConfig tableConfig = new TableConfig();
+	private final CatalogManager catalogManager = new CatalogManager(
+			"default_catalog",
+			new GenericInMemoryCatalog("default_catalog", "default_database"));
+	private final PlannerContext plannerContext = new PlannerContext(
+			tableConfig,
+			new FunctionCatalog(tableConfig, catalogManager, new ModuleManager()),
+			catalogManager,
+			CalciteSchema.from(MetadataTestUtil.initRootSchema()),
+			Arrays.asList(
+					ConventionTraitDef.INSTANCE,
+					FlinkRelDistributionTraitDef.INSTANCE(),
+					RelCollationTraitDef.INSTANCE
+			)
+	);
+	private final ExpressionConverter converter = new ExpressionConverter(
+			plannerContext.createRelBuilder("default_catalog", "default_database"));
+
+	@Test
+	public void testLiteral() {
+		RexNode rex = converter.visit(new ValueLiteralExpression((byte) 1, DataTypes.TINYINT()));
+		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
+		Assert.assertEquals(SqlTypeName.TINYINT, rex.getType().getSqlTypeName());
+
+		rex = converter.visit(new ValueLiteralExpression((short) 1, DataTypes.SMALLINT()));
+		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
+		Assert.assertEquals(SqlTypeName.SMALLINT, rex.getType().getSqlTypeName());
+
+		rex = converter.visit(new ValueLiteralExpression(1, DataTypes.INT()));
+		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
+		Assert.assertEquals(SqlTypeName.INTEGER, rex.getType().getSqlTypeName());
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
@@ -1007,6 +1007,28 @@ class OverWindowITCase extends BatchTestBase {
         row(5, 1, 10)
       )
     )
+
+    // test tinyint and smallint.
+    checkResult(
+      "SELECT d, h, dense_rank() over (order by cast(d as tinyint), cast(h as smallint) desc) FROM Table5",
+      Seq(
+        row(1, 1, 1),
+        row(2, 2, 2),
+        row(2, 1, 3),
+        row(3, 3, 4),
+        row(3, 2, 5),
+        row(3, 2, 5),
+        row(4, 2, 6),
+        row(4, 2, 6),
+        row(4, 1, 7),
+        row(4, 1, 7),
+        row(5, 3, 8),
+        row(5, 3, 8),
+        row(5, 2, 9),
+        row(5, 2, 9),
+        row(5, 1, 10)
+      )
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/OverWindowITCase.scala
@@ -1010,7 +1010,8 @@ class OverWindowITCase extends BatchTestBase {
 
     // test tinyint and smallint.
     checkResult(
-      "SELECT d, h, dense_rank() over (order by cast(d as tinyint), cast(h as smallint) desc) FROM Table5",
+      "SELECT d, h, dense_rank() over (order by cast(d as tinyint), cast(h as smallint) desc)" +
+          " FROM Table5",
       Seq(
         row(1, 1, 1),
         row(2, 2, 2),


### PR DESCRIPTION

## What is the purpose of the change

In ExpressionConverter, we convert Flink expression to Calcite RexNode. For literal, Flink TinyInt/SmallInt literals are wrongly converted to Calcite Int/Int literals. This lead to incompatible types of expression and result type.

## Brief change log

Fix tinyint/smallint/int literals in `ExpressionConverter.visit(ValueLiteralExpression)`.

## Verifying this change

- `ExpressionConverter`
- `OverWindowITCase.testOverWindowWithUDAG11G`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:no

## Documentation

  - Does this pull request introduce a new feature? no