### PR TITLE
[FLINK-15602][table-planner-blink] Padding TIMESTAMP type to respect …

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableTestBase.java
@@ -160,8 +160,8 @@ public abstract class KafkaTableTestBase extends KafkaTestBase {
 		}
 
 		List<String> expected = Arrays.asList(
-			"2019-12-12 00:00:05,2019-12-12 00:00:04.004,3,50.00",
-			"2019-12-12 00:00:10,2019-12-12 00:00:06.006,2,5.33");
+			"2019-12-12 00:00:05.000,2019-12-12 00:00:04.004,3,50.00",
+			"2019-12-12 00:00:10.000,2019-12-12 00:00:06.006,2,5.33");
 
 		assertEquals(expected, TestingSinkFunction.rows);
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -218,12 +218,12 @@ object BuiltInMethods {
   val TIMESTAMP_TO_STRING = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampToString",
-    classOf[SqlTimestamp])
+    classOf[SqlTimestamp], classOf[Int])
 
   val TIMESTAMP_TO_STRING_TIME_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],
     "timestampToString",
-    classOf[SqlTimestamp], classOf[TimeZone])
+    classOf[SqlTimestamp], classOf[TimeZone], classOf[Int])
 
   val TIMESTAMP_TO_TIMESTAMP_WITH_LOCAL_ZONE = Types.lookupMethod(
     classOf[SqlDateTimeUtils],

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -2305,11 +2305,13 @@ object ScalarOperatorGens {
       case TIMESTAMP_WITHOUT_TIME_ZONE => // including rowtime indicator
         // The interpreted string conforms to the definition of timestamp literal
         // SQL 2011 Part 2 Section 6.13 General Rules 11) d)
-        s"${qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING)}($operandTerm)"
+        val precision = fromType.asInstanceOf[TimestampType].getPrecision
+        s"${qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING)}($operandTerm, $precision)"
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING_TIME_ZONE)
         val zone = ctx.addReusableTimeZone()
-        s"$method($operandTerm, $zone)"
+        val precision = fromType.asInstanceOf[LocalZonedTimestampType].getPrecision
+        s"$method($operandTerm, $zone, $precision)"
     }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -90,9 +90,11 @@ class ArrayTypeTest extends ArrayTypeTestBase {
       "ARRAY[TIME '14:15:16', TIME '17:18:19']",
       "[14:15:16, 17:18:19]")
 
