### PR TITLE
[FLINK-14701][runtime] Fix MultiTaskSlot to not remove slots which are not its children

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotSharingManager.java
@@ -612,6 +612,10 @@ public class SlotSharingManager {
 				TaskSlot child = children.remove(childGroupId);
 
 				if (child != null) {
+					Preconditions.checkState(
+						child == allTaskSlots.get(child.getSlotRequestId()),
+						"The child task slot is no longer registered. This might indicate that its " +
+							"SlotRequestId has been reused for another slot which is not allowed.");
 					allTaskSlots.remove(child.getSlotRequestId());
 
 					// Update the resources of this slot and the parents


### PR DESCRIPTION
## What is the purpose of the change

If a SharedSlotOversubscribedException happens, the MultiTaskSlot will release some of its child SingleTaskSlot. The triggered releasing will trigger a re-allocation of the task slot right inside SingleTaskSlot#release(...). So that a previous allocation in SloSharingManager#allTaskSlots will be replaced by the new allocation because they share the same slotRequestId.
However, the SingleTaskSlot#release(...) will then invoke MultiTaskSlot#releaseChild to release the previous allocation with the slotRequestId, which will unexpectedly remove the new allocation from the SloSharingManager.
In this way, slot leak happens because the pending slot request is not tracked by the SloSharingManager and cannot be released when its payload terminates.

Note that it's an issue in 1.9. And it's not a problem in 1.10/master now since SharedSlotOversubscribedException is removed in FLINK-14314. 
However, the fix would still help in master to avoid similar issue to happen in the future.

A test case testNoSlotLeakOnSharedSlotOversubscribedException which exhibits this issue can be found at https://github.com/zhuzhurk/flink/commit/19f4de04b124011f00ab508174bebe82f7e093d2.

## Brief change log

  - *See the code change.*


## Verifying this change

The change is verified on 1.9 with the test in https://github.com/zhuzhurk/flink/commit/9024e2e9eb4bd17f371896d6dbc745bc9e585e14.
However, I would like to not introduce that test since SharedSlotOversubscribedException is already removed in master.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
