### PR TITLE
[FLINK-15575] [filesystems] fix shading of azure filesystem

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -131,8 +131,8 @@ under the License.
 
 								<!-- shade dependencies internally used by Azure and never exposed downstream -->
 								<relocation>
-									<pattern>org.apache.httpcomponents</pattern>
-									<shadedPattern>org.apache.flink.fs.azure.shaded.org.apache.httpcomponents</shadedPattern>
+									<pattern>org.apache.http</pattern>
+									<shadedPattern>org.apache.flink.fs.azure.shaded.org.apache.http</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>commons-logging</pattern>


### PR DESCRIPTION
## What is the purpose of the change

fix shading of azure filesystem

## Brief change log

* instead of shading the non-existing package org.apache.httpcomponents, we shaded org.apache.http now


## Verifying this change

*(example:)*
  - build azure-hadoop-fs and check that classes are correctly shaded

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
