### PR TITLE
Enable TTL compaction filter by default and deprecate/remove some other TTL API

### DIFF
--- a/docs/_includes/generated/rocks_db_configuration.html
+++ b/docs/_includes/generated/rocks_db_configuration.html
@@ -62,11 +62,5 @@
             <td>String</td>
             <td>This determines the factory for timer service state implementation. Options are either HEAP (heap-based, default) or ROCKSDB for an implementation based on RocksDB .</td>
         </tr>
-        <tr>
-            <td><h5>state.backend.rocksdb.ttl.compaction.filter.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>This determines if compaction filter to cleanup state with TTL is enabled for backend.Note: User can still decide in state TTL configuration in state descriptor whether the filter is active for particular state or not.</td>
-        </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -79,17 +79,6 @@ public class StateTtlConfig implements Serializable {
 
 	/**
 	 * This option configures time scale to use for ttl.
-	 *
-	 * @deprecated will be removed in a future version in favor of {@link TtlTimeCharacteristic}
-	 */
-	@Deprecated
-	public enum TimeCharacteristic {
-		/** Processing time, see also <code>TimeCharacteristic.ProcessingTime</code>. */
-		ProcessingTime
-	}
-
-	/**
-	 * This option configures time scale to use for ttl.
 	 */
 	public enum TtlTimeCharacteristic {
 		/** Processing time, see also <code>org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime</code>. */
@@ -217,22 +206,6 @@ public class StateTtlConfig implements Serializable {
 		@Nonnull
 		public Builder neverReturnExpired() {
 			return setStateVisibility(StateVisibility.NeverReturnExpired);
-		}
-
-		/**
-		 * Sets the time characteristic.
-		 *
-		 * @param timeCharacteristic The time characteristic configures time scale to use for ttl.
-		 *
-		 * @deprecated will be removed in a future version in favor of {@link #setTtlTimeCharacteristic}
-		 */
-		@Deprecated
-		@Nonnull
-		public Builder setTimeCharacteristic(@Nonnull TimeCharacteristic timeCharacteristic) {
-			checkArgument(timeCharacteristic.equals(TimeCharacteristic.ProcessingTime),
-				"Only support TimeCharacteristic.ProcessingTime, this function has replaced by setTtlTimeCharacteristic.");
-			setTtlTimeCharacteristic(TtlTimeCharacteristic.ProcessingTime);
-			return this;
 		}
 
 		/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -314,8 +314,11 @@ public class StateTtlConfig implements Serializable {
 		 * <p>Depending on actually used backend, the corresponding default cleanup will kick in if supported.
 		 * If some specific cleanup is also configured, e.g. {@link #cleanupIncrementally(int, boolean)} or
 		 * {@link #cleanupInRocksdbCompactFilter()}, then the specific one will kick in instead of default.
+		 *
+		 * @deprecated enabled by default, no need to enable it manually
 		 */
 		@Nonnull
+		@Deprecated
 		public Builder cleanupInBackground() {
 			isCleanupInBackground = true;
 			return this;

--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 ################################################################################
 
+import warnings
+
 from abc import ABCMeta
 
 from py4j.java_gateway import get_java_class
@@ -562,7 +564,12 @@ class RocksDBStateBackend(StateBackend):
         Gets whether compaction filter to cleanup state with TTL is enabled.
 
         :return: True if enabled, false otherwise.
+
+        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
         """
+        warnings.warn(
+            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
+            DeprecationWarning)
         return self._j_rocks_db_state_backend.isTtlCompactionFilterEnabled()
 
     def enable_ttl_compaction_filter(self):
@@ -572,8 +579,28 @@ class RocksDBStateBackend(StateBackend):
         .. note::
             User can still decide in state TTL configuration in state descriptor
             whether the filter is active for particular state or not.
+
+        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
         """
+        warnings.warn(
+            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
+            DeprecationWarning)
         self._j_rocks_db_state_backend.enableTtlCompactionFilter()
+
+    def disable_ttl_compaction_filter(self):
+        """
+        Disable compaction filter to cleanup state with TTL.
+
+        .. note::
+            This is an advanced option and the method should only be used
+            when experiencing serious performance degradations during compaction in RocksDB.
+
+        .. note:: Deprecated in 1.10. Enabled by default and will be removed in the future.
+        """
+        warnings.warn(
+            "Deprecated in 1.10. Enabled by default and will be removed in the future.",
+            DeprecationWarning)
+        self._j_rocks_db_state_backend.disableTtlCompactionFilter()
 
     def set_predefined_options(self, options):
         """

--- a/flink-python/pyflink/datastream/tests/test_state_backend.py
+++ b/flink-python/pyflink/datastream/tests/test_state_backend.py
@@ -148,11 +148,11 @@ class RocksDBStateBackendTests(PyFlinkTestCase):
 
         state_backend = RocksDBStateBackend("file://var/checkpoints/")
 
-        self.assertFalse(state_backend.is_ttl_compaction_filter_enabled())
-
-        state_backend.enable_ttl_compaction_filter()
-
         self.assertTrue(state_backend.is_ttl_compaction_filter_enabled())
+
+        state_backend.disable_ttl_compaction_filter()
+
+        self.assertFalse(state_backend.is_ttl_compaction_filter_enabled())
 
     def test_get_set_predefined_options(self):
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -69,7 +69,7 @@ public class RocksDBOptions {
 	public static final ConfigOption<Boolean> TTL_COMPACT_FILTER_ENABLED = ConfigOptions
 		.key("state.backend.rocksdb.ttl.compaction.filter.enabled")
 		.defaultValue(true)
-		.withDescription("This determines if compaction filter to cleanup state with TTL is enabled for backend." +
+		.withDescription("This determines if compaction filter to cleanup state with TTL is enabled for backend. " +
 			"Note: User can still decide in state TTL configuration in state descriptor " +
 			"whether the filter is active for particular state or not.");
 	/**

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBOptions.java
@@ -59,10 +59,16 @@ public class RocksDBOptions {
 		.defaultValue(1)
 		.withDescription("The number of threads (per stateful operator) used to transfer (download and upload) files in RocksDBStateBackend.");
 
-	/** This determines if compaction filter to cleanup state with TTL is enabled. */
+	/**
+	 * This determines if compaction filter to cleanup state with TTL is enabled.
+	 *
+	 * @deprecated the option will be removed in the future and should only be used
+	 * when experiencing serious performance degradations.
+	 */
+	@Deprecated
 	public static final ConfigOption<Boolean> TTL_COMPACT_FILTER_ENABLED = ConfigOptions
 		.key("state.backend.rocksdb.ttl.compaction.filter.enabled")
-		.defaultValue(false)
+		.defaultValue(true)
 		.withDescription("This determines if compaction filter to cleanup state with TTL is enabled for backend." +
 			"Note: User can still decide in state TTL configuration in state descriptor " +
 			"whether the filter is active for particular state or not.");

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -736,19 +736,38 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 
 	/**
 	 * Gets whether incremental checkpoints are enabled for this state backend.
+	 *
+	 * @deprecated enabled by default and will be removed in the future.
 	 */
+	@Deprecated
 	public boolean isTtlCompactionFilterEnabled() {
 		return enableTtlCompactionFilter.getOrDefault(TTL_COMPACT_FILTER_ENABLED.defaultValue());
 	}
 
 	/**
-	 * Enable compaction filter to cleanup state with TTL is enabled.
+	 * Enable compaction filter to cleanup state with TTL.
 	 *
 	 * <p>Note: User can still decide in state TTL configuration in state descriptor
 	 * whether the filter is active for particular state or not.
+	 *
+	 * @deprecated enabled by default and will be removed in the future.
 	 */
+	@Deprecated
 	public void enableTtlCompactionFilter() {
 		enableTtlCompactionFilter = TernaryBoolean.TRUE;
+	}
+
+	/**
+	 * Disable compaction filter to cleanup state with TTL.
+	 *
+	 * <p>Note: This is an advanced option and the method should only be used
+	 * when experiencing serious performance degradations during compaction in RocksDB.
+	 *
+	 * @deprecated enabled by default and will be removed in the future.
+	 */
+	@Deprecated
+	public void disableTtlCompactionFilter() {
+		enableTtlCompactionFilter = TernaryBoolean.FALSE;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Addressing [FLINK-15605](https://issues.apache.org/jira/browse/FLINK-15605), [FLINK-15606](https://issues.apache.org/jira/browse/FLINK-15606), [FLINK-15506](https://issues.apache.org/jira/browse/FLINK-15506).

## Brief change log

  - remove `StateTtlConfig.TimeCharacteristic`
  - deprecate `StateTtlConfig.cleanupInBackground`
  - set `RocksDBOptions.TTL_COMPACT_FILTER_ENABLED.defaultValue` to `true` and deprecate it


## Verifying this change

trivial change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs / JavaDocs)
