### PR TITLE
[FLINK-15603][web] Expose checkpointStartDelayNanos metric in the WebUI

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1255,6 +1255,10 @@
                   "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
                 }
               }
+            },
+            "start_delay" : {
+              "type" : "object",
+              "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:checkpoints:MinMaxAvgStatistics"
             }
           }
         },

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-checkpoint.ts
@@ -164,6 +164,7 @@ export interface CheckPointSubTaskInterface {
       buffered: CheckPointMinMaxAvgStatisticsInterface;
       duration: CheckPointMinMaxAvgStatisticsInterface;
     };
+    start_delay: CheckPointMinMaxAvgStatisticsInterface;
   };
   subtasks: Array<{
     index: number;

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
@@ -30,8 +30,8 @@
         <th></th>
         <th><strong>End to End Duration</strong></th>
         <th><strong>State Size</strong></th>
-        <th><strong>Checkpoint Duration (Sync)</strong></th>
-        <th><strong>Checkpoint Duration (Async)</strong></th>
+        <th><strong>Sync Duration</strong></th>
+        <th><strong>Async Duration</strong></th>
         <th><strong>Alignment Buffered</strong></th>
         <th><strong>Alignment Duration</strong></th>
       </tr>
@@ -79,13 +79,13 @@
     <thead (nzSortChange)="sort($event)" nzSingleSort>
       <tr>
         <th><strong>ID</strong></th>
-        <th nzSortKey="ack_timestamp" nzShowSort><strong>Acknowledgement Time</strong></th>
-        <th nzSortKey="end_to_end_duration" nzShowSort><strong>E2E Duration</strong></th>
+        <th nzSortKey="ack_timestamp" nzShowSort><strong>Acknowledged</strong></th>
+        <th nzSortKey="end_to_end_duration" nzShowSort><strong>End to End Duration</strong></th>
         <th nzSortKey="state_size" nzShowSort><strong>State Size</strong></th>
-        <th nzSortKey="checkpoint.sync" nzShowSort><strong>Checkpoint Duration (Sync)</strong></th>
-        <th nzSortKey="checkpoint.async" nzShowSort><strong>Checkpoint Duration (Async)</strong></th>
-        <th nzSortKey="alignment.buffered" nzShowSort><strong>Align Buffered</strong></th>
-        <th nzSortKey="alignment.duration" nzShowSort><strong>Align Duration</strong></th>
+        <th nzSortKey="checkpoint.sync" nzShowSort><strong>Sync Duration</strong></th>
+        <th nzSortKey="checkpoint.async" nzShowSort><strong>Async Duration</strong></th>
+        <th nzSortKey="alignment.buffered" nzShowSort><strong>Alignment Buffered</strong></th>
+        <th nzSortKey="alignment.duration" nzShowSort><strong>Alignment Duration</strong></th>
       </tr>
     </thead>
     <tbody>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
@@ -34,6 +34,7 @@
         <th><strong>Async Duration</strong></th>
         <th><strong>Alignment Buffered</strong></th>
         <th><strong>Alignment Duration</strong></th>
+        <th><strong>Start Delay</strong></th>
       </tr>
     </thead>
     <tbody>
@@ -46,6 +47,7 @@
           <td>{{ subTaskCheckPoint['summary']['checkpoint_duration']['async']['min'] | humanizeDuration}}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['buffered']['min'] | humanizeBytes }}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['duration']['min'] | humanizeDuration}}</td>
+          <td>{{ subTaskCheckPoint['summary']['start_delay']['min'] | humanizeDuration}}</td>
         </tr>
         <tr>
           <td><strong>Average</strong></td>
@@ -55,6 +57,7 @@
           <td>{{ subTaskCheckPoint['summary']['checkpoint_duration']['async']['avg'] | humanizeDuration}}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['buffered']['avg'] | humanizeBytes }}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['duration']['avg'] | humanizeDuration}}</td>
+          <td>{{ subTaskCheckPoint['summary']['start_delay']['avg'] | humanizeDuration}}</td>
         </tr>
         <tr>
           <td><strong>Maximum</strong></td>
@@ -64,6 +67,7 @@
           <td>{{ subTaskCheckPoint['summary']['checkpoint_duration']['async']['max'] | humanizeDuration}}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['buffered']['max'] | humanizeBytes }}</td>
           <td>{{ subTaskCheckPoint['summary']['alignment']['duration']['max'] | humanizeDuration}}</td>
+          <td>{{ subTaskCheckPoint['summary']['start_delay']['max'] | humanizeDuration}}</td>
         </tr>
       </ng-container>
     </tbody>
@@ -86,6 +90,7 @@
         <th nzSortKey="checkpoint.async" nzShowSort><strong>Async Duration</strong></th>
         <th nzSortKey="alignment.buffered" nzShowSort><strong>Alignment Buffered</strong></th>
         <th nzSortKey="alignment.duration" nzShowSort><strong>Alignment Duration</strong></th>
+        <th nzSortKey="start_delay" nzShowSort><strong>Start Delay</strong></th>
       </tr>
     </thead>
     <tbody>
