### PR TITLE
[FLINK-15307][failover]Rename Subclasses of FailoverStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/AdaptedRestartPipelinedRegionStrategyNG.java
@@ -29,7 +29,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.GlobalModVersionMismatch;
 import org.apache.flink.runtime.executiongraph.SchedulingUtils;
-import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.executiongraph.restart.RestartCallback;
 import org.apache.flink.runtime.executiongraph.restart.RestartStrategy;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -60,7 +60,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * This failover strategy uses flip1.RestartPipelinedRegionStrategy to make task failover decisions.
+ * This failover strategy uses flip1.RestartPipelinedRegionFailoverStrategy to make task failover decisions.
  */
 public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 
@@ -73,7 +73,7 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 	private final ExecutionVertexVersioner executionVertexVersioner;
 
 	/** The underlying new generation region failover strategy. */
-	private RestartPipelinedRegionStrategy restartPipelinedRegionStrategy;
+	private RestartPipelinedRegionFailoverStrategy restartPipelinedRegionFailoverStrategy;
 
 	public AdaptedRestartPipelinedRegionStrategyNG(final ExecutionGraph executionGraph) {
 		this.executionGraph = checkNotNull(executionGraph);
@@ -96,7 +96,7 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 
 		final ExecutionVertexID vertexID = getExecutionVertexID(taskExecution.getVertex());
 
-		final Set<ExecutionVertexID> tasksToRestart = restartPipelinedRegionStrategy.getTasksNeedingRestart(vertexID, cause);
+		final Set<ExecutionVertexID> tasksToRestart = restartPipelinedRegionFailoverStrategy.getTasksNeedingRestart(vertexID, cause);
 		restartTasks(tasksToRestart);
 	}
 
