### PR TITLE
[FLINK-15564][yarn][test] Fix YarnClusterDescriptorTest that failed to validate the original intended behavior

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
@@ -65,7 +65,7 @@ public final class ClusterSpecification {
 	 */
 	public static class ClusterSpecificationBuilder {
 		private int masterMemoryMB = 768;
-		private int taskManagerMemoryMB = 768;
+		private int taskManagerMemoryMB = 1024;
 		private int numberTaskManagers = 1;
 		private int slotsPerTaskManager = 1;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClientClusterInformationRetriever.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClientClusterInformationRetriever.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+
+/**
+ * Implementation of {@link YarnClusterInformationRetriever} that work with a {@link YarnClient}.
+ */
+public class YarnClientClusterInformationRetriever implements YarnClusterInformationRetriever {
+	private final YarnClient yarnClient;
+
+	public YarnClientClusterInformationRetriever(final YarnClient yarnClient) {
+		this.yarnClient = yarnClient;
+	}
+
+	@Override
+	public int numMaxVcores() throws Exception {
+		// Fetch numYarnMaxVcores from all the RUNNING nodes via yarnClient
+		return yarnClient.getNodeReports(NodeState.RUNNING)
+			.stream()
+			.mapToInt(report -> report.getCapability().getVirtualCores())
+			.max()
+			.orElse(0);
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -67,6 +67,8 @@ public class YarnClusterClientFactory extends AbstractContainerizedClusterClient
 	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {
 		final YarnClient yarnClient = YarnClient.createYarnClient();
 		final YarnConfiguration yarnConfiguration = new YarnConfiguration();
+		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
+			new YarnClientClusterInformationRetriever(yarnClient);
 
 		yarnClient.init(yarnConfiguration);
 		yarnClient.start();
@@ -75,6 +77,7 @@ public class YarnClusterClientFactory extends AbstractContainerizedClusterClient
 				configuration,
 				yarnConfiguration,
 				yarnClient,
-				false);
+				false,
+				yarnClusterInformationRetriever);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterInformationRetriever.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterInformationRetriever.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+/**
+ * Interface for retrieving yarn cluster information.
+ */
+public interface YarnClusterInformationRetriever {
+	int numMaxVcores() throws Exception;
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnClusterInformationRetriever.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnClusterInformationRetriever.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+/**
+ * Implementation of {@link YarnClusterInformationRetriever} for testing purpose.
+ */
+public class TestingYarnClusterInformationRetriever implements YarnClusterInformationRetriever {
+
+	private final int maxVcores;
+
+	public TestingYarnClusterInformationRetriever(int maxVcores) {
+		this.maxVcores = maxVcores;
+	}
+
+	@Override
+	public int numMaxVcores() throws Exception {
+		return maxVcores;
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -104,9 +104,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
 
 		ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.setMasterMemoryMB(1)
-			.setTaskManagerMemoryMB(1)
-			.setNumberTaskManagers(1)
 			.setSlotsPerTaskManager(Integer.MAX_VALUE)
 			.createClusterSpecification();
 
@@ -137,10 +134,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 		// configure slots
 		ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.setMasterMemoryMB(1)
-			.setTaskManagerMemoryMB(1)
-			.setNumberTaskManagers(1)
-			.setSlotsPerTaskManager(1)
 			.createClusterSpecification();
 
 		try {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
@@ -49,6 +49,8 @@ public class YarnTestUtils {
 			final YarnClient yarnClient,
 			final boolean sharedYarnClient) {
 		final Configuration effectiveConfiguration = FlinkYarnSessionCli.setLogConfigFileInConfig(flinkConfiguration, flinkConfDir);
-		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient);
+		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
+			new YarnClientClusterInformationRetriever(yarnClient);
+		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient, yarnClusterInformationRetriever);
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
  */
 public class YarnTestUtils {
 
+	private static final int MAX_VCORES = 16;
+
 	static boolean isHadoopVersionGreaterThanOrEquals(final int major, final int minor) {
 		final String[] splitVersion = VersionInfo.getVersion().split("\\.");
 		final int[] versions = Arrays.stream(splitVersion).mapToInt(Integer::parseInt).toArray();
@@ -50,7 +52,7 @@ public class YarnTestUtils {
 			final boolean sharedYarnClient) {
 		final Configuration effectiveConfiguration = FlinkYarnSessionCli.setLogConfigFileInConfig(flinkConfiguration, flinkConfDir);
 		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
-			new YarnClientClusterInformationRetriever(yarnClient);
+			new TestingYarnClusterInformationRetriever(MAX_VCORES);
 		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient, yarnClusterInformationRetriever);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the `YarnClusterDescriptorTest#testFailIfTaskSlotsHigherThanMaxVcores` and `#testFailIfTaskSlotsHigherThanMaxVcores`, which should have failed long ago but was covered by other problem.

The original purpose of these two test cases was to verify the validation logic against yarn max allocation vcores. These two cases should have failed when we change the validation logic to get yarn max allocation vcores from yarnClient instead of configuration, because there are no yarn cluster (neither `MiniYARNCluster`) started in these cases, thus `yarnClient#getNodeReports` will never return.

The cases have not failed because another `IllegalConfigurationException` was thrown in `validateClusterSpecification`, because of memory validation failure. The memory validation failure was by design, and in order to verify the original purpose these two test cases should have been updated with reasonable memory sizes, which is unfortunately overlooked. 

## Brief change log

- 04ffffe5cf919ab07ddba656a68d4cd2d17c64c5: Update memory setups to uncover the problem.
  - I leave this as a separate commit for the convenience of code review. This should be squashed at the merging time. 
- 54fdafd9c9d9c4bd6df9bd9b25de461f8f5bbcec: Fix test cases by mocking the yarn max allocation vcores.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
