### PR TITLE
 [FLINK-15690][core][configuration] Enable configuring ExecutionConfig & CheckpointConfig from flink-conf.yaml

### DIFF
--- a/docs/_includes/generated/pipeline_configuration.html
+++ b/docs/_includes/generated/pipeline_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>pipeline.cached-files</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
-            <td>Files to be registered at the distributed cache under the given name. The files will be accessible from any user-defined function in the (distributed) runtime under a local path. Files may be local files (which will be distributed via BlobServer), or files in a distributed file system. The runtime will copy the files temporarily to a local cache, if needed.</td>
+            <td>Files to be registered at the distributed cache under the given name. The files will be accessible from any user-defined function in the (distributed) runtime under a local path. Files may be local files (which will be distributed via BlobServer), or files in a distributed file system. The runtime will copy the files temporarily to a local cache, if needed.<br /><br />Example:<br /><span markdown="span">`name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2``</span></td>
         </tr>
         <tr>
             <td><h5>pipeline.classpaths</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.DetachedJobExecutionResult;
 import org.apache.flink.core.execution.JobClient;
@@ -47,11 +46,6 @@ public class ContextEnvironment extends ExecutionEnvironment {
 			final Configuration configuration,
 			final ClassLoader userCodeClassLoader) {
 		super(executorServiceLoader, configuration, userCodeClassLoader);
-
-		final int parallelism = configuration.getInteger(CoreOptions.DEFAULT_PARALLELISM);
-		if (parallelism > 0) {
-			setParallelism(parallelism);
-		}
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -99,7 +99,7 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
 
 	private ClosureCleanerLevel closureCleanerLevel = ClosureCleanerLevel.RECURSIVE;
 
-	private int parallelism = PARALLELISM_DEFAULT;
+	private int parallelism = CoreOptions.DEFAULT_PARALLELISM.defaultValue();
 
 	/**
 	 * The program wide maximum parallelism used for operators which haven't specified a maximum

--- a/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/cache/DistributedCache.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.common.cache;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 
@@ -28,12 +29,15 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * DistributedCache provides static methods to write the registered cache files into job configuration or decode
@@ -181,6 +185,33 @@ public class DistributedCache {
 			cacheFiles.put(name, new DistributedCacheEntry(filePath, isExecutable, blobKey, isDirectory));
 		}
 		return cacheFiles.entrySet();
+	}
+
+	/**
+	 * Parses a list of distributed cache entries encoded in a string. Can be used to parse a config option
+	 * described by {@link org.apache.flink.configuration.PipelineOptions#CACHED_FILES}.
+	 *
+	 * <p>See {@link org.apache.flink.configuration.PipelineOptions#CACHED_FILES} for the format.
+	 *
+	 * @param files List of string encoded distributed cache entries.
+	 */
+	public static List<Tuple2<String, DistributedCacheEntry>> parseCachedFilesFromString(List<String> files) {
+		return files.stream()
+			.map(v -> Arrays.stream(v.split(","))
+				.map(p -> p.split(":"))
+				.collect(
+					Collectors.toMap(
+						arr -> arr[0], // key name
+						arr -> arr[1] // value
+					)
+				)
+			)
+			.map(m -> Tuple2.of(
+				m.get("name"),
+				new DistributedCacheEntry(
+					m.get("path"),
+					Optional.ofNullable(m.get("executable")).map(Boolean::parseBoolean).orElse(false)))
+			).collect(Collectors.toList());
 	}
 
 	private static final String CACHE_FILE_NUM = "DISTRIBUTED_CACHE_FILE_NUM";

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -226,6 +226,9 @@ public class PipelineOptions {
 					"Files may be local files (which will be distributed via BlobServer), or files in a distributed " +
 					"file system. The runtime will copy the files temporarily to a local cache, if needed.")
 				.linebreak()
+				.linebreak()
+				.text("Example:")
+				.linebreak()
 				.add(TextElement.code("name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2`"))
 				.build());
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -225,5 +225,7 @@ public class PipelineOptions {
 					"accessible from any user-defined function in the (distributed) runtime under a local path. " +
 					"Files may be local files (which will be distributed via BlobServer), or files in a distributed " +
 					"file system. The runtime will copy the files temporarily to a local cache, if needed.")
+				.linebreak()
+				.add(TextElement.code("name:file1,path:`file:///tmp/file1`;name:file2,path:`hdfs:///tmp/file2`"))
 				.build());
 }

--- a/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
@@ -51,7 +51,7 @@ class ExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createCollectionsEnvironment', 'readFile', 'readFileOfPrimitives',
                 'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput',
                 'getUserCodeClassLoader', 'getExecutorServiceLoader', 'getConfiguration',
-                'executeAsync', 'registerJobListener', 'clearJobListeners'}
+                'executeAsync', 'registerJobListener', 'clearJobListeners', 'configure'}
 
 
 if __name__ == '__main__':

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/WebFrontendITCase.java
@@ -287,7 +287,7 @@ public class WebFrontendITCase extends TestLogger {
 			assertEquals("application/json; charset=UTF-8", response.getType());
 			assertEquals("{\"jid\":\"" + jid + "\",\"name\":\"Stoppable streaming test job\"," +
 				"\"execution-config\":{\"execution-mode\":\"PIPELINED\",\"restart-strategy\":\"Cluster level default restart strategy\"," +
-				"\"job-parallelism\":-1,\"object-reuse-mode\":false,\"user-config\":{}}}", response.getContent());
+				"\"job-parallelism\":1,\"object-reuse-mode\":false,\"user-config\":{}}}", response.getContent());
 		}
 
 		BlockingInvokable.reset();

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -204,6 +204,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * @param configuration a configuration to read the values from
    * @param classLoader   a class loader to use when loading classes
    */
