### PR TITLE
[FLINK-15616][python] Move boot error messages from python-udf-boot.log to taskmanager's log file

### DIFF
--- a/flink-python/bin/pyflink-udf-runner.sh
+++ b/flink-python/bin/pyflink-udf-runner.sh
@@ -39,12 +39,5 @@ if [[ "$_PYTHON_WORKING_DIR" != "" ]]; then
     fi
 fi
 
-if [[ "$FLINK_LOG_DIR" != "" ]]; then
-    if [[ "$FLINK_IDENT_STRING" = "" ]]; then
-        FLINK_IDENT_STRING="$USER"
-    fi
-    log="$FLINK_LOG_DIR/flink-$USER-python-udf-boot-$HOSTNAME.log"
-    ${python} -m pyflink.fn_execution.boot $@ 2>&1 | tee -a ${log}
-else
-    ${python} -m pyflink.fn_execution.boot $@
-fi
+log="$BOOT_LOG_DIR/flink-python-udf-boot.log"
+${python} -m pyflink.fn_execution.boot $@ 2>&1 | tee -a ${log}

--- a/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
+++ b/flink-python/pyflink/fn_execution/tests/test_process_mode_boot.py
@@ -97,7 +97,7 @@ class PythonBootTests(PyFlinkTestCase):
         self.env = dict(os.environ)
         self.env["python"] = sys.executable
         self.env["FLINK_BOOT_TESTING"] = "1"
-        self.env["FLINK_LOG_DIR"] = os.path.join(self.env["FLINK_HOME"], "log")
+        self.env["BOOT_LOG_DIR"] = os.path.join(self.env["FLINK_HOME"], "log")
 
         self.tmp_dir = tempfile.mkdtemp(str(time.time()), dir=self.tempdir)
         # assume that this file is in flink-python source code directory.

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -25,7 +25,6 @@ import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.python.env.ProcessPythonEnvironmentManager;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.util.Preconditions;
 
