### PR TITLE
[FLINK-15576][table] remove isTemporary property from CatalogFunction API

### DIFF
--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -797,13 +797,6 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.isGeneric()
 
-    def is_temporary(self):
-        """
-        Wheter or not the function is a temporary function.
-        :return: Wheter is a temporary function.
-        """
-        return self._j_catalog_function.isTemporary()
-
     def get_function_language(self):
         """
         Get the language used for the function definition.

--- a/flink-python/pyflink/table/tests/test_catalog.py
+++ b/flink-python/pyflink/table/tests/test_catalog.py
@@ -68,7 +68,6 @@ class CatalogTestBase(PyFlinkTestCase):
     def check_catalog_function_equals(self, f1, f2):
         self.assertEqual(f1.get_class_name(), f2.get_class_name())
         self.assertEqual(f1.is_generic(), f2.is_generic())
-        self.assertEqual(f1.is_temporary(), f2.is_temporary())
         self.assertEqual(f1.get_function_language(), f2.get_function_language())
 
     def check_catalog_partition_equals(self, p1, p2):

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -753,7 +753,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		String exMsg = getDDLOpExecuteErrorMsg(createCatalogFunctionOperation.asSummaryString());
 		try {
 			CatalogFunction function = createCatalogFunctionOperation.getCatalogFunction();
-			if (function.isTemporary()) {
+			if (createCatalogFunctionOperation.isTemporary()) {
 				boolean exist = functionCatalog.hasTemporaryCatalogFunction(
 					createCatalogFunctionOperation.getFunctionIdentifier());
 				if (!exist) {
@@ -787,7 +787,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		String exMsg = getDDLOpExecuteErrorMsg(alterCatalogFunctionOperation.asSummaryString());
 		try {
 			CatalogFunction function = alterCatalogFunctionOperation.getCatalogFunction();
-			if (function.isTemporary()) {
+			if (alterCatalogFunctionOperation.isTemporary()) {
 				throw new ValidationException(
 					"Alter temporary catalog function is not supported");
 			} else {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -32,20 +32,17 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class CatalogFunctionImpl implements CatalogFunction {
 	private final String className; // Fully qualified class name of the function
 	private final FunctionLanguage functionLanguage;
-	private final boolean isTemporary;
 
 	public CatalogFunctionImpl(String className) {
-		this(className, FunctionLanguage.JAVA, false);
+		this(className, FunctionLanguage.JAVA);
 	}
 
 	public CatalogFunctionImpl(
 			String className,
-			FunctionLanguage functionLanguage,
-			boolean isTemporary) {
+			FunctionLanguage functionLanguage) {
 		checkArgument(!StringUtils.isNullOrWhitespaceOnly(className), "className cannot be null or empty");
 		this.className = className;
 		this.functionLanguage = checkNotNull(functionLanguage, "functionLanguage cannot be null");
-		this.isTemporary = isTemporary;
 	}
 
 	@Override
@@ -55,7 +52,7 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
 	@Override
 	public CatalogFunction copy() {
-		return new CatalogFunctionImpl(getClassName(), functionLanguage, isTemporary);
+		return new CatalogFunctionImpl(getClassName(), functionLanguage);
 	}
 
 	@Override
@@ -82,11 +79,6 @@ public class CatalogFunctionImpl implements CatalogFunction {
 	}
 
 	@Override
-	public boolean isTemporary() {
-		return isTemporary;
-	}
-
-	@Override
 	public FunctionLanguage getFunctionLanguage() {
 		return functionLanguage;
 	}
@@ -96,8 +88,7 @@ public class CatalogFunctionImpl implements CatalogFunction {
 		return "CatalogFunctionImpl{" +
 			"className='" + getClassName() + "', " +
 			"functionLanguage='" + getFunctionLanguage() + "', " +
-			"isGeneric='" + isGeneric() + "', " +
-			"isTemporary='" + isTemporary() +
+			"isGeneric='" + isGeneric() +
 			"'}";
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterCatalogFunctionOperation.java
@@ -34,14 +34,17 @@ public class AlterCatalogFunctionOperation implements AlterOperation  {
 	private final ObjectIdentifier functionIdentifier;
 	private CatalogFunction catalogFunction;
 	private boolean ifExists;
+	private boolean isTemporary;
 
 	public AlterCatalogFunctionOperation(
 			ObjectIdentifier functionIdentifier,
 			CatalogFunction catalogFunction,
-			boolean ifExists) {
+			boolean ifExists,
+			boolean isTemporary) {
 		this.functionIdentifier = functionIdentifier;
 		this.catalogFunction = catalogFunction;
 		this.ifExists = ifExists;
+		this.isTemporary = isTemporary;
 	}
 
 	public CatalogFunction getCatalogFunction() {
@@ -56,12 +59,17 @@ public class AlterCatalogFunctionOperation implements AlterOperation  {
 		return this.ifExists;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("catalogFunction", catalogFunction.getDetailedDescription());
 		params.put("identifier", functionIdentifier);
 		params.put("ifExists", ifExists);
+		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
 			"ALTER CATALOG FUNCTION",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateCatalogFunctionOperation.java
@@ -34,14 +34,17 @@ public class CreateCatalogFunctionOperation implements CreateOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private CatalogFunction catalogFunction;
 	private boolean ignoreIfExists;
+	private boolean isTemporary;
 
 	public CreateCatalogFunctionOperation(
 		ObjectIdentifier functionIdentifier,
 		CatalogFunction catalogFunction,
-		boolean ignoreIfExists) {
+		boolean ignoreIfExists,
+		boolean isTemporary) {
 		this.functionIdentifier = functionIdentifier;
 		this.catalogFunction = catalogFunction;
 		this.ignoreIfExists = ignoreIfExists;
+		this.isTemporary = isTemporary;
 	}
 
 	public CatalogFunction getCatalogFunction() {
@@ -56,12 +59,17 @@ public class CreateCatalogFunctionOperation implements CreateOperation {
 		return this.ignoreIfExists;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("catalogFunction", catalogFunction.getDetailedDescription());
 		params.put("identifier", functionIdentifier);
 		params.put("ignoreIfExists", ignoreIfExists);
+		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
 			"CREATE CATALOG FUNCTION",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropCatalogFunctionOperation.java
@@ -33,17 +33,14 @@ public class DropCatalogFunctionOperation implements DropOperation {
 	private final ObjectIdentifier functionIdentifier;
 	private final boolean ifExists;
 	private final boolean isTemporary;
-	private final boolean isSystemFunction;
 
 	public DropCatalogFunctionOperation(
 			ObjectIdentifier functionIdentifier,
-			boolean isTemporary,
-			boolean isSystemFunction,
-			boolean ifExists) {
+			boolean ifExists,
+			boolean isTemporary) {
 		this.functionIdentifier = functionIdentifier;
 		this.ifExists = ifExists;
 		this.isTemporary = isTemporary;
-		this.isSystemFunction = isSystemFunction;
 	}
 
 	public ObjectIdentifier getFunctionIdentifier() {
@@ -59,7 +56,6 @@ public class DropCatalogFunctionOperation implements DropOperation {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("identifier", functionIdentifier);
 		params.put("ifExists", ifExists);
-		params.put("isSystemFunction", isSystemFunction);
 		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
@@ -71,10 +67,6 @@ public class DropCatalogFunctionOperation implements DropOperation {
 
 	public boolean isTemporary() {
 		return isTemporary;
-	}
-
-	public boolean isSystemFunction() {
-		return isSystemFunction;
 	}
 
 	public String getFunctionName() {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -162,6 +162,6 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 
 	@Override
 	protected CatalogFunction createAnotherFunction() {
-		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA, false);
+		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogFunction.java
@@ -61,13 +61,6 @@ public interface CatalogFunction {
 	boolean isGeneric();
 
 	/**
-	 * Distinguish if the function is a temporary function.
-	 *
-	 * @return whether the function is a generic function
-	 */
-	boolean isTemporary();
-
-	/**
 	 * Get the language used for the definition of function.
 	 *
 	 * @return  the language type of the function definition

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -252,14 +252,14 @@ public class SqlToOperationConverter {
 			FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
 			CatalogFunction catalogFunction = new CatalogFunctionImpl(
 				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
-				language,
-				sqlCreateFunction.isTemporary());
+				language);
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 			return new CreateCatalogFunctionOperation(
 				identifier,
 				catalogFunction,
-				sqlCreateFunction.isIfNotExists()
+				sqlCreateFunction.isIfNotExists(),
+				sqlCreateFunction.isTemporary()
 			);
 		}
 	}
@@ -273,15 +273,15 @@ public class SqlToOperationConverter {
 		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
 			sqlAlterFunction.getFunctionClassName().getValueAs(String.class),
-			language,
-			sqlAlterFunction.isTemporary());
+			language);
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 		return new AlterCatalogFunctionOperation(
 			identifier,
 			catalogFunction,
-			sqlAlterFunction.isIfExists()
+			sqlAlterFunction.isIfExists(),
+			sqlAlterFunction.isTemporary()
 		);
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -298,9 +298,8 @@ public class SqlToOperationConverter {
 
 			return new DropCatalogFunctionOperation(
 				identifier,
-				sqlDropFunction.isTemporary(),
-				sqlDropFunction.isSystemFunction(),
-				sqlDropFunction.getIfExists()
+				sqlDropFunction.getIfExists(),
+				sqlDropFunction.isTemporary()
 			);
 		}
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -99,7 +99,7 @@ public class FunctionITCase extends StreamingTestBase {
 		} catch (Exception e){
 			assertEquals(e.getMessage(), "Could not execute CREATE CATALOG FUNCTION:" +
 				" (catalogFunction: [Optional[This is a user-defined function]], identifier:" +
-				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false])");
+				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false], isTemporary: [false])");
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -257,15 +257,15 @@ public class SqlToOperationConverter {
 			FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
 			CatalogFunction catalogFunction = new CatalogFunctionImpl(
 				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
-				language,
-				sqlCreateFunction.isTemporary());
+				language);
 
 			ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 			return new CreateCatalogFunctionOperation(
 				identifier,
 				catalogFunction,
-				sqlCreateFunction.isIfNotExists()
+				sqlCreateFunction.isIfNotExists(),
+				sqlCreateFunction.isTemporary()
 			);
 		}
 	}
@@ -279,15 +279,15 @@ public class SqlToOperationConverter {
 		FunctionLanguage language = parseLanguage(sqlAlterFunction.getFunctionLanguage());
 		CatalogFunction catalogFunction = new CatalogFunctionImpl(
 			sqlAlterFunction.getFunctionClassName().getValueAs(String.class),
-			language,
-			sqlAlterFunction.isTemporary());
+			language);
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlAlterFunction.getFunctionIdentifier());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 		return new AlterCatalogFunctionOperation(
 			identifier,
 			catalogFunction,
-			sqlAlterFunction.isIfExists()
+			sqlAlterFunction.isIfExists(),
+			sqlAlterFunction.isTemporary()
 		);
 	}
 
@@ -304,9 +304,8 @@ public class SqlToOperationConverter {
 
 			return new DropCatalogFunctionOperation(
 				identifier,
-				sqlDropFunction.isTemporary(),
-				sqlDropFunction.isSystemFunction(),
-				sqlDropFunction.getIfExists()
+				sqlDropFunction.getIfExists(),
+				sqlDropFunction.isTemporary()
 			);
 		}
 	}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -704,7 +704,7 @@ abstract class TableEnvImpl(
     val exMsg = getDDLOpExecuteErrorMsg(createFunctionOperation.asSummaryString)
     try {
       val function = createFunctionOperation.getCatalogFunction
-      if (function.isTemporary) {
+      if (createFunctionOperation.isTemporary) {
         val exist = functionCatalog.hasTemporaryCatalogFunction(
           createFunctionOperation.getFunctionIdentifier);
         if (!exist) {
@@ -737,7 +737,7 @@ abstract class TableEnvImpl(
     val exMsg = getDDLOpExecuteErrorMsg(alterFunctionOperation.asSummaryString)
     try {
       val function = alterFunctionOperation.getCatalogFunction
-      if (function.isTemporary) {
+      if (alterFunctionOperation.isTemporary) {
         throw new ValidationException("Alter temporary catalog function is not supported")
       } else {
         val catalog = getCatalogOrThrowException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
@@ -106,7 +106,7 @@ public class FunctionITCase extends AbstractTestBase {
 		} catch (Exception e){
 			assertEquals(e.getMessage(), "Could not execute CREATE CATALOG FUNCTION:" +
 				" (catalogFunction: [Optional[This is a user-defined function]], identifier:" +
-				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false])");
+				" [`default_catalog`.`database1`.`f3`], ignoreIfExists: [false], isTemporary: [false])");
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

according to FLIP-79, CatalogFunction shouldn't have "isTemporary" property. Moving that from CatalogFunction to Create/AlterCatalogFunctionOperation

## Brief change log

- removed "isTemporary" property from CatalogFunction
- moved "isTemporary" property from CatalogFunction to Create/AlterCatalogFunctionOperation

## Verifying this change

This change is already covered by existing tests, such as *FunctionITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
