### PR TITLE
[FLINK-15276] Update CLI documentation to reflect the addition of the ExecutorCLI

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -293,9 +293,9 @@ Action "run" compiles and runs a program.
   Syntax: run [OPTIONS] <jar-file> <arguments>
   "run" action options:
      -c,--class <classname>               Class with the program entry point
-                                          ("main()" method or "getPlan()" method).
-                                          Only needed if the JAR file does not
-                                          specify the class in its manifest.
+                                          ("main()" method). Only needed if the
+                                          JAR file does not specify the class in
+                                          its manifest.
      -C,--classpath <url>                 Adds a URL to each user code
                                           classloader  on all nodes in the
                                           cluster. The paths must specify a
@@ -384,7 +384,7 @@ Action "run" compiles and runs a program.
                                           if the optional parameter exists
                                           (e.g.: --pyRequirements
                                           file:///tmp/requirements.txt#file:///t
-                                          mp/cached_dir).                                                                          
+                                          mp/cached_dir).
      -q,--sysoutLogging                   If present, suppress logging output to
                                           standard out.
      -s,--fromSavepoint <savepointPath>   Path to a savepoint to restore the job
@@ -403,11 +403,6 @@ Action "run" compiles and runs a program.
                                           connect to a different JobManager than
                                           the one specified in the
                                           configuration.
-     -sae,--shutdownOnAttachedExit        If the job is submitted in attached
-                                          mode, perform a best-effort cluster
-                                          shutdown when the CLI is terminated
-                                          abruptly, e.g., in response to a user
-                                          interrupt, such as typing Ctrl + C.
      -yat,--yarnapplicationType <arg>     Set a custom application type for the
                                           application on YARN
      -yD <property=value>                 use value for given property
@@ -417,8 +412,10 @@ Action "run" compiles and runs a program.
      -yh,--yarnhelp                       Help for the Yarn session CLI.
      -yid,--yarnapplicationId <arg>       Attach to running YARN session
      -yj,--yarnjar <arg>                  Path to Flink jar file
-     -yjm,--yarnjobManagerMemory <arg>    Memory for JobManager Container
-                                          with optional unit (default: MB)
+     -yjm,--yarnjobManagerMemory <arg>    Memory for JobManager Container with
+                                          optional unit (default: MB)
+     -ynl,--yarnnodeLabel <arg>           Specify YARN node label for the YARN
+                                          application
      -ynm,--yarnname <arg>                Set a custom name for the application
                                           on YARN
      -yq,--yarnquery                      Display available YARN resources
@@ -426,16 +423,19 @@ Action "run" compiles and runs a program.
      -yqu,--yarnqueue <arg>               Specify YARN queue.
      -ys,--yarnslots <arg>                Number of slots per TaskManager
      -yt,--yarnship <arg>                 Ship files in the specified directory
-                                          (t for transfer), multiple options are 
-                                          supported.
-     -ytm,--yarntaskManagerMemory <arg>   Memory per TaskManager Container
-                                          with optional unit (default: MB)
+                                          (t for transfer)
+     -ytm,--yarntaskManagerMemory <arg>   Memory per TaskManager Container with
+                                          optional unit (default: MB)
      -yz,--yarnzookeeperNamespace <arg>   Namespace to create the Zookeeper
                                           sub-paths for high availability mode
-     -ynl,--yarnnodeLabel <arg>           Specify YARN node label for 
-                                          the YARN application 
      -z,--zookeeperNamespace <arg>        Namespace to create the Zookeeper
                                           sub-paths for high availability mode
+
+  Options for executor mode:
+     -D <property=value>   use value for given property
+     -e,--executor <arg>   The name of the executor to be used for executing the
+                           given job, e.g. "local". This is equivalent to the
+                           "execution.target" config option.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -451,10 +451,10 @@ Action "info" shows the optimized execution plan of the program (JSON).
 
   Syntax: info [OPTIONS] <jar-file> <arguments>
   "info" action options:
-     -c,--class <classname>           Class with the program entry point ("main()"
-                                      method or "getPlan()" method). Only needed
-                                      if the JAR file does not specify the class
-                                      in its manifest.
+     -c,--class <classname>           Class with the program entry point
+                                      ("main()" method). Only needed if the JAR
+                                      file does not specify the class in its
+                                      manifest.
      -p,--parallelism <parallelism>   The parallelism with which to run the
                                       program. Optional flag to override the
                                       default value specified in the
@@ -465,6 +465,7 @@ Action "list" lists running and scheduled programs.
 
   Syntax: list [OPTIONS]
   "list" action options:
