### PR TITLE
[FLINK-15595][table] Remove CoreMudule in ModuleManager

### DIFF
--- a/docs/dev/table/functions/index.md
+++ b/docs/dev/table/functions/index.md
@@ -50,31 +50,31 @@ The two dimensions give Flink users 4 categories of functions:
 3. Temporary catalog functions
 4. Catalog functions
 
-Referencing Functions
+## Referencing Functions
 ---------------------
 
 There are two ways users can reference a function in Flink - referencing function precisely or ambiguously.
 
-## Precise Function Reference
+### Precise Function Reference
 
 Precise function reference empowers users to use catalog functions specifically, and across catalog and across database, 
 e.g. `select mycatalog.mydb.myfunc(x) from mytable` and `select mydb.myfunc(x) from mytable`.
 
 This is only supported starting from Flink 1.10.
 
-## Ambiguous Function Reference
+### Ambiguous Function Reference
 
 In ambiguous function reference, users just specify the function's name in SQL query, e.g. `select myfunc(x) from mytable`.
 
 
-Function Resolution Order
+## Function Resolution Order
 -------------------------
 
 The resolution order only matters when there are functions of different types but the same name, 
 e.g. when there’re three functions all named “myfunc” but are of temporary catalog, catalog, and system function respectively. 
 If there’s no function name collision, functions will just be resolved to the sole one.
 
-## Precise Function Reference
+### Precise Function Reference
 
 Because system functions don’t have namespaces, a precise function reference in Flink must be pointing to either a temporary catalog 
 function or a catalog function.
@@ -84,11 +84,13 @@ The resolution order is:
 1. Temporary catalog function
 2. Catalog function
 
-## Ambiguous Function Reference
+### Ambiguous Function Reference
 
 The resolution order is:
 
 1. Temporary system function
-2. System function
-3. Temporary catalog function, in the current catalog and current database of the session
-4. Catalog function, in the current catalog and current database of the session
+2. Temporary catalog function, in the current catalog and current database of the session
+3. Catalog function, in the current catalog and current database of the session
+4. System function
+
+We are trying to put the order of system function in the second place in later versions.

--- a/docs/dev/table/functions/index.zh.md
+++ b/docs/dev/table/functions/index.zh.md
@@ -50,34 +50,31 @@ The two dimensions give Flink users 4 categories of functions:
 3. Temporary catalog functions
 4. Catalog functions
 
-Note that system functions always precede catalog's, and temporary functions always precede persistent on their own dimension
-in function resolution order explained below.
-
-Referencing Functions
+## Referencing Functions
 ---------------------
 
 There are two ways users can reference a function in Flink - referencing function precisely or ambiguously.
 
-## Precise Function Reference
+### Precise Function Reference
 
 Precise function reference empowers users to use catalog functions specifically, and across catalog and across database, 
 e.g. `select mycatalog.mydb.myfunc(x) from mytable` and `select mydb.myfunc(x) from mytable`.
 
 This is only supported starting from Flink 1.10.
 
-## Ambiguous Function Reference
+### Ambiguous Function Reference
 
 In ambiguous function reference, users just specify the function's name in SQL query, e.g. `select myfunc(x) from mytable`.
 
 
-Function Resolution Order
+## Function Resolution Order
 -------------------------
 
 The resolution order only matters when there are functions of different types but the same name, 
 e.g. when there’re three functions all named “myfunc” but are of temporary catalog, catalog, and system function respectively. 
 If there’s no function name collision, functions will just be resolved to the sole one.
 
-## Precise Function Reference
+### Precise Function Reference
 
 Because system functions don’t have namespaces, a precise function reference in Flink must be pointing to either a temporary catalog 
 function or a catalog function.
@@ -87,11 +84,13 @@ The resolution order is:
 1. Temporary catalog function
 2. Catalog function
 
-## Ambiguous Function Reference
+### Ambiguous Function Reference
 
 The resolution order is:
 
 1. Temporary system function
