### PR TITLE
[FLINK-15561][Security][hotfix] Add Delegation Token checker in YarnClusterDescriptor

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -112,21 +112,17 @@ public class HadoopUtils {
 		return result;
 	}
 
-	public static boolean isCredentialsConfigured(boolean useTicketCache) throws Exception {
-		UserGroupInformation loginUser = UserGroupInformation.getCurrentUser();
+	public static boolean isCredentialsConfigured(UserGroupInformation ugi, boolean useTicketCache) throws Exception {
 		if (UserGroupInformation.isSecurityEnabled()) {
-			// note: UGI::hasKerberosCredentials inaccurately reports false
-			// for logins based on a keytab (fixed in Hadoop 2.6.1, see HADOOP-10786),
-			// so we check only in ticket cache scenario.
-			if (useTicketCache && !loginUser.hasKerberosCredentials()) {
+			if (useTicketCache && !ugi.hasKerberosCredentials()) {
 				// a delegation token is an adequate substitute in most cases
 				if (!HadoopUtils.hasHDFSDelegationToken()) {
-					LOG.warn("Hadoop security is enabled but current login user does not have Kerberos credentials, " +
-						"use delegation token instead. Flink application will terminate after token expires.");
-				} else {
 					LOG.error("Hadoop security is enabled, but current login user has neither Kerberos credential " +
 						"nor delegation token!");
 					return false;
+				} else {
+					LOG.warn("Hadoop security is enabled but current login user does not have Kerberos credentials, " +
+						"use delegation token instead. Flink application will terminate after token expires.");
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -137,7 +137,8 @@ public class HadoopModule implements SecurityModule {
 				loginUser = UserGroupInformation.getLoginUser();
 			}
 
-			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(securityConfig.useTicketCache());
+			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(
+				loginUser, securityConfig.useTicketCache());
 
 			LOG.info("Hadoop user set to {}, credential check status: {}", loginUser, isCredentialsConfigured);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -137,19 +137,9 @@ public class HadoopModule implements SecurityModule {
 				loginUser = UserGroupInformation.getLoginUser();
 			}
 
-			if (UserGroupInformation.isSecurityEnabled()) {
-				// note: UGI::hasKerberosCredentials inaccurately reports false
-				// for logins based on a keytab (fixed in Hadoop 2.6.1, see HADOOP-10786),
-				// so we check only in ticket cache scenario.
-				if (securityConfig.useTicketCache() && !loginUser.hasKerberosCredentials()) {
-					// a delegation token is an adequate substitute in most cases
-					if (!HadoopUtils.hasHDFSDelegationToken()) {
-						LOG.warn("Hadoop security is enabled but current login user does not have Kerberos credentials");
-					}
-				}
-			}
+			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(securityConfig.useTicketCache());
 
-			LOG.info("Hadoop user set to {}", loginUser);
+			LOG.info("Hadoop user set to {}, credential check status: {}", loginUser, isCredentialsConfigured);
 
 		} catch (Throwable ex) {
 			throw new SecurityInstallException("Unable to set the Hadoop login user", ex);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -433,10 +433,11 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			// so we check only in ticket cache scenario.
 			boolean useTicketCache = flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
 
-			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(useTicketCache);
+			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(
+				UserGroupInformation.getCurrentUser(), useTicketCache);
 			if (!isCredentialsConfigured) {
 				throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +
-					"does not have Kerberos credentials");
+					"does not have Kerberos credentials or delegation token!");
 			}
 		}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -433,16 +433,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			// so we check only in ticket cache scenario.
 			boolean useTicketCache = flinkConfiguration.getBoolean(SecurityOptions.KERBEROS_LOGIN_USETICKETCACHE);
 
-			UserGroupInformation loginUser = UserGroupInformation.getCurrentUser();
-			if (loginUser.getAuthenticationMethod() == UserGroupInformation.AuthenticationMethod.KERBEROS
-					&& useTicketCache && !loginUser.hasKerberosCredentials()) {
-				// a delegation token is an adequate substitute in most cases
-				if (!HadoopUtils.hasHDFSDelegationToken()) {
-					LOG.error("Hadoop security with Kerberos is enabled but the login user " +
-						"does not have Kerberos credentials");
-					throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +
-						"does not have Kerberos credentials");
-				}
+			boolean isCredentialsConfigured = HadoopUtils.isCredentialsConfigured(useTicketCache);
+			if (!isCredentialsConfigured) {
+				throw new RuntimeException("Hadoop security with Kerberos is enabled but the login user " +
+					"does not have Kerberos credentials");
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

* YarnClusterDescriptor doesn't have the delegation token checker in security `HadoopModule`. Thus causes delegation token launch path problematically fails.

## Brief change log

add identical delegation token checker in YarnClusterDescriptor.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: YARN
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