+     -a,--all         Show all programs and their JobIDs
      -r,--running     Show only running programs and their JobIDs
      -s,--scheduled   Show only scheduled programs and their JobIDs
   Options for yarn-cluster mode:
@@ -475,6 +476,12 @@ Action "list" lists running and scheduled programs.
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
+
+  Options for executor mode:
+     -D <property=value>   use value for given property
+     -e,--executor <arg>   The name of the executor to be used for executing the
+                           given job, e.g. "local". This is equivalent to the
+                           "execution.target" config option.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -505,6 +512,12 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
+
+  Options for executor mode:
+     -D <property=value>   use value for given property
+     -e,--executor <arg>   The name of the executor to be used for executing the
+                           given job, e.g. "local". This is equivalent to the
+                           "execution.target" config option.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -537,6 +550,12 @@ Action "cancel" cancels a running program.
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
 
+  Options for executor mode:
+     -D <property=value>   use value for given property
+     -e,--executor <arg>   The name of the executor to be used for executing the
+                           given job, e.g. "local". This is equivalent to the
+                           "execution.target" config option.
+
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
                                      to connect. Use this flag to connect to a
@@ -561,6 +580,12 @@ Action "savepoint" triggers savepoints for a running job or disposes existing on
      -yid,--yarnapplicationId <arg>   Attach to running YARN session
      -z,--zookeeperNamespace <arg>    Namespace to create the Zookeeper
                                       sub-paths for high availability mode
+
+  Options for executor mode:
+     -D <property=value>   use value for given property
+     -e,--executor <arg>   The name of the executor to be used for executing the
+                           given job, e.g. "local". This is equivalent to the
+                           "execution.target" config option.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -432,10 +432,16 @@ Action "run" compiles and runs a program.
                                           sub-paths for high availability mode
 
   Options for executor mode:
-     -D <property=value>   use value for given property
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
      -e,--executor <arg>   The name of the executor to be used for executing the
-                           given job, e.g. "local". This is equivalent to the
-                           "execution.target" config option.
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: remote, local,
+                           kubernetes-session, yarn-per-job, yarn-session.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -478,10 +484,16 @@ Action "list" lists running and scheduled programs.
                                       sub-paths for high availability mode
 
   Options for executor mode:
-     -D <property=value>   use value for given property
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
      -e,--executor <arg>   The name of the executor to be used for executing the
-                           given job, e.g. "local". This is equivalent to the
-                           "execution.target" config option.
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: remote, local,
+                           kubernetes-session, yarn-per-job, yarn-session.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -514,10 +526,16 @@ Action "stop" stops a running program with a savepoint (streaming jobs only).
                                       sub-paths for high availability mode
 
   Options for executor mode:
-     -D <property=value>   use value for given property
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
      -e,--executor <arg>   The name of the executor to be used for executing the
-                           given job, e.g. "local". This is equivalent to the
-                           "execution.target" config option.
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: remote, local,
+                           kubernetes-session, yarn-per-job, yarn-session.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -551,10 +569,16 @@ Action "cancel" cancels a running program.
                                       sub-paths for high availability mode
 
   Options for executor mode:
-     -D <property=value>   use value for given property
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
      -e,--executor <arg>   The name of the executor to be used for executing the
-                           given job, e.g. "local". This is equivalent to the
-                           "execution.target" config option.
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: remote, local,
+                           kubernetes-session, yarn-per-job, yarn-session.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which
@@ -582,10 +606,16 @@ Action "savepoint" triggers savepoints for a running job or disposes existing on
                                       sub-paths for high availability mode
 
   Options for executor mode:
-     -D <property=value>   use value for given property
+     -D <property=value>   Generic configuration options for
+                           execution/deployment and for the configured executor.
+                           The available options can be found at
+                           https://ci.apache.org/projects/flink/flink-docs-stabl
+                           e/ops/config.html
      -e,--executor <arg>   The name of the executor to be used for executing the
