### PR TITLE
[FLINK-15682][kubernetes]fix bug for kubernetes command

### DIFF
--- a/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-entry.sh
+++ b/flink-dist/src/main/flink-bin/kubernetes-bin/kubernetes-entry.sh
@@ -32,4 +32,4 @@ export FLINK_CLASSPATH
 
 echo "Start command : $*"
 
-exec "$@"
+eval "$@"

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -316,7 +315,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			KubernetesTaskExecutorRunner.class.getCanonicalName(),
 			mainClassArgs);
 
-		return Arrays.asList("/bin/bash", "-c", command);
+		return Collections.singletonList(command);
 	}
 
 	/**

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
@@ -45,6 +45,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentSpecBuilder;
 
 import java.io.File;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -130,7 +131,7 @@ public class FlinkMasterDeploymentDecorator extends Decorator<Deployment, Kubern
 		return new ContainerBuilder()
 			.withName(CONTAINER_NAME)
 			.withCommand(flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_ENTRY_PATH))
-			.withArgs(Arrays.asList("/bin/bash", "-c", startCommand))
+			.withArgs(Collections.singletonList(startCommand))
 			.withImage(flinkConfig.getString(KubernetesConfigOptions.CONTAINER_IMAGE))
 			.withImagePullPolicy(flinkConfig.getString(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY))
 			.withResources(requirements)


### PR DESCRIPTION
## What is the purpose of the change

Currently,native kubernetes use exec /bin/bash -c java_command to start jobmanager and taskmanager.but there are $Flink_ClassPath in java_command,when use exec $@,this env can't be parse. So, I use eval to instead of exec and delete /bin/bash -c because eval only parse the first parameter.


## Brief change log
  - *use eval to instead of exec*
  - *delete /bin/bash -c*


## Verifying this change

*Test on a real Kubernetes cluster*

This change added tests and can be verified as follows:

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
