### PR TITLE
[FLINK-15691][tests] Remove runInTaskExecutorThreadAndWait()

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -72,6 +72,7 @@ import org.apache.flink.util.function.TriConsumer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -101,9 +102,9 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 	private static final Time timeout = Time.seconds(10L);
 
-	private static final TestingRpcService RPC = new TestingRpcService();
+	private static TestingRpcService RPC;
 
-	private static final MetricRegistryImpl metricRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
+	private static MetricRegistryImpl metricRegistry;
 
 	private String metricQueryServiceAddress;
 
@@ -126,6 +127,12 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 	@After
 	public void shutdown() {
 		RPC.clearGateways();
+	}
+
+	@BeforeClass
+	public static void setupClass() {
+		RPC = new TestingRpcService();
+		metricRegistry = new MetricRegistryImpl(MetricRegistryConfiguration.defaultMetricRegistryConfiguration());
 	}
 
 	@AfterClass


### PR DESCRIPTION
Removes `TaskExecutorPartitionLifecycleTest#runInTaskExecutorThreadAndWait()` and refactors existing usages.

The method did not achieve the desired effect of running the action in the TE main thread. Given that the test has not shown instabilities despite this we can conclude that these actions can just be executed in the tests main thread instead.

Additionally, this test removes/replaces accesses to the JobManagerTable of the TaskExecutor.
The first access was removed since it is not really necessary since it effectively verified the test setup.
The second access was replaced with a check for whether the disconnect-from-JM future has been completed, which _should_ behave the same way.