-    testAllApis(
+    testTableApi(
       Array(localDateTime("1985-04-11 14:15:16"), localDateTime("2018-07-26 17:18:19")),
-      "array('1985-04-11 14:15:16'.toTimestamp, '2018-07-26 17:18:19'.toTimestamp)",
+      "[1985-04-11 14:15:16, 2018-07-26 17:18:19]")
+
+    testSqlApi(
       "ARRAY[TIMESTAMP '1985-04-11 14:15:16', TIMESTAMP '2018-07-26 17:18:19']",
       "[1985-04-11 14:15:16, 2018-07-26 17:18:19]")
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ArrayTypeTest.scala
@@ -90,6 +90,8 @@ class ArrayTypeTest extends ArrayTypeTestBase {
       "ARRAY[TIME '14:15:16', TIME '17:18:19']",
       "[14:15:16, 17:18:19]")
 
+    // There is no such thing in Table API which align to Timestamp literal in SQL
+    // toTimestamp is a shortcut of casting.
     testTableApi(
       Array(localDateTime("1985-04-11 14:15:16"), localDateTime("2018-07-26 17:18:19")),
       "[1985-04-11 14:15:16, 2018-07-26 17:18:19]")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/DecimalTypeTest.scala
@@ -189,6 +189,12 @@ class DecimalTypeTest extends ExpressionTestBase {
       BigDecimal("123456789.123456789123456789").cast(DataTypes.DOUBLE),
       "(123456789.123456789123456789p).cast(DOUBLE)",
       "1.2345678912345679E8")
+
+    // testing padding behaviour
+    testSqlApi(
+      "CAST(CAST(f67 AS DECIMAL(10, 5)) AS VARCHAR)",
+      "1.00000"
+    )
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
@@ -85,13 +85,14 @@ class MapTypeTest extends MapTypeTestBase {
       "MAP[DATE '1985-04-11', TIME '14:15:16', DATE '2018-07-26', TIME '17:18:19']",
       "{1985-04-11=14:15:16, 2018-07-26=17:18:19}")
 
-    testAllApis(
+    testTableApi(
       map(valueLiteral(gLocalTime("14:15:16")), valueLiteral(localDateTime("1985-04-11 14:15:16")),
         valueLiteral(gLocalTime("17:18:19")), valueLiteral(localDateTime("2018-07-26 17:18:19"))),
-      "map('14:15:16'.toTime, '1985-04-11 14:15:16'.toTimestamp, " +
-          "'17:18:19'.toTime, '2018-07-26 17:18:19'.toTimestamp)",
+      "{14:15:16=1985-04-11 14:15:16, 17:18:19=2018-07-26 17:18:19}")
+
+    testSqlApi(
       "MAP[TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16', " +
-          "TIME '17:18:19', TIMESTAMP '2018-07-26 17:18:19']",
+        "TIME '17:18:19', TIMESTAMP '2018-07-26 17:18:19']",
       "{14:15:16=1985-04-11 14:15:16, 17:18:19=2018-07-26 17:18:19}")
 
     testAllApis(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/MapTypeTest.scala
@@ -85,6 +85,8 @@ class MapTypeTest extends MapTypeTestBase {
       "MAP[DATE '1985-04-11', TIME '14:15:16', DATE '2018-07-26', TIME '17:18:19']",
       "{1985-04-11=14:15:16, 2018-07-26=17:18:19}")
 
+    // There is no such thing in Table API which align to Timestamp literal in SQL
+    // toTimestamp is a shortcut of casting.
     testTableApi(
       map(valueLiteral(gLocalTime("14:15:16")), valueLiteral(localDateTime("1985-04-11 14:15:16")),
         valueLiteral(gLocalTime("17:18:19")), valueLiteral(localDateTime("2018-07-26 17:18:19"))),

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
@@ -38,7 +38,7 @@ class RowTypeTest extends RowTypeTestBase {
       "(1,foo,true)")
 
     // special literal
-    testAllApis(
+    testTableApi(
       row(
         localDate("1985-04-11"),
         gLocalTime("14:15:16"),
@@ -47,10 +47,6 @@ class RowTypeTest extends RowTypeTestBase {
         array(1, 2, 3),
         map("foo", "bar"),
         row(1, true)),
-      "row('1985-04-11'.toDate, '14:15:16'.toTime, '1985-04-11 14:15:16'.toTimestamp, " +
-          "0.1p, Array(1, 2, 3), Map('foo', 'bar'), row(1, true))",
-      "ROW(DATE '1985-04-11', TIME '14:15:16', TIMESTAMP '1985-04-11 14:15:16', " +
-          "CAST(0.1 AS DECIMAL(2, 1)), ARRAY[1, 2, 3], MAP['foo', 'bar'], row(1, true))",
       "(1985-04-11,14:15:16,1985-04-11 14:15:16,0.1,[1, 2, 3],{foo=bar},(1,true))")
 
     testSqlApi(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -3018,37 +3018,37 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f18.floor(TimeIntervalUnit.YEAR),
       "f18.floor(YEAR)",
       "FLOOR(f18 TO YEAR)",
-      "1996-01-01 00:00:00")
+      "1996-01-01 00:00:00.000")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.MONTH),
       "f18.floor(MONTH)",
       "FLOOR(f18 TO MONTH)",
-      "1996-11-01 00:00:00")
+      "1996-11-01 00:00:00.000")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.DAY),
       "f18.floor(DAY)",
       "FLOOR(f18 TO DAY)",
-      "1996-11-10 00:00:00")
+      "1996-11-10 00:00:00.000")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.HOUR),
       "f18.floor(HOUR)",
       "FLOOR(f18 TO HOUR)",
-      "1996-11-10 06:00:00")
+      "1996-11-10 06:00:00.000")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.MINUTE),
       "f18.floor(MINUTE)",
       "FLOOR(f18 TO MINUTE)",
