### PR TITLE
[Flink-15627] [cep] correct the wrong naming of compareMaps in NFATestUtilities

### DIFF
--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/AfterMatchSkipITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/AfterMatchSkipITCase.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -79,7 +79,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, a2, a3),
 			Lists.newArrayList(a2, a3, a4),
 			Lists.newArrayList(a3, a4, a5),
@@ -91,7 +91,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testNoSkipWithFollowedByAny() throws Exception {
 		List<List<Event>> resultingPatterns = TwoVariablesFollowedByAny.compute(AfterMatchSkipStrategy.noSkip());
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(TwoVariablesFollowedByAny.a1, TwoVariablesFollowedByAny.b1),
 			Lists.newArrayList(TwoVariablesFollowedByAny.a1, TwoVariablesFollowedByAny.b2),
 			Lists.newArrayList(TwoVariablesFollowedByAny.a2, TwoVariablesFollowedByAny.b2)
@@ -102,7 +102,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testSkipToNextWithFollowedByAny() throws Exception {
 		List<List<Event>> resultingPatterns = TwoVariablesFollowedByAny.compute(AfterMatchSkipStrategy.skipToNext());
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(TwoVariablesFollowedByAny.a1, TwoVariablesFollowedByAny.b1),
 			Lists.newArrayList(TwoVariablesFollowedByAny.a2, TwoVariablesFollowedByAny.b2)
 		));
@@ -151,7 +151,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testNoSkipWithQuantifierAtTheEnd() throws Exception {
 		List<List<Event>> resultingPatterns = QuantifierAtEndOfPattern.compute(AfterMatchSkipStrategy.noSkip());
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(QuantifierAtEndOfPattern.a1, QuantifierAtEndOfPattern.b1,  QuantifierAtEndOfPattern.b2,  QuantifierAtEndOfPattern.b3),
 			Lists.newArrayList(QuantifierAtEndOfPattern.a1, QuantifierAtEndOfPattern.b1,  QuantifierAtEndOfPattern.b2),
 			Lists.newArrayList(QuantifierAtEndOfPattern.a1, QuantifierAtEndOfPattern.b1)
@@ -162,7 +162,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testSkipToNextWithQuantifierAtTheEnd() throws Exception {
 		List<List<Event>> resultingPatterns = QuantifierAtEndOfPattern.compute(AfterMatchSkipStrategy.skipToNext());
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(QuantifierAtEndOfPattern.a1, QuantifierAtEndOfPattern.b1)
 		));
 	}
@@ -237,7 +237,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, a2, a3),
 			Lists.newArrayList(a4, a5, a6)
 		));
@@ -281,7 +281,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(ab1, ab2, ab3, ab4),
 			Lists.newArrayList(ab3, ab4, ab5, ab6)
 		));
@@ -324,7 +324,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(ab1, ab2, ab3, ab4),
 			Lists.newArrayList(ab4, ab5, ab6, ab7)
 		));
@@ -382,7 +382,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Collections.singletonList(
+		compareLists(resultingPatterns, Collections.singletonList(
 			Lists.newArrayList(a1, b1, c1, d1)
 		));
 	}
@@ -421,7 +421,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a2, b2)
 		));
 	}
@@ -465,7 +465,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(ab1, c1),
 			Lists.newArrayList(ab2, c2)
 		));
@@ -504,7 +504,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(ab1, c1),
 			Lists.newArrayList(ab2, c2)
 		));
@@ -549,7 +549,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, b1),
 			Lists.newArrayList(a2, b2),
 			Lists.newArrayList(a3, b4)