-2. System function
-3. Temporary catalog function, in the current catalog and current database of the session
-4. Catalog function, in the current catalog and current database of the session
+2. Temporary catalog function, in the current catalog and current database of the session
+3. Catalog function, in the current catalog and current database of the session
+4. System function
+
+We are trying to put the order of system function in the second place in later versions.

--- a/docs/dev/table/modules.md
+++ b/docs/dev/table/modules.md
@@ -36,10 +36,6 @@ functions as Flink built-in functions.
 
 ## Module Types
 
-### CoreModule
-
-`CoreModule` contains all of Flink's system (built-in) functions and is loaded by default.
-
 ### HiveModule
 
 The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
@@ -89,10 +85,6 @@ The following types are supported out of the box.
   </thead>
   <tbody>
     <tr>
-        <td class="text-center">CoreModule</td>
-        <td class="text-center">core</td>
-    </tr>
-    <tr>
         <td class="text-center">HiveModule</td>
         <td class="text-center">hive</td>
     </tr>
@@ -101,8 +93,6 @@ The following types are supported out of the box.
 
 {% highlight yaml %}
 modules:
-   - name: core
-     type: core
    - name: myhive
      type: hive
      hive-version: 1.2.1

--- a/docs/dev/table/modules.zh.md
+++ b/docs/dev/table/modules.zh.md
@@ -36,10 +36,6 @@ functions as Flink built-in functions.
 
 ## Module Types
 
-### CoreModule
-
-`CoreModule` contains all of Flink's system (built-in) functions and is loaded by default.
-
 ### HiveModule
 
 The `HiveModule` provides Hive built-in functions as Flink's system functions to SQL and Table API users.
@@ -89,10 +85,6 @@ The following types are supported out of the box.
   </thead>
   <tbody>
     <tr>
-        <td class="text-center">CoreModule</td>
-        <td class="text-center">core</td>
-    </tr>
-    <tr>
         <td class="text-center">HiveModule</td>
         <td class="text-center">hive</td>
     </tr>
@@ -101,8 +93,6 @@ The following types are supported out of the box.
 
 {% highlight yaml %}
 modules:
-   - name: core
-     type: core
    - name: myhive
      type: hive
      hive-version: 1.2.1

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/module/ModuleManager.java
@@ -33,7 +33,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.descriptors.CoreModuleDescriptorValidator.MODULE_TYPE_CORE;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -48,8 +47,6 @@ public class ModuleManager {
 
 	public ModuleManager() {
 		this.modules = new LinkedHashMap<>();
-
-		modules.put(MODULE_TYPE_CORE, CoreModule.INSTANCE);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
@@ -29,7 +29,9 @@ import java.util.stream.Collectors;
 /**
  * Module of default core metadata in Flink.
  *
- * <p>NOTE: {@link BuiltInFunctionDefinitions} is not ready now,
+ * <p>NOTE: This class is not exposed to the user temporarily, {@link BuiltInFunctionDefinitions}
+ * is not ready now, there are still many functions in the planner, which will lead to the
+ * incomplete core module, so the function resolution order is unclear.
  */
 public class CoreModule implements Module {
 	public static final CoreModule INSTANCE = new CoreModule();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/module/CoreModule.java
@@ -28,6 +28,8 @@ import java.util.stream.Collectors;
 
 /**
  * Module of default core metadata in Flink.
+ *
+ * <p>NOTE: {@link BuiltInFunctionDefinitions} is not ready now,
  */
 public class CoreModule implements Module {
 	public static final CoreModule INSTANCE = new CoreModule();


### PR DESCRIPTION

## What is the purpose of the change

First of all, the implementation is problematic. CoreModule returns BuiltinFunctionDefinition, which cannot be resolved in FunctionCatalogOperatorTable, so it will fall back to FlinkSqlOperatorTable.

Second, the function defined by CoreModule is seriously incomplete. You can compare it with FunctionCatalogOperatorTable, a lot less. This leads to the fact that the priority of some functions is in CoreModule, and the priority of some functions is behind all modules. This is confusing, which is not what we want. 

## Brief change log

Dropping the core module for now. The class CoreModule is implemented correctly but underlying layers are not ready yet.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no