### PR TITLE
[FLINK-15593][doc] add doc to remind users not using Hive aggregate f…

### DIFF
--- a/docs/dev/table/hive/hive_functions.md
+++ b/docs/dev/table/hive/hive_functions.md
@@ -82,7 +82,14 @@ To use a Hive User Defined Function, user have to
 
 - set a HiveCatalog backed by Hive Metastore that contains that function as current catalog of the session
 - include a jar that contains that function in Flink's classpath
-- use Blink planner.
+- use Blink planner
+
+Note that Hive scalar and table functions implementing UDF, GenericUDF, and GenericUDTF interfaces should be good to run in both 
+streaming and batch mode in Flink.
+
+Due to that Hive functions are all built for batch processing, aggregate functions in Hive that implement UDAF and GenericUDAFResolver2 
+interfaces may have unpredictable behaviors when used in streaming mode in Flink. We advice users to only use Hive aggregate functions
+interfaces in batch mode.
 
 ## Using Hive User Defined Functions
 

--- a/docs/dev/table/hive/hive_functions.zh.md
+++ b/docs/dev/table/hive/hive_functions.zh.md
@@ -82,7 +82,14 @@ To use a Hive User Defined Function, user have to
 
 - set a HiveCatalog backed by Hive Metastore that contains that function as current catalog of the session
 - include a jar that contains that function in Flink's classpath
-- use Blink planner.
+- use Blink planner
+
+Note that Hive scalar and table functions implementing UDF, GenericUDF, and GenericUDTF interfaces should be good to run in both 
+streaming and batch mode in Flink.
+
+Due to that Hive functions are all built for batch processing, aggregate functions in Hive that implement UDAF and GenericUDAFResolver2 
+interfaces may have unpredictable behaviors when used in streaming mode in Flink. We advice users to only use Hive aggregate functions
+interfaces in batch mode.
 
 ## Using Hive User Defined Functions
 


### PR DESCRIPTION
…unctions in streaming mode

## What is the purpose of the change

Due to that Hive functions are all built for batch processing, aggregate functions in Hive that implement UDAF and GenericUDAFResolver2 interfaces may have unpredictable behaviors when used in streaming mode in Flink. We advice users to only use Hive aggregate functions interfaces in batch mode.

## Brief change log

update doc

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

n/a

## Documentation

n/a