### PR TITLE
[FLINK-15549][API/DataSet] Fix Integer overflow in ResettableIterator*.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/SpillingResettableIterator.java
@@ -58,9 +58,9 @@ public class SpillingResettableIterator<T> implements ResettableIterator<T> {
 	
 	protected final TypeSerializer<T> serializer;
 	
-	private int elementCount;
+	private long elementCount;
 	
-	private int currentElementNum;
+	private long currentElementNum;
 	
 	protected final SpillingBuffer buffer;
 	

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIterator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/resettable/SpillingResettableMutableObjectIterator.java
@@ -53,9 +53,9 @@ public class SpillingResettableMutableObjectIterator<T> implements ResettableMut
 	
 	protected final TypeSerializer<T> serializer;
 	
-	private int elementCount;
+	private long elementCount;
 	
-	private int currentElementNum;
+	private long currentElementNum;
 	
 	protected final SpillingBuffer buffer;
 	


### PR DESCRIPTION
## What is the purpose of the change

The ResettableIterator has a data overflow problem if the number of elements in a single input exceeds Integer.MAX_VALUE. This pull request intend to fix this problem.

## Brief change log

  - *Fix Integer overflow in ResettableIterator*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no