### PR TITLE
[FLINK-15669] [sql client] fix SQL client can't cancel flink job

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -656,7 +656,7 @@ public class LocalExecutor implements Executor {
 		try {
 			jobClient = deployer.deploy().get();
 		} catch (Exception e) {
-			throw new SqlExecutionException("Error running SQL job.", e);
+			throw new SqlExecutionException("Error while submitting job.", e);
 		}
 
 		String jobId = jobClient.getJobID().toString();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -656,7 +656,7 @@ public class LocalExecutor implements Executor {
 		try {
 			jobClient = deployer.deploy().get();
 		} catch (Exception e) {
-			throw new RuntimeException("Error running SQL job.", e);
+			throw new SqlExecutionException("Error running SQL job.", e);
 		}
 
 		String jobId = jobClient.getJobID().toString();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -76,7 +76,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
@@ -641,10 +640,6 @@ public class LocalExecutor implements Executor {
 			});
 		}
 
-		// store the result with a unique id
-		final String resultId = UUID.randomUUID().toString();
-		resultStore.storeResult(resultId, result);
-
 		// create a copy so that we can change settings without affecting the original config
 		Configuration configuration = new Configuration(context.getFlinkConfig());
 		// for queries we wait for the job result, so run in attached mode
@@ -656,11 +651,23 @@ public class LocalExecutor implements Executor {
 		final ProgramDeployer deployer = new ProgramDeployer(
 				configuration, jobName, pipeline);
 
+		JobClient jobClient;
+		// blocking deployment
+		try {
+			jobClient = deployer.deploy().get();
+		} catch (Exception e) {
+			throw new RuntimeException("Error running SQL job.", e);
+		}
+
+		String jobId = jobClient.getJobID().toString();
+		// store the result with a unique id
+		resultStore.storeResult(jobId, result);
+
 		// start result retrieval
-		result.startRetrieval(deployer);
+		result.startRetrieval(jobClient);
 
 		return new ResultDescriptor(
-				resultId,
+				jobId,
 				removeTimeAttributes(table.getSchema()),
 				result.isMaterialized(),
 				context.getEnvironment().getExecution().isTableauMode());

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -96,7 +96,7 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 					if (throwable != null) {
 						executionException.compareAndSet(
 								null,
-								new SqlExecutionException("Error while submitting job.", throwable));
+								new SqlExecutionException("Error while retrieving result.", throwable));
 					}
 				});
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamUtils;
 import org.apache.flink.streaming.experimental.SocketStreamIterator;
@@ -32,7 +33,6 @@ import org.apache.flink.table.client.SqlClientException;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.local.CollectStreamTableSink;
-import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 
@@ -86,13 +86,12 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 	}
 
 	@Override
