### PR TITLE
[FLINK-15684][docs][bp-1.10] Add taskmanager.memory.flink.size to common options

### DIFF
--- a/docs/_includes/generated/common_section.html
+++ b/docs/_includes/generated/common_section.html
@@ -15,10 +15,16 @@
             <td>JVM heap size for the JobManager.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.memory.flink.size</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>MemorySize</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory. See also 'taskmanager.memory.process.size' for total process memory size configuration.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.memory.process.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
+            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory (configured with 'taskmanager.memory.flink.size'), JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
         </tr>
         <tr>
             <td><h5>parallelism.default</h5></td>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>taskmanager.memory.flink.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory.</td>
+            <td>Total Flink Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory. See also 'taskmanager.memory.process.size' for total process memory size configuration.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.framework.heap.size</h5></td>
@@ -84,7 +84,7 @@
             <td><h5>taskmanager.memory.process.size</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>MemorySize</td>
-            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
+            <td>Total Process Memory size for the TaskExecutors. This includes all the memory that a TaskExecutor consumes, consisting of Total Flink Memory (configured with 'taskmanager.memory.flink.size'), JVM Metaspace, and JVM Overhead. On containerized setups, this should be set to the container memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.segment-size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -257,20 +257,25 @@ public class TaskManagerOptions {
 		key("taskmanager.memory.process.size")
 			.memoryType()
 			.noDefaultValue()
-			.withDescription("Total Process Memory size for the TaskExecutors. This includes all the memory that a"
-				+ " TaskExecutor consumes, consisting of Total Flink Memory, JVM Metaspace, and JVM Overhead. On"
-				+ " containerized setups, this should be set to the container memory.");
+			.withDescription("Total Process Memory size for the TaskExecutors. This includes all the memory that a "
+				+ "TaskExecutor consumes, consisting of Total Flink Memory (configured with "
+				+ "'taskmanager.memory.flink.size'), JVM Metaspace, and JVM Overhead. On "
+				+ "containerized setups, this should be set to the container memory."
+			);
 
 	/**
 	 * Total Flink Memory size for the TaskExecutors.
 	 */
+	@Documentation.CommonOption(position = Documentation.CommonOption.POSITION_MEMORY)
 	public static final ConfigOption<MemorySize> TOTAL_FLINK_MEMORY =
 		key("taskmanager.memory.flink.size")
-		.memoryType()
-		.noDefaultValue()
-		.withDescription("Total Flink Memory size for the TaskExecutors. This includes all the memory that a"
-			+ " TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of Framework Heap Memory,"
-			+ " Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network Memory.");
+			.memoryType()
+			.noDefaultValue()
+			.withDescription(String.format("Total Flink Memory size for the TaskExecutors. This includes all the "
+					+ "memory that a TaskExecutor consumes, except for JVM Metaspace and JVM Overhead. It consists of "
+					+ "Framework Heap Memory, Task Heap Memory, Task Off-Heap Memory, Managed Memory, and Network "
+					+ "Memory. See also '%s' for total process memory size configuration.",
+				TOTAL_PROCESS_MEMORY.key()));
 
 	/**
 	 * Framework Heap Memory size for TaskExecutors.


### PR DESCRIPTION
## What is the purpose of the change

Add `taskmanager.memory.flink.size` to common options.

Backport of #10916 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
