### PR TITLE
[FLINK-15587][container] Initial container for OpenShift.

### DIFF
--- a/flink-container/docker/Dockerfile.openshift
+++ b/flink-container/docker/Dockerfile.openshift
@@ -1,0 +1,71 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+FROM openjdk:8-jre-alpine
+
+# Install requirements
+RUN apk add --no-cache bash snappy libc6-compat
+
+# Flink environment variables
+ENV FLINK_INSTALL_PATH=/opt
+ENV FLINK_HOME $FLINK_INSTALL_PATH/flink
+ENV FLINK_LIB_DIR $FLINK_HOME/lib
+ENV FLINK_PLUGINS_DIR $FLINK_HOME/plugins
+ENV FLINK_OPT_DIR $FLINK_HOME/opt
+ENV FLINK_JOB_ARTIFACTS_DIR $FLINK_INSTALL_PATH/artifacts
+ENV FLINK_USR_LIB_DIR $FLINK_HOME/usrlib
+ENV PATH $PATH:$FLINK_HOME/bin
+
+# flink-dist can point to a directory or a tarball on the local system
+ARG flink_dist=NOT_SET
+ARG job_artifacts=NOT_SET
+ARG python_version=NOT_SET
+# hadoop jar is optional
+ARG hadoop_jar=NOT_SET*
+
+# Install Python
+RUN \
+  if [ "$python_version" = "2" ]; then \
+    apk add --no-cache python; \
+  elif [ "$python_version" = "3" ]; then \
+    apk add --no-cache python3 && ln -s /usr/bin/python3 /usr/bin/python; \
+  fi
+
+# Install build dependencies and flink
+ADD $flink_dist $hadoop_jar $FLINK_INSTALL_PATH/
+ADD $job_artifacts/* $FLINK_JOB_ARTIFACTS_DIR/
+
+RUN set -x && \
+  ln -s $FLINK_INSTALL_PATH/flink-[0-9]* $FLINK_HOME && \
+  ln -s $FLINK_JOB_ARTIFACTS_DIR $FLINK_USR_LIB_DIR && \
+  if [ -n "$python_version" ]; then ln -s $FLINK_OPT_DIR/flink-python*.jar $FLINK_LIB_DIR; fi && \
+  if [ -f ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* ]; then ln -s ${FLINK_INSTALL_PATH}/flink-shaded-hadoop* $FLINK_LIB_DIR; fi
+
+RUN set -x && \
+  chgrp -R 0 ${FLINK_INSTALL_PATH}/flink-* && \
+  chmod -R g=u ${FLINK_INSTALL_PATH}/flink-* && \
+  chgrp -R 0 ${FLINK_JOB_ARTIFACTS_DIR}/ && \
+  chmod -R g=u ${FLINK_JOB_ARTIFACTS_DIR}/ && \
+  chgrp -h 0 $FLINK_HOME && \
+  chmod -R g=u $FLINK_HOME
+
+COPY docker-entrypoint.sh /
+
+USER 1001
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["--help"]


### PR DESCRIPTION
## What is the purpose of the change

OpenShift needs a minimum set of file level rights to work. Thus use best-practise for OpenShift to minimize rights so an image can run inside of OpenShift.

## Brief change log

- Created new `Dockerfile.openshift` since changes are incompatible with default variant.
- Set group rights to special group 0 (used by OpenShift container runtime).
- Set user to 1001 since user will be generated at runtime.

## Verifying this change

I have no idea how I am supposed to test this. Building the image seems quite complicated and not straight forward.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