-	public void startRetrieval(ProgramDeployer deployer) {
+	public void startRetrieval(JobClient jobClient) {
 		// start listener thread
 		retrievalThread.start();
 
-		jobExecutionResultFuture = deployer
-				.deploy()
-				.thenCompose(jobClient -> jobClient.getJobExecutionResult(classLoader))
+		jobExecutionResultFuture = CompletableFuture.completedFuture(jobClient)
+				.thenCompose(client -> client.getJobExecutionResult(classLoader))
 				.whenComplete((unused, throwable) -> {
 					if (throwable != null) {
 						executionException.compareAndSet(

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/CollectStreamResult.java
@@ -90,8 +90,7 @@ public abstract class CollectStreamResult<C> extends BasicResult<C> implements D
 		// start listener thread
 		retrievalThread.start();
 
-		jobExecutionResultFuture = CompletableFuture.completedFuture(jobClient)
-				.thenCompose(client -> client.getJobExecutionResult(classLoader))
+		jobExecutionResultFuture = jobClient.getJobExecutionResult(classLoader)
 				.whenComplete((unused, throwable) -> {
 					if (throwable != null) {
 						executionException.compareAndSet(

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.client.gateway.local.result;
 
-import org.apache.flink.table.client.gateway.local.ProgramDeployer;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.sinks.TableSink;
 
 /**
@@ -39,7 +39,7 @@ public interface DynamicResult<C> extends Result<C> {
 	/**
 	 * Starts the table program using the given deployer and monitors it's execution.
 	 */
-	void startRetrieval(ProgramDeployer deployer);
+	void startRetrieval(JobClient jobClient);
 
 	/**
 	 * Returns the table sink required by this result type.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -37,7 +37,7 @@ public interface DynamicResult<C> extends Result<C> {
 	boolean isMaterialized();
 
 	/**
-	 * Starts the table program using the given deployer and monitors it's execution.
+	 * Starts retrieve the result using the given jobClient and monitors it's execution.
 	 */
 	void startRetrieval(JobClient jobClient);
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -85,7 +85,7 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 					if (throwable != null) {
 						executionException.compareAndSet(null,
 								new SqlExecutionException(
-										"Error while submitting job.",
+										"Error while retrieving result.",
 										throwable));
 					}
 				});

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -34,7 +34,6 @@ import org.apache.flink.util.AbstractID;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -78,8 +77,7 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 
 	@Override
 	public void startRetrieval(JobClient jobClient) {
-		CompletableFuture.completedFuture(jobClient)
-				.thenCompose(client -> client.getJobExecutionResult(classLoader))
+		jobClient.getJobExecutionResult(classLoader)
 				.thenAccept(new ResultRetrievalHandler())
 				.whenComplete((unused, throwable) -> {
 					if (throwable != null) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -22,11 +22,11 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.table.client.gateway.local.CollectBatchTableSink;
-import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.AbstractID;
@@ -34,6 +34,7 @@ import org.apache.flink.util.AbstractID;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -76,10 +77,9 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	}
 
 	@Override
-	public void startRetrieval(ProgramDeployer deployer) {
-		deployer
-				.deploy()
-				.thenCompose(jobClient -> jobClient.getJobExecutionResult(classLoader))
+	public void startRetrieval(JobClient jobClient) {
+		CompletableFuture.completedFuture(jobClient)
+				.thenCompose(client -> client.getJobExecutionResult(classLoader))
 				.thenAccept(new ResultRetrievalHandler())
 				.whenComplete((unused, throwable) -> {
 					if (throwable != null) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -19,11 +19,13 @@
 
 package org.apache.flink.table.client.gateway.local;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.cli.DefaultCLI;
+import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.DefaultClusterClientServiceLoader;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.ConfigConstants;
@@ -84,6 +86,7 @@ import java.util.stream.IntStream;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -483,6 +486,51 @@ public class LocalExecutorITCase extends TestLogger {
 		}
 	}
 
+	@Test(timeout = 30_000L)
+	public void testStreamQueryCancel() throws Exception {
+		final URL url = getClass().getClassLoader().getResource("test-data.csv");
+		Objects.requireNonNull(url);
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
+		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
+		replaceVars.put("$VAR_EXECUTION_TYPE", "streaming");
+		replaceVars.put("$VAR_RESULT_MODE", "changelog");
+		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
+
+		final LocalExecutor executor = createModifiedExecutor(clusterClient, replaceVars);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		try {
+			final ResultDescriptor desc = executor.executeQuery(sessionId, "SELECT * FROM TestView1");
+			final JobID jobId = JobID.fromHexString(desc.getResultId());
+
+			assertFalse(desc.isMaterialized());
+
+			JobStatus jobStatus1 = getJobStatus(executor, sessionId, jobId);
+
+			assertNotEquals(JobStatus.CANCELED, jobStatus1);
+
+			executor.cancelQuery(sessionId, desc.getResultId());
+
+			JobStatus jobStatus2 = null;
+			// wait up to 30 seconds
+			for (int i = 0; i < 300; ++i) {
+				jobStatus2 = getJobStatus(executor, sessionId, jobId);
+				if (jobStatus2 != JobStatus.CANCELED) {
+					Thread.sleep(100);
+				} else {
+					break;
+				}
+			}
+			assertEquals(JobStatus.CANCELED, jobStatus2);
+		} finally {
+			executor.closeSession(sessionId);
+		}
+	}
+
 	@Test(timeout = 90_000L)
 	public void testStreamQueryExecutionChangelogMultipleTimes() throws Exception {
 		final URL url = getClass().getClassLoader().getResource("test-data.csv");
@@ -644,6 +692,50 @@ public class LocalExecutorITCase extends TestLogger {
 			expectedResults.add("57,ABC");
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
+		} finally {
+			executor.closeSession(sessionId);
+		}
+	}
+
+	@Test(timeout = 30_000L)
+	public void testBatchQueryCancel() throws Exception {
+		final URL url = getClass().getClassLoader().getResource("test-data.csv");
+		Objects.requireNonNull(url);
+		final Map<String, String> replaceVars = new HashMap<>();
+		replaceVars.put("$VAR_PLANNER", planner);
+		replaceVars.put("$VAR_SOURCE_PATH1", url.getPath());
+		replaceVars.put("$VAR_EXECUTION_TYPE", "batch");
+		replaceVars.put("$VAR_RESULT_MODE", "table");
+		replaceVars.put("$VAR_UPDATE_MODE", "");
+		replaceVars.put("$VAR_MAX_ROWS", "100");
+
+		final LocalExecutor executor = createModifiedExecutor(clusterClient, replaceVars);
+		final SessionContext session = new SessionContext("test-session", new Environment());
+		String sessionId = executor.openSession(session);
+		assertEquals("test-session", sessionId);
+
+		try {
+			final ResultDescriptor desc = executor.executeQuery(sessionId, "SELECT * FROM TestView1");
+			final JobID jobId = JobID.fromHexString(desc.getResultId());
+			assertTrue(desc.isMaterialized());
+
+			JobStatus jobStatus1 = getJobStatus(executor, sessionId, jobId);
+
+			assertNotEquals(JobStatus.CANCELED, jobStatus1);
+
+			executor.cancelQuery(sessionId, desc.getResultId());
+
+			JobStatus jobStatus2 = null;
+			// wait up to 30 seconds
+			for (int i = 0; i < 300; ++i) {
+				jobStatus2 = getJobStatus(executor, sessionId, jobId);
+				if (jobStatus2 != JobStatus.CANCELED) {
+					Thread.sleep(100);
+				} else {
+					break;
+				}
+			}
+			assertEquals(JobStatus.CANCELED, jobStatus2);
 		} finally {
 			executor.closeSession(sessionId);
 		}
@@ -1303,5 +1395,23 @@ public class LocalExecutorITCase extends TestLogger {
 			}
 		}
 		return actualResults;
+	}
+
+	private JobStatus getJobStatus(LocalExecutor executor, String sessionId, JobID jobId) {
+		final ExecutionContext<?> context = executor.getExecutionContext(sessionId);
+		return getJobStatusInternal(context, jobId);
+	}
+
+	private <T> JobStatus getJobStatusInternal(ExecutionContext<T> context, JobID jobId) {
+		// stop Flink job
+		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
+			// retrieve existing cluster
+			ClusterClient<T> clusterClient = clusterDescriptor.retrieve(context.getClusterId()).getClusterClient();
+			return clusterClient.getJobStatus(jobId).get();
+		} catch (SqlExecutionException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new SqlExecutionException("Could not locate a cluster.", e);
+		}
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -85,8 +85,8 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -1403,7 +1403,6 @@ public class LocalExecutorITCase extends TestLogger {
 	}
 
 	private <T> JobStatus getJobStatusInternal(ExecutionContext<T> context, JobID jobId) {
-		// stop Flink job
 		try (final ClusterDescriptor<T> clusterDescriptor = context.createClusterDescriptor()) {
 			// retrieve existing cluster
 			ClusterClient<T> clusterClient = clusterDescriptor.retrieve(context.getClusterId()).getClusterClient();


### PR DESCRIPTION
## What is the purpose of the change

*reason: in sql client, CLI client do cancel query operaiton through void cancelQuery(String sessionId, String resultId) method in Executor. However, the resultId is a random UUID, is not the job id. 
solution: changes the non-blocking deployment to blocking deployment in LocalExecutor#executeQueryInternal method, and then we can get jobId from JobClient, and then use it as resultId. The parameter of DynamicResult#startRetrieval method should also be changed from ProgramDeployer to JobClient, like void startRetrieval(JobClient jobClient);*


## Brief change log

  - *changes the non-blocking deployment to blocking deployment in LocalExecutor#executeQueryInternal method*
  - *changes the DynamicResult#startRetrieval method's parameter from ProgramDeployer to JobClient*


## Verifying this change

This change added tests and can be verified as follows:

*add testStreamQueryCancel and testBatchQueryCancel methods to verify query cancel*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
