### PR TITLE
[FLINK-15751][task] Let all exceptions propagate from the StreamTask#runMailboxLoop

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -87,7 +87,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -483,23 +482,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	private void runMailboxLoop() throws Exception {
-		try {
-			mailboxProcessor.runMailboxLoop();
-		}
-		catch (Exception e) {
-			Optional<InterruptedException> interruption = ExceptionUtils.findThrowable(e, InterruptedException.class);
-			if (interruption.isPresent()) {
-				if (!canceled) {
-					Thread.currentThread().interrupt();
-					throw interruption.get();
-				}
-			} else if (canceled) {
-				LOG.warn("Error while canceling task.", e);
-			}
-			else {
-				throw e;
-			}
-		}
+		mailboxProcessor.runMailboxLoop();
 	}
 
 	private void afterInvoke() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTaskTest.java
@@ -312,7 +312,8 @@ public class SourceStreamTaskTest {
 		try {
 			testHarness.waitForTaskCompletion();
 		} catch (Throwable t) {
-			if (!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
+			if (!ExceptionUtils.findThrowable(t, InterruptedException.class).isPresent() &&
+				!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
 				throw t;
 			}
 		}
@@ -406,7 +407,7 @@ public class SourceStreamTaskTest {
 		try {
 			testHarness.waitForTaskCompletion();
 		} catch (Exception e) {
-			if (!(e.getCause() instanceof InterruptedException)) {
+			if (!ExceptionUtils.findThrowable(e, InterruptedException.class).isPresent()) {
 				throw e;
 			}
 		}

--- a/tools/travis/splits/split_checkpoints.sh
+++ b/tools/travis/splits/split_checkpoints.sh
@@ -74,7 +74,7 @@ run_test "Resuming Externalized Checkpoint after terminal failure (file, sync) e
 run_test "Resuming Externalized Checkpoint after terminal failure (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true false true" "skip_check_exceptions"
 run_test "Resuming Externalized Checkpoint after terminal failure (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_resume_externalized_checkpoints.sh 2 2 rocks true true true" "skip_check_exceptions"
 
-run_test "RocksDB Memory Management end-to-end test" "$END_TO_END_DIR/test-scripts/test_rocksdb_state_memory_control.sh" "skip_check_exceptions"
+run_test "RocksDB Memory Management end-to-end test" "$END_TO_END_DIR/test-scripts/test_rocksdb_state_memory_control.sh"
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
If the StreamTask is being cancelled, let the Task handle the exception.

## Verifying this change

This change is already covered by existing tests, like end to end tests checking logs for unexpected exceptions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
