### PR TITLE
[FLINK-15517][Runtime][Configuration][Network] Use back 'network' in 'shuffle' memory config option names

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>taskmanager.memory.flink.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.framework.heap.size</h5></td>
             <td style="word-wrap: break-word;">134217728 bytes</td>
             <td>MemorySize</td>
@@ -57,52 +63,46 @@
             <td>Managed Memory size for TaskExecutors. This is the size of off-heap memory managed by the memory manager, reserved for sorting, hash tables, caching of intermediate results and RocksDB state backend. Memory consumers can either allocate memory from the memory manager in the form of MemorySegments, or reserve bytes from the memory manager and keep their memory usage within that boundary. If unspecified, it will be derived to make up the configured fraction of the Total Flink Memory.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.segment-size</h5></td>
-            <td style="word-wrap: break-word;">32768 bytes</td>
-            <td>MemorySize</td>
-            <td>Size of memory buffers used by the network stack and the memory manager.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.shuffle.fraction</h5></td>
+            <td><h5>taskmanager.memory.network.fraction</h5></td>
             <td style="word-wrap: break-word;">0.1</td>
             <td>Float</td>
-            <td>Fraction of Total Flink Memory to be used as Shuffle Memory. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max size to the same value.</td>
+            <td>Fraction of Total Flink Memory to be used as Network Memory. Network Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Network Memory can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.shuffle.max</h5></td>
+            <td><h5>taskmanager.memory.network.max</h5></td>
             <td style="word-wrap: break-word;">1073741824 bytes</td>
             <td>MemorySize</td>
-            <td>Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
+            <td>Max Network Memory size for TaskExecutors. Network Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Network Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
         <tr>
-            <td><h5>taskmanager.memory.shuffle.min</h5></td>
+            <td><h5>taskmanager.memory.network.min</h5></td>
             <td style="word-wrap: break-word;">67108864 bytes</td>
             <td>MemorySize</td>
-            <td>Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by setting the min/max to the same value.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.task.heap.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>MemorySize</td>
-            <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for tasks. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, Managed Memory and Shuffle Memory.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
-            <td style="word-wrap: break-word;">0 bytes</td>
-            <td>MemorySize</td>
-            <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for tasks. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
-        </tr>
-        <tr>
-            <td><h5>taskmanager.memory.flink.size</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>MemorySize</td>
-            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.</td>
+            <td>Min Network Memory size for TaskExecutors. Network Memory is off-heap memory reserved for ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of Network Memory can be explicitly specified by setting the min/max to the same value.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.process.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
             <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.segment-size</h5></td>
+            <td style="word-wrap: break-word;">32768 bytes</td>
+            <td>MemorySize</td>
+            <td>Size of memory buffers used by the network stack and the memory manager.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.task.heap.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for tasks. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory, Task Off-Heap Memory, Managed Memory and Network Memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.memory.task.off-heap.size</h5></td>
+            <td style="word-wrap: break-word;">0 bytes</td>
+            <td>MemorySize</td>
+            <td>Task Off-Heap Memory size for TaskExecutors. This is the size of off heap memory (JVM direct memory and native memory) reserved for tasks. The configured value will be fully counted when Flink calculates the JVM max direct memory size parameter.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/ops/config.md
+++ b/docs/ops/config.md
@@ -284,9 +284,9 @@ Previously, the number of network buffers was set manually which became a quite 
 (see below). Since Flink 1.3, it is possible to define a fraction of memory that is being used for
 network buffers with the following configuration parameters:
 
-- `taskmanager.memory.shuffle.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
-- `taskmanager.memory.shuffle.min`: Minimum memory size for network buffers (DEFAULT: 64MB),
-- `taskmanager.memory.shuffle.max`: Maximum memory size for network buffers (DEFAULT: 1GB), and
+- `taskmanager.memory.network.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
+- `taskmanager.memory.network.min`: Minimum memory size for network buffers (DEFAULT: 64MB),
+- `taskmanager.memory.network.max`: Maximum memory size for network buffers (DEFAULT: 1GB), and
 - `taskmanager.memory.segment-size`: Size of memory buffers used by the memory manager and the
 network stack in bytes (DEFAULT: 32KB).
 

--- a/docs/ops/config.zh.md
+++ b/docs/ops/config.zh.md
@@ -284,9 +284,9 @@ Previously, the number of network buffers was set manually which became a quite 
 (see below). Since Flink 1.3, it is possible to define a fraction of memory that is being used for
 network buffers with the following configuration parameters:
 
