### PR TITLE
[FLINK-15675][python] Add exception and documentation that Python UDF is not supported for Flink Planner under batch mode

### DIFF
--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -144,7 +144,7 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Currently, Python UDF is supported for Blink planner both under streaming and batch mode while is only supported under streaming mode for Flink Planner.
+<span class="label label-info">Note</span> Currently, Python UDF is supported in Blink planner both under streaming and batch mode while is only supported under streaming mode in old planner.
 
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 

--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -144,6 +144,8 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
+<span class="label label-info">Note</span> Currently, Python UDF is supported for Blink planner both under streaming and batch mode while is only supported under streaming mode for Flink Planner.
+
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 
 The following example shows how to define your own Java and Python hash code functions, register them in the TableEnvironment, and call them in a query. Note that you can configure your scalar function via a constructor before it is registered:

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -144,7 +144,7 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Currently, Python UDF is supported for Blink planner both under streaming and batch mode while is only supported under streaming mode for Flink Planner.
+<span class="label label-info">Note</span> Currently, Python UDF is supported in Blink planner both under streaming and batch mode while is only supported under streaming mode in old planner.
 
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -144,6 +144,8 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
+<span class="label label-info">Note</span> Currently, Python UDF is supported for Blink planner both under streaming and batch mode while is only supported under streaming mode for Flink Planner.
+
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 
 The following example shows how to define your own Java and Python hash code functions, register them in the TableEnvironment, and call them in a query. Note that you can configure your scalar function via a constructor before it is registered:

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -744,7 +744,7 @@ class TableEnvironment(object):
         :type function: pyflink.table.udf.UserDefinedFunctionWrapper
         """
         if not self._is_blink_planner and isinstance(self, BatchTableEnvironment):
-            raise Exception("Python UDF is not supported for Flink Planner under batch mode!")
+            raise Exception("Python UDF is not supported in old planner under batch mode!")
         self._j_tenv.registerFunction(name, function._judf(self._is_blink_planner,
                                                            self.get_config()._j_table_config))
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -743,6 +743,8 @@ class TableEnvironment(object):
         :param function: The python user-defined function to register.
         :type function: pyflink.table.udf.UserDefinedFunctionWrapper
         """
+        if not self._is_blink_planner and isinstance(self, BatchTableEnvironment):
+            raise Exception("Python UDF is not supported for Flink Planner under batch mode!")
         self._j_tenv.registerFunction(name, function._judf(self._is_blink_planner,
                                                            self.get_config()._j_table_config))
 

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -19,7 +19,8 @@ from pyflink.table import DataTypes
 from pyflink.table.udf import ScalarFunction, udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
-    PyFlinkBlinkStreamTableTestCase, PyFlinkBlinkBatchTableTestCase
+    PyFlinkBlinkStreamTableTestCase, PyFlinkBlinkBatchTableTestCase, \
+    PyFlinkBatchTableTestCase
 
 
 class UserDefinedFunctionTests(object):
@@ -476,6 +477,17 @@ def float_equal(a, b, rel_tol=1e-09, abs_tol=0.0):
 class PyFlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
                                             PyFlinkStreamTableTestCase):
     pass
+
+
+class PyFlinkBatchUserDefinedFunctionTests(PyFlinkBatchTableTestCase):
+
+    def test_invalid_register_udf(self):
+        self.assertRaises(
+            Exception,
+            lambda: self.t_env.register_function(
+                "add_one",
+                udf(lambda i: i + 1, DataTypes.BIGINT(), DataTypes.BIGINT()))
+        )
 
 
 class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds straightforward exceptions and document to info users that Python UDF is not supported for Flink Planner under batch mode.


## Brief change log

  - Throw exceptions when registering Python UDFs under flink planner batch mode.
  - Add document to info users that Python UDF is not supported for Flink Planner under batch mode.


## Verifying this change

This change added tests and can be verified as follows:

  - Add test_udf.test_invalid_register_udf to test exception has been thrown.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
