### PR TITLE
[FLINK-15574][table-planner-blink] Remove deprecated logic in LogicalTypeDataTypeConverter.fromDataTypeToLogicalType

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/LogicalTypeDataTypeConverter.java
@@ -18,38 +18,10 @@
 
 package org.apache.flink.table.runtime.types;
 
-import org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo;
-import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.common.typeutils.CompositeType;
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.dataformat.Decimal;
-import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.BinaryStringTypeInfo;
-import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo;
-import org.apache.flink.table.runtime.typeutils.LegacyInstantTypeInfo;
-import org.apache.flink.table.runtime.typeutils.LegacyLocalDateTimeTypeInfo;
-import org.apache.flink.table.runtime.typeutils.LegacyTimestampTypeInfo;
-import org.apache.flink.table.runtime.typeutils.SqlTimestampTypeInfo;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
-import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.MapType;
-import org.apache.flink.table.types.logical.MultisetType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.TypeInformationRawType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.table.types.utils.TypeConversions;
-
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType;
 
 /**
  * Converter between {@link DataType} and {@link LogicalType}.
@@ -70,91 +42,6 @@ public class LogicalTypeDataTypeConverter {
 	 * It convert {@link LegacyTypeInformationType} to planner types.
 	 */
 	public static LogicalType fromDataTypeToLogicalType(DataType dataType) {
-		return dataType.getLogicalType().accept(new LegacyTypeToPlannerTypeConverter());
-	}
-
-	private static class LegacyTypeToPlannerTypeConverter extends LogicalTypeDefaultVisitor<LogicalType> {
-
-		@Override
-		protected LogicalType defaultMethod(LogicalType logicalType) {
-			if (logicalType instanceof LegacyTypeInformationType) {
-				TypeInformation typeInfo = ((LegacyTypeInformationType) logicalType).getTypeInformation();
-				if (typeInfo.equals(BasicTypeInfo.BIG_DEC_TYPE_INFO)) {
-					// BigDecimal have infinity precision and scale, but we converted it into a limited
-					// Decimal(38, 18). If the user's BigDecimal is more precision than this, we will
-					// throw Exception to remind user to use GenericType in real data conversion.
-					return Decimal.DECIMAL_SYSTEM_DEFAULT;
-				} else if (typeInfo.equals(BinaryStringTypeInfo.INSTANCE)) {
-					return DataTypes.STRING().getLogicalType();
-				} else if (typeInfo instanceof BasicArrayTypeInfo) {
-					return new ArrayType(
-							fromTypeInfoToLogicalType(((BasicArrayTypeInfo) typeInfo).getComponentInfo()));
-				} else if (typeInfo instanceof CompositeType) {
-					CompositeType compositeType = (CompositeType) typeInfo;
-					return RowType.of(
-							Stream.iterate(0, x -> x + 1).limit(compositeType.getArity())
-									.map((Function<Integer, TypeInformation>) compositeType::getTypeAt)
-									.map(TypeInfoLogicalTypeConverter::fromTypeInfoToLogicalType)
-									.toArray(LogicalType[]::new),
-							compositeType.getFieldNames()
-					);
-				} else if (typeInfo instanceof DecimalTypeInfo) {
-					DecimalTypeInfo decimalType = (DecimalTypeInfo) typeInfo;
-					return new DecimalType(decimalType.precision(), decimalType.scale());
-				} else if (typeInfo instanceof BigDecimalTypeInfo) {
-					BigDecimalTypeInfo decimalType = (BigDecimalTypeInfo) typeInfo;
-					return new DecimalType(decimalType.precision(), decimalType.scale());
-				} else if (typeInfo instanceof SqlTimestampTypeInfo) {
-					SqlTimestampTypeInfo sqlTimestampTypeInfo = (SqlTimestampTypeInfo) typeInfo;
-					return new TimestampType(sqlTimestampTypeInfo.getPrecision());
-				} else if (typeInfo instanceof LegacyLocalDateTimeTypeInfo) {
-					LegacyLocalDateTimeTypeInfo dateTimeType = (LegacyLocalDateTimeTypeInfo) typeInfo;
-					return new TimestampType(dateTimeType.getPrecision());
-				} else if (typeInfo instanceof LegacyTimestampTypeInfo) {
-					LegacyTimestampTypeInfo timstampType = (LegacyTimestampTypeInfo) typeInfo;
-					return new TimestampType(timstampType.getPrecision());
-				} else if (typeInfo instanceof LegacyInstantTypeInfo) {
-					LegacyInstantTypeInfo instantTypeInfo = (LegacyInstantTypeInfo) typeInfo;
-					return new LocalZonedTimestampType(instantTypeInfo.getPrecision());
-				} else {
-					return new TypeInformationRawType<>(typeInfo);
-				}
-			} else {
-				return logicalType;
-			}
-		}
-
-		@Override
-		public LogicalType visit(ArrayType arrayType) {
-			return new ArrayType(
-					arrayType.isNullable(),
-					arrayType.getElementType().accept(this));
-		}
-
-		@Override
-		public LogicalType visit(MultisetType multisetType) {
-			return new MultisetType(
-					multisetType.isNullable(),
-					multisetType.getElementType().accept(this));
-		}
-
-		@Override
-		public LogicalType visit(MapType mapType) {
-			return new MapType(
-					mapType.isNullable(),
-					mapType.getKeyType().accept(this),
-					mapType.getValueType().accept(this));
-		}
-
-		@Override
-		public LogicalType visit(RowType rowType) {
-			return new RowType(
-					rowType.isNullable(),
-					rowType.getFields().stream().map(field ->
-							new RowType.RowField(
-									field.getName(),
-									field.getType().accept(LegacyTypeToPlannerTypeConverter.this)))
-							.collect(Collectors.toList()));
-		}
+		return TypeConversions.fromDataToLogicalType(dataType);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

It seems there exists 2 paths to do the conversion from DataType to LogicalType:

1. TypeConversions.fromLegacyInfoToDataType():
used for instance when calling TableSchema.fromTypeInformation().

2. LogicalTypeDataTypeConverter.fromDataTypeToLogicalType():
Deprecated but still used in TableSourceUtil and many other places.

These 2 code paths can return a different LogicalType for the same input, leading to the planner throwing a ValidationException when the LogicalTypes are compared to ensure they are compatible.

More info in https://issues.apache.org/jira/browse/FLINK-15574

## Brief change log

- Removed the deprecated logic in LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(), make it call directly TypeConversions.fromDataToLogicalType() instead.

## Verifying this change

This change is already covered by existing tests, such as DataType.getLogicalType() implementations (TypeConversions.fromDataToLogicalType() simply calls DataType.getLogicalType()).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
