### PR TITLE
[FLINK-15489][web]: add cache control no-cache to log api

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job-manager.service.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { BASE_URL } from 'config';
 
@@ -35,14 +35,20 @@ export class JobManagerService {
    * Load JM logs
    */
   loadLogs() {
-    return this.httpClient.get(`${BASE_URL}/jobmanager/log`, { responseType: 'text' });
+    return this.httpClient.get(`${BASE_URL}/jobmanager/log`, {
+      responseType: 'text',
+      headers: new HttpHeaders().append('Cache-Control', 'no-cache')
+    });
   }
 
   /**
    * Load JM stdout
    */
   loadStdout() {
-    return this.httpClient.get(`${BASE_URL}/jobmanager/stdout`, { responseType: 'text' });
+    return this.httpClient.get(`${BASE_URL}/jobmanager/stdout`, {
+      responseType: 'text',
+      headers: new HttpHeaders().append('Cache-Control', 'no-cache')
+    });
   }
 
   constructor(private httpClient: HttpClient) {}

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { EMPTY, of, ReplaySubject } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
@@ -54,7 +54,10 @@ export class TaskManagerService {
    * @param taskManagerId
    */
   loadLogs(taskManagerId: string) {
-    return this.httpClient.get(`${BASE_URL}/taskmanagers/${taskManagerId}/log`, { responseType: 'text' });
+    return this.httpClient.get(`${BASE_URL}/taskmanagers/${taskManagerId}/log`, {
+      responseType: 'text',
+      headers: new HttpHeaders().append('Cache-Control', 'no-cache')
+    });
   }
 
   /**
@@ -62,7 +65,10 @@ export class TaskManagerService {
    * @param taskManagerId
    */
   loadStdout(taskManagerId: string) {
-    return this.httpClient.get(`${BASE_URL}/taskmanagers/${taskManagerId}/stdout`, { responseType: 'text' });
+    return this.httpClient.get(`${BASE_URL}/taskmanagers/${taskManagerId}/stdout`, {
+      responseType: 'text',
+      headers: new HttpHeaders().append('Cache-Control', 'no-cache')
+    });
   }
 
   constructor(private httpClient: HttpClient) {}


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/FLINK-15489

## Brief change log

support more metric display at once

## Verifying this change

  - *Go to the log page*
  - *Click the refresh button*
  - *Check the network panel if the log with no-cache header*


before:
<img width="1022" alt="before" src="https://user-images.githubusercontent.com/1506722/72252288-f7674f00-3639-11ea-9861-93157e789082.png">


after:
<img width="1190" alt="after" src="https://user-images.githubusercontent.com/1506722/72252293-fa623f80-3639-11ea-8a8a-049bf09b2677.png">



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
