### PR TITLE
[hotfix][typo] Fix doc typo for the java doc of MultiStateKeyIteratorTest

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/input/MultiStateKeyIteratorTest.java
@@ -42,7 +42,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Test for the mulit-state key iterator.
+ * Test for the multi-state key iterator.
  */
 public class MultiStateKeyIteratorTest {
 	private static final List<ValueStateDescriptor<Integer>> descriptors;


### PR DESCRIPTION


## What is the purpose of the change

*This pull request fixes doc typo for the java doc of MultiStateKeyIteratorTest*

## Brief change log

  - *Fix doc typo for the java doc of MultiStateKeyIteratorTest*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
