### PR TITLE
[FLINK-15686][sql-client] Use old type system in CollectStreamTableSink

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -43,7 +43,11 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 	private final TypeSerializer<Tuple2<Boolean, Row>> serializer;
 	private final TableSchema tableSchema;
 
-	public CollectStreamTableSink(InetAddress targetAddress, int targetPort, TypeSerializer<Tuple2<Boolean, Row>> serializer, TableSchema tableSchema) {
+	public CollectStreamTableSink(
+			InetAddress targetAddress,
+			int targetPort,
+			TypeSerializer<Tuple2<Boolean, Row>> serializer,
+			TableSchema tableSchema) {
 		this.targetAddress = targetAddress;
 		this.targetPort = targetPort;
 		this.serializer = serializer;
@@ -51,13 +55,20 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 	}
 
 	@Override
-	public TableSchema getTableSchema() {
-		return tableSchema;
-	}
-
-	@Override
 	public CollectStreamTableSink configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		return new CollectStreamTableSink(targetAddress, targetPort, serializer, tableSchema);
+	}
+
+	// Retract stream sinks work only with the old type system.
+	@Override
+	public String[] getFieldNames() {
+		return tableSchema.getFieldNames();
+	}
+
+	// Retract stream sinks work only with the old type system.
+	@Override
+	public TypeInformation<?>[] getFieldTypes() {
+		return tableSchema.getFieldTypes();
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ResultStore.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.client.gateway.local;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.net.ConnectionUtils;
@@ -63,8 +62,6 @@ public class ResultStore {
 			ExecutionConfig config,
 			ClassLoader classLoader) {
 
-		final RowTypeInfo outputType = new RowTypeInfo(schema.getFieldTypes(), schema.getFieldNames());
-
 		if (env.getExecution().inStreamingMode()) {
 			// determine gateway address (and port if possible)
 			final InetAddress gatewayAddress = getGatewayAddress(env.getDeployment());
@@ -72,7 +69,6 @@ public class ResultStore {
 
 			if (env.getExecution().isChangelogMode()) {
 				return new ChangelogCollectStreamResult<>(
-						outputType,
 						schema,
 						config,
 						gatewayAddress,
@@ -80,7 +76,6 @@ public class ResultStore {
 						classLoader);
 			} else {
 				return new MaterializedCollectStreamResult<>(
-						outputType,
 						schema,
 						config,
 						gatewayAddress,
@@ -94,7 +89,7 @@ public class ResultStore {
 			if (!env.getExecution().isTableMode()) {
 				throw new SqlExecutionException("Results of batch queries can only be served in table mode.");
 			}
-			return new MaterializedCollectBatchResult<>(schema, outputType, config, classLoader);
+			return new MaterializedCollectBatchResult<>(schema, config, classLoader);
 		}
 	}
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/ChangelogCollectStreamResult.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.TypedResult;
 import org.apache.flink.types.Row;
@@ -40,13 +39,12 @@ public class ChangelogCollectStreamResult<C> extends CollectStreamResult<C> impl
 	private static final int CHANGE_RECORD_BUFFER_SIZE = 5_000;
 
 	public ChangelogCollectStreamResult(
-			RowTypeInfo outputType,
 			TableSchema tableSchema,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
 			int gatewayPort,
 			ClassLoader classLoader) {
-		super(outputType, tableSchema, config, gatewayAddress, gatewayPort, classLoader);
+		super(tableSchema, config, gatewayAddress, gatewayPort, classLoader);
 
 		// prepare for changelog
 		changeRecordBuffer = new ArrayList<>();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/DynamicResult.java
@@ -18,10 +18,8 @@
 
 package org.apache.flink.table.client.gateway.local.result;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.client.gateway.local.ProgramDeployer;
 import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.types.Row;
 
 /**
  * A result of a dynamic table program.
@@ -37,11 +35,6 @@ public interface DynamicResult<C> extends Result<C> {
 	 * must be retrieved record-wise.
 	 */
 	boolean isMaterialized();
-
-	/**
-	 * Returns the output type as defined by the query.
-	 */
-	TypeInformation<Row> getOutputType();
 
 	/**
 	 * Starts the table program using the given deployer and monitors it's execution.

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResult.java
@@ -21,8 +21,7 @@ package org.apache.flink.table.client.gateway.local.result;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.common.accumulators.SerializedListAccumulator;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
@@ -45,7 +44,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements MaterializedResult<C> {
 
-	private final TypeInformation<Row> outputType;
 	private final String accumulatorName;
 	private final CollectBatchTableSink tableSink;
 	private final Object resultLock;
@@ -60,13 +58,12 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 
 	public MaterializedCollectBatchResult(
 			TableSchema tableSchema,
-			RowTypeInfo outputType,
 			ExecutionConfig config,
 			ClassLoader classLoader) {
-		this.outputType = outputType;
 
 		accumulatorName = new AbstractID().toString();
-		tableSink = new CollectBatchTableSink(accumulatorName, outputType.createSerializer(config), tableSchema);
+		TypeSerializer<Row> serializer = tableSchema.toRowType().createSerializer(config);
+		tableSink = new CollectBatchTableSink(accumulatorName, serializer, tableSchema);
 		resultLock = new Object();
 		this.classLoader = checkNotNull(classLoader);
 
@@ -76,11 +73,6 @@ public class MaterializedCollectBatchResult<C> extends BasicResult<C> implements
 	@Override
 	public boolean isMaterialized() {
 		return true;
-	}
-
-	@Override
-	public TypeInformation<Row> getOutputType() {
-		return outputType;
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResult.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.client.gateway.local.result;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
@@ -91,7 +90,6 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 
 	@VisibleForTesting
 	public MaterializedCollectStreamResult(
-			RowTypeInfo outputType,
 			TableSchema tableSchema,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
@@ -99,7 +97,7 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			int maxRowCount,
 			int overcommitThreshold,
 			ClassLoader classLoader) {
-		super(outputType, tableSchema, config, gatewayAddress, gatewayPort, classLoader);
+		super(tableSchema, config, gatewayAddress, gatewayPort, classLoader);
 
 		if (maxRowCount <= 0) {
 			this.maxRowCount = Integer.MAX_VALUE;
@@ -120,7 +118,6 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 	}
 
 	public MaterializedCollectStreamResult(
-			RowTypeInfo outputType,
 			TableSchema tableSchema,
 			ExecutionConfig config,
 			InetAddress gatewayAddress,
@@ -129,7 +126,6 @@ public class MaterializedCollectStreamResult<C> extends CollectStreamResult<C> i
 			ClassLoader classLoader) {
 
 		this(
-			outputType,
 			tableSchema,
 			config,
 			gatewayAddress,

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -429,7 +429,7 @@ public class LocalExecutorITCase extends TestLogger {
 			// start job and retrieval
 			final ResultDescriptor desc = executor.executeQuery(
 				sessionId,
-				"SELECT scalarUDF(IntegerField1), StringField1 FROM TableNumber1");
+				"SELECT scalarUDF(IntegerField1), StringField1, 'ABC' FROM TableNumber1");
 
 			assertFalse(desc.isMaterialized());
 
@@ -437,12 +437,12 @@ public class LocalExecutorITCase extends TestLogger {
 				retrieveChangelogResult(executor, sessionId, desc.getResultId());
 
 			final List<String> expectedResults = new ArrayList<>();
-			expectedResults.add("(true,47,Hello World)");
-			expectedResults.add("(true,27,Hello World)");
-			expectedResults.add("(true,37,Hello World)");
-			expectedResults.add("(true,37,Hello World)");
-			expectedResults.add("(true,47,Hello World)");
-			expectedResults.add("(true,57,Hello World!!!!)");
+			expectedResults.add("(true,47,Hello World,ABC)");
+			expectedResults.add("(true,27,Hello World,ABC)");
+			expectedResults.add("(true,37,Hello World,ABC)");
+			expectedResults.add("(true,37,Hello World,ABC)");
+			expectedResults.add("(true,47,Hello World,ABC)");
+			expectedResults.add("(true,57,Hello World!!!!,ABC)");
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
 		} finally {
@@ -507,15 +507,15 @@ public class LocalExecutorITCase extends TestLogger {
 		replaceVars.put("$VAR_UPDATE_MODE", "update-mode: append");
 		replaceVars.put("$VAR_MAX_ROWS", "100");
 
-		final String query = "SELECT scalarUDF(IntegerField1), StringField1 FROM TableNumber1";
+		final String query = "SELECT scalarUDF(IntegerField1), StringField1, 'ABC' FROM TableNumber1";
 
 		final List<String> expectedResults = new ArrayList<>();
-		expectedResults.add("47,Hello World");
-		expectedResults.add("27,Hello World");
-		expectedResults.add("37,Hello World");
-		expectedResults.add("37,Hello World");
-		expectedResults.add("47,Hello World");
-		expectedResults.add("57,Hello World!!!!");
+		expectedResults.add("47,Hello World,ABC");
+		expectedResults.add("27,Hello World,ABC");
+		expectedResults.add("37,Hello World,ABC");
+		expectedResults.add("37,Hello World,ABC");
+		expectedResults.add("47,Hello World,ABC");
+		expectedResults.add("57,Hello World!!!!,ABC");
 
 		executeStreamQueryTable(replaceVars, query, expectedResults);
 	}
@@ -596,19 +596,19 @@ public class LocalExecutorITCase extends TestLogger {
 		assertEquals("test-session", sessionId);
 
 		try {
-			final ResultDescriptor desc = executor.executeQuery(sessionId, "SELECT * FROM TestView1");
+			final ResultDescriptor desc = executor.executeQuery(sessionId, "SELECT *, 'ABC' FROM TestView1");
 
 			assertTrue(desc.isMaterialized());
 
 			final List<String> actualResults = retrieveTableResult(executor, sessionId, desc.getResultId());
 
 			final List<String> expectedResults = new ArrayList<>();
-			expectedResults.add("47");
-			expectedResults.add("27");
-			expectedResults.add("37");
-			expectedResults.add("37");
-			expectedResults.add("47");
-			expectedResults.add("57");
+			expectedResults.add("47,ABC");
+			expectedResults.add("27,ABC");
+			expectedResults.add("37,ABC");
+			expectedResults.add("37,ABC");
+			expectedResults.add("47,ABC");
+			expectedResults.add("57,ABC");
 
 			TestBaseUtils.compareResultCollections(expectedResults, actualResults, Comparator.naturalOrder());
 		} finally {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectStreamResultTest.java
@@ -19,9 +19,7 @@
 package org.apache.flink.table.client.gateway.local.result;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.gateway.TypedResult;
@@ -45,14 +43,12 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testSnapshot() throws UnknownHostException {
-		final RowTypeInfo type = new RowTypeInfo(Types.STRING, Types.LONG);
 		TableSchema tableSchema = TableSchema.builder().fields(
 				new String[]{"f0", "f1"}, new DataType[]{DataTypes.STRING(), DataTypes.BIGINT()}).build();
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {
 			result = new TestMaterializedCollectStreamResult<>(
-				type,
 				tableSchema,
 				new ExecutionConfig(),
 				InetAddress.getLocalHost(),
@@ -96,14 +92,12 @@ public class MaterializedCollectStreamResultTest {
 
 	@Test
 	public void testLimitedSnapshot() throws UnknownHostException {
-		final RowTypeInfo type = new RowTypeInfo(Types.STRING, Types.LONG);
 		TableSchema tableSchema = TableSchema.builder().fields(
 				new String[]{"f0", "f1"}, new DataType[]{DataTypes.STRING(), DataTypes.BIGINT()}).build();
 
 		TestMaterializedCollectStreamResult<?> result = null;
 		try {
 			result = new TestMaterializedCollectStreamResult<>(
-				type,
 				tableSchema,
 				new ExecutionConfig(),
 				InetAddress.getLocalHost(),
@@ -154,7 +148,6 @@ public class MaterializedCollectStreamResultTest {
 		public boolean isRetrieving;
 
 		public TestMaterializedCollectStreamResult(
-				RowTypeInfo outputType,
 				TableSchema tableSchema,
 				ExecutionConfig config,
 				InetAddress gatewayAddress,
@@ -163,7 +156,6 @@ public class MaterializedCollectStreamResultTest {
 				int overcommitThreshold) {
 
 			super(
-				outputType,
 				tableSchema,
 				config,
 				gatewayAddress,
@@ -174,7 +166,6 @@ public class MaterializedCollectStreamResultTest {
 		}
 
 		public TestMaterializedCollectStreamResult(
-				RowTypeInfo outputType,
 				TableSchema tableSchema,
 				ExecutionConfig config,
 				InetAddress gatewayAddress,
@@ -182,7 +173,6 @@ public class MaterializedCollectStreamResultTest {
 				int maxRowCount) {
 
 			super(
-				outputType,
 				tableSchema,
 				config,
 				gatewayAddress,


### PR DESCRIPTION
## What is the purpose of the change

Fix mismatch between a declared logical schema  with a declared physical schema of a `CollectStreamTableSink`.

## Brief change log

  - Do not pass around a `RowType` in sql-client as it contains duplicated information with `TableSchema`
  - Use legacy types in `CollectStreamTableSink#getTableSchema` via `CollectStreamTableSink#getFieldTypes` & `CollectStreamTableSink#getFieldNames`


## Verifying this change

Extended tests in `LocalExecutorITCase` to include a problematic `CHAR(3)` coming from a string literal in a result of a query.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
