### PR TITLE
[FLINK-15469][SQL] Update UpsertStreamTableSink and RetractStreamTabl…

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/RetractStreamTableSink.java
@@ -23,7 +23,13 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.types.DataType;
+
+import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 /**
  * Defines an external {@link TableSink} to emit a streaming {@link Table} with insert, update,
@@ -43,12 +49,30 @@ import org.apache.flink.table.api.Table;
 public interface RetractStreamTableSink<T> extends StreamTableSink<Tuple2<Boolean, T>> {
 
 	/**
-	 * Returns the requested record type.
+	 * Returns the requested record data type.
 	 */
-	TypeInformation<T> getRecordType();
+	default DataType getRecordDataType() {
+		final TypeInformation<T> legacyType = getRecordType();
+		if (legacyType == null) {
+			throw new TableException("UpsertStreamTableSink does not implement a record data type.");
+		}
+		return fromLegacyInfoToDataType(legacyType);
+	}
+
+	/**
+	 * @deprecated This method will be removed in future versions as it uses the old type system. It
+	 *             is recommended to use {@link #getRecordDataType()} instead which uses the new type
+	 *             system based on {@link DataTypes}. Please make sure to use either the old or the new type
+	 *             system consistently to avoid unintended behavior. See the website documentation
+	 *             for more information.
+	 */
+	@Deprecated
+	default TypeInformation<T> getRecordType() {
+		return null;
+	}
 
 	@Override
 	default TypeInformation<Tuple2<Boolean, T>> getOutputType() {
-		return new TupleTypeInfo<>(Types.BOOLEAN, getRecordType());
+		return new TupleTypeInfo<>(Types.BOOLEAN, fromDataTypeToLegacyInfo(getRecordDataType()));
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
@@ -162,12 +162,13 @@ object TableSinkUtils {
   def inferSinkPhysicalSchema(
       queryLogicalType: RowType,
       sink: TableSink[_]): TableSchema = {
-    val withChangeFlag = sink match {
-      case _: RetractStreamTableSink[_] | _: UpsertStreamTableSink[_] => true
-      case _: StreamTableSink[_] => false
-      case dsts: DataStreamTableSink[_] => dsts.withChangeFlag
+    val (consumedDataType, withChangeFlag) = sink match {
+      case retract: RetractStreamTableSink[_] => (retract.getRecordDataType, false)
+      case upsert: UpsertStreamTableSink[_] => (upsert.getRecordDataType, false)
+      case _: StreamTableSink[_] => (sink.getConsumedDataType, false)
+      case dsts: DataStreamTableSink[_] => (sink.getConsumedDataType, dsts.withChangeFlag)
     }
-    inferSinkPhysicalSchema(sink.getConsumedDataType, queryLogicalType, withChangeFlag)
+    inferSinkPhysicalSchema(consumedDataType, queryLogicalType, withChangeFlag)
   }
 
   /**


### PR DESCRIPTION
…eSink and related interface to new type system


## What is the purpose of the change

Currently UpsertStreamTableSink/RetractStreamTableSink can only returns TypeInformation of the requested record, which can't support types with precision and scale, e.g. TIMESTAMP(p), DECIMAL(p,s).
This PR would deprecate the getRecordType API and adding a getRecordDataType API instead to return the data type of the requested record. 

## Brief change log

- e0f8cdb Update UpsertStreamTableSink and RetractStreamTableSink and related interface to new type system

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
