### PR TITLE
[FLINK-15632][kubernetes] Make zookeeper HA service could work for active kubernetes integration

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -157,9 +157,20 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 	public RestClusterClient(Configuration config, T clusterId) throws Exception {
 		this(
 			config,
+			clusterId,
+			HighAvailabilityServicesUtils.createClientHAService(config));
+	}
+
+	public RestClusterClient(
+			Configuration config,
+			T clusterId,
+			ClientHighAvailabilityServices clientHAServices) throws Exception {
+		this(
+			config,
 			null,
 			clusterId,
-			new ExponentialWaitStrategy(10L, 2000L));
+			new ExponentialWaitStrategy(10L, 2000L),
+			clientHAServices);
 	}
 
 	@VisibleForTesting
@@ -168,7 +179,20 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 		@Nullable RestClient restClient,
 		T clusterId,
 		WaitStrategy waitStrategy) throws Exception {
+		this(
+			configuration,
+			restClient,
+			clusterId,
+			waitStrategy,
+			HighAvailabilityServicesUtils.createClientHAService(configuration));
+	}
 
+	private RestClusterClient(
+		Configuration configuration,
+		@Nullable RestClient restClient,
+		T clusterId,
+		WaitStrategy waitStrategy,
+		ClientHighAvailabilityServices clientHAServices) throws Exception {
 		this.configuration = checkNotNull(configuration);
 
 		this.restClusterClientConfiguration = RestClusterClientConfiguration.fromConfiguration(configuration);
@@ -182,7 +206,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 		this.waitStrategy = checkNotNull(waitStrategy);
 		this.clusterId = checkNotNull(clusterId);
 
-		this.clientHAServices = HighAvailabilityServicesUtils.createClientHAService(configuration);
+		this.clientHAServices = checkNotNull(clientHAServices);
 
 		this.webMonitorRetrievalService = clientHAServices.getClusterRestEndpointLeaderRetriever();
 		this.retryExecutorService = Executors.newSingleThreadScheduledExecutor(new ExecutorThreadFactory("Flink-RestClusterClient-Retry"));

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesEntrypointUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.KubernetesClusterDescriptor;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.Preconditions;
+
+/**
+ * This class contains utility methods for the {@link KubernetesSessionClusterEntrypoint}.
+ */
+class KubernetesEntrypointUtils {
+
+	/**
+	 * For non-HA cluster, {@link JobManagerOptions#ADDRESS} has be set to Kubernetes service name on client side. See
+	 * {@link KubernetesClusterDescriptor#deployClusterInternal}. So the TaskManager will use service address to contact
+	 * with JobManager.
+	 * For HA cluster, {@link JobManagerOptions#ADDRESS} will be set to the pod ip address. The TaskManager use Zookeeper
+	 * or other high-availability service to find the address of JobManager.
+	 *
+	 * @return Updated configuration
+	 */
+	static Configuration loadConfiguration() {
+		final String configDir = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
+		Preconditions.checkNotNull(
+			configDir,
+			"Flink configuration directory (%s) in environment should not be null!",
+			ConfigConstants.ENV_FLINK_CONF_DIR);
+
+		final Configuration configuration = GlobalConfiguration.loadConfiguration(configDir);
+
+		if (HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
+			final String ipAddress = System.getenv().get(Constants.ENV_FLINK_POD_IP_ADDRESS);
+			Preconditions.checkState(
+				ipAddress != null,
+				"JobManager ip address environment variable %s not set",
+				Constants.ENV_FLINK_POD_IP_ADDRESS);
+			configuration.setString(JobManagerOptions.ADDRESS, ipAddress);
+			configuration.setString(RestOptions.ADDRESS, ipAddress);
+		}
+
+		return configuration;
+	}
+
+	private KubernetesEntrypointUtils() {}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesSessionClusterEntrypoint.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.kubernetes.entrypoint;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.component.DefaultDispatcherResourceManagerComponentFactory;
@@ -28,7 +26,6 @@ import org.apache.flink.runtime.entrypoint.component.DispatcherResourceManagerCo
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
-import org.apache.flink.util.Preconditions;
 
 /**
  * Entry point for a Kubernetes session cluster.
@@ -51,14 +48,8 @@ public class KubernetesSessionClusterEntrypoint extends SessionClusterEntrypoint
 		SignalHandler.register(LOG);
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-		final String configDir = System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR);
-		Preconditions.checkNotNull(
-			configDir,
-			"Flink configuration directory (%s) in environment should not be null!",
-			ConfigConstants.ENV_FLINK_CONF_DIR);
-		final Configuration configuration = GlobalConfiguration.loadConfiguration(configDir);
-
-		ClusterEntrypoint entrypoint = new KubernetesSessionClusterEntrypoint(configuration);
+		final ClusterEntrypoint entrypoint = new KubernetesSessionClusterEntrypoint(
+			KubernetesEntrypointUtils.loadConfiguration());
 		ClusterEntrypoint.runClusterEntrypoint(entrypoint);
 	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -60,4 +60,8 @@ public class Constants {
 	public static final String ENV_FLINK_CLASSPATH = "FLINK_CLASSPATH";
 
 	public static final String ENV_FLINK_POD_NAME = "_FLINK_POD_NAME";
+
+	public static final String ENV_FLINK_POD_IP_ADDRESS = "_POD_IP_ADDRESS";
+
+	public static final String POD_IP_FIELD_PATH = "status.podIP";
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -36,6 +36,8 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -62,6 +64,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class KubernetesUtils {
 
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
+
 	/**
 	 * Read file content to string.
 	 *
@@ -83,6 +87,25 @@ public class KubernetesUtils {
 			return content.toString();
 		}
 		throw new FileNotFoundException("File " + filePath + " not exists.");
+	}
+
+	/**
+	 * Check whether the port config option is a fixed port. If not, the fallback port will be set to configuration.
+	 * @param flinkConfig flink configuration
+	 * @param port config option need to be checked
+	 * @param fallbackPort the fallback port that will be set to the configuration
+	 */
+	public static void checkAndUpdatePortConfigOption(
+			Configuration flinkConfig,
+			ConfigOption<String> port,
+			int fallbackPort) {
+		if (KubernetesUtils.parsePort(flinkConfig, port) == 0) {
+			flinkConfig.setString(port, String.valueOf(fallbackPort));
+			LOG.info(
+				"Kubernetes deployment requires a fixed port. Configuration {} will be set to {}",
+				port.key(),
+				fallbackPort);
+		}
 	}
 
 	/**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -236,6 +237,26 @@ public class KubernetesUtilsTest extends TestLogger {
 				e.getMessage(),
 				containsString(testingPort.key() + " should not be null."));
 		}
+	}
+
+	@Test
+	public void testCheckWithDynamicPort() {
+		testCheckAndUpdatePortConfigOption("0", "6123", "6123");
+	}
+
+	@Test
+	public void testCheckWithFixedPort() {
+		testCheckAndUpdatePortConfigOption("6123", "16123", "6123");
+	}
+
+	private void testCheckAndUpdatePortConfigOption(String port, String fallbackPort, String expectedPort) {
+		final Configuration cfg = new Configuration();
+		cfg.setString(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE, port);
+		KubernetesUtils.checkAndUpdatePortConfigOption(
+			cfg,
+			HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE,
+			Integer.valueOf(fallbackPort));
+		assertEquals(expectedPort, cfg.get(HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE));
 	}
 
 	private String getJobManagerExpectedCommand(String jvmAllOpts, String logging, String mainClassArgs) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
@@ -51,6 +51,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for Fabric implementation of {@link FlinkKubeClient}.
@@ -189,7 +190,10 @@ public class Fabric8ClientTest extends KubernetesTestBase {
 			jmContainer.getVolumeMounts().get(0).getMountPath());
 		assertEquals(FLINK_CONF_FILENAME, jmContainer.getVolumeMounts().get(0).getSubPath());
 
-		assertThat(jmContainer.getEnv(), Matchers.contains(new EnvVar(FLINK_MASTER_ENV_KEY, FLINK_MASTER_ENV_VALUE, null)));
+		EnvVar masterEnv = new EnvVar(FLINK_MASTER_ENV_KEY, FLINK_MASTER_ENV_VALUE, null);
+		assertTrue(
+			"Environment " + masterEnv.toString() + " should be set.",
+			jmContainer.getEnv().contains(masterEnv));
 	}
 
 	@Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when we deploy Flink cluster natively on Kubernetes and HA enabled, it could not work because of following two limitations
1. Flink client could not connect to the jobmanager when HA enabled. It will get a internal address that could not be accessed outside of Kubernetes cluster.
2. `JobManagerOptions#ADDRESS` has been set to service address when HA enabled. It has a risk  that the TaskManager will register to a wrong jobmanager when two jobmanagers are running. We need to use the pod ip address instead.


## Brief change log

* `hotfix` to make test could work for multiple pod environments.
* Always use Kubernetes service for client to contact with jobmanager in `KubernetesClusterDescriptor`
* Set ip address to `jobmanager.rpc.address` in `ClusterEntrypoint`
* Update `HighAvailabilityOptions.HA_CLUSTER_ID` and `HighAvailabilityOptions.HA_JOB_MANAGER_PORT_RANGE` when HA enabled


## Verifying this change

* Add a new unit test `testDeployHighAvailabilitySessionCluster`
* Test on a real Kubernetes cluster with zookeeper HA

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
