### PR TITLE
[FLINK-15603][metrics] Add checkpointStartDelay metric

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1341,9 +1341,14 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="1">Task</th>
+      <th rowspan="2">Task</th>
       <td>checkpointAlignmentTime</td>
       <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>checkpointStartDelayNanos</td>
+      <td>The time in nanoseconds that elapsed between the creation of the last checkpoint and the time when the checkpointing process has started by this Task. This delay shows how long it takes for the first checkpoint barrier to reach the task. A high value indicates back-pressure. If only a specific task has a long start delay, the most likely reason is data skew.</td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1348,9 +1348,14 @@ Metrics related to data exchange between task executors using netty network comm
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="1">Task</th>
+      <th rowspan="2">Task</th>
       <td>checkpointAlignmentTime</td>
       <td>The time in nanoseconds that the last barrier alignment took to complete, or how long the current alignment has taken so far (in nanoseconds).</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>checkpointStartDelayNanos</td>
+      <td>The time in nanoseconds that elapsed between the creation of the last checkpoint and the time when the checkpointing process has started by this Task. This delay shows how long it takes for the first checkpoint barrier to reach the task. A high value indicates back-pressure. If only a specific task has a long start delay, the most likely reason is data skew.</td>
       <td>Gauge</td>
     </tr>
   </tbody>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -143,7 +143,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 				checkpointAborted = true;
 
 				// begin a new checkpoint
-				beginNewAlignment(barrierId, channelIndex);
+				beginNewAlignment(barrierId, channelIndex, receivedBarrier.getTimestamp());
 			}
 			else {
 				// ignore trailing barrier from an earlier checkpoint (obsolete now)
@@ -152,7 +152,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 		}
 		else if (barrierId > currentCheckpointId) {
 			// first barrier of a new checkpoint
-			beginNewAlignment(barrierId, channelIndex);
+			beginNewAlignment(barrierId, channelIndex, receivedBarrier.getTimestamp());
 		}
 		else {
 			// either the current checkpoint was canceled (numBarriers == 0) or
@@ -178,7 +178,11 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 		return checkpointAborted;
 	}
 
-	protected void beginNewAlignment(long checkpointId, int channelIndex) throws IOException {
+	protected void beginNewAlignment(
+			long checkpointId,
+			int channelIndex,
+			long checkpointTimestamp) throws IOException {
+		markCheckpointStart(checkpointTimestamp);
 		currentCheckpointId = checkpointId;
 		onBarrier(channelIndex);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -38,6 +38,8 @@ public abstract class CheckpointBarrierHandler {
 	/** The listener to be notified on complete checkpoints. */
 	private final AbstractInvokable toNotifyOnCheckpoint;
 
+	private long latestCheckpointStartDelayNanos;
+
 	public CheckpointBarrierHandler(AbstractInvokable toNotifyOnCheckpoint) {
 		this.toNotifyOnCheckpoint = checkNotNull(toNotifyOnCheckpoint);
 	}
@@ -71,6 +73,10 @@ public abstract class CheckpointBarrierHandler {
 
 	public abstract long getAlignmentDurationNanos();
 
+	public long getCheckpointStartDelayNanos() {
+		return latestCheckpointStartDelayNanos;
+	}
+
 	public abstract void checkpointSizeLimitExceeded(long maxBufferedBytes) throws Exception;
 
 	protected void notifyCheckpoint(CheckpointBarrier checkpointBarrier, long bufferedBytes, long alignmentDurationNanos) throws Exception {
@@ -94,5 +100,11 @@ public abstract class CheckpointBarrierHandler {
 
 	protected void notifyAbort(long checkpointId, CheckpointException cause) throws Exception {
 		toNotifyOnCheckpoint.abortCheckpointOnBarrier(checkpointId, cause);
+	}
+
+	protected void markCheckpointStart(long checkpointCreationTimestamp) {
+		latestCheckpointStartDelayNanos = 1_000_000 * Math.max(
+			0,
+			System.currentTimeMillis() - checkpointCreationTimestamp);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -138,6 +138,7 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 			// if it is not newer than the latest checkpoint ID, then there cannot be a
 			// successful checkpoint for that ID anyways
 			if (barrierId > latestPendingCheckpointID) {
+				markCheckpointStart(receivedBarrier.getTimestamp());
 				latestPendingCheckpointID = barrierId;
 				pendingCheckpoints.addLast(new CheckpointBarrierCount(barrierId));
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -238,6 +238,14 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 	}
 
 	/**
+	 * @return the time that elapsed, in nanoseconds, between the creation of the latest checkpoint
+	 * and the time when it's first {@link CheckpointBarrier} was received by this {@link InputGate}.
+	 */
+	public long getCheckpointStartDelayNanos() {
+		return barrierHandler.getCheckpointStartDelayNanos();
+	}
+
+	/**
 	 * @return number of underlying input channels.
 	 */
 	public int getNumberOfInputChannels() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -90,6 +90,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 			CheckpointedInputGate inputGate = createCheckpointedInputGate();
 			TaskIOMetricGroup taskIOMetricGroup = getEnvironment().getMetricGroup().getIOMetricGroup();
 			taskIOMetricGroup.gauge("checkpointAlignmentTime", inputGate::getAlignmentDurationNanos);
+			taskIOMetricGroup.gauge("checkpointStartDelayNanos", inputGate::getCheckpointStartDelayNanos);
 
 			DataOutput<IN> output = createDataOutput();
 			StreamTaskInput<IN> input = createTaskInput(inputGate, output);


### PR DESCRIPTION
Introduce a `checkpointStartDelay` metric: the time in nanoseconds that elapsed between the creation of the last checkpoint and the time when the checkpointing process has started by this Task. This delay shows how long it takes for a first checkpoint barrier to reach the task. Back-pressure will increase this value.

## Verifying this change

This change is hard to test, however I've added some rudimentary checks in `CheckpointBarrierAlignerTestBase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
