### PR TITLE
[FLINK-15601] Remove useless constant field NUM_STOP_CALL_TRIES in Execution

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -124,8 +124,6 @@ public class Execution implements AccessExecution, Archiveable<ArchivedExecution
 
 	private static final int NUM_CANCEL_CALL_TRIES = 3;
 
-	private static final int NUM_STOP_CALL_TRIES = 3;
-
 	// --------------------------------------------------------------------------------------------
 
 	/** The executor which is used to execute futures. */


### PR DESCRIPTION


## What is the purpose of the change

*This pull request removes useless constant field NUM_STOP_CALL_TRIES in Execution*


## Brief change log

  - *Remove useless constant field NUM_STOP_CALL_TRIES in Execution*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