-      "1996-11-10 06:55:00")
+      "1996-11-10 06:55:00.000")
 
     testAllApis(
       'f18.floor(TimeIntervalUnit.SECOND),
       "f18.floor(SECOND)",
       "FLOOR(f18 TO SECOND)",
-      "1996-11-10 06:55:44")
+      "1996-11-10 06:55:44.000")
 
     testAllApis(
       'f17.floor(TimeIntervalUnit.HOUR),
@@ -3084,37 +3084,37 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       'f18.ceil(TimeIntervalUnit.YEAR),
       "f18.ceil(YEAR)",
       "CEIL(f18 TO YEAR)",
-      "1997-01-01 00:00:00")
+      "1997-01-01 00:00:00.000")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.MONTH),
       "f18.ceil(MONTH)",
       "CEIL(f18 TO MONTH)",
-      "1996-12-01 00:00:00")
+      "1996-12-01 00:00:00.000")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.DAY),
       "f18.ceil(DAY)",
       "CEIL(f18 TO DAY)",
-      "1996-11-11 00:00:00")
+      "1996-11-11 00:00:00.000")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.HOUR),
       "f18.ceil(HOUR)",
       "CEIL(f18 TO HOUR)",
-      "1996-11-10 07:00:00")
+      "1996-11-10 07:00:00.000")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.MINUTE),
       "f18.ceil(MINUTE)",
       "CEIL(f18 TO MINUTE)",
-      "1996-11-10 06:56:00")
+      "1996-11-10 06:56:00.000")
 
     testAllApis(
       'f18.ceil(TimeIntervalUnit.SECOND),
       "f18.ceil(SECOND)",
       "CEIL(f18 TO SECOND)",
-      "1996-11-10 06:55:45")
+      "1996-11-10 06:55:45.000")
 
     testAllApis(
       'f17.ceil(TimeIntervalUnit.HOUR),
@@ -3538,25 +3538,36 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "timestampadd(DAY, 1, date '2016-06-15')",
       "2016-06-16")
 
-    testAllApis("2016-06-15".toTimestamp - 1.hour,
+    testTableApi("2016-06-15".toTimestamp - 1.hour,
       "'2016-06-15'.toTimestamp - 1.hour",
+      "2016-06-14 23:00:00.000")
+
+    testSqlApi(
       "timestampadd(HOUR, -1, date '2016-06-15')",
-      "2016-06-14 23:00:00")
+      "2016-06-14 23:00:00.000000")
 
-    testAllApis("2016-06-15".toTimestamp + 1.minute,
+
+    testTableApi("2016-06-15".toTimestamp + 1.minute,
       "'2016-06-15'.toTimestamp + 1.minute",
-      "timestampadd(MINUTE, 1, date '2016-06-15')",
-      "2016-06-15 00:01:00")
+      "2016-06-15 00:01:00.000")
 
-    testAllApis("2016-06-15".toTimestamp - 1.second,
+    testSqlApi("timestampadd(MINUTE, 1, date '2016-06-15')",
+      "2016-06-15 00:01:00.000000")
+
+
+    testTableApi("2016-06-15".toTimestamp - 1.second,
       "'2016-06-15'.toTimestamp - 1.second",
-      "timestampadd(SQL_TSI_SECOND, -1, date '2016-06-15')",
-      "2016-06-14 23:59:59")
+      "2016-06-14 23:59:59.000")
 
