### PR TITLE
[FLINK-15615][docs] fix File Sink consistency guarantees

### DIFF
--- a/docs/dev/connectors/guarantees.md
+++ b/docs/dev/connectors/guarantees.md
@@ -124,7 +124,7 @@ state updates) of Flink coupled with bundled sinks:
     </tr>
     <tr>
         <td>File sinks</td>
-        <td>at least once</td>
+        <td>exactly once</td>
         <td></td>
     </tr>
     <tr>

--- a/docs/dev/connectors/guarantees.zh.md
+++ b/docs/dev/connectors/guarantees.zh.md
@@ -124,7 +124,7 @@ state updates) of Flink coupled with bundled sinks:
     </tr>
     <tr>
         <td>File sinks</td>
-        <td>at least once</td>
+        <td>exactly once</td>
         <td></td>
     </tr>
     <tr>


### PR DESCRIPTION
At https://ci.apache.org/projects/flink/flink-docs-release-1.9/dev/connectors/guarantees.html

Instead of "at least once" should be "exactly once".

This change is a trivial rework without any test coverage.