### PR TITLE
[FLINK-15150][tests] Prevent job from reaching terminal state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRunningJobsRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperRunningJobsRegistry.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -36,6 +38,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * A zookeeper based registry for running jobs, highly available.
  */
 public class ZooKeeperRunningJobsRegistry implements RunningJobsRegistry {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperRunningJobsRegistry.class);
 
 	private static final Charset ENCODING = Charset.forName("utf-8");
 
@@ -122,6 +126,7 @@ public class ZooKeeperRunningJobsRegistry implements RunningJobsRegistry {
 	}
 
 	private void writeEnumToZooKeeper(JobID jobID, JobSchedulingStatus status) throws Exception {
+		LOG.debug("Setting scheduling state for job {} to {}.", jobID, status);
 		final String zkPath = createZkPath(jobID);
 		this.client.newNamespaceAwareEnsurePath(zkPath).ensure(client.getZookeeperClient());
 		this.client.setData().forPath(zkPath, status.name().getBytes(ENCODING));


### PR DESCRIPTION
Fixes an instability in the `ZookeeperLeaderElectionITCase` where the shutdown of the Dispatcher caused a slot allocation to fail, resulting in the job failing, reaching a terminal state and afterwards being removed from Zookeeper.

We now prevent the job from reaching a terminal state by enabling a fixed-delay restart strategy. Should the allocation fail the JM will retry until the JM itself is being shut down. On shutdown the JM will suspend the job, allowing it to be recovered by other Dispatchers.

I verified the fix by re-running the test until I ran into the same exception as reporter in the JIRA.

The exact behavior for what happens to running jobs when the Dispatcher is shut down in an orderly fashion is currently undefined, and this PR makes no attempt remedy this.