+  @PublicEvolving
   def configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit = {
     javaEnv.configure(configuration, classLoader)
   }

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -29,7 +29,7 @@ import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfoBase, ValueTypeInfo}
 import org.apache.flink.api.java.{CollectionEnvironment, ExecutionEnvironment => JavaEnv}
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.{Configuration, ReadableConfig}
 import org.apache.flink.core.execution.{JobClient, JobListener, PipelineExecutor}
 import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
@@ -190,6 +190,22 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def registerType(typeClass: Class[_]) {
     javaEnv.registerType(typeClass)
+  }
+
+  /**
+   * Sets all relevant options contained in the [[ReadableConfig]] such as e.g.
+   * [[org.apache.flink.configuration.PipelineOptions#CACHED_FILES]]. It will reconfigure
+   * [[ExecutionEnvironment]] and [[ExecutionConfig]].
+   *
+   * It will change the value of a setting only if a corresponding option was set in the
+   * `configuration`. If a key is not present, the current value of a field will remain
+   * untouched.
+   *
+   * @param configuration a configuration to read the values from
+   * @param classLoader   a class loader to use when loading classes
+   */
+  def configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit = {
+    javaEnv.configure(configuration, classLoader)
   }
 
   /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -46,7 +46,6 @@ import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.client.program.ContextEnvironment;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.PipelineOptions;
@@ -104,7 +103,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -208,16 +206,16 @@ public class StreamExecutionEnvironment {
 		this.configuration = checkNotNull(configuration);
 		this.userClassloader = userClassloader == null ? getClass().getClassLoader() : userClassloader;
 
-		// the parallelism of a job or an operator can only be specified at the following places:
-		//     i) at the operator level using the SingleOutputStreamOperator.setParallelism().
-		//     ii) programmatically by using the env.setParallelism() method, or
+		// the configuration of a job or an operator can be specified at the following places:
+		//     i) at the operator level using e.g. parallelism using the SingleOutputStreamOperator.setParallelism().
+		//     ii) programmatically by using e.g. the env.setRestartStrategy() method
 		//     iii) in the configuration passed here
 		//
 		// if specified in multiple places, the priority order is the above.
 		//
-		// Given this, it is safe to overwrite the execution config default value here because all other ways assume
+		// Given this, it is safe to overwrite the execution config default values here because all other ways assume
 		// that the env is already instantiated so they will overwrite the value passed here.
-		this.config.setParallelism(configuration.get(CoreOptions.DEFAULT_PARALLELISM));
+		this.configure(this.configuration, this.userClassloader);
 	}
 
 	protected Configuration getConfiguration() {
@@ -758,7 +756,7 @@ public class StreamExecutionEnvironment {
 		configuration.getOptional(PipelineOptions.CACHED_FILES)
 			.ifPresent(f -> {
 				this.cacheFile.clear();
-				parseCachedFiles(f).forEach(t -> registerCachedFile(t.f1, t.f0, t.f2));
+				this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
 			});
 		config.configure(configuration, classLoader);
 		checkpointCfg.configure(configuration);
@@ -773,24 +771,6 @@ public class StreamExecutionEnvironment {
 		} catch (DynamicCodeLoadingException | IOException e) {
 			throw new WrappingRuntimeException(e);
 		}
-	}
-
-	private List<Tuple3<String, String, Boolean>> parseCachedFiles(List<String> s) {
-		return s.stream()
-			.map(v -> Arrays.stream(v.split(","))
-				.map(p -> p.split(":"))
-				.collect(
-					Collectors.toMap(
-						arr -> arr[0], // key name
-						arr -> arr[1] // value
-					)
-				)
-			)
-			.map(m -> Tuple3.of(
-				m.get("name"),
-				m.get("path"),
-				Optional.ofNullable(m.get("executable")).map(Boolean::parseBoolean).orElse(false)))
-			.collect(Collectors.toList());
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
@@ -64,7 +64,7 @@ public class StreamExecutionEnvironmentConfigurationTest {
 				.whenSetFromFile("pipeline.operator-chaining", "false")
 				.viaSetter((env, b) -> {
 					if (b) {
-						throw new IllegalArgumentException("Cannot programatically enable operator chaining");
+						throw new IllegalArgumentException("Cannot programmatically enable operator chaining");
 					} else {
 						env.disableOperatorChaining();
 					}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -300,6 +300,9 @@ abstract class BatchTableEnvImpl(
 
     logicalPlan match {
       case node: DataSetRel =>
+        execEnv.configure(
+          config.getConfiguration,
+          Thread.currentThread().getContextClassLoader)
         val plan = node.translateToPlan(this, new BatchQueryConfig)
         val conversion =
           getConversionMapper(


### PR DESCRIPTION
## What is the purpose of the change

* Add a `configure` method to `ExecutionEnvironment` similar to the one in `StreamExecutionEnvironment`
* Pass configuration read from `flink-conf.yaml` to `configure` method on instantiation of `(Stream)ExecutionEnvironment`
* Pass configuration from `BatchTableEnvironment` to the underlying `ExecutionEnvironment`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