-    testAllApis("2016-06-15".toTimestamp + 1.second,
+    testSqlApi("timestampadd(SQL_TSI_SECOND, -1, date '2016-06-15')",
+      "2016-06-14 23:59:59.000000")
+
+    testTableApi("2016-06-15".toTimestamp + 1.second,
       "'2016-06-15'.toTimestamp + 1.second",
-      "timestampadd(SECOND, 1, date '2016-06-15')",
-      "2016-06-15 00:00:01")
+      "2016-06-15 00:00:01.000")
+
+    testSqlApi("timestampadd(SECOND, 1, date '2016-06-15')",
+      "2016-06-15 00:00:01.000000")
 
     testAllApis(nullOf(Types.SQL_TIMESTAMP) + 1.second,
       "nullOf(SQL_TIMESTAMP) + 1.second",
@@ -3615,9 +3626,9 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
   @Test
   def testToTimestamp(): Unit = {
     testSqlApi("to_timestamp('abc')", "null")
-    testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00")
-    testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00")
-    testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00")
+    testSqlApi("to_timestamp('2017-09-15 00:00:00')", "2017-09-15 00:00:00.000")
+    testSqlApi("to_timestamp('20170915000000', 'yyyyMMddHHmmss')", "2017-09-15 00:00:00.000")
+    testSqlApi("to_timestamp('2017-09-15', 'yyyy-MM-dd')", "2017-09-15 00:00:00.000")
     // test with null input
     testSqlApi("to_timestamp(cast(null as varchar))", "null")
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -83,14 +83,13 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testTableApi(
       localDateTime2Literal(localDateTime("2040-09-11 00:00:00.000")),
-      "'2040-09-11 00:00:00.000'.toTimestamp",
       "2040-09-11 00:00:00")
 
     testAllApis(
       "1500-04-30 12:00:00".cast(DataTypes.TIMESTAMP(3)),
       "'1500-04-30 12:00:00'.cast(SQL_TIMESTAMP)",
       "CAST('1500-04-30 12:00:00' AS TIMESTAMP(3))",
-      "1500-04-30 12:00:00")
+      "1500-04-30 12:00:00.000")
 
     testSqlApi(
       "TIMESTAMP '1500-04-30 12:00:00.123456789'",
@@ -209,14 +208,14 @@ class TemporalTypesTest extends ExpressionTestBase {
     testAllApis(
       'f0.cast(DataTypes.TIMESTAMP(3)),
       "f0.cast(SQL_TIMESTAMP)",
-      "CAST(f0 AS TIMESTAMP)",
-      "1990-10-14 00:00:00")
+      "CAST(f0 AS TIMESTAMP(3))",
+      "1990-10-14 00:00:00.000")
 
     testAllApis(
       'f1.cast(DataTypes.TIMESTAMP(3)),
       "f1.cast(SQL_TIMESTAMP)",
-      "CAST(f1 AS TIMESTAMP)",
-      "1970-01-01 10:20:45")
+      "CAST(f1 AS TIMESTAMP(3))",
+      "1970-01-01 10:20:45.000")
 
     testAllApis(
       'f2.cast(DataTypes.DATE),
@@ -259,12 +258,12 @@ class TemporalTypesTest extends ExpressionTestBase {
     testTableApi(
       'f15.cast(DataTypes.TIMESTAMP(3)),
       "f15.cast(SQL_TIMESTAMP)",
-      "2016-06-27 07:23:33")
+      "2016-06-27 07:23:33.000")
 
     testTableApi(
       'f15.toTimestamp,
       "f15.toTimestamp",
-      "2016-06-27 07:23:33")
+      "2016-06-27 07:23:33.000")
 
     testTableApi(
       'f8.cast(DataTypes.TIMESTAMP(3)).cast(DataTypes.BIGINT()),
@@ -273,7 +272,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST(CAST('123' as DECIMAL(5, 2)) AS TIMESTAMP)",
-      "1970-01-01 00:02:03")
+      "1970-01-01 00:02:03.000000")
 
     testSqlApi(
       "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DECIMAL(5, 2))",
@@ -281,7 +280,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST(CAST('123' AS FLOAT) AS TIMESTAMP)",
-      "1970-01-01 00:02:03")
+      "1970-01-01 00:02:03.000000")
 
     testSqlApi(
       "CAST(TIMESTAMP '1970-01-01 00:02:03' AS FLOAT)",
@@ -289,7 +288,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST(CAST('123' AS DOUBLE) AS TIMESTAMP)",
-      "1970-01-01 00:02:03")
+      "1970-01-01 00:02:03.000000")
 
     testSqlApi(
       "CAST(TIMESTAMP '1970-01-01 00:02:03' AS DOUBLE)",
@@ -309,11 +308,11 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST(f0 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
-      "1990-10-14 00:00:00")
+      "1990-10-14 00:00:00.000")
 
     testSqlApi(
       "CAST(f1 AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
-      "1970-01-01 10:20:45")
+      "1970-01-01 10:20:45.000")
 
     testSqlApi(
       s"CAST(${timestampTz("2018-03-14 01:02:03")} AS TIME)",
@@ -795,8 +794,8 @@ class TemporalTypesTest extends ExpressionTestBase {
   def testTemporalShanghai(): Unit = {
     config.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 
-    testSqlApi(timestampTz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123")
-    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.01")
+    testSqlApi(timestampTz("2018-03-14 19:01:02.123"), "2018-03-14 19:01:02.123000")
+    testSqlApi(timestampTz("2018-03-14 19:00:00.010"), "2018-03-14 19:00:00.010000")
 
     testSqlApi(
       timestampTz("2018-03-14 19:00:00.010") + " > " + "f25",
@@ -852,21 +851,36 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi("CEIL(TIMESTAMP '2018-01-01 21:00:01' TO YEAR)", "2018-01-01 00:00:00")
     testSqlApi("CEIL(TIMESTAMP '2018-01-02 21:00:01' TO YEAR)", "2019-01-01 00:00:00")
 
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-20 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)", "2018-03-20 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)", "2018-04-01 00:00:00")
-    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)", "2018-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)", "2018-03-20 07:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)", "2018-03-21 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)", "2018-04-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)", "2018-03-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)", "2019-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)", "2018-01-01 00:00:00")
-    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)", "2019-01-01 00:00:00")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO HOUR)",
+      "2018-03-20 06:00:00.000000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 06:44:31")} TO DAY)",
+      "2018-03-20 00:00:00.000000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-03-20 00:00:00")} TO DAY)",
+      "2018-03-20 00:00:00.000000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-04-01 06:44:31")} TO MONTH)",
+      "2018-04-01 00:00:00.000000")
+    testSqlApi(s"FLOOR(${timestampTz("2018-01-01 06:44:31")} TO MONTH)",
+      "2018-01-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO HOUR)",
+      "2018-03-20 07:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:00:00")} TO HOUR)",
+      "2018-03-20 06:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-20 06:44:31")} TO DAY)",
+      "2018-03-21 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-1 00:00:00")} TO DAY)",
+      "2018-03-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-31 00:00:01")} TO DAY)",
+      "2018-04-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 21:00:01")} TO MONTH)",
+      "2018-03-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-03-01 00:00:00")} TO MONTH)",
+      "2018-03-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-12-02 00:00:00")} TO MONTH)",
+      "2019-01-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-01 21:00:01")} TO YEAR)",
+      "2018-01-01 00:00:00.000000")
+    testSqlApi(s"CEIL(${timestampTz("2018-01-02 21:00:01")} TO YEAR)",
+      "2019-01-01 00:00:00.000000")
 
     // others
     testSqlApi("QUARTER(DATE '2016-04-12')", "2")
