### PR TITLE
[FLINK-15487][table] Allow registering FLIP-65 functions in TableEnvironment

### DIFF
--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -43,7 +43,13 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
             'getCompletionHints',
             'create',
             'loadModule',
-            'unloadModule'}
+            'unloadModule',
+            'createTemporarySystemFunction',
+            'dropTemporarySystemFunction',
+            'createFunction',
+            'dropFunction',
+            'createTemporaryFunction',
+            'dropTemporaryFunction'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-table/flink-table-api-java/pom.xml
+++ b/flink-table/flink-table-api-java/pom.xml
@@ -55,6 +55,14 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 		</dependency>
 	</dependencies>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
@@ -60,7 +61,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public final class FunctionCatalog implements FunctionLookup {
-	private final TableConfig config;
+	private final ReadableConfig config;
 	private final CatalogManager catalogManager;
 	private final ModuleManager moduleManager;
 
@@ -76,7 +77,7 @@ public final class FunctionCatalog implements FunctionLookup {
 			TableConfig config,
 			CatalogManager catalogManager,
 			ModuleManager moduleManager) {
-		this.config = checkNotNull(config);
+		this.config = checkNotNull(config).getConfiguration();
 		this.catalogManager = checkNotNull(catalogManager);
 		this.moduleManager = checkNotNull(moduleManager);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.functions.TableAggregateFunctionDefinition;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.TableFunctionDefinition;
 import org.apache.flink.table.functions.UserDefinedAggregateFunction;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.util.Preconditions;
@@ -53,9 +54,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Simple function catalog to store {@link FunctionDefinition}s in catalogs.
+ *
+ * <p>Note: This class can be cleaned up a lot once we drop the methods deprecated as part of FLIP-65. In
+ * the long-term, the class should be a part of catalog manager similar to {@link DataTypeFactory}.
  */
 @Internal
-public class FunctionCatalog implements FunctionLookup {
+public final class FunctionCatalog implements FunctionLookup {
 	private final TableConfig config;
 	private final CatalogManager catalogManager;
 	private final ModuleManager moduleManager;
@@ -81,8 +85,283 @@ public class FunctionCatalog implements FunctionLookup {
 		this.plannerTypeInferenceUtil = plannerTypeInferenceUtil;
 	}
 
+	/**
+	 * Registers a temporary system function.
+	 */
+	public void registerTemporarySystemFunction(
+			String name,
+			FunctionDefinition definition,
+			boolean ignoreIfExists) {
+		final String normalizedName = FunctionIdentifier.normalizeName(name);
+
+		if (definition instanceof UserDefinedFunction) {
+			try {
+				UserDefinedFunctionHelper.prepareInstance(config, (UserDefinedFunction) definition);
+			} catch (Throwable t) {
+				throw new ValidationException(
+					String.format(
+						"Could not register temporary system function '%s' due to implementation errors.",
+						name),
+					t);
+			}
+		}
+
+		if (!tempSystemFunctions.containsKey(normalizedName)) {
+			tempSystemFunctions.put(normalizedName, definition);
+		} else if (!ignoreIfExists) {
+			throw new ValidationException(
+				String.format(
+					"Could not register temporary system function. A function named '%s' does already exist.",
+					name));
+		}
+	}
+
+	/**
+	 * Drops a temporary system function. Returns true if a function was dropped.
+	 */
+	public boolean dropTemporarySystemFunction(
+			String name,
+			boolean ignoreIfNotExist) {
+		final String normalizedName = FunctionIdentifier.normalizeName(name);
+		final FunctionDefinition definition = tempSystemFunctions.remove(normalizedName);
+
+		if (definition == null && !ignoreIfNotExist) {
+			throw new ValidationException(
+				String.format(
+					"Could not drop temporary system function. A function named '%s' doesn't exist.",
+					name));
+		}
+
+		return definition != null;
+	}
+
+	/**
+	 * Registers a temporary catalog function.
+	 */
+	public void registerTemporaryCatalogFunction(
+			UnresolvedIdentifier unresolvedIdentifier,
+			FunctionDefinition definition,
+			boolean ignoreIfExists) {
+		final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		final ObjectIdentifier normalizedIdentifier = FunctionIdentifier.normalizeObjectIdentifier(identifier);
+
+		if (definition instanceof UserDefinedFunction) {
+			try {
+				UserDefinedFunctionHelper.prepareInstance(config, (UserDefinedFunction) definition);
+			} catch (Throwable t) {
+				throw new ValidationException(
+					String.format(
+						"Could not register temporary catalog function '%s' due to implementation errors.",
+						identifier.asSummaryString()),
+					t);
+			}
+		}
+
+		if (!tempCatalogFunctions.containsKey(normalizedIdentifier)) {
+			tempCatalogFunctions.put(normalizedIdentifier, definition);
+		} else if (!ignoreIfExists) {
+			throw new ValidationException(
+				String.format(
+					"Could not register temporary catalog function. A function '%s' does already exist.",
+					identifier.asSummaryString()));
+		}
+	}
+
+	/**
+	 * Drops a temporary catalog function. Returns true if a function was dropped.
+	 */
+	public boolean dropTemporaryCatalogFunction(
+			UnresolvedIdentifier unresolvedIdentifier,
+			boolean ignoreIfNotExist) {
+		final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		final ObjectIdentifier normalizedIdentifier = FunctionIdentifier.normalizeObjectIdentifier(identifier);
+		final FunctionDefinition definition = tempCatalogFunctions.remove(normalizedIdentifier);
+
+		if (definition == null && !ignoreIfNotExist) {
+			throw new ValidationException(
+				String.format(
+					"Could not drop temporary catalog function. A function '%s' doesn't exist.",
+					identifier.asSummaryString()));
+		}
+
+		return definition != null;
+	}
+
+	/**
+	 * Registers a catalog function by also considering temporary catalog functions.
+	 */
+	public void registerCatalogFunction(
+			UnresolvedIdentifier unresolvedIdentifier,
+			Class<? extends UserDefinedFunction> functionClass,
+			boolean ignoreIfExists) {
+		final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		final ObjectIdentifier normalizedIdentifier = FunctionIdentifier.normalizeObjectIdentifier(identifier);
+
+		try {
+			UserDefinedFunctionHelper.validateClass(functionClass);
+		} catch (Throwable t) {
+			throw new ValidationException(
+				String.format(
+					"Could not register catalog function '%s' due to implementation errors.",
+					identifier.asSummaryString()),
+				t);
+		}
+
+		final Catalog catalog = catalogManager.getCatalog(normalizedIdentifier.getCatalogName())
+			.orElseThrow(IllegalStateException::new);
+		final ObjectPath path = identifier.toObjectPath();
+
+		// we force users to deal with temporary catalog functions first
+		if (tempCatalogFunctions.containsKey(normalizedIdentifier)) {
+			if (ignoreIfExists) {
+				return;
+			}
+			throw new ValidationException(
+				String.format(
+					"Could not register catalog function. A temporary function '%s' does already exist. " +
+						"Please drop the temporary function first.",
+					identifier.asSummaryString()));
+		}
+
+		if (catalog.functionExists(path)) {
+			if (ignoreIfExists) {
+				return;
+			}
+			throw new ValidationException(
+				String.format(
+					"Could not register catalog function. A function '%s' does already exist.",
+					identifier.asSummaryString()));
+		}
+
+		final CatalogFunction catalogFunction = new CatalogFunctionImpl(
+			functionClass.getName(),
+			FunctionLanguage.JAVA);
+		try {
+			catalog.createFunction(path, catalogFunction, ignoreIfExists);
+		} catch (Throwable t) {
+			throw new TableException(
+				String.format(
+					"Could not register catalog function '%s'.",
+					identifier.asSummaryString()),
+				t);
+		}
+	}
+
+	/**
+	 * Drops a catalog function by also considering temporary catalog functions. Returns true if a
+	 * function was dropped.
+	 */
+	public boolean dropCatalogFunction(
+			UnresolvedIdentifier unresolvedIdentifier,
+			boolean ignoreIfNotExist) {
+		final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		final ObjectIdentifier normalizedIdentifier = FunctionIdentifier.normalizeObjectIdentifier(identifier);
+
+		final Catalog catalog = catalogManager.getCatalog(normalizedIdentifier.getCatalogName())
+			.orElseThrow(IllegalStateException::new);
+		final ObjectPath path = identifier.toObjectPath();
+
+		// we force users to deal with temporary catalog functions first
+		if (tempCatalogFunctions.containsKey(normalizedIdentifier)) {
+			throw new ValidationException(
+				String.format(
+					"Could not drop catalog function. A temporary function '%s' does already exist. " +
+						"Please drop the temporary function first.",
+					identifier.asSummaryString()));
+		}
+
+		if (!catalog.functionExists(path)) {
+			if (ignoreIfNotExist) {
+				return false;
+			}
+			throw new ValidationException(
+				String.format(
+					"Could not drop catalog function. A function '%s' doesn't exist.",
+					identifier.asSummaryString()));
+		}
+
+		try {
+			catalog.dropFunction(path, ignoreIfNotExist);
+		} catch (Throwable t) {
+			throw new TableException(
+				String.format(
+					"Could not drop catalog function '%s'.",
+					identifier.asSummaryString()),
+				t);
+		}
+		return true;
+	}
+
+	/**
+	 * Get names of all user defined functions, including temp system functions, temp catalog functions and catalog functions
+	 * in the current catalog and current database.
+	 */
+	public String[] getUserDefinedFunctions() {
+		return getUserDefinedFunctionNames().toArray(new String[0]);
+	}
+
+	/**
+	 * Get names of all functions, including temp system functions, system functions, temp catalog functions and catalog functions
+	 * in the current catalog and current database.
+	 */
+	public String[] getFunctions() {
+		Set<String> result = getUserDefinedFunctionNames();
+
+		// add system functions
+		result.addAll(moduleManager.listFunctions());
+
+		return result.toArray(new String[0]);
+	}
+
+	/**
+	 * Check whether a temporary catalog function is already registered.
+	 * @param functionIdentifier the object identifier of function
+	 * @return whether the temporary catalog function exists in the function catalog
+	 */
+	public boolean hasTemporaryCatalogFunction(ObjectIdentifier functionIdentifier) {
+		ObjectIdentifier normalizedIdentifier =
+			FunctionIdentifier.normalizeObjectIdentifier(functionIdentifier);
+		return tempCatalogFunctions.containsKey(normalizedIdentifier);
+	}
+
+	/**
+	 * Check whether a temporary system function is already registered.
+	 * @param functionName the name of the function
+	 * @return whether the temporary system function exists in the function catalog
+	 */
+	public boolean hasTemporarySystemFunction(String functionName) {
+		return tempSystemFunctions.containsKey(functionName);
+	}
+
+	@Override
+	public Optional<FunctionLookup.Result> lookupFunction(UnresolvedIdentifier identifier) {
+		// precise function reference
+		if (identifier.getDatabaseName().isPresent()) {
+			return resolvePreciseFunctionReference(catalogManager.qualifyIdentifier(identifier));
+		} else {
+			// ambiguous function reference
+			return resolveAmbiguousFunctionReference(identifier.getObjectName());
+		}
+	}
+
+	@Override
+	public PlannerTypeInferenceUtil getPlannerTypeInferenceUtil() {
+		Preconditions.checkNotNull(
+			plannerTypeInferenceUtil,
+			"A planner should have set the type inference utility.");
+		return plannerTypeInferenceUtil;
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Legacy function handling before FLIP-65
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * @deprecated Use {@link #registerTemporarySystemFunction(String, FunctionDefinition, boolean)} instead.
+	 */
+	@Deprecated
 	public void registerTempSystemScalarFunction(String name, ScalarFunction function) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		registerTempSystemFunction(
 			name,
@@ -94,7 +373,7 @@ public class FunctionCatalog implements FunctionLookup {
 			String name,
 			TableFunction<T> function,
 			TypeInformation<T> resultType) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		registerTempSystemFunction(
 			name,
@@ -110,7 +389,7 @@ public class FunctionCatalog implements FunctionLookup {
 			UserDefinedAggregateFunction<T, ACC> function,
 			TypeInformation<T> resultType,
 			TypeInformation<ACC> accType) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		final FunctionDefinition definition;
 		if (function instanceof AggregateFunction) {
@@ -136,7 +415,7 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	public void registerTempCatalogScalarFunction(ObjectIdentifier oi, ScalarFunction function) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		registerTempCatalogFunction(
 			oi,
@@ -148,7 +427,7 @@ public class FunctionCatalog implements FunctionLookup {
 			ObjectIdentifier oi,
 			TableFunction<T> function,
 			TypeInformation<T> resultType) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		registerTempCatalogFunction(
 			oi,
@@ -164,7 +443,7 @@ public class FunctionCatalog implements FunctionLookup {
 			UserDefinedAggregateFunction<T, ACC> function,
 			TypeInformation<T> resultType,
 			TypeInformation<ACC> accType) {
-		UserDefinedFunctionHelper.prepareFunction(config, function);
+		UserDefinedFunctionHelper.prepareInstance(config, function);
 
 		final FunctionDefinition definition;
 		if (function instanceof AggregateFunction) {
@@ -190,44 +469,6 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	/**
-	 * Check whether a temporary catalog function is already registered.
-	 * @param functionIdentifier the object identifier of function
-	 * @return whether the temporary catalog function exists in the function catalog
-	 */
-	public boolean hasTemporaryCatalogFunction(ObjectIdentifier functionIdentifier) {
-		ObjectIdentifier normalizedIdentifier =
-			FunctionIdentifier.normalizeObjectIdentifier(functionIdentifier);
-		return tempCatalogFunctions.containsKey(normalizedIdentifier);
-	}
-
-	/**
-	 * Check whether a temporary system function is already registered.
-	 * @param functionName the name of the function
-	 * @return whether the temporary system function exists in the function catalog
-	 */
-	public boolean hasTemporarySystemFunction(String functionName) {
-		return tempSystemFunctions.containsKey(functionName);
-	}
-
-	/**
-	 * Drop a temporary system function.
-	 *
-	 * @param funcName name of the function
-	 * @param ignoreIfNotExist Flag to specify behavior when the function does not exist:
-	 *                         if set to false, throw an exception,
-	 *                         if set to true, do nothing.
-	 */
-	public void dropTempSystemFunction(String funcName, boolean ignoreIfNotExist) {
-		String normalizedName = FunctionIdentifier.normalizeName(funcName);
-
-		FunctionDefinition fd = tempSystemFunctions.remove(normalizedName);
-
-		if (fd == null && !ignoreIfNotExist) {
-			throw new ValidationException(String.format("Temporary system function %s doesn't exist", funcName));
-		}
-	}
-
-	/**
 	 * Drop a temporary catalog function.
 	 *
 	 * @param identifier identifier of the function
@@ -246,25 +487,22 @@ public class FunctionCatalog implements FunctionLookup {
 	}
 
 	/**
-	 * Get names of all user defined functions, including temp system functions, temp catalog functions and catalog functions
-	 * in the current catalog and current database.
+	 * @deprecated Use {@link #registerTemporarySystemFunction(String, FunctionDefinition, boolean)} instead.
 	 */
-	public String[] getUserDefinedFunctions() {
-		return getUserDefinedFunctionNames().toArray(new String[0]);
+	@Deprecated
+	private void registerTempSystemFunction(String name, FunctionDefinition functionDefinition) {
+		tempSystemFunctions.put(FunctionIdentifier.normalizeName(name), functionDefinition);
 	}
 
 	/**
-	 * Get names of all functions, including temp system functions, system functions, temp catalog functions and catalog functions
-	 * in the current catalog and current database.
+	 * @deprecated Use {@link #registerTemporaryCatalogFunction(UnresolvedIdentifier, FunctionDefinition, boolean)} instead.
 	 */
-	public String[] getFunctions() {
-		Set<String> result = getUserDefinedFunctionNames();
-
-		// add system functions
-		result.addAll(moduleManager.listFunctions());
-
-		return result.toArray(new String[0]);
+	@Deprecated
+	private void registerTempCatalogFunction(ObjectIdentifier oi, FunctionDefinition functionDefinition) {
+		tempCatalogFunctions.put(FunctionIdentifier.normalizeObjectIdentifier(oi), functionDefinition);
 	}
+
+	// --------------------------------------------------------------------------------------------
 
 	private Set<String> getUserDefinedFunctionNames() {
 
@@ -291,17 +529,6 @@ public class FunctionCatalog implements FunctionLookup {
 		}
 
 		return result;
-	}
-
-	@Override
-	public Optional<FunctionLookup.Result> lookupFunction(UnresolvedIdentifier identifier) {
-		// precise function reference
-		if (identifier.getDatabaseName().isPresent()) {
-			return resolvePreciseFunctionReference(catalogManager.qualifyIdentifier(identifier));
-		} else {
-			// ambiguous function reference
-			return resolveAmbiguousFunctionReference(identifier.getObjectName());
-		}
 	}
 
 	private Optional<FunctionLookup.Result> resolvePreciseFunctionReference(ObjectIdentifier oi) {
@@ -333,6 +560,7 @@ public class FunctionCatalog implements FunctionLookup {
 					fd = catalog.getFunctionDefinitionFactory().get()
 						.createFunctionDefinition(oi.getObjectName(), catalogFunction);
 				} else {
+					// TODO update the FunctionDefinitionUtil once we drop the old function stack in DDL
 					fd = FunctionDefinitionUtil.createFunctionDefinition(
 						oi.getObjectName(), catalogFunction.getClassName());
 				}
@@ -372,21 +600,5 @@ public class FunctionCatalog implements FunctionLookup {
 		return candidate.map(fd ->
 			Optional.of(new Result(FunctionIdentifier.of(funcName), fd)
 		)).orElseGet(() -> resolvePreciseFunctionReference(oi));
-	}
-
-	@Override
-	public PlannerTypeInferenceUtil getPlannerTypeInferenceUtil() {
-		Preconditions.checkNotNull(
-			plannerTypeInferenceUtil,
-			"A planner should have set the type inference utility.");
-		return plannerTypeInferenceUtil;
-	}
-
-	private void registerTempSystemFunction(String name, FunctionDefinition functionDefinition) {
-		tempSystemFunctions.put(FunctionIdentifier.normalizeName(name), functionDefinition);
-	}
-
-	private void registerTempCatalogFunction(ObjectIdentifier oi, FunctionDefinition functionDefinition) {
-		tempCatalogFunctions.put(FunctionIdentifier.normalizeObjectIdentifier(oi), functionDefinition);
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionIdentifier;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -59,7 +60,7 @@ public interface FunctionLookup {
 	/**
 	 * Result of a function lookup.
 	 */
-	class Result {
+	final class Result {
 
 		private final FunctionIdentifier functionIdentifier;
 
@@ -76,6 +77,26 @@ public interface FunctionLookup {
 
 		public FunctionDefinition getFunctionDefinition() {
 			return functionDefinition;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			Result result = (Result) o;
+			return functionIdentifier.equals(result.functionIdentifier) &&
+				functionDefinition.equals(result.functionDefinition);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(
+				functionIdentifier,
+				functionDefinition);
 		}
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/ExpressionResolver.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.expressions.resolver;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.GroupWindow;
 import org.apache.flink.table.api.OverWindow;
 import org.apache.flink.table.api.TableConfig;
@@ -97,7 +98,7 @@ public class ExpressionResolver {
 
 	private static final VerifyResolutionVisitor VERIFY_RESOLUTION_VISITOR = new VerifyResolutionVisitor();
 
-	private final TableConfig config;
+	private final ReadableConfig config;
 
 	private final FieldReferenceLookup fieldLookup;
 
@@ -121,7 +122,7 @@ public class ExpressionResolver {
 			FieldReferenceLookup fieldLookup,
 			List<OverWindow> localOverWindows,
 			List<LocalReferenceExpression> localReferences) {
-		this.config = Preconditions.checkNotNull(config);
+		this.config = Preconditions.checkNotNull(config).getConfiguration();
 		this.tableLookup = Preconditions.checkNotNull(tableLookup);
 		this.fieldLookup = Preconditions.checkNotNull(fieldLookup);
 		this.functionLookup = Preconditions.checkNotNull(functionLookup);
@@ -261,7 +262,7 @@ public class ExpressionResolver {
 	private class ExpressionResolverContext implements ResolverRule.ResolutionContext {
 
 		@Override
-		public TableConfig configuration() {
+		public ReadableConfig configuration() {
 			return config;
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
@@ -97,7 +97,13 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 
 		@Override
 		public List<ResolvedExpression> visit(UnresolvedCallExpression unresolvedCall) {
-			final FunctionDefinition definition = prepareUserDefinedFunction(unresolvedCall.getFunctionDefinition());
+			final FunctionDefinition definition;
+			// clean functions that were not registered in a catalog
+			if (!unresolvedCall.getFunctionIdentifier().isPresent()) {
+				definition = prepareInlineUserDefinedFunction(unresolvedCall.getFunctionDefinition());
+			} else {
+				definition = unresolvedCall.getFunctionDefinition();
+			}
 
 			final String name = unresolvedCall.getFunctionIdentifier()
 				.map(FunctionIdentifier::toString)
@@ -238,23 +244,23 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 		/**
 		 * Validates and cleans an inline, unregistered {@link UserDefinedFunction}.
 		 */
-		private FunctionDefinition prepareUserDefinedFunction(FunctionDefinition definition) {
+		private FunctionDefinition prepareInlineUserDefinedFunction(FunctionDefinition definition) {
 			if (definition instanceof ScalarFunctionDefinition) {
 				final ScalarFunctionDefinition sf = (ScalarFunctionDefinition) definition;
-				UserDefinedFunctionHelper.prepareFunction(resolutionContext.configuration(), sf.getScalarFunction());
+				UserDefinedFunctionHelper.prepareInstance(resolutionContext.configuration(), sf.getScalarFunction());
 				return new ScalarFunctionDefinition(
 					sf.getName(),
 					sf.getScalarFunction());
 			} else if (definition instanceof TableFunctionDefinition) {
 				final TableFunctionDefinition tf = (TableFunctionDefinition) definition;
-				UserDefinedFunctionHelper.prepareFunction(resolutionContext.configuration(), tf.getTableFunction());
+				UserDefinedFunctionHelper.prepareInstance(resolutionContext.configuration(), tf.getTableFunction());
 				return new TableFunctionDefinition(
 					tf.getName(),
 					tf.getTableFunction(),
 					tf.getResultType());
 			} else if (definition instanceof AggregateFunctionDefinition) {
 				final AggregateFunctionDefinition af = (AggregateFunctionDefinition) definition;
-				UserDefinedFunctionHelper.prepareFunction(resolutionContext.configuration(), af.getAggregateFunction());
+				UserDefinedFunctionHelper.prepareInstance(resolutionContext.configuration(), af.getAggregateFunction());
 				return new AggregateFunctionDefinition(
 					af.getName(),
 					af.getAggregateFunction(),
@@ -262,12 +268,16 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 					af.getAccumulatorTypeInfo());
 			} else if (definition instanceof TableAggregateFunctionDefinition) {
 				final TableAggregateFunctionDefinition taf = (TableAggregateFunctionDefinition) definition;
-				UserDefinedFunctionHelper.prepareFunction(resolutionContext.configuration(), taf.getTableAggregateFunction());
+				UserDefinedFunctionHelper.prepareInstance(resolutionContext.configuration(), taf.getTableAggregateFunction());
 				return new TableAggregateFunctionDefinition(
 					taf.getName(),
 					taf.getTableAggregateFunction(),
 					taf.getResultTypeInfo(),
 					taf.getAccumulatorTypeInfo());
+			} else if (definition instanceof UserDefinedFunction) {
+				UserDefinedFunctionHelper.prepareInstance(
+					resolutionContext.configuration(),
+					(UserDefinedFunction) definition);
 			}
 			return definition;
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolverRule.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.expressions.resolver.rules;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.expressions.Expression;
@@ -52,7 +52,7 @@ public interface ResolverRule {
 		/**
 		 * Access to configuration.
 		 */
-		TableConfig configuration();
+		ReadableConfig configuration();
 
 		/**
 		 * Access to available {@link org.apache.flink.table.expressions.FieldReferenceExpression} in inputs.

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/FunctionCatalogTest.java
@@ -19,16 +19,16 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.table.api.TableConfig;
-import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
-import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
-import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
 import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
+import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,34 +38,61 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_CATALOG;
+import static org.apache.flink.table.utils.CatalogManagerMocks.DEFAULT_DATABASE;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 /**
- * Test for {@link FunctionCatalog}.
+ * Tests for {@link FunctionCatalog}.
  */
 public class FunctionCatalogTest {
-	private FunctionCatalog functionCatalog;
-	private Catalog catalog;
+
+	// TODO for now the resolution still returns the marker interfaces for functions
+	//  until we drop the old function stack in DDL
+
+	private static final ScalarFunction FUNCTION_1 = new TestFunction1();
+
+	private static final ScalarFunction FUNCTION_2 = new TestFunction2();
+
+	private static final ScalarFunction FUNCTION_INVALID = new InvalidTestFunction();
+
+	private static final String NAME = "test_function";
+
+	private static final ObjectIdentifier IDENTIFIER = ObjectIdentifier.of(
+		DEFAULT_CATALOG,
+		DEFAULT_DATABASE, NAME);
+
+	private static final UnresolvedIdentifier FULL_UNRESOLVED_IDENTIFIER = UnresolvedIdentifier.of(
+		DEFAULT_CATALOG,
+		DEFAULT_DATABASE, NAME);
+
+	private static final UnresolvedIdentifier PARTIAL_UNRESOLVED_IDENTIFIER = UnresolvedIdentifier.of(NAME);
+
 	private ModuleManager moduleManager;
 
-	private final String testCatalogName = "test";
-	private final ObjectIdentifier oi = ObjectIdentifier.of(
-		testCatalogName,
-		GenericInMemoryCatalog.DEFAULT_DB,
-		TEST_FUNCTION_NAME);
+	private FunctionCatalog functionCatalog;
 
-	private static final String TEST_FUNCTION_NAME = "test_function";
+	private Catalog catalog;
 
 	@Before
-	public void init() throws DatabaseAlreadyExistException {
-		catalog = new GenericInMemoryCatalog(testCatalogName);
+	public void init() {
+		catalog = new GenericInMemoryCatalog(
+			DEFAULT_CATALOG,
+			DEFAULT_DATABASE);
+
 		moduleManager = new ModuleManager();
+
 		functionCatalog = new FunctionCatalog(
 			TableConfig.getDefault(),
 			CatalogManagerMocks.preparedCatalogManager()
-				.defaultCatalog(testCatalogName, catalog)
+				.defaultCatalog(DEFAULT_CATALOG, catalog)
 				.build(),
 			moduleManager);
 	}
@@ -81,160 +108,439 @@ public class FunctionCatalogTest {
 	}
 
 	@Test
-	public void testPreciseFunctionReference() throws FunctionAlreadyExistException, DatabaseNotExistException {
-		ObjectIdentifier oi = ObjectIdentifier.of(
-			testCatalogName,
-			GenericInMemoryCatalog.DEFAULT_DB,
-			TEST_FUNCTION_NAME);
-		UnresolvedIdentifier identifier = UnresolvedIdentifier.of(
-			testCatalogName,
-			GenericInMemoryCatalog.DEFAULT_DB,
-			TEST_FUNCTION_NAME);
-
+	public void testPreciseFunctionReference() throws Exception {
 		// test no function is found
-		assertFalse(functionCatalog.lookupFunction(identifier).isPresent());
+		assertFalse(functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER).isPresent());
 
 		// test catalog function is found
 		catalog.createFunction(
-			oi.toObjectPath(),
-			new CatalogFunctionImpl(TestFunction1.class.getName()), false);
+			IDENTIFIER.toObjectPath(),
+			new CatalogFunctionImpl(TestFunction1.class.getName()),
+			false);
 
-		FunctionLookup.Result result = functionCatalog.lookupFunction(identifier).get();
+		FunctionLookup.Result result = functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER).get();
 
-		assertFalse(result.getFunctionIdentifier().getSimpleName().isPresent());
-		assertEquals(oi, result.getFunctionIdentifier().getIdentifier().get());
+		assertEquals(Optional.of(IDENTIFIER), result.getFunctionIdentifier().getIdentifier());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction1);
 
 		// test temp catalog function is found
 		functionCatalog.registerTempCatalogScalarFunction(
-			oi,
+			IDENTIFIER,
 			new TestFunction2()
 		);
 
-		result = functionCatalog.lookupFunction(identifier).get();
+		result = functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER).get();
 
-		assertFalse(result.getFunctionIdentifier().getSimpleName().isPresent());
-		assertEquals(oi, result.getFunctionIdentifier().getIdentifier().get());
+		assertEquals(Optional.of(IDENTIFIER), result.getFunctionIdentifier().getIdentifier());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction2);
 	}
 
 	@Test
-	public void testAmbiguousFunctionReference() throws FunctionAlreadyExistException, DatabaseNotExistException {
-		ObjectIdentifier oi = ObjectIdentifier.of(
-			testCatalogName,
-			GenericInMemoryCatalog.DEFAULT_DB,
-			TEST_FUNCTION_NAME);
-
+	public void testAmbiguousFunctionReference() throws Exception {
 		// test no function is found
-		assertFalse(functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).isPresent());
+		assertFalse(functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER).isPresent());
 
 		// test catalog function is found
 		catalog.createFunction(
-			oi.toObjectPath(),
-			new CatalogFunctionImpl(TestFunction1.class.getName()), false);
+			IDENTIFIER.toObjectPath(),
+			new CatalogFunctionImpl(TestFunction1.class.getName()),
+			false);
 
-		FunctionLookup.Result result = functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).get();
+		FunctionLookup.Result result = functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER).get();
 
-		assertFalse(result.getFunctionIdentifier().getSimpleName().isPresent());
-		assertEquals(oi, result.getFunctionIdentifier().getIdentifier().get());
+		assertEquals(Optional.of(IDENTIFIER), result.getFunctionIdentifier().getIdentifier());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction1);
 
 		// test temp catalog function is found
 		functionCatalog.registerTempCatalogScalarFunction(
-			oi,
+			IDENTIFIER,
 			new TestFunction2()
 		);
 
-		result = functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).get();
+		result = functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER).get();
 
-		assertFalse(result.getFunctionIdentifier().getSimpleName().isPresent());
-		assertEquals(oi, result.getFunctionIdentifier().getIdentifier().get());
+		assertEquals(Optional.of(IDENTIFIER), result.getFunctionIdentifier().getIdentifier());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction2);
 
 		// test system function is found
 		moduleManager.loadModule("test_module", new TestModule());
 
-		result = functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).get();
+		result = functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER).get();
 
-		assertEquals(TEST_FUNCTION_NAME, result.getFunctionIdentifier().getSimpleName().get());
+		assertEquals(Optional.of(NAME), result.getFunctionIdentifier().getSimpleName());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction3);
 
 		// test temp system function is found
-		functionCatalog.registerTempSystemScalarFunction(TEST_FUNCTION_NAME, new TestFunction4());
+		functionCatalog.registerTempSystemScalarFunction(NAME, new TestFunction4());
 
-		result = functionCatalog.lookupFunction(UnresolvedIdentifier.of(TEST_FUNCTION_NAME)).get();
+		result = functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER).get();
 
-		assertEquals(TEST_FUNCTION_NAME, result.getFunctionIdentifier().getSimpleName().get());
+		assertEquals(Optional.of(NAME), result.getFunctionIdentifier().getSimpleName());
 		assertTrue(((ScalarFunctionDefinition) result.getFunctionDefinition()).getScalarFunction() instanceof TestFunction4);
 	}
 
+	@Test
+	public void testTemporarySystemFunction() {
+		// register first time
+		functionCatalog.registerTemporarySystemFunction(
+			NAME,
+			FUNCTION_1,
+			false);
+		assertThat(
+			functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(FunctionIdentifier.of(NAME), FUNCTION_1));
+
+		// register second time lenient
+		functionCatalog.registerTemporarySystemFunction(NAME,
+			FUNCTION_2,
+			true);
+		assertThat(
+			functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(FunctionIdentifier.of(NAME), FUNCTION_1));
+
+		// register second time not lenient
+		try {
+			functionCatalog.registerTemporarySystemFunction(NAME, FUNCTION_2, false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function named '" + NAME + "' does already exist.")));
+		}
+
+		// drop first time
+		assertThat(
+			functionCatalog.dropTemporarySystemFunction(NAME, false),
+			equalTo(true));
+		assertThat(
+			functionCatalog.lookupFunction(PARTIAL_UNRESOLVED_IDENTIFIER),
+			returnsNoFunction());
+
+		// drop second time lenient
+		assertThat(
+			functionCatalog.dropTemporarySystemFunction(NAME, true),
+			equalTo(false));
+
+		// drop second time not lenient
+		try {
+			functionCatalog.dropTemporarySystemFunction(NAME, false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function named '" + NAME + "' doesn't exist.")));
+		}
+
+		// register invalid
+		try {
+			functionCatalog.registerTemporarySystemFunction(NAME, FUNCTION_INVALID, false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString(
+					"Could not register temporary system function '" + NAME +
+						"' due to implementation errors.")));
+		}
+	}
+
+	@Test
+	public void testCatalogFunction() {
+		// register first time
+		functionCatalog.registerCatalogFunction(
+			PARTIAL_UNRESOLVED_IDENTIFIER,
+			FUNCTION_1.getClass(),
+			false);
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				new ScalarFunctionDefinition(NAME, FUNCTION_1)));
+
+		// register second time lenient
+		functionCatalog.registerCatalogFunction(
+			PARTIAL_UNRESOLVED_IDENTIFIER,
+			FUNCTION_2.getClass(),
+			true);
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				new ScalarFunctionDefinition(NAME, FUNCTION_1)));
+
+		// register second time not lenient
+		try {
+			functionCatalog.registerCatalogFunction(
+				PARTIAL_UNRESOLVED_IDENTIFIER,
+				FUNCTION_2.getClass(),
+				false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function '" + IDENTIFIER.asSummaryString() + "' does already exist.")));
+		}
+
+		// drop first time
+		assertThat(
+			functionCatalog.dropCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, false),
+			equalTo(true));
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsNoFunction());
+
+		// drop second time lenient
+		assertThat(
+			functionCatalog.dropCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, true),
+			equalTo(false));
+
+		// drop second time not lenient
+		try {
+			functionCatalog.dropCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function '" + IDENTIFIER.asSummaryString() + "' doesn't exist.")));
+		}
+
+		// register invalid
+		try {
+			functionCatalog.registerCatalogFunction(
+				PARTIAL_UNRESOLVED_IDENTIFIER,
+				FUNCTION_INVALID.getClass(),
+				false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString(
+					"Could not register catalog function '" + IDENTIFIER.asSummaryString() +
+						"' due to implementation errors.")));
+		}
+	}
+
+	@Test
+	public void testTemporaryCatalogFunction() {
+		// register permanent function
+		functionCatalog.registerCatalogFunction(
+			PARTIAL_UNRESOLVED_IDENTIFIER,
+			FUNCTION_2.getClass(),
+			false);
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				new ScalarFunctionDefinition(NAME, FUNCTION_2)));
+
+		// register temporary first time
+		functionCatalog.registerTemporaryCatalogFunction(
+			PARTIAL_UNRESOLVED_IDENTIFIER,
+			FUNCTION_1,
+			false);
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				FUNCTION_1)); // temporary function hides catalog function
+
+		// dropping catalog functions is not possible in this state
+		try {
+			functionCatalog.dropCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, true);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString(
+					"A temporary function '" + IDENTIFIER.asSummaryString() + "' does already exist. " +
+						"Please drop the temporary function first.")));
+		}
+
+		// registering catalog functions is not possible in this state
+		try {
+			functionCatalog.registerCatalogFunction(
+				PARTIAL_UNRESOLVED_IDENTIFIER,
+				FUNCTION_2.getClass(),
+				false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString(
+					"A temporary function '" + IDENTIFIER.asSummaryString() + "' does already exist. " +
+						"Please drop the temporary function first.")));
+		}
+
+		// register temporary second time lenient
+		functionCatalog.registerTemporaryCatalogFunction(
+			PARTIAL_UNRESOLVED_IDENTIFIER,
+			FUNCTION_1,
+			true);
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				FUNCTION_1));
+
+		// register temporary second time not lenient
+		try {
+			functionCatalog.registerTemporaryCatalogFunction(
+				PARTIAL_UNRESOLVED_IDENTIFIER,
+				FUNCTION_2,
+				false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function '" + IDENTIFIER.asSummaryString() + "' does already exist.")));
+		}
+
+		// drop temporary first time
+		assertThat(
+			functionCatalog.dropTemporaryCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, false),
+			equalTo(true));
+		assertThat(
+			functionCatalog.lookupFunction(FULL_UNRESOLVED_IDENTIFIER),
+			returnsFunction(
+				FunctionIdentifier.of(IDENTIFIER),
+				new ScalarFunctionDefinition(NAME, FUNCTION_2))); // permanent function is visible again
+
+		// drop temporary second time lenient
+		assertThat(
+			functionCatalog.dropTemporaryCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, true),
+			equalTo(false));
+
+		// drop temporary second time not lenient
+		try {
+			functionCatalog.dropTemporaryCatalogFunction(PARTIAL_UNRESOLVED_IDENTIFIER, false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString("A function '" + IDENTIFIER.asSummaryString() + "' doesn't exist.")));
+		}
+
+		// register invalid
+		try {
+			functionCatalog.registerTemporaryCatalogFunction(
+				PARTIAL_UNRESOLVED_IDENTIFIER,
+				FUNCTION_INVALID,
+				false);
+			fail();
+		} catch (ValidationException e) {
+			assertThat(
+				e,
+				hasMessage(containsString(
+					"Could not register temporary catalog function '" + IDENTIFIER.asSummaryString() +
+						"' due to implementation errors.")));
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Legacy function handling before FLIP-65
+	// --------------------------------------------------------------------------------------------
+
+	@Test
+	public void testRegisterAndDropTempSystemFunction() {
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(NAME));
+
+		functionCatalog.registerTempSystemScalarFunction(NAME, new TestFunction1());
+		assertTrue(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(NAME));
+
+		functionCatalog.dropTemporarySystemFunction(NAME, false);
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(NAME));
+
+		functionCatalog.dropTemporarySystemFunction(NAME, true);
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(NAME));
+	}
+
+	@Test
+	public void testRegisterAndDropTempCatalogFunction() {
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(NAME));
+
+		functionCatalog.registerTempCatalogScalarFunction(IDENTIFIER, new TestFunction1());
+		assertTrue(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(IDENTIFIER.getObjectName()));
+
+		functionCatalog.dropTempCatalogFunction(IDENTIFIER, false);
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(IDENTIFIER.getObjectName()));
+
+		functionCatalog.dropTempCatalogFunction(IDENTIFIER, true);
+		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(IDENTIFIER.getObjectName()));
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test utilities
+	// --------------------------------------------------------------------------------------------
+
+	private static Matcher<Optional<FunctionLookup.Result>> returnsFunction(
+			FunctionIdentifier identifier,
+			FunctionDefinition definition) {
+		return equalTo(Optional.of(new FunctionLookup.Result(identifier, definition)));
+	}
+
+	private static Matcher<Optional<FunctionLookup.Result>> returnsNoFunction() {
+		return equalTo(Optional.empty());
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test classes
+	// --------------------------------------------------------------------------------------------
+
 	private static class TestModule implements Module {
+
 		@Override
 		public Set<String> listFunctions() {
 			return new HashSet<String>() {{
-				add(TEST_FUNCTION_NAME);
+				add(NAME);
 			}};
 		}
 
 		@Override
 		public Optional<FunctionDefinition> getFunctionDefinition(String name) {
-			return Optional.of(new ScalarFunctionDefinition(TEST_FUNCTION_NAME, new TestFunction3()));
+			return Optional.of(new ScalarFunctionDefinition(NAME, new TestFunction3()));
 		}
-	}
-
-	@Test
-	public void testRegisterAndDropTempSystemFunction() {
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(TEST_FUNCTION_NAME));
-
-		functionCatalog.registerTempSystemScalarFunction(TEST_FUNCTION_NAME, new TestFunction1());
-		assertTrue(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(TEST_FUNCTION_NAME));
-
-		functionCatalog.dropTempSystemFunction(TEST_FUNCTION_NAME, false);
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(TEST_FUNCTION_NAME));
-
-		functionCatalog.dropTempSystemFunction(TEST_FUNCTION_NAME, true);
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(TEST_FUNCTION_NAME));
-	}
-
-	@Test
-	public void testRegisterAndDropTempCatalogFunction() {
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(TEST_FUNCTION_NAME));
-
-		functionCatalog.registerTempCatalogScalarFunction(oi, new TestFunction1());
-		assertTrue(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(oi.getObjectName()));
-
-		functionCatalog.dropTempCatalogFunction(oi, false);
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(oi.getObjectName()));
-
-		functionCatalog.dropTempCatalogFunction(oi, true);
-		assertFalse(Arrays.asList(functionCatalog.getUserDefinedFunctions()).contains(oi.getObjectName()));
 	}
 
 	/**
 	 * Testing function.
 	 */
 	public static class TestFunction1 extends ScalarFunction {
-
+		public String eval(){
+			return null;
+		}
 	}
 
 	/**
 	 * Testing function.
 	 */
 	public static class TestFunction2 extends ScalarFunction {
-
+		public String eval(){
+			return null;
+		}
 	}
 
 	/**
 	 * Testing function.
 	 */
 	public static class TestFunction3 extends ScalarFunction {
-
+		public String eval(){
+			return null;
+		}
 	}
 
 	/**
 	 * Testing function.
 	 */
 	public static class TestFunction4 extends ScalarFunction {
+		public String eval(){
+			return null;
+		}
+	}
 
