### PR TITLE
[FLINK-15638][release][python] Change version of pyflink to the release version when creating release branch

### DIFF
--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -68,6 +68,11 @@ VERSION_TITLE=$(echo $NEW_VERSION | sed 's/\.[^.]*$//')
 perl -pi -e "s#^version_title: .*#version_title: ${VERSION_TITLE}#" _config.yml
 cd ..
 
+#change version of pyflink
+cd flink-python/pyflink
+perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${NEW_VERSION}\"#" version.py
+cd ../..
+
 git commit -am "Commit for release $NEW_VERSION"
 
 RELEASE_HASH=`git rev-parse HEAD`


### PR DESCRIPTION
## What is the purpose of the change

This pull request sets the version in flink-python/pyflink/version.py when creating release branch.


## Brief change log

  - Sets the version in flink-python/pyflink/version.py when creating release branch

## Verifying this change

 - This change is a trivial rework / code cleanup without any test coverage.
 - Test manually by creating the release branch and install pyflink on local. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