@@ -596,7 +596,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testSkipToFirstNonExistentPositionWithoutException() throws Exception {
 		List<List<Event>> resultingPatterns = MissedSkipTo.compute(AfterMatchSkipStrategy.skipToFirst("b"));
 
-		compareMaps(resultingPatterns, Collections.singletonList(
+		compareLists(resultingPatterns, Collections.singletonList(
 			Lists.newArrayList(MissedSkipTo.a, MissedSkipTo.c)
 		));
 	}
@@ -612,7 +612,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 	public void testSkipToLastNonExistentPositionWithoutException() throws Exception {
 		List<List<Event>> resultingPatterns = MissedSkipTo.compute(AfterMatchSkipStrategy.skipToFirst("b"));
 
-		compareMaps(resultingPatterns, Collections.singletonList(
+		compareLists(resultingPatterns, Collections.singletonList(
 			Lists.newArrayList(MissedSkipTo.a, MissedSkipTo.c)
 		));
 	}
@@ -694,7 +694,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, b1),
 			Lists.newArrayList(a2, b2),
 			Lists.newArrayList(a3, b4)
@@ -736,7 +736,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Collections.singletonList(
+		compareLists(resultingPatterns, Collections.singletonList(
 			Lists.newArrayList(a1, a2, a3, b1)
 		));
 	}
@@ -776,7 +776,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, a2, a3, b1),
 			Lists.newArrayList(a3, b1)
 		));
@@ -817,7 +817,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, a2, a3, b1),
 			Lists.newArrayList(a2, a3, b1),
 			Lists.newArrayList(a3, b1)
@@ -859,7 +859,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, a2, a3, b1),
 			Lists.newArrayList(a2, a3, b1),
 			Lists.newArrayList(a3, b1)
@@ -921,7 +921,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a, b, c1, c2, c3, d),
 			Lists.newArrayList(c1, c2, c3, d)
 		));
@@ -970,7 +970,7 @@ public class AfterMatchSkipITCase extends TestLogger{
 
 		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(streamEvents);
 
-		compareMaps(resultingPatterns, Lists.newArrayList(
+		compareLists(resultingPatterns, Lists.newArrayList(
 			Lists.newArrayList(a1, c1, b2),
 			Lists.newArrayList(a2, c2, b1)
 		));

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GreedyITCase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 
@@ -84,7 +84,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -136,7 +136,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -184,7 +184,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, d)
 		));
 	}
@@ -228,7 +228,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d)
 		));
 	}
@@ -285,7 +285,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -342,7 +342,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d)
 		));
 	}
@@ -391,7 +391,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -443,7 +443,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -491,7 +491,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, d)
 		));
 	}
@@ -535,7 +535,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList());
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -590,7 +590,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d)
 		));
 	}
@@ -647,7 +647,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList());
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -717,7 +717,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, d1, e1, d2, e2, f)
 		));
 	}
@@ -758,7 +758,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c),
 			Lists.newArrayList(c, a1),
 			Lists.newArrayList(c, a1, a2),
@@ -802,7 +802,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c),
 			Lists.newArrayList(c, a1),
 			Lists.newArrayList(c, a1, a2)
@@ -847,7 +847,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2),
 			Lists.newArrayList(c, a1, a2, a3),
 			Lists.newArrayList(c, a1, a2, a3, a4)
@@ -900,7 +900,7 @@ public class GreedyITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, a2, a3, a4, d)
 		));
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GroupITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/GroupITCase.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -97,7 +97,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, b1, a2, b2, d)
 		));
 	}
@@ -153,7 +153,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d),
 			Lists.newArrayList(c, a1, b, d)
 		));
@@ -206,7 +206,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d)
 		));
 	}
@@ -264,7 +264,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, b1, d),
 			Lists.newArrayList(c, a1, b1, a2, b2, d)
 		));
@@ -323,7 +323,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d),
 			Lists.newArrayList(c, a1, b1, d),
 			Lists.newArrayList(c, a1, b1, a2, b2, d)
@@ -387,7 +387,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, b1, a2, b2, d),
 			Lists.newArrayList(c, a1, b1, a3, b3, d),
 			Lists.newArrayList(c, a2, b2, a3, b3, d)
@@ -451,7 +451,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d),
 			Lists.newArrayList(c, a1, b1, a2, b2, d),
 			Lists.newArrayList(c, a2, b2, a3, b3, d)
@@ -515,7 +515,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, b1, d),
 			Lists.newArrayList(c, a2, b2, d),
 			Lists.newArrayList(c, a3, b3, d),
@@ -582,7 +582,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, d),
 			Lists.newArrayList(c, a1, b1, d),
 			Lists.newArrayList(c, a1, b1, a2, b2, d),