@@ -292,8 +292,8 @@ public class AdaptedRestartPipelinedRegionStrategyNG extends FailoverStrategy {
 		// build the underlying new generation failover strategy when the executionGraph vertices are all added,
 		// otherwise the failover topology will not be correctly built.
 		// currently it's safe to add it here, as this method is invoked only once in production code.
-		checkState(restartPipelinedRegionStrategy == null, "notifyNewVertices() must be called only once");
-		this.restartPipelinedRegionStrategy = new RestartPipelinedRegionStrategy(
+		checkState(restartPipelinedRegionFailoverStrategy == null, "notifyNewVertices() must be called only once");
+		this.restartPipelinedRegionFailoverStrategy = new RestartPipelinedRegionFailoverStrategy(
 			executionGraph.getFailoverTopology(),
 			executionGraph.getResultPartitionAvailabilityChecker());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoader.java
@@ -29,10 +29,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public final class FailoverStrategyFactoryLoader {
 
-	/** Config name for the {@link RestartAllStrategy}. */
+	/** Config name for the {@link RestartAllFailoverStrategy}. */
 	public static final String FULL_RESTART_STRATEGY_NAME = "full";
 
-	/** Config name for the {@link RestartPipelinedRegionStrategy}. */
+	/** Config name for the {@link RestartPipelinedRegionFailoverStrategy}. */
 	public static final String PIPELINED_REGION_RESTART_STRATEGY_NAME = "region";
 
 	private FailoverStrategyFactoryLoader() {
@@ -57,10 +57,10 @@ public final class FailoverStrategyFactoryLoader {
 
 		switch (strategyParam.toLowerCase()) {
 			case FULL_RESTART_STRATEGY_NAME:
-				return new RestartAllStrategy.Factory();
+				return new RestartAllFailoverStrategy.Factory();
 
 			case PIPELINED_REGION_RESTART_STRATEGY_NAME:
-				return new RestartPipelinedRegionStrategy.Factory();
+				return new RestartPipelinedRegionFailoverStrategy.Factory();
 
 			default:
 				throw new IllegalConfigurationException("Unknown failover strategy: " + strategyParam);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllFailoverStrategy.java
@@ -28,11 +28,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * A failover strategy that proposes to restart all vertices when a vertex fails.
  */
-public class RestartAllStrategy implements FailoverStrategy {
+public class RestartAllFailoverStrategy implements FailoverStrategy {
 
 	private final FailoverTopology<?, ?> topology;
 
-	public RestartAllStrategy(final FailoverTopology<?, ?> topology) {
+	public RestartAllFailoverStrategy(final FailoverTopology<?, ?> topology) {
 		this.topology = checkNotNull(topology);
 	}
 
@@ -51,7 +51,7 @@ public class RestartAllStrategy implements FailoverStrategy {
 	}
 
 	/**
-	 * The factory to instantiate {@link RestartAllStrategy}.
+	 * The factory to instantiate {@link RestartAllFailoverStrategy}.
 	 */
 	public static class Factory implements FailoverStrategy.Factory {
 
@@ -60,7 +60,7 @@ public class RestartAllStrategy implements FailoverStrategy {
 				final FailoverTopology<?, ?> topology,
 				final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
 
-			return new RestartAllStrategy(topology);
+			return new RestartAllFailoverStrategy(topology);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
@@ -42,10 +42,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A failover strategy that proposes to restart involved regions when a vertex fails.
  * A region is defined by this strategy as tasks that communicate via pipelined data exchange.
  */
-public class RestartPipelinedRegionStrategy implements FailoverStrategy {
+public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy {
 
 	/** The log object used for debugging. */
-	private static final Logger LOG = LoggerFactory.getLogger(RestartPipelinedRegionStrategy.class);
+	private static final Logger LOG = LoggerFactory.getLogger(RestartPipelinedRegionFailoverStrategy.class);
 
 	/** The topology containing info about all the vertices and result partitions. */
 	private final FailoverTopology<?, ?> topology;
@@ -66,7 +66,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	 * @param topology containing info about all the vertices and result partitions
 	 */
 	@VisibleForTesting
-	public RestartPipelinedRegionStrategy(FailoverTopology<?, ?> topology) {
+	public RestartPipelinedRegionFailoverStrategy(FailoverTopology<?, ?> topology) {
 		this(topology, resultPartitionID -> true);
 	}
 
@@ -76,7 +76,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	 * @param topology containing info about all the vertices and result partitions
 	 * @param resultPartitionAvailabilityChecker helps to query result partition availability
 	 */
-	public RestartPipelinedRegionStrategy(
+	public RestartPipelinedRegionFailoverStrategy(
 		FailoverTopology<?, ?> topology,
 		ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
 
@@ -262,7 +262,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 	}
 
 	/**
-	 * The factory to instantiate {@link RestartPipelinedRegionStrategy}.
+	 * The factory to instantiate {@link RestartPipelinedRegionFailoverStrategy}.
 	 */
 	public static class Factory implements FailoverStrategy.Factory {
 
@@ -271,7 +271,7 @@ public class RestartPipelinedRegionStrategy implements FailoverStrategy {
 				final FailoverTopology<?, ?> topology,
 				final ResultPartitionAvailabilityChecker resultPartitionAvailabilityChecker) {
 
-			return new RestartPipelinedRegionStrategy(topology, resultPartitionAvailabilityChecker);
+			return new RestartPipelinedRegionFailoverStrategy(topology, resultPartitionAvailabilityChecker);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailoverStrategyFactoryLoaderTest.java
@@ -41,7 +41,7 @@ public class FailoverStrategyFactoryLoaderTest extends TestLogger {
 			FailoverStrategyFactoryLoader.FULL_RESTART_STRATEGY_NAME);
 		assertThat(
 			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
-			instanceOf(RestartAllStrategy.Factory.class));
+			instanceOf(RestartAllFailoverStrategy.Factory.class));
 	}
 
 	@Test
@@ -52,7 +52,7 @@ public class FailoverStrategyFactoryLoaderTest extends TestLogger {
 			FailoverStrategyFactoryLoader.PIPELINED_REGION_RESTART_STRATEGY_NAME);
 		assertThat(
 			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
-			instanceOf(RestartPipelinedRegionStrategy.Factory.class));
+			instanceOf(RestartPipelinedRegionFailoverStrategy.Factory.class));
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class FailoverStrategyFactoryLoaderTest extends TestLogger {
 		final Configuration config = new Configuration();
 		assertThat(
 			FailoverStrategyFactoryLoader.loadFailoverStrategyFactory(config),
-			instanceOf(RestartPipelinedRegionStrategy.Factory.class));
+			instanceOf(RestartPipelinedRegionFailoverStrategy.Factory.class));
 	}
 
 	@Test(expected = IllegalConfigurationException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllFailoverStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartAllFailoverStrategyTest.java
@@ -29,9 +29,9 @@ import java.util.HashSet;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests for {@link RestartAllStrategy}.
+ * Tests for {@link RestartAllFailoverStrategy}.
  */
-public class RestartAllStrategyTest extends TestLogger {
+public class RestartAllFailoverStrategyTest extends TestLogger {
 
 	@Test
 	public void testGetTasksNeedingRestart() {
@@ -46,7 +46,7 @@ public class RestartAllStrategyTest extends TestLogger {
 
 		final TestFailoverTopology topology = topologyBuilder.build();
 
-		final RestartAllStrategy strategy = new RestartAllStrategy(topology);
+		final RestartAllFailoverStrategy strategy = new RestartAllFailoverStrategy(topology);
 
 		assertEquals(
 			new HashSet<>(Arrays.asList(v1.getId(), v2.getId(), v3.getId())),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyBuildingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyBuildingTest.java
@@ -28,9 +28,9 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 
 /**
- * Tests the failover region building logic of the {@link RestartPipelinedRegionStrategy}.
+ * Tests the failover region building logic of the {@link RestartPipelinedRegionFailoverStrategy}.
  */
-public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
+public class RestartPipelinedRegionFailoverStrategyBuildingTest extends TestLogger {
 
 	/**
 	 * Tests that validates that a graph with single unconnected vertices works correctly.
@@ -53,7 +53,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion r1 = strategy.getFailoverRegion(v1.getId());
 		FailoverRegion r2 = strategy.getFailoverRegion(v2.getId());
@@ -91,7 +91,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());
@@ -140,7 +140,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());
@@ -188,7 +188,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion r1 = strategy.getFailoverRegion(v1.getId());
 		FailoverRegion r2 = strategy.getFailoverRegion(v2.getId());
@@ -237,7 +237,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion r1 = strategy.getFailoverRegion(v1.getId());
 		FailoverRegion r2 = strategy.getFailoverRegion(v2.getId());
@@ -283,7 +283,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());
@@ -332,7 +332,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());
@@ -386,7 +386,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion r1 = strategy.getFailoverRegion(v1.getId());
 		FailoverRegion r2 = strategy.getFailoverRegion(v2.getId());
@@ -432,7 +432,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion r1 = strategy.getFailoverRegion(v1.getId());
 		FailoverRegion r2 = strategy.getFailoverRegion(v2.getId());
@@ -474,7 +474,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 		topologyBuilder.setContainsCoLocationConstraints(true);
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());
@@ -510,7 +510,7 @@ public class RestartPipelinedRegionStrategyBuildingTest extends TestLogger {
 		topologyBuilder.setContainsCoLocationConstraints(true);
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		FailoverRegion ra1 = strategy.getFailoverRegion(va1.getId());
 		FailoverRegion ra2 = strategy.getFailoverRegion(va2.getId());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategyTest.java
@@ -37,9 +37,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Tests the failure handling logic of the {@link RestartPipelinedRegionStrategy}.
+ * Tests the failure handling logic of the {@link RestartPipelinedRegionFailoverStrategy}.
  */
-public class RestartPipelinedRegionStrategyTest extends TestLogger {
+public class RestartPipelinedRegionFailoverStrategyTest extends TestLogger {
 
 	/**
 	 * Tests for scenes that a task fails for its own error, in which case the
@@ -76,7 +76,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		// when v1 fails, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -156,7 +156,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		// when v4 fails to consume data from v1, {v1,v4,v5} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();
@@ -252,7 +252,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 		TestFailoverTopology topology = topologyBuilder.build();
 
 		TestResultPartitionAvailabilityChecker availabilityChecker = new TestResultPartitionAvailabilityChecker();
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology, availabilityChecker);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology, availabilityChecker);
 
 		IntermediateResultPartitionID rp1ID = v1.getProducedResults().iterator().next().getId();
 		IntermediateResultPartitionID rp2ID = v2.getProducedResults().iterator().next().getId();
@@ -372,7 +372,7 @@ public class RestartPipelinedRegionStrategyTest extends TestLogger {
 
 		TestFailoverTopology topology = topologyBuilder.build();
 
-		RestartPipelinedRegionStrategy strategy = new RestartPipelinedRegionStrategy(topology);
+		RestartPipelinedRegionFailoverStrategy strategy = new RestartPipelinedRegionFailoverStrategy(topology);
 
 		// when v3 fails due to internal error, {v3,v4,v5,v6} should be restarted
 		HashSet<ExecutionVertexID> expectedResult = new HashSet<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -35,7 +35,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionStrategy;
+import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.TestRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleSlotProvider;
 import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
@@ -736,7 +736,7 @@ public class DefaultSchedulerTest extends TestLogger {
 			NettyShuffleMaster.INSTANCE,
 			NoOpJobMasterPartitionTracker.INSTANCE,
 			schedulingStrategyFactory,
-			new RestartPipelinedRegionStrategy.Factory(),
+			new RestartPipelinedRegionFailoverStrategy.Factory(),
 			testRestartBackoffTimeStrategy,
 			testExecutionVertexOperations,
 			executionVertexVersioner,

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ContinuousFileProcessingCheckpointITCase.java
@@ -76,7 +76,7 @@ public class ContinuousFileProcessingCheckpointITCase extends StreamFaultToleran
 
 	@Before
 	public void createHDFS() throws IOException {
-		if (failoverStrategy.equals(FailoverStrategy.RestartPipelinedRegionStrategy)) {
+		if (failoverStrategy.equals(FailoverStrategy.RestartPipelinedRegionFailoverStrategy)) {
 			// TODO the 'NO_OF_RETRIES' is useless for current RestartPipelinedRegionStrategy,
 			// for this ContinuousFileProcessingCheckpointITCase, using RestartPipelinedRegionStrategy would result in endless running.
 			throw new AssumptionViolatedException("ignored ContinuousFileProcessingCheckpointITCase when using RestartPipelinedRegionStrategy");

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/StreamFaultToleranceTestBase.java
@@ -54,15 +54,15 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
 
 	@Parameterized.Parameters(name = "FailoverStrategy: {0}")
 	public static Collection<FailoverStrategy> parameters() {
-		return Arrays.asList(FailoverStrategy.RestartAllStrategy, FailoverStrategy.RestartPipelinedRegionStrategy);
+		return Arrays.asList(FailoverStrategy.RestartAllFailoverStrategy, FailoverStrategy.RestartPipelinedRegionFailoverStrategy);
 	}
 
 	/**
 	 * The failover strategy to use.
 	 */
 	public enum FailoverStrategy{
-		RestartAllStrategy,
-		RestartPipelinedRegionStrategy
+		RestartAllFailoverStrategy,
+		RestartPipelinedRegionFailoverStrategy
 	}
 
 	@Parameterized.Parameter
@@ -78,10 +78,10 @@ public abstract class StreamFaultToleranceTestBase extends TestLogger {
 	public void setup() throws Exception {
 		Configuration configuration = new Configuration();
 		switch (failoverStrategy) {
-			case RestartPipelinedRegionStrategy:
+			case RestartPipelinedRegionFailoverStrategy:
 				configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "region");
 				break;
-			case RestartAllStrategy:
+			case RestartAllFailoverStrategy:
 				configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
 		}
 


### PR DESCRIPTION
## What is the purpose of the change
Subclasses of FailoverStrategy are easily confused with implementation classes of RestartStrategy
Given that the failover strategy class names are transparent to users 

## Brief change log
  - *Rename Subclasses of FailoverStrategy *


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
