### PR TITLE
[FLINK-13689] [Connectors/ElasticSearch] Fix thread leak in Elasticsearch connector when cluster is down

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -50,7 +50,7 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
 	 * @param clientConfig The configuration to use when constructing the client.
 	 * @return The created client.
 	 */
-	C createClient(Map<String, String> clientConfig) throws IOException;
+	C createClient(Map<String, String> clientConfig);
 
 	/**
 	 * Creates a {@link BulkProcessor.Builder} for creating the bulk processor.
@@ -79,6 +79,17 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
 	void configureBulkProcessorBackoff(
 		BulkProcessor.Builder builder,
 		@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy);
+
+	/**
+	 * <p>Verify the client connection by making a test request/ping to the Elasticsearch cluster.
+	 * 
+	 * 
+	 * <p>Called by {@link ElasticsearchSinkBase#open(org.apache.flink.configuration.Configuration)} after creating the client. This makes sure the underlying
+	 * client is closed if the connection is not successful and preventing thread leak.
+	 *
+	 * @param client the Elasticsearch client.
+	 */
+	void verifyClientConnection(C client) throws IOException;
 
 	/**
 	 * Creates a {@link RequestIndexer} that is able to work with {@link BulkProcessor} binary compatible.

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchApiCallBridge.java
@@ -81,9 +81,8 @@ public interface ElasticsearchApiCallBridge<C extends AutoCloseable> extends Ser
 		@Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy);
 
 	/**
-	 * <p>Verify the client connection by making a test request/ping to the Elasticsearch cluster.
-	 * 
-	 * 
+	 * Verify the client connection by making a test request/ping to the Elasticsearch cluster.
+	 *
 	 * <p>Called by {@link ElasticsearchSinkBase#open(org.apache.flink.configuration.Configuration)} after creating the client. This makes sure the underlying
 	 * client is closed if the connection is not successful and preventing thread leak.
 	 *

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBase.java
@@ -297,6 +297,7 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
 	@Override
 	public void open(Configuration parameters) throws Exception {
 		client = callBridge.createClient(userConfig);
+		callBridge.verifyClientConnection(client);
 		bulkProcessor = buildBulkProcessor(new BulkProcessorListener());
 		requestIndexer = callBridge.createBulkProcessorIndexer(bulkProcessor, flushOnCheckpoint, numPendingRequests);
 		failureRequestIndexer = new BufferingNoOpRequestIndexer();

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -559,6 +559,11 @@ public class ElasticsearchSinkBaseTest {
 		public void configureBulkProcessorBackoff(BulkProcessor.Builder builder, @Nullable ElasticsearchSinkBase.BulkFlushBackoffPolicy flushBackoffPolicy) {
 			// no need for this in the test cases here
 		}
+
+		@Override
+		public void verifyClientConnection(Client client) {
+			// no need for this in the test cases here
+		}
 	}
 
 	private static class SimpleSinkFunction<String> implements ElasticsearchSinkFunction<String> {

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
@@ -71,19 +71,6 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 			transportClient.addTransportAddress(address);
 		}
 
-		// verify that we actually are connected to a cluster
-		if (transportClient.connectedNodes().isEmpty()) {
-
-			// close the transportClient here
-			IOUtils.closeQuietly(transportClient);
-
-			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", transportClient.connectedNodes());
-		}
-
 		return transportClient;
 	}
 
@@ -125,5 +112,20 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		builder.setBackoffPolicy(backoffPolicy);
+	}
+
+	@Override
+	public void verifyClientConnection(TransportClient client) {
+		// verify that we actually are connected to a cluster
+		if (client.connectedNodes().isEmpty()) {
+			// close the transportClient here
+			IOUtils.closeQuietly(client);
+
+			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", client.connectedNodes());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/java/org/apache/flink/streaming/connectors/elasticsearch2/Elasticsearch2ApiCallBridge.java
@@ -125,7 +125,7 @@ public class Elasticsearch2ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", client.connectedNodes());
+			LOG.info("Elasticsearch TransportClient is connected to nodes {}", client.connectedNodes());
 		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
@@ -77,19 +77,6 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 			transportClient.addTransportAddress(transport);
 		}
 
-		// verify that we actually are connected to a cluster
-		if (transportClient.connectedNodes().isEmpty()) {
-
-			// close the transportClient here
-			IOUtils.closeQuietly(transportClient);
-
-			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", transportClient.connectedNodes());
-		}
-
 		return transportClient;
 	}
 
@@ -131,5 +118,20 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		builder.setBackoffPolicy(backoffPolicy);
+	}
+
+	@Override
+	public void verifyClientConnection(TransportClient client) {
+		// verify that we actually are connected to a cluster
+		if (client.connectedNodes().isEmpty()) {
+			// close the transportClient here
+			IOUtils.closeQuietly(client);
+
+			throw new RuntimeException("Elasticsearch client is not connected to any Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", client.connectedNodes());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
@@ -131,7 +131,7 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 		}
 
 		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch TransportClient with connected nodes {}", client.connectedNodes());
+			LOG.info("Elasticsearch TransportClient is connected to nodes {}", client.connectedNodes());
 		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -68,23 +68,11 @@ public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge<R
 	}
 
 	@Override
-	public RestHighLevelClient createClient(Map<String, String> clientConfig) throws IOException {
+	public RestHighLevelClient createClient(Map<String, String> clientConfig) {
 		RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]));
 		restClientFactory.configureRestClientBuilder(builder);
 
 		RestHighLevelClient rhlClient = new RestHighLevelClient(builder);
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
-		}
-
-		if (!rhlClient.ping()) {
-			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
-		}
 
 		return rhlClient;
 	}
@@ -138,5 +126,20 @@ public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge<R
 			bulkProcessor,
 			flushOnCheckpoint,
 			numPendingRequestsRef);
+	}
+
+	@Override
+	public void verifyClientConnection(RestHighLevelClient client) throws IOException {
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
+		}
+
+		if (!client.ping()) {
+			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/main/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6ApiCallBridge.java
@@ -139,7 +139,7 @@ public class Elasticsearch6ApiCallBridge implements ElasticsearchApiCallBridge<R
 		}
 
 		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
+			LOG.info("Elasticsearch RestHighLevelClient is connected to {}", httpHosts.toString());
 		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
@@ -69,23 +69,11 @@ public class Elasticsearch7ApiCallBridge implements ElasticsearchApiCallBridge<R
 	}
 
 	@Override
-	public RestHighLevelClient createClient(Map<String, String> clientConfig) throws IOException {
+	public RestHighLevelClient createClient(Map<String, String> clientConfig) {
 		RestClientBuilder builder = RestClient.builder(httpHosts.toArray(new HttpHost[httpHosts.size()]));
 		restClientFactory.configureRestClientBuilder(builder);
 
 		RestHighLevelClient rhlClient = new RestHighLevelClient(builder);
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
-		}
-
-		if (!rhlClient.ping(RequestOptions.DEFAULT)) {
-			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
-		}
-
-		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
-		}
 
 		return rhlClient;
 	}
@@ -139,5 +127,20 @@ public class Elasticsearch7ApiCallBridge implements ElasticsearchApiCallBridge<R
 			bulkProcessor,
 			flushOnCheckpoint,
 			numPendingRequestsRef);
+	}
+
+	@Override
+	public void verifyClientConnection(RestHighLevelClient client) throws IOException {
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Pinging Elasticsearch cluster via hosts {} ...", httpHosts);
+		}
+
+		if (!client.ping(RequestOptions.DEFAULT)) {
+			throw new RuntimeException("There are no reachable Elasticsearch nodes!");
+		}
+
+		if (LOG.isInfoEnabled()) {
+			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
+		}
 	}
 }

--- a/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/main/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7ApiCallBridge.java
@@ -140,7 +140,7 @@ public class Elasticsearch7ApiCallBridge implements ElasticsearchApiCallBridge<R
 		}
 
 		if (LOG.isInfoEnabled()) {
-			LOG.info("Created Elasticsearch RestHighLevelClient connected to {}", httpHosts.toString());
+			LOG.info("Elasticsearch RestHighLevelClient is connected to {}", httpHosts.toString());
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

Fixes thread leaks caused by unclosed Elasticsearch clients

## Brief change log

  - Created new method *verifyClientConnection()* in *ElasticsearchApiCallBridge*
  - Moved test calls in existing Elasticsearch connectors to this new method
  - verifyClientConnection() is called in *ElasticsearchSinkBase#open()* after client has been created. If an error occurs, close() in 'ElasticsearchSinkBase' can now clean up the client. This was not possible before as the Exception was thrown before the client variable was assigned.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I tested the change on our development cluster by applying the change on top of release tag 1.9.1. No problems so far and the threads don't leak anymore. Recovery works fine, I tested different scenarios with the Elasticsearch cluster shut down,.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