+	/**
+	 * Invalid testing function.
+	 */
+	public static class InvalidTestFunction extends ScalarFunction {
+		// missing implementation
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.util.Collector;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link UserDefinedFunctionHelper}.
+ */
+@RunWith(Parameterized.class)
+@SuppressWarnings("unused")
+public class UserDefinedFunctionHelperTest {
+
+	@Parameterized.Parameters
+	public static List<TestSpec> testData() {
+		return Arrays.asList(
+			TestSpec
+				.forClass(ValidScalarFunction.class)
+				.expectSuccess(),
+
+			TestSpec
+				.forInstance(new ValidScalarFunction())
+				.expectSuccess(),
+
+			TestSpec
+				.forClass(PrivateScalarFunction.class)
+				.expectErrorMessage(
+					"Function class '" + PrivateScalarFunction.class.getName() + "' is not public."),
+
+			TestSpec
+				.forClass(MissingImplementationScalarFunction.class)
+				.expectErrorMessage(
+					"Function class '" + MissingImplementationScalarFunction.class.getName() +
+						"' does not implement a method named 'eval'."),
+
+			TestSpec
+				.forClass(PrivateMethodScalarFunction.class)
+				.expectErrorMessage(
+					"Method 'eval' of function class '" + PrivateMethodScalarFunction.class.getName() +
+						"' is not public."),
+
+			TestSpec
+				.forInstance(new ValidTableAggregateFunction())
+				.expectSuccess(),
+
+			TestSpec
+				.forInstance(new MissingEmitTableAggregateFunction())
+				.expectErrorMessage(
+					"Function class '" + MissingEmitTableAggregateFunction.class.getName() +
+						"' does not implement a method named 'emitUpdateWithRetract' or 'emitValue'."),
+
+			TestSpec
+				.forInstance(new ValidTableFunction())
+				.expectSuccess(),
+
+			TestSpec
+				.forInstance(new ParameterizedTableFunction(12))
+				.expectSuccess(),
+
+			TestSpec
+				.forClass(ParameterizedTableFunction.class)
+				.expectErrorMessage(
+					"Function class '" + ParameterizedTableFunction.class.getName() +
+						"' must have a public default constructor."),
+
+			TestSpec
+				.forClass(HierarchicalTableAggregateFunction.class)
+				.expectSuccess()
+		);
+	}
+
+	@Parameter
+	public TestSpec testSpec;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testInstantiation() {
+		if (testSpec.functionClass != null) {
+			if (testSpec.expectedErrorMessage != null) {
+				thrown.expect(ValidationException.class);
+				thrown.expectMessage(testSpec.expectedErrorMessage);
+			}
+			assertThat(
+				UserDefinedFunctionHelper.instantiateFunction(testSpec.functionClass),
+				notNullValue());
+		}
+	}
+
+	@Test
+	public void testValidation() {
+		if (testSpec.expectedErrorMessage != null) {
+			thrown.expect(ValidationException.class);
+			thrown.expectMessage(testSpec.expectedErrorMessage);
+		}
+		if (testSpec.functionClass != null) {
+			UserDefinedFunctionHelper.validateClass(testSpec.functionClass);
+		} else if (testSpec.functionInstance != null) {
+			UserDefinedFunctionHelper.prepareInstance(new TableConfig(), testSpec.functionInstance);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test utilities
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Test specification shared with the Scala tests.
+	 */
+	private static class TestSpec {
+
+		final @Nullable Class<? extends UserDefinedFunction> functionClass;
+
+		final @Nullable UserDefinedFunction functionInstance;
+
+		@Nullable String expectedErrorMessage;
+
+		TestSpec(Class<? extends UserDefinedFunction> functionClass) {
+			this.functionClass = functionClass;
+			this.functionInstance = null;
+		}
+
+		TestSpec(UserDefinedFunction functionInstance) {
+			this.functionClass = null;
+			this.functionInstance = functionInstance;
+		}
+
+		static TestSpec forClass(Class<? extends UserDefinedFunction> function) {
+			return new TestSpec(function);
+		}
+
+		static TestSpec forInstance(UserDefinedFunction function) {
+			return new TestSpec(function);
+		}
+
+		TestSpec expectErrorMessage(String expectedErrorMessage) {
+			this.expectedErrorMessage = expectedErrorMessage;
+			return this;
+		}
+
+		TestSpec expectSuccess() {
+			this.expectedErrorMessage = null;
+			return this;
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test classes for validation
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Valid scalar function.
+	 */
+	public static class ValidScalarFunction extends ScalarFunction {
+		public String eval(int i) {
+			return null;
+		}
+	}
+
+	private static class PrivateScalarFunction extends ScalarFunction {
+		public String eval(int i) {
+			return null;
+		}
+	}
+
+	/**
+	 * No implementation method.
+	 */
+	public static class MissingImplementationScalarFunction extends ScalarFunction {
+		// nothing to do
+	}
+
+	/**
+	 * Implementation method is private.
+	 */
+	public static class PrivateMethodScalarFunction extends ScalarFunction {
+		private String eval(int i) {
+			return null;
+		}
+	}
+
+	/**
+	 * Valid table aggregate function.
+	 */
+	public static class ValidTableAggregateFunction extends TableAggregateFunction<String, String> {
+
+		public void accumulate(String acc, String in) {
+			// nothing to do
+		}
+
+		public void emitValue(String acc, Collector<String> out) {
+			// nothing to do
+		}
+
+		@Override
+		public String createAccumulator() {
+			return null;
+		}
+	}
+
+	/**
+	 * No emitting method implementation.
+	 */
+	public static class MissingEmitTableAggregateFunction extends TableAggregateFunction<String, String> {
+
+		public void accumulate(String acc, String in) {
+			// nothing to do
+		}
+
+		@Override
+		public String createAccumulator() {
+			return null;
+		}
+	}
+
+	/**
+	 * Valid table function.
+	 */
+	public static class ValidTableFunction extends TableFunction<String> {
+		public void eval(String i) {
+			// nothing to do
+		}
+	}
+
+	/**
+	 * Table function with parameters in constructor.
+	 */
+	public static class ParameterizedTableFunction extends TableFunction<String> {
+
+		public ParameterizedTableFunction(int param) {
+			// nothing to do
+		}
+
+		public void eval(String i) {
+			// nothing to do
+		}
+	}
+
+	private abstract static class AbstractTableAggregateFunction extends TableAggregateFunction<String, String> {
+		public void accumulate(String acc, String in) {
+			// nothing to do
+		}
+	}
+
+	/**
+	 * Hierarchy that is implementing different methods.
+	 */
+	public static class HierarchicalTableAggregateFunction extends AbstractTableAggregateFunction {
+
+		public void emitValue(String acc, Collector<String> out) {
+			// nothing to do
+		}
+
+		@Override
+		public String createAccumulator() {
+			return null;
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/UnresolvedIdentifier.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/UnresolvedIdentifier.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.StringUtils;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -72,6 +73,15 @@ public final class UnresolvedIdentifier {
 		} else {
 			return new UnresolvedIdentifier(null, null, path[0]);
 		}
+	}
+
+	/**
+	 * Constructs an {@link UnresolvedIdentifier} from a list of identifier segments.
+	 *
+	 * @see UnresolvedIdentifier#of(String...)
+	 */
+	public static UnresolvedIdentifier of(List<String> path) {
+		return of(path.toArray(new String[0]));
 	}
 
 	private UnresolvedIdentifier(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/TypeInferenceExtractor.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.extraction.utils.FunctionMappingExtractor;
 import org.apache.flink.table.types.extraction.utils.FunctionResultTemplate;
@@ -79,7 +80,7 @@ public final class TypeInferenceExtractor {
 		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
 			typeFactory,
 			function,
-			"eval",
+			UserDefinedFunctionHelper.SCALAR_EVAL,
 			createParameterSignatureExtraction(0),
 			null,
 			createReturnTypeResultExtraction(),
@@ -96,7 +97,7 @@ public final class TypeInferenceExtractor {
 		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
 			typeFactory,
 			function,
-			"accumulate",
+			UserDefinedFunctionHelper.AGGREGATE_ACCUMULATE,
 			createParameterSignatureExtraction(1),
 			createGenericResultExtraction(AggregateFunction.class, 1),
 			createGenericResultExtraction(AggregateFunction.class, 0),
@@ -113,7 +114,7 @@ public final class TypeInferenceExtractor {
 		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
 			typeFactory,
 			function,
-			"eval",
+			UserDefinedFunctionHelper.TABLE_EVAL,
 			createParameterSignatureExtraction(0),
 			null,
 			createGenericResultExtraction(TableFunction.class, 0),
@@ -130,7 +131,7 @@ public final class TypeInferenceExtractor {
 		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
 			typeFactory,
 			function,
-			"accumulate",
+			UserDefinedFunctionHelper.TABLE_AGGREGATE_ACCUMULATE,
 			createParameterSignatureExtraction(1),
 			createGenericResultExtraction(TableAggregateFunction.class, 1),
 			createGenericResultExtraction(TableAggregateFunction.class, 0),
@@ -147,7 +148,7 @@ public final class TypeInferenceExtractor {
 		final FunctionMappingExtractor mappingExtractor = new FunctionMappingExtractor(
 			typeFactory,
 			function,
-			"eval",
+			UserDefinedFunctionHelper.ASYNC_TABLE_EVAL,
 			createParameterSignatureExtraction(1),
 			null,
 			createGenericResultExtraction(AsyncTableFunction.class, 0),

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/functions/UserDefinedFunctionHelperTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.table.functions;
 
-import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.util.Collector;
 
@@ -130,7 +130,7 @@ public class UserDefinedFunctionHelperTest {
 		if (testSpec.functionClass != null) {
 			UserDefinedFunctionHelper.validateClass(testSpec.functionClass);
 		} else if (testSpec.functionInstance != null) {
-			UserDefinedFunctionHelper.prepareInstance(new TableConfig(), testSpec.functionInstance);
+			UserDefinedFunctionHelper.prepareInstance(new Configuration(), testSpec.functionInstance);
 		}
 	}
 
@@ -138,9 +138,6 @@ public class UserDefinedFunctionHelperTest {
 	// Test utilities
 	// --------------------------------------------------------------------------------------------
 
-	/**
-	 * Test specification shared with the Scala tests.
-	 */
 	private static class TestSpec {
 
 		final @Nullable Class<? extends UserDefinedFunction> functionClass;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/FunctionCatalogOperatorTable.java
@@ -20,31 +20,40 @@ package org.apache.flink.table.planner.catalog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.catalog.FunctionLookup;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.functions.AggregateFunctionDefinition;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionIdentifier;
+import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
 import org.apache.flink.table.functions.TableFunctionDefinition;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlAggFunction;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
 import org.apache.flink.table.planner.functions.utils.HiveAggSqlFunction;
 import org.apache.flink.table.planner.functions.utils.HiveScalarSqlFunction;
 import org.apache.flink.table.planner.functions.utils.HiveTableSqlFunction;
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils;
 import org.apache.flink.table.planner.plan.schema.DeferredTypeFlinkTableFunction;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
 
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.validate.SqlNameMatcher;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Optional;
@@ -59,12 +68,17 @@ import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoT
 public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 
 	private final FunctionCatalog functionCatalog;
+
+	private final DataTypeFactory dataTypeFactory;
+
 	private final FlinkTypeFactory typeFactory;
 
 	public FunctionCatalogOperatorTable(
 			FunctionCatalog functionCatalog,
+			DataTypeFactory dataTypeFactory,
 			FlinkTypeFactory typeFactory) {
 		this.functionCatalog = functionCatalog;
+		this.dataTypeFactory = dataTypeFactory;
 		this.typeFactory = typeFactory;
 	}
 
@@ -79,39 +93,32 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 			return;
 		}
 
-		// We lookup only user functions via CatalogOperatorTable. Built in functions should
-		// go through BasicOperatorTable
-		if (isNotUserFunction(category)) {
-			return;
-		}
+		final UnresolvedIdentifier identifier = UnresolvedIdentifier.of(opName.names);
 
-		UnresolvedIdentifier identifier = UnresolvedIdentifier.of(opName.names.toArray(new String[0]));
-
-		Optional<FunctionLookup.Result> candidateFunction = functionCatalog.lookupFunction(identifier);
-
-		candidateFunction.flatMap(lookupResult ->
-			convertToSqlFunction(category, lookupResult.getFunctionIdentifier(), lookupResult.getFunctionDefinition())
-		).ifPresent(operatorList::add);
-	}
-
-	private boolean isNotUserFunction(SqlFunctionCategory category) {
-		return category != null && !category.isUserDefinedNotSpecificFunction();
+		functionCatalog.lookupFunction(identifier)
+			.flatMap(lookupResult ->
+				convertToSqlFunction(
+					category,
+					lookupResult.getFunctionIdentifier(),
+					lookupResult.getFunctionDefinition()))
+			.ifPresent(operatorList::add);
 	}
 
 	private Optional<SqlFunction> convertToSqlFunction(
-			SqlFunctionCategory category,
+			@Nullable SqlFunctionCategory category,
 			FunctionIdentifier identifier,
-			FunctionDefinition functionDefinition) {
-		if (functionDefinition instanceof AggregateFunctionDefinition) {
-			AggregateFunctionDefinition def = (AggregateFunctionDefinition) functionDefinition;
+			FunctionDefinition definition) {
+		// legacy
+		if (definition instanceof AggregateFunctionDefinition) {
+			AggregateFunctionDefinition def = (AggregateFunctionDefinition) definition;
 			if (isHiveFunc(def.getAggregateFunction())) {
 				return Optional.of(new HiveAggSqlFunction(
 						identifier, def.getAggregateFunction(), typeFactory));
 			} else {
-				return convertAggregateFunction(identifier, (AggregateFunctionDefinition) functionDefinition);
+				return convertAggregateFunction(identifier, (AggregateFunctionDefinition) definition);
 			}
-		} else if (functionDefinition instanceof ScalarFunctionDefinition) {
-			ScalarFunctionDefinition def = (ScalarFunctionDefinition) functionDefinition;
+		} else if (definition instanceof ScalarFunctionDefinition) {
+			ScalarFunctionDefinition def = (ScalarFunctionDefinition) definition;
 			if (isHiveFunc(def.getScalarFunction())) {
 				return Optional.of(new HiveScalarSqlFunction(
 						identifier,
@@ -120,10 +127,10 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 			} else {
 				return convertScalarFunction(identifier, def);
 			}
-		} else if (functionDefinition instanceof TableFunctionDefinition &&
+		} else if (definition instanceof TableFunctionDefinition &&
 				category != null &&
 				category.isTableFunction()) {
-			TableFunctionDefinition def = (TableFunctionDefinition) functionDefinition;
+			TableFunctionDefinition def = (TableFunctionDefinition) definition;
 			if (isHiveFunc(def.getTableFunction())) {
 				DataType returnType = fromLegacyInfoToDataType(new GenericTypeInfo<>(Row.class));
 				return Optional.of(new HiveTableSqlFunction(
@@ -134,11 +141,50 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 						new DeferredTypeFlinkTableFunction(def.getTableFunction(), returnType),
 						HiveTableSqlFunction.operandTypeChecker(identifier.toString(), def.getTableFunction())));
 			} else {
-				return convertTableFunction(identifier, (TableFunctionDefinition) functionDefinition);
+				return convertTableFunction(identifier, (TableFunctionDefinition) definition);
 			}
 		}
+		// new stack
+		return convertToBridgingSqlFunction(identifier, definition);
+	}
 
-		return Optional.empty();
+	private Optional<SqlFunction> convertToBridgingSqlFunction(
+			FunctionIdentifier identifier,
+			FunctionDefinition definition) {
+		final TypeInference typeInference;
+		try {
+			typeInference = definition.getTypeInference(dataTypeFactory);
+		} catch (Throwable t) {
+			throw new ValidationException(
+				String.format(
+					"An error occurred in the type inference logic of function '%s'.",
+					identifier.asSummaryString()),
+				t);
+		}
+		if (typeInference.getOutputTypeStrategy() == TypeStrategies.MISSING) {
+			return Optional.empty();
+		}
+
+		final SqlFunction function;
+		if (definition.getKind() == FunctionKind.AGGREGATE ||
+				definition.getKind() == FunctionKind.TABLE_AGGREGATE) {
+			function = BridgingSqlAggFunction.of(
+				dataTypeFactory,
+				typeFactory,
+				SqlKind.OTHER_FUNCTION,
+				identifier,
+				definition,
+				typeInference);
+		} else {
+			function = BridgingSqlFunction.of(
+				dataTypeFactory,
+				typeFactory,
+				SqlKind.OTHER_FUNCTION,
+				identifier,
+				definition,
+				typeInference);
+		}
+		return Optional.of(function);
 	}
 
 	private Optional<SqlFunction> convertAggregateFunction(

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ParserImpl.java
@@ -72,6 +72,6 @@ public class ParserImpl implements Parser {
 	public UnresolvedIdentifier parseIdentifier(String identifier) {
 		CalciteParser parser = calciteParserSupplier.get();
 		SqlIdentifier sqlIdentifier = parser.parseIdentifier(identifier);
-		return UnresolvedIdentifier.of(sqlIdentifier.names.toArray(new String[0]));
+		return UnresolvedIdentifier.of(sqlIdentifier.names);
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -301,6 +301,7 @@ public class PlannerContext {
 		return ChainedSqlOperatorTable.of(
 				new FunctionCatalogOperatorTable(
 						context.getFunctionCatalog(),
+						context.getCatalogManager().getDataTypeFactory(),
 						typeFactory),
 				FlinkSqlOperatorTable.instance());
 	}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -336,7 +336,7 @@ public class SqlToOperationConverter {
 		// get name of sink table
 		List<String> targetTablePath = ((SqlIdentifier) insert.getTargetTable()).names;
 
-		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath.toArray(new String[0]));
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		PlannerQueryOperation query = (PlannerQueryOperation) SqlToOperationConverter.convert(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -344,7 +344,9 @@ public class FunctionITCase extends StreamingTestBase {
 		try {
 			tEnv().sqlUpdate(ddl2);
 		} catch (Exception e) {
-			assertEquals(e.getMessage(), "Temporary system function f5 doesn't exist");
+			assertEquals(
+				e.getMessage(),
+				"Could not drop temporary system function. A function named 'f5' doesn't exist.");
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.runtime.utils.TestData.tupleData3
 import org.apache.flink.table.planner.runtime.utils.{StreamingWithStateTestBase, TestingRetractSink}
-import org.apache.flink.table.planner.utils.{EmptyTableAggFuncWithoutEmit, TableAggSum, Top3, Top3WithMapView, Top3WithRetractInput}
+import org.apache.flink.table.planner.utils.{TableAggSum, Top3, Top3WithMapView, Top3WithRetractInput}
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
@@ -215,24 +215,6 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .select('b, 'a.sum as 'a)
       .flatAggregate(top3('a) as ('v1, 'v2))
-      .select('v1, 'v2)
-      .toRetractStream[Row]
-
-    env.execute()
-  }
-
-  @Test
-  def testTableAggFunctionWithoutEmitValueMethod(): Unit = {
-    expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Function class " +
-      "'org.apache.flink.table.planner.utils.EmptyTableAggFuncWithoutEmit' does not " +
-      "implement at least one method named 'emitValue' which is public, " +
-      "not abstract and (in case of table functions) not static.")
-
-    val func = new EmptyTableAggFuncWithoutEmit
-    val source = env.fromCollection(tupleData3).toTable(tEnv, 'a, 'b, 'c)
-    source
-      .flatAggregate(func('a) as ('v1, 'v2))
       .select('v1, 'v2)
       .toRetractStream[Row]
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableAggFunctions.scala
@@ -272,7 +272,7 @@ class TableAggSum extends TableAggregateFunction[JInt, GenericRow] {
 /**
   * Test function for plan test.
   */
-class EmptyTableAggFuncWithoutEmit extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Accum] {
+class EmptyTableAggFunc extends TableAggregateFunction[JTuple2[JInt, JInt], Top3Accum] {
 
   override def createAccumulator(): Top3Accum = new Top3Accum
 
@@ -283,9 +283,6 @@ class EmptyTableAggFuncWithoutEmit extends TableAggregateFunction[JTuple2[JInt, 
   def accumulate(acc: Top3Accum, category: Long, value: Int): Unit = {}
 
   def accumulate(acc: Top3Accum, value: Int): Unit = {}
-}
-
-class EmptyTableAggFunc extends EmptyTableAggFuncWithoutEmit {
 
   def emitValue(acc: Top3Accum, out: Collector[JTuple2[JInt, JInt]]): Unit = {}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/FunctionCatalogOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/catalog/FunctionCatalogOperatorTable.java
@@ -19,8 +19,10 @@
 package org.apache.flink.table.catalog;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.calcite.FlinkTypeFactory;
 import org.apache.flink.table.functions.AggregateFunctionDefinition;
+import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.ScalarFunctionDefinition;
 import org.apache.flink.table.functions.TableFunctionDefinition;
@@ -95,9 +97,11 @@ public class FunctionCatalogOperatorTable implements SqlOperatorTable {
 				category != null &&
 				category.isTableFunction()) {
 			return convertTableFunction(name, (TableFunctionDefinition) functionDefinition);
+		} else if (functionDefinition instanceof BuiltInFunctionDefinition) {
+			return Optional.empty();
 		}
-
-		return Optional.empty();
+		throw new TableException(
+			"The new type inference for functions is only supported in the Blink planner.");
 	}
 
 	private Optional<SqlFunction> convertAggregateFunction(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/ParserImpl.java
@@ -76,6 +76,6 @@ public class ParserImpl implements Parser {
 	public UnresolvedIdentifier parseIdentifier(String identifier) {
 		CalciteParser parser = calciteParserSupplier.get();
 		SqlIdentifier sqlIdentifier = parser.parseIdentifier(identifier);
-		return UnresolvedIdentifier.of(sqlIdentifier.names.toArray(new String[0]));
+		return UnresolvedIdentifier.of(sqlIdentifier.names);
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -320,7 +320,7 @@ public class SqlToOperationConverter {
 		// get name of sink table
 		List<String> targetTablePath = ((SqlIdentifier) insert.getTargetTable()).names;
 
-		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath.toArray(new String[0]));
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		PlannerQueryOperation query = (PlannerQueryOperation) SqlToOperationConverter.convert(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/PathResolutionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/PathResolutionTest.java
@@ -191,7 +191,7 @@ public class PathResolutionTest {
 		testSpec.getDefaultCatalog().ifPresent(catalogManager::setCurrentCatalog);
 		testSpec.getDefaultDatabase().ifPresent(catalogManager::setCurrentDatabase);
 
-		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(lookupPath.toArray(new String[0]));
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(lookupPath);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		assertThat(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
@@ -362,7 +362,9 @@ public class FunctionITCase extends AbstractTestBase {
 		try {
 			tableEnv.sqlUpdate(ddl2);
 		} catch (Exception e) {
-			assertEquals(e.getMessage(), "Temporary system function f5 doesn't exist");
+			assertEquals(
+				"Could not drop temporary system function. A function named 'f5' doesn't exist.",
+				e.getMessage());
 		}
 	}
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.util.CollectionDataSets
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.ValidationException
-import org.apache.flink.table.expressions.utils.SplitUDF
+import org.apache.flink.table.expressions.utils.{Func13, SplitUDF}
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.runtime.batch.table.OldHashCode
 import org.apache.flink.table.runtime.utils.TableProgramsTestBase.TableConfigMode
@@ -391,6 +391,15 @@ class CalcITCase(
 
     val expected = List("a,a,d,d,e,e", "x,x,z,z,z,z").mkString("\n")
     TestBaseUtils.compareResultAsText(results.asJava, expected)
+  }
+
+  // new type inference for functions is only supported in the Blink planner
+  @Test(expected = classOf[ValidationException])
+  def testUnsupportedNewFunctionTypeInference(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env)
+    tEnv.createTemporarySystemFunction("testFunc", new Func13(">>"))
+    tEnv.sqlQuery("SELECT testFunc('fail')").toDataSet[Row]
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableAggregateITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.{StreamQueryConfig, ValidationException}
 import org.apache.flink.table.runtime.utils.{StreamITCase, StreamTestData, StreamingWithStateTestBase}
-import org.apache.flink.table.utils.{EmptyTableAggFuncWithoutEmit, Top3, Top3WithEmitRetractValue, Top3WithMapView}
+import org.apache.flink.table.utils.{Top3, Top3WithEmitRetractValue, Top3WithMapView}
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -183,28 +183,6 @@ class TableAggregateITCase extends StreamingWithStateTestBase {
       .groupBy('b)
       .select('b, 'a.sum as 'a)
       .flatAggregate(top3('a) as ('v1, 'v2))
-      .select('v1, 'v2)
-      .toRetractStream[Row]
-
-    env.execute()
-  }
-
-  @Test
-  def testTableAggFunctionWithoutEmitValueMethod(): Unit = {
-    expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("Function class 'org.apache.flink.table.utils." +
-      "EmptyTableAggFuncWithoutEmit' does not implement at least one method named 'emitValue' " +
-      "which is public, not abstract and (in case of table functions) not static.")
-
-    val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStateBackend(getStateBackend)
-    val tEnv = StreamTableEnvironment.create(env)
-    StreamITCase.clear
-
-    val func = new EmptyTableAggFuncWithoutEmit
-    val source = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-    source
-      .flatAggregate(func('a) as ('v1, 'v2))
       .select('v1, 'v2)
       .toRetractStream[Row]
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.api.{Table, TableConfig, TableEnvironment}
 import org.apache.flink.table.catalog.Catalog
 import org.apache.flink.table.descriptors.{ConnectTableDescriptor, ConnectorDescriptor}
-import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.functions.{ScalarFunction, UserDefinedFunction}
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.sources.TableSource
 import java.util.Optional
@@ -118,4 +118,33 @@ class MockTableEnvironment extends TableEnvironment {
 
   override def dropTemporaryView(path: String): Boolean = ???
 
+  override def createTemporarySystemFunction(
+    name: String,
+    functionClass: Class[_ <: UserDefinedFunction]): Unit = ???
+
+  override def createTemporarySystemFunction(
+    name: String,
+    functionInstance: UserDefinedFunction): Unit = ???
+
+  override def dropTemporarySystemFunction(name: String): Boolean = ???
+
+  override def createFunction(
+    path: String,
+    functionClass: Class[_ <: UserDefinedFunction]): Unit = ???
+
+  override def createFunction(
+    path: String,
+    functionClass: Class[_ <: UserDefinedFunction], ignoreIfExists: Boolean): Unit = ???
+
+  override def dropFunction(path: String): Boolean = ???
+
+  override def createTemporaryFunction(
+    path: String,
+    functionClass: Class[_ <: UserDefinedFunction]): Unit = ???
+
+  override def createTemporaryFunction(
+    path: String,
+    functionInstance: UserDefinedFunction): Unit = ???
+
+  override def dropTemporaryFunction(path: String): Boolean = ???
 }


### PR DESCRIPTION
## What is the purpose of the change

This updates all catalog related interfaces to FLIP-65. It also continues FLIP-64 by exposing new interfaces in table environment for registering functions of temporary/system/catalog kind. Furthermore, it adds early class validation to the function catalog.

The first functions will be fully functional once the code generator has been updated.

## Brief change log

- Update of `TableEnvironment`
- Update of `FunctionCatalog`
- Update of `FunctionCatalogOperatorTable`

## Verifying this change

- New `FunctionCatalogTest` cases
- New `UserDefinedFunctionHelperTest` case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
