### PR TITLE
[FLINK-15624][connectors]Pulsar sink

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.10-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-connector-pulsar_${scala.binary.version}</artifactId>
+	<name>flink-connector-pulsar</name>
+
+	<packaging>jar</packaging>
+
+	<!-- Allow users to pass custom connector versions -->
+	<properties>
+		<pulsar.version>2.4.1</pulsar.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.pulsar</groupId>
+			<artifactId>pulsar-client-all</artifactId>
+			<version>${pulsar.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- Table ecosystem -->
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-tests</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Pulsar table descriptor testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Pulsar catalog testing -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-client_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -37,7 +37,9 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<pulsar.version>2.4.1</pulsar.version>
+		<pulsar.version>2.4.2</pulsar.version>
+		<streamnative-tests.version>2.4.2</streamnative-tests.version>
+		<testcontainers.version>1.10.6</testcontainers.version>
 	</properties>
 
 	<dependencies>
@@ -80,6 +82,13 @@ under the License.
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-metrics-jmx_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -138,6 +147,48 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.streamnative.tests</groupId>
+			<artifactId>framework-common</artifactId>
+			<version>${streamnative-tests.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-common</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>io.streamnative.tests</groupId>
+			<artifactId>framework-pulsar</artifactId>
+			<version>${streamnative-tests.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.pulsar</groupId>
+					<artifactId>pulsar-client-original</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.pulsar</groupId>
+					<artifactId>pulsar-client-admin-original</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>central</id>
+			<layout>default</layout>
+			<url>https://repo1.maven.org/maven2</url>
+		</repository>
+		<repository>
+			<id>bintray-streamnative-maven</id>
+			<name>bintray</name>
+			<url>https://dl.bintray.com/streamnative/maven</url>
+		</repository>
+	</repositories>
 
 </project>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSink.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarRowSink.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.pulsar.internal.DateTimeUtils;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarSerializer;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.EVENT_TIME_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.KEY_ATTRIBUTE_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.META_FIELD_NAMES;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.TOPIC_ATTRIBUTE_NAME;
+
+public class FlinkPulsarRowSink extends FlinkPulsarSinkBase<Row> {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(FlinkPulsarRowSink.class);
+
+	protected final DataType dataType;
+
+    private DataType valueType;
+
+    private SerializableFunction<Row, Row> valueProjection;
+
+    private SerializableFunction<Row, Row> metaProjection;
+
+    private transient PulsarSerializer serializer;
+
+    public FlinkPulsarRowSink(
+            String adminUrl,
+            Optional<String> defaultTopicName,
+            ClientConfigurationData clientConf,
+            Properties properties,
+            DataType dataType) {
+        super(
+                adminUrl,
+                defaultTopicName,
+                clientConf,
+                properties,
+                TopicKeyExtractor.DUMMY_FOR_ROW);
+
+        this.dataType = dataType;
+        createProjection();
+    }
+
+    public FlinkPulsarRowSink(
+            String serviceUrl,
+            String adminUrl,
+            Optional<String> defaultTopicName,
+            Properties properties,
+            DataType dataType) {
+        this(adminUrl, defaultTopicName, newClientConf(serviceUrl), properties, dataType);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        this.serializer = new PulsarSerializer(valueType, false);
+    }
+
+    private void createProjection() {
+        int[] metas = new int[3];
+
+        FieldsDataType fdt = (FieldsDataType) dataType;
+        Map<String, DataType> fdtm = fdt.getFieldDataTypes();
+
+        List<RowType.RowField> rowFields = ((RowType) fdt.getLogicalType()).getFields();
+        Map<String, Tuple2<LogicalTypeRoot, Integer>> name2Type = new HashMap<>();
+        for (int i = 0; i < rowFields.size(); i++) {
+            RowType.RowField rf = rowFields.get(i);
+            name2Type.put(rf.getName(), new Tuple2<>(rf.getType().getTypeRoot(), i));
+        }
+
+        // topic
+        if (name2Type.containsKey(TOPIC_ATTRIBUTE_NAME)) {
+            Tuple2<LogicalTypeRoot, Integer> value = name2Type.get(TOPIC_ATTRIBUTE_NAME);
+            if (value.f0 == LogicalTypeRoot.VARCHAR) {
+                metas[0] = value.f1;
+            } else {
+                throw new IllegalStateException(
+                        String.format("attribute unsupported type %s, %s must be a string", value.f0.toString(), TOPIC_ATTRIBUTE_NAME));
+            }
+        } else {
+            if (!forcedTopic) {
+                throw new IllegalStateException(
+                        String.format("topic option required when no %s attribute is present.", TOPIC_ATTRIBUTE_NAME));
+            }
+            metas[0] = -1;
+        }
+
+        // key
+        if (name2Type.containsKey(KEY_ATTRIBUTE_NAME)) {
+            Tuple2<LogicalTypeRoot, Integer> value = name2Type.get(KEY_ATTRIBUTE_NAME);
+            if (value.f0 == LogicalTypeRoot.VARBINARY) {
+                metas[1] = value.f1;
+            } else {
+                throw new IllegalStateException(
+                        String.format("%s attribute unsupported type %s", KEY_ATTRIBUTE_NAME, value.f0.toString()));
+            }
+        } else {
+            metas[1] = -1;
+        }
+
+        // eventTime
+        if (name2Type.containsKey(EVENT_TIME_NAME)) {
+            Tuple2<LogicalTypeRoot, Integer> value = name2Type.get(EVENT_TIME_NAME);
+            if (value.f0 == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
+                metas[2] = value.f1;
+            } else {
+                throw new IllegalStateException(
+                        String.format("%s attribute unsupported type %s", EVENT_TIME_NAME, value.f0.toString()));
+            }
+        } else {
+            metas[2] = -1;
+        }
+
+        List<RowType.RowField> nonInternalFields = rowFields.stream()
+                .filter(f -> !META_FIELD_NAMES.contains(f.getName())).collect(Collectors.toList());
+
+        if (nonInternalFields.size() == 1) {
+            String fieldName = nonInternalFields.get(0).getName();
+            valueType = fdtm.get(fieldName);
+        } else {
+            List<DataTypes.Field> fields = nonInternalFields.stream()
+                    .map(f -> {
+                        String fieldName = f.getName();
+                        return DataTypes.FIELD(fieldName, fdtm.get(fieldName));
+                    }).collect(Collectors.toList());
+            valueType = DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
+        }
+
+        List<Integer> values = nonInternalFields.stream()
+                .map(f -> name2Type.get(f.getName()).f1).collect(Collectors.toList());
+
+        metaProjection = row -> {
+            Row result = new Row(3);
+            for (int i = 0; i < metas.length; i++) {
+                if (metas[i] != -1) {
+                    result.setField(i, row.getField(metas[i]));
+                }
+            }
+            return result;
+        };
+
+        valueProjection = row -> {
+            Row result = new Row(values.size());
+            for (int i = 0; i < values.size(); i++) {
+                result.setField(i, row.getField(values.get(i)));
+            }
+            return result;
+        };
+    }
+
+    @Override
+    protected Schema<?> getPulsarSchema() {
+        try {
+            return SchemaUtils.sqlType2PulsarSchema(valueType);
+        } catch (SchemaUtils.IncompatibleSchemaException e) {
+            LOG.error(ExceptionUtils.stringifyException(e));
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void invoke(Row value, Context context) throws Exception {
+        checkErroneous();
+        initializeSendCallback();
+
+        Row metaRow = metaProjection.apply(value);
+        Row valueRow = valueProjection.apply(value);
+        Object v = serializer.serialize(valueRow);
+
+        String topic;
+        if (forcedTopic) {
+            topic = defaultTopic;
+        } else {
+            topic = (String) metaRow.getField(0);
+        }
+
+        String key = (String) metaRow.getField(1);
+        java.sql.Timestamp eventTime = (java.sql.Timestamp) metaRow.getField(2);
+
+        if (topic == null) {
+            if (failOnWrite) {
+                throw new NullPointerException("null topic present in the data");
+            }
+            return;
+        }
+
+        TypedMessageBuilder builder = getProducer(topic).newMessage().value(v);
+
+        if (key != null) {
+            builder.keyBytes(key.getBytes());
+        }
+
+        if (eventTime != null) {
+            long et = DateTimeUtils.fromJavaTimestamp(eventTime);
+            if (et > 0) {
+                builder.eventTime(et);
+            }
+        }
+
+        if (flushOnCheckpoint) {
+            synchronized (pendingRecordsLock) {
+                pendingRecords++;
+            }
+        }
+        builder.sendAsync().whenComplete(sendCallback);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSink.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.TypedMessageBuilder;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+
+import java.util.Optional;
+import java.util.Properties;
+
+public class FlinkPulsarSink<T> extends FlinkPulsarSinkBase<T> {
+
+    private final Class<T> recordClazz;
+
+    public FlinkPulsarSink(
+            String adminUrl,
+            Optional<String> defaultTopicName,
+            ClientConfigurationData clientConf,
+            Properties properties,
+            TopicKeyExtractor<T> topicKeyExtractor,
+            Class<T> recordClazz) {
+        super(adminUrl, defaultTopicName, clientConf, properties, topicKeyExtractor);
+        this.recordClazz = recordClazz;
+    }
+
+    public FlinkPulsarSink(
+            String serviceUrl,
+            String adminUrl,
+            Optional<String> defaultTopicName,
+            Properties properties,
+            TopicKeyExtractor<T> topicKeyExtractor,
+            Class<T> recordClazz) {
+        this(adminUrl, defaultTopicName, newClientConf(serviceUrl), properties, topicKeyExtractor, recordClazz);
+    }
+
+    @Override
+    protected Schema<T> getPulsarSchema() {
+        return Schema.AVRO(recordClazz);
+    }
+
+    @Override
+    public void invoke(T value, Context context) throws Exception {
+        checkErroneous();
+        initializeSendCallback();
+
+        TypedMessageBuilder<T> mb;
+
+        if (forcedTopic) {
+            mb = (TypedMessageBuilder<T>) getProducer(defaultTopic).newMessage().value(value);
+        } else {
+            byte[] key = topicKeyExtractor.serializeKey(value);
+            String topic = topicKeyExtractor.getTopic(value);
+
+            if (topic == null) {
+                if (failOnWrite) {
+                    throw new NullPointerException("no topic present in the data.");
+                }
+                return;
+            }
+
+            mb = (TypedMessageBuilder<T>) getProducer(topic).newMessage().value(value);
+            if (key != null) {
+                mb.keyBytes(key);
+            }
+        }
+
+        if (flushOnCheckpoint) {
+            synchronized (pendingRecordsLock) {
+                pendingRecords++;
+            }
+        }
+        mb.sendAsync().whenComplete(sendCallback);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkBase.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import avro.shaded.com.google.common.collect.Maps;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.connectors.pulsar.internal.CachedPulsarClient;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils;
+import org.apache.flink.streaming.connectors.pulsar.internal.SourceSinkUtils;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.SerializableObject;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+abstract class FlinkPulsarSinkBase<T> extends RichSinkFunction<T> implements CheckpointedFunction {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(FlinkPulsarSinkBase.class);
+
+	protected String adminUrl;
+
+	protected ClientConfigurationData clientConfigurationData;
+
+	protected final Map<String, String> caseInsensitiveParams;
+
+	protected final Map<String, Object> producerConf;
+
+	protected final Properties properties;
+
+	protected boolean flushOnCheckpoint;
+
+	protected boolean failOnWrite;
+
+	/** Lock for accessing the pending records. */
+	protected final SerializableObject pendingRecordsLock = new SerializableObject();
+
+	/** Number of unacknowledged records. */
+	protected long pendingRecords = 0L;
+
+	protected final boolean forcedTopic;
+
+	protected final String defaultTopic;
+
+	protected final TopicKeyExtractor<T> topicKeyExtractor;
+
+	protected transient volatile Throwable failedWrite;
+
+	protected transient PulsarAdmin admin;
+
+	protected transient BiConsumer<MessageId, Throwable> sendCallback;
+
+	protected transient Producer<?> singleProducer;
+
+	protected transient Map<String, Producer<?>> topic2Producer;
+
+	public FlinkPulsarSinkBase(
+		String adminUrl,
+		Optional<String> defaultTopicName,
+		ClientConfigurationData clientConf,
+		Properties properties,
+		TopicKeyExtractor<T> topicKeyExtractor) {
+
+		this.adminUrl = checkNotNull(adminUrl);
+
+		if (defaultTopicName.isPresent()) {
+			this.forcedTopic = true;
+			this.defaultTopic = defaultTopicName.get();
+			this.topicKeyExtractor = null;
+		} else {
+			this.forcedTopic = false;
+			this.defaultTopic = null;
+			ClosureCleaner.clean(
+				topicKeyExtractor, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+			this.topicKeyExtractor = checkNotNull(topicKeyExtractor);
+		}
+
+		this.clientConfigurationData = clientConf;
+
+		this.properties = checkNotNull(properties);
+
+		this.caseInsensitiveParams =
+			SourceSinkUtils.toCaceInsensitiveParams(Maps.fromProperties(properties));
+
+		this.producerConf =
+			SourceSinkUtils.getProducerParams(caseInsensitiveParams);
+
+		this.flushOnCheckpoint =
+			SourceSinkUtils.flushOnCheckpoint(caseInsensitiveParams);
+
+		this.failOnWrite =
+			SourceSinkUtils.failOnWrite(caseInsensitiveParams);
+
+		CachedPulsarClient.setCacheSize(SourceSinkUtils.getClientCacheSize(caseInsensitiveParams));
+
+		if (this.clientConfigurationData.getServiceUrl() == null) {
+			throw new IllegalArgumentException("ServiceUrl must be supplied in the client configuration");
+		}
+	}
+
+	public FlinkPulsarSinkBase(
+		String serviceUrl,
+		String adminUrl,
+		Optional<String> defaultTopicName,
+		Properties properties,
+		TopicKeyExtractor<T> topicKeyExtractor) {
+		this(adminUrl, defaultTopicName, newClientConf(checkNotNull(serviceUrl)), properties, topicKeyExtractor);
+	}
+
+	protected static ClientConfigurationData newClientConf(String serviceUrl) {
+		ClientConfigurationData clientConf = new ClientConfigurationData();
+		clientConf.setServiceUrl(serviceUrl);
+		return clientConf;
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		checkErroneous();
+
+		if (flushOnCheckpoint) {
+			producerFlush();
+			synchronized (pendingRecordsLock) {
+				if (pendingRecords != 0) {
+					throw new IllegalStateException("Pending record count must be zero at this point " + pendingRecords);
+				}
+				checkErroneous();
+			}
+		}
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+	}
+
+	protected abstract Schema<?> getPulsarSchema();
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		if (flushOnCheckpoint && !((StreamingRuntimeContext) this.getRuntimeContext()).isCheckpointingEnabled()) {
+			LOG.warn("Flushing on checkpoint is enabled, but checkpointing is not enabled. Disabling flushing.");
+			flushOnCheckpoint = false;
+		}
+
+		admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
+
+		if (forcedTopic) {
+			uploadSchema(defaultTopic);
+			singleProducer = createProducer(clientConfigurationData, producerConf, defaultTopic, getPulsarSchema());
+		} else {
+			topic2Producer = new HashMap<>();
+		}
+	}
+
+	protected void initializeSendCallback() {
+		if (sendCallback != null) {
+			return;
+		}
+
+		if (failOnWrite) {
+			this.sendCallback = (t, u) -> {
+				if (failedWrite == null && u == null) {
+					acknowledgeMessage();
+				} else if (failedWrite == null && u != null) {
+					failedWrite = u;
+				} else { // failedWrite != null
+					// do nothing and wait next checkForError to throw exception
+				}
+			};
+		} else {
+			this.sendCallback = (t, u) -> {
+				if (failedWrite == null && u != null) {
+					LOG.error("Error while sending message to Pulsar: {}", ExceptionUtils.stringifyException(u));
+				}
+				acknowledgeMessage();
+			};
+		}
+	}
+
+	private void uploadSchema(String topic) {
+		SchemaUtils.uploadPulsarSchema(admin, topic, getPulsarSchema().getSchemaInfo());
+	}
+
+	@Override
+	public void close() throws Exception {
+		checkErroneous();
+		producerClose();
+		checkErroneous();
+	}
+
+	protected <R> Producer<R> getProducer(String topic) {
+		if (forcedTopic) {
+			return (Producer<R>) singleProducer;
+		}
+
+		if (topic2Producer.containsKey(topic)) {
+			return (Producer<R>) topic2Producer.get(topic);
+		} else {
+			uploadSchema(topic);
+			Producer p = createProducer(clientConfigurationData, producerConf, topic, getPulsarSchema());
+			topic2Producer.put(topic, p);
+			return (Producer<R>) p;
+		}
+	}
+
+	protected Producer<?> createProducer(
+		ClientConfigurationData clientConf,
+		Map<String, Object> producerConf,
+		String topic,
+		Schema<?> schema) {
+
+		try {
+			return CachedPulsarClient
+				.getOrCreate(clientConf)
+				.newProducer(schema)
+				.topic(topic)
+				.batchingMaxPublishDelay(100, TimeUnit.MILLISECONDS)
+				// maximizing the throughput
+				.batchingMaxMessages(5 * 1024 * 1024)
+				.loadConf(producerConf)
+				.create();
+		} catch (PulsarClientException e) {
+			LOG.error("Failed to create producer for topic {}", topic);
+			throw new RuntimeException(e);
+		} catch (ExecutionException e) {
+			LOG.error("Failed to getOrCreate a PulsarClient");
+			throw new RuntimeException(e);
+		}
+	}
+
+	public void producerFlush() throws Exception {
+		if (singleProducer != null) {
+			singleProducer.flush();
+		} else {
+			if (topic2Producer != null) {
+				for (Producer<?> p : topic2Producer.values()) {
+					p.flush();
+				}
+			}
+		}
+		synchronized (pendingRecordsLock) {
+			while (pendingRecords > 0) {
+				try {
+					pendingRecordsLock.wait();
+				} catch (InterruptedException e) {
+					// this can be interrupted when the Task has been cancelled.
+					// by throwing an exception, we ensure that this checkpoint doesn't get confirmed
+					throw new RuntimeException("Flushing got interrupted while checkpointing", e);
+				}
+			}
+		}
+	}
+
+	protected void producerClose() throws Exception {
+		producerFlush();
+		if (admin != null) {
+			admin.close();
+		}
+		if (singleProducer != null) {
+			singleProducer.close();
+		} else {
+			if (topic2Producer != null) {
+				for (Producer<?> p : topic2Producer.values()) {
+					p.close();
+				}
+				topic2Producer.clear();
+			}
+		}
+	}
+
+	protected void checkErroneous() throws Exception {
+		Throwable e = failedWrite;
+		if (e != null) {
+			// prevent double throwing
+			failedWrite = null;
+			throw new Exception("Failed to send data to Kafka: " + e.getMessage(), e);
+		}
+	}
+
+	private void acknowledgeMessage() {
+		if (flushOnCheckpoint) {
+			synchronized (pendingRecordsLock) {
+				pendingRecords--;
+				if (pendingRecords == 0) {
+					pendingRecordsLock.notifyAll();
+				}
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/SerializableFunction.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/SerializableFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/**
+ * Represents a serializable function that accepts one argument and produces a result.
+ *
+ *
+ * @param <T> the type of the input to the function
+ * @param <R> the type of the result of the function
+ */
+public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/TopicKeyExtractor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/TopicKeyExtractor.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.types.Row;
+
+import java.io.Serializable;
+
+/**
+ * Extract key and topic from a value.
+ */
+public interface TopicKeyExtractor<T> extends Serializable {
+
+    TopicKeyExtractor DUMMY_FOR_ROW = new TopicKeyExtractor<Row>() {
+        @Override
+        public byte[] serializeKey(Row element) {
+            return null;
+        }
+
+        @Override
+        public String getTopic(Row element) {
+            return null;
+        }
+    };
+
+    byte[] serializeKey(T element);
+
+    String getTopic(T element);
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/CachedPulsarClient.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/CachedPulsarClient.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.PulsarClientImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.apache.pulsar.shade.com.google.common.cache.CacheBuilder;
+import org.apache.pulsar.shade.com.google.common.cache.CacheLoader;
+import org.apache.pulsar.shade.com.google.common.cache.LoadingCache;
+import org.apache.pulsar.shade.com.google.common.cache.RemovalListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+
+public class CachedPulsarClient {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(CachedPulsarClient.class);
+
+	private static int cacheSize = 5;
+
+    public static void setCacheSize(int size) {
+        cacheSize = size;
+    }
+
+    public static int getCacheSize() {
+        return cacheSize;
+    }
+
+    private static CacheLoader<ClientConfigurationData, PulsarClientImpl> cacheLoader =
+            new CacheLoader<ClientConfigurationData, PulsarClientImpl>() {
+                @Override
+                public PulsarClientImpl load(ClientConfigurationData key) throws Exception {
+                    return createPulsarClient(key);
+                }
+            };
+
+    private static RemovalListener<ClientConfigurationData, PulsarClientImpl> removalListener = notification -> {
+        ClientConfigurationData config = notification.getKey();
+        PulsarClientImpl client = notification.getValue();
+        LOG.debug("Evicting pulsar client {} with config {}, due to {}",
+                client.toString(), config.toString(), notification.getCause().toString());
+        close(config, client);
+    };
+
+    private static LoadingCache<ClientConfigurationData, PulsarClientImpl> guavaCache =
+            CacheBuilder.newBuilder().maximumSize(cacheSize).removalListener(removalListener).build(cacheLoader);
+
+    private static PulsarClientImpl createPulsarClient(
+            ClientConfigurationData clientConfig) throws PulsarClientException {
+        PulsarClientImpl client;
+        try {
+            client = new PulsarClientImpl(clientConfig);
+            LOG.debug("Created a new instance of PulsarClientImpl for clientConf = {}",
+                    clientConfig.toString());
+        } catch (PulsarClientException e) {
+            LOG.error("Failed to create PulsarClientImpl for clientConf = {}",
+                    clientConfig.toString());
+            throw e;
+        }
+        return client;
+    }
+
+    public static PulsarClientImpl getOrCreate(ClientConfigurationData config) throws ExecutionException {
+        return guavaCache.get(config);
+    }
+
+    private static void close(ClientConfigurationData clientConfig, PulsarClientImpl client) {
+        try {
+            LOG.info("Closing the Pulsar client with conifg {}", clientConfig.toString());
+            client.close();
+        } catch (PulsarClientException e) {
+            LOG.warn(String.format("Error while closing the Pulsar client %s", clientConfig.toString()), e);
+        }
+    }
+
+    static void close(ClientConfigurationData clientConfig) {
+        guavaCache.invalidate(clientConfig);
+    }
+
+    static void clear() {
+        LOG.info("Cleaning up guava cache.");
+        guavaCache.invalidateAll();
+    }
+
+    static ConcurrentMap<ClientConfigurationData, PulsarClientImpl> getAsMap() {
+        return guavaCache.asMap();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/DateTimeUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/DateTimeUtils.java
@@ -1,0 +1,342 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import javax.xml.bind.DatatypeConverter;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+public class DateTimeUtils {
+
+    private static final long SECONDS_PER_DAY = 60 * 60 * 24L;
+    private static final long MILLIS_PER_DAY = SECONDS_PER_DAY * 1000L;
+
+    // number of days between 1.1.1970 and 1.1.2001
+    private static final int to2001 = -11323;
+    private static final int toYearZero = to2001 + 7304850;
+
+    // number of days in 400 years
+    private static final int daysIn400Years = 146097;
+
+    private static final long MICROS_PER_MILLIS = 1000L;
+    private static final long MILLIS_PER_SECOND = 1000L;
+    private static final long MICROS_PER_SECOND = MICROS_PER_MILLIS * MILLIS_PER_SECOND;
+
+    public static Date stringToTime(String s) {
+        int indexOfGMT = s.indexOf("GMT");
+        if (indexOfGMT != -1) {
+            // ISO8601 with a weird time zone specifier (2000-01-01T00:00GMT+01:00)
+            String s0 = s.substring(0, indexOfGMT);
+            String s1 = s.substring(indexOfGMT + 3);
+            // Mapped to 2000-01-01T00:00+01:00
+            return stringToTime(s0 + s1);
+        } else if (!s.contains("T")) {
+            // JDBC escape string
+            if (s.contains(" ")) {
+                return Timestamp.valueOf(s);
+            } else {
+                return java.sql.Date.valueOf(s);
+            }
+        } else {
+            return DatatypeConverter.parseDateTime(s).getTime();
+        }
+    }
+
+    /**
+     * Returns the number of days since epoch from java.sql.Date.
+     */
+    public static int fromJavaDate(Date date) {
+        return millisToDays(date.getTime());
+    }
+
+    // we should use the exact day as Int, for example, (year, month, day) -> day
+    public static int millisToDays(long millisUtc) {
+        return millisToDays(millisUtc, defaultTimeZone());
+    }
+
+    public static int millisToDays(long millisUtc, TimeZone timeZone) {
+        long millisLocal = millisUtc + timeZone.getOffset(millisUtc);
+        return (int) Math.floor((double) millisLocal / MILLIS_PER_DAY);
+    }
+
+    public static TimeZone defaultTimeZone() {
+        return TimeZone.getDefault();
+    }
+
+    /**
+     * Returns the number of micros since epoch from java.sql.Timestamp.
+     */
+    public static long fromJavaTimestamp(Timestamp t) {
+        if (t != null) {
+            return t.getTime() * 1000L + ((long) t.getNanos() / 1000) % 1000L;
+        } else {
+            return 0L;
+        }
+    }
+
+    // Converts Timestamp to string according to Hive TimestampWritable convention.
+    public static String timestampToString(long us, TimeZone timeZone) {
+        Timestamp ts = toJavaTimestamp(us);
+        String timestampString = ts.toString();
+        DateFormat timestampFormat = getThreadLocalTimestampFormat(timeZone);
+        String formatted = timestampFormat.format(ts);
+
+        if (timestampString.length() > 19 && !timestampString.substring(19).equals(".0")) {
+            return formatted + timestampString.substring(19);
+        } else {
+            return formatted;
+        }
+    }
+
+    // `SimpleDateFormat` is not thread-safe.
+    private static ThreadLocal<DateFormat> threadLocalTimestampFormat =
+            ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US));
+
+    public static DateFormat getThreadLocalTimestampFormat(TimeZone timeZone) {
+        DateFormat sdf = threadLocalTimestampFormat.get();
+        sdf.setTimeZone(timeZone);
+        return sdf;
+    }
+
+    /**
+     * Returns a java.sql.Timestamp from number of micros since epoch.
+     */
+    public static Timestamp toJavaTimestamp(long us) {
+        // setNanos() will overwrite the millisecond part, so the milliseconds should be
+        // cut off at seconds
+        long seconds = us / MICROS_PER_SECOND;
+        long micros = us % MICROS_PER_SECOND;
+        // setNanos() can not accept negative value
+        if (micros < 0) {
+            micros += MICROS_PER_SECOND;
+            seconds -= 1;
+        }
+        Timestamp t = new Timestamp(seconds * 1000);
+        t.setNanos((int) micros * 1000);
+        return t;
+    }
+
+    /**
+     * Returns a java.sql.Date from number of days since epoch.
+     */
+    public static Date toJavaDate(int daysSinceEpoch) {
+        return new Date(daysToMillis(daysSinceEpoch));
+    }
+
+    // reverse of millisToDays
+    public static long daysToMillis(int days) {
+        return daysToMillis(days, defaultTimeZone());
+    }
+
+    public static long daysToMillis(int days, TimeZone timeZone) {
+        long millisLocal = (long) days * MILLIS_PER_DAY;
+        return millisLocal - getOffsetFromLocalMillis(millisLocal, timeZone);
+    }
+
+    /**
+     * Lookup the offset for given millis seconds since 1970-01-01 00:00:00 in given timezone.
+     * TODO: Improve handling of normalization differences.
+     * TODO: Replace with JSR-310 or similar system
+     */
+    private static long getOffsetFromLocalMillis(long millisLocal, TimeZone tz) {
+        int guess = tz.getRawOffset();
+        // the actual offset should be calculated based on milliseconds in UTC
+        int offset = tz.getOffset(millisLocal - guess);
+        if (offset != guess) {
+            guess = tz.getOffset(millisLocal - offset);
+            if (guess != offset) {
+                // fallback to do the reverse lookup using java.sql.Timestamp
+                // this should only happen near the start or end of DST
+                int days = (int) Math.floor((double) millisLocal / MILLIS_PER_DAY);
+                int year = getYear(days);
+                int month = getMonth(days);
+                int day = getDayOfMonth(days);
+
+                int millisOfDay = (int) (millisLocal % MILLIS_PER_DAY);
+                if (millisOfDay < 0) {
+                    millisOfDay += (int) MILLIS_PER_DAY;
+                }
+                int seconds = (int) (millisOfDay / 1000L);
+                int hh = seconds / 3600;
+                int mm = seconds / 60 % 60;
+                int ss = seconds % 60;
+                int ms = millisOfDay % 1000;
+                Calendar calendar = Calendar.getInstance(tz);
+                calendar.set(year, month - 1, day, hh, mm, ss);
+                calendar.set(Calendar.MILLISECOND, ms);
+                guess = (int) (millisLocal - calendar.getTimeInMillis());
+            }
+        }
+        return guess;
+    }
+
+    /**
+     * Returns the year value for the given date. The date is expressed in days
+     * since 1.1.1970.
+     */
+    public static int getYear(int date) {
+        return getYearAndDayInYear(date).f0;
+    }
+
+    /**
+     * Calculates the year and the number of the day in the year for the given
+     * number of days. The given days is the number of days since 1.1.1970.
+     *
+     * The calculation uses the fact that the period 1.1.2001 until 31.12.2400 is
+     * equals to the period 1.1.1601 until 31.12.2000.
+     */
+    private static Tuple2<Integer, Integer> getYearAndDayInYear(int daysSince1970) {
+        // add the difference (in days) between 1.1.1970 and the artificial year 0 (-17999)
+        int daysSince1970Tmp = daysSince1970;
+        // Since Julian calendar was replaced with the Gregorian calendar,
+        // the 10 days after Oct. 4 were skipped.
+        // (1582-10-04) -141428 days since 1970-01-01
+        if (daysSince1970 <= -141428) {
+            daysSince1970Tmp -= 10;
+        }
+        int daysNormalized = daysSince1970Tmp + toYearZero;
+        int numOfQuarterCenturies = daysNormalized / daysIn400Years;
+        int daysInThis400 = daysNormalized % daysIn400Years + 1;
+        Tuple2<Integer, Integer> yD = numYears(daysInThis400);
+        int year = (2001 - 20000) + 400 * numOfQuarterCenturies + yD.f0;
+        return Tuple2.of(year, yD.f1);
+    }
+
+    /**
+     * Calculates the number of years for the given number of days. This depends
+     * on a 400 year period.
+     * @param days days since the beginning of the 400 year period
+     * @return (number of year, days in year)
+     */
+    private static Tuple2<Integer, Integer> numYears(int days) {
+        int year = days / 365;
+        int boundary = yearBoundary(year);
+        if (days > boundary) {
+            return new Tuple2<>(year, days - boundary);
+        } else {
+            return new Tuple2<>(year - 1, days - yearBoundary(year - 1));
+        }
+    }
+
+    /**
+     * Return the number of days since the start of 400 year period.
+     * The second year of a 400 year period (year 1) starts on day 365.
+     */
+    private static int yearBoundary(int year) {
+        return year * 365 + ((year / 4) - (year / 100) + (year / 400));
+    }
+
+    /**
+     * Returns the month value for the given date. The date is expressed in days
+     * since 1.1.1970. January is month 1.
+     */
+    public static int getMonth(int date) {
+        Tuple2<Integer, Integer> entry = getYearAndDayInYear(date);
+        int year = entry.f0;
+        int dayInYear = entry.f1;
+
+        if (isLeapYear(year)) {
+            if (dayInYear == 60) {
+                return 2;
+            } else if (dayInYear > 60) {
+                dayInYear = dayInYear - 1;
+            }
+        }
+
+        if (dayInYear <= 31) {
+            return 1;
+        } else if (dayInYear <= 59) {
+            return 2;
+        } else if (dayInYear <= 90) {
+            return 3;
+        } else if (dayInYear <= 120) {
+            return 4;
+        } else if (dayInYear <= 151) {
+            return 5;
+        } else if (dayInYear <= 181) {
+            return 6;
+        } else if (dayInYear <= 212) {
+            return 7;
+        } else if (dayInYear <= 243) {
+            return 8;
+        } else if (dayInYear <= 273) {
+            return 9;
+        } else if (dayInYear <= 304) {
+            return 10;
+        } else if (dayInYear <= 334) {
+            return 11;
+        } else {
+            return 12;
+        }
+    }
+
+    /**
+     * Returns the 'day of month' value for the given date. The date is expressed in days
+     * since 1.1.1970.
+     */
+    public static int getDayOfMonth(int date) {
+        Tuple2<Integer, Integer> entry = getYearAndDayInYear(date);
+        int year = entry.f0;
+        int dayInYear = entry.f1;
+
+        if (isLeapYear(year)) {
+            if (dayInYear == 60) {
+                return 29;
+            } else if (dayInYear > 60) {
+                dayInYear = dayInYear - 1;
+            }
+        }
+
+        if (dayInYear <= 31) {
+            return dayInYear;
+        } else if (dayInYear <= 59) {
+            return dayInYear - 31;
+        } else if (dayInYear <= 90) {
+            return dayInYear - 59;
+        } else if (dayInYear <= 120) {
+            return dayInYear - 90;
+        } else if (dayInYear <= 151) {
+            return dayInYear - 120;
+        } else if (dayInYear <= 181) {
+            return dayInYear - 151;
+        } else if (dayInYear <= 212) {
+            return dayInYear - 181;
+        } else if (dayInYear <= 243) {
+            return dayInYear - 212;
+        } else if (dayInYear <= 273) {
+            return dayInYear - 243;
+        } else if (dayInYear <= 304) {
+            return dayInYear - 273;
+        } else if (dayInYear <= 334) {
+            return dayInYear - 304;
+        } else {
+            return dayInYear - 334;
+        }
+    }
+
+    private static boolean isLeapYear(int year) {
+        return (year % 4) == 0 && ((year % 100) != 0 || (year % 400) == 0);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PulsarMetadataReader implements Closeable {
+
+	private PulsarAdmin admin;
+
+	private volatile boolean closed = false;
+
+	public PulsarMetadataReader(String adminUrl) throws PulsarClientException {
+		this.admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
+	}
+
+	@Override
+	public void close() {
+		closed = true;
+		if (admin != null) {
+			admin.close();
+			admin = null;
+		}
+	}
+	
+	public List<String> listNamespaces() throws PulsarAdminException {
+		List<String> tenants = admin.tenants().getTenants();
+		List<String> namespaces = new ArrayList<>();
+		for (String tenant : tenants) {
+			namespaces.addAll(admin.namespaces().getNamespaces(tenant));
+		}
+		return namespaces;
+	}
+
+	public boolean namespaceExists(String ns) throws PulsarAdminException {
+		try {
+			admin.namespaces().getTopics(ns);
+		} catch (PulsarAdminException.NotFoundException e) {
+			return false;
+		}
+		return true;
+	}
+
+	public void createNamespace(String ns) throws PulsarAdminException {
+		String nsName = NamespaceName.get(ns).toString();
+		admin.namespaces().createNamespace(nsName);
+	}
+
+	public void deleteNamespace(String ns) throws PulsarAdminException {
+		String nsName = NamespaceName.get(ns).toString();
+		admin.namespaces().deleteNamespace(nsName);
+	}
+
+	public List<String> getTopics(String ns) throws PulsarAdminException {
+		List<String> nonPartitionedTopics = getNonPartitionedTopics(ns);
+		List<String> partitionedTopics = admin.topics().getPartitionedTopicList(ns);
+		List<String> allTopics = new ArrayList<>();
+		Stream.of(partitionedTopics, nonPartitionedTopics).forEach(allTopics::addAll);
+		return allTopics.stream().map(t -> TopicName.get(t).getLocalName()).collect(Collectors.toList());
+	}
+
+	private List<String> getNonPartitionedTopics(String databaseName) throws PulsarAdminException {
+		return admin
+			.topics()
+			.getList(databaseName)
+			.stream()
+			.filter(t -> !TopicName.get(t).isPartitioned()).collect(Collectors.toList());
+	}
+
+	public TableSchema getTableSchema(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		FieldsDataType fieldsDataType = getSchema(topicName);
+		return SchemaUtils.toTableSchema(fieldsDataType);
+	}
+
+	public boolean topicExists(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		int partitionNum = admin.topics().getPartitionedTopicMetadata(topicName).partitions;
+		if (partitionNum > 0) {
+			return true;
+		} else {
+			admin.topics().getStats(topicName);
+		}
+		return true;
+	}
+
+	public void deleteTopic(ObjectPath objectPath) throws PulsarAdminException {
+		String topicName = objectPath2TopicName(objectPath);
+		int partitionNum = admin.topics().getPartitionedTopicMetadata(topicName).partitions;
+		if (partitionNum > 0) {
+			admin.topics().deletePartitionedTopic(topicName, true);
+		} else {
+			admin.topics().delete(topicName, true);
+		}
+	}
+
+	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, SchemaUtils.IncompatibleSchemaException {
+		String topicName = objectPath2TopicName(objectPath);
+		admin.topics().createPartitionedTopic(topicName, defaultPartitionNum);
+		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(table.getSchema().toRowDataType()).getSchemaInfo();
+	}
+
+	private FieldsDataType getSchema(String topic) throws PulsarAdminException {
+		SchemaInfo si = getPulsarSchema(topic);
+		try {
+			return SchemaUtils.pulsarSourceSchema(si);
+		} catch (SchemaUtils.IncompatibleSchemaException e) {
+			throw new PulsarAdminException(e);
+		}
+	}
+
+	private SchemaInfo getPulsarSchema(String topic) throws PulsarAdminException {
+		try {
+			return admin.schemas().getSchemaInfo(TopicName.get(topic).toString());
+		} catch (PulsarAdminException e) {
+			if (e.getStatusCode() == 404) {
+				return BytesSchema.of().getSchemaInfo();
+			} else {
+				throw e;
+			}
+		}
+	}
+
+	private static String objectPath2TopicName(ObjectPath objectPath) {
+		NamespaceName ns = NamespaceName.get(objectPath.getDatabaseName());
+		String topic = objectPath.getObjectName();
+		TopicName fullName = TopicName.get(TopicDomain.persistent.toString(), ns, topic);
+		return fullName.toString();
+	}
+
+
+
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarMetadataReader.java
@@ -15,12 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
+import com.google.common.collect.Iterables;
+import org.apache.commons.collections.ListUtils;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils.IncompatibleSchemaException;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
@@ -30,35 +34,65 @@ import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.schema.SchemaInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class PulsarMetadataReader implements Closeable {
+/**
+ * A Helper class that responsible for catalog administration.
+ */
+public class PulsarMetadataReader implements AutoCloseable {
 
-	private PulsarAdmin admin;
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarMetadataReader.class);
+
+	private final String adminUrl;
+
+	private final String driverGroupIdPrefix;
+
+	private final Map<String, String> caseInsensitiveParams;
+
+	private final int indexOfThisSubtask;
+
+	private final int numParallelSubtasks;
+
+	private final PulsarAdmin admin;
 
 	private volatile boolean closed = false;
 
-	public PulsarMetadataReader(String adminUrl) throws PulsarClientException {
+	public PulsarMetadataReader(
+		String adminUrl,
+		String driverGroupIdPrefix,
+		Map<String, String> caseInsensitiveParams,
+		int indexOfThisSubtask,
+		int numParallelSubtasks) throws PulsarClientException {
+
+		this.adminUrl = adminUrl;
+		this.driverGroupIdPrefix = driverGroupIdPrefix;
+		this.caseInsensitiveParams = caseInsensitiveParams;
+		this.indexOfThisSubtask = indexOfThisSubtask;
+		this.numParallelSubtasks = numParallelSubtasks;
 		this.admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build();
 	}
 
 	@Override
 	public void close() {
 		closed = true;
-		if (admin != null) {
-			admin.close();
-			admin = null;
-		}
+		admin.close();
 	}
-	
+
 	public List<String> listNamespaces() throws PulsarAdminException {
 		List<String> tenants = admin.tenants().getTenants();
-		List<String> namespaces = new ArrayList<>();
+		List<String> namespaces = new ArrayList<String>();
 		for (String tenant : tenants) {
 			namespaces.addAll(admin.namespaces().getNamespaces(tenant));
 		}
@@ -92,17 +126,14 @@ public class PulsarMetadataReader implements Closeable {
 		return allTopics.stream().map(t -> TopicName.get(t).getLocalName()).collect(Collectors.toList());
 	}
 
-	private List<String> getNonPartitionedTopics(String databaseName) throws PulsarAdminException {
-		return admin
-			.topics()
-			.getList(databaseName)
-			.stream()
-			.filter(t -> !TopicName.get(t).isPartitioned()).collect(Collectors.toList());
-	}
-
 	public TableSchema getTableSchema(ObjectPath objectPath) throws PulsarAdminException {
 		String topicName = objectPath2TopicName(objectPath);
-		FieldsDataType fieldsDataType = getSchema(topicName);
+		FieldsDataType fieldsDataType = null;
+		try {
+			fieldsDataType = getSchema(Collections.singletonList(topicName));
+		} catch (IncompatibleSchemaException e) {
+			throw new PulsarAdminException(e);
+		}
 		return SchemaUtils.toTableSchema(fieldsDataType);
 	}
 
@@ -127,40 +158,139 @@ public class PulsarMetadataReader implements Closeable {
 		}
 	}
 
-	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, SchemaUtils.IncompatibleSchemaException {
+	public void createTopic(ObjectPath objectPath, int defaultPartitionNum, CatalogBaseTable table) throws PulsarAdminException, IncompatibleSchemaException {
 		String topicName = objectPath2TopicName(objectPath);
 		admin.topics().createPartitionedTopic(topicName, defaultPartitionNum);
-		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(table.getSchema().toRowDataType()).getSchemaInfo();
 	}
 
-	private FieldsDataType getSchema(String topic) throws PulsarAdminException {
-		SchemaInfo si = getPulsarSchema(topic);
-		try {
-			return SchemaUtils.pulsarSourceSchema(si);
-		} catch (SchemaUtils.IncompatibleSchemaException e) {
-			throw new PulsarAdminException(e);
+	public void putSchema(ObjectPath tablePath, CatalogBaseTable table) throws IncompatibleSchemaException {
+		String topic = objectPath2TopicName(tablePath);
+		TableSchema tableSchema = table.getSchema();
+		List<String> fieldsRemaining = new ArrayList<>(tableSchema.getFieldCount());
+		for (String fieldName : tableSchema.getFieldNames()) {
+			if (!PulsarOptions.META_FIELD_NAMES.contains(fieldName)) {
+				fieldsRemaining.add(fieldName);
+			}
+		}
+
+		DataType dataType;
+
+		if (fieldsRemaining.size() == 1) {
+			dataType = tableSchema.getFieldDataType(fieldsRemaining.get(0)).get();
+		} else {
+			List<DataTypes.Field> fieldList = fieldsRemaining.stream()
+				.map(f -> DataTypes.FIELD(f, tableSchema.getFieldDataType(f).get()))
+				.collect(Collectors.toList());
+			dataType = DataTypes.ROW(fieldList.toArray(new DataTypes.Field[0]));
+		}
+
+		SchemaInfo si = SchemaUtils.sqlType2PulsarSchema(dataType).getSchemaInfo();
+		SchemaUtils.uploadPulsarSchema(admin, topic, si);
+	}
+
+	public FieldsDataType getSchema(List<String> topics) throws IncompatibleSchemaException {
+		SchemaInfo si = getPulsarSchema(topics);
+		return SchemaUtils.pulsarSourceSchema(si);
+	}
+
+	public SchemaInfo getPulsarSchema(List<String> topics) throws IncompatibleSchemaException {
+		Set<SchemaInfo> schemas = new HashSet<>();
+		if (topics.size() > 0) {
+			topics.forEach(t -> schemas.add(getPulsarSchema(t)));
+
+			if (schemas.size() != 1) {
+				throw new IncompatibleSchemaException(
+					String.format("Topics to read must share identical schema, however we got %d distinct schemas [%s]",
+						schemas.size(),
+						String.join(",", schemas.stream().map(SchemaInfo::toString).collect(Collectors.toList()))),
+					null);
+			}
+			return Iterables.getFirst(schemas, SchemaUtils.emptySchemaInfo());
+		} else {
+			return SchemaUtils.emptySchemaInfo();
 		}
 	}
 
-	private SchemaInfo getPulsarSchema(String topic) throws PulsarAdminException {
+	public SchemaInfo getPulsarSchema(String topic) {
 		try {
 			return admin.schemas().getSchemaInfo(TopicName.get(topic).toString());
-		} catch (PulsarAdminException e) {
-			if (e.getStatusCode() == 404) {
+		} catch (Throwable e) {
+			if (e instanceof PulsarAdminException && ((PulsarAdminException) e).getStatusCode() == 404) {
 				return BytesSchema.of().getSchemaInfo();
 			} else {
-				throw e;
+				throw new RuntimeException(
+					String.format("Failed to get schema information for %s", TopicName.get(topic).toString()), e);
 			}
 		}
 	}
 
-	private static String objectPath2TopicName(ObjectPath objectPath) {
+	public Set<String> getTopicPartitionsAll() throws PulsarAdminException {
+		List<String> topics = getTopics();
+		HashSet<String> allTopics = new HashSet<>();
+		for (String topic : topics) {
+			int partNum = admin.topics().getPartitionedTopicMetadata(topic).partitions;
+			if (partNum == 0) {
+				allTopics.add(topic);
+			} else {
+				for (int i = 0; i < partNum; i++) {
+					allTopics.add(topic + PulsarOptions.PARTITION_SUFFIX + i);
+				}
+			}
+		}
+		return allTopics;
+	}
+
+	public List<String> getTopics() throws PulsarAdminException {
+		for (Map.Entry<String, String> e : caseInsensitiveParams.entrySet()) {
+			if (PulsarOptions.TOPIC_OPTION_KEYS.contains(e.getKey())) {
+				String key = e.getKey();
+				if (key.equals("topic")) {
+					return Collections.singletonList(TopicName.get(e.getValue()).toString());
+				} else if (key.equals("topics")) {
+					return Arrays.asList(e.getValue().split(",")).stream()
+						.filter(s -> !s.isEmpty())
+						.map(t -> TopicName.get(t).toString())
+						.collect(Collectors.toList());
+				} else { // topicspattern
+					return getTopicsWithPattern(e.getValue());
+				}
+			}
+		}
+		return null;
+	}
+
+	private List<String> getTopicsWithPattern(String topicsPattern) throws PulsarAdminException {
+		TopicName dest = TopicName.get(topicsPattern);
+		List<String> allNonPartitionedTopics = getNonPartitionedTopics(dest.getNamespace());
+		List<String> nonPartitionedMatch = topicsPatternFilter(allNonPartitionedTopics, dest.toString());
+
+		List<String> allPartitionedTopics = admin.topics().getPartitionedTopicList(dest.getNamespace());
+		List<String> partitionedMatch = topicsPatternFilter(allPartitionedTopics, dest.toString());
+
+		return ListUtils.union(nonPartitionedMatch, partitionedMatch);
+	}
+
+	private List<String> getNonPartitionedTopics(String namespace) throws PulsarAdminException {
+		return admin.topics().getList(namespace).stream()
+			.filter(t -> !TopicName.get(t).isPartitioned())
+			.collect(Collectors.toList());
+	}
+
+	private List<String> topicsPatternFilter(List<String> allTopics, String topicsPattern) {
+		Pattern shortenedTopicsPattern = Pattern.compile(topicsPattern.split("\\:\\/\\/")[1]);
+		return allTopics.stream().map(t -> TopicName.get(t).toString())
+			.filter(t -> shortenedTopicsPattern.matcher(t.split("\\:\\/\\/")[1]).matches())
+			.collect(Collectors.toList());
+	}
+
+	public static String objectPath2TopicName(ObjectPath objectPath) {
 		NamespaceName ns = NamespaceName.get(objectPath.getDatabaseName());
 		String topic = objectPath.getObjectName();
 		TopicName fullName = TopicName.get(TopicDomain.persistent.toString(), ns, topic);
 		return fullName.toString();
 	}
 
+	public static class ClosedException extends Exception {
 
-
+	}
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class PulsarOptions {
+
+	public static final String TOPIC_ATTRIBUTE_NAME = "__topic";
+	public static final String KEY_ATTRIBUTE_NAME = "__key";
+	public static final String MESSAGE_ID_NAME = "__messageId";
+	public static final String PUBLISH_TIME_NAME = "__publishTime";
+	public static final String EVENT_TIME_NAME = "__eventTime";
+
+	public static final List<String> META_FIELD_NAMES = ImmutableList.of(
+		TOPIC_ATTRIBUTE_NAME,
+		KEY_ATTRIBUTE_NAME,
+		MESSAGE_ID_NAME,
+		PUBLISH_TIME_NAME,
+		EVENT_TIME_NAME);
+
+	public static final String DEFAULT_PARTITIONS = "tableDefaultPartitions";
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -30,6 +30,11 @@ import java.util.Set;
  */
 public class PulsarOptions {
 
+	// option key prefix for different modules
+	public static final String PULSAR_CLIENT_OPTION_KEY_PREFIX = "pulsar.client.";
+	public static final String PULSAR_PRODUCER_OPTION_KEY_PREFIX = "pulsar.producer.";
+	public static final String PULSAR_READER_OPTION_KEY_PREFIX = "pulsar.reader.";
+
 	// topic options
 	public static final String TOPIC_SINGLE_OPTION_KEY = "topic";
 	public static final String TOPIC_MULTI_OPTION_KEY = "topics";

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarOptions.java
@@ -19,10 +19,39 @@
 package org.apache.flink.streaming.connectors.pulsar.internal;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.shade.com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Set;
 
+/**
+ * Multiple options keys to work with the Pulsar connector.
+ */
 public class PulsarOptions {
+
+	// topic options
+	public static final String TOPIC_SINGLE_OPTION_KEY = "topic";
+	public static final String TOPIC_MULTI_OPTION_KEY = "topics";
+	public static final String TOPIC_PATTERN_OPTION_KEY = "topicspattern";
+
+	public static final String PARTITION_SUFFIX = TopicName.PARTITIONED_TOPIC_SUFFIX;
+
+	public static final Set<String> TOPIC_OPTION_KEYS = ImmutableSet.of(
+		TOPIC_SINGLE_OPTION_KEY,
+		TOPIC_MULTI_OPTION_KEY,
+		TOPIC_PATTERN_OPTION_KEY);
+
+	public static final String SERVICE_URL_OPTION_KEY = "service-url";
+	public static final String ADMIN_URL_OPTION_KEY = "admin-url";
+	public static final String STARTUP_MODE_OPTION_KEY = "startup-mode";
+
+	public static final String PARTITION_DISCOVERY_INTERVAL_MS_OPTION_KEY = "partitiondiscoveryintervalmillis";
+	public static final String CLIENT_CACHE_SIZE_OPTION_KEY = "clientcachesize";
+	public static final String FLUSH_ON_CHECKPOINT_OPTION_KEY = "flushoncheckpoint";
+	public static final String FAIL_ON_WRITE_OPTION_KEY = "failonwrite";
+	public static final String POLL_TIMEOUT_MS_OPTION_KEY = "polltimeoutms";
+	public static final String FAIL_ON_DATA_LOSS_OPTION_KEY = "failondataloss";
 
 	public static final String TOPIC_ATTRIBUTE_NAME = "__topic";
 	public static final String KEY_ATTRIBUTE_NAME = "__key";
@@ -37,5 +66,5 @@ public class PulsarOptions {
 		PUBLISH_TIME_NAME,
 		EVENT_TIME_NAME);
 
-	public static final String DEFAULT_PARTITIONS = "tableDefaultPartitions";
+	public static final String DEFAULT_PARTITIONS = "table-default-partitions";
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSerializer.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/PulsarSerializer.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.pulsar.client.api.schema.Field;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericRecordBuilder;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.schema.generic.GenericAvroRecord;
+import org.apache.pulsar.shade.org.apache.avro.Conversions;
+import org.apache.pulsar.shade.org.apache.avro.LogicalType;
+import org.apache.pulsar.shade.org.apache.avro.LogicalTypes;
+import org.apache.pulsar.shade.org.apache.avro.Schema;
+import org.apache.pulsar.shade.org.apache.avro.generic.GenericData;
+import org.apache.pulsar.shade.org.apache.avro.util.Utf8;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.ARRAY;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.BYTES;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.ENUM;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.FIXED;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.MAP;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.RECORD;
+import static org.apache.pulsar.shade.org.apache.avro.Schema.Type.STRING;
+
+public class PulsarSerializer {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarSerializer.class);
+
+	private final DataType flinkType;
+
+    private final boolean nullable;
+
+    private final Conversions.DecimalConversion decimalConversion =
+            new Conversions.DecimalConversion();
+
+    private final Schema rootAvroType;
+
+    private final Function<Object, Object> converter;
+
+    public PulsarSerializer(DataType flinkType, boolean nullable) {
+        this.flinkType = flinkType;
+        this.nullable = nullable;
+
+        try {
+            this.rootAvroType = SchemaUtils.sqlType2AvroSchema(flinkType);
+
+            Schema actualAvroType = resolveNullableType(rootAvroType, nullable);
+            Function<Object, Object> baseConverter;
+            if (flinkType instanceof FieldsDataType) {
+                FieldsDataType st = (FieldsDataType) flinkType;
+                baseConverter = newStructConverter(st, actualAvroType);
+            } else {
+                BiFunction<PositionedGetter, Integer, Object> converter = singleValueConverter(flinkType, actualAvroType);
+                baseConverter =
+                        data -> converter.apply(new PositionedGetter((Row) data), 0);
+            }
+
+            if (nullable) {
+                this.converter = data -> {
+                    if (data == null) {
+                        return null;
+                    } else {
+                        return baseConverter.apply(data);
+                    }
+                };
+            } else {
+                this.converter = baseConverter;
+            }
+
+        } catch (SchemaUtils.IncompatibleSchemaException e) {
+            LOG.error("Failed to create serializer while converting flink type to avro type");
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Object serialize(Object flinkData) {
+        return converter.apply(flinkData);
+    }
+
+    private BiFunction<PositionedGetter, Integer, Object> singleValueConverter(DataType dataType, Schema avroType) throws SchemaUtils.IncompatibleSchemaException {
+        LogicalTypeRoot tpe = dataType.getLogicalType().getTypeRoot();
+        Schema.Type atpe = avroType.getType();
+        if (tpe == LogicalTypeRoot.NULL && atpe == Schema.Type.NULL) {
+            return (getter, ordinal) -> null;
+        } else if ((tpe == LogicalTypeRoot.BOOLEAN && atpe == Schema.Type.BOOLEAN) ||
+                (tpe == LogicalTypeRoot.TINYINT && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.SMALLINT && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.INTEGER && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.BIGINT && atpe == Schema.Type.LONG) ||
+                (tpe == LogicalTypeRoot.FLOAT && atpe == Schema.Type.FLOAT) ||
+                (tpe == LogicalTypeRoot.DOUBLE && atpe == Schema.Type.DOUBLE) ||
+                (tpe == LogicalTypeRoot.VARCHAR && atpe == Schema.Type.STRING) ||
+                (tpe == LogicalTypeRoot.VARBINARY && atpe == Schema.Type.BYTES) ||
+                (tpe == LogicalTypeRoot.DATE && atpe == Schema.Type.INT)) {
+            return (getter, ordinal) -> getter.getField(ordinal);
+        } else if (tpe == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE && atpe == Schema.Type.LONG) {
+            LogicalType altpe = avroType.getLogicalType();
+            if (altpe instanceof LogicalTypes.TimestampMillis || altpe instanceof LogicalTypes.TimestampMicros) {
+                return (getter, ordinal) -> getter.getField(ordinal);
+            } else {
+                throw new SchemaUtils.IncompatibleSchemaException(
+                        "Cannot convert flink timestamp to avro logical type " + altpe.toString());
+            }
+        } else {
+            throw new SchemaUtils.IncompatibleSchemaException(String.format(
+                    "Cannot convert flink type %s to avro type %s", dataType.toString(), avroType.toString(true)));
+        }
+    }
+
+    private Function<Object, Object> newStructConverter(FieldsDataType dataType, Schema avroStruct) throws SchemaUtils.IncompatibleSchemaException {
+        if (avroStruct.getType() != RECORD ||
+                avroStruct.getFields().size() != dataType.getFieldDataTypes().size()) {
+            throw new SchemaUtils.IncompatibleSchemaException(
+                    String.format("Cannot convert Flink type %s to Avro type %s.", dataType.toString(), avroStruct.toString(true)));
+        }
+
+        Map<String, DataType> fieldsType = dataType.getFieldDataTypes();
+        List<RowType.RowField> fields = ((RowType) dataType.getLogicalType()).getFields();
+
+        List<BiFunction<PositionedGetter, Integer, Object>> fieldConverters = new ArrayList<>();
+
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField rf = fields.get(i);
+            DataType dt = fieldsType.get(rf.getName());
+            Schema.Field at = avroStruct.getFields().get(i);
+            fieldConverters.add(newConverter(dt, resolveNullableType(at.schema(), dt.getLogicalType().isNullable())));
+        }
+        int numFields = fieldsType.size();
+
+        return row -> {
+            GenericSchema<GenericRecord> pSchema = SchemaUtils.avroSchema2PulsarSchema(avroStruct);
+            GenericRecordBuilder builder = pSchema.newRecordBuilder();
+            Row rowX = (Row) row;
+
+            for (int i = 0; i < numFields; i++) {
+                if (rowX.getField(i) == null) {
+                    builder.set(pSchema.getFields().get(i), null);
+                } else {
+                    builder.set(pSchema.getFields().get(i), fieldConverters.get(i).apply(new PositionedGetter(rowX), i));
+                }
+            }
+            return (GenericAvroRecord) builder.build();
+        };
+
+    }
+
+    private BiFunction<PositionedGetter, Integer, Object> newConverter(DataType dataType, Schema avroType) throws SchemaUtils.IncompatibleSchemaException {
+        LogicalTypeRoot tpe = dataType.getLogicalType().getTypeRoot();
+        Schema.Type atpe = avroType.getType();
+        if (tpe == LogicalTypeRoot.NULL && atpe == Schema.Type.NULL) {
+            return (getter, ordinal) -> null;
+        } else if ((tpe == LogicalTypeRoot.BOOLEAN && atpe == Schema.Type.BOOLEAN) ||
+                (tpe == LogicalTypeRoot.TINYINT && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.SMALLINT && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.INTEGER && atpe == Schema.Type.INT) ||
+                (tpe == LogicalTypeRoot.BIGINT && atpe == Schema.Type.LONG) ||
+                (tpe == LogicalTypeRoot.FLOAT && atpe == Schema.Type.FLOAT) ||
+                (tpe == LogicalTypeRoot.DOUBLE && atpe == Schema.Type.DOUBLE) ||
+                (tpe == LogicalTypeRoot.VARBINARY && atpe == BYTES)) {
+            return (getter, ordinal) -> getter.getField(ordinal);
+        } else if (tpe == LogicalTypeRoot.DECIMAL && (atpe == FIXED || atpe == BYTES)) {
+            DecimalType d = (DecimalType) dataType.getLogicalType();
+            if (avroType.getLogicalType() == LogicalTypes.decimal(d.getPrecision(), d.getScale())) {
+                return (getter, ordinal) -> {
+                    java.math.BigDecimal decimal = (java.math.BigDecimal) getter.getField(ordinal);
+                    return decimalConversion.toFixed(
+                            decimal,
+                            avroType,
+                            LogicalTypes.decimal(d.getPrecision(), d.getScale()));
+                };
+            } else {
+                throw new SchemaUtils.IncompatibleSchemaException(
+                        "Cannot convert flink decimal type to Avro logical type");
+            }
+        } else if (tpe == LogicalTypeRoot.BIGINT && atpe == BYTES) {
+            return (getter, ordinal) -> ByteBuffer.wrap((byte[]) getter.getField(ordinal));
+        } else if (tpe == LogicalTypeRoot.DATE && atpe == Schema.Type.INT) {
+            return (getter, ordinal) -> DateTimeUtils.fromJavaDate((java.sql.Date) getter.getField(ordinal));
+        } else if (tpe == LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE && atpe == Schema.Type.LONG) {
+            LogicalType altpe = avroType.getLogicalType();
+            if (altpe instanceof LogicalTypes.TimestampMillis) {
+                return (getter, ordinal) -> DateTimeUtils.fromJavaTimestamp((java.sql.Timestamp) getter.getField(ordinal)) / 1000;
+            } else if (altpe instanceof LogicalTypes.TimestampMicros) {
+                return (getter, ordinal) -> DateTimeUtils.fromJavaTimestamp((java.sql.Timestamp) getter.getField(ordinal));
+            } else {
+                throw new SchemaUtils.IncompatibleSchemaException(
+                        "Cannot convert flink timestamp to avro logical type " + altpe.toString());
+            }
+        } else if (tpe == LogicalTypeRoot.VARCHAR && atpe == STRING) {
+            return (getter, ordinal) -> new Utf8((String) getter.getField(ordinal));
+        } else if (tpe == LogicalTypeRoot.VARCHAR && atpe == ENUM) {
+            HashSet<String> enumSymbols = new HashSet<>(avroType.getEnumSymbols());
+            return (getter, ordinal) -> {
+                String data = (String) getter.getField(ordinal);
+                if (!enumSymbols.contains(data)) {
+                    throw new RuntimeException(String.format(
+                            "Cannot write %s since it's not defined in enum %s", data, String.join(", ", enumSymbols)));
+                }
+                return new GenericData.EnumSymbol(avroType, data);
+            };
+        } else if (tpe == LogicalTypeRoot.ARRAY && atpe == ARRAY && dataType instanceof CollectionDataType) {
+            DataType et = ((CollectionDataType) dataType).getElementDataType();
+            boolean containsNull = et.getLogicalType().isNullable();
+            BiFunction<PositionedGetter, Integer, Object> elementConverter =
+                    newConverter(et, resolveNullableType(avroType.getElementType(), containsNull));
+            return (getter, ordinal) -> {
+                Object[] arrayData = (Object[]) getter.getField(ordinal);
+                int len = arrayData.length;
+                Object[] result = new Object[len];
+                for (int i = 0; i < len; i++) {
+                    if (containsNull && arrayData[i] == null) {
+                        result[i] = null;
+                    } else {
+                        result[i] = elementConverter.apply(new PositionedGetter(arrayData), i);
+                    }
+                }
+                // avro writer is expecting a Java Collection, so we convert it into
+                // `ArrayList` backed by the specified array without data copying.
+                return Arrays.asList(result);
+            };
+        } else if (tpe == LogicalTypeRoot.MAP && atpe == MAP &&
+                ((KeyValueDataType) dataType).getKeyDataType().getLogicalType().getTypeRoot() == LogicalTypeRoot.VARCHAR) {
+
+            KeyValueDataType kvt = (KeyValueDataType) dataType;
+            org.apache.flink.table.types.logical.LogicalType ktl = kvt.getKeyDataType().getLogicalType();
+            DataType vt = kvt.getValueDataType();
+            org.apache.flink.table.types.logical.LogicalType vtl = kvt.getValueDataType().getLogicalType();
+            boolean valueContainsNull = vt.getLogicalType().isNullable();
+
+            BiFunction<PositionedGetter, Integer, Object> valueConverter =
+                    newConverter(vt, resolveNullableType(avroType.getValueType(), valueContainsNull));
+
+            return (getter, ordinal) -> getter.getField(ordinal);
+        } else if (tpe == LogicalTypeRoot.ROW && atpe == RECORD) {
+            FieldsDataType st = (FieldsDataType) dataType;
+            Function<Object, Object> structConverter = newStructConverter(st, avroType);
+            return (getter, ordinal) -> ((GenericAvroRecord) structConverter.apply(getter.getField(ordinal))).getAvroRecord();
+        } else {
+            throw new SchemaUtils.IncompatibleSchemaException(String.format(
+                    "Cannot convert flink type %s to avro type %s", dataType.toString(), avroType.toString(true)));
+        }
+    }
+
+    private List<Field> getFields(Schema aschema) {
+        return aschema.getFields().stream()
+                .map(f -> new Field(f.name(), f.pos())).collect(Collectors.toList());
+    }
+
+    private Schema resolveNullableType(Schema avroType, boolean nullable) {
+        if (nullable && avroType.getType() != Schema.Type.NULL) {
+            List<Schema> fields = avroType.getTypes();
+            assert fields.size() == 2;
+            List<Schema> actualType = fields.stream()
+                    .filter(f -> f.getType() != Schema.Type.NULL).collect(Collectors.toList());
+            assert actualType.size() == 1;
+            return actualType.get(0);
+        } else {
+            return avroType;
+        }
+    }
+
+    public static class PositionedGetter {
+        private final Object[] array;
+        private final Row row;
+
+
+        public PositionedGetter(Object[] array, Row row) {
+            this.array = array;
+            this.row = row;
+        }
+
+        public PositionedGetter(Row row) {
+            this(null, row);
+        }
+
+        public PositionedGetter(Object[] array) {
+            this(array, null);
+        }
+
+        public Object getField(int i) {
+            if (array != null) {
+                return array[i];
+            } else {
+                return row.getField(i);
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SchemaUtils.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.AtomicDataType;
+import org.apache.flink.table.types.CollectionDataType;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.pulsar.client.api.schema.GenericRecord;
+import org.apache.pulsar.client.api.schema.GenericSchema;
+import org.apache.pulsar.client.impl.schema.BooleanSchema;
+import org.apache.pulsar.client.impl.schema.ByteSchema;
+import org.apache.pulsar.client.impl.schema.BytesSchema;
+import org.apache.pulsar.client.impl.schema.DateSchema;
+import org.apache.pulsar.client.impl.schema.DoubleSchema;
+import org.apache.pulsar.client.impl.schema.FloatSchema;
+import org.apache.pulsar.client.impl.schema.IntSchema;
+import org.apache.pulsar.client.impl.schema.LongSchema;
+import org.apache.pulsar.client.impl.schema.ShortSchema;
+import org.apache.pulsar.client.impl.schema.TimestampSchema;
+import org.apache.pulsar.common.schema.SchemaInfo;
+
+import org.apache.pulsar.common.schema.SchemaType;
+import org.apache.pulsar.shade.org.apache.avro.LogicalType;
+import org.apache.pulsar.shade.org.apache.avro.LogicalTypes;
+import org.apache.pulsar.shade.org.apache.avro.Schema;
+import org.apache.pulsar.shade.org.apache.avro.SchemaBuilder;
+import scala.NotImplementedError;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.TOPIC_ATTRIBUTE_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.KEY_ATTRIBUTE_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.MESSAGE_ID_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.PUBLISH_TIME_NAME;
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.EVENT_TIME_NAME;
+
+public class SchemaUtils {
+
+	public static TableSchema toTableSchema(FieldsDataType schema) {
+		RowType rt = (RowType) schema.getLogicalType();
+		List<DataType> fieldTypes = rt.getFieldNames().stream().map(fn -> schema.getFieldDataTypes().get(fn)).collect(Collectors.toList());
+
+		return TableSchema.builder().fields(
+			rt.getFieldNames().toArray(new String[0]), fieldTypes.toArray(new DataType[0])).build();
+	}
+
+	public static FieldsDataType pulsarSourceSchema(SchemaInfo si) throws IncompatibleSchemaException {
+		List<DataTypes.Field> mainSchema = new ArrayList<>();
+		DataType dataType = si2SqlType(si);
+		if (dataType instanceof FieldsDataType) {
+			FieldsDataType fieldsDataType = (FieldsDataType) dataType;
+			RowType rowType = (RowType) fieldsDataType.getLogicalType();
+			rowType.getFieldNames().stream()
+				.map(fieldName -> DataTypes.FIELD(fieldName, fieldsDataType.getFieldDataTypes().get(fieldName)))
+				.forEach(mainSchema::add);
+		} else {
+			mainSchema.add(DataTypes.FIELD("value", dataType));
+		}
+
+		mainSchema.addAll(metadataFields);
+		return (FieldsDataType) DataTypes.ROW(mainSchema.toArray(new DataTypes.Field[0]));
+	}
+
+	public static List<DataTypes.Field> metadataFields = ImmutableList.of(
+		DataTypes.FIELD(
+			KEY_ATTRIBUTE_NAME,
+			DataTypes.BYTES()),
+		DataTypes.FIELD(
+			TOPIC_ATTRIBUTE_NAME,
+			DataTypes.STRING()),
+		DataTypes.FIELD(
+			MESSAGE_ID_NAME,
+			DataTypes.BYTES()),
+		DataTypes.FIELD(
+			PUBLISH_TIME_NAME,
+			DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class)),
+		DataTypes.FIELD(
+			EVENT_TIME_NAME,
+			DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class)));
+
+	public static DataType si2SqlType(SchemaInfo si) throws IncompatibleSchemaException, NotImplementedError {
+		switch (si.getType()) {
+			case NONE:
+			case BYTES:
+				return DataTypes.BYTES();
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+			case DATE:
+				return DataTypes.DATE();
+			case STRING:
+				return DataTypes.STRING();
+			case TIMESTAMP:
+				return DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class);
+			case INT8:
+				return DataTypes.TINYINT();
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+			case FLOAT:
+				return DataTypes.FLOAT();
+			case INT32:
+				return DataTypes.INT();
+			case INT64:
+				return DataTypes.BIGINT();
+			case INT16:
+				return DataTypes.SMALLINT();
+			case AVRO:
+			case JSON:
+				Schema avroSchema =
+					new Schema.Parser().parse(new String(si.getSchema(), StandardCharsets.UTF_8));
+				return avro2SqlType(avroSchema, Collections.emptySet());
+			default:
+				throw new NotImplementedError(String.format("We do not support %s currently.", si.getType()));
+		}
+	}
+
+	private static DataType avro2SqlType(Schema avroSchema, Set<String> existingRecordNames) throws IncompatibleSchemaException {
+		LogicalType logicalType = avroSchema.getLogicalType();
+		switch (avroSchema.getType()) {
+			case INT:
+				if (logicalType instanceof LogicalTypes.Date) {
+					return DataTypes.DATE();
+				} else {
+					return DataTypes.INT();
+				}
+
+			case STRING:
+			case ENUM:
+				return DataTypes.STRING();
+
+			case BOOLEAN:
+				return DataTypes.BOOLEAN();
+
+			case BYTES:
+			case FIXED:
+				// For FIXED type, if the precision requires more bytes than fixed size, the logical
+				// type will be null, which is handled by Avro library.
+				if (logicalType instanceof LogicalTypes.Decimal) {
+					LogicalTypes.Decimal d = (LogicalTypes.Decimal) logicalType;
+					return DataTypes.DECIMAL(d.getPrecision(), d.getScale());
+				} else {
+					return DataTypes.BYTES();
+				}
+
+			case DOUBLE:
+				return DataTypes.DOUBLE();
+
+			case FLOAT:
+				return DataTypes.FLOAT();
+
+			case LONG:
+				if (logicalType instanceof LogicalTypes.TimestampMillis ||
+					logicalType instanceof LogicalTypes.TimestampMicros) {
+					return DataTypes.TIMESTAMP(3).bridgedTo(java.sql.Timestamp.class);
+				} else {
+					return DataTypes.BIGINT();
+				}
+
+			case RECORD:
+				if (existingRecordNames.contains(avroSchema.getFullName())) {
+					throw new IncompatibleSchemaException(
+						String.format("Found recursive reference in Avro schema, which can not be processed by Flink: %s", avroSchema.toString(true)), null);
+				}
+
+				Set<String> newRecordName = ImmutableSet.<String>builder()
+					.addAll(existingRecordNames).add(avroSchema.getFullName()).build();
+				List<DataTypes.Field> fields = new ArrayList<>();
+				for (Schema.Field f: avroSchema.getFields()) {
+					DataType fieldType = avro2SqlType(f.schema(), newRecordName);
+					fields.add(DataTypes.FIELD(f.name(), fieldType));
+				}
+				return DataTypes.ROW(fields.toArray(new DataTypes.Field[0]));
+
+			case ARRAY:
+				DataType elementType = avro2SqlType(avroSchema.getElementType(), existingRecordNames);
+				return DataTypes.ARRAY(elementType);
+
+			case MAP:
+				DataType valueType = avro2SqlType(avroSchema.getValueType(), existingRecordNames);
+				return DataTypes.MAP(DataTypes.STRING(), valueType);
+
+			case UNION:
+				if (avroSchema.getTypes().stream().anyMatch(f -> f.getType() == Schema.Type.NULL)) {
+					// In case of a union with null, eliminate it and make a recursive call
+					List<Schema> remainingUnionTypes =
+						avroSchema.getTypes().stream().filter(f -> f.getType() != Schema.Type.NULL).collect(Collectors.toList());
+					if (remainingUnionTypes.size() == 1) {
+						return avro2SqlType(remainingUnionTypes.get(0), existingRecordNames).nullable();
+					} else {
+						return avro2SqlType(Schema.createUnion(remainingUnionTypes), existingRecordNames).nullable();
+					}
+				} else {
+					List<Schema.Type> types = avroSchema.getTypes().stream().map(Schema::getType).collect(Collectors.toList());
+					if (types.size() == 1) {
+						return avro2SqlType(avroSchema.getTypes().get(0), existingRecordNames);
+					} else if (types.size() == 2 && types.contains(Schema.Type.INT) && types.contains(Schema.Type.LONG)) {
+						return DataTypes.BIGINT();
+					} else if (types.size() == 2 && types.contains(Schema.Type.FLOAT) && types.contains(Schema.Type.DOUBLE)) {
+						return DataTypes.DOUBLE();
+					} else {
+						// Convert complex unions to struct types where field names are member0, member1, etc.
+						// This is consistent with the behavior when converting between Avro and Parquet.
+						List<DataTypes.Field> memberFields = new ArrayList<>();
+						List<Schema> schemas = avroSchema.getTypes();
+						for (int i = 0; i < schemas.size(); i++) {
+							DataType memberType = avro2SqlType(schemas.get(i), existingRecordNames);
+							memberFields.add(DataTypes.FIELD("member" + i, memberType));
+						}
+						return DataTypes.ROW(memberFields.toArray(new DataTypes.Field[0]));
+					}
+				}
+
+			default:
+				throw new IncompatibleSchemaException(String.format("Unsupported type %s", avroSchema.toString(true)), null);
+		}
+	}
+
+	public static org.apache.pulsar.client.api.Schema sqlType2PulsarSchema(DataType flinkType) throws IncompatibleSchemaException {
+		if (flinkType instanceof AtomicDataType) {
+			LogicalTypeRoot type = flinkType.getLogicalType().getTypeRoot();
+			switch (type) {
+				case BOOLEAN: return BooleanSchema.of();
+				case VARBINARY: return BytesSchema.of();
+				case DATE: return DateSchema.of();
+				case VARCHAR: return org.apache.pulsar.client.api.Schema.STRING;
+				case TIMESTAMP_WITHOUT_TIME_ZONE: return TimestampSchema.of();
+				case TINYINT: return ByteSchema.of();
+				case DOUBLE: return DoubleSchema.of();
+				case FLOAT: return FloatSchema.of();
+				case INTEGER: return IntSchema.of();
+				case BIGINT: return LongSchema.of();
+				case SMALLINT: return ShortSchema.of();
+				default:
+					throw new IncompatibleSchemaException(String.format("%s is not supported by Pulsar yet", flinkType.toString()), null);
+			}
+		} else if (flinkType instanceof FieldsDataType) {
+			return avroSchema2PulsarSchema(sqlType2AvroSchema(flinkType));
+		}
+		throw new IncompatibleSchemaException(String.format("%s is not supported by Pulsar yet", flinkType.toString()), null);
+	}
+
+	private static GenericSchema<GenericRecord> avroSchema2PulsarSchema(Schema avroSchema) {
+		byte[] schemaBytes = avroSchema.toString().getBytes(StandardCharsets.UTF_8);
+		SchemaInfo si = new SchemaInfo();
+		si.setName("Avro");
+		si.setSchema(schemaBytes);
+		si.setType(SchemaType.AVRO);
+		return org.apache.pulsar.client.api.Schema.generic(si);
+	}
+
+	public static Schema sqlType2AvroSchema(DataType flinkType) throws IncompatibleSchemaException {
+		return sqlType2AvroSchema(flinkType, false, "topLevelRecord", "");
+	}
+
+	private static Schema sqlType2AvroSchema(DataType flinkType, boolean nullable, String recordName, String namespace) throws IncompatibleSchemaException {
+		SchemaBuilder.TypeBuilder<Schema> builder = SchemaBuilder.builder();
+		LogicalTypeRoot type = flinkType.getLogicalType().getTypeRoot();
+		Schema schema = null;
+
+		if (flinkType instanceof AtomicDataType) {
+			switch (type) {
+				case BOOLEAN:
+					schema = builder.booleanType();
+					break;
+				case TINYINT:
+				case SMALLINT:
+				case INTEGER:
+					schema = builder.intType();
+					break;
+				case BIGINT:
+					schema = builder.longType();
+					break;
+				case DATE:
+					schema = LogicalTypes.date().addToSchema(builder.intType());
+					break;
+				case TIMESTAMP_WITHOUT_TIME_ZONE:
+					schema = LogicalTypes.timestampMicros().addToSchema(builder.longType());
+					break;
+				case FLOAT:
+					schema = builder.floatType();
+					break;
+				case DOUBLE:
+					schema = builder.doubleType();
+					break;
+				case VARCHAR:
+					schema = builder.stringType();
+					break;
+				case BINARY:
+				case VARBINARY:
+					schema = builder.bytesType();
+					break;
+				case DECIMAL:
+					DecimalType dt = (DecimalType) flinkType.getLogicalType();
+					LogicalTypes.Decimal avroType = LogicalTypes.decimal(dt.getPrecision(), dt.getScale());
+					int fixedSize = minBytesForPrecision[dt.getPrecision()];
+					// Need to avoid naming conflict for the fixed fields
+					String name;
+					if (namespace.equals("")) {
+						name = recordName + ".fixed";
+					} else {
+						name = namespace + recordName + ".fixed";
+					}
+					schema = avroType.addToSchema(SchemaBuilder.fixed(name).size(fixedSize));
+					break;
+				default:
+					throw new IncompatibleSchemaException(String.format("Unsupported type %s", flinkType.toString()),null);
+			}
+		} else if (flinkType instanceof CollectionDataType) {
+			if (type == LogicalTypeRoot.ARRAY) {
+				CollectionDataType cdt = (CollectionDataType) flinkType;
+				DataType elementType = cdt.getElementDataType();
+				schema = builder.array().items(sqlType2AvroSchema(elementType, elementType.getLogicalType().isNullable(), recordName, namespace));
+			} else {
+				throw new IncompatibleSchemaException("Pulsar only support collection as array", null);
+			}
+		} else if (flinkType instanceof KeyValueDataType) {
+			KeyValueDataType kvType = (KeyValueDataType) flinkType;
+			DataType keyType = kvType.getKeyDataType();
+			DataType valueType = kvType.getValueDataType();
+			if (!(keyType instanceof AtomicDataType) || keyType.getLogicalType().getTypeRoot() != LogicalTypeRoot.VARCHAR) {
+				throw new IncompatibleSchemaException("Pulsar only support string key map", null);
+			}
+			schema = builder.map().values(sqlType2AvroSchema(valueType, valueType.getLogicalType().isNullable(), recordName, namespace));
+		} else if (flinkType instanceof FieldsDataType) {
+			FieldsDataType fieldsDataType = (FieldsDataType) flinkType;
+			String childNamespace = namespace.equals("") ? recordName : namespace + "." + recordName;
+			SchemaBuilder.FieldAssembler<Schema> fieldsAssembler = builder.record(recordName).namespace(namespace).fields();
+			RowType rowType = (RowType) fieldsDataType.getLogicalType();
+
+			for (String fieldName : rowType.getFieldNames()) {
+				DataType ftype = fieldsDataType.getFieldDataTypes().get(fieldName);
+				Schema fieldAvroSchema = sqlType2AvroSchema(ftype, ftype.getLogicalType().isNullable(), fieldName, childNamespace);
+				fieldsAssembler.name(fieldName).type(fieldAvroSchema).noDefault();
+			}
+			schema = fieldsAssembler.endRecord();
+		} else {
+			throw new IncompatibleSchemaException(String.format("Unexpected type %s", flinkType.toString()),null);
+		}
+
+		if (nullable) {
+			return Schema.createUnion(schema, NULL_SCHEMA);
+		} else {
+			return schema;
+		}
+	}
+
+	private static Schema NULL_SCHEMA = Schema.create(Schema.Type.NULL);
+
+	private static int[] minBytesForPrecision = new int[39];
+
+	static {
+		for (int i = 0; i < minBytesForPrecision.length; i++) {
+			minBytesForPrecision[i] = computeMinBytesForPrecision(i);
+		}
+	}
+
+	private static int computeMinBytesForPrecision(int precision) {
+		int numBytes = 1;
+		while (Math.pow(2.0, 8 * numBytes - 1) < Math.pow(10.0, precision)) {
+			numBytes += 1;
+		}
+		return numBytes;
+	}
+
+	public static class IncompatibleSchemaException extends Exception {
+		public IncompatibleSchemaException(String message, Throwable e) {
+			super(message, e);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/streaming/connectors/pulsar/internal/SourceSinkUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.internal;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SourceSinkUtils {
+
+    public static Map<String, String> validateStreamSourceOptions(Map<String, String> parameters) {
+        Map<String, String> caseInsensitiveParams = parameters.entrySet().stream()
+                .collect(Collectors.toMap(t -> t.getKey().toLowerCase(Locale.ROOT), t -> t.getValue()));
+
+        return validateSourceOptions(caseInsensitiveParams);
+    }
+
+    private static Map<String, String> validateSourceOptions(Map<String, String> caseInsensitiveParams) {
+        Map<String, String> topicOptions = caseInsensitiveParams.entrySet().stream()
+                .filter(t -> PulsarOptions.TOPIC_OPTION_KEYS.contains(t.getKey()))
+                .collect(Collectors.toMap(map -> map.getKey(), map -> map.getValue()));
+
+        if (topicOptions.isEmpty() || topicOptions.size() > 1) {
+            throw new IllegalArgumentException(
+                    "You should specify topic(s) using one of the topic options: " +
+                            StringUtils.join(PulsarOptions.TOPIC_OPTION_KEYS, ","));
+        }
+
+        for (Map.Entry<String, String> topicEntry : topicOptions.entrySet()) {
+            String key = topicEntry.getKey();
+            String value = topicEntry.getValue();
+            if (key.equals("topic")) {
+                if (value.contains(",")) {
+                    throw new IllegalArgumentException(
+                            "Use `topics` instead of `topic` for multi topic read");
+                }
+            } else if (key.equals("topics")) {
+                List<String> topics = Arrays.asList(value.split(",")).stream()
+                        .map(String::trim).filter(t -> !t.isEmpty()).collect(Collectors.toList());
+                if (topics.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "No topics is specified for read with option" + value);
+                }
+            } else {
+                if (value.trim().length() == 0) {
+                    throw new IllegalArgumentException("TopicsPattern is empty");
+                }
+            }
+        }
+        return caseInsensitiveParams;
+    }
+
+    public static boolean belongsTo(String topic, int numParallelSubtasks, int index) {
+        return (topic.hashCode() * 31 & Integer.MAX_VALUE) % numParallelSubtasks == index;
+    }
+
+    public static long getPartitionDiscoveryIntervalInMillis(Map<String, String> parameters) {
+        String interval = parameters.getOrDefault(PulsarOptions.PARTITION_DISCOVERY_INTERVAL_MS_OPTION_KEY, "-1");
+        return Long.parseLong(interval);
+    }
+
+    public static int getPollTimeoutMs(Map<String, String> parameters) {
+        String interval = parameters.getOrDefault(PulsarOptions.POLL_TIMEOUT_MS_OPTION_KEY, "120000");
+        return Integer.parseInt(interval);
+    }
+
+    public static int getClientCacheSize(Map<String, String> parameters) {
+        String size = parameters.getOrDefault(PulsarOptions.CLIENT_CACHE_SIZE_OPTION_KEY, "5");
+        return Integer.parseInt(size);
+    }
+
+    public static boolean flushOnCheckpoint(Map<String, String> parameters) {
+        String b = parameters.getOrDefault(PulsarOptions.FLUSH_ON_CHECKPOINT_OPTION_KEY, "true");
+        return Boolean.parseBoolean(b);
+    }
+
+    public static boolean failOnWrite(Map<String, String> parameters) {
+        String b = parameters.getOrDefault(PulsarOptions.FAIL_ON_WRITE_OPTION_KEY, "false");
+        return Boolean.parseBoolean(b);
+    }
+
+    public static Map<String, Object> getReaderParams(Map<String, String> parameters) {
+        return parameters.keySet().stream()
+                .filter(k -> k.startsWith(PulsarOptions.PULSAR_READER_OPTION_KEY_PREFIX))
+                .collect(Collectors.toMap(k -> k.substring(PulsarOptions.PULSAR_READER_OPTION_KEY_PREFIX.length()), k -> parameters.get(k)));
+    }
+
+    public static Map<String, String> toCaceInsensitiveParams(Map<String, String> parameters) {
+        return parameters.entrySet().stream()
+                .collect(Collectors.toMap(t -> t.getKey().toLowerCase(Locale.ROOT), t -> t.getValue()));
+    }
+
+    public static Map<String, Object> getProducerParams(Map<String, String> parameters) {
+        return parameters.keySet().stream()
+                .filter(k -> k.startsWith(PulsarOptions.PULSAR_PRODUCER_OPTION_KEY_PREFIX))
+                .collect(Collectors.toMap(k -> k.substring(PulsarOptions.PULSAR_PRODUCER_OPTION_KEY_PREFIX.length()), k -> parameters.get(k)));
+    }
+
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/PulsarCatalog.java
@@ -1,0 +1,356 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar;
+
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
+import org.apache.flink.streaming.connectors.pulsar.internal.SchemaUtils;
+import org.apache.flink.table.catalog.AbstractCatalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogDatabase;
+import org.apache.flink.table.catalog.CatalogDatabaseImpl;
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionAlreadyExistsException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionSpecInvalidException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.table.catalog.exceptions.TablePartitionedException;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.factories.TableFactory;
+
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class PulsarCatalog extends AbstractCatalog {
+
+	private static final Logger LOG = LoggerFactory.getLogger(PulsarCatalog.class);
+
+	private String adminUrl;
+	private Map<String, String> properties;
+
+	private PulsarMetadataReader metadataReader;
+
+	public PulsarCatalog(String adminUrl, String catalogName, Map<String, String> properties, String defaultDatabase) {
+		super(catalogName, defaultDatabase);
+
+		this.adminUrl = adminUrl;
+		this.properties = properties;
+
+		LOG.info("Created PulsarCatalog '{}'", catalogName);
+	}
+
+	@Override
+	public void open() throws CatalogException {
+		if (metadataReader == null) {
+			try {
+				metadataReader = new PulsarMetadataReader(adminUrl);
+			} catch (PulsarClientException e) {
+				throw new CatalogException("Failed to create Pulsar admin using " + adminUrl, e);
+			}
+		}
+	}
+
+	@Override
+	public void close() throws CatalogException {
+		if (metadataReader != null) {
+			metadataReader.close();
+			metadataReader = null;
+			LOG.info("Close connection to Pulsar");
+		}
+	}
+
+	@Override
+	public Optional<TableFactory> getTableFactory() {
+		// TODO
+		return Optional.empty();
+	}
+
+	@Override
+	public List<String> listDatabases() throws CatalogException {
+		try {
+			return metadataReader.listNamespaces();
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to list all databases in %s", getName()), e);
+		}
+	}
+
+	@Override
+	public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
+		Map<String, String> properties = new HashMap<>();
+		return new CatalogDatabaseImpl(properties, databaseName);
+	}
+
+	@Override
+	public boolean databaseExists(String databaseName) throws CatalogException {
+		try {
+			return metadataReader.namespaceExists(databaseName);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check existence of databases %s", databaseName), e);
+		}
+	}
+
+	@Override
+	public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists) throws DatabaseAlreadyExistException, CatalogException {
+		try {
+			metadataReader.createNamespace(name);
+		} catch (PulsarAdminException.ConflictException e) {
+			if (!ignoreIfExists) {
+				throw new DatabaseAlreadyExistException(getName(), name, e);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to create database %s", name), e);
+		}
+	}
+
+	@Override
+	public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade) throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+		try {
+			metadataReader.deleteNamespace(name);
+		} catch (PulsarAdminException.NotFoundException e) {
+			if (!ignoreIfNotExists) {
+				throw new DatabaseNotExistException(getName(), name);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to drop database %s", name), e);
+		}
+	}
+
+	@Override
+	public List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException {
+		try {
+			return metadataReader.getTopics(databaseName);
+		} catch (PulsarAdminException.NotFoundException e) {
+			throw new DatabaseNotExistException(getName(), databaseName, e);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to list tables in database %s", databaseName), e);
+		}
+	}
+
+	@Override
+	public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		try {
+			return new CatalogTableImpl(metadataReader.getTableSchema(tablePath), properties, "");
+		} catch (PulsarAdminException.NotFoundException e) {
+			throw new TableNotExistException(getName(), tablePath, e);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to get table %s schema", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+		try {
+			return metadataReader.topicExists(tablePath);
+		} catch (PulsarAdminException.NotFoundException e) {
+			return false;
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check table %s existence", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		try {
+			metadataReader.deleteTopic(tablePath);
+		} catch (PulsarAdminException.NotFoundException e) {
+			if (!ignoreIfNotExists) {
+				throw new TableNotExistException(getName(), tablePath, e);
+			}
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to drop table %s", tablePath.getFullName()), e);
+		}
+	}
+
+	@Override
+	public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists) throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+		int defaultNumPartitions = Integer.parseInt(properties.getOrDefault(PulsarOptions.DEFAULT_PARTITIONS, "5"));
+		String databaseName = tablePath.getDatabaseName();
+		Boolean databaseExists;
+		try {
+			databaseExists = metadataReader.namespaceExists(databaseName);
+		} catch (PulsarAdminException e) {
+			throw new CatalogException(String.format("Failed to check existence of databases %s", databaseName), e);
+		}
+
+		if (!databaseExists) {
+			throw new DatabaseNotExistException(getName(), databaseName);
+		}
+
+		try {
+			metadataReader.createTopic(tablePath, defaultNumPartitions, table);
+		} catch (PulsarAdminException e) {
+			if (e.getStatusCode() == 409) {
+				throw new TableAlreadyExistException(getName(), tablePath, e);
+			} else {
+				throw new CatalogException(String.format("Failed to create table %s", tablePath.getFullName()), e);
+			}
+		} catch (SchemaUtils.IncompatibleSchemaException e) {
+			throw new CatalogException("Failed to translate Flink type to Pulsar", e);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Unsupported catalog operations for Pulsar
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists) throws TableNotExistException, TableAlreadyExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath) throws TableNotExistException, TableNotPartitionedException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws TableNotExistException, TableNotPartitionedException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition partition, boolean ignoreIfExists) throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionAlreadyExistsException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void createFunction(ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists) throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterFunction(ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists) throws FunctionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogTableStatistics getTableStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogTableStatistics getPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CatalogColumnStatistics getPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTableStatistics(ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterTableColumnStatistics(ObjectPath tablePath, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws TableNotExistException, CatalogException, TablePartitionedException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogTableStatistics partitionStatistics, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void alterPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists) throws PartitionNotExistException, CatalogException {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.descriptors;
+
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.descriptors.CatalogDescriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_TYPE_VALUE_PULSAR;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_PULSAR_VERSION;
+
+/**
+ * Catalog descriptor for {@link PulsarCatalog}.
+ */
+public class PulsarCatalogDescriptor extends CatalogDescriptor {
+
+	private String pulsarVersion;
+
+	public PulsarCatalogDescriptor() {
+		super(CATALOG_TYPE_VALUE_PULSAR, 1, "public/default");
+	}
+
+	public PulsarCatalogDescriptor pulsarVersion(String version) {
+		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(version));
+		this.pulsarVersion = version;
+		return this;
+	}
+
+	@Override
+	protected Map<String, String> toCatalogProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+
+		if (pulsarVersion != null) {
+			properties.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
+		}
+
+		return properties.asMap();
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogDescriptor.java
@@ -40,20 +40,21 @@ public class PulsarCatalogDescriptor extends CatalogDescriptor {
 		super(CATALOG_TYPE_VALUE_PULSAR, 1, "public/default");
 	}
 
-	public PulsarCatalogDescriptor pulsarVersion(String version) {
-		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(version));
-		this.pulsarVersion = version;
+	public PulsarCatalogDescriptor pulsarVersion(String pulsarVersion) {
+		Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(pulsarVersion));
+		this.pulsarVersion = pulsarVersion;
+
 		return this;
 	}
 
 	@Override
 	protected Map<String, String> toCatalogProperties() {
-		final DescriptorProperties properties = new DescriptorProperties();
+		DescriptorProperties props = new DescriptorProperties();
 
 		if (pulsarVersion != null) {
-			properties.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
+			props.putString(CATALOG_PULSAR_VERSION, pulsarVersion);
 		}
 
-		return properties.asMap();
+		return props.asMap();
 	}
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.descriptors;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.descriptors.CatalogDescriptorValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.DEFAULT_PARTITIONS;
+
+/**
+ * Validator for {@link PulsarCatalogDescriptor}.
+ */
+public class PulsarCatalogValidator extends CatalogDescriptorValidator {
+	public static final String CATALOG_TYPE_VALUE_PULSAR = "pulsar";
+	public static final String CATALOG_PULSAR_VERSION = "pulsar-version";
+	public static final String CATALOG_SERVICE_URL = "serviceUrl";
+	public static final String CATALOG_ADMIN_URL = "adminUrl";
+	public static final String CATALOG_STARTING_POS = "startingOffsets";
+	public static final String CATALOG_DEFAULT_PARTITIONS = DEFAULT_PARTITIONS;
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		super.validate(properties);
+		properties.validateValue(CATALOG_TYPE, CATALOG_TYPE_VALUE_PULSAR, false);
+		properties.validateString(CATALOG_PULSAR_VERSION, true, 1);
+		properties.validateString(CATALOG_SERVICE_URL, false, 1);
+		properties.validateString(CATALOG_ADMIN_URL, false, 1);
+		properties.validateInt(CATALOG_DEFAULT_PARTITIONS, true, 1);
+		validateStartingOffsets(properties);
+	}
+
+	private void validateStartingOffsets(DescriptorProperties properties) {
+		if (properties.containsKey(CATALOG_STARTING_POS)) {
+			String v = properties.getString(CATALOG_STARTING_POS);
+			if (v != "earliest" && v != "latest") {
+				throw new ValidationException(CATALOG_STARTING_POS + " should be either earliest or latest");
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/descriptors/PulsarCatalogValidator.java
@@ -18,22 +18,22 @@
 
 package org.apache.flink.table.catalog.pulsar.descriptors;
 
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.CatalogDescriptorValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
-
-import static org.apache.flink.streaming.connectors.pulsar.internal.PulsarOptions.DEFAULT_PARTITIONS;
 
 /**
  * Validator for {@link PulsarCatalogDescriptor}.
  */
 public class PulsarCatalogValidator extends CatalogDescriptorValidator {
+
 	public static final String CATALOG_TYPE_VALUE_PULSAR = "pulsar";
 	public static final String CATALOG_PULSAR_VERSION = "pulsar-version";
-	public static final String CATALOG_SERVICE_URL = "serviceUrl";
-	public static final String CATALOG_ADMIN_URL = "adminUrl";
-	public static final String CATALOG_STARTING_POS = "startingOffsets";
-	public static final String CATALOG_DEFAULT_PARTITIONS = DEFAULT_PARTITIONS;
+	public static final String CATALOG_SERVICE_URL = PulsarOptions.SERVICE_URL_OPTION_KEY;
+	public static final String CATALOG_ADMIN_URL = PulsarOptions.ADMIN_URL_OPTION_KEY;
+	public static final String CATALOG_STARTUP_MODE = PulsarOptions.STARTUP_MODE_OPTION_KEY;
+	public static final String CATALOG_DEFAULT_PARTITIONS = PulsarOptions.DEFAULT_PARTITIONS;
 
 	@Override
 	public void validate(DescriptorProperties properties) {
@@ -47,10 +47,10 @@ public class PulsarCatalogValidator extends CatalogDescriptorValidator {
 	}
 
 	private void validateStartingOffsets(DescriptorProperties properties) {
-		if (properties.containsKey(CATALOG_STARTING_POS)) {
-			String v = properties.getString(CATALOG_STARTING_POS);
-			if (v != "earliest" && v != "latest") {
-				throw new ValidationException(CATALOG_STARTING_POS + " should be either earliest or latest");
+		if (properties.containsKey(CATALOG_STARTUP_MODE)) {
+			String v = properties.getString(CATALOG_STARTUP_MODE);
+			if (!v.equals("earliest") && !v.equals("latest")) {
+				throw new ValidationException(CATALOG_STARTUP_MODE + " should be either earliest or latest");
 			}
 		}
 	}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/catalog/pulsar/factories/PulsarCatalogFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.pulsar.factories;
+
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.CatalogFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_PULSAR_VERSION;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_SERVICE_URL;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_ADMIN_URL;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_STARTING_POS;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_DEFAULT_PARTITIONS;
+import static org.apache.flink.table.catalog.pulsar.descriptors.PulsarCatalogValidator.CATALOG_TYPE_VALUE_PULSAR;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
+
+
+public class PulsarCatalogFactory implements CatalogFactory {
+
+	@Override
+	public Catalog createCatalog(String name, Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = getValidatedProperties(properties);
+
+		final String defaultDatabase =
+			descriptorProperties.getOptionalString(CATALOG_DEFAULT_DATABASE)
+				.orElse("public/default");
+
+		String adminUrl = descriptorProperties.getString(CATALOG_ADMIN_URL);
+
+		return new PulsarCatalog(adminUrl, name, descriptorProperties.asMap(), defaultDatabase);
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_PULSAR);
+		context.put(CATALOG_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+		properties.add(CATALOG_DEFAULT_DATABASE);
+		properties.add(CATALOG_PULSAR_VERSION);
+		properties.add(CATALOG_SERVICE_URL);
+		properties.add(CATALOG_ADMIN_URL);
+		properties.add(CATALOG_STARTING_POS);
+		properties.add(CATALOG_DEFAULT_PARTITIONS);
+		return properties;
+	}
+
+	private static DescriptorProperties getValidatedProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putProperties(properties);
+		new PulsarCatalogValidator().validate(descriptorProperties);
+		return descriptorProperties;
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/package-info.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/table/package-info.java
@@ -1,0 +1,1 @@
+package org.apache.flink.table;

--- a/flink-connectors/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-connector-pulsar/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.flink.table.catalog.pulsar.factories.PulsarCatalogFactory

--- a/flink-connectors/flink-connector-pulsar/src/main/resources/log4j.properties
+++ b/flink-connectors/flink-connector-pulsar/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, testlogger
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target=System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger
+

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/CatalogITest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/CatalogITest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.commons.cli.Options;
+import org.apache.flink.client.cli.DefaultCLI;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.pulsar.testutils.EnvironmentFileUtil;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.pulsar.PulsarCatalog;
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.local.ExecutionContext;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class CatalogITest extends PulsarTestBaseWithFlink {
+
+	private static final String CATALOGS_ENVIRONMENT_FILE = "test-sql-client-pulsar-catalog.yaml";
+	private static final String CATALOGS_ENVIRONMENT_FILE_START = "test-sql-client-pulsar-start-catalog.yaml";
+
+	@Test
+	public void testCatalogs() throws Exception {
+		String inmemoryCatalog = "inmemorycatalog";
+		String pulsarCatalog1 = "pulsarcatalog1";
+		String pulsarCatalog2 = "pulsarcatalog2";
+
+		ExecutionContext context = createExecutionContext(CATALOGS_ENVIRONMENT_FILE, getStreamingConfs());
+		TableEnvironment tableEnv = context.getTableEnvironment();
+
+		assertEquals(tableEnv.getCurrentCatalog(), inmemoryCatalog);
+		assertEquals(tableEnv.getCurrentDatabase(), "mydatabase");
+
+		Catalog catalog = tableEnv.getCatalog(pulsarCatalog1).orElse(null);
+		assertNotNull(catalog);
+		assertTrue(catalog instanceof PulsarCatalog);
+		tableEnv.useCatalog(pulsarCatalog1);
+		assertEquals(tableEnv.getCurrentDatabase(), "public/default");
+
+		catalog = tableEnv.getCatalog(pulsarCatalog2).orElse(null);
+		assertNotNull(catalog);
+		assertTrue(catalog instanceof PulsarCatalog);
+		tableEnv.useCatalog(pulsarCatalog2);
+		assertEquals(tableEnv.getCurrentDatabase(), "tn/ns");
+	}
+
+	@Test
+	public void testDatabases() throws Exception {
+		String pulsarCatalog1 = "pulsarcatalog1";
+		List<String> namespaces = Arrays.asList("tn1/ns1", "tn1/ns2");
+		List<String> topics = Arrays.asList("tp1", "tp2");
+		List<String> topicsFullName = topics.stream().map(a -> "tn1/ns1/" + a).collect(Collectors.toList());
+		List<String> partitionedTopics = Arrays.asList("ptp1", "ptp2");
+		List<String> partitionedTopicsFullName = partitionedTopics.stream().map(a -> "tn1/ns1/" + a).collect(Collectors.toList());
+
+		ExecutionContext context = createExecutionContext(CATALOGS_ENVIRONMENT_FILE, getStreamingConfs());
+		TableEnvironment tableEnv = context.getTableEnvironment();
+
+		tableEnv.useCatalog(pulsarCatalog1);
+		assertEquals(tableEnv.getCurrentDatabase(), "public/default");
+
+		try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(getAdminUrl()).build()) {
+			admin.tenants().createTenant("tn1",
+				new TenantInfo(Sets.newHashSet(), Sets.newHashSet("standalone")));
+			for (String ns : namespaces) {
+				admin.namespaces().createNamespace(ns);
+			}
+
+			for (String tp : topicsFullName) {
+				admin.topics().createNonPartitionedTopic(tp);
+			}
+
+			for (String tp : partitionedTopicsFullName) {
+				admin.topics().createPartitionedTopic(tp, 5);
+			}
+
+			assertTrue(Sets.newHashSet(tableEnv.listDatabases()).containsAll(namespaces));
+
+			tableEnv.useDatabase("tn1/ns1");
+
+			assertTrue(
+				Sets.symmetricDifference(
+					Sets.newHashSet(tableEnv.listTables()),
+					Sets.newHashSet(Iterables.concat(topics, partitionedTopics)))
+					.isEmpty());
+
+			for (String tp : topicsFullName) {
+				admin.topics().delete(tp);
+			}
+
+			for (String tp : partitionedTopicsFullName) {
+				admin.topics().deletePartitionedTopic(tp);
+			}
+
+			for (String ns : namespaces) {
+				admin.namespaces().deleteNamespace(ns);
+			}
+		}
+	}
+
+	private <T> ExecutionContext<T> createExecutionContext(String file, Map<String, String> replaceVars) throws Exception {
+		final Environment env = EnvironmentFileUtil.parseModified(
+			file,
+			replaceVars);
+		final Configuration flinkConfig = new Configuration();
+		return new ExecutionContext<>(
+			env,
+			new SessionContext("test-session", new Environment()),
+			Collections.emptyList(),
+			flinkConfig,
+			new Options(),
+			Collections.singletonList(new DefaultCLI(flinkConfig)));
+	}
+
+	private Map<String, String> getStreamingConfs() {
+		Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+		replaceVars.put("$VAR_RESULT_MODE", "changelog");
+		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
+		replaceVars.put("$VAR_SERVICEURL", getServiceUrl());
+		replaceVars.put("$VAR_ADMINURL", getAdminUrl());
+		return replaceVars;
+	}
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/FlinkPulsarSinkTest.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.core.testutils.MultiShotLatch;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.util.TestLogger;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.impl.TypedMessageBuilderImpl;
+import org.apache.pulsar.client.impl.conf.ClientConfigurationData;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class FlinkPulsarSinkTest extends TestLogger {
+
+    /**
+     * Tests that the constructor eagerly checks bootstrap servers are set in config.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testInstantiationFailsWhenServiceUrlMissing() throws Exception {
+        new DummyFlinkPulsarSink<Long>(new ClientConfigurationData(), new Properties(), null, null);
+    }
+
+    public static ClientConfigurationData dummyClientConf() {
+        ClientConfigurationData clientConf = new ClientConfigurationData();
+        clientConf.setServiceUrl("abc");
+        return clientConf;
+    }
+
+    public static Properties dummyProperties() {
+        Properties pros = new Properties();
+        pros.setProperty("failonwrite", "true");
+        return pros;
+    }
+
+    /**
+     * Test ensuring that if an invoke call happens right after an async exception is caught, it should be rethrown.
+     */
+    @Test
+    public void testAsyncErrorRethrownOnInvoke() throws Throwable {
+        DummyFlinkPulsarSink<String> sink = new DummyFlinkPulsarSink<>(dummyClientConf(), dummyProperties(), mock(TopicKeyExtractor.class), null);
+
+        OneInputStreamOperatorTestHarness<String, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>("msg-1"));
+
+        // let the message request return an async exception
+        sink.getPendingCallbacks().get(0).accept(null, new Exception("artificial async exception"));
+
+        try {
+            testHarness.processElement(new StreamRecord<>("msg-2"));
+        } catch (Exception e) {
+            // the next invoke should rethrow the async exception
+            Assert.assertTrue(e.getCause().getMessage().contains("artificial async exception"));
+
+            // test succeeded
+            return;
+        }
+
+        Assert.fail();
+    }
+
+    /**
+     * Test ensuring that if a snapshot call happens right after an async exception is caught, it should be rethrown.
+     */
+    @Test
+    public void testAsyncErrorRethrownOnCheckpoint() throws Throwable {
+        final DummyFlinkPulsarSink<String> producer = new DummyFlinkPulsarSink<>(
+                dummyClientConf(), dummyProperties(), mock(TopicKeyExtractor.class), null);
+
+        OneInputStreamOperatorTestHarness<String, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(producer));
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>("msg-1"));
+
+        // let the message request return an async exception
+        producer.getPendingCallbacks().get(0).accept(null, new Exception("artificial async exception"));
+
+        try {
+            testHarness.snapshot(123L, 123L);
+        } catch (Exception e) {
+            // the next invoke should rethrow the async exception
+            Assert.assertTrue(e.getCause().getMessage().contains("artificial async exception"));
+
+            // test succeeded
+            return;
+        }
+
+        Assert.fail();
+    }
+
+    /**
+     * Test ensuring that if an async exception is caught for one of the flushed requests on checkpoint,
+     * it should be rethrown; we set a timeout because the test will not finish if the logic is broken.
+     *
+     * <p>Note that this test does not test the snapshot method is blocked correctly when there are pending records.
+     * The test for that is covered in testAtLeastOnceProducer.
+     */
+    @SuppressWarnings("unchecked")
+    @Test//(timeout = 5000)
+    public void testAsyncErrorRethrownOnCheckpointAfterFlush() throws Throwable {
+        final DummyFlinkPulsarSink<String> sink = new DummyFlinkPulsarSink<>(dummyClientConf(), dummyProperties(), mock(TopicKeyExtractor.class), null);
+        Producer mockProducer = sink.getProducer("tp");
+
+        final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>("msg-1"));
+        testHarness.processElement(new StreamRecord<>("msg-2"));
+        testHarness.processElement(new StreamRecord<>("msg-3"));
+
+        verify(mockProducer, times(3)).newMessage();
+
+        // only let the first callback succeed for now
+        sink.getPendingCallbacks().get(0).accept(null, null);
+
+        CheckedThread snapshotThread = new CheckedThread() {
+            @Override
+            public void go() throws Exception {
+                // this should block at first, since there are still two pending records that needs to be flushed
+                testHarness.snapshot(123L, 123L);
+            }
+        };
+        snapshotThread.start();
+
+        // let the 2nd message fail with an async exception
+        sink.getPendingCallbacks().get(1).accept(null, new Exception("artificial async failure for 2nd message"));
+        sink.getPendingCallbacks().get(2).accept(null, null);
+
+        try {
+            snapshotThread.sync();
+        } catch (Exception e) {
+            // the snapshot should have failed with the async exception
+            Assert.assertTrue(e.getCause().getMessage().contains("artificial async failure for 2nd message"));
+
+            // test succeeded
+            return;
+        }
+
+        Assert.fail();
+    }
+
+    /**
+     * Test ensuring that the producer is not dropping buffered records;
+     * we set a timeout because the test will not finish if the logic is broken.
+     */
+    @SuppressWarnings("unchecked")
+    @Test(timeout = 10000)
+    public void testAtLeastOnceProducer() throws Throwable {
+        final DummyFlinkPulsarSink<String> sink = new DummyFlinkPulsarSink<>(dummyClientConf(), dummyProperties(), mock(TopicKeyExtractor.class), null);
+
+        final Producer mockProducer = sink.getProducer("tp");
+
+        final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>("msg-1"));
+        testHarness.processElement(new StreamRecord<>("msg-2"));
+        testHarness.processElement(new StreamRecord<>("msg-3"));
+
+        verify(mockProducer, times(3));
+        Assert.assertEquals(3, sink.getPendingSize());
+
+        // start a thread to perform checkpointing
+        CheckedThread snapshotThread = new CheckedThread() {
+            @Override
+            public void go() throws Exception {
+                // this should block until all records are flushed;
+                // if the snapshot implementation returns before pending records are flushed,
+                testHarness.snapshot(123L, 123L);
+            }
+        };
+        snapshotThread.start();
+
+        // before proceeding, make sure that flushing has started and that the snapshot is still blocked;
+        // this would block forever if the snapshot didn't perform a flush
+        sink.waitUntilFlushStarted();
+        Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+
+        // now, complete the callbacks
+        sink.getPendingCallbacks().get(0).accept(null, null);
+        Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+        Assert.assertEquals(2, sink.getPendingSize());
+
+        sink.getPendingCallbacks().get(1).accept(null, null);
+        Assert.assertTrue("Snapshot returned before all records were flushed", snapshotThread.isAlive());
+        Assert.assertEquals(1, sink.getPendingSize());
+
+        sink.getPendingCallbacks().get(2).accept(null, null);
+        Assert.assertEquals(0, sink.getPendingSize());
+
+        // this would fail with an exception if flushing wasn't completed before the snapshot method returned
+        snapshotThread.sync();
+
+        testHarness.close();
+    }
+
+    /**
+     * This test is meant to assure that testAtLeastOnceProducer is valid by testing that if flushing is disabled,
+     * the snapshot method does indeed finishes without waiting for pending records;
+     * we set a timeout because the test will not finish if the logic is broken.
+     */
+    @SuppressWarnings("unchecked")
+    @Test//(timeout = 5000)
+    public void testDoesNotWaitForPendingRecordsIfFlushingDisabled() throws Throwable {
+        Properties props = dummyProperties();
+        props.setProperty("flushoncheckpoint", "false");
+
+        final DummyFlinkPulsarSink<String> sink = new DummyFlinkPulsarSink<>(dummyClientConf(), props, mock(TopicKeyExtractor.class), null);
+
+        final Producer mockProducer = sink.getProducer("tp");
+
+        final OneInputStreamOperatorTestHarness<String, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(new StreamSink<>(sink));
+
+        testHarness.open();
+
+        testHarness.processElement(new StreamRecord<>("msg"));
+
+        // make sure that all callbacks have not been completed
+        verify(mockProducer, times(1)).newMessage();
+
+        // should return even if there are pending records
+        testHarness.snapshot(123L, 123L);
+
+        testHarness.close();
+    }
+
+
+    private static class DummyFlinkPulsarSink<T> extends FlinkPulsarSink<T> {
+
+        private static final long serialVersionUID = 1L;
+
+        private static final String DUMMY_TOPIC = "dummy-topic";
+
+        private transient Producer<T> mockProducer;
+        private transient TypedMessageBuilderImpl<T> mockMessageBuilder;
+
+        public List<BiConsumer<MessageId, Throwable>> getPendingCallbacks() {
+            return pendingCallbacks;
+        }
+
+        private transient List<BiConsumer<MessageId, Throwable>> pendingCallbacks;
+        private transient MultiShotLatch flushLatch;
+        private boolean isFlushed;
+
+
+        public DummyFlinkPulsarSink(ClientConfigurationData clientConf, Properties properties, TopicKeyExtractor<T> topicKeyExtractor, Class<T> recordClazz) {
+            super(
+                    "",
+                    Optional.of(DUMMY_TOPIC),
+                    clientConf,
+                    properties,
+                    topicKeyExtractor,
+                    recordClazz);
+
+            this.mockProducer = mock(Producer.class);
+            this.mockMessageBuilder = mock(TypedMessageBuilderImpl.class);
+
+            this.pendingCallbacks = new ArrayList<>();
+            this.flushLatch = new MultiShotLatch();
+
+            when(mockMessageBuilder.sendAsync()).thenAnswer((Answer<CompletableFuture<MessageId>>) invocation -> {
+
+                CompletableFuture<MessageId> mockFuture = mock(CompletableFuture.class);
+
+                when(mockFuture.whenComplete(ArgumentMatchers.any(BiConsumer.class))).thenAnswer(new Answer<T>() {
+                    @Override
+                    public T answer(InvocationOnMock i) throws Throwable {
+                        pendingCallbacks.add(i.getArgument(0));
+                        return null;
+                    }
+                });
+                return mockFuture;
+            });
+
+            when(mockMessageBuilder.value(ArgumentMatchers.any())).thenReturn(mockMessageBuilder);
+            when(mockMessageBuilder.keyBytes(ArgumentMatchers.any())).thenReturn(mockMessageBuilder);
+            when(mockMessageBuilder.eventTime(anyLong())).thenReturn(mockMessageBuilder);
+
+            when(mockProducer.newMessage()).thenAnswer(new Answer<TypedMessageBuilderImpl<T>>() {
+                @Override
+                public TypedMessageBuilderImpl<T> answer(InvocationOnMock invocation) throws Throwable {
+                    return mockMessageBuilder;
+                }
+            });
+        }
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {
+            isFlushed = false;
+            super.snapshotState(context);
+            // if the snapshot implementation doesn't wait until
+            // all pending records are flushed, we should fail the test
+            if (flushOnCheckpoint && !isFlushed) {
+                throw new RuntimeException("Flushing is enabled; snapshots should be blocked" +
+                        " until all pending records are flushed");
+            }
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            if (flushOnCheckpoint && !((StreamingRuntimeContext) this.getRuntimeContext()).isCheckpointingEnabled()) {
+                flushOnCheckpoint = false;
+            }
+        }
+
+        public void waitUntilFlushStarted() throws InterruptedException {
+            flushLatch.await();
+        }
+
+        @Override
+        public void producerFlush() throws Exception {
+            flushLatch.trigger();
+
+            // simply wait until the producer's pending records become zero.
+            // This relies on the fact that the producer's Callback implementation
+            // and pending records tracking logic is implemented correctly, otherwise
+            // we will loop forever.
+            while (numPendingRecords() > 0) {
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException("Unable to flush producer, task was interrupted");
+                }
+            }
+
+            isFlushed = true;
+        }
+
+        @Override
+        protected Producer<T> getProducer(String topic) {
+            return mockProducer;
+        }
+
+        public long getPendingSize() {
+            if (flushOnCheckpoint) {
+                return numPendingRecords();
+            } else {
+                throw new UnsupportedOperationException("Get pending size");
+            }
+        }
+
+        public long numPendingRecords() {
+            synchronized (pendingRecordsLock) {
+                return pendingRecords;
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import com.google.common.collect.Sets;
+import io.streamnative.tests.pulsar.service.PulsarService;
+import io.streamnative.tests.pulsar.service.PulsarServiceFactory;
+import io.streamnative.tests.pulsar.service.PulsarServiceSpec;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.metrics.jmx.JMXReporter;
+import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
+import org.apache.flink.streaming.util.TestStreamEnvironment;
+import org.apache.flink.util.TestLogger;
+import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.util.UUID;
+
+public abstract class PulsarTestBase extends TestLogger {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarMetadataReader.class);
+
+    protected static PulsarService pulsarService;
+
+    protected static String serviceUrl;
+
+    protected static String adminUrl;
+
+    public static String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    public static String getAdminUrl() {
+        return adminUrl;
+    }
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+
+        LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Starting PulsarTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+        PulsarServiceSpec spec = PulsarServiceSpec.builder()
+                .clusterName("standalone-" + UUID.randomUUID())
+                .enableContainerLogging(false)
+                .build();
+
+        pulsarService = PulsarServiceFactory.createPulsarService(spec);
+        pulsarService.start();
+
+        for (URI uri : pulsarService.getServiceUris()) {
+            if (uri != null && uri.getScheme().equals("pulsar")) {
+                serviceUrl = uri.toString();
+            } else if (uri != null && !uri.getScheme().equals("pulsar")) {
+                adminUrl = uri.toString();
+            }
+        }
+
+        try (PulsarAdmin admin = PulsarAdmin.builder().serviceHttpUrl(adminUrl).build()) {
+            admin.namespaces().createNamespace("public/default", Sets.newHashSet("standalone"));
+        }
+
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("Successfully started pulsar service at cluster " + spec.clusterName());
+		LOG.info("-------------------------------------------------------------------------");
+
+    }
+
+
+    @AfterClass
+    public static void shutDownServices() throws Exception {
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    Shut down PulsarTestBase ");
+		LOG.info("-------------------------------------------------------------------------");
+
+        TestStreamEnvironment.unsetAsContext();
+
+        if (pulsarService != null) {
+            pulsarService.stop();
+        }
+
+		LOG.info("-------------------------------------------------------------------------");
+		LOG.info("    PulsarTestBase finished");
+		LOG.info("-------------------------------------------------------------------------");
+    }
+
+    protected static Configuration getFlinkConfiguration() {
+        Configuration flinkConfig = new Configuration();
+        flinkConfig.setString(TaskManagerOptions.MANAGED_MEMORY_SIZE, "16m");
+        flinkConfig.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "my_reporter." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, JMXReporter.class.getName());
+        return flinkConfig;
+    }
+
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBase.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.jmx.JMXReporter;
-import org.apache.flink.streaming.connectors.pulsar.internal.PulsarMetadataReader;
 import org.apache.flink.streaming.util.TestStreamEnvironment;
 import org.apache.flink.util.TestLogger;
 import org.apache.pulsar.client.admin.PulsarAdmin;
@@ -36,7 +35,7 @@ import java.util.UUID;
 
 public abstract class PulsarTestBase extends TestLogger {
 
-	protected static final Logger LOG = LoggerFactory.getLogger(PulsarMetadataReader.class);
+	protected static final Logger LOG = LoggerFactory.getLogger(PulsarTestBase.class);
 
     protected static PulsarService pulsarService;
 

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBaseWithFlink.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/PulsarTestBaseWithFlink.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.pulsar.common.naming.TopicName;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public abstract class PulsarTestBaseWithFlink extends PulsarTestBase {
+
+    protected static final int NUM_TMS = 1;
+
+    protected static final int TM_SLOTS = 8;
+
+    protected ClusterClient<?> client;
+
+    @ClassRule
+    public static MiniClusterWithClientResource flink = new MiniClusterWithClientResource(
+            new MiniClusterResourceConfiguration.Builder()
+                    .setConfiguration(getFlinkConfiguration())
+                    .setNumberTaskManagers(NUM_TMS)
+                    .setNumberSlotsPerTaskManager(TM_SLOTS)
+                    .build());
+
+    @Before
+    public void noJobIsRunning() throws Exception {
+        client = flink.getClusterClient();
+        waitUntilNoJobIsRunning(client);
+    }
+
+    public static void waitUntilJobIsRunning(ClusterClient<?> client) throws Exception {
+        while (getRunningJobs(client).isEmpty()) {
+            Thread.sleep(50);
+        }
+    }
+
+    public static void waitUntilNoJobIsRunning(ClusterClient<?> client) throws Exception {
+        while (!getRunningJobs(client).isEmpty()) {
+            Thread.sleep(50);
+            cancelRunningJobs(client);
+        }
+    }
+
+    public static List<JobID> getRunningJobs(ClusterClient<?> client) throws Exception {
+        Collection<JobStatusMessage> statusMessages = client.listJobs().get();
+        return statusMessages.stream()
+                .filter(status -> !status.getJobState().isGloballyTerminalState())
+                .map(JobStatusMessage::getJobId)
+                .collect(Collectors.toList());
+    }
+
+    public static void cancelRunningJobs(ClusterClient<?> client) throws Exception {
+        List<JobID> runningJobs = getRunningJobs(client);
+        for (JobID runningJob : runningJobs) {
+            client.cancel(runningJob);
+        }
+    }
+
+    public static final AtomicInteger topicId = new AtomicInteger(0);
+
+    public static String newTopic() {
+        synchronized (topicId) {
+            int i = topicId.getAndIncrement();
+            return TopicName.get("topic-" + i).toString();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/EnvironmentFileUtil.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/streaming/connectors/pulsar/testutils/EnvironmentFileUtil.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.pulsar.testutils;
+
+import org.apache.flink.table.client.config.Environment;
+import org.apache.flink.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Utilities for reading an environment file.
+ */
+public final class EnvironmentFileUtil {
+
+    private EnvironmentFileUtil() {
+        // private
+    }
+
+    public static Environment parseUnmodified(String fileName) throws IOException {
+        final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+        Objects.requireNonNull(url);
+        return Environment.parse(url);
+    }
+
+    public static Environment parseModified(String fileName, Map<String, String> replaceVars) throws IOException {
+        final URL url = EnvironmentFileUtil.class.getClassLoader().getResource(fileName);
+        Objects.requireNonNull(url);
+        String schema = FileUtils.readFileUtf8(new File(url.getFile()));
+
+        for (Map.Entry<String, String> replaceVar : replaceVars.entrySet()) {
+            schema = schema.replace(replaceVar.getKey(), replaceVar.getValue());
+        }
+
+        return Environment.parse(schema);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-catalog.yaml
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-catalog.yaml
@@ -1,0 +1,45 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+execution:
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: none
+  current-catalog: inmemorycatalog
+  current-database: mydatabase
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+  - name: pulsarcatalog1
+    type: pulsar
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+  - name: pulsarcatalog2
+    type: pulsar
+    default-database: tn/ns
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+  - name: inmemorycatalog
+    type: generic_in_memory
+    default-database: mydatabase

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-start-catalog.yaml
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/test-sql-client-pulsar-start-catalog.yaml
@@ -1,0 +1,48 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+execution:
+  type: "$VAR_EXECUTION_TYPE"
+  time-characteristic: event-time
+  periodic-watermarks-interval: 99
+  parallelism: 1
+  max-parallelism: 16
+  min-idle-state-retention: 0
+  max-idle-state-retention: 0
+  result-mode: "$VAR_RESULT_MODE"
+  max-table-result-rows: "$VAR_MAX_ROWS"
+  restart-strategy:
+    type: none
+  current-catalog: inmemorycatalog
+  current-database: mydatabase
+
+deployment:
+  response-timeout: 5000
+
+catalogs:
+  - name: pulsarcatalog1
+    type: pulsar
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+    startup-mode: "$VAR_STARTING"
+    table-default-partitions: 5
+  - name: pulsarcatalog2
+    type: pulsar
+    default-database: tn/ns
+    service-url: "$VAR_SERVICEURL"
+    admin-url: "$VAR_ADMINURL"
+    startup-mode: "$VAR_STARTING"
+  - name: inmemorycatalog
+    type: generic_in_memory
+    default-database: mydatabase

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -53,6 +53,7 @@ under the License.
 		<module>flink-connector-rabbitmq</module>
 		<module>flink-connector-twitter</module>
 		<module>flink-connector-nifi</module>
+		<module>flink-connector-pulsar</module>
 		<module>flink-connector-cassandra</module>
 		<module>flink-connector-filesystem</module>
 		<module>flink-connector-kafka</module>


### PR DESCRIPTION
## What is the purpose of the change

This PR implements Pulsar sink which is part of FLIP-72, and based on #10455 .

## Brief change log

  - `FlinkPulsarSinkBase` for the common structure of a sink which supports at-least-once sink.
  -  `FlinkPulsarRowSink` for row sink and `FlinkPulsarSink` for POJO sink.
  - `CachedPulsarClient` to enable share PulsarClient among tasks in the same JVM. PulsarClient holds all the resources that talks to Pulsar and could be shared by multiple producers.

## Verifying this change

This change is already covered by existing tests, `FlinkPulsarSinkTest`

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes )

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
