### PR TITLE
[FLINK-15145][config] Change TM memory configuration default values for FLIP-49.

### DIFF
--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">100663296 bytes</td>
             <td>MemorySize</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>
         </tr>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -40,7 +40,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-overhead.min</h5></td>
-            <td style="word-wrap: break-word;">134217728 bytes</td>
+            <td style="word-wrap: break-word;">201326592 bytes</td>
             <td>MemorySize</td>
             <td>Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size of JVM Overhead is derived to make up the configured fraction of the Total Process Memory. If the derived size is less/greater than the configured min/max size, the min/max size will be used. The exact size of JVM Overhead can be explicitly specified by setting the min/max size to the same value.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -389,7 +389,7 @@ public class TaskManagerOptions {
 	public static final ConfigOption<MemorySize> JVM_METASPACE =
 		key("taskmanager.memory.jvm-metaspace.size")
 			.memoryType()
-			.defaultValue(MemorySize.parse("128m"))
+			.defaultValue(MemorySize.parse("96m"))
 			.withDescription("JVM Metaspace Size for the TaskExecutors.");
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -398,7 +398,7 @@ public class TaskManagerOptions {
 	public static final ConfigOption<MemorySize> JVM_OVERHEAD_MIN =
 		key("taskmanager.memory.jvm-overhead.min")
 			.memoryType()
-			.defaultValue(MemorySize.parse("128m"))
+			.defaultValue(MemorySize.parse("192m"))
 			.withDescription("Min JVM Overhead size for the TaskExecutors. This is off-heap memory reserved for JVM"
 				+ " overhead, such as thread stack space, compile cache, etc. This includes native memory but not direct"
 				+ " memory, and will not be counted when Flink calculates JVM max direct memory size parameter. The size"

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -46,12 +46,12 @@ jobmanager.heap.size: 1024m
 #
 # Note this accounts for all memory usage within the TaskExecutor process, including JVM metaspace and other overhead.
 
-taskmanager.memory.process.size: 1024m
+taskmanager.memory.process.size: 1568m
 
 # To exclude JVM metaspace and overhead, please, use total Flink memory size instead of 'taskmanager.memory.process.size'.
 # It is not recommended to set both 'taskmanager.memory.process.size' and Flink memory.
 #
-# taskmanager.memory.flink.size: 1024m
+# taskmanager.memory.flink.size: 1280m
 
 # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -42,9 +42,9 @@ jobmanager.rpc.port: 6123
 jobmanager.heap.size: 1024m
 
 
-# The total process memory size for the TaskExecutor.
+# The total process memory size for the TaskManager.
 #
-# Note this accounts for all memory usage within the TaskExecutor process, including JVM metaspace and other overhead.
+# Note this accounts for all memory usage within the TaskManager process, including JVM metaspace and other overhead.
 
 taskmanager.memory.process.size: 1568m
 

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -42,10 +42,16 @@ jobmanager.rpc.port: 6123
 jobmanager.heap.size: 1024m
 
 
-# The heap size for the TaskManager JVM
+# The total process memory size for the TaskExecutor.
+#
+# Note this accounts for all memory usage within the TaskExecutor process, including JVM metaspace and other overhead.
 
 taskmanager.memory.process.size: 1024m
 
+# To exclude JVM metaspace and overhead, please, use total Flink memory size instead of 'taskmanager.memory.process.size'.
+# It is not recommended to set both 'taskmanager.memory.process.size' and Flink memory.
+#
+# taskmanager.memory.flink.size: 1024m
 
 # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.
 


### PR DESCRIPTION
## What is the purpose of the change

This PR updates FLIP-49 TM memory sizes configuration default values according to the outcome of tuning with real jobs.

## Brief change log

- JVM overhead min: 128MB -> 192MB
- JVM metaspace: 128MB -> 96MB
- Total process size (in default flink-conf.yaml): 1024MB -> 1568MB

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