-- `taskmanager.memory.shuffle.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
-- `taskmanager.memory.shuffle.min`: Minimum memory size for network buffers (DEFAULT: 64MB),
-- `taskmanager.memory.shuffle.max`: Maximum memory size for network buffers (DEFAULT: 1GB), and
+- `taskmanager.memory.network.fraction`: Fraction of JVM memory to use for network buffers (DEFAULT: 0.1),
+- `taskmanager.memory.network.min`: Minimum memory size for network buffers (DEFAULT: 64MB),
+- `taskmanager.memory.network.max`: Maximum memory size for network buffers (DEFAULT: 1GB), and
 - `taskmanager.memory.segment-size`: Size of memory buffers used by the memory manager and the
 network stack in bytes (DEFAULT: 32KB).
 

--- a/docs/ops/deployment/yarn_setup.md
+++ b/docs/ops/deployment/yarn_setup.md
@@ -121,7 +121,7 @@ The system will use the configuration in `conf/flink-conf.yaml`. Please follow o
 
 Flink on YARN will overwrite the following configuration parameters `jobmanager.rpc.address` (because the JobManager is always allocated at different machines), `io.tmp.dirs` (we are using the tmp directories given by YARN) and `parallelism.default` if the number of slots has been specified.
 
-If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.memory.shuffle.min=536346624`.
+If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.memory.network.min=536346624`.
 
 The example invocation starts a single container for the ApplicationMaster which runs the Job Manager.
 

--- a/docs/ops/deployment/yarn_setup.zh.md
+++ b/docs/ops/deployment/yarn_setup.zh.md
@@ -121,7 +121,7 @@ The system will use the configuration in `conf/flink-conf.yaml`. Please follow o
 
 Flink on YARN will overwrite the following configuration parameters `jobmanager.rpc.address` (because the JobManager is always allocated at different machines), `io.tmp.dirs` (we are using the tmp directories given by YARN) and `parallelism.default` if the number of slots has been specified.
 
-If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.memory.shuffle.min=536346624`.
+If you don't want to change the configuration file to set configuration parameters, there is the option to pass dynamic properties via the `-D` flag. So you can pass parameters this way: `-Dfs.overwrite-files=true -Dtaskmanager.memory.network.min=536346624`.
 
 The example invocation starts a single container for the ApplicationMaster which runs the Job Manager.
 

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
@@ -53,7 +53,7 @@ public class ExecutorCLI implements CustomCommandLine {
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.shuffle.min=536346624</tt>.
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.network.min=536346624</tt>.
 	 */
 	private final Option dynamicProperties = Option.builder("D")
 			.argName("property=value")

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigurationUtils.java
@@ -180,8 +180,8 @@ public class ConfigurationUtils {
 		checkConfigContains(configs, TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key());
 		checkConfigContains(configs, TaskManagerOptions.TASK_HEAP_MEMORY.key());
 		checkConfigContains(configs, TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key());
-		checkConfigContains(configs, TaskManagerOptions.SHUFFLE_MEMORY_MAX.key());
-		checkConfigContains(configs, TaskManagerOptions.SHUFFLE_MEMORY_MIN.key());
+		checkConfigContains(configs, TaskManagerOptions.NETWORK_MEMORY_MAX.key());
+		checkConfigContains(configs, TaskManagerOptions.NETWORK_MEMORY_MIN.key());
 		checkConfigContains(configs, TaskManagerOptions.MANAGED_MEMORY_SIZE.key());
 
 		return configs;

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -91,8 +91,8 @@ public class NettyShuffleEnvironmentOptions {
 	 * Number of buffers used in the network stack. This defines the number of possible tasks and
 	 * shuffles.
 	 *
-	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_FRACTION}, {@link TaskManagerOptions#SHUFFLE_MEMORY_MIN},
-	 * and {@link TaskManagerOptions#SHUFFLE_MEMORY_MAX} instead
+	 * @deprecated use {@link TaskManagerOptions#NETWORK_MEMORY_FRACTION}, {@link TaskManagerOptions#NETWORK_MEMORY_MIN},
+	 * and {@link TaskManagerOptions#NETWORK_MEMORY_MAX} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<Integer> NETWORK_NUM_BUFFERS =
@@ -102,7 +102,7 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Fraction of JVM memory to use for network buffers.
 	 *
-	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_FRACTION} instead
+	 * @deprecated use {@link TaskManagerOptions#NETWORK_MEMORY_FRACTION} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<Float> NETWORK_BUFFERS_MEMORY_FRACTION =
@@ -117,7 +117,7 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Minimum memory size for network buffers.
 	 *
-	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_MIN} instead
+	 * @deprecated use {@link TaskManagerOptions#NETWORK_MEMORY_MIN} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MIN =
@@ -128,7 +128,7 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Maximum memory size for network buffers.
 	 *
-	 * @deprecated use {@link TaskManagerOptions#SHUFFLE_MEMORY_MAX} instead
+	 * @deprecated use {@link TaskManagerOptions#NETWORK_MEMORY_MAX} instead
 	 */
 	@Deprecated
 	public static final ConfigOption<String> NETWORK_BUFFERS_MEMORY_MAX =

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -270,7 +270,7 @@ public class TaskManagerOptions {
 		.noDefaultValue()
 		.withDescription("Total Flink Memory size for the TaskExecutors. This includes all the memory that a"
 			+ " TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory,"
-			+ " Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Shuffle Memory.");
+			+ " Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory.");
 
 	/**
 	 * Framework Heap Memory size for TaskExecutors.
@@ -303,7 +303,7 @@ public class TaskManagerOptions {
 			.noDefaultValue()
 			.withDescription("Task Heap Memory size for TaskExecutors. This is the size of JVM heap memory reserved for"
 				+ " tasks. If not specified, it will be derived as Total Flink Memory minus Framework Heap Memory,"
-				+ " Task Off-Heap Memory, Managed Memory and Shuffle Memory.");
+				+ " Task Off-Heap Memory, Managed Memory and Network Memory.");
 
 	/**
 	 * Task Off-Heap Memory size for TaskExecutors.
@@ -342,45 +342,45 @@ public class TaskManagerOptions {
 				+ " explicitly specified.");
 
 	/**
-	 * Min Shuffle Memory size for TaskExecutors.
+	 * Min Network Memory size for TaskExecutors.
 	 */
-	public static final ConfigOption<MemorySize> SHUFFLE_MEMORY_MIN =
-		key("taskmanager.memory.shuffle.min")
+	public static final ConfigOption<MemorySize> NETWORK_MEMORY_MIN =
+		key("taskmanager.memory.network.min")
 			.memoryType()
 			.defaultValue(MemorySize.parse("64m"))
 			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MIN.key())
-			.withDescription("Min Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for"
-				+ " ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured"
+			.withDescription("Min Network Memory size for TaskExecutors. Network Memory is off-heap memory reserved for"
+				+ " ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to make up the configured"
 				+ " fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max"
-				+ " size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by"
+				+ " size, the min/max size will be used. The exact size of Network Memory can be explicitly specified by"
 				+ " setting the min/max to the same value.");
 
 	/**
-	 * Max Shuffle Memory size for TaskExecutors.
+	 * Max Network Memory size for TaskExecutors.
 	 */
-	public static final ConfigOption<MemorySize> SHUFFLE_MEMORY_MAX =
-		key("taskmanager.memory.shuffle.max")
+	public static final ConfigOption<MemorySize> NETWORK_MEMORY_MAX =
+		key("taskmanager.memory.network.max")
 			.memoryType()
 			.defaultValue(MemorySize.parse("1g"))
 			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX.key())
-			.withDescription("Max Shuffle Memory size for TaskExecutors. Shuffle Memory is off-heap memory reserved for"
-				+ " ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to make up the configured"
+			.withDescription("Max Network Memory size for TaskExecutors. Network Memory is off-heap memory reserved for"
+				+ " ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to make up the configured"
 				+ " fraction of the Total Flink Memory. If the derived size is less/greater than the configured min/max"
-				+ " size, the min/max size will be used. The exact size of Shuffle Memory can be explicitly specified by"
+				+ " size, the min/max size will be used. The exact size of Network Memory can be explicitly specified by"
 				+ " setting the min/max to the same value.");
 
 	/**
-	 * Fraction of Total Flink Memory to be used as Shuffle Memory.
+	 * Fraction of Total Flink Memory to be used as Network Memory.
 	 */
-	public static final ConfigOption<Float> SHUFFLE_MEMORY_FRACTION =
-		key("taskmanager.memory.shuffle.fraction")
+	public static final ConfigOption<Float> NETWORK_MEMORY_FRACTION =
+		key("taskmanager.memory.network.fraction")
 			.floatType()
 			.defaultValue(0.1f)
 			.withDeprecatedKeys(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_FRACTION.key())
-			.withDescription("Fraction of Total Flink Memory to be used as Shuffle Memory. Shuffle Memory is off-heap"
-				+ " memory reserved for ShuffleEnvironment (e.g., network buffers). Shuffle Memory size is derived to"
+			.withDescription("Fraction of Total Flink Memory to be used as Network Memory. Network Memory is off-heap"
+				+ " memory reserved for ShuffleEnvironment (e.g., network buffers). Network Memory size is derived to"
 				+ " make up the configured fraction of the Total Flink Memory. If the derived size is less/greater than"
-				+ " the configured min/max size, the min/max size will be used. The exact size of Shuffle Memory can be"
+				+ " the configured min/max size, the min/max size will be used. The exact size of Network Memory can be"
 				+ " explicitly specified by setting the min/max size to the same value.");
 
 	/**

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -186,9 +186,9 @@ jobmanager.execution.failover-strategy: region
 # no tuning. Adjusting them may be necessary in case of an "Insufficient number
 # of network buffers" error. The default min is 64MB, the default max is 1GB.
 # 
-# taskmanager.memory.shuffle.fraction: 0.1
-# taskmanager.memory.shuffle.min: 64mb
-# taskmanager.memory.shuffle.max: 1gb
+# taskmanager.memory.network.fraction: 0.1
+# taskmanager.memory.network.min: 64mb
+# taskmanager.memory.network.max: 1gb
 
 #==============================================================================
 # Flink Cluster Security Configuration

--- a/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
+++ b/flink-end-to-end-tests/test-scripts/test_batch_allround.sh
@@ -26,8 +26,8 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-dataset-allround-test/target/DataSetAll
 echo "Run DataSet-Allround-Test Program"
 
 # modify configuration to include spilling to disk
-set_config_key "taskmanager.memory.shuffle.min" "111149056"
-set_config_key "taskmanager.memory.shuffle.max" "111149056"
+set_config_key "taskmanager.memory.network.min" "111149056"
+set_config_key "taskmanager.memory.network.max" "111149056"
 
 set_conf_ssl "server"
 start_cluster

--- a/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
+++ b/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
@@ -31,8 +31,8 @@ set_config_key "web.timeout" "60000"
 set_config_key "taskmanager.memory.process.size" "1024m" # 1024Mb x 5TMs = 5Gb total heap
 
 set_config_key "taskmanager.memory.managed.size" "8" # 8Mb
-set_config_key "taskmanager.memory.shuffle.min" "128mb"
-set_config_key "taskmanager.memory.shuffle.max" "128mb"
+set_config_key "taskmanager.memory.network.min" "128mb"
+set_config_key "taskmanager.memory.network.max" "128mb"
 set_config_key "taskmanager.network.request-backoff.max" "60000"
 set_config_key "taskmanager.memory.segment-size" "8kb"
 set_config_key "taskmanager.memory.jvm-metaspace.size" "64m"

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -30,8 +30,8 @@ TEST_PROGRAM_NAME=HighParallelismIterationsTestProgram
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 
 set_config_key "taskmanager.numberOfTaskSlots" "$SLOTS_PER_TM"
-set_config_key "taskmanager.memory.shuffle.min" "160m"
-set_config_key "taskmanager.memory.shuffle.max" "160m"
+set_config_key "taskmanager.memory.network.min" "160m"
+set_config_key "taskmanager.memory.network.max" "160m"
 
 print_mem_use
 start_cluster

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -73,7 +73,7 @@ public class KubernetesUtilsTest extends TestLogger {
 		new MemorySize(0), // frameworkOffHeapSize
 		new MemorySize(111), // taskHeapSize
 		new MemorySize(0), // taskOffHeapSize
-		new MemorySize(222), // shuffleMemSize
+		new MemorySize(222), // networkMemSize
 		new MemorySize(0), // managedMemorySize
 		new MemorySize(333), // jvmMetaspaceSize
 		new MemorySize(0)); // jvmOverheadSize

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -348,7 +348,7 @@ public class BootstrapTools {
 	 * Get an instance of the dynamic properties option.
 	 *
 	 * <p>Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.shuffle.min=536346624</tt>
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.network.min=536346624</tt>
      */
 	public static Option newDynamicPropertiesOption() {
 		return new Option(DYNAMIC_PROPERTIES_OPT, true, "Dynamic properties");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorResourceSpec.java
@@ -32,7 +32,7 @@ import java.io.Serializable;
  *     <li>Framework Off-Heap Memory</li>
  *     <li>Task Heap Memory</li>
  *     <li>Task Off-Heap Memory</li>
- *     <li>Shuffle Memory</li>
+ *     <li>Network Memory</li>
  *     <li>Managed Memory</li>
  *     <li>JVM Metaspace</li>
  *     <li>JVM Overhead</li>
@@ -58,7 +58,7 @@ import java.io.Serializable;
  *            ├─  ││   Task Off-Heap Memory    ││
  *            │  │ └───────────────────────────┘ │
  *            │   │┌───────────────────────────┐│
- *            ├─ │ │      Shuffle Memory       │ │
+ *            ├─ │ │      Network Memory       │ │
  *            │   │└───────────────────────────┘│
  *            │  │ ┌───────────────────────────┐ │
  *  Off-Heap ─┼─   │      Managed Memory       │
@@ -85,7 +85,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 
 	private final MemorySize taskOffHeapSize;
 
-	private final MemorySize shuffleMemSize;
+	private final MemorySize networkMemSize;
 
 	private final MemorySize managedMemorySize;
 
@@ -99,7 +99,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 		MemorySize frameworkOffHeapSize,
 		MemorySize taskHeapSize,
 		MemorySize taskOffHeapSize,
-		MemorySize shuffleMemSize,
+		MemorySize networkMemSize,
 		MemorySize managedMemorySize,
 		MemorySize jvmMetaspaceSize,
 		MemorySize jvmOverheadSize) {
@@ -109,7 +109,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 		this.frameworkOffHeapMemorySize = frameworkOffHeapSize;
 		this.taskHeapSize = taskHeapSize;
 		this.taskOffHeapSize = taskOffHeapSize;
-		this.shuffleMemSize = shuffleMemSize;
+		this.networkMemSize = networkMemSize;
 		this.managedMemorySize = managedMemorySize;
 		this.jvmMetaspaceSize = jvmMetaspaceSize;
 		this.jvmOverheadSize = jvmOverheadSize;
@@ -135,8 +135,8 @@ public class TaskExecutorResourceSpec implements Serializable {
 		return taskOffHeapSize;
 	}
 
-	public MemorySize getShuffleMemSize() {
-		return shuffleMemSize;
+	public MemorySize getNetworkMemSize() {
+		return networkMemSize;
 	}
 
 	public MemorySize getManagedMemorySize() {
@@ -152,7 +152,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 	}
 
 	public MemorySize getTotalFlinkMemorySize() {
-		return frameworkHeapSize.add(frameworkOffHeapMemorySize).add(taskHeapSize).add(taskOffHeapSize).add(shuffleMemSize).add(getManagedMemorySize());
+		return frameworkHeapSize.add(frameworkOffHeapMemorySize).add(taskHeapSize).add(taskOffHeapSize).add(networkMemSize).add(getManagedMemorySize());
 	}
 
 	public MemorySize getTotalProcessMemorySize() {
@@ -164,7 +164,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 	}
 
 	public MemorySize getJvmDirectMemorySize() {
-		return frameworkOffHeapMemorySize.add(taskOffHeapSize).add(shuffleMemSize);
+		return frameworkOffHeapMemorySize.add(taskOffHeapSize).add(networkMemSize);
 	}
 
 	@Override
@@ -175,7 +175,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toString()
 			+ ", taskHeapSize=" + taskHeapSize.toString()
 			+ ", taskOffHeapSize=" + taskOffHeapSize.toString()
-			+ ", shuffleMemSize=" + shuffleMemSize.toString()
+			+ ", networkMemSize=" + networkMemSize.toString()
 			+ ", managedMemorySize=" + managedMemorySize.toString()
 			+ ", jvmMetaspaceSize=" + jvmMetaspaceSize.toString()
 			+ ", jvmOverheadSize=" + jvmOverheadSize.toString()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -72,7 +72,7 @@ public class ResourceProfile implements Serializable {
 		.setTaskHeapMemory(MemorySize.MAX_VALUE)
 		.setTaskOffHeapMemory(MemorySize.MAX_VALUE)
 		.setManagedMemory(MemorySize.MAX_VALUE)
-		.setShuffleMemory(MemorySize.MAX_VALUE)
+		.setNetworkMemory(MemorySize.MAX_VALUE)
 		.build();
 
 	/** A ResourceProfile describing zero resources. */
@@ -96,9 +96,9 @@ public class ResourceProfile implements Serializable {
 	@Nullable // can be null only for UNKNOWN
 	private final MemorySize managedMemory;
 
-	/** How much shuffle memory is needed. */
+	/** How much network memory is needed. */
 	@Nullable // can be null only for UNKNOWN
-	private final MemorySize shuffleMemory;
+	private final MemorySize networkMemory;
 
 	/** A extensible field for user specified resources from {@link ResourceSpec}. */
 	private final Map<String, Resource> extendedResources = new HashMap<>(1);
@@ -112,7 +112,7 @@ public class ResourceProfile implements Serializable {
 	 * @param taskHeapMemory The size of the task heap memory.
 	 * @param taskOffHeapMemory The size of the task off-heap memory.
 	 * @param managedMemory The size of the managed memory.
-	 * @param shuffleMemory The size of the shuffle memory.
+	 * @param networkMemory The size of the network memory.
 	 * @param extendedResources The extended resources such as GPU and FPGA
 	 */
 	private ResourceProfile(
@@ -120,7 +120,7 @@ public class ResourceProfile implements Serializable {
 			final MemorySize taskHeapMemory,
 			final MemorySize taskOffHeapMemory,
 			final MemorySize managedMemory,
-			final MemorySize shuffleMemory,
+			final MemorySize networkMemory,
 			final Map<String, Resource> extendedResources) {
 
 		checkNotNull(cpuCores);
@@ -130,7 +130,7 @@ public class ResourceProfile implements Serializable {
 		this.taskHeapMemory = checkNotNull(taskHeapMemory);
 		this.taskOffHeapMemory = checkNotNull(taskOffHeapMemory);
 		this.managedMemory = checkNotNull(managedMemory);
-		this.shuffleMemory = checkNotNull(shuffleMemory);
+		this.networkMemory = checkNotNull(networkMemory);
 		if (extendedResources != null) {
 			this.extendedResources.putAll(extendedResources);
 		}
@@ -144,7 +144,7 @@ public class ResourceProfile implements Serializable {
 		this.taskHeapMemory = null;
 		this.taskOffHeapMemory = null;
 		this.managedMemory = null;
-		this.shuffleMemory = null;
+		this.networkMemory = null;
 	}
 
 	// ------------------------------------------------------------------------
@@ -190,13 +190,13 @@ public class ResourceProfile implements Serializable {
 	}
 
 	/**
-	 * Get the shuffle memory needed.
+	 * Get the network memory needed.
 	 *
-	 * @return The shuffle memory
+	 * @return The network memory
 	 */
-	public MemorySize getShuffleMemory() {
+	public MemorySize getNetworkMemory() {
 		throwUnsupportedOperationExecptionIfUnknown();
-		return shuffleMemory;
+		return networkMemory;
 	}
 
 	/**
@@ -206,7 +206,7 @@ public class ResourceProfile implements Serializable {
 	 */
 	public MemorySize getTotalMemory() {
 		throwUnsupportedOperationExecptionIfUnknown();
-		return getOperatorsMemory().add(shuffleMemory);
+		return getOperatorsMemory().add(networkMemory);
 	}
 
 	/**
@@ -264,7 +264,7 @@ public class ResourceProfile implements Serializable {
 			taskHeapMemory.compareTo(required.taskHeapMemory) >= 0 &&
 			taskOffHeapMemory.compareTo(required.taskOffHeapMemory) >= 0 &&
 			managedMemory.compareTo(required.managedMemory) >= 0 &&
-			shuffleMemory.compareTo(required.shuffleMemory) >= 0) {
+			networkMemory.compareTo(required.networkMemory) >= 0) {
 
 			for (Map.Entry<String, Resource> resource : required.extendedResources.entrySet()) {
 				if (!extendedResources.containsKey(resource.getKey()) ||
@@ -285,7 +285,7 @@ public class ResourceProfile implements Serializable {
 		result = 31 * result + Objects.hashCode(taskHeapMemory);
 		result = 31 * result + Objects.hashCode(taskOffHeapMemory);
 		result = 31 * result + Objects.hashCode(managedMemory);
-		result = 31 * result + Objects.hashCode(shuffleMemory);
+		result = 31 * result + Objects.hashCode(networkMemory);
 		result = 31 * result + extendedResources.hashCode();
 		return result;
 	}
@@ -300,7 +300,7 @@ public class ResourceProfile implements Serializable {
 				Objects.equals(taskHeapMemory, that.taskHeapMemory) &&
 				Objects.equals(taskOffHeapMemory, that.taskOffHeapMemory) &&
 				Objects.equals(managedMemory, that.managedMemory) &&
-				Objects.equals(shuffleMemory, that.shuffleMemory) &&
+				Objects.equals(networkMemory, that.networkMemory) &&
 				Objects.equals(extendedResources, that.extendedResources);
 		}
 		return false;
@@ -336,7 +336,7 @@ public class ResourceProfile implements Serializable {
 			taskHeapMemory.add(other.taskHeapMemory),
 			taskOffHeapMemory.add(other.taskOffHeapMemory),
 			managedMemory.add(other.managedMemory),
-			shuffleMemory.add(other.shuffleMemory),
+			networkMemory.add(other.networkMemory),
 			resultExtendedResource);
 	}
 
@@ -373,7 +373,7 @@ public class ResourceProfile implements Serializable {
 			taskHeapMemory.subtract(other.taskHeapMemory),
 			taskOffHeapMemory.subtract(other.taskOffHeapMemory),
 			managedMemory.subtract(other.managedMemory),
-			shuffleMemory.subtract(other.shuffleMemory),
+			networkMemory.subtract(other.networkMemory),
 			resultExtendedResource
 		);
 	}
@@ -397,7 +397,7 @@ public class ResourceProfile implements Serializable {
 			", taskHeapMemory=" + taskHeapMemory +
 			", taskOffHeapMemory=" + taskOffHeapMemory +
 			", managedMemory=" + managedMemory +
-			", shuffleMemory=" + shuffleMemory + resources +
+			", networkMemory=" + networkMemory + resources +
 			'}';
 	}
 
@@ -438,7 +438,7 @@ public class ResourceProfile implements Serializable {
 			.setTaskHeapMemory(resourceSpec.getTaskHeapMemory())
 			.setTaskOffHeapMemory(resourceSpec.getTaskOffHeapMemory())
 			.setManagedMemory(resourceSpec.getManagedMemory())
-			.setShuffleMemory(networkMemory)
+			.setNetworkMemory(networkMemory)
 			.addExtendedResources(resourceSpec.getExtendedResources())
 			.build();
 	}
@@ -464,7 +464,7 @@ public class ResourceProfile implements Serializable {
 		private MemorySize taskHeapMemory = MemorySize.ZERO;
 		private MemorySize taskOffHeapMemory = MemorySize.ZERO;
 		private MemorySize managedMemory = MemorySize.ZERO;
-		private MemorySize shuffleMemory = MemorySize.ZERO;
+		private MemorySize networkMemory = MemorySize.ZERO;
 		private Map<String, Resource> extendedResources = new HashMap<>();
 
 		private Builder() {
@@ -510,13 +510,13 @@ public class ResourceProfile implements Serializable {
 			return this;
 		}
 
-		public Builder setShuffleMemory(MemorySize shuffleMemory) {
-			this.shuffleMemory = shuffleMemory;
+		public Builder setNetworkMemory(MemorySize networkMemory) {
+			this.networkMemory = networkMemory;
 			return this;
 		}
 
-		public Builder setShuffleMemoryMB(int shuffleMemoryMB) {
-			this.shuffleMemory = MemorySize.parse(shuffleMemoryMB + "m");
+		public Builder setNetworkMemoryMB(int networkMemoryMB) {
+			this.networkMemory = MemorySize.parse(networkMemoryMB + "m");
 			return this;
 		}
 
@@ -538,7 +538,7 @@ public class ResourceProfile implements Serializable {
 				taskHeapMemory,
 				taskOffHeapMemory,
 				managedMemory,
-				shuffleMemory,
+				networkMemory,
 				extendedResources);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -58,7 +58,7 @@ public class NettyShuffleServiceFactory implements ShuffleServiceFactory<NettySh
 		checkNotNull(shuffleEnvironmentContext);
 		NettyShuffleEnvironmentConfiguration networkConfig = NettyShuffleEnvironmentConfiguration.fromConfiguration(
 			shuffleEnvironmentContext.getConfiguration(),
-			shuffleEnvironmentContext.getShuffleMemorySize(),
+			shuffleEnvironmentContext.getNetworkMemorySize(),
 			shuffleEnvironmentContext.isLocalCommunicationOnly(),
 			shuffleEnvironmentContext.getHostAddress());
 		return createNettyShuffleEnvironment(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -505,8 +505,8 @@ public class NetworkBufferPool implements BufferPoolFactory, MemorySegmentProvid
 						"You can increase this number by setting the configuration keys '%s', '%s', and '%s'",
 				totalNumberOfMemorySegments,
 				memorySegmentSize,
-				TaskManagerOptions.SHUFFLE_MEMORY_FRACTION.key(),
-				TaskManagerOptions.SHUFFLE_MEMORY_MIN.key(),
-				TaskManagerOptions.SHUFFLE_MEMORY_MAX.key());
+				TaskManagerOptions.NETWORK_MEMORY_FRACTION.key(),
+				TaskManagerOptions.NETWORK_MEMORY_MIN.key(),
+				TaskManagerOptions.NETWORK_MEMORY_MAX.key());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -99,10 +99,10 @@ public class MiniClusterConfiguration {
 			toBeModifiedConfiguration.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("100m"));
 		}
 
-		if (!TaskExecutorResourceUtils.isShuffleMemoryExplicitlyConfigured(toBeModifiedConfiguration)) {
-			toBeModifiedConfiguration.set(TaskManagerOptions.SHUFFLE_MEMORY_MIN, DEFAULT_SHUFFLE_MEMORY_SIZE);
-			toBeModifiedConfiguration.set(TaskManagerOptions.SHUFFLE_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
-			LOG.info("Shuffle memory is not explicitly configured, use {} for local execution.", DEFAULT_SHUFFLE_MEMORY_SIZE);
+		if (!TaskExecutorResourceUtils.isNetworkMemoryExplicitlyConfigured(toBeModifiedConfiguration)) {
+			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, DEFAULT_SHUFFLE_MEMORY_SIZE);
+			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
+			LOG.info("Network memory is not explicitly configured, use {} for local execution.", DEFAULT_SHUFFLE_MEMORY_SIZE);
 		}
 
 		if (!TaskExecutorResourceUtils.isManagedMemorySizeExplicitlyConfigured(toBeModifiedConfiguration)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
@@ -34,7 +34,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ShuffleEnvironmentContext {
 	private final Configuration configuration;
 	private final ResourceID taskExecutorResourceId;
-	private final MemorySize shuffleMemorySize;
+	private final MemorySize networkMemorySize;
 	private final boolean localCommunicationOnly;
 	private final InetAddress hostAddress;
 	private final TaskEventPublisher eventPublisher;
@@ -43,14 +43,14 @@ public class ShuffleEnvironmentContext {
 	public ShuffleEnvironmentContext(
 			Configuration configuration,
 			ResourceID taskExecutorResourceId,
-			MemorySize shuffleMemorySize,
+			MemorySize networkMemorySize,
 			boolean localCommunicationOnly,
 			InetAddress hostAddress,
 			TaskEventPublisher eventPublisher,
 			MetricGroup parentMetricGroup) {
 		this.configuration = checkNotNull(configuration);
 		this.taskExecutorResourceId = checkNotNull(taskExecutorResourceId);
-		this.shuffleMemorySize = shuffleMemorySize;
+		this.networkMemorySize = networkMemorySize;
 		this.localCommunicationOnly = localCommunicationOnly;
 		this.hostAddress = checkNotNull(hostAddress);
 		this.eventPublisher = checkNotNull(eventPublisher);
@@ -65,8 +65,8 @@ public class ShuffleEnvironmentContext {
 		return taskExecutorResourceId;
 	}
 
-	public MemorySize getShuffleMemorySize() {
-		return shuffleMemorySize;
+	public MemorySize getNetworkMemorySize() {
+		return networkMemorySize;
 	}
 
 	public boolean isLocalCommunicationOnly() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -302,7 +302,7 @@ public class TaskManagerServices {
 		final ShuffleEnvironmentContext shuffleEnvironmentContext = new ShuffleEnvironmentContext(
 			taskManagerServicesConfiguration.getConfiguration(),
 			taskManagerServicesConfiguration.getResourceID(),
-			taskManagerServicesConfiguration.getShuffleMemorySize(),
+			taskManagerServicesConfiguration.getNetworkMemorySize(),
 			taskManagerServicesConfiguration.isLocalCommunicationOnly(),
 			taskManagerServicesConfiguration.getTaskManagerAddress(),
 			taskEventDispatcher,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -159,8 +159,8 @@ public class TaskManagerServicesConfiguration {
 		return taskExecutorResourceSpec;
 	}
 
-	public MemorySize getShuffleMemorySize() {
-		return taskExecutorResourceSpec.getShuffleMemSize();
+	public MemorySize getNetworkMemorySize() {
+		return taskExecutorResourceSpec.getNetworkMemSize();
 	}
 
 	public MemorySize getManagedMemorySize() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -171,14 +171,14 @@ public class NettyShuffleEnvironmentConfiguration {
 	 * sanity check them.
 	 *
 	 * @param configuration configuration object
-	 * @param shuffleMemorySize the size of memory reserved for shuffle environment
+	 * @param networkMemorySize the size of memory reserved for shuffle environment
 	 * @param localTaskManagerCommunication true, to skip initializing the network stack
 	 * @param taskManagerAddress identifying the IP address under which the TaskManager will be accessible
 	 * @return NettyShuffleEnvironmentConfiguration
 	 */
 	public static NettyShuffleEnvironmentConfiguration fromConfiguration(
 		Configuration configuration,
-		MemorySize shuffleMemorySize,
+		MemorySize networkMemorySize,
 		boolean localTaskManagerCommunication,
 		InetAddress taskManagerAddress) {
 
@@ -190,7 +190,7 @@ public class NettyShuffleEnvironmentConfiguration {
 
 		final int numberOfNetworkBuffers = calculateNumberOfNetworkBuffers(
 			configuration,
-			shuffleMemorySize,
+			networkMemorySize,
 			pageSize);
 
 		int initialRequestBackoff = configuration.getInteger(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_INITIAL);
@@ -250,21 +250,21 @@ public class NettyShuffleEnvironmentConfiguration {
 	 * Calculates the number of network buffers based on configuration and jvm heap size.
 	 *
 	 * @param configuration configuration object
-	 * @param shuffleMemorySize the size of memory reserved for shuffle environment
+	 * @param networkMemorySize the size of memory reserved for shuffle environment
 	 * @param pageSize size of memory segment
 	 * @return the number of network buffers
 	 */
 	private static int calculateNumberOfNetworkBuffers(
 		Configuration configuration,
-		MemorySize shuffleMemorySize,
+		MemorySize networkMemorySize,
 		int pageSize) {
 
 		logIfIgnoringOldConfigs(configuration);
 
 		// tolerate offcuts between intended and allocated memory due to segmentation (will be available to the user-space memory)
-		long numberOfNetworkBuffersLong = shuffleMemorySize.getBytes() / pageSize;
+		long numberOfNetworkBuffersLong = networkMemorySize.getBytes() / pageSize;
 		if (numberOfNetworkBuffersLong > Integer.MAX_VALUE) {
-			throw new IllegalArgumentException("The given number of memory bytes (" + shuffleMemorySize.getBytes()
+			throw new IllegalArgumentException("The given number of memory bytes (" + networkMemorySize.getBytes()
 				+ ") corresponds to more than MAX_INT pages.");
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -155,7 +155,7 @@ public class BootstrapToolsTest extends TestLogger {
 			new MemorySize(0), // frameworkOffHeapSize
 			new MemorySize(111), // taskHeapSize
 			new MemorySize(0), // taskOffHeapSize
-			new MemorySize(222), // shuffleMemSize
+			new MemorySize(222), // networkMemSize
 			new MemorySize(0), // managedMemorySize
 			new MemorySize(333), // jvmMetaspaceSize
 			new MemorySize(0)); // jvmOverheadSize

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -87,7 +87,7 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		assertFalse(rp4.isMatching(rp5));
 
@@ -133,56 +133,56 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
 			.setCpuCores(1.1)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp3 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(110)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp4 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(110)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp5 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(110)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp6 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(110)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp7 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(110)
+			.setNetworkMemoryMB(110)
 			.build();
 		final ResourceProfile rp8 = ResourceProfile.newBuilder()
 			.setCpuCores(1.0)
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 
 		assertNotEquals(rp1, rp2);
@@ -214,14 +214,14 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
 			.setCpuCores(2.0)
 			.setTaskHeapMemoryMB(200)
 			.setTaskOffHeapMemoryMB(200)
 			.setManagedMemoryMB(200)
-			.setShuffleMemoryMB(200)
+			.setNetworkMemoryMB(200)
 			.addExtendedResource("gpu", new GPUResource(2.0))
 			.build();
 
@@ -230,14 +230,14 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(200)
 			.setTaskOffHeapMemoryMB(200)
 			.setManagedMemoryMB(200)
-			.setShuffleMemoryMB(200)
+			.setNetworkMemoryMB(200)
 			.build();
 		final ResourceProfile rp1MergeRp2 = ResourceProfile.newBuilder()
 			.setCpuCores(3.0)
 			.setTaskHeapMemoryMB(300)
 			.setTaskOffHeapMemoryMB(300)
 			.setManagedMemoryMB(300)
-			.setShuffleMemoryMB(300)
+			.setNetworkMemoryMB(300)
 			.addExtendedResource("gpu", new GPUResource(2.0))
 			.build();
 		final ResourceProfile rp2MergeRp2 = ResourceProfile.newBuilder()
@@ -245,7 +245,7 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(400)
 			.setTaskOffHeapMemoryMB(400)
 			.setManagedMemoryMB(400)
-			.setShuffleMemoryMB(400)
+			.setNetworkMemoryMB(400)
 			.addExtendedResource("gpu", new GPUResource(4.0))
 			.build();
 
@@ -272,14 +272,14 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(300)
 			.setTaskOffHeapMemoryMB(300)
 			.setManagedMemoryMB(300)
-			.setShuffleMemoryMB(300)
+			.setNetworkMemoryMB(300)
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
 			.setCpuCores(largeDouble)
 			.setTaskHeapMemory(largeMemory)
 			.setTaskOffHeapMemory(largeMemory)
 			.setManagedMemory(largeMemory)
-			.setShuffleMemory(largeMemory)
+			.setNetworkMemory(largeMemory)
 			.build();
 
 		List<ArithmeticException> exceptions = new ArrayList<>();
@@ -308,21 +308,21 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
 			.setCpuCores(2.0)
 			.setTaskHeapMemoryMB(200)
 			.setTaskOffHeapMemoryMB(200)
 			.setManagedMemoryMB(200)
-			.setShuffleMemoryMB(200)
+			.setNetworkMemoryMB(200)
 			.build();
 		final ResourceProfile rp3 = ResourceProfile.newBuilder()
 			.setCpuCores(3.0)
 			.setTaskHeapMemoryMB(300)
 			.setTaskOffHeapMemoryMB(300)
 			.setManagedMemoryMB(300)
-			.setShuffleMemoryMB(300)
+			.setNetworkMemoryMB(300)
 			.build();
 
 		assertEquals(rp1, rp3.subtract(rp2));
@@ -352,7 +352,7 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(Integer.MAX_VALUE)
 			.setTaskOffHeapMemoryMB(Integer.MAX_VALUE)
 			.setManagedMemoryMB(Integer.MAX_VALUE)
-			.setShuffleMemoryMB(Integer.MAX_VALUE)
+			.setNetworkMemoryMB(Integer.MAX_VALUE)
 			.addExtendedResource("gpu", new GPUResource(4.0))
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
@@ -360,7 +360,7 @@ public class ResourceProfileTest {
 			.setTaskHeapMemoryMB(200)
 			.setTaskOffHeapMemoryMB(200)
 			.setManagedMemoryMB(200)
-			.setShuffleMemoryMB(200)
+			.setNetworkMemoryMB(200)
 			.build();
 
 		rp2.subtract(rp1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManagerTest.java
@@ -545,14 +545,14 @@ public class SlotSharingManagerTest extends TestLogger {
 			.setTaskHeapMemoryMB(100)
 			.setTaskOffHeapMemoryMB(100)
 			.setManagedMemoryMB(100)
-			.setShuffleMemoryMB(100)
+			.setNetworkMemoryMB(100)
 			.build();
 		final ResourceProfile rp2 = ResourceProfile.newBuilder()
 			.setCpuCores(2.0)
 			.setTaskHeapMemoryMB(200)
 			.setTaskOffHeapMemoryMB(200)
 			.setManagedMemoryMB(200)
-			.setShuffleMemoryMB(200)
+			.setNetworkMemoryMB(200)
 			.addExtendedResource("gpu", new GPUResource(2.0))
 			.build();
 		final ResourceProfile rp3 = ResourceProfile.newBuilder()
@@ -560,7 +560,7 @@ public class SlotSharingManagerTest extends TestLogger {
 			.setTaskHeapMemoryMB(300)
 			.setTaskOffHeapMemoryMB(300)
 			.setManagedMemoryMB(300)
-			.setShuffleMemoryMB(300)
+			.setNetworkMemoryMB(300)
 			.addExtendedResource("gpu", new GPUResource(3.0))
 			.build();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
@@ -85,8 +85,8 @@ public class MiniClusterConfigurationTest extends TestLogger {
 		final Configuration actualConfiguration = miniClusterConfiguration.getConfiguration();
 		final Configuration expectedConfiguration = MiniClusterConfiguration.adjustTaskManagerMemoryConfigurations(new Configuration());
 
-		assertThat(actualConfiguration.get(TaskManagerOptions.SHUFFLE_MEMORY_MIN), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
-		assertThat(actualConfiguration.get(TaskManagerOptions.SHUFFLE_MEMORY_MAX), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
+		assertThat(actualConfiguration.get(TaskManagerOptions.NETWORK_MEMORY_MIN), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
+		assertThat(actualConfiguration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
 		assertThat(actualConfiguration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE), is(MiniClusterConfiguration.DEFAULT_MANAGED_MEMORY_SIZE));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -123,8 +123,8 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 		Configuration cfg = createFlinkConfiguration();
 
 		// something invalid
-		cfg.set(TaskManagerOptions.SHUFFLE_MEMORY_MIN, MemorySize.parse("100m"));
-		cfg.set(TaskManagerOptions.SHUFFLE_MEMORY_MAX, MemorySize.parse("10m"));
+		cfg.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("100m"));
+		cfg.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("10m"));
 		startTaskManager(
 			cfg,
 			rpcService,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/slot/TaskSlotUtils.java
@@ -36,7 +36,7 @@ public enum TaskSlotUtils {
 		.setTaskHeapMemory(new MemorySize(100 * 1024))
 		.setTaskOffHeapMemory(MemorySize.ZERO)
 		.setManagedMemory(new MemorySize(10 * MemoryManager.MIN_PAGE_SIZE))
-		.setShuffleMemory(new MemorySize(100 * 1024))
+		.setNetworkMemory(new MemorySize(100 * 1024))
 		.build();
 
 	public static TaskSlotTable createTaskSlotTable(int numberOfSlots) {

--- a/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/failing/JobSubmissionFailsITCase.java
@@ -72,7 +72,7 @@ public class JobSubmissionFailsITCase extends TestLogger {
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
 
 		// to accommodate for 10 netty arenas (NUM_SLOTS / NUM_TM) x 16Mb (NettyBufferPool.ARENA_SIZE)
-		config.set(TaskManagerOptions.SHUFFLE_MEMORY_MIN, MemorySize.parse("256m"));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("256m"));
 
 		return config;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
@@ -97,8 +97,8 @@ public class BackPressureITCase extends TestLogger {
 		final MemorySize networkBuffersMemory = MemorySize.parse(memorySegmentSizeKb * (NUM_TASKS + 2) + "kb");
 
 		configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse(memorySegmentSizeKb + "kb"));
-		configuration.set(TaskManagerOptions.SHUFFLE_MEMORY_MIN, networkBuffersMemory);
-		configuration.set(TaskManagerOptions.SHUFFLE_MEMORY_MAX, networkBuffersMemory);
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, networkBuffersMemory);
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, networkBuffersMemory);
 		return configuration;
 	}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -140,7 +140,7 @@ public class FlinkYarnSessionCli extends AbstractCustomCommandLine {
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
-	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.shuffle.min=536346624</tt>.
+	 * <tt> -Dfs.overwrite-files=true  -Dtaskmanager.memory.network.min=536346624</tt>.
 	 */
 	private final Option dynamicproperties;
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -404,7 +404,7 @@ public class YarnResourceManagerTest extends TestLogger {
 					.setTaskHeapMemoryMB(1)
 					.setTaskOffHeapMemoryMB(1)
 					.setManagedMemoryMB(1)
-					.setShuffleMemoryMB(0)
+					.setNetworkMemoryMB(0)
 					.build();
 				final SlotReport slotReport = new SlotReport(
 					new SlotStatus(new SlotID(taskManagerResourceId, 1), resourceProfile));


### PR DESCRIPTION
## What is the purpose of the change

As there is no strong consensus about using new 'shuffle' naming for memory config options. We decided to fallback to the the existing naming and use 'network' instead of 'shuffle'. We still keeping the new naming convention with prefix 'taskmanager.memory.*'.

## Brief change log

Basically, we just need to rename 'taskmanager.memory.shuffle.' to 'taskmanager.memory.network.' as 'shuffle' naming has never been released and adjust docs/comments.

Replacements:
- memory.shuffle -> memory.network
- s(S)huffleMemory -> n(N)etworkMemory
- s(S)huffle m(M)emory -> n(N)etwork m(M)emory

## Verifying this change

trivial renaming

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs / JavaDocs)