@@ -99,6 +104,7 @@
           <td>{{ subTask['checkpoint']['async'] | humanizeDuration}}</td>
           <td>{{ subTask['alignment']['buffered'] | humanizeBytes}}</td>
           <td>{{ subTask['alignment']['duration'] | humanizeDuration}}</td>
+          <td>{{ subTask['start_delay'] | humanizeDuration}}</td>
         </ng-container>
         <ng-container *ngIf="subTask['status'] == 'pending_or_failed'">
           <td colspan="7">n/a</td>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointMetrics.java
@@ -18,9 +18,10 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-
 import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A collection of simple metrics, around the triggering of a checkpoint.
@@ -40,6 +41,7 @@ public class CheckpointMetrics implements Serializable {
 
 	/* The duration (in milliseconds) of the asynchronous part of the operator checkpoint  */
 	private long asyncDurationMillis;
+	private long checkpointStartDelayNanos;
 
 	public CheckpointMetrics() {
 		this(-1L, -1L, -1L, -1L);
@@ -99,6 +101,15 @@ public class CheckpointMetrics implements Serializable {
 		return this;
 	}
 
+	public CheckpointMetrics setCheckpointStartDelayNanos(long checkpointStartDelayNanos) {
+		this.checkpointStartDelayNanos = checkpointStartDelayNanos;
+		return this;
+	}
+
+	public long getCheckpointStartDelayNanos() {
+		return checkpointStartDelayNanos;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -111,28 +122,31 @@ public class CheckpointMetrics implements Serializable {
 		CheckpointMetrics that = (CheckpointMetrics) o;
 
 		return bytesBufferedInAlignment == that.bytesBufferedInAlignment && 
-				alignmentDurationNanos == that.alignmentDurationNanos && 
-				syncDurationMillis == that.syncDurationMillis && 
-				asyncDurationMillis == that.asyncDurationMillis;
+			alignmentDurationNanos == that.alignmentDurationNanos &&
+			syncDurationMillis == that.syncDurationMillis &&
+			asyncDurationMillis == that.asyncDurationMillis &&
+			checkpointStartDelayNanos == that.checkpointStartDelayNanos;
 
 	}
 
 	@Override
 	public int hashCode() {
-		int result = (int) (bytesBufferedInAlignment ^ (bytesBufferedInAlignment >>> 32));
-		result = 31 * result + (int) (alignmentDurationNanos ^ (alignmentDurationNanos >>> 32));
-		result = 31 * result + (int) (syncDurationMillis ^ (syncDurationMillis >>> 32));
-		result = 31 * result + (int) (asyncDurationMillis ^ (asyncDurationMillis >>> 32));
-		return result;
+		return Objects.hash(
+			bytesBufferedInAlignment,
+			alignmentDurationNanos,
+			syncDurationMillis,
+			asyncDurationMillis,
+			checkpointStartDelayNanos);
 	}
 
 	@Override
 	public String toString() {
 		return "CheckpointMetrics{" +
-				"bytesBufferedInAlignment=" + bytesBufferedInAlignment +
-				", alignmentDurationNanos=" + alignmentDurationNanos +
-				", syncDurationMillis=" + syncDurationMillis +
-				", asyncDurationMillis=" + asyncDurationMillis +
-				'}';
+			"bytesBufferedInAlignment=" + bytesBufferedInAlignment +
+			", alignmentDurationNanos=" + alignmentDurationNanos +
+			", syncDurationMillis=" + syncDurationMillis +
+			", asyncDurationMillis=" + asyncDurationMillis +
+			", checkpointStartDelayNanos=" + checkpointStartDelayNanos +
+			'}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -413,6 +413,7 @@ public class PendingCheckpoint {
 			if (statsCallback != null) {
 				// Do this in millis because the web frontend works with them
 				long alignmentDurationMillis = metrics.getAlignmentDurationNanos() / 1_000_000;
+				long checkpointStartDelayMillis = metrics.getCheckpointStartDelayNanos() / 1_000_000;
 
 				SubtaskStateStats subtaskStateStats = new SubtaskStateStats(
 					subtaskIndex,
@@ -421,7 +422,8 @@ public class PendingCheckpoint {
 					metrics.getSyncDurationMillis(),
 					metrics.getAsyncDurationMillis(),
 					metrics.getBytesBufferedInAlignment(),
-					alignmentDurationMillis);
+					alignmentDurationMillis,
+					checkpointStartDelayMillis);
 
 				statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
 			}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -56,8 +56,11 @@ public class SubtaskStateStats implements Serializable {
 	/** Number of buffered bytes during alignment. */
 	private final long alignmentBuffered;
 
-	/** Alignment duration in . */
+	/** Alignment duration in milliseconds. */
 	private final long alignmentDuration;
+
+	/** Checkpoint start delay in milliseconds. */
+	private final long checkpointStartDelay;
 
 	SubtaskStateStats(
 			int subtaskIndex,
@@ -66,7 +69,8 @@ public class SubtaskStateStats implements Serializable {
 			long syncCheckpointDuration,
 			long asyncCheckpointDuration,
 			long alignmentBuffered,
-			long alignmentDuration) {
+			long alignmentDuration,
+			long checkpointStartDelay) {
 
 		checkArgument(subtaskIndex >= 0, "Negative subtask index");
 		this.subtaskIndex = subtaskIndex;
@@ -77,6 +81,7 @@ public class SubtaskStateStats implements Serializable {
 		this.asyncCheckpointDuration = asyncCheckpointDuration;
 		this.alignmentBuffered = alignmentBuffered;
 		this.alignmentDuration = alignmentDuration;
+		this.checkpointStartDelay = checkpointStartDelay;
 	}
 
 	public int getSubtaskIndex() {
@@ -147,4 +152,7 @@ public class SubtaskStateStats implements Serializable {
 		return alignmentDuration;
 	}
 
+	public long getCheckpointStartDelay() {
+		return checkpointStartDelay;
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/SubtaskStateStats.java
@@ -36,7 +36,6 @@ public class SubtaskStateStats implements Serializable {
 
 	private static final long serialVersionUID = 8928594531621862214L;
 
-	/** Index of this sub task. */
 	private final int subtaskIndex;
 
 	/**
@@ -60,17 +59,6 @@ public class SubtaskStateStats implements Serializable {
 	/** Alignment duration in . */
 	private final long alignmentDuration;
 
-	/**
-	 * Creates the stats for a single subtask.
-	 *
-	 * @param subtaskIndex Index of the subtask.
-	 * @param ackTimestamp Timestamp when the acknowledgement of this subtask was received at the coordinator.
-	 * @param stateSize Size of the checkpointed state at this subtask.
-	 * @param syncCheckpointDuration Checkpoint duration at the task (synchronous part)
-	 * @param asyncCheckpointDuration  Checkpoint duration at the task (asynchronous part)
-	 * @param alignmentBuffered Bytes buffered during stream alignment (for exactly-once only).
-	 * @param alignmentDuration Duration of the stream alignment (for exactly-once only).
-	 */
 	SubtaskStateStats(
 			int subtaskIndex,
 			long ackTimestamp,
@@ -91,11 +79,6 @@ public class SubtaskStateStats implements Serializable {
 		this.alignmentDuration = alignmentDuration;
 	}
 
-	/**
-	 * Returns the subtask index.
-	 *
-	 * @return Subtask index.
-	 */
 	public int getSubtaskIndex() {
 		return subtaskIndex;
 	}
@@ -133,45 +116,32 @@ public class SubtaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the duration of the synchronous part of the checkpoint.
-	 *
-	 * <p>Can return <code>-1</code> if the runtime did not report this.
-	 *
-	 * @return Duration of the synchronous part of the checkpoint or <code>-1</code>.
+	 * @return Duration of the synchronous part of the checkpoint or <code>-1</code> if the runtime
+	 * did not report this.
 	 */
 	public long getSyncCheckpointDuration() {
 		return syncCheckpointDuration;
 	}
 
 	/**
-	 * Returns the duration of the asynchronous part of the checkpoint.
-	 *
-	 * <p>Can return <code>-1</code> if the runtime did not report this.
-	 *
-	 * @return Duration of the asynchronous part of the checkpoint or <code>-1</code>.
+	 * @return Duration of the asynchronous part of the checkpoint or <code>-1</code> if the runtime
+	 * did not report this.
 	 */
 	public long getAsyncCheckpointDuration() {
 		return asyncCheckpointDuration;
 	}
 
 	/**
-	 * Returns the number of bytes buffered during stream alignment (for
-	 * exactly-once only).
-	 *
-	 * <p>Can return <code>-1</code> if the runtime did not report this.
-	 *
-	 * @return Number of bytes buffered during stream alignment or <code>-1</code>.
+	 * @return Number of bytes buffered during stream alignment (for exactly-once only) or
+	 * <code>-1</code> if the runtime did not report this.
 	 */
 	public long getAlignmentBuffered() {
 		return alignmentBuffered;
 	}
 
 	/**
-	 * Returns the duration of the stream alignment (for exactly-once only).
-	 *
-	 * <p>Can return <code>-1</code> if the runtime did not report this.
-	 *
-	 * @return Duration of the stream alignment or <code>-1</code>.
+	 * @return Duration of the stream alignment (for exactly-once only) or <code>-1</code> if the
+	 * runtime did not report this.
 	 */
 	public long getAlignmentDuration() {
 		return alignmentDuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
@@ -37,16 +37,13 @@ public class TaskStateStats implements Serializable {
 	/** ID of the task the stats belong to. */
 	private final JobVertexID jobVertexId;
 
-	/** Stats for each subtask */
 	private final SubtaskStateStats[] subtaskStats;
 
 	/** A summary of the subtask stats. */
 	private final TaskStateStatsSummary summaryStats = new TaskStateStatsSummary();
 
-	/** Number of acknowledged subtasks. */
 	private int numAcknowledgedSubtasks;
 
-	/** The latest acknowledged subtask stats. */
 	@Nullable
 	private SubtaskStateStats latestAckedSubtaskStats;
 
@@ -56,11 +53,6 @@ public class TaskStateStats implements Serializable {
 		this.subtaskStats = new SubtaskStateStats[numSubtasks];
 	}
 
-	/**
-	 * Hands in the stats for a subtask.
-	 *
-	 * @param subtask Stats for the sub task to hand in.
-	 */
 	boolean reportSubtaskStats(SubtaskStateStats subtask) {
 		checkNotNull(subtask, "Subtask stats");
 		int subtaskIndex = subtask.getSubtaskIndex();
@@ -84,37 +76,23 @@ public class TaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the ID of the operator the statistics belong to.
-	 *
 	 * @return ID of the operator the statistics belong to.
 	 */
 	public JobVertexID getJobVertexId() {
 		return jobVertexId;
 	}
 
-	/**
-	 * Returns the number of subtasks.
-	 *
-	 * @return Number of subtasks.
-	 */
 	public int getNumberOfSubtasks() {
 		return subtaskStats.length;
 	}
 
-	/**
-	 * Returns the number of acknowledged subtasks.
-	 *
-	 * @return Number of acknowledged subtasks.
-	 */
 	public int getNumberOfAcknowledgedSubtasks() {
 		return numAcknowledgedSubtasks;
 	}
 
 	/**
-	 * Returns the latest acknowledged subtask stats or <code>null</code>
+	 * @return The latest acknowledged subtask stats or <code>null</code>
 	 * if none was acknowledged yet.
-	 *
-	 * @return The latest acknowledged subtask stats.
 	 */
 	@Nullable
 	public SubtaskStateStats getLatestAcknowledgedSubtaskStats() {
@@ -122,10 +100,8 @@ public class TaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the ack timestamp of the latest acknowledged subtask or
-	 * <code>-1</code> if none was acknowledged yet.
-	 *
-	 * @return Ack timestamp of the latest acknowledged subtask or <code>-1</code>.
+	 * @return Ack timestamp of the latest acknowledged subtask or <code>-1</code> if none was
+	 * acknowledged yet..
 	 */
 	public long getLatestAckTimestamp() {
 		SubtaskStateStats subtask = latestAckedSubtaskStats;
@@ -137,8 +113,6 @@ public class TaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the total checkpoint state size over all subtasks.
-	 *
 	 * @return Total checkpoint state size over all subtasks.
 	 */
 	public long getStateSize() {
@@ -146,11 +120,8 @@ public class TaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the total buffered bytes during alignment over all subtasks.
-	 *
-	 * <p>Can return <code>-1</code> if the runtime did not report this.
-	 *
-	 * @return Total buffered bytes during alignment over all subtasks.
+	 * @return Total buffered bytes during alignment over all subtasks or <code>-1</code> if the
+	 * runtime did not report this..
 	 */
 	public long getAlignmentBuffered() {
 		return summaryStats.getAlignmentBufferedStats().getSum();
@@ -187,8 +158,6 @@ public class TaskStateStats implements Serializable {
 	}
 
 	/**
-	 * Returns the summary of the subtask stats.
-	 *
 	 * @return Summary of the subtask stats.
 	 */
 	public TaskStateStatsSummary getSummaryStats() {
@@ -209,11 +178,6 @@ public class TaskStateStats implements Serializable {
 		private MinMaxAvgStats alignmentBuffered = new MinMaxAvgStats();
 		private MinMaxAvgStats alignmentDuration = new MinMaxAvgStats();
 
-		/**
-		 * Updates the summary with the given subtask.
-		 *
-		 * @param subtaskStats Subtask stats to update the summary with.
-		 */
 		void updateSummary(SubtaskStateStats subtaskStats) {
 			stateSize.add(subtaskStats.getStateSize());
 			ackTimestamp.add(subtaskStats.getAckTimestamp());
@@ -223,56 +187,26 @@ public class TaskStateStats implements Serializable {
 			alignmentDuration.add(subtaskStats.getAlignmentDuration());
 		}
 
-		/**
-		 * Returns the summary stats for the state size.
-		 *
-		 * @return Summary stats for the state size.
-		 */
 		public MinMaxAvgStats getStateSizeStats() {
 			return stateSize;
 		}
 
-		/**
-		 * Returns the summary stats for the ACK timestamps.
-		 *
-		 * @return Summary stats for the state size.
-		 */
 		public MinMaxAvgStats getAckTimestampStats() {
 			return ackTimestamp;
 		}
 
-		/**
-		 * Returns the summary stats for the sync checkpoint duration.
-		 *
-		 * @return Summary stats for the sync checkpoint duration.
-		 */
 		public MinMaxAvgStats getSyncCheckpointDurationStats() {
 			return syncCheckpointDuration;
 		}
 
-		/**
-		 * Returns the summary stats for the async checkpoint duration.
-		 *
-		 * @return Summary stats for the async checkpoint duration.
-		 */
 		public MinMaxAvgStats getAsyncCheckpointDurationStats() {
 			return asyncCheckpointDuration;
 		}
 
-		/**
-		 * Returns the summary stats for the buffered bytes during alignments.
-		 *
-		 * @return Summary stats for the buffered state size during alignment.
-		 */
 		public MinMaxAvgStats getAlignmentBufferedStats() {
 			return alignmentBuffered;
 		}
 
-		/**
-		 * Returns the summary stats for the alignment duration.
-		 *
-		 * @return Summary stats for the duration of the alignment.
-		 */
 		public MinMaxAvgStats getAlignmentDurationStats() {
 			return alignmentDuration;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/TaskStateStats.java
@@ -177,6 +177,7 @@ public class TaskStateStats implements Serializable {
 		private MinMaxAvgStats asyncCheckpointDuration = new MinMaxAvgStats();
 		private MinMaxAvgStats alignmentBuffered = new MinMaxAvgStats();
 		private MinMaxAvgStats alignmentDuration = new MinMaxAvgStats();
+		private MinMaxAvgStats checkpointStartDelay = new MinMaxAvgStats();
 
 		void updateSummary(SubtaskStateStats subtaskStats) {
 			stateSize.add(subtaskStats.getStateSize());
@@ -185,6 +186,7 @@ public class TaskStateStats implements Serializable {
 			asyncCheckpointDuration.add(subtaskStats.getAsyncCheckpointDuration());
 			alignmentBuffered.add(subtaskStats.getAlignmentBuffered());
 			alignmentDuration.add(subtaskStats.getAlignmentDuration());
+			checkpointStartDelay.add(subtaskStats.getCheckpointStartDelay());
 		}
 
 		public MinMaxAvgStats getStateSizeStats() {
@@ -211,6 +213,9 @@ public class TaskStateStats implements Serializable {
 			return alignmentDuration;
 		}
 
+		public MinMaxAvgStats getCheckpointStartDelayStats() {
+			return checkpointStartDelay;
+		}
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/CheckpointingStatisticsHandler.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointStatsCounts;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsHistory;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStatsSummary;
-import org.apache.flink.runtime.checkpoint.MinMaxAvgStats;
 import org.apache.flink.runtime.checkpoint.RestoredCheckpointStats;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -104,23 +103,11 @@ public class CheckpointingStatisticsHandler extends AbstractExecutionGraphHandle
 				checkpointStatsCounts.getNumberOfFailedCheckpoints());
 
 			final CompletedCheckpointStatsSummary checkpointStatsSummary = checkpointStatsSnapshot.getSummaryStats();
-			final MinMaxAvgStats stateSize = checkpointStatsSummary.getStateSizeStats();
-			final MinMaxAvgStats duration = checkpointStatsSummary.getEndToEndDurationStats();
-			final MinMaxAvgStats alignment = checkpointStatsSummary.getAlignmentBufferedStats();
 
 			final CheckpointingStatistics.Summary summary = new CheckpointingStatistics.Summary(
-				new MinMaxAvgStatistics(
-					stateSize.getMinimum(),
-					stateSize.getMaximum(),
-					stateSize.getAverage()),
-				new MinMaxAvgStatistics(
-					duration.getMinimum(),
-					duration.getMaximum(),
-					duration.getAverage()),
-				new MinMaxAvgStatistics(
-					alignment.getMinimum(),
-					alignment.getMaximum(),
-					alignment.getAverage()));
+				MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getStateSizeStats()),
+				MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getEndToEndDurationStats()),
+				MinMaxAvgStatistics.valueOf(checkpointStatsSummary.getAlignmentBufferedStats()));
 
 			final CheckpointStatsHistory checkpointStatsHistory = checkpointStatsSnapshot.getHistory();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -139,24 +139,18 @@ public class TaskCheckpointStatisticDetailsHandler
 	}
 
 	private static TaskCheckpointStatisticsWithSubtaskDetails.Summary createSummary(TaskStateStats.TaskStateStatsSummary taskStatisticsSummary, long triggerTimestamp) {
-		final MinMaxAvgStats stateSizeStats = taskStatisticsSummary.getStateSizeStats();
 		final MinMaxAvgStats ackTSStats = taskStatisticsSummary.getAckTimestampStats();
-		final MinMaxAvgStats syncDurationStats = taskStatisticsSummary.getSyncCheckpointDurationStats();
-		final MinMaxAvgStats asyncDurationStats = taskStatisticsSummary.getAsyncCheckpointDurationStats();
 
 		final TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration checkpointDuration = new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointDuration(
-			new MinMaxAvgStatistics(syncDurationStats.getMinimum(), syncDurationStats.getMaximum(), syncDurationStats.getAverage()),
-			new MinMaxAvgStatistics(asyncDurationStats.getMinimum(), asyncDurationStats.getMaximum(), asyncDurationStats.getAverage()));
-
-		final MinMaxAvgStats alignmentBufferedStats = taskStatisticsSummary.getAlignmentBufferedStats();
-		final MinMaxAvgStats alignmentDurationStats = taskStatisticsSummary.getAlignmentDurationStats();
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getSyncCheckpointDurationStats()),
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getAsyncCheckpointDurationStats()));
 
 		final TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment checkpointAlignment = new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
-			new MinMaxAvgStatistics(alignmentBufferedStats.getMinimum(), alignmentBufferedStats.getMaximum(), alignmentBufferedStats.getAverage()),
-			new MinMaxAvgStatistics(alignmentDurationStats.getMinimum(), alignmentDurationStats.getMaximum(), alignmentDurationStats.getAverage()));
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getAlignmentBufferedStats()),
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getAlignmentDurationStats()));
 
 		return new TaskCheckpointStatisticsWithSubtaskDetails.Summary(
-			new MinMaxAvgStatistics(stateSizeStats.getMinimum(), stateSizeStats.getMaximum(), stateSizeStats.getAverage()),
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getStateSizeStats()),
 			new MinMaxAvgStatistics(
 				Math.max(0L, ackTSStats.getMinimum() - triggerTimestamp),
 				Math.max(0L, ackTSStats.getMaximum() - triggerTimestamp),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/checkpoints/TaskCheckpointStatisticDetailsHandler.java
@@ -156,7 +156,8 @@ public class TaskCheckpointStatisticDetailsHandler
 				Math.max(0L, ackTSStats.getMaximum() - triggerTimestamp),
 				Math.max(0L, ackTSStats.getAverage() - triggerTimestamp)),
 			checkpointDuration,
-			checkpointAlignment);
+			checkpointAlignment,
+			MinMaxAvgStatistics.valueOf(taskStatisticsSummary.getCheckpointStartDelayStats()));
 	}
 
 	private static List<SubtaskCheckpointStatistics> createSubtaskCheckpointStatistics(SubtaskStateStats[] subtaskStateStats, long triggerTimestamp) {
@@ -178,7 +179,8 @@ public class TaskCheckpointStatisticDetailsHandler
 						subtask.getAsyncCheckpointDuration()),
 					new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(
 						subtask.getAlignmentBuffered(),
-						subtask.getAlignmentDuration())
+						subtask.getAlignmentDuration()),
+					subtask.getCheckpointStartDelay()
 				));
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/MinMaxAvgStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/MinMaxAvgStatistics.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.rest.messages.checkpoints;
 
+import org.apache.flink.runtime.checkpoint.MinMaxAvgStats;
+
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -42,6 +44,13 @@ public final class MinMaxAvgStatistics {
 
 	@JsonProperty(FIELD_NAME_AVERAGE)
 	private final long average;
+
+	public static MinMaxAvgStatistics valueOf(MinMaxAvgStats stats) {
+		return new MinMaxAvgStatistics(
+			stats.getMinimum(),
+			stats.getMaximum(),
+			stats.getAverage());
+	}
 
 	@JsonCreator
 	public MinMaxAvgStatistics(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/SubtaskCheckpointStatistics.java
@@ -97,6 +97,8 @@ public class SubtaskCheckpointStatistics {
 
 		public static final String FIELD_NAME_ALIGNMENT = "alignment";
 
+		public static final String FIELD_NAME_START_DELAY = "start_delay";
+
 		@JsonProperty(FIELD_NAME_ACK_TIMESTAMP)
 		private final long ackTimestamp;
 
@@ -112,6 +114,9 @@ public class SubtaskCheckpointStatistics {
 		@JsonProperty(FIELD_NAME_ALIGNMENT)
 		private final CheckpointAlignment alignment;
 
+		@JsonProperty(FIELD_NAME_START_DELAY)
+		private final long startDelay;
+
 		@JsonCreator
 		public CompletedSubtaskCheckpointStatistics(
 				@JsonProperty(FIELD_NAME_INDEX) int index,
@@ -119,13 +124,15 @@ public class SubtaskCheckpointStatistics {
 				@JsonProperty(FIELD_NAME_DURATION) long duration,
 				@JsonProperty(FIELD_NAME_STATE_SIZE) long stateSize,
 				@JsonProperty(FIELD_NAME_CHECKPOINT_DURATION) CheckpointDuration checkpointDuration,
-				@JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment alignment) {
+				@JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment alignment,
+				@JsonProperty(FIELD_NAME_START_DELAY) long startDelay) {
 			super(index, "completed");
 			this.ackTimestamp = ackTimestamp;
 			this.duration = duration;
 			this.stateSize = stateSize;
 			this.checkpointDuration = checkpointDuration;
 			this.alignment = alignment;
+			this.startDelay = startDelay;
 		}
 
 		public long getAckTimestamp() {
@@ -148,6 +155,10 @@ public class SubtaskCheckpointStatistics {
 			return alignment;
 		}
 
+		public long getStartDelay() {
+			return startDelay;
+		}
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -161,12 +172,19 @@ public class SubtaskCheckpointStatistics {
 				duration == that.duration &&
 				stateSize == that.stateSize &&
 				Objects.equals(checkpointDuration, that.checkpointDuration) &&
-				Objects.equals(alignment, that.alignment);
+				Objects.equals(alignment, that.alignment) &&
+				startDelay == that.startDelay;
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(ackTimestamp, duration, stateSize, checkpointDuration, alignment);
+			return Objects.hash(
+				ackTimestamp,
+				duration,
+				stateSize,
+				checkpointDuration,
+				alignment,
+				startDelay);
 		}
 
 		/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetails.java
@@ -115,6 +115,8 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 
 		public static final String FIELD_NAME_ALIGNMENT = "alignment";
 
+		public static final String FIELD_NAME_START_DELAY = "start_delay";
+
 		@JsonProperty(FIELD_NAME_STATE_SIZE)
 		private final MinMaxAvgStatistics stateSize;
 
@@ -127,16 +129,21 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 		@JsonProperty(FIELD_NAME_ALIGNMENT)
 		private final CheckpointAlignment checkpointAlignment;
 
+		@JsonProperty(FIELD_NAME_START_DELAY)
+		private final MinMaxAvgStatistics checkpointStartDelay;
+
 		@JsonCreator
 		public Summary(
 				@JsonProperty(FIELD_NAME_STATE_SIZE) MinMaxAvgStatistics stateSize,
 				@JsonProperty(FIELD_NAME_DURATION) MinMaxAvgStatistics duration,
 				@JsonProperty(FIELD_NAME_CHECKPOINT_DURATION) CheckpointDuration checkpointDuration,
-				@JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment checkpointAlignment) {
+				@JsonProperty(FIELD_NAME_ALIGNMENT) CheckpointAlignment checkpointAlignment,
+				@JsonProperty(FIELD_NAME_START_DELAY) MinMaxAvgStatistics checkpointStartDelay) {
 			this.stateSize = Preconditions.checkNotNull(stateSize);
 			this.duration = Preconditions.checkNotNull(duration);
 			this.checkpointDuration = Preconditions.checkNotNull(checkpointDuration);
 			this.checkpointAlignment = Preconditions.checkNotNull(checkpointAlignment);
+			this.checkpointStartDelay = Preconditions.checkNotNull(checkpointStartDelay);
 		}
 
 		public MinMaxAvgStatistics getStateSize() {
@@ -155,6 +162,10 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 			return checkpointAlignment;
 		}
 
+		public MinMaxAvgStatistics getCheckpointStartDelay() {
+			return checkpointStartDelay;
+		}
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -167,12 +178,18 @@ public final class TaskCheckpointStatisticsWithSubtaskDetails extends TaskCheckp
 			return Objects.equals(stateSize, summary.stateSize) &&
 				Objects.equals(duration, summary.duration) &&
 				Objects.equals(checkpointDuration, summary.checkpointDuration) &&
-				Objects.equals(checkpointAlignment, summary.checkpointAlignment);
+				Objects.equals(checkpointAlignment, summary.checkpointAlignment) &&
+				Objects.equals(checkpointStartDelay, summary.checkpointStartDelay);
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(stateSize, duration, checkpointDuration, checkpointAlignment);
+			return Objects.hash(
+				stateSize,
+				duration,
+				checkpointDuration,
+				checkpointAlignment,
+				checkpointStartDelay);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -18,21 +18,6 @@
 
 package org.apache.flink.runtime.checkpoint;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
@@ -42,6 +27,22 @@ import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguratio
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CheckpointStatsTrackerTest {
 
@@ -396,6 +397,7 @@ public class CheckpointStatsTrackerTest {
 			ignored,
 			ignored,
 			alignmenetBuffered,
+			ignored,
 			ignored);
 
 		assertTrue(pending.reportSubtaskStats(jobVertex.getJobVertexId(), subtaskStats));
@@ -475,6 +477,6 @@ public class CheckpointStatsTrackerTest {
 	}
 
 	private SubtaskStateStats createSubtaskStats(int index) {
-		return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0);
+		return new SubtaskStateStats(index, 0, 0, 0, 0, 0, 0, 0);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointTest.java
@@ -322,7 +322,7 @@ public class CompletedCheckpointTest {
 			1337,
 			123129837912L,
 			123819239812L,
-			new SubtaskStateStats(123, 213123, 123123, 0, 0, 0, 0),
+			new SubtaskStateStats(123, 213123, 123123, 0, 0, 0, 0, 0),
 			null);
 
 		CompletedCheckpointStats copy = CommonTestUtils.createCopySerializable(completed);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointStatsTest.java
@@ -279,6 +279,7 @@ public class PendingCheckpointStatsTest {
 			Integer.MAX_VALUE + (long) index,
 			Integer.MAX_VALUE + (long) index,
 			Integer.MAX_VALUE + (long) index,
+			Integer.MAX_VALUE + (long) index,
 			Integer.MAX_VALUE + (long) index);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/SubtaskStateStatsTest.java
@@ -37,7 +37,8 @@ public class SubtaskStateStatsTest {
 			Integer.MAX_VALUE + 3L,
 			Integer.MAX_VALUE + 4L,
 			Integer.MAX_VALUE + 5L,
-			Integer.MAX_VALUE + 6L);
+			Integer.MAX_VALUE + 6L,
+			Integer.MAX_VALUE + 7L);
 
 		assertEquals(0, stats.getSubtaskIndex());
 		assertEquals(Integer.MAX_VALUE + 1L, stats.getAckTimestamp());
@@ -46,6 +47,7 @@ public class SubtaskStateStatsTest {
 		assertEquals(Integer.MAX_VALUE + 4L, stats.getAsyncCheckpointDuration());
 		assertEquals(Integer.MAX_VALUE + 5L, stats.getAlignmentBuffered());
 		assertEquals(Integer.MAX_VALUE + 6L, stats.getAlignmentDuration());
+		assertEquals(Integer.MAX_VALUE + 7L, stats.getCheckpointStartDelay());
 
 		// Check duration helper
 		long ackTimestamp = stats.getAckTimestamp();
@@ -68,7 +70,9 @@ public class SubtaskStateStatsTest {
 			Integer.MAX_VALUE + 3L,
 			Integer.MAX_VALUE + 4L,
 			Integer.MAX_VALUE + 5L,
-			Integer.MAX_VALUE + 6L);
+			Integer.MAX_VALUE + 6L,
+			Integer.MAX_VALUE + 7L);
+
 
 		SubtaskStateStats copy = CommonTestUtils.createCopySerializable(stats);
 
@@ -79,6 +83,7 @@ public class SubtaskStateStatsTest {
 		assertEquals(Integer.MAX_VALUE + 4L, copy.getAsyncCheckpointDuration());
 		assertEquals(Integer.MAX_VALUE + 5L, copy.getAlignmentBuffered());
 		assertEquals(Integer.MAX_VALUE + 6L, copy.getAlignmentDuration());
+		assertEquals(Integer.MAX_VALUE + 7L, stats.getCheckpointStartDelay());
 
 		// Check duration helper
 		long ackTimestamp = copy.getAckTimestamp();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/TaskStateStatsTest.java
@@ -63,6 +63,7 @@ public class TaskStateStatsTest {
 				rand.nextInt(128),
 				rand.nextInt(128),
 				rand.nextInt(128),
+				rand.nextInt(128),
 				rand.nextInt(128));
 
 			stateSize += subtasks[i].getStateSize();
@@ -78,7 +79,7 @@ public class TaskStateStatsTest {
 			assertEquals(alignmentBuffered, taskStats.getAlignmentBuffered());
 		}
 
-		assertFalse(taskStats.reportSubtaskStats(new SubtaskStateStats(0, 0, 0, 0, 0, 0, 0)));
+		assertFalse(taskStats.reportSubtaskStats(new SubtaskStateStats(0, 0, 0, 0, 0, 0, 0, 0)));
 
 		// Test that all subtasks are taken into the account for the summary.
 		// The correctness of the actual results is checked in the test of the
@@ -105,6 +106,7 @@ public class TaskStateStatsTest {
 		for (int i = 0; i < subtasks.length; i++) {
 			subtasks[i] = new SubtaskStateStats(
 				i,
+				rand.nextInt(128),
 				rand.nextInt(128),
 				rand.nextInt(128),
 				rand.nextInt(128),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/checkpoints/TaskCheckpointStatisticsWithSubtaskDetailsTest.java
@@ -44,7 +44,8 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest extends RestResponse
 				new MinMaxAvgStatistics(1L, 2L, 3L)),
 			new TaskCheckpointStatisticsWithSubtaskDetails.CheckpointAlignment(
 				new MinMaxAvgStatistics(1L, 2L, 3L),
-			new MinMaxAvgStatistics(1L, 2L, 3L)));
+				new MinMaxAvgStatistics(1L, 2L, 3L)),
+			new MinMaxAvgStatistics(1L, 2L, 3L));
 
 		List<SubtaskCheckpointStatistics> subtaskCheckpointStatistics = new ArrayList<>(2);
 
@@ -55,7 +56,8 @@ public class TaskCheckpointStatisticsWithSubtaskDetailsTest extends RestResponse
 			13L,
 			1337L,
 			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointDuration(1L, 2L),
-			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(2L, 3L)));
+			new SubtaskCheckpointStatistics.CompletedSubtaskCheckpointStatistics.CheckpointAlignment(2L, 3L),
+			42L));
 
 		return new TaskCheckpointStatisticsWithSubtaskDetails(
 			4L,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -85,7 +85,8 @@ public abstract class CheckpointBarrierHandler {
 
 		CheckpointMetrics checkpointMetrics = new CheckpointMetrics()
 			.setBytesBufferedInAlignment(bufferedBytes)
-			.setAlignmentDurationNanos(alignmentDurationNanos);
+			.setAlignmentDurationNanos(alignmentDurationNanos)
+			.setCheckpointStartDelayNanos(latestCheckpointStartDelayNanos);
 
 		toNotifyOnCheckpoint.triggerCheckpointOnBarrier(
 			checkpointMetaData,


### PR DESCRIPTION
This PR exposes the new `checkpointStartDelayNanos` metric in the WebUI.

Screenshot of how does the proposed change look like can be found in the [ticket](https://issues.apache.org/jira/browse/FLINK-15603).

## Verifying this change

This change is covered by some existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
