### PR TITLE
[FLINK-15702][SQL]Make sqlClient classloader aligned with other components

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.client.ClientUtils;
 import org.apache.flink.client.cli.CliArgsException;
 import org.apache.flink.client.cli.CustomCommandLine;
 import org.apache.flink.client.cli.ExecutionConfigAccessor;
@@ -31,9 +32,7 @@ import org.apache.flink.client.deployment.ClusterClientServiceLoader;
 import org.apache.flink.client.deployment.ClusterDescriptor;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.core.plugin.TemporaryClassLoaderContext;
-import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.BatchQueryConfig;
@@ -97,6 +96,7 @@ import javax.annotation.Nullable;
 
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -152,13 +152,11 @@ public class ExecutionContext<ClusterID> {
 		this.flinkConfig = flinkConfig;
 
 		// create class loader
-		final String[] parentFirstLoaderPatterns = CoreOptions.getParentFirstLoaderPatterns(flinkConfig);
-		final String classloaderResolverOrder = flinkConfig.getString(CoreOptions.CLASSLOADER_RESOLVE_ORDER);
-		classLoader = FlinkUserCodeClassLoaders.create(
-			FlinkUserCodeClassLoaders.ResolveOrder.fromString(classloaderResolverOrder),
-			dependencies.toArray(new URL[dependencies.size()]),
+		classLoader = ClientUtils.buildUserCodeClassLoader(
+			dependencies,
+			Collections.emptyList(),
 			this.getClass().getClassLoader(),
-			parentFirstLoaderPatterns);
+			flinkConfig);
 
 		// Initialize the TableEnvironment.
 		initializeTableEnvironment(sessionState);


### PR DESCRIPTION
## What is the purpose of the change

Currently, Flink sqlClient still use hardcoded `parentFirst` classloader to load user specified jars and libraries, this is easily causing classes conflicts. In [FLINK-13749](https://issues.apache.org/jira/browse/FLINK-13749) , we already make the classloader consistent in both client and remote components.

So this PR will try to do the same for sqlClient, and make the classloaders consistent.


## Brief change log

  - *Make the classloader of sqlClient respecting the classloading policy and thus make it consistent with other flink components*

## Verifying this change

Can be verified by existing UT: *DependencyTest*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
