### PR TITLE
[FLINK-15631][table-planner-blink] Fix equals code generation for raw and timestamp type

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/codegen/EqualiserCodeGeneratorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen;
+
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.table.dataformat.BinaryGeneric;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryRowWriter;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.runtime.generated.RecordEqualiser;
+import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TypeInformationRawType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.apache.flink.table.dataformat.SqlTimestamp.fromEpochMillis;
+
+/**
+ * Test for {@link EqualiserCodeGenerator}.
+ */
+public class EqualiserCodeGeneratorTest {
+
+	@Test
+	public void testRaw() {
+		RecordEqualiser equaliser = new EqualiserCodeGenerator(
+				new LogicalType[]{new TypeInformationRawType<>(Types.INT)})
+				.generateRecordEqualiser("RAW")
+				.newInstance(Thread.currentThread().getContextClassLoader());
+		Function<BinaryGeneric, BinaryRow> func = o -> {
+			BinaryRow row = new BinaryRow(1);
+			BinaryRowWriter writer = new BinaryRowWriter(row);
+			writer.writeGeneric(0, o, new BinaryGenericSerializer<>(IntSerializer.INSTANCE));
+			writer.complete();
+			return row;
+		};
+		assertBoolean(equaliser, func, new BinaryGeneric<>(1), new BinaryGeneric<>(1), true);
+		assertBoolean(equaliser, func, new BinaryGeneric<>(1), new BinaryGeneric<>(2), false);
+	}
+
+	@Test
+	public void testTimestamp() {
+		RecordEqualiser equaliser = new EqualiserCodeGenerator(
+				new LogicalType[]{new TimestampType()})
+				.generateRecordEqualiser("TIMESTAMP")
+				.newInstance(Thread.currentThread().getContextClassLoader());
+		Function<SqlTimestamp, BinaryRow> func = o -> {
+			BinaryRow row = new BinaryRow(1);
+			BinaryRowWriter writer = new BinaryRowWriter(row);
+			writer.writeTimestamp(0, o, 9);
+			writer.complete();
+			return row;
+		};
+		assertBoolean(equaliser, func, fromEpochMillis(1024), fromEpochMillis(1024), true);
+		assertBoolean(equaliser, func, fromEpochMillis(1024), fromEpochMillis(1025), false);
+	}
+
+	private static <T> void assertBoolean(
+			RecordEqualiser equaliser,
+			Function<T, BinaryRow> toBinaryRow,
+			T o1,
+			T o2,
+			boolean bool) {
+		Assert.assertEquals(bool, equaliser.equalsWithoutHeader(
+				GenericRow.of(o1),
+				GenericRow.of(o2)));
+		Assert.assertEquals(bool, equaliser.equalsWithoutHeader(
+				toBinaryRow.apply(o1),
+				GenericRow.of(o2)));
+		Assert.assertEquals(bool, equaliser.equalsWithoutHeader(
+				GenericRow.of(o1),
+				toBinaryRow.apply(o2)));
+		Assert.assertEquals(bool, equaliser.equalsWithoutHeader(
+				toBinaryRow.apply(o1),
+				toBinaryRow.apply(o2)));
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -4159,4 +4159,15 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "IS_ALPHA(f33)",
       "false")
   }
+
+  @Test
+  def testRawTypeEquality(): Unit = {
+    testSqlApi(
+      "f55=f56",
+      "false")
+
+    testSqlApi(
+      "f55=f57",
+      "true")
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarTypesTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarTypesTestBase.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.expressions.utils
 
 import org.apache.flink.api.common.typeinfo.{PrimitiveArrayTypeInfo, Types}
-import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, RowTypeInfo}
 import org.apache.flink.table.dataformat.Decimal
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.runtime.typeutils.DecimalTypeInfo
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets
 abstract class ScalarTypesTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val testData = new Row(55)
+    val testData = new Row(58)
     testData.setField(0, "This is a test String.")
     testData.setField(1, true)
     testData.setField(2, 42.toByte)
@@ -87,6 +87,9 @@ abstract class ScalarTypesTestBase extends ExpressionTestBase {
     testData.setField(52, localDateTime("1997-11-11 09:44:55.333"))
     testData.setField(53, "hello world".getBytes(StandardCharsets.UTF_8))
     testData.setField(54, "This is a testing string.".getBytes(StandardCharsets.UTF_8))
+    testData.setField(55, 1)
+    testData.setField(56, 2)
+    testData.setField(57, 1)
     testData
   }
 
