### PR TITLE
[FLINK-15368][e2e] Add end-to-end test for controlling RocksDB memory usage

### DIFF
--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-parent</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.11-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-rocksdb-state-memory-control-test</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-statebackend-rocksdb_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-datastream-allround-test</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>RocksDBStateMemoryControlTestProgram</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>RocksDBStateMemoryControlTestProgram</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.streaming.tests.RocksDBStateMemoryControlTestProgram</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/src/main/java/org/apache/flink/streaming/tests/RocksDBStateMemoryControlTestProgram.java
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/src/main/java/org/apache/flink/streaming/tests/RocksDBStateMemoryControlTestProgram.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapState;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.KeyedStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.windowing.WindowFunction;
+import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
+import org.apache.flink.util.Collector;
+
+import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.applyTumblingWindows;
+import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.createTimestampExtractor;
+import static org.apache.flink.streaming.tests.DataStreamAllroundTestJobFactory.setupEnvironment;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.EVENT_SOURCE;
+import static org.apache.flink.streaming.tests.TestOperatorEnum.TIME_WINDOW_OPER;
+
+/**
+ *
+ */
+public class RocksDBStateMemoryControlTestProgram {
+
+	public static void main(String[] args) throws Exception {
+		final ParameterTool pt = ParameterTool.fromArgs(args);
+
+		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		setupEnvironment(env, pt);
+		KeyedStream<Event, Integer> keyedStream = env
+			.addSource(DataStreamAllroundTestJobFactory.createEventSource(pt))
+			.name(EVENT_SOURCE.getName())
+			.uid(EVENT_SOURCE.getUid())
+			.assignTimestampsAndWatermarks(createTimestampExtractor(pt))
+			.keyBy(Event::getKey);
+		keyedStream.map(new ValueStateMapper(pt)).returns(Event.class).name("ValueStateMapper").uid("ValueStateMapper");
+		keyedStream.map(new ListStateMapper(pt)).returns(Event.class).name("ListStateMapper").uid("ListStateMapper");
+		keyedStream.map(new MapStateMapper(pt)).returns(Event.class).name("MapStateMapper").uid("MapStateMapper");
+
+		boolean useWindow = pt.getBoolean("useWindow", false);
+		if (useWindow) {
+			applyTumblingWindows(keyedStream, pt)
+				.apply(new WindowFunction<Event, Event, Integer, TimeWindow>() {
+					@Override
+					public void apply(Integer integer, TimeWindow window, Iterable<Event> input, Collector<Event> out) {
+						for (Event e : input) {
+							out.collect(e);
+						}
+					}
+				})
+				.name(TIME_WINDOW_OPER.getName())
+				.uid(TIME_WINDOW_OPER.getUid());
+		}
+
+		env.execute("RocksDB test job");
+	}
+
+	private static class ValueStateMapper extends RichMapFunction<Event, Event> {
+
+		private static final long serialVersionUID = 1L;
+
+		private ValueState<String> valueState;
+
+		private boolean useValueState = false;
+
+		ValueStateMapper(ParameterTool parameterTool) {
+			this.useValueState = parameterTool.getBoolean("useValueState", false);
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			int index = getRuntimeContext().getIndexOfThisSubtask();
+			if (useValueState) {
+				valueState = getRuntimeContext()
+					.getState(new ValueStateDescriptor<>("valueState-" + index, StringSerializer.INSTANCE));
+			}
+		}
+
+		@Override
+		public Event map(Event event) throws Exception {
+			if (useValueState) {
+				String value = valueState.value();
+				if (value != null) {
+					valueState.update(event.getPayload().concat(value));
+				} else {
+					valueState.update(event.getPayload());
+				}
+			}
+			return event;
+		}
+	}
+
+	private static class ListStateMapper extends RichMapFunction<Event, Event> {
+
+		private static final long serialVersionUID = 1L;
+
+		private ListState<String> listState;
+
+		private boolean useListState = false;
+
+		ListStateMapper(ParameterTool parameterTool) {
+			this.useListState = parameterTool.getBoolean("useListState", false);
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			int index = getRuntimeContext().getIndexOfThisSubtask();
+			if (useListState) {
+				listState = getRuntimeContext()
+					.getListState(new ListStateDescriptor<>("listState-" + index, StringSerializer.INSTANCE));
+			}
+		}
+
+		@Override
+		public Event map(Event event) throws Exception {
+			if (useListState) {
+				listState.add(event.getPayload());
+			}
+			return event;
+		}
+	}
+
+	private static class MapStateMapper extends RichMapFunction<Event, Event> {
+
+		private static final long serialVersionUID = 1L;
+
+		private MapState<Long, String> mapState;
+
+		private boolean useMapState = false;
+
+		MapStateMapper(ParameterTool parameterTool) {
+			this.useMapState = parameterTool.getBoolean("useMapState", false);
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			int index = getRuntimeContext().getIndexOfThisSubtask();
+			if (useMapState) {
+				mapState = getRuntimeContext()
+					.getMapState(new MapStateDescriptor<>("mapState-" + index, LongSerializer.INSTANCE, StringSerializer.INSTANCE));
+			}
+		}
+
+		@Override
+		public Event map(Event event) throws Exception {
+			if (useMapState) {
+				mapState.put(event.getSequenceNumber(), event.getPayload());
+			}
+			return event;
+		}
+	}
+
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -63,6 +63,7 @@ under the License.
 		<module>flink-sql-client-test</module>
 		<module>flink-streaming-file-sink-test</module>
 		<module>flink-state-evolution-test</module>
+		<module>flink-rocksdb-state-memory-control-test</module>
 		<module>flink-end-to-end-tests-common</module>
 		<module>flink-metrics-availability-test</module>
 		<module>flink-metrics-reporter-prometheus-test</module>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -171,6 +171,8 @@ run_test "ConnectedComponents iterations with high parallelism end-to-end test" 
 
 run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-scripts/test_table_shaded_dependencies.sh"
 
+run_test "RocksDB memory control end-to-end test" "$END_TO_END_DIR/test-scripts/test_rocksdb_state_memory_control.sh" "skip_check_exceptions"
+
 ################################################################################
 # Sticky Scheduling
 ################################################################################

--- a/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#if [ -z $1 ] || [ -z $2 ]; then
+# echo "Usage: ./test_rocksdb_state_memory_control.sh "
+# exit 1
+#fi
+
+source "$(dirname "$0")"/common.sh
+
+PARALLELISM=2
+CHECKPOINT_DIR="$TEST_DATA_DIR/test_rocksdb_state_memory_control-dir"
+mkdir -p $CHECKPOINT_DIR
+CHECKPOINT_DIR_URI="file://$CHECKPOINT_DIR"
+# 161061276 + 4 * 8 * 1024 * 1024 = 194615708 bytes
+EXPECTED_MAX_MEMORY_USAGE=194615708
+
+set_config_key "taskmanager.memory.process.size" "1024m"
+set_config_key "state.backend.rocksdb.memory.managed" "true"
+set_config_key "state.backend.rocksdb.metrics.size-all-mem-tables" "true"
+set_config_key "state.backend.rocksdb.metrics.cur-size-active-mem-table" "true"
+set_config_key "state.backend.rocksdb.metrics.num-immutable-mem-table" "true"
+set_config_key "state.backend.rocksdb.memory.`write`-buffer-ratio" "0.8"
+set_config_key "state.backend.rocksdb.metrics.block-cache-usage" "true"
+set_config_key "state.backend.rocksdb.metrics.estimate-table-readers-mem" "true"
+set_config_key "taskmanager.numberOfTaskSlots" "$PARALLELISM"
+set_config_key "metrics.fetcher.update-interval" "1000"
+setup_flink_slf4j_metric_reporter
+start_cluster
+
+echo "Running rocksdb state backend memory control test"
+
+TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-rocksdb-state-memory-control-test/target/RocksDBStateMemoryControlTestProgram.jar
+
+function buildBaseJobCmd {
+  local flink_args="$1"
+
+  echo "$FLINK_DIR/bin/flink run -d ${flink_args} -p $PARALLELISM $TEST_PROGRAM_JAR \
+    --environment.parallelism $PARALLELISM \
+    --environment.checkpoint_interval 600000 \
+    --state_backend rocks \
+    --state_backend.checkpoint_directory $CHECKPOINT_DIR_URI \
+    --state_backend.rocks.incremental true \
+    --sequence_generator_source.sleep_time 1 \
+    --sequence_generator_source.keyspace 1000000 \
+    --sequence_generator_source.payload_size 50000 \
+    --useValueState true \
+    --useListState true \
+    --useMapState true \
+    --useWindow true \
+    --sequence_generator_source.sleep_after_elements 1"
+}
+
+function find_max_block_cache_usage() {
+  OPERATOR=$1
+  JOB_NAME="${2:-General purpose test job}"
+  N=$(grep ".${JOB_NAME}.$OPERATOR.rocksdb.block-cache-usage:" $FLINK_DIR/log/*taskexecutor*.log | sed 's/.* //g' | sort -rn | head -n 1)
+  if [ -z $N ]; then
+    N=0
+  fi
+  echo $N
+}
+
+function memory_under_limit() {
+    local MAX_BLOCK_CACHE_USAGE=$1
+    local EXPECTED_MAX_MEMORY_USAGE=$2
+    if [ "$MAX_BLOCK_CACHE_USAGE" -gt "$EXPECTED_MAX_MEMORY_USAGE" ]; then
+      echo "[ERROR] Current block cache uaage $MAX_BLOCK_CACHE_USAGE larger than expected memory limit $EXPECTED_MAX_MEMORY_USAGE"
+      exit 1
+    fi
+
+}
+
+JOB_CMD=`buildBaseJobCmd `
+
+DATASTREAM_JOB=$($JOB_CMD | grep "Job has been submitted with JobID" | sed 's/.* //g')
+
+wait_job_running $DATASTREAM_JOB
+wait_oper_metric_num_in_records TumblingWindowOperator.0 10000 'RocksDB test job'
+cancel_job $DATASTREAM_JOB
+
+
+MAX_BLOCK_CACHE_0_USAGE=$(find_max_block_cache_usage 'TumblingWindowOperator.0.window-contents' 'RocksDB test job')
+MAX_BLOCK_CACHE_1_USAGE=$(find_max_block_cache_usage 'TumblingWindowOperator.1.window-contents' 'RocksDB test job')
+memory_under_limit $MAX_BLOCK_CACHE_0_USAGE $EXPECTED_MAX_MEMORY_USAGE
+memory_under_limit $MAX_BLOCK_CACHE_1_USAGE $EXPECTED_MAX_MEMORY_USAGE
+
+
+


### PR DESCRIPTION
## What is the purpose of the change

Add end-to-end test for controlling RocksDB memory usage. This job has 4 states in 4 different operator, and all the operators are shared in one slot.

**NOTE:** This end-to-end test could be a unstable one when too many unflushed immutable mem-tables. I wrote [a doc to explain how write buffer manager works in RocksDB.](https://docs.google.com/document/d/1_4Brwy2Axzzqu7SJ4hLLl92hVCpeRlVEG-fj8KsTMUo/edit#heading=h.f5wfmsmpemd0) In this doc I explained the most total memory usage could be much higher than expected in the **worst** case.

Below is the general test result:
1GB TM, 2 slot each without memory control. To compare fairly, I also cache index & filter into cache but not change other configurations of RocksDB.
When we do not control memory usage over RocksDB instances, the total memory should be summed as `block-cache-usgae` + `total-mem-table` from all 4 states. As you can see, the total memory usage in one slot could be 400MB+
<img width="1319" alt="111" src="https://user-images.githubusercontent.com/1709104/72965411-31cdaa80-3df7-11ea-843d-1565d7b7b89d.png">

1GB TM, 2 slot each has 161061276 bytes of managed off-heap memory
Since we use the same cache to share among all rocksDB instances, the total memory usage is the block cache usage. As you can see, the memory usage could be near the vicinity of 161061276 bytes.
<img width="1266" alt="image" src="https://user-images.githubusercontent.com/1709104/72965622-ce904800-3df7-11ea-8a04-b818f67929c4.png">



## Brief change log
Add end-to-end test for controlling RocksDB memory usage.


## Verifying this change
This change added tests and can be verified as follows:

  - Added `RocksDBStateMemoryControlTestProgram` to verify end-to-end.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
