### PR TITLE
[FLINK-15275] Deprecated ineffectual sysoutLogging CLI option

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -409,8 +409,6 @@ Action "run" compiles and runs a program.
                                           (e.g.: --pyRequirements
                                           file:///tmp/requirements.txt#file:///t
                                           mp/cached_dir).
-     -q,--sysoutLogging                   If present, suppress logging output to
-                                          standard out.
      -s,--fromSavepoint <savepointPath>   Path to a savepoint to restore the job
                                           from (for example
                                           hdfs:///flink/savepoint-1537).

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -408,8 +408,6 @@ Action "run" compiles and runs a program.
                                           (e.g.: --pyRequirements
                                           file:///tmp/requirements.txt#file:///t
                                           mp/cached_dir).
-     -q,--sysoutLogging                   If present, suppress logging output to
-                                          standard out.
      -s,--fromSavepoint <savepointPath>   Path to a savepoint to restore the job
                                           from (for example
                                           hdfs:///flink/savepoint-1537).

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -57,6 +57,10 @@ public class CliFrontendParser {
 			"The parallelism with which to run the program. Optional flag to override the default value " +
 			"specified in the configuration.");
 
+	/**
+	 * @deprecated This has no effect anymore, we're keeping it to not break existing bash scripts.
+	 */
+	@Deprecated
 	static final Option LOGGING_OPTION = new Option("q", "sysoutLogging", false, "If present, " +
 			"suppress logging output to standard out.");
 
@@ -258,7 +262,6 @@ public class CliFrontendParser {
 		options.addOption(CLASS_OPTION);
 		options.addOption(CLASSPATH_OPTION);
 		options.addOption(PARALLELISM_OPTION);
-		options.addOption(LOGGING_OPTION);
 		options.addOption(DETACHED_OPTION);
 		options.addOption(SHUTDOWN_IF_ATTACHED_OPTION);
 		options.addOption(PY_OPTION);


### PR DESCRIPTION
We don't remove it completely, so as not to break existing tooling but
we don't print it in the CLI help anymore and don't show it in cli.md.

## Brief change log

- deprecate option
- remove from help printing
- update md.cli/md.zh.cli