@@ -146,6 +149,9 @@ abstract class ScalarTypesTestBase extends ExpressionTestBase {
       /* 51 */ Types.LOCAL_TIME,
       /* 52 */ Types.LOCAL_DATE_TIME,
       /* 53 */ Types.PRIMITIVE_ARRAY(Types.BYTE),
-      /* 54 */ Types.PRIMITIVE_ARRAY(Types.BYTE))
+      /* 54 */ Types.PRIMITIVE_ARRAY(Types.BYTE),
+      /* 55 */ new GenericTypeInfo[Integer](classOf[Integer]),
+      /* 56 */ new GenericTypeInfo[Integer](classOf[Integer]),
+      /* 57 */ new GenericTypeInfo[Integer](classOf[Integer]))
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.table.planner.runtime.stream.sql
 
+import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.TimeCharacteristic
@@ -31,7 +32,7 @@ import org.apache.flink.table.planner.runtime.utils.StreamingWithMiniBatchTestBa
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TimeTestUtil.TimestampAndWatermarkWithOffset
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils._
-import org.apache.flink.table.planner.runtime.utils.{StreamingWithAggTestBase, TestData, TestingRetractSink}
+import org.apache.flink.table.planner.runtime.utils.{GenericAggregateFunction, StreamingWithAggTestBase, TestData, TestingRetractSink}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => mLocalTime}
 import org.apache.flink.table.runtime.typeutils.BigDecimalTypeInfo
 import org.apache.flink.types.Row
@@ -1186,4 +1187,18 @@ class AggregateITCase(
     assertEquals(expected, sink.getRetractResults)
   }
 
+  @Test
+  def testGenericTypesWithoutStateClean(): Unit = {
+    // because we don't provide a way to disable state cleanup.
+    // TODO verify all tests with state cleanup closed.
+    tEnv.getConfig.setIdleStateRetentionTime(Time.days(0), Time.days(0))
+    val t = failingDataSource(Seq(1, 2, 3)).toTable(tEnv, 'a)
+    val results = t
+        .select(new GenericAggregateFunction()('a))
+        .toRetractStream[Row]
+
+    val sink = new TestingRetractSink
+    results.addSink(sink).setParallelism(1)
+    env.execute()
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/UserDefinedFunctionTestUtils.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.runtime.utils
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.{Tuple1, Tuple2}
-import org.apache.flink.api.java.typeutils.{ListTypeInfo, PojoField, PojoTypeInfo, RowTypeInfo}
+import org.apache.flink.api.java.typeutils.{GenericTypeInfo, ListTypeInfo, PojoField, PojoTypeInfo, RowTypeInfo}
 import org.apache.flink.api.scala.ExecutionEnvironment
 import org.apache.flink.api.scala.typeutils.Types
 import org.apache.flink.configuration.Configuration
@@ -441,5 +441,31 @@ object UserDefinedFunctionTestUtils {
     tempFile.deleteOnExit()
     Files.write(contents, tempFile, Charsets.UTF_8)
     tempFile.getAbsolutePath
+  }
+}
+
+class RandomClass(var i: Int)
+
+class GenericAggregateFunction extends AggregateFunction[java.lang.Integer, RandomClass] {
+  override def getValue(accumulator: RandomClass): java.lang.Integer = accumulator.i
+
+  override def createAccumulator(): RandomClass = new RandomClass(0)
+
+  override def getResultType: TypeInformation[java.lang.Integer] =
+    new GenericTypeInfo[Integer](classOf[Integer])
+
+  override def getAccumulatorType: TypeInformation[RandomClass] = new GenericTypeInfo[RandomClass](
+    classOf[RandomClass])
+
+  def accumulate(acc: RandomClass, value: Int): Unit = {
+    acc.i = value
+  }
+
+  def retract(acc: RandomClass, value: Int): Unit = {
+    acc.i = value
+  }
+
+  def resetAccumulator(acc: RandomClass): Unit = {
+    acc.i = 0
   }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/LazyBinaryFormat.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/LazyBinaryFormat.java
@@ -71,6 +71,10 @@ public abstract class LazyBinaryFormat<T> implements BinaryFormat {
 		return javaObject;
 	}
 
+	public BinarySection getBinarySection() {
+		return binarySection;
+	}
+
 	/**
 	 * Must be public as it is used during code generation.
 	 */


### PR DESCRIPTION

## What is the purpose of the change

- equals for generic type not work
- when close idle state, aggregation not work for generic type and timestamp type

## Brief change log

- Fix equals code generation for raw type in ScalarOperatorGens
- Fix raw and timestamp type in EqualiserCodeGenerator

## Verifying this change

- ScalarFunctionsTest.testEquality
- EqualiserCodeGeneratorTest
- AggregateITCase.testGenericTypesWithoutStateClean

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no