### PR TITLE
[FLINK-15598][yarn] Memory accuracy loss in YarnClusterDescriptor may lead to deployment failure.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
@@ -65,7 +65,7 @@ public final class ClusterSpecification {
 	 */
 	public static class ClusterSpecificationBuilder {
 		private int masterMemoryMB = 768;
-		private int taskManagerMemoryMB = 768;
+		private int taskManagerMemoryMB = 1024;
 		private int numberTaskManagers = 1;
 		private int slotsPerTaskManager = 1;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterSpecification.java
@@ -24,13 +24,11 @@ package org.apache.flink.client.deployment;
 public final class ClusterSpecification {
 	private final int masterMemoryMB;
 	private final int taskManagerMemoryMB;
-	private final int numberTaskManagers;
 	private final int slotsPerTaskManager;
 
-	private ClusterSpecification(int masterMemoryMB, int taskManagerMemoryMB, int numberTaskManagers, int slotsPerTaskManager) {
+	private ClusterSpecification(int masterMemoryMB, int taskManagerMemoryMB, int slotsPerTaskManager) {
 		this.masterMemoryMB = masterMemoryMB;
 		this.taskManagerMemoryMB = taskManagerMemoryMB;
-		this.numberTaskManagers = numberTaskManagers;
 		this.slotsPerTaskManager = slotsPerTaskManager;
 	}
 
@@ -42,10 +40,6 @@ public final class ClusterSpecification {
 		return taskManagerMemoryMB;
 	}
 
-	public int getNumberTaskManagers() {
-		return numberTaskManagers;
-	}
-
 	public int getSlotsPerTaskManager() {
 		return slotsPerTaskManager;
 	}
@@ -55,7 +49,6 @@ public final class ClusterSpecification {
 		return "ClusterSpecification{" +
 			"masterMemoryMB=" + masterMemoryMB +
 			", taskManagerMemoryMB=" + taskManagerMemoryMB +
-			", numberTaskManagers=" + numberTaskManagers +
 			", slotsPerTaskManager=" + slotsPerTaskManager +
 			'}';
 	}
@@ -66,7 +59,6 @@ public final class ClusterSpecification {
 	public static class ClusterSpecificationBuilder {
 		private int masterMemoryMB = 768;
 		private int taskManagerMemoryMB = 1024;
-		private int numberTaskManagers = 1;
 		private int slotsPerTaskManager = 1;
 
 		public ClusterSpecificationBuilder setMasterMemoryMB(int masterMemoryMB) {
@@ -79,11 +71,6 @@ public final class ClusterSpecification {
 			return this;
 		}
 
-		public ClusterSpecificationBuilder setNumberTaskManagers(int numberTaskManagers) {
-			this.numberTaskManagers = numberTaskManagers;
-			return this;
-		}
-
 		public ClusterSpecificationBuilder setSlotsPerTaskManager(int slotsPerTaskManager) {
 			this.slotsPerTaskManager = slotsPerTaskManager;
 			return this;
@@ -93,7 +80,6 @@ public final class ClusterSpecification {
 			return new ClusterSpecification(
 				masterMemoryMB,
 				taskManagerMemoryMB,
-				numberTaskManagers,
 				slotsPerTaskManager);
 		}
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -51,7 +51,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 			.setMasterMemoryMB(1234)
 			.setTaskManagerMemoryMB(1222)
-			.setNumberTaskManagers(1)
 			.setSlotsPerTaskManager(1)
 			.createClusterSpecification();
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesSessionCliTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesSessionCliTest.java
@@ -93,7 +93,6 @@ public class KubernetesSessionCliTest {
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
-		assertEquals(1, clusterSpecification.getNumberTaskManagers());
 	}
 
 	@Test

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -26,8 +26,10 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestartStrategyOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -271,6 +273,7 @@ public class YARNHighAvailabilityITCase extends YarnTestBase {
 	@Nonnull
 	private YarnClusterDescriptor setupYarnClusterDescriptor() {
 		final Configuration flinkConfiguration = new Configuration();
+		flinkConfiguration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
 		flinkConfiguration.setString(YarnConfigOptions.APPLICATION_ATTEMPTS, "10");
 		flinkConfiguration.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
 		flinkConfiguration.setString(HighAvailabilityOptions.HA_STORAGE_PATH, storageDir);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -22,6 +22,8 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -85,6 +87,7 @@ public class YARNITCase extends YarnTestBase {
 	private void deployPerjob(YarnConfigOptions.UserJarInclusion userJarInclusion, JobGraph jobGraph) throws Exception {
 
 		Configuration configuration = new Configuration();
+		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
 		configuration.setString(AkkaOptions.ASK_TIMEOUT, "30 s");
 		configuration.setString(CLASSPATH_INCLUDE_USER_JAR, userJarInclusion.toString());
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNITCase.java
@@ -98,7 +98,6 @@ public class YARNITCase extends YarnTestBase {
 				.setMasterMemoryMB(768)
 				.setTaskManagerMemoryMB(1024)
 				.setSlotsPerTaskManager(1)
-				.setNumberTaskManagers(1)
 				.createClusterSpecification();
 
 			File testingJar = YarnTestBase.findFile("..", new YarnTestUtils.TestJarFinder("flink-yarn-tests"));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -85,10 +86,12 @@ public class YarnConfigurationITCase extends YarnTestBase {
 			// disable heap cutoff min
 			configuration.setInteger(ResourceManagerOptions.CONTAINERIZED_HEAP_CUTOFF_MIN, 0);
 
+			final int slotsPerTaskManager = 3;
+			configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
+
 			final TaskExecutorResourceSpec tmResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
 			final int masterMemory = 64;
 			final int taskManagerMemory = tmResourceSpec.getTotalProcessMemorySize().getMebiBytes();
-			final int slotsPerTaskManager = 3;
 
 			final YarnConfiguration yarnConfiguration = getYarnConfiguration();
 			final YarnClusterDescriptor clusterDescriptor = YarnTestUtils.createClusterDescriptorWithLogging(

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClientClusterInformationRetriever.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClientClusterInformationRetriever.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.yarn.api.records.NodeState;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+
+/**
+ * Implementation of {@link YarnClusterInformationRetriever} that work with a {@link YarnClient}.
+ */
+public class YarnClientClusterInformationRetriever implements YarnClusterInformationRetriever {
+	private final YarnClient yarnClient;
+
+	public YarnClientClusterInformationRetriever(final YarnClient yarnClient) {
+		this.yarnClient = yarnClient;
+	}
+
+	@Override
+	public int numMaxVcores() throws Exception {
+		// Fetch numYarnMaxVcores from all the RUNNING nodes via yarnClient
+		return yarnClient.getNodeReports(NodeState.RUNNING)
+			.stream()
+			.mapToInt(report -> report.getCapability().getVirtualCores())
+			.max()
+			.orElse(0);
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -67,6 +67,8 @@ public class YarnClusterClientFactory extends AbstractContainerizedClusterClient
 	private YarnClusterDescriptor getClusterDescriptor(Configuration configuration) {
 		final YarnClient yarnClient = YarnClient.createYarnClient();
 		final YarnConfiguration yarnConfiguration = new YarnConfiguration();
+		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
+			new YarnClientClusterInformationRetriever(yarnClient);
 
 		yarnClient.init(yarnConfiguration);
 		yarnClient.start();
@@ -75,6 +77,7 @@ public class YarnClusterClientFactory extends AbstractContainerizedClusterClient
 				configuration,
 				yarnConfiguration,
 				yarnClient,
-				false);
+				false,
+				yarnClusterInformationRetriever);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1006,13 +1006,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		appMasterEnv.put(YarnConfigKeys.ENV_FLINK_CLASSPATH, classPathBuilder.toString());
 
 		// set Flink on YARN internal configuration values
-		appMasterEnv.put(YarnConfigKeys.ENV_TM_COUNT, String.valueOf(clusterSpecification.getNumberTaskManagers()));
-		appMasterEnv.put(YarnConfigKeys.ENV_TM_MEMORY, String.valueOf(clusterSpecification.getTaskManagerMemoryMB()));
 		appMasterEnv.put(YarnConfigKeys.FLINK_JAR_PATH, remotePathJar.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_APP_ID, appId.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_HOME_DIR, homeDir.toString());
 		appMasterEnv.put(YarnConfigKeys.ENV_CLIENT_SHIP_FILES, envShipFileList.toString());
-		appMasterEnv.put(YarnConfigKeys.ENV_SLOTS, String.valueOf(clusterSpecification.getSlotsPerTaskManager()));
 		appMasterEnv.put(YarnConfigKeys.ENV_ZOOKEEPER_NAMESPACE, getZookeeperNamespace());
 		appMasterEnv.put(YarnConfigKeys.FLINK_YARN_FILES, yarnFilesDir.toUri().toString());
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -527,7 +527,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		ClusterResourceDescription freeClusterResources) throws YarnDeploymentException {
 
 		int jobManagerMemoryMb = clusterSpecification.getMasterMemoryMB();
-		int taskManagerMemoryMb = clusterSpecification.getTaskManagerMemoryMB();
+		final int taskManagerMemoryMb = clusterSpecification.getTaskManagerMemoryMB();
 
 		if (jobManagerMemoryMb < yarnMinAllocationMB || taskManagerMemoryMb < yarnMinAllocationMB) {
 			LOG.warn("The JobManager or TaskManager memory is below the smallest possible YARN Container size. "
@@ -539,9 +539,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		// set the memory to minAllocationMB to do the next checks correctly
 		if (jobManagerMemoryMb < yarnMinAllocationMB) {
 			jobManagerMemoryMb =  yarnMinAllocationMB;
-		}
-		if (taskManagerMemoryMb < yarnMinAllocationMB) {
-			taskManagerMemoryMb =  yarnMinAllocationMB;
 		}
 
 		final String note = "Please check the 'yarn.scheduler.maximum-allocation-mb' and the 'yarn.nodemanager.resource.memory-mb' configuration values\n";

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -34,11 +34,9 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.SecurityOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
@@ -781,15 +779,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		paths.add(remotePathJar);
 		classPathBuilder.append(flinkJarPath.getName()).append(File.pathSeparator);
-
-		// set the right configuration values for the TaskManager
-		configuration.setInteger(
-				TaskManagerOptions.NUM_TASK_SLOTS,
-				clusterSpecification.getSlotsPerTaskManager());
-
-		configuration.set(
-				TaskManagerOptions.TOTAL_PROCESS_MEMORY,
-				MemorySize.parse(clusterSpecification.getTaskManagerMemoryMB() + "m"));
 
 		// Upload the flink configuration
 		// write out configuration file

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -101,7 +101,6 @@ import java.nio.file.Files;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -272,9 +271,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 	private void isReadyForDeployment(ClusterSpecification clusterSpecification) throws YarnDeploymentException {
 
-		if (clusterSpecification.getNumberTaskManagers() <= 0) {
-			throw new YarnDeploymentException("Taskmanager count must be positive");
-		}
 		if (this.flinkJarPath == null) {
 			throw new YarnDeploymentException("The Flink jar path is null");
 		}
@@ -317,16 +313,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					"The Flink YARN Client needs one of these to be set to properly load the Hadoop " +
 					"configuration for accessing YARN.");
 		}
-	}
-
-	private static boolean allocateResource(int[] nodeManagers, int toAllocate) {
-		for (int i = 0; i < nodeManagers.length; i++) {
-			if (nodeManagers[i] >= toAllocate) {
-				nodeManagers[i] -= toAllocate;
-				return true;
-			}
-		}
-		return false;
 	}
 
 	public String getZookeeperNamespace() {
@@ -566,7 +552,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		Resource maximumResourceCapability,
 		ClusterResourceDescription freeClusterResources) throws YarnDeploymentException {
 
-		int taskManagerCount = clusterSpecification.getNumberTaskManagers();
 		int jobManagerMemoryMb = clusterSpecification.getMasterMemoryMB();
 		int taskManagerMemoryMb = clusterSpecification.getTaskManagerMemoryMB();
 
@@ -600,13 +585,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				"connecting from the beginning because the resources are currently not available in the cluster. " +
 				"The allocation might take more time than usual because the Flink YARN client needs to wait until " +
 				"the resources become available.";
-		int totalMemoryRequired = jobManagerMemoryMb + taskManagerMemoryMb * taskManagerCount;
 
-		if (freeClusterResources.totalFreeMemory < totalMemoryRequired) {
-			LOG.warn("This YARN session requires " + totalMemoryRequired + "MB of memory in the cluster. "
-					+ "There are currently only " + freeClusterResources.totalFreeMemory + "MB available." + noteRsc);
-
-		}
 		if (taskManagerMemoryMb > freeClusterResources.containerLimit) {
 			LOG.warn("The requested amount of memory for the TaskManagers (" + taskManagerMemoryMb + "MB) is more than "
 					+ "the largest possible YARN container: " + freeClusterResources.containerLimit + noteRsc);
@@ -616,30 +595,9 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					+ "the largest possible YARN container: " + freeClusterResources.containerLimit + noteRsc);
 		}
 
-		// ----------------- check if the requested containers fit into the cluster.
-
-		int[] nmFree = Arrays.copyOf(freeClusterResources.nodeManagersFree, freeClusterResources.nodeManagersFree.length);
-		// first, allocate the jobManager somewhere.
-		if (!allocateResource(nmFree, jobManagerMemoryMb)) {
-			LOG.warn("Unable to find a NodeManager that can fit the JobManager/Application master. " +
-					"The JobManager requires " + jobManagerMemoryMb + "MB. NodeManagers available: " +
-					Arrays.toString(freeClusterResources.nodeManagersFree) + noteRsc);
-		}
-		// allocate TaskManagers
-		for (int i = 0; i < taskManagerCount; i++) {
-			if (!allocateResource(nmFree, taskManagerMemoryMb)) {
-				LOG.warn("There is not enough memory available in the YARN cluster. " +
-						"The TaskManager(s) require " + taskManagerMemoryMb + "MB each. " +
-						"NodeManagers available: " + Arrays.toString(freeClusterResources.nodeManagersFree) + "\n" +
-						"After allocating the JobManager (" + jobManagerMemoryMb + "MB) and (" + i + "/" + taskManagerCount + ") TaskManagers, " +
-						"the following NodeManagers are available: " + Arrays.toString(nmFree)  + noteRsc);
-			}
-		}
-
 		return new ClusterSpecification.ClusterSpecificationBuilder()
 				.setMasterMemoryMB(jobManagerMemoryMb)
 				.setTaskManagerMemoryMB(taskManagerMemoryMb)
-				.setNumberTaskManagers(clusterSpecification.getNumberTaskManagers())
 				.setSlotsPerTaskManager(clusterSpecification.getSlotsPerTaskManager())
 				.createClusterSpecification();
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -42,7 +42,6 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginConfig;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
@@ -421,26 +420,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	}
 
 	/**
-	 * Method to validate cluster specification before deploy it, it will throw
-	 * an {@link FlinkException} if the {@link ClusterSpecification} is invalid.
-	 *
-	 * @param clusterSpecification cluster specification to check against the configuration of the
-	 *                             YarnClusterDescriptor
-	 * @throws FlinkException if the cluster cannot be started with the provided {@link ClusterSpecification}
-	 */
-	private void validateClusterSpecification(ClusterSpecification clusterSpecification) throws FlinkException {
-		MemorySize totalProcessMemory = MemorySize.parse(clusterSpecification.getTaskManagerMemoryMB() + "m");
-		try {
-			TaskExecutorResourceUtils
-				.newResourceSpecBuilder(flinkConfiguration)
-				.withTotalProcessMemory(totalProcessMemory)
-				.build();
-		} catch (IllegalArgumentException iae) {
-			throw new FlinkException("Inconsistent cluster specification.", iae);
-		}
-	}
-
-	/**
 	 * This method will block until the ApplicationMaster/JobManager have been deployed on YARN.
 	 *
 	 * @param clusterSpecification Initial cluster specification for the Flink cluster to be deployed
@@ -455,9 +434,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			String yarnClusterEntrypoint,
 			@Nullable JobGraph jobGraph,
 			boolean detached) throws Exception {
-
-		// ------------------ Check if configuration is valid --------------------
-		validateClusterSpecification(clusterSpecification);
 
 		if (UserGroupInformation.isSecurityEnabled()) {
 			// note: UGI::hasKerberosCredentials inaccurately reports false

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterInformationRetriever.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterInformationRetriever.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+/**
+ * Interface for retrieving yarn cluster information.
+ */
+public interface YarnClusterInformationRetriever {
+	int numMaxVcores() throws Exception;
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnConfigKeys.java
@@ -27,12 +27,9 @@ public class YarnConfigKeys {
 	//  Environment variable names
 	// ------------------------------------------------------------------------
 
-	public static final String ENV_TM_MEMORY = "_CLIENT_TM_MEMORY";
-	public static final String ENV_TM_COUNT = "_CLIENT_TM_COUNT";
 	public static final String ENV_APP_ID = "_APP_ID";
 	public static final String ENV_CLIENT_HOME_DIR = "_CLIENT_HOME_DIR";
 	public static final String ENV_CLIENT_SHIP_FILES = "_CLIENT_SHIP_FILES";
-	public static final String ENV_SLOTS = "_SLOTS";
 
 	public static final String ENV_FLINK_CLASSPATH = "_FLINK_CLASSPATH";
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/FlinkYarnSessionCliTest.java
@@ -114,7 +114,6 @@ public class FlinkYarnSessionCliTest extends TestLogger {
 
 		// each task manager has 3 slots but the parallelism is 7. Thus the slots should be increased.
 		assertEquals(3, clusterSpecification.getSlotsPerTaskManager());
-		assertEquals(1, clusterSpecification.getNumberTaskManagers());
 	}
 
 	@Test

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnClusterInformationRetriever.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnClusterInformationRetriever.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+/**
+ * Implementation of {@link YarnClusterInformationRetriever} for testing purpose.
+ */
+public class TestingYarnClusterInformationRetriever implements YarnClusterInformationRetriever {
+
+	private final int maxVcores;
+
+	public TestingYarnClusterInformationRetriever(int maxVcores) {
+		this.maxVcores = maxVcores;
+	}
+
+	@Override
+	public int numMaxVcores() throws Exception {
+		return maxVcores;
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -104,9 +104,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		clusterDescriptor.setLocalJarPath(new Path(flinkJar.getPath()));
 
 		ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.setMasterMemoryMB(1)
-			.setTaskManagerMemoryMB(1)
-			.setNumberTaskManagers(1)
 			.setSlotsPerTaskManager(Integer.MAX_VALUE)
 			.createClusterSpecification();
 
@@ -137,10 +134,6 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 		// configure slots
 		ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.setMasterMemoryMB(1)
-			.setTaskManagerMemoryMB(1)
-			.setNumberTaskManagers(1)
-			.setSlotsPerTaskManager(1)
 			.createClusterSpecification();
 
 		try {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
@@ -49,6 +49,8 @@ public class YarnTestUtils {
 			final YarnClient yarnClient,
 			final boolean sharedYarnClient) {
 		final Configuration effectiveConfiguration = FlinkYarnSessionCli.setLogConfigFileInConfig(flinkConfiguration, flinkConfDir);
-		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient);
+		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
+			new YarnClientClusterInformationRetriever(yarnClient);
+		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient, yarnClusterInformationRetriever);
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnTestUtils.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
  */
 public class YarnTestUtils {
 
+	private static final int MAX_VCORES = 16;
+
 	static boolean isHadoopVersionGreaterThanOrEquals(final int major, final int minor) {
 		final String[] splitVersion = VersionInfo.getVersion().split("\\.");
 		final int[] versions = Arrays.stream(splitVersion).mapToInt(Integer::parseInt).toArray();
@@ -50,7 +52,7 @@ public class YarnTestUtils {
 			final boolean sharedYarnClient) {
 		final Configuration effectiveConfiguration = FlinkYarnSessionCli.setLogConfigFileInConfig(flinkConfiguration, flinkConfDir);
 		final YarnClusterInformationRetriever yarnClusterInformationRetriever =
-			new YarnClientClusterInformationRetriever(yarnClient);
+			new TestingYarnClusterInformationRetriever(MAX_VCORES);
 		return new YarnClusterDescriptor(effectiveConfiguration, yarnConfiguration, yarnClient, sharedYarnClient, yarnClusterInformationRetriever);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR removes  memory validations and overwrites in YarnClusterDescriptor, which is unnecessary and may cause failures.

This PR is based on #10852 
## Brief change log
- 532b89b02d7d0148340c4fa2c40f175c87a05dd1..494422cbcad72a0aab8c2df77be76422f2e6085e: commits of previous PR
- df5f8e44c335cdd2b6f8eb6974af28d7bb856ae7: Hotfix to remove unsed env keys
- da1ec060cbef03b127f6f763e14e6ac5c7f82ff7: Hotfix to remove unsed numberTaskManagers from ClusterSpecification
- d924dfce471036d6bcd7cca5d0548d9b78a08ed1: Remove memory validation from YarnClusterDescriptor
- cd199a2a3b3dba0c38c38df5db11278feabb544d: Remove memory overwriting from YarnClusterDescriptor

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