-                           given job, e.g. "local". This is equivalent to the
-                           "execution.target" config option.
+                           given job, which is equivalent to the
+                           "execution.target" config option. The currently
+                           available executors are: remote, local,
+                           kubernetes-session, yarn-per-job, yarn-session.
 
   Options for default mode:
      -m,--jobmanager <arg>           Address of the JobManager (master) to which

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -44,7 +44,7 @@ public class CliFrontendParser {
 	static final Option JAR_OPTION = new Option("j", "jarfile", true, "Flink program JAR file.");
 
 	static final Option CLASS_OPTION = new Option("c", "class", true,
-			"Class with the program entry point (\"main()\" method or \"getPlan()\" method). Only needed if the " +
+			"Class with the program entry point (\"main()\" method). Only needed if the " +
 			"JAR file does not specify the class in its manifest.");
 
 	static final Option CLASSPATH_OPTION = new Option("C", "classpath", true, "Adds a URL to each user code " +

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
@@ -24,9 +24,6 @@ import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
 import org.apache.flink.core.execution.PipelineExecutor;
-import org.apache.flink.core.execution.PipelineExecutorFactory;
-
-import org.apache.flink.shaded.guava18.com.google.common.base.Joiner;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Option;
@@ -34,8 +31,8 @@ import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -55,9 +52,7 @@ public class ExecutorCLI implements CustomCommandLine {
 	private final Option executorOption = new Option("e", "executor", true,
 			"The name of the executor to be used for executing the given job, which is equivalent " +
 					"to the \"" + DeploymentOptions.TARGET.key() + "\" config option. The " +
-					"currently available executors are: " +
-					Joiner.on(", ").join(getExecutorFactoryNames()) +
-					".");
+					"currently available executors are: " + getExecutorFactoryNames() + ".");
 
 	/**
 	 * Dynamic properties allow the user to specify additional configuration values with -D, such as
@@ -131,19 +126,9 @@ public class ExecutorCLI implements CustomCommandLine {
 				});
 	}
 
-	private static Iterator<String> getExecutorFactoryNames() {
-		final Iterator<PipelineExecutorFactory> executorFactories =
-				DefaultExecutorServiceLoader.INSTANCE.getExecutorFactories();
-		return new Iterator<String>() {
-			@Override
-			public boolean hasNext() {
-				return executorFactories.hasNext();
-			}
-
-			@Override
-			public String next() {
-				return executorFactories.next().getName();
-			}
-		};
+	private static String getExecutorFactoryNames() {
+		return DefaultExecutorServiceLoader.INSTANCE.getExecutors()
+				.map(name -> String.format("\"%s\"", name))
+				.collect(Collectors.joining(", "));
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
@@ -45,7 +45,7 @@ public class ExecutorCLI implements CustomCommandLine {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutorCLI.class);
 
-	private static final String ID = "Executor-CLI";
+	private static final String ID = "executor";
 
 	private final Option executorOption = new Option("e", "executor", true,
 			"The name of the executor to be used for executing the given job, e.g. \"local\"." +
@@ -59,7 +59,9 @@ public class ExecutorCLI implements CustomCommandLine {
 			.argName("property=value")
 			.numberOfArgs(2)
 			.valueSeparator('=')
-			.desc("use value for given property")
+			.desc("Generic configuration options for execution/deployment and for the configured " +
+					"executor. The available options can be found at " +
+					"https://ci.apache.org/projects/flink/flink-docs-stable/ops/config.html")
 			.build();
 
 	private final Configuration baseConfiguration;

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutorCLI.java
@@ -127,7 +127,7 @@ public class ExecutorCLI implements CustomCommandLine {
 	}
 
 	private static String getExecutorFactoryNames() {
-		return DefaultExecutorServiceLoader.INSTANCE.getExecutors()
+		return DefaultExecutorServiceLoader.INSTANCE.getExecutorNames()
 				.map(name -> String.format("\"%s\"", name))
 				.collect(Collectors.joining(", "));
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutorFactory.java
@@ -31,6 +31,11 @@ import org.apache.flink.core.execution.PipelineExecutorFactory;
 public class LocalExecutorFactory implements PipelineExecutorFactory {
 
 	@Override
+	public String getName() {
+		return LocalExecutor.NAME;
+	}
+
+	@Override
 	public boolean isCompatibleWith(final Configuration configuration) {
 		return LocalExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutorFactory.java
@@ -31,6 +31,11 @@ import org.apache.flink.core.execution.PipelineExecutorFactory;
 public class RemoteExecutorFactory implements PipelineExecutorFactory {
 
 	@Override
+	public String getName() {
+		return RemoteExecutor.NAME;
+	}
+
+	@Override
 	public boolean isCompatibleWith(final Configuration configuration) {
 		return RemoteExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -67,6 +67,7 @@ import javax.annotation.Nonnull;
 
 import java.net.URL;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -356,6 +357,12 @@ public class ClientTest extends TestLogger {
 		@Override
 		public PipelineExecutorFactory getExecutorFactory(@Nonnull Configuration configuration) {
 			return new PipelineExecutorFactory() {
+
+				@Override
+				public String getName() {
+					return "my-name";
+				}
+
 				@Override
 				public boolean isCompatibleWith(@Nonnull Configuration configuration) {
 					return TEST_EXECUTOR_NAME.equalsIgnoreCase(configuration.getString(DeploymentOptions.TARGET));
@@ -376,6 +383,11 @@ public class ClientTest extends TestLogger {
 					};
 				}
 			};
+		}
+
+		@Override
+		public Iterator<PipelineExecutorFactory> getExecutorFactories() {
+			throw new UnsupportedOperationException("not implemented");
 		}
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -67,8 +67,8 @@ import javax.annotation.Nonnull;
 
 import java.net.URL;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
@@ -386,7 +386,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		@Override
-		public Iterator<PipelineExecutorFactory> getExecutorFactories() {
+		public Stream<String> getExecutors() {
 			throw new UnsupportedOperationException("not implemented");
 		}
 	}

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -386,7 +386,7 @@ public class ClientTest extends TestLogger {
 		}
 
 		@Override
-		public Stream<String> getExecutors() {
+		public Stream<String> getExecutorNames() {
 			throw new UnsupportedOperationException("not implemented");
 		}
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
@@ -82,6 +82,11 @@ public class DefaultExecutorServiceLoader implements PipelineExecutorServiceLoad
 		return compatibleFactories.isEmpty() ? null : compatibleFactories.get(0);
 	}
 
+	@Override
+	public Iterator<PipelineExecutorFactory> getExecutorFactories() {
+		return defaultLoader.iterator();
+	}
+
 	private DefaultExecutorServiceLoader() {
 		// make sure nobody instantiates us explicitly.
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -83,8 +85,9 @@ public class DefaultExecutorServiceLoader implements PipelineExecutorServiceLoad
 	}
 
 	@Override
-	public Iterator<PipelineExecutorFactory> getExecutorFactories() {
-		return defaultLoader.iterator();
+	public Stream<String> getExecutors() {
+		return StreamSupport.stream(defaultLoader.spliterator(), false)
+				.map(PipelineExecutorFactory::getName);
 	}
 
 	private DefaultExecutorServiceLoader() {

--- a/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/DefaultExecutorServiceLoader.java
@@ -85,7 +85,7 @@ public class DefaultExecutorServiceLoader implements PipelineExecutorServiceLoad
 	}
 
 	@Override
-	public Stream<String> getExecutors() {
+	public Stream<String> getExecutorNames() {
 		return StreamSupport.stream(defaultLoader.spliterator(), false)
 				.map(PipelineExecutorFactory::getName);
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorFactory.java
@@ -29,6 +29,11 @@ import org.apache.flink.configuration.Configuration;
 public interface PipelineExecutorFactory {
 
 	/**
+	 * Returns the name of the executor that this factory creates.
+	 */
+	String getName();
+
+	/**
 	 * Returns {@code true} if this factory is compatible with the options in the
 	 * provided configuration, {@code false} otherwise.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
@@ -21,7 +21,7 @@ package org.apache.flink.core.execution;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 
-import java.util.Iterator;
+import java.util.stream.Stream;
 
 /**
  * An interface to be implemented by the entity responsible for finding the correct {@link PipelineExecutor} to
@@ -42,8 +42,7 @@ public interface PipelineExecutorServiceLoader {
 	PipelineExecutorFactory getExecutorFactory(final Configuration configuration) throws Exception;
 
 	/**
-	 * Loads and returns an iterator over all available {@link PipelineExecutorFactory
-	 * PipelineExecutorFactories}.
+	 * Loads and returns a stream of the names of all available executors.
 	 */
-	Iterator<PipelineExecutorFactory> getExecutorFactories();
+	Stream<String> getExecutors();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
@@ -21,6 +21,8 @@ package org.apache.flink.core.execution;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 
+import java.util.Iterator;
+
 /**
  * An interface to be implemented by the entity responsible for finding the correct {@link PipelineExecutor} to
  * execute a given {@link org.apache.flink.api.dag.Pipeline}.
@@ -38,4 +40,10 @@ public interface PipelineExecutorServiceLoader {
 	 * 			loading the registered factories.
 	 */
 	PipelineExecutorFactory getExecutorFactory(final Configuration configuration) throws Exception;
+
+	/**
+	 * Loads and returns an iterator over all available {@link PipelineExecutorFactory
+	 * PipelineExecutorFactories}.
+	 */
+	Iterator<PipelineExecutorFactory> getExecutorFactories();
 }

--- a/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/execution/PipelineExecutorServiceLoader.java
@@ -44,5 +44,5 @@ public interface PipelineExecutorServiceLoader {
 	/**
 	 * Loads and returns a stream of the names of all available executors.
 	 */
-	Stream<String> getExecutors();
+	Stream<String> getExecutorNames();
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/ExecutorDiscoveryAndJobClientTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/ExecutorDiscoveryAndJobClientTest.java
@@ -75,6 +75,11 @@ public class ExecutorDiscoveryAndJobClientTest {
 	public static class IDReportingExecutorFactory implements PipelineExecutorFactory {
 
 		@Override
+		public String getName() {
+			return EXEC_NAME;
+		}
+
+		@Override
 		public boolean isCompatibleWith(Configuration configuration) {
 			return EXEC_NAME.equals(configuration.get(DeploymentOptions.TARGET));
 		}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutorFactory.java
@@ -33,6 +33,11 @@ import javax.annotation.Nonnull;
 public class KubernetesSessionClusterExecutorFactory implements PipelineExecutorFactory {
 
 	@Override
+	public String getName() {
+		return KubernetesSessionClusterExecutor.NAME;
+	}
+
+	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
 		return configuration.get(DeploymentOptions.TARGET)
 				.equalsIgnoreCase(KubernetesSessionClusterExecutor.NAME);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -45,6 +45,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -133,6 +134,12 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		@Override
 		public PipelineExecutorFactory getExecutorFactory(@Nonnull Configuration configuration) {
 			return new PipelineExecutorFactory() {
+
+				@Override
+				public String getName() {
+					return "my-name";
+				}
+
 				@Override
 				public boolean isCompatibleWith(@Nonnull Configuration configuration) {
 					return true;
@@ -153,6 +160,11 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 					};
 				}
 			};
+		}
+
+		@Override
+		public Iterator<PipelineExecutorFactory> getExecutorFactories() {
+			throw new UnsupportedOperationException("not implemented");
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -45,9 +45,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.hamcrest.Matchers.is;
@@ -163,7 +163,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		}
 
 		@Override
-		public Iterator<PipelineExecutorFactory> getExecutorFactories() {
+		public Stream<String> getExecutors() {
 			throw new UnsupportedOperationException("not implemented");
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/RemoteStreamExecutionEnvironmentTest.java
@@ -163,7 +163,7 @@ public class RemoteStreamExecutionEnvironmentTest extends TestLogger {
 		}
 
 		@Override
-		public Stream<String> getExecutors() {
+		public Stream<String> getExecutorNames() {
 			throw new UnsupportedOperationException("not implemented");
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/ExecutorDiscoveryAndJobClientTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/environment/ExecutorDiscoveryAndJobClientTest.java
@@ -75,6 +75,11 @@ public class ExecutorDiscoveryAndJobClientTest {
 	public static class IDReportingExecutorFactory implements PipelineExecutorFactory {
 
 		@Override
+		public String getName() {
+			return EXEC_NAME;
+		}
+
+		@Override
 		public boolean isCompatibleWith(Configuration configuration) {
 			return EXEC_NAME.equals(configuration.get(DeploymentOptions.TARGET));
 		}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.yarn.executors;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.executors.RemoteExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.PipelineExecutor;
@@ -31,6 +32,11 @@ import javax.annotation.Nonnull;
  */
 @Internal
 public class YarnJobClusterExecutorFactory implements PipelineExecutorFactory {
+
+	@Override
+	public String getName() {
+		return YarnJobClusterExecutor.NAME;
+	}
 
 	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutorFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.yarn.executors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.executors.RemoteExecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.PipelineExecutor;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutorFactory.java
@@ -33,6 +33,11 @@ import javax.annotation.Nonnull;
 public class YarnSessionClusterExecutorFactory implements PipelineExecutorFactory {
 
 	@Override
+	public String getName() {
+		return YarnSessionClusterExecutor.NAME;
+	}
+
+	@Override
 	public boolean isCompatibleWith(@Nonnull final Configuration configuration) {
 		return YarnSessionClusterExecutor.NAME.equalsIgnoreCase(configuration.get(DeploymentOptions.TARGET));
 	}


### PR DESCRIPTION
This does:
 - update the cli documentation to remove some outdated mentions of `getPlan()`
 - adds more helpful information to the executor-cli output
 - prints the list of available executors in the CLI by using service discovery to get a list of available executors.