### PR TITLE
[hotfix] [javadocs] fix typo in KafkaTopicPartitionStateWithPunctuatedWatermarks class introduction

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionStateWithPunctuatedWatermarks.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionStateWithPunctuatedWatermarks.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 
 /**
  * A special version of the per-kafka-partition-state that additionally holds
- * a periodic watermark generator (and timestamp extractor) per partition.
+ * a punctuated watermark generator (and timestamp extractor) per partition.
  *
  * <p>This class is not thread safe, but it gives volatile access to the current
  * partition watermark ({@link #getCurrentPartitionWatermark()}).


### PR DESCRIPTION
## What is the purpose of the change
   fix typo in KafkaTopicPartitionStateWithPunctuatedWatermarks class introduction

## Brief change log
  - * fix typo in KafkaTopicPartitionStateWithPunctuatedWatermarks class introduction*

## Verifying this change
  This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
    - Dependencies (does it add or upgrade a dependency): (no)
    - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
    - The serializers: (no)
    - The runtime per-record code paths (performance sensitive): (no)
    - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no )
    - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)