### PR TITLE
[FLINK-15636][python] Supports Python UDF in old planner under batch mode

### DIFF
--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -144,8 +144,6 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Currently, Python UDF is supported in Blink planner both under streaming and batch mode while is only supported under streaming mode in old planner.
-
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 
 The following example shows how to define your own Java and Python hash code functions, register them in the TableEnvironment, and call them in a query. Note that you can configure your scalar function via a constructor before it is registered:

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -144,8 +144,6 @@ $ python --version
 $ python -m pip install apache-beam==2.15.0
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Currently, Python UDF is supported in Blink planner both under streaming and batch mode while is only supported under streaming mode in old planner.
-
 It supports to use both Java/Scala scalar functions and Python scalar functions in Python Table API and SQL. In order to define a Python scalar function, one can extend the base class `ScalarFunction` in `pyflink.table.udf` and implement an evaluation method. The behavior of a Python scalar function is determined by the evaluation method. An evaluation method must be named `eval`. Evaluation method can also support variable arguments, such as `eval(*args)`.
 
 The following example shows how to define your own Java and Python hash code functions, register them in the TableEnvironment, and call them in a query. Note that you can configure your scalar function via a constructor before it is registered:

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -743,8 +743,6 @@ class TableEnvironment(object):
         :param function: The python user-defined function to register.
         :type function: pyflink.table.udf.UserDefinedFunctionWrapper
         """
-        if not self._is_blink_planner and isinstance(self, BatchTableEnvironment):
-            raise Exception("Python UDF is not supported in old planner under batch mode!")
         self._j_tenv.registerFunction(name, function._judf(self._is_blink_planner,
                                                            self.get_config()._j_table_config))
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonScalarFunctionFlatMap.java
@@ -64,7 +64,7 @@ public final class PythonScalarFunctionFlatMap
 
 	private static final long serialVersionUID = 1L;
 
-	protected static final Logger LOG = LoggerFactory.getLogger(PythonScalarFunctionFlatMap.class);
+	private static final Logger LOG = LoggerFactory.getLogger(PythonScalarFunctionFlatMap.class);
 
 	/**
 	 * The type serializer for the forwarded fields.
@@ -74,48 +74,48 @@ public final class PythonScalarFunctionFlatMap
 	/**
 	 * The Python {@link ScalarFunction}s to be executed.
 	 */
-	protected final PythonFunctionInfo[] scalarFunctions;
+	private final PythonFunctionInfo[] scalarFunctions;
 
 	/**
 	 * The input logical type.
 	 */
-	protected final RowType inputType;
+	private final RowType inputType;
 
 	/**
 	 * The output logical type.
 	 */
-	protected final RowType outputType;
+	private final RowType outputType;
 
 	/**
 	 * The offsets of udf inputs.
 	 */
-	protected final int[] udfInputOffsets;
+	private final int[] udfInputOffsets;
 
 	/**
 	 * The offset of the fields which should be forwarded.
 	 */
-	protected final int[] forwardedFields;
+	private final int[] forwardedFields;
 
 	/**
 	 * The udf input logical type.
 	 */
-	protected transient RowType udfInputType;
+	private transient RowType udfInputType;
 
 	/**
 	 * The udf output logical type.
 	 */
-	protected transient RowType udfOutputType;
+	private transient RowType udfOutputType;
 
 	/**
 	 * The queue holding the input elements for which the execution results have not been received.
 	 */
-	protected transient LinkedBlockingQueue<Row> forwardedInputQueue;
+	private transient LinkedBlockingQueue<Row> forwardedInputQueue;
 
 	/**
 	 * The queue holding the user-defined function execution results. The execution results are in
 	 * the same order as the input elements.
 	 */
-	protected transient LinkedBlockingQueue<Row> udfResultQueue;
+	private transient LinkedBlockingQueue<Row> udfResultQueue;
 
 	/**
 	 * The python config.
@@ -202,7 +202,6 @@ public final class PythonScalarFunctionFlatMap
 
 		this.pythonFunctionRunner = createPythonFunctionRunner();
 		this.pythonFunctionRunner.open();
-		this.resultCollector = null;
 	}
 
 	@Override
@@ -226,7 +225,7 @@ public final class PythonScalarFunctionFlatMap
 	}
 
 	/**
-	 * Checks whether to invoke finishBundle by elements count. Called in processElement.
+	 * Checks whether to invoke finishBundle by elements count. Called in flatMap.
 	 */
 	private void checkInvokeFinishBundleByCount() throws Exception {
 		elementCount++;

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonScalarFunctionFlatMap.java
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.python.PythonConfig;
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.PythonOptions;
+import org.apache.flink.python.env.ProcessPythonEnvironmentManager;
+import org.apache.flink.python.env.PythonDependencyInfo;
+import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.python.PythonEnv;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.runners.python.PythonScalarFunctionRunner;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link RichFlatMapFunction} used to invoke Python {@link ScalarFunction} functions for the
+ * old planner.
+ */
+@Internal
+public final class PythonScalarFunctionFlatMap
+		extends RichFlatMapFunction<Row, Row> implements ResultTypeQueryable<Row> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected static final Logger LOG = LoggerFactory.getLogger(PythonScalarFunctionFlatMap.class);
+
+	/**
+	 * The type serializer for the forwarded fields.
+	 */
+	private transient TypeSerializer<Row> forwardedInputSerializer;
+
+	/**
+	 * The Python {@link ScalarFunction}s to be executed.
+	 */
+	protected final PythonFunctionInfo[] scalarFunctions;
+
+	/**
+	 * The input logical type.
+	 */
+	protected final RowType inputType;
+
+	/**
+	 * The output logical type.
+	 */
+	protected final RowType outputType;
+
+	/**
+	 * The offsets of udf inputs.
+	 */
+	protected final int[] udfInputOffsets;
+
+	/**
+	 * The offset of the fields which should be forwarded.
+	 */
+	protected final int[] forwardedFields;
+
+	/**
+	 * The udf input logical type.
+	 */
+	protected transient RowType udfInputType;
+
+	/**
+	 * The udf output logical type.
+	 */
+	protected transient RowType udfOutputType;
+
+	/**
+	 * The queue holding the input elements for which the execution results have not been received.
+	 */
+	protected transient LinkedBlockingQueue<Row> forwardedInputQueue;
+
+	/**
+	 * The queue holding the user-defined function execution results. The execution results are in
+	 * the same order as the input elements.
+	 */
+	protected transient LinkedBlockingQueue<Row> udfResultQueue;
+
+	/**
+	 * The python config.
+	 */
+	private final PythonConfig config;
+
+	/**
+	 * Use an AtomicBoolean because we start/stop bundles by a timer thread.
+	 */
+	private transient AtomicBoolean bundleStarted;
+
+	/**
+	 * Max number of elements to include in a bundle.
+	 */
+	private transient int maxBundleSize;
+
+	/**
+	 * The collector used to collect records.
+	 */
+	private transient Collector<Row> resultCollector;
+
+	/**
+	 * Number of processed elements in the current bundle.
+	 */
+	private transient int elementCount;
+
+	/**
+	 * The {@link PythonFunctionRunner} which is responsible for Python user-defined function execution.
+	 */
+	private transient PythonFunctionRunner<Row> pythonFunctionRunner;
+
+	public PythonScalarFunctionFlatMap(
+		Configuration config,
+		PythonFunctionInfo[] scalarFunctions,
+		RowType inputType,
+		RowType outputType,
+		int[] udfInputOffsets,
+		int[] forwardedFields) {
+		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
+		this.inputType = Preconditions.checkNotNull(inputType);
+		this.outputType = Preconditions.checkNotNull(outputType);
+		this.udfInputOffsets = Preconditions.checkNotNull(udfInputOffsets);
+		this.forwardedFields = Preconditions.checkNotNull(forwardedFields);
+		this.config = new PythonConfig(Preconditions.checkNotNull(config));
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		this.elementCount = 0;
+		this.bundleStarted = new AtomicBoolean(false);
+		this.maxBundleSize = config.getMaxBundleSize();
+		if (this.maxBundleSize <= 0) {
+			this.maxBundleSize = PythonOptions.MAX_BUNDLE_SIZE.defaultValue();
+			LOG.error("Invalid value for the maximum bundle size. Using default value of " +
+				this.maxBundleSize + '.');
+		} else {
+			LOG.info("The maximum bundle size is configured to {}.", this.maxBundleSize);
+		}
+
+		if (config.getMaxBundleTimeMills() != PythonOptions.MAX_BUNDLE_TIME_MILLS.defaultValue()) {
+			LOG.info("Maximum bundle time takes no effect in old planner under batch mode. " +
+				"Config maximum bundle size instead! " +
+				"Under batch mode, bundle size should be enough to control both throughput and latency.");
+		}
+
+		forwardedInputQueue = new LinkedBlockingQueue<>();
+		udfResultQueue = new LinkedBlockingQueue<>();
+		udfInputType = new RowType(
+			Arrays.stream(udfInputOffsets)
+				.mapToObj(i -> inputType.getFields().get(i))
+				.collect(Collectors.toList()));
+		udfOutputType = new RowType(outputType.getFields().subList(forwardedFields.length, outputType.getFieldCount()));
+
+		RowTypeInfo forwardedInputTypeInfo = new RowTypeInfo(
+			Arrays.stream(forwardedFields)
+				.mapToObj(i -> inputType.getFields().get(i))
+				.map(RowType.RowField::getType)
+				.map(TypeConversions::fromLogicalToDataType)
+				.map(TypeConversions::fromDataTypeToLegacyInfo)
+				.toArray(TypeInformation[]::new));
+		forwardedInputSerializer = forwardedInputTypeInfo.createSerializer(getRuntimeContext().getExecutionConfig());
+
+		this.pythonFunctionRunner = createPythonFunctionRunner();
+		this.pythonFunctionRunner.open();
+		this.resultCollector = null;
+	}
+
+	@Override
+	public void flatMap(Row value, Collector<Row> out) throws Exception {
+		this.resultCollector = out;
+		bufferInput(value);
+
+		checkInvokeStartBundle();
+		pythonFunctionRunner.processElement(getUdfInput(value));
+		checkInvokeFinishBundleByCount();
+		emitResults();
+	}
+
+	/**
+	 * Checks whether to invoke startBundle.
+	 */
+	private void checkInvokeStartBundle() throws Exception {
+		if (bundleStarted.compareAndSet(false, true)) {
+			pythonFunctionRunner.startBundle();
+		}
+	}
+
+	/**
+	 * Checks whether to invoke finishBundle by elements count. Called in processElement.
+	 */
+	private void checkInvokeFinishBundleByCount() throws Exception {
+		elementCount++;
+		if (elementCount >= maxBundleSize) {
+			invokeFinishBundle();
+		}
+	}
+
+	private void invokeFinishBundle() throws Exception {
+		if (bundleStarted.compareAndSet(true, false)) {
+			pythonFunctionRunner.finishBundle();
+			emitResults();
+			elementCount = 0;
+		}
+	}
+
+	private Row getUdfInput(Row element) {
+		return Row.project(element, udfInputOffsets);
+	}
+
+	private PythonEnv getPythonEnv() {
+		return scalarFunctions[0].getPythonFunction().getPythonEnv();
+	}
+
+	private PythonFunctionRunner<Row> createPythonFunctionRunner() throws IOException {
+		FnDataReceiver<Row> udfResultReceiver = input -> {
+			// handover to queue, do not block the result receiver thread
+			udfResultQueue.put(input);
+		};
+
+		return new PythonScalarFunctionRunner(
+			getRuntimeContext().getTaskName(),
+			udfResultReceiver,
+			scalarFunctions,
+			createPythonEnvironmentManager(),
+			udfInputType,
+			udfOutputType);
+	}
+
+	private PythonEnvironmentManager createPythonEnvironmentManager() throws IOException {
+		PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(
+			config, getRuntimeContext().getDistributedCache());
+		PythonEnv pythonEnv = getPythonEnv();
+		if (pythonEnv.getExecType() == PythonEnv.ExecType.PROCESS) {
+			return new ProcessPythonEnvironmentManager(
+				dependencyInfo,
+				ConfigurationUtils.splitPaths(System.getProperty("java.io.tmpdir")),
+				System.getenv());
+		} else {
+			throw new UnsupportedOperationException(String.format(
+				"Execution type '%s' is not supported.", pythonEnv.getExecType()));
+		}
+	}
+
+	private void bufferInput(Row input) {
+		Row forwardedFieldsRow = Row.project(input, forwardedFields);
+		if (getRuntimeContext().getExecutionConfig().isObjectReuseEnabled()) {
+			forwardedFieldsRow = forwardedInputSerializer.copy(forwardedFieldsRow);
+		}
+		forwardedInputQueue.add(forwardedFieldsRow);
+	}
+
+	private void emitResults() {
+		Row udfResult;
+		while ((udfResult = udfResultQueue.poll()) != null) {
+			Row input = forwardedInputQueue.poll();
+			this.resultCollector.collect(Row.join(input, udfResult));
+		}
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return (TypeInformation<Row>) LegacyTypeInfoDataTypeConverter
+			.toLegacyTypeInfo(LogicalTypeDataTypeConverter.toDataType(outputType));
+	}
+
+	@Override
+	public void close() throws Exception {
+		try {
+			invokeFinishBundle();
+
+			if (pythonFunctionRunner != null) {
+				pythonFunctionRunner.close();
+				pythonFunctionRunner = null;
+			}
+		} finally {
+			super.close();
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/BatchOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/BatchOptimizer.scala
@@ -54,7 +54,8 @@ class BatchOptimizer(
     val decorPlan = RelDecorrelator.decorrelateQuery(expandedPlan)
     val normalizedPlan = optimizeNormalizeLogicalPlan(decorPlan)
     val logicalPlan = optimizeLogicalPlan(normalizedPlan)
-    optimizePhysicalPlan(logicalPlan, FlinkConventions.DATASET)
+    val logicalRewritePlan = optimizeLogicalRewritePlan(logicalPlan)
+    optimizePhysicalPlan(logicalRewritePlan, FlinkConventions.DATASET)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -97,7 +97,7 @@ trait CommonPythonCalc {
       .toArray
   }
 
-  private [flink] def getForwardFields(calcProgram: RexProgram): Array[Int] = {
+  private[flink] def getForwardedFields(calcProgram: RexProgram): Array[Int] = {
     calcProgram.getProjectList
       .map(calcProgram.expandLocalRef)
       .collect { case inputRef: RexInputRef => inputRef.getIndex }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.plan.nodes
 
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexLiteral, RexNode}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexLiteral, RexNode, RexProgram}
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo, SimplePythonFunction}
@@ -88,5 +88,19 @@ trait CommonPythonCalc {
           sfc.getScalarFunction.asInstanceOf[PythonFunction].getPythonEnv)
         new PythonFunctionInfo(pythonFunction, inputs.toArray)
     }
+  }
+
+  private[flink] def getPythonRexCalls(calcProgram: RexProgram): Array[RexCall] = {
+    calcProgram.getProjectList
+      .map(calcProgram.expandLocalRef)
+      .collect { case call: RexCall => call }
+      .toArray
+  }
+
+  private [flink] def getForwardFields(calcProgram: RexProgram): Array[Int] = {
+    calcProgram.getProjectList
+      .map(calcProgram.expandLocalRef)
+      .collect { case inputRef: RexInputRef => inputRef.getIndex }
+      .toArray
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCalc.scala
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.plan.nodes.dataset
 
-import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.Calc
-import org.apache.calcite.rel.metadata.RelMetadataQuery
-import org.apache.calcite.rel.{RelNode, RelWriter}
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex._
 import org.apache.flink.api.common.functions.FlatMapFunction
 import org.apache.flink.api.java.DataSet
@@ -31,7 +30,6 @@ import org.apache.flink.table.api.BatchQueryConfig
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.codegen.FunctionCodeGenerator
-import org.apache.flink.table.plan.nodes.CommonCalc
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.runtime.FlatMapRunner
 import org.apache.flink.types.Row
@@ -40,7 +38,6 @@ import scala.collection.JavaConverters._
 
 /**
   * Flink RelNode which matches along with LogicalCalc.
-  *
   */
 class DataSetCalc(
     cluster: RelOptCluster,
@@ -49,38 +46,16 @@ class DataSetCalc(
     rowRelDataType: RelDataType,
     calcProgram: RexProgram,
     ruleDescription: String)
-  extends Calc(cluster, traitSet, input, calcProgram)
-  with CommonCalc
-  with DataSetRel {
-
-  override def deriveRowType(): RelDataType = rowRelDataType
+  extends DataSetCalcBase(
+    cluster,
+    traitSet,
+    input,
+    rowRelDataType,
+    calcProgram,
+    ruleDescription) {
 
   override def copy(traitSet: RelTraitSet, child: RelNode, program: RexProgram): Calc = {
     new DataSetCalc(cluster, traitSet, child, getRowType, program, ruleDescription)
-  }
-
-  override def toString: String = calcToString(calcProgram, getExpressionString)
-
-  override def explainTerms(pw: RelWriter): RelWriter = {
-    pw.input("input", getInput)
-      .item("select", selectionToString(calcProgram, getExpressionString))
-      .itemIf("where",
-        conditionToString(calcProgram, getExpressionString),
-        calcProgram.getCondition != null)
-  }
-
-  override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
-    val child = this.getInput
-    val rowCnt = metadata.getRowCount(child)
-
-    computeSelfCost(calcProgram, planner, rowCnt)
-  }
-
-  override def estimateRowCount(metadata: RelMetadataQuery): Double = {
-    val child = this.getInput
-    val rowCnt = metadata.getRowCount(child)
-
-    estimateRowCount(calcProgram, rowCnt)
   }
 
   override def translateToPlan(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCalcBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetCalcBase.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.dataset
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptCost, RelOptPlanner, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, RelWriter}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.Calc
+import org.apache.calcite.rel.metadata.RelMetadataQuery
+import org.apache.calcite.rex.RexProgram
+import org.apache.flink.table.plan.nodes.CommonCalc
+
+/**
+  * Base RelNode for data set calc.
+  */
+abstract class DataSetCalcBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    rowRelDataType: RelDataType,
+    calcProgram: RexProgram,
+    ruleDescription: String)
+  extends Calc(cluster, traitSet, input, calcProgram)
+  with CommonCalc
+  with DataSetRel {
+
+  override def deriveRowType(): RelDataType = rowRelDataType
+
+  override def toString: String = calcToString(calcProgram, getExpressionString)
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    pw.input("input", getInput)
+      .item("select", selectionToString(calcProgram, getExpressionString))
+      .itemIf("where",
+        conditionToString(calcProgram, getExpressionString),
+        calcProgram.getCondition != null)
+  }
+
+  override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {
+    val child = this.getInput
+    val rowCnt = metadata.getRowCount(child)
+
+    computeSelfCost(calcProgram, planner, rowCnt)
+  }
+
+  override def estimateRowCount(metadata: RelMetadataQuery): Double = {
+    val child = this.getInput
+    val rowCnt = metadata.getRowCount(child)
+
+    estimateRowCount(calcProgram, rowCnt)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -72,7 +72,7 @@ class DataSetPythonCalc(
     val inputDS = getInput.asInstanceOf[DataSetRel].translateToPlan(tableEnv, queryConfig)
 
     val flatMapFunctionResultTypeInfo = new RowTypeInfo(
-      getForwardFields(calcProgram).map(inputSchema.fieldTypeInfos.get(_)) ++
+      getForwardedFields(calcProgram).map(inputSchema.fieldTypeInfos.get(_)) ++
         getPythonRexCalls(calcProgram).map(node => FlinkTypeFactory.toTypeInfo(node.getType)): _*)
 
     // construct the Python ScalarFunction flatMap function
@@ -110,7 +110,7 @@ class DataSetPythonCalc(
       inputRowType,
       outputRowType,
       udfInputOffsets,
-      getForwardFields(calcProgram))
+      getForwardedFields(calcProgram))
       .asInstanceOf[RichFlatMapFunction[Row, Row]]
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -79,7 +79,7 @@ class DataStreamPythonCalc(
     val inputParallelism = inputDataStream.getParallelism
 
     val pythonOperatorResultTypeInfo = new RowTypeInfo(
-      getForwardFields(calcProgram).map(inputSchema.fieldTypeInfos.get(_)) ++
+      getForwardedFields(calcProgram).map(inputSchema.fieldTypeInfos.get(_)) ++
         getPythonRexCalls(calcProgram).map(node => FlinkTypeFactory.toTypeInfo(node.getType)): _*)
 
     // construct the Python operator
@@ -123,7 +123,7 @@ class DataStreamPythonCalc(
       inputRowType,
       outputRowType,
       udfInputOffsets,
-      getForwardFields(calcProgram))
+      getForwardedFields(calcProgram))
       .asInstanceOf[OneInputStreamOperator[CRow, CRow]]
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -196,6 +196,7 @@ object FlinkRuleSets {
     DataSetAggregateRule.INSTANCE,
     DataSetDistinctRule.INSTANCE,
     DataSetCalcRule.INSTANCE,
+    DataSetPythonCalcRule.INSTANCE,
     DataSetJoinRule.INSTANCE,
     DataSetSingleRowJoinRule.INSTANCE,
     DataSetScanRule.INSTANCE,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetPythonCalcRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetPythonCalcRule.scala
@@ -22,23 +22,23 @@ import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.flink.table.plan.nodes.FlinkConventions
-import org.apache.flink.table.plan.nodes.dataset.DataSetCalc
+import org.apache.flink.table.plan.nodes.dataset.DataSetPythonCalc
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc
 import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
 
 import scala.collection.JavaConverters._
 
-class DataSetCalcRule
+class DataSetPythonCalcRule
   extends ConverterRule(
     classOf[FlinkLogicalCalc],
     FlinkConventions.LOGICAL,
     FlinkConventions.DATASET,
-    "DataSetCalcRule") {
+    "DataSetPythonCalcRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    !program.getExprList.asScala.exists(containsPythonCall)
+    program.getExprList.asScala.exists(containsPythonCall)
   }
 
   def convert(rel: RelNode): RelNode = {
@@ -46,16 +46,16 @@ class DataSetCalcRule
     val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASET)
     val convInput: RelNode = RelOptRule.convert(calc.getInput, FlinkConventions.DATASET)
 
-    new DataSetCalc(
+    new DataSetPythonCalc(
       rel.getCluster,
       traitSet,
       convInput,
       rel.getRowType,
       calc.getProgram,
-      "DataSetCalcRule")
+      "DataSetPythonCalcRule")
   }
 }
 
-object DataSetCalcRule {
-  val INSTANCE: RelOptRule = new DataSetCalcRule
+object DataSetPythonCalcRule {
+  val INSTANCE: RelOptRule = new DataSetPythonCalcRule
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -266,26 +266,4 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
     util.verifyTable(resultTable, expected)
   }
-
-  @Test
-  def testSplitRuleForBatch(): Unit = {
-    val util = batchTestUtil()
-    val table = util.addTable[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
-    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
-
-    val resultTable = table
-      .select("pyFunc1(a, b) + 1")
-
-    val expected = unaryNode(
-      "DataSetCalc",
-      unaryNode(
-        "DataSetPythonCalc",
-        batchTableNode(table),
-        term("select", "pyFunc1(a, b) AS f0")
-      ),
-      term("select", "+(f0, 1) AS _c0")
-    )
-
-    util.verifyTable(resultTable, expected)
-  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -266,4 +266,26 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
     util.verifyTable(resultTable, expected)
   }
+
+  @Test
+  def testSplitRuleForBatch(): Unit = {
+    val util = batchTestUtil()
+    val table = util.addTable[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table
+      .select("pyFunc1(a, b) + 1")
+
+    val expected = unaryNode(
+      "DataSetCalc",
+      unaryNode(
+        "DataSetPythonCalc",
+        batchTableNode(table),
+        term("select", "pyFunc1(a, b) AS f0")
+      ),
+      term("select", "+(f0, 1) AS _c0")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

Currently, Python UDF has been supported under old planner(only stream) and blink planner(stream&batch). This pull request dedicates to add Python UDF support in old planner under batch mode.


## Brief change log

  - Add rules to convert RelNode to DataSetPythonCalc Node.
  - Add PythonScalarFunctionFlatMap function to invoke Python ScalarFunctions for the legacy planner.
  - Add IT Tests.

## Verifying this change

This change added tests and can be verified as follows:

  - Added integration tests for Python UDF(test_udf.test_chaining_scalar_function) and dependency management(test_dependency.test_add_python_file).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