@@ -875,11 +889,11 @@ class TemporalTypesTest extends ExpressionTestBase {
       "true")
     testSqlApi(
       "CEIL(f17 TO HOUR)",
-      "1990-10-14 08:00:00"
+      "1990-10-14 08:00:00.000"
     )
     testSqlApi(
       "FLOOR(f17 TO DAY)",
-      "1990-10-14 00:00:00"
+      "1990-10-14 00:00:00.000"
     )
 
     // TIMESTAMP_ADD
@@ -919,10 +933,10 @@ class TemporalTypesTest extends ExpressionTestBase {
     val t2 = timestampTz("2018-03-20 06:00:00")
     // 1521502831000,  2018-03-19 23:40:31 UTC,  2018-03-20 06:10:31 +06:30
     testSqlApi(s"EXTRACT(HOUR FROM $t1)", "6")
-    testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"FLOOR($t2 TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"CEIL($t2 TO HOUR)", "2018-03-20 06:00:00")
-    testSqlApi(s"CEIL($t1 TO HOUR)", "2018-03-20 07:00:00")
+    testSqlApi(s"FLOOR($t1 TO HOUR)", "2018-03-20 06:00:00.000000")
+    testSqlApi(s"FLOOR($t2 TO HOUR)", "2018-03-20 06:00:00.000000")
+    testSqlApi(s"CEIL($t2 TO HOUR)", "2018-03-20 06:00:00.000000")
+    testSqlApi(s"CEIL($t1 TO HOUR)", "2018-03-20 07:00:00.000000")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -248,13 +248,13 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func10('f6),
       "Func10(f6)",
       "Func10(f6)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
 
     testAllApis(
       Func26('f6),
       "Func26(f6)",
       "Func26(f6)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
   }
 
   @Test
@@ -265,20 +265,20 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func27('f17),
       "Func27(f17)",
       "Func27(f17)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
 
     // Func28 needs a Long parameter, pass a Instant
     testAllApis(
       Func28('f17),
       "Func28(f17)",
       "Func28(f17)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
 
     testAllApis(
       Func30('f17),
       "Func30(f17)",
       "Func30(f17)",
-      "1990-10-14 12:10:10"
+      "1990-10-14 12:10:10.000"
     )
 
     // Func29 declares return a Instant, but returns a Long actually
@@ -287,7 +287,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func29('f18),
       "Func29(f18)",
       "Func29(f18)",
-      "1970-01-01 08:00:00")
+      "1970-01-01 08:00:00.000")
   }
 
   @Test
@@ -298,14 +298,14 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func27('f17),
       "Func27(f17)",
       "Func27(f17)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
 
     // Func28 needs a Long parameter, pass a Instant
     testAllApis(
       Func28('f17),
       "Func28(f17)",
       "Func28(f17)",
-      "1990-10-14 12:10:10")
+      "1990-10-14 12:10:10.000")
 
     // Func29 declares return a Instant, but returns a Long actually
     // the framework helps convert Long to Instant
@@ -313,7 +313,7 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       Func29('f18),
       "Func29(f18)",
       "Func29(f18)",
-      "1969-12-31 16:00:00")
+      "1969-12-31 16:00:00.000")
   }
 
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CalcITCase.scala
@@ -343,7 +343,7 @@ class CalcITCase extends BatchTestBase {
     tEnv.getConfig.setLocalTimeZone(pairs)
     checkResult(
       "SELECT CAST(a AS VARCHAR), b, CAST(b AS VARCHAR) FROM T",
-      Seq(row("1969-07-20 16:17:39", "1969-07-20T20:17:39Z", "1969-07-20 21:17:39"))
+      Seq(row("1969-07-20 16:17:39.000", "1969-07-20T20:17:39Z", "1969-07-20 21:17:39.000"))
     )
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableScanITCase.scala
@@ -134,7 +134,7 @@ class TableScanITCase extends StreamingTestBase {
     result.addSink(sink)
     env.execute()
 
-    val expected = Seq("1970-01-01 00:00:00.01,4")
+    val expected = Seq("1970-01-01 00:00:00.010,4")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlDateTimeUtils.java
@@ -1391,11 +1391,11 @@ public class SqlDateTimeUtils {
 		return r;
 	}
 
-	public static String timestampToString(SqlTimestamp ts) {
+	public static String timestampToString(SqlTimestamp ts, int precision) {
 		LocalDateTime ldt = ts.toLocalDateTime();
 
 		String fraction = pad(9, (long) ldt.getNano());
-		while (fraction.endsWith("0")) {
+		while (fraction.length() > precision && fraction.endsWith("0")) {
 			fraction = fraction.substring(0, fraction.length() - 1);
 		}
 
@@ -1411,8 +1411,8 @@ public class SqlDateTimeUtils {
 		return ymdhms.toString();
 	}
 
-	public static String timestampToString(SqlTimestamp ts, TimeZone tz) {
-		return timestampToString(timestampWithLocalZoneToTimestamp(ts, tz));
+	public static String timestampToString(SqlTimestamp ts, TimeZone tz, int precision) {
+		return timestampToString(timestampWithLocalZoneToTimestamp(ts, tz), precision);
 	}
 
 	private static String pad(int length, long v) {


### PR DESCRIPTION
…the precision when casting timestamp to varchar

## What is the purpose of the change

According to SQL 2011 Part 2 Section 6.13 General Rules 11) d)

> If SD is a datetime data type or an interval data type then let Y be the shortest character string that
> conforms to the definition of <literal> in Subclause 5.3, “<literal>”, and such that the interpreted value of Y is SV and the interpreted precision of Y is the precision of SD.

This PR padding the TIMESTAMP type to respect the precision when casting timestamp to varchar. 

## Brief change log

- c53d150 Padding TIMESTAMP type to respect precision

## Verifying this change

This change is already covered by existing tests, such as *TempralTypeTests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