@@ -49,8 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.util.List;
 
 /**
@@ -184,21 +181,13 @@ public abstract class AbstractPythonFunctionRunner<IN, OUT> implements PythonFun
 	}
 
 	/**
-	 * To make the error messages more user friendly, read the boot logs from the temp log file and
-	 * throw an exception directly.
+	 * To make the error messages more user friendly, throws an exception with the boot logs.
 	 */
 	private StageBundleFactory createStageBundleFactory() throws Exception {
 		try {
 			return jobBundleFactory.forStage(createExecutableStage());
-		} catch (Exception e) {
-			byte[] output =
-				Files.readAllBytes(
-					new File(((ProcessPythonEnvironmentManager) environmentManager).getBaseDirectory()
-						+ "/flink-python-udf-boot.log").toPath());
-			String msg =
-				String.format(
-					"Failed to start PythonFunctionRunner: %s", new String(output, Charset.defaultCharset()));
-			throw new RuntimeException(msg, e);
+		} catch (Throwable e) {
+			throw new RuntimeException(environmentManager.getBootLog(), e);
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
@@ -33,8 +33,6 @@ import org.codehaus.commons.nullanalysis.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -100,16 +98,13 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 	@NotNull private final PythonDependencyInfo dependencyInfo;
 	@NotNull private final Map<String, String> systemEnv;
 	@NotNull private final String[] tmpDirectories;
-	@Nullable private final String logDirectory;
 
 	public ProcessPythonEnvironmentManager(
 		@NotNull PythonDependencyInfo dependencyInfo,
 		@NotNull String[] tmpDirectories,
-		@Nullable String logDirectory,
 		@NotNull Map<String, String> systemEnv) {
 		this.dependencyInfo = Objects.requireNonNull(dependencyInfo);
 		this.tmpDirectories = Objects.requireNonNull(tmpDirectories);
-		this.logDirectory = logDirectory;
 		this.systemEnv = Objects.requireNonNull(systemEnv);
 	}
 
@@ -193,10 +188,8 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 
 		constructRequirementsDirectory(env);
 
-		// set FLINK_LOG_DIR if the log directory exists
-		if (!Strings.isNullOrEmpty(logDirectory)) {
-			env.put("FLINK_LOG_DIR", logDirectory);
-		}
+		// set BOOT_LOG_DIR.
+		env.put("BOOT_LOG_DIR", baseDirectory);
 
 		// set the path of python interpreter, it will be used to execute the udf worker.
 		if (dependencyInfo.getPythonExec().isPresent()) {
@@ -300,8 +293,7 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 		}
 	}
 
-	@VisibleForTesting
-	String getBaseDirectory() {
+	public String getBaseDirectory() {
 		return baseDirectory;
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
@@ -37,6 +37,7 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -293,8 +294,20 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 		}
 	}
 
-	public String getBaseDirectory() {
+	@VisibleForTesting
+	String getBaseDirectory() {
 		return baseDirectory;
+	}
+
+	@Override
+	public String getBootLog() throws Exception {
+		File bootLogFile = new File(baseDirectory + File.separator + "flink-python-udf-boot.log");
+		String msg = "Failed to create stage bundle factory!";
+		if (bootLogFile.exists()) {
+			byte[] output = Files.readAllBytes(bootLogFile.toPath());
+			msg += String.format(" %s", new String(output, Charset.defaultCharset()));
+		}
+		return msg;
 	}
 
 	private static void appendToPythonPath(Map<String, String> env, List<String> pythonDependencies) {

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonEnvironmentManager.java
@@ -49,4 +49,9 @@ public interface PythonEnvironmentManager extends AutoCloseable {
 	 * @return The path of the RetrievalToken file.
 	 */
 	String createRetrievalToken() throws Exception;
+
+	/**
+	 * Returns the boot log of the Python Environment.
+	 */
+	String getBootLog() throws Exception;
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.operators.python;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.memory.MemoryType;
@@ -40,7 +39,6 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.util.Preconditions;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -342,16 +340,9 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 			config, getRuntimeContext().getDistributedCache());
 		PythonEnv pythonEnv = getPythonEnv();
 		if (pythonEnv.getExecType() == PythonEnv.ExecType.PROCESS) {
-			String taskManagerLogFile = getContainingTask()
-				.getEnvironment()
-				.getTaskManagerInfo()
-				.getConfiguration()
-				.getString(ConfigConstants.TASK_MANAGER_LOG_PATH_KEY, System.getProperty("log.file"));
-			String logDirectory = taskManagerLogFile == null ? null : new File(taskManagerLogFile).getParent();
 			return new ProcessPythonEnvironmentManager(
 				dependencyInfo,
 				getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories(),
-				logDirectory,
 				System.getenv());
 		} else {
 			throw new UnsupportedOperationException(String.format(

--- a/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
@@ -287,7 +287,7 @@ public class ProcessPythonEnvironmentManagerTest {
 		sysEnv.put("FLINK_HOME", "/flink");
 
 		try (ProcessPythonEnvironmentManager environmentManager =
-				new ProcessPythonEnvironmentManager(dependencyInfo, new String[] {tmpDir}, null, sysEnv)) {
+				new ProcessPythonEnvironmentManager(dependencyInfo, new String[] {tmpDir}, sysEnv)) {
 			environmentManager.open();
 			String retrievalToken = environmentManager.createRetrievalToken();
 
@@ -310,11 +310,11 @@ public class ProcessPythonEnvironmentManagerTest {
 			null);
 
 		try (ProcessPythonEnvironmentManager environmentManager = new ProcessPythonEnvironmentManager(
-				dependencyInfo, new String[] {tmpDir}, "/tmp/log", new HashMap<>())) {
+				dependencyInfo, new String[] {tmpDir}, new HashMap<>())) {
 			environmentManager.open();
 			Map<String, String> env = environmentManager.constructEnvironmentVariables();
 			Map<String, String> expected = getBasicExpectedEnv(environmentManager);
-			expected.put("FLINK_LOG_DIR", "/tmp/log");
+			expected.put("BOOT_LOG_DIR", environmentManager.getBaseDirectory());
 			assertEquals(expected, env);
 		}
 	}
@@ -387,12 +387,13 @@ public class ProcessPythonEnvironmentManagerTest {
 				String.join(File.separator, tmpBase, "pyflink.zip"),
 				String.join(File.separator, tmpBase, "py4j-0.10.8.1-src.zip"),
 				String.join(File.separator, tmpBase, "cloudpickle-1.2.2-src.zip")));
+		map.put("BOOT_LOG_DIR", tmpBase);
 		return map;
 	}
 
 	private static ProcessPythonEnvironmentManager createBasicPythonEnvironmentManager(
 			PythonDependencyInfo dependencyInfo) {
 		return new ProcessPythonEnvironmentManager(
-			dependencyInfo, new String[] {tmpDir}, null, new HashMap<>());
+			dependencyInfo, new String[] {tmpDir}, new HashMap<>());
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
@@ -104,7 +104,6 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 			new ProcessPythonEnvironmentManager(
 				new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), null),
 				new String[] {System.getProperty("java.io.tmpdir")},
-				null,
 				new HashMap<>());
 
 		return new BaseRowPythonScalarFunctionRunner(

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
@@ -231,7 +231,6 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			new ProcessPythonEnvironmentManager(
 				new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), null),
 				new String[] {System.getProperty("java.io.tmpdir")},
-				null,
 				new HashMap<>());
 
 		return new PythonScalarFunctionRunner(
@@ -257,7 +256,6 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			new ProcessPythonEnvironmentManager(
 				new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), null),
 				new String[] {System.getProperty("java.io.tmpdir")},
-				null,
 				new HashMap<>());
 
 		return new PythonScalarFunctionRunnerTestHarness(


### PR DESCRIPTION

## What is the purpose of the change

Previously, the boot error messages are printed in the log file under FLINK_LOG_DIR, i.e., "$FLINK_LOG_DIR/flink-$USER-python-udf-boot-$HOSTNAME.log". This additional file is very hard to locate for users.

This pull request also prints the error messages into the taskmanager log file to make it more user-friendly. And throws an exception when there is an error during boot.


## Brief change log

  - Put the boot log file in the taskmanager's temp directly.
  - Prints the error messages into the taskmanager log file to make it more user-friendly.
  - Throws an exception when there is an error during boot.

## Verifying this change

This change is already covered by existing tests, such as `ProcessPythonEnvironmentManagerTest.testSetLogDirectory()`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
