### PR TITLE
[FLINK-15754][docs] Remove config options table.exec.resource.*memory from docs

### DIFF
--- a/docs/_includes/generated/execution_config_configuration.html
+++ b/docs/_includes/generated/execution_config_configuration.html
@@ -53,30 +53,6 @@ By default no operator is disabled.</td>
             <td>Sets default parallelism for all operators (such as aggregate, join, filter) to run with parallel instances. This config has a higher priority than parallelism of StreamExecutionEnvironment (actually, this config overrides the parallelism of StreamExecutionEnvironment). A value of -1 indicates that no default parallelism is set, then it will fallback to use the parallelism of StreamExecutionEnvironment.</td>
         </tr>
         <tr>
-            <td><h5>table.exec.resource.external-buffer-memory</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">"10 mb"</td>
-            <td>String</td>
-            <td>Sets the external buffer memory size that is used in sort merge join and nested join and over window. Note: memory size is only a weight hint, it will affect the weight of memory that can be applied by a single operator in the task, the actual memory used depends on the running environment.</td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.resource.hash-agg.memory</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">"128 mb"</td>
-            <td>String</td>
-            <td>Sets the managed memory size of hash aggregate operator. Note: memory size is only a weight hint, it will affect the weight of memory that can be applied by a single operator in the task, the actual memory used depends on the running environment.</td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.resource.hash-join.memory</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">"128 mb"</td>
-            <td>String</td>
-            <td>Sets the managed memory for hash join operator. It defines the lower limit. Note: memory size is only a weight hint, it will affect the weight of memory that can be applied by a single operator in the task, the actual memory used depends on the running environment.</td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.resource.sort.memory</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">"128 mb"</td>
-            <td>String</td>
-            <td>Sets the managed buffer memory size for sort operator. Note: memory size is only a weight hint, it will affect the weight of memory that can be applied by a single operator in the task, the actual memory used depends on the running environment.</td>
-        </tr>
-        <tr>
             <td><h5>table.exec.shuffle-mode</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"batch"</td>
             <td>String</td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -100,7 +100,8 @@ public class ExecutionConfigOptions {
 					"default parallelism is set, then it will fallback to use the parallelism " +
 					"of StreamExecutionEnvironment.");
 
-	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	@Documentation.ExcludeFromDocumentation("Beginning from Flink 1.10, this is interpreted as a weight hint " +
+		"instead of an absolute memory requirement. Users should not need to change these carefully tuned weight hints.")
 	public static final ConfigOption<String> TABLE_EXEC_RESOURCE_EXTERNAL_BUFFER_MEMORY =
 		key("table.exec.resource.external-buffer-memory")
 			.defaultValue("10 mb")
@@ -109,7 +110,8 @@ public class ExecutionConfigOptions {
 					" it will affect the weight of memory that can be applied by a single operator" +
 					" in the task, the actual memory used depends on the running environment.");
 
-	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	@Documentation.ExcludeFromDocumentation("Beginning from Flink 1.10, this is interpreted as a weight hint " +
+		"instead of an absolute memory requirement. Users should not need to change these carefully tuned weight hints.")
 	public static final ConfigOption<String> TABLE_EXEC_RESOURCE_HASH_AGG_MEMORY =
 		key("table.exec.resource.hash-agg.memory")
 			.defaultValue("128 mb")
@@ -118,7 +120,8 @@ public class ExecutionConfigOptions {
 					" that can be applied by a single operator in the task, the actual memory used" +
 					" depends on the running environment.");
 
-	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	@Documentation.ExcludeFromDocumentation("Beginning from Flink 1.10, this is interpreted as a weight hint " +
+		"instead of an absolute memory requirement. Users should not need to change these carefully tuned weight hints.")
 	public static final ConfigOption<String> TABLE_EXEC_RESOURCE_HASH_JOIN_MEMORY =
 		key("table.exec.resource.hash-join.memory")
 			.defaultValue("128 mb")
@@ -127,7 +130,8 @@ public class ExecutionConfigOptions {
 					" memory that can be applied by a single operator in the task, the actual" +
 					" memory used depends on the running environment.");
 
-	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
+	@Documentation.ExcludeFromDocumentation("Beginning from Flink 1.10, this is interpreted as a weight hint " +
+		"instead of an absolute memory requirement. Users should not need to change these carefully tuned weight hints.")
 	public static final ConfigOption<String> TABLE_EXEC_RESOURCE_SORT_MEMORY =
 		key("table.exec.resource.sort.memory")
 			.defaultValue("128 mb")


### PR DESCRIPTION
## What is the purpose of the change

*This removes the configuration options table.exec.resource.*memory from the documentation.*


## Brief change log

  - *See commits*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