@@ -652,7 +652,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a2, b2, e)
 		));
 	}
@@ -719,7 +719,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a2, b2, e)
 		));
 	}
@@ -786,7 +786,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(d, e),
 			Lists.newArrayList(d, a1, e),
 			Lists.newArrayList(d, a1, b1, c1, e),
@@ -874,7 +874,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(d, e),
 			Lists.newArrayList(d, a1, b1, c1, b2, c2, b3, c3, e),
 			Lists.newArrayList(d, a2, b4, c4, b5, c5, b6, c6, e),
@@ -963,7 +963,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(d, e),
 			Lists.newArrayList(d, a1, b1, c1, b2, c2, b3, c3, e)
 		));
@@ -1013,7 +1013,7 @@ public class GroupITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, b1, d),
 			Lists.newArrayList(a2, b2, d),
 			Lists.newArrayList(a1, b1, a2, b2, d)
@@ -1081,7 +1081,7 @@ public class GroupITCase extends TestLogger {
 		NFATestHarness nfaTestHarness = NFATestHarness.forNFA(nfa).withNFAState(nfaState).build();
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(c, a1, b1, d),
 			Lists.newArrayList(c, a1, b1, a2, b2, d)
 		));

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/IterativeConditionsITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/IterativeConditionsITCase.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 
@@ -60,7 +60,7 @@ public class IterativeConditionsITCase extends TestLogger {
 	public void testIterativeWithBranchingPatternEager() throws Exception {
 		List<List<Event>> actual = testIterativeWithBranchingPattern(true);
 
-		compareMaps(actual,
+		compareLists(actual,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, endEvent, middleEvent1, middleEvent2, middleEvent4),
 				Lists.newArrayList(startEvent1, endEvent, middleEvent2, middleEvent1),
@@ -75,7 +75,7 @@ public class IterativeConditionsITCase extends TestLogger {
 	public void testIterativeWithBranchingPatternCombinations() throws Exception {
 		List<List<Event>> actual = testIterativeWithBranchingPattern(false);
 
-		compareMaps(actual,
+		compareLists(actual,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, endEvent, middleEvent1, middleEvent2, middleEvent4),
 				Lists.newArrayList(startEvent1, endEvent, middleEvent2, middleEvent1),
@@ -164,7 +164,7 @@ public class IterativeConditionsITCase extends TestLogger {
 	public void testIterativeWithLoopingStartingEager() throws Exception {
 		List<List<Event>> actual = testIterativeWithLoopingStarting(true);
 
-		compareMaps(actual,
+		compareLists(actual,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, endEvent),
 				Lists.newArrayList(startEvent1, endEvent),
@@ -179,7 +179,7 @@ public class IterativeConditionsITCase extends TestLogger {
 	public void testIterativeWithLoopingStartingCombination() throws Exception {
 		List<List<Event>> actual = testIterativeWithLoopingStarting(false);
 
-		compareMaps(actual,
+		compareLists(actual,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, endEvent),
 				Lists.newArrayList(startEvent1, startEvent3, endEvent),
@@ -283,7 +283,7 @@ public class IterativeConditionsITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns,
+		compareLists(resultingPatterns,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, endEvent),
 				Lists.newArrayList(startEvent2, endEvent)
@@ -350,7 +350,7 @@ public class IterativeConditionsITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns,
+		compareLists(resultingPatterns,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, startEvent3, middleEvent1, endEvent),
 				Lists.newArrayList(startEvent1, middleEvent1, startEvent2, endEvent),
@@ -407,7 +407,7 @@ public class IterativeConditionsITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns,
+		compareLists(resultingPatterns,
 			Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, middleEvent1, endEvent),
 				Lists.newArrayList(startEvent2, middleEvent1, endEvent),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -100,7 +100,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(a, b),
 				Lists.newArrayList(b, c),
 				Lists.newArrayList(c, d),
@@ -130,7 +130,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a, b, c, d, e),
 			Lists.newArrayList(a, b, c, d),
 			Lists.newArrayList(a, b, c),
@@ -166,7 +166,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(a, b),
 				Lists.newArrayList(a, c),
 				Lists.newArrayList(a, d),
@@ -222,7 +222,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent, endEvent)
 		));
 	}
@@ -257,7 +257,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(middleEvent1, end)
 		));
 	}
@@ -294,7 +294,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList());
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList());
 	}
 
 	/**
@@ -343,7 +343,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(events, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent, endEvent)
 		));
 	}
@@ -488,7 +488,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, nextOne1, endEvent),
 				Lists.newArrayList(startEvent, middleEvent2, nextOne1, endEvent),
 				Lists.newArrayList(startEvent, middleEvent3, nextOne1, endEvent),
@@ -561,7 +561,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end1, end2, end4),
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1, end2, end4),
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent3, end1, end2, end4),
@@ -622,7 +622,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent1, end1),
 			Lists.newArrayList(startEvent, middleEvent2, end1),
@@ -674,7 +674,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end1),
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 				Lists.newArrayList(startEvent, middleEvent1, end1),
@@ -716,7 +716,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(middleEvent1, middleEvent2, middleEvent3, end),
 				Lists.newArrayList(middleEvent1, middleEvent2, end),
 				Lists.newArrayList(middleEvent2, middleEvent3, end),
@@ -779,7 +779,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end),
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end),
 				Lists.newArrayList(startEvent, middleEvent2, middleEvent3, end),
@@ -850,7 +850,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, merging, end),
 				Lists.newArrayList(startEvent, middleEvent1, merging, kleene1, end),
 				Lists.newArrayList(startEvent, middleEvent1, merging, kleene2, end),
@@ -906,7 +906,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList());
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -950,7 +950,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(start, middleEvent1, middleEvent2, end),
 			Lists.newArrayList(start, middleEvent2, end)
 		));
@@ -997,7 +997,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 				Lists.newArrayList(startEvent, middleEvent1, end1),
 				Lists.newArrayList(startEvent, middleEvent2, end1)
@@ -1038,7 +1038,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent1, startEvent2, startEvent3, end1),
 				Lists.newArrayList(startEvent1, startEvent2, end1),
 				Lists.newArrayList(startEvent1, startEvent3, end1),
@@ -1093,7 +1093,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, endEvent)
 		));
 	}
@@ -1141,7 +1141,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent2, middleEvent3, end1),
@@ -1190,7 +1190,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent, end1),
 				Lists.newArrayList(startEvent, end1)
 		));
@@ -1239,7 +1239,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, end1)
 		));
@@ -1279,7 +1279,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(middleEvent2, middleEvent3, end1)
 		));
@@ -1325,7 +1325,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end)
 		));
@@ -1368,7 +1368,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end)
 		));
 	}
@@ -1410,7 +1410,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent1, ConsecutiveData.end)
@@ -1455,7 +1455,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList());
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -1488,7 +1488,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, end1),
 				Lists.newArrayList(end1)
 		));
@@ -1528,7 +1528,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3),
 				Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 				Lists.newArrayList(startEvent, middleEvent1),
@@ -1569,7 +1569,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(middleEvent1, middleEvent2, middleEvent3),
 			Lists.newArrayList(middleEvent1, middleEvent2),
 			Lists.newArrayList(middleEvent1),
@@ -1609,7 +1609,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(startEvent, middleEvent1),
 				Lists.newArrayList(startEvent)
 		));
@@ -1649,7 +1649,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1)
@@ -1693,7 +1693,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
 	}
@@ -1737,7 +1737,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -1784,7 +1784,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end), // this exists because of the optional()
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
@@ -1830,7 +1830,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
@@ -1875,7 +1875,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.end),
@@ -1921,7 +1921,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
@@ -1966,7 +1966,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 				Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
@@ -1990,7 +1990,7 @@ public class NFAITCase extends TestLogger {
 	public void testStrictOneOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testOneOrMore(Quantifier.ConsumingStrategy.STRICT);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end)
@@ -2001,7 +2001,7 @@ public class NFAITCase extends TestLogger {
 	public void testSkipTillNextOneOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testOneOrMore(Quantifier.ConsumingStrategy.SKIP_TILL_NEXT);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
@@ -2013,7 +2013,7 @@ public class NFAITCase extends TestLogger {
 	public void testSkipTillAnyOneOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testOneOrMore(Quantifier.ConsumingStrategy.SKIP_TILL_ANY);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -2082,7 +2082,7 @@ public class NFAITCase extends TestLogger {
 	public void testStrictEagerZeroOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testZeroOrMore(Quantifier.ConsumingStrategy.STRICT);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end),
@@ -2094,7 +2094,7 @@ public class NFAITCase extends TestLogger {
 	public void testSkipTillAnyZeroOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testZeroOrMore(Quantifier.ConsumingStrategy.SKIP_TILL_ANY);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
@@ -2111,7 +2111,7 @@ public class NFAITCase extends TestLogger {
 	public void testSkipTillNextZeroOrMore() throws Exception {
 		List<List<Event>> resultingPatterns = testZeroOrMore(Quantifier.ConsumingStrategy.SKIP_TILL_NEXT);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.middleEvent4, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
@@ -2212,7 +2212,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end)
 		));
 	}
@@ -2256,7 +2256,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end)
@@ -2305,7 +2305,7 @@ public class NFAITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.middleEvent1),
 			Lists.newArrayList(ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3),
 			Lists.newArrayList(ConsecutiveData.middleEvent2),
@@ -2560,7 +2560,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> patterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(patterns, Lists.<List<Event>>newArrayList(
+		compareLists(patterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, nextOne1, endEvent)
 		));
 	}
@@ -2619,7 +2619,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> patterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(patterns, Lists.<List<Event>>newArrayList(
+		compareLists(patterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, nextOne1, endEvent),
 			Lists.newArrayList(startEvent, middleEvent2, nextOne1, endEvent),
 			Lists.newArrayList(startEvent, middleEvent3, nextOne1, endEvent)
@@ -2680,7 +2680,7 @@ public class NFAITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, middleEvent4, middleEvent5, end),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, middleEvent4, middleEvent5, end),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAIterativeConditionTimeContextTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAIterativeConditionTimeContextTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 import static org.apache.flink.cep.utils.EventBuilder.event;
 import static org.apache.flink.cep.utils.NFATestHarness.forPattern;
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 
 /**
  * Tests for accesing time properties from {@link IterativeCondition}.
@@ -56,7 +56,7 @@ public class NFAIterativeConditionTimeContextTest extends TestLogger {
 
 		final List<List<Event>> resultingPattern = testHarness.feedRecord(new StreamRecord<>(event, timestamp));
 
-		compareMaps(resultingPattern, Collections.singletonList(
+		compareLists(resultingPattern, Collections.singletonList(
 			Collections.singletonList(event)
 		));
 	}
@@ -83,8 +83,8 @@ public class NFAIterativeConditionTimeContextTest extends TestLogger {
 		cepTimerService.setCurrentProcessingTime(3);
 		final List<List<Event>> resultingPatterns2 = testHarness.feedRecord(new StreamRecord<>(event2, 8));
 
-		compareMaps(resultingPatterns1, Collections.emptyList());
-		compareMaps(resultingPatterns2, Collections.singletonList(
+		compareLists(resultingPatterns1, Collections.emptyList());
+		compareLists(resultingPatterns2, Collections.singletonList(
 			Collections.singletonList(event2)
 		));
 	}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -92,7 +92,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, c1, d),
 			Lists.newArrayList(a1, c2, d)
 		));
@@ -254,7 +254,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, c1, d)
 		));
 	}
@@ -309,7 +309,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, c1, d)
 		));
 	}
@@ -364,7 +364,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList());
+		compareLists(matches, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -421,7 +421,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, d1)
 		));
 	}
@@ -480,7 +480,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList());
+		compareLists(matches, Lists.<List<Event>>newArrayList());
 	}
 
 	@Test
@@ -524,7 +524,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, c1),
 			Lists.newArrayList(a1)
 		));
@@ -580,7 +580,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a1, c1, c2, d)
 		));
 	}
@@ -637,7 +637,7 @@ public class NotPatternITCase extends TestLogger {
 
 		final List<List<Event>> matches = feedNFA(inputEvents, nfa);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(a2, c2, d)
 		));
 	}
@@ -666,7 +666,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotNextAfterOneOrMoreSkipTillAny() throws Exception {
 		final List<List<Event>> matches = testNotNextAfterOneOrMore(true);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_2, NotFollowByData.D_1)
 		));
 	}
@@ -730,7 +730,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByAnyAfterOneOrMoreEager() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByAfterOneOrMore(true, true);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.D_1),
@@ -749,7 +749,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByAnyAfterOneOrMoreCombinations() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByAfterOneOrMore(false, true);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_4, NotFollowByData.B_6, NotFollowByData.D_1),
@@ -821,7 +821,7 @@ public class NotPatternITCase extends TestLogger {
 	public void testNotFollowedByAnyBeforeOneOrMoreEager() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeOneOrMore(true, true);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.D_1),
@@ -833,7 +833,7 @@ public class NotPatternITCase extends TestLogger {
 	public void testNotFollowedByAnyBeforeOneOrMoreCombinations() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeOneOrMore(false, true);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
@@ -849,7 +849,7 @@ public class NotPatternITCase extends TestLogger {
 	public void testNotFollowedByBeforeOneOrMoreEager() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeOneOrMore(true, false);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.D_1),
@@ -861,7 +861,7 @@ public class NotPatternITCase extends TestLogger {
 	public void testNotFollowedByBeforeOneOrMoreCombinations() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeOneOrMore(false, false);
 
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
@@ -931,7 +931,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByBeforeZeroOrMoreEagerSkipTillNext() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeZeroOrMore(true, false);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.D_1),
@@ -942,7 +942,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByBeforeZeroOrMoreCombinationsSkipTillNext() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeZeroOrMore(false, false);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_6, NotFollowByData.D_1),
@@ -957,7 +957,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByBeforeZeroOrMoreEagerSkipTillAny() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeZeroOrMore(true, true);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.D_1),
@@ -968,7 +968,7 @@ public class NotPatternITCase extends TestLogger {
 	@Test
 	public void testNotFollowedByBeforeZeroOrMoreCombinationsSkipTillAny() throws Exception {
 		final List<List<Event>> matches = testNotFollowedByBeforeZeroOrMore(false, true);
-		compareMaps(matches, Lists.<List<Event>>newArrayList(
+		compareLists(matches, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.B_6, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_5, NotFollowByData.D_1),
 			Lists.newArrayList(NotFollowByData.A_1, NotFollowByData.B_1, NotFollowByData.B_4, NotFollowByData.B_6, NotFollowByData.D_1),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/SameElementITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/SameElementITCase.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -92,7 +92,7 @@ public class SameElementITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1, middleEvent1, middleEvent2, middleEvent3, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1, middleEvent1, middleEvent2, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1, middleEvent1, middleEvent2, end1),
@@ -145,7 +145,7 @@ public void testClearingBuffer() throws Exception {
 	NFATestHarness nfaTestHarness = NFATestHarness.forNFA(nfa).withNFAState(nfaState).build();
 
 	List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
-	compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+	compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 		Lists.newArrayList(a1, b1, c1, d)
 	));
 	assertEquals(1, nfaState.getPartialMatches().size());
@@ -191,7 +191,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 	NFATestHarness nfaTestHarness = NFATestHarness.forNFA(nfa).withNFAState(nfaState).build();
 
 	List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
-	compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+	compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 		Lists.newArrayList(a1, d1, d2, d3),
 		Lists.newArrayList(a1, d1, d2),
 		Lists.newArrayList(a1, d1)
@@ -248,7 +248,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1a, middleEvent2, middleEvent3, middleEvent3a, end1),
 
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1a, middleEvent2, middleEvent3, end1),
@@ -329,7 +329,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, end1),
 			Lists.newArrayList(startEvent, middleEvent1, end1)
 		));
@@ -384,7 +384,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1a, end),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent1a, middleEvent1b),
 			Lists.newArrayList(startEvent, middleEvent1a, middleEvent1b, end)
@@ -427,7 +427,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent),
 			Lists.newArrayList(startEvent, middleEvent1),
 			Lists.newArrayList(startEvent, middleEvent1a),
@@ -490,7 +490,7 @@ public void testClearingBufferWithUntilAtTheEnd() throws Exception {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middle1Event1),
 
 			Lists.newArrayList(startEvent, middle1Event1, middle1Event1),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/TimesOrMoreITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/TimesOrMoreITCase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 
@@ -83,7 +83,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, end1)
@@ -130,7 +130,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -178,7 +178,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end)
 		));
 	}
@@ -223,7 +223,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
@@ -267,7 +267,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
@@ -310,7 +310,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
 	}
@@ -355,7 +355,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -404,7 +404,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -452,7 +452,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end)
@@ -497,7 +497,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end)
 		));
@@ -541,7 +541,7 @@ public class TimesOrMoreITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/TimesRangeITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/TimesRangeITCase.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 
@@ -84,7 +84,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, end1),
@@ -135,7 +135,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, end1),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, end1),
 			Lists.newArrayList(startEvent, middleEvent1, end1),
@@ -182,7 +182,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -232,7 +232,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.end),
@@ -280,7 +280,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.end),
@@ -326,7 +326,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.end),
@@ -369,7 +369,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.end)
 		));
 	}
@@ -413,7 +413,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -461,7 +461,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
@@ -508,7 +508,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent3, ConsecutiveData.end)
@@ -552,7 +552,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end)
 		));
@@ -595,7 +595,7 @@ public class TimesRangeITCase extends TestLogger {
 
 		List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent1, ConsecutiveData.middleEvent2, ConsecutiveData.end),
 			Lists.newArrayList(ConsecutiveData.startEvent, ConsecutiveData.middleEvent2, ConsecutiveData.middleEvent3, ConsecutiveData.end),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/UntilConditionITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/UntilConditionITCase.java
@@ -32,7 +32,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.cep.utils.NFATestUtilities.compareMaps;
+import static org.apache.flink.cep.utils.NFATestUtilities.compareLists;
 import static org.apache.flink.cep.utils.NFATestUtilities.feedNFA;
 import static org.apache.flink.cep.utils.NFAUtils.compile;
 import static org.junit.Assert.assertEquals;
@@ -97,7 +97,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, breaking)
 		));
@@ -148,7 +148,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, breaking),
@@ -200,7 +200,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, breaking)
 		));
@@ -252,7 +252,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, breaking)
 		));
 		assertEquals(1, nfaState.getPartialMatches().size());
@@ -301,7 +301,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, breaking),
 			Lists.newArrayList(startEvent, breaking)
@@ -352,7 +352,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent3, breaking),
@@ -405,7 +405,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, breaking),
 			Lists.newArrayList(startEvent, middleEvent1, breaking),
 			Lists.newArrayList(startEvent, breaking)
@@ -450,7 +450,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1),
 			Lists.newArrayList(startEvent, middleEvent2),
@@ -494,7 +494,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = feedNFA(inputEvents, nfa);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1),
 			Lists.newArrayList(startEvent, middleEvent2),
@@ -537,7 +537,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1)
@@ -592,7 +592,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1)
@@ -646,7 +646,7 @@ public class UntilConditionITCase {
 
 		final List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
 
-		compareMaps(resultingPatterns, Lists.<List<Event>>newArrayList(
+		compareLists(resultingPatterns, Lists.<List<Event>>newArrayList(
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2, middleEvent3),
 			Lists.newArrayList(startEvent, middleEvent1, middleEvent2),
 			Lists.newArrayList(startEvent, middleEvent1),

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestUtilities.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestUtilities.java
@@ -41,7 +41,7 @@ public class NFATestUtilities {
 		return nfaTestHarness.feedRecords(inputEvents);
 	}
 
-	public static void compareMaps(List<List<Event>> actual, List<List<Event>> expected) {
+	public static void compareLists(List<List<Event>> actual, List<List<Event>> expected) {
 		Assert.assertEquals(expected.size(), actual.size());
 
 		for (List<Event> p: actual) {


### PR DESCRIPTION

## What is the purpose of the change

*This pull request rename the compareMaps in NFATestUtilities to compareLists as this function compares two list in fact.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
