### PR TITLE
[FLINK-15739] Fix TypeSerializerUpgradeTestBase on Java 12

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ClassRelocator.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/ClassRelocator.java
@@ -148,6 +148,7 @@ public final class ClassRelocator {
 
 			return renaming.getDefinedClassesUnderRoot()
 				.stream()
+				.filter(klass -> klass.getClassLoader() != null)
 				.collect(Collectors.toMap(renaming::newNameFor, classToTransform -> {
 					ClassReader providerClassReader = classReaderFor(classToTransform);
 					ClassWriter transformedProvider = remap(renames, providerClassReader);


### PR DESCRIPTION
The problem was that some of the relocated classes in
PojoSerializerUpgradeTest have enums in them. Java 12 introduced the
EnumDesc class and enums will have an inner subclass of this defined
that does not have a ClassLoader. We now filter out classes that don't
have a classloader in the ClassRelocator because these classes don't
have bytecode that we could relocate.

cc @igalshilman Do you have an opinion on this?