### PR TITLE
FLINK-15174 bind all parameters for update SQL

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
@@ -198,6 +198,8 @@ public abstract class UpsertWriter implements JDBCWriter {
 		private transient PreparedStatement insertStatement;
 		private transient PreparedStatement updateStatement;
 
+		private final int[] fieldsAndPkTypes;
+
 		private UpsertWriterUsingInsertUpdateStatement(
 			int[] fieldTypes,
 			int[] pkFields,
@@ -211,6 +213,8 @@ public abstract class UpsertWriter implements JDBCWriter {
 			this.existSQL = existSQL;
 			this.insertSQL = insertSQL;
 			this.updateSQL = updateSQL;
+
+			this.fieldsAndPkTypes = concatArray(fieldTypes, pkTypes);
 		}
 
 		@Override
@@ -229,7 +233,7 @@ public abstract class UpsertWriter implements JDBCWriter {
 			resultSet.close();
 			if (exist) {
 				// do update
-				setRecordToStatement(updateStatement, fieldTypes, row);
+				setRecordToStatement(updateStatement, fieldsAndPkTypes, Row.join(row, pk));
 				updateStatement.addBatch();
 			} else {
 				// do insert
@@ -260,5 +264,17 @@ public abstract class UpsertWriter implements JDBCWriter {
 				updateStatement = null;
 			}
 		}
+
+		private int[] concatArray(int[] left, int[] right) {
+			if (left == null){
+				return null;
+			}
+
+			int[] result = new int[left.length + right.length];
+			System.arraycopy(left, 0, result, 0, left.length);
+			System.arraycopy(right, 0, result, left.length, right.length);
+			return result;
+		}
+
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertOutputFormatTest.java
@@ -34,6 +34,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -50,23 +51,35 @@ public class JDBCUpsertOutputFormatTest extends JDBCTestBase {
 	private JDBCUpsertOutputFormat format;
 	private String[] fieldNames;
 	private String[] keyFields;
+	private int[] fieldTypes;
 
 	@Before
 	public void setup() {
 		fieldNames = new String[]{"id", "title", "author", "price", "qty"};
+		fieldTypes = new int[]{Types.INTEGER, Types.VARCHAR, Types.VARCHAR, Types.DOUBLE, Types.INTEGER};
 		keyFields = new String[]{"id"};
 	}
 
 	@Test
 	public void testJDBCOutputFormat() throws Exception {
+		testJDBCOutputFormat(null);
+	}
+
+	@Test
+	public void testJDBCOutputFormatWithFiledTypes() throws Exception {
+		testJDBCOutputFormat(fieldTypes);
+	}
+
+	private void testJDBCOutputFormat(int[] fieldSqlTypes) throws Exception {
 		format = JDBCUpsertOutputFormat.builder()
-				.setOptions(JDBCOptions.builder()
-						.setDBUrl(DB_URL)
-						.setTableName(OUTPUT_TABLE)
-						.build())
-				.setFieldNames(fieldNames)
-				.setKeyFields(keyFields)
-				.build();
+			.setOptions(JDBCOptions.builder()
+				.setDBUrl(DB_URL)
+				.setTableName(OUTPUT_TABLE)
+				.build())
+			.setFieldNames(fieldNames)
+			.setKeyFields(keyFields)
+			.setFieldTypes(fieldSqlTypes)
+			.build();
 		RuntimeContext context = Mockito.mock(RuntimeContext.class);
 		ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
 		doReturn(config).when(context).getExecutionConfig();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the bug with binding setField for UpdateSQL *

Fixes issue https://issues.apache.org/jira/browse/FLINK-15728 

## Brief change log

  - *Added additional combined field to hold fieldtypes with pk types*
  - * When using **UpsertWriterUsingInsertUpdateStatement** for update statement added additional field values for pk.
 

## Verifying this change

This change added tests and can be verified as follows:

  - *Refactored JDBCUpsertOutputFormatTest to cover scenario of filedTypes specified*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
