### PR TITLE
[FLINK-15763][Runtime] Running TM checks only necessary resource config, set to default for local execution

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -40,8 +40,8 @@ public abstract class AbstractContainerizedClusterClientFactory<ClusterID> imple
 			.getJobManagerHeapMemory(configuration)
 			.getMebiBytes();
 
-		final int taskManagerMemoryMB = TaskExecutorResourceUtils
-			.resourceSpecFromConfig(TaskExecutorResourceUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
+		final int taskManagerMemoryMB = TaskExecutorProcessUtils
+			.processSpecFromConfig(TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 				configuration, TaskManagerOptions.TOTAL_PROCESS_MEMORY))
 			.getTotalProcessMemorySize()
 			.getMebiBytes();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -119,12 +119,12 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			fatalErrorHandler,
 			resourceManagerMetricGroup);
 		this.clusterId = flinkConfig.getString(KubernetesConfigOptions.CLUSTER_ID);
-		this.defaultCpus = taskExecutorResourceSpec.getCpuCores().getValue().doubleValue();
+		this.defaultCpus = taskExecutorProcessSpec.getCpuCores().getValue().doubleValue();
 
 		this.kubeClient = createFlinkKubeClient();
 
 		this.taskManagerParameters =
-			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorResourceSpec, numSlotsPerTaskManager);
+			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec, numSlotsPerTaskManager);
 
 		this.taskManagerStartCommand = getTaskManagerStartCommand();
 	}
@@ -269,7 +269,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			defaultCpus,
 			env);
 
-		log.info("TaskManager {} will be started with {}.", podName, taskExecutorResourceSpec);
+		log.info("TaskManager {} will be started with {}.", podName, taskExecutorProcessSpec);
 		kubeClient.createTaskManagerPod(parameter);
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -24,8 +24,8 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
@@ -186,9 +186,9 @@ public class KubernetesUtils {
 			boolean hasLog4j,
 			String mainClass,
 			@Nullable String mainArgs) {
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = tmParams.getTaskExecutorResourceSpec();
-		final String jvmMemOpts = TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec);
-		String args = TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec);
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = tmParams.getTaskExecutorProcessSpec();
+		final String jvmMemOpts = TaskExecutorProcessUtils.generateJvmParametersStr(taskExecutorProcessSpec);
+		String args = TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec);
 		if (mainArgs != null) {
 			args += " " + mainArgs;
 		}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -29,8 +29,8 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
@@ -68,7 +68,7 @@ public class KubernetesUtilsTest extends TestLogger {
 	private static final int jobManagerMem = 768;
 	private static final String jmJvmMem = "-Xms168m -Xmx168m";
 
-	private static final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
+	private static final TaskExecutorProcessSpec TASK_EXECUTOR_PROCESS_SPEC = new TaskExecutorProcessSpec(
 		new CPUResource(1.0),
 		new MemorySize(0), // frameworkHeapSize
 		new MemorySize(0), // frameworkOffHeapSize
@@ -81,7 +81,7 @@ public class KubernetesUtilsTest extends TestLogger {
 
 	private static final String tmJvmMem = "-Xmx111 -Xms111 -XX:MaxDirectMemorySize=222 -XX:MaxMetaspaceSize=333";
 	private static final String tmMemDynamicProperties =
-		TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec).trim();
+		TaskExecutorProcessUtils.generateDynamicConfigsStr(TASK_EXECUTOR_PROCESS_SPEC).trim();
 
 	@Test
 	public void testGetJobManagerStartCommand() {
@@ -297,7 +297,7 @@ public class KubernetesUtilsTest extends TestLogger {
 			String mainClassArgs) {
 
 		final ContaineredTaskManagerParameters containeredParams =
-			new ContaineredTaskManagerParameters(taskExecutorResourceSpec, 4, new HashMap<>());
+			new ContaineredTaskManagerParameters(TASK_EXECUTOR_PROCESS_SPEC, 4, new HashMap<>());
 
 		return KubernetesUtils.getTaskManagerStartCommand(
 			cfg,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -28,7 +28,7 @@ import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.mesos.util.MesosResourceAllocation;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.netflix.fenzo.ConstraintEvaluator;
@@ -136,7 +136,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 
 		@Override
 		public double getMemory() {
-			return params.containeredParameters().getTaskExecutorResourceSpec().getTotalProcessMemorySize().getMebiBytes();
+			return params.containeredParameters().getTaskExecutorProcessSpec().getTotalProcessMemorySize().getMebiBytes();
 		}
 
 		@Override
@@ -276,7 +276,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		env.addVariables(variable(MesosConfigKeys.ENV_FLINK_CONTAINER_ID, taskInfo.getTaskId().getValue()));
 
 		// finalize the memory parameters
-		jvmArgs.append(" ").append(TaskExecutorResourceUtils.generateJvmParametersStr(tmParams.getTaskExecutorResourceSpec()));
+		jvmArgs.append(" ").append(TaskExecutorProcessUtils.generateJvmParametersStr(tmParams.getTaskExecutorProcessSpec()));
 
 		// pass dynamic system properties
 		jvmArgs.append(' ').append(
@@ -299,7 +299,7 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			.append(" ")
 			.append(ContainerSpecification.formatSystemProperties(dynamicProperties))
 			.append(" ")
-			.append(TaskExecutorResourceUtils.generateDynamicConfigsStr(tmParams.getTaskExecutorResourceSpec()));
+			.append(TaskExecutorProcessUtils.generateDynamicConfigsStr(tmParams.getTaskExecutorProcessSpec()));
 		cmd.setValue(launchCommand.toString());
 
 		// build the container info

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -42,7 +42,7 @@ import org.apache.flink.mesos.util.MesosArtifactServer;
 import org.apache.flink.mesos.util.MesosConfiguration;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -194,8 +194,8 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 		this.workersInLaunch = new HashMap<>(8);
 		this.workersBeingReturned = new HashMap<>(8);
 
-		this.slotsPerWorker = TaskExecutorResourceUtils.createDefaultWorkerSlotProfiles(
-			taskManagerParameters.containeredParameters().getTaskExecutorResourceSpec(),
+		this.slotsPerWorker = TaskExecutorProcessUtils.createDefaultWorkerSlotProfiles(
+			taskManagerParameters.containeredParameters().getTaskExecutorProcessSpec(),
 			taskManagerParameters.containeredParameters().numSlots());
 	}
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -25,8 +25,8 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.Preconditions;
 
 import com.netflix.fenzo.ConstraintEvaluator;
@@ -215,7 +215,7 @@ public class MesosTaskManagerParameters {
 	 * Get the CPU units to use for the TaskManager process.
 	 */
 	public double cpus() {
-		return containeredParameters.getTaskExecutorResourceSpec().getCpuCores().getValue().doubleValue();
+		return containeredParameters.getTaskExecutorProcessSpec().getCpuCores().getValue().doubleValue();
 	}
 
 	/**
@@ -411,21 +411,21 @@ public class MesosTaskManagerParameters {
 	private static ContaineredTaskManagerParameters createContaineredTaskManagerParameters(final Configuration flinkConfig) {
 		double cpus = getCpuCores(flinkConfig);
 		MemorySize totalProcessMemory = getTotalProcessMemory(flinkConfig);
-		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils
-			.newResourceSpecBuilder(flinkConfig)
+		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils
+			.newProcessSpecBuilder(flinkConfig)
 			.withCpuCores(cpus)
 			.withTotalProcessMemory(totalProcessMemory)
 			.build();
 
 		return ContaineredTaskManagerParameters.create(
 			flinkConfig,
-			taskExecutorResourceSpec,
+			taskExecutorProcessSpec,
 			flinkConfig.getInteger(MESOS_RM_TASKS_SLOTS));
 	}
 
 	private static double getCpuCores(final Configuration configuration) {
 		double fallback = configuration.getDouble(MESOS_RM_TASKS_CPUS);
-		return TaskExecutorResourceUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
+		return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
 	}
 
 	private static MemorySize getTotalProcessMemory(final Configuration configuration) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -26,7 +26,7 @@ import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.overlays.CompositeContainerOverlay;
 import org.apache.flink.runtime.clusterframework.overlays.FlinkDistributionOverlay;
 import org.apache.flink.runtime.clusterframework.overlays.HadoopConfOverlay;
@@ -107,15 +107,15 @@ public class MesosUtils {
 	public static MesosTaskManagerParameters createTmParameters(Configuration configuration, Logger log) {
 		// TM configuration
 		final MesosTaskManagerParameters taskManagerParameters = MesosTaskManagerParameters.create(configuration);
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = taskManagerParameters.containeredParameters().getTaskExecutorResourceSpec();
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = taskManagerParameters.containeredParameters().getTaskExecutorProcessSpec();
 
 		log.info("TaskManagers will be created with {} task slots",
 			taskManagerParameters.containeredParameters().numSlots());
 		log.info("TaskManagers will be started with container size {} MB, JVM heap size {} MB, " +
 				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB",
-			taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes(),
-			taskExecutorResourceSpec.getJvmHeapMemorySize().getMebiBytes(),
-			taskExecutorResourceSpec.getJvmDirectMemorySize().getMebiBytes(),
+			taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes(),
+			taskExecutorProcessSpec.getJvmHeapMemorySize().getMebiBytes(),
+			taskExecutorProcessSpec.getJvmDirectMemorySize().getMebiBytes(),
 			taskManagerParameters.cpus(),
 			taskManagerParameters.gpus(),
 			taskManagerParameters.disk());

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -41,8 +41,8 @@ import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -276,8 +276,8 @@ public class MesosResourceManagerTest extends TestLogger {
 			ContainerSpecification containerSpecification = new ContainerSpecification();
 
 			MemorySize totalProcessMemory = MemorySize.parse("2g");
-			TaskExecutorResourceSpec spec = TaskExecutorResourceUtils
-				.newResourceSpecBuilder(flinkConfig)
+			TaskExecutorProcessSpec spec = TaskExecutorProcessUtils
+				.newProcessSpecBuilder(flinkConfig)
 				.withCpuCores(1.0)
 				.withTotalProcessMemory(totalProcessMemory)
 				.build();

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -280,7 +280,7 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 
 	private void assertTotalProcessMemory(MesosTaskManagerParameters mesosTaskManagerParameters) {
 		assertThat(
-			mesosTaskManagerParameters.containeredParameters().getTaskExecutorResourceSpec().getTotalProcessMemorySize(),
+			mesosTaskManagerParameters.containeredParameters().getTaskExecutorProcessSpec().getTotalProcessMemorySize(),
 			is(TOTAL_PROCESS_MEMORY_SIZE));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -401,8 +401,8 @@ public class BootstrapTools {
 		final Map<String, String> startCommandValues = new HashMap<>();
 		startCommandValues.put("java", "$JAVA_HOME/bin/java");
 
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = tmParams.getTaskExecutorResourceSpec();
-		startCommandValues.put("jvmmem", TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec));
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = tmParams.getTaskExecutorProcessSpec();
+		startCommandValues.put("jvmmem", TaskExecutorProcessUtils.generateJvmParametersStr(taskExecutorProcessSpec));
 
 		String javaOpts = flinkConfig.getString(CoreOptions.FLINK_JVM_OPTIONS);
 		if (flinkConfig.getString(CoreOptions.FLINK_TM_JVM_OPTIONS).length() > 0) {
@@ -435,7 +435,7 @@ public class BootstrapTools {
 			"1> " + logDirectory + "/taskmanager.out " +
 			"2> " + logDirectory + "/taskmanager.err");
 
-		String argsStr = TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec) + " --configDir " + configDirectory;
+		String argsStr = TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec) + " --configDir " + configDirectory;
 		if (!mainArgs.isEmpty()) {
 			argsStr += " " + mainArgs;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -37,22 +37,22 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	/** Environment variables to add to the Java process. */
 	private final HashMap<String, String> taskManagerEnv;
 
-	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
+	private final TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	public ContaineredTaskManagerParameters(
-			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			TaskExecutorProcessSpec taskExecutorProcessSpec,
 			int numSlots,
 			HashMap<String, String> taskManagerEnv) {
 
-		this.taskExecutorResourceSpec = taskExecutorResourceSpec;
+		this.taskExecutorProcessSpec = taskExecutorProcessSpec;
 		this.numSlots = numSlots;
 		this.taskManagerEnv = taskManagerEnv;
 	}
 
 	// ------------------------------------------------------------------------
 
-	public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
-		return taskExecutorResourceSpec;
+	public TaskExecutorProcessSpec getTaskExecutorProcessSpec() {
+		return taskExecutorProcessSpec;
 	}
 
 	public int numSlots() {
@@ -69,7 +69,7 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	@Override
 	public String toString() {
 		return "TaskManagerParameters {" +
-			"taskExecutorResourceSpec=" + taskExecutorResourceSpec +
+			"taskExecutorProcessSpec=" + taskExecutorProcessSpec +
 			", numSlots=" + numSlots +
 			", taskManagerEnv=" + taskManagerEnv +
 			'}';
@@ -83,13 +83,13 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	 * Computes the parameters to be used to start a TaskManager Java process.
 	 *
 	 * @param config The Flink configuration.
-	 * @param taskExecutorResourceSpec The resource specifics of the task executor.
+	 * @param taskExecutorProcessSpec The resource specifics of the task executor.
 	 * @param numSlots Number of slots of the task executor.
 	 * @return The parameters to start the TaskManager processes with.
 	 */
 	public static ContaineredTaskManagerParameters create(
 			Configuration config,
-			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			TaskExecutorProcessSpec taskExecutorProcessSpec,
 			int numSlots) {
 
 		// obtain the additional environment variables from the configuration
@@ -106,6 +106,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 		// done
 		return new ContaineredTaskManagerParameters(
-			taskExecutorResourceSpec, numSlots, envVars);
+			taskExecutorProcessSpec, numSlots, envVars);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.MemorySize;
 import java.io.Serializable;
 
 /**
- * Describe the specifics of different resource dimensions of the TaskExecutor.
+ * Describe the specifics of different resource dimensions of the TaskExecutor process.
  *
  * <p>A TaskExecutor's memory consists of the following components.
  * <ul>
@@ -73,7 +73,7 @@ import java.io.Serializable;
  *               └ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
  * </pre>
  */
-public class TaskExecutorResourceSpec implements Serializable {
+public class TaskExecutorProcessSpec implements Serializable {
 
 	private final CPUResource cpuCores;
 
@@ -93,7 +93,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 
 	private final MemorySize jvmOverheadSize;
 
-	public TaskExecutorResourceSpec(
+	public TaskExecutorProcessSpec(
 		CPUResource cpuCores,
 		MemorySize frameworkHeapSize,
 		MemorySize frameworkOffHeapSize,
@@ -169,7 +169,7 @@ public class TaskExecutorResourceSpec implements Serializable {
 
 	@Override
 	public String toString() {
-		return "TaskExecutorResourceSpec {"
+		return "TaskExecutorProcessSpec {"
 			+ "cpuCores=" + cpuCores.getValue().doubleValue()
 			+ ", frameworkHeapSize=" + frameworkHeapSize.toHumanReadableString()
 			+ ", frameworkOffHeapSize=" + frameworkOffHeapMemorySize.toHumanReadableString()

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpecBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpecBuilder.java
@@ -26,35 +26,35 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Builder for {@link TaskExecutorResourceSpec}.
+ * Builder for {@link TaskExecutorProcessSpec}.
  */
-public class TaskExecutorResourceSpecBuilder {
+public class TaskExecutorProcessSpecBuilder {
 
 	private final Configuration configuration;
 
-	private TaskExecutorResourceSpecBuilder(final Configuration configuration) {
+	private TaskExecutorProcessSpecBuilder(final Configuration configuration) {
 		this.configuration = new Configuration(checkNotNull(configuration));
 	}
 
-	static TaskExecutorResourceSpecBuilder newBuilder(final Configuration configuration) {
-		return new TaskExecutorResourceSpecBuilder(configuration);
+	static TaskExecutorProcessSpecBuilder newBuilder(final Configuration configuration) {
+		return new TaskExecutorProcessSpecBuilder(configuration);
 	}
 
-	public TaskExecutorResourceSpecBuilder withCpuCores(double cpuCores) {
+	public TaskExecutorProcessSpecBuilder withCpuCores(double cpuCores) {
 		return withCpuCores(new CPUResource(cpuCores));
 	}
 
-	public TaskExecutorResourceSpecBuilder withCpuCores(CPUResource cpuCores) {
+	public TaskExecutorProcessSpecBuilder withCpuCores(CPUResource cpuCores) {
 		configuration.setDouble(TaskManagerOptions.CPU_CORES, cpuCores.getValue().doubleValue());
 		return this;
 	}
 
-	public TaskExecutorResourceSpecBuilder withTotalProcessMemory(MemorySize totalProcessMemory) {
+	public TaskExecutorProcessSpecBuilder withTotalProcessMemory(MemorySize totalProcessMemory) {
 		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalProcessMemory);
 		return this;
 	}
 
-	public TaskExecutorResourceSpec build() {
-		return TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+	public TaskExecutorProcessSpec build() {
+		return TaskExecutorProcessUtils.processSpecFromConfig(configuration);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -43,21 +43,21 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Utility class for TaskExecutor memory configurations.
  *
- * <p>See {@link TaskExecutorResourceSpec} for details about memory components of TaskExecutor and their relationships.
+ * <p>See {@link TaskExecutorProcessSpec} for details about memory components of TaskExecutor and their relationships.
  */
-public class TaskExecutorResourceUtils {
-	private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorResourceUtils.class);
+public class TaskExecutorProcessUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorProcessUtils.class);
 
-	private TaskExecutorResourceUtils() {}
+	private TaskExecutorProcessUtils() {}
 
 	// ------------------------------------------------------------------------
 	//  Generating JVM Parameters
 	// ------------------------------------------------------------------------
 
-	public static String generateJvmParametersStr(final TaskExecutorResourceSpec taskExecutorResourceSpec) {
-		final MemorySize jvmHeapSize = taskExecutorResourceSpec.getJvmHeapMemorySize();
-		final MemorySize jvmDirectSize = taskExecutorResourceSpec.getJvmDirectMemorySize();
-		final MemorySize jvmMetaspaceSize = taskExecutorResourceSpec.getJvmMetaspaceSize();
+	public static String generateJvmParametersStr(final TaskExecutorProcessSpec taskExecutorProcessSpec) {
+		final MemorySize jvmHeapSize = taskExecutorProcessSpec.getJvmHeapMemorySize();
+		final MemorySize jvmDirectSize = taskExecutorProcessSpec.getJvmDirectMemorySize();
+		final MemorySize jvmMetaspaceSize = taskExecutorProcessSpec.getJvmMetaspaceSize();
 
 		return "-Xmx" + jvmHeapSize.getBytes()
 			+ " -Xms" + jvmHeapSize.getBytes()
@@ -69,17 +69,17 @@ public class TaskExecutorResourceUtils {
 	//  Generating Dynamic Config Options
 	// ------------------------------------------------------------------------
 
-	public static String generateDynamicConfigsStr(final TaskExecutorResourceSpec taskExecutorResourceSpec) {
+	public static String generateDynamicConfigsStr(final TaskExecutorProcessSpec taskExecutorProcessSpec) {
 		final Map<String, String> configs = new HashMap<>();
 		configs.put(TaskManagerOptions.CPU_CORES.key(),
-			String.valueOf(taskExecutorResourceSpec.getCpuCores().getValue().doubleValue()));
-		configs.put(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(), taskExecutorResourceSpec.getFrameworkHeapSize().getBytes() + "b");
-		configs.put(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key(), taskExecutorResourceSpec.getFrameworkOffHeapMemorySize().getBytes() + "b");
-		configs.put(TaskManagerOptions.TASK_HEAP_MEMORY.key(), taskExecutorResourceSpec.getTaskHeapSize().getBytes() + "b");
-		configs.put(TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key(), taskExecutorResourceSpec.getTaskOffHeapSize().getBytes() + "b");
-		configs.put(TaskManagerOptions.NETWORK_MEMORY_MIN.key(), taskExecutorResourceSpec.getNetworkMemSize().getBytes() + "b");
-		configs.put(TaskManagerOptions.NETWORK_MEMORY_MAX.key(), taskExecutorResourceSpec.getNetworkMemSize().getBytes() + "b");
-		configs.put(TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), taskExecutorResourceSpec.getManagedMemorySize().getBytes() + "b");
+			String.valueOf(taskExecutorProcessSpec.getCpuCores().getValue().doubleValue()));
+		configs.put(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(), taskExecutorProcessSpec.getFrameworkHeapSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY.key(), taskExecutorProcessSpec.getFrameworkOffHeapMemorySize().getBytes() + "b");
+		configs.put(TaskManagerOptions.TASK_HEAP_MEMORY.key(), taskExecutorProcessSpec.getTaskHeapSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.TASK_OFF_HEAP_MEMORY.key(), taskExecutorProcessSpec.getTaskOffHeapSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.NETWORK_MEMORY_MIN.key(), taskExecutorProcessSpec.getNetworkMemSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.NETWORK_MEMORY_MAX.key(), taskExecutorProcessSpec.getNetworkMemSize().getBytes() + "b");
+		configs.put(TaskManagerOptions.MANAGED_MEMORY_SIZE.key(), taskExecutorProcessSpec.getManagedMemorySize().getBytes() + "b");
 		return assembleDynamicConfigsStr(configs);
 	}
 
@@ -96,32 +96,32 @@ public class TaskExecutorResourceUtils {
 	// ------------------------------------------------------------------------
 
 	public static List<ResourceProfile> createDefaultWorkerSlotProfiles(
-			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			TaskExecutorProcessSpec taskExecutorProcessSpec,
 			int numberOfSlots) {
 		final ResourceProfile resourceProfile =
-			generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots);
+			generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberOfSlots);
 		return Collections.nCopies(numberOfSlots, resourceProfile);
 	}
 
 	public static ResourceProfile generateDefaultSlotResourceProfile(
-			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			TaskExecutorProcessSpec taskExecutorProcessSpec,
 			int numberOfSlots) {
 		return ResourceProfile.newBuilder()
-			.setCpuCores(taskExecutorResourceSpec.getCpuCores().divide(numberOfSlots))
-			.setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize().divide(numberOfSlots))
-			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize().divide(numberOfSlots))
-			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize().divide(numberOfSlots))
-			.setNetworkMemory(taskExecutorResourceSpec.getNetworkMemSize().divide(numberOfSlots))
+			.setCpuCores(taskExecutorProcessSpec.getCpuCores().divide(numberOfSlots))
+			.setTaskHeapMemory(taskExecutorProcessSpec.getTaskHeapSize().divide(numberOfSlots))
+			.setTaskOffHeapMemory(taskExecutorProcessSpec.getTaskOffHeapSize().divide(numberOfSlots))
+			.setManagedMemory(taskExecutorProcessSpec.getManagedMemorySize().divide(numberOfSlots))
+			.setNetworkMemory(taskExecutorProcessSpec.getNetworkMemSize().divide(numberOfSlots))
 			.build();
 	}
 
-	public static ResourceProfile generateTotalAvailableResourceProfile(TaskExecutorResourceSpec taskExecutorResourceSpec) {
+	public static ResourceProfile generateTotalAvailableResourceProfile(TaskExecutorProcessSpec taskExecutorProcessSpec) {
 		return ResourceProfile.newBuilder()
-			.setCpuCores(taskExecutorResourceSpec.getCpuCores())
-			.setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize())
-			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize())
-			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize())
-			.setNetworkMemory(taskExecutorResourceSpec.getNetworkMemSize())
+			.setCpuCores(taskExecutorProcessSpec.getCpuCores())
+			.setTaskHeapMemory(taskExecutorProcessSpec.getTaskHeapSize())
+			.setTaskOffHeapMemory(taskExecutorProcessSpec.getTaskOffHeapSize())
+			.setManagedMemory(taskExecutorProcessSpec.getManagedMemorySize())
+			.setNetworkMemory(taskExecutorProcessSpec.getNetworkMemSize())
 			.build();
 	}
 
@@ -129,22 +129,22 @@ public class TaskExecutorResourceUtils {
 	//  Memory Configuration Calculations
 	// ------------------------------------------------------------------------
 
-	public static TaskExecutorResourceSpecBuilder newResourceSpecBuilder(final Configuration config) {
-		return TaskExecutorResourceSpecBuilder.newBuilder(config);
+	public static TaskExecutorProcessSpecBuilder newProcessSpecBuilder(final Configuration config) {
+		return TaskExecutorProcessSpecBuilder.newBuilder(config);
 	}
 
-	public static TaskExecutorResourceSpec resourceSpecFromConfig(final Configuration config) {
+	public static TaskExecutorProcessSpec processSpecFromConfig(final Configuration config) {
 		if (isTaskHeapMemorySizeExplicitlyConfigured(config) && isManagedMemorySizeExplicitlyConfigured(config)) {
 			// both task heap memory and managed memory are configured, use these to derive total flink memory
-			return deriveResourceSpecWithExplicitTaskAndManagedMemory(config);
+			return deriveProcessSpecWithExplicitTaskAndManagedMemory(config);
 		} else if (isTotalFlinkMemorySizeExplicitlyConfigured(config)) {
 			// either of task heap memory and managed memory is not configured, total flink memory is configured,
 			// derive from total flink memory
-			return deriveResourceSpecWithTotalFlinkMemory(config);
+			return deriveProcessSpecWithTotalFlinkMemory(config);
 		} else if (isTotalProcessMemorySizeExplicitlyConfigured(config)) {
 			// total flink memory is not configured, total process memory is configured,
 			// derive from total process memory
-			return deriveResourceSpecWithTotalProcessMemory(config);
+			return deriveProcessSpecWithTotalProcessMemory(config);
 		} else {
 			throw new IllegalConfigurationException(String.format("Either Task Heap Memory size (%s) and Managed Memory size (%s), or Total Flink"
 				+ " Memory size (%s), or Total Process Memory size (%s) need to be configured explicitly.",
@@ -155,13 +155,13 @@ public class TaskExecutorResourceUtils {
 		}
 	}
 
-	public static boolean isTaskExecutorResourceExplicitlyConfigured(final Configuration config) {
+	public static boolean isTaskExecutorProcessResourceExplicitlyConfigured(final Configuration config) {
 		return (isTaskHeapMemorySizeExplicitlyConfigured(config) && isManagedMemorySizeExplicitlyConfigured(config))
 			|| isTotalFlinkMemorySizeExplicitlyConfigured(config)
 			|| isTotalProcessMemorySizeExplicitlyConfigured(config);
 	}
 
-	private static TaskExecutorResourceSpec deriveResourceSpecWithExplicitTaskAndManagedMemory(final Configuration config) {
+	private static TaskExecutorProcessSpec deriveProcessSpecWithExplicitTaskAndManagedMemory(final Configuration config) {
 		// derive flink internal memory from explicitly configure task heap memory size and managed memory size
 
 		final MemorySize taskHeapMemorySize = getTaskHeapMemorySize(config);
@@ -211,10 +211,10 @@ public class TaskExecutorResourceUtils {
 
 		final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead = deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(config, flinkInternalMemory.getTotalFlinkMemorySize());
 
-		return createTaskExecutorResourceSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
+		return createTaskExecutorProcessSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
 	}
 
-	private static TaskExecutorResourceSpec deriveResourceSpecWithTotalFlinkMemory(final Configuration config) {
+	private static TaskExecutorProcessSpec deriveProcessSpecWithTotalFlinkMemory(final Configuration config) {
 		// derive flink internal memory from explicitly configured total flink memory
 
 		final MemorySize totalFlinkMemorySize = getTotalFlinkMemorySize(config);
@@ -224,10 +224,10 @@ public class TaskExecutorResourceUtils {
 
 		final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead = deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(config, totalFlinkMemorySize);
 
-		return createTaskExecutorResourceSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
+		return createTaskExecutorProcessSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
 	}
 
-	private static TaskExecutorResourceSpec deriveResourceSpecWithTotalProcessMemory(final Configuration config) {
+	private static TaskExecutorProcessSpec deriveProcessSpecWithTotalProcessMemory(final Configuration config) {
 		// derive total flink memory from explicitly configured total process memory size
 
 		final MemorySize totalProcessMemorySize = getTotalProcessMemorySize(config);
@@ -247,7 +247,7 @@ public class TaskExecutorResourceUtils {
 
 		final FlinkInternalMemory flinkInternalMemory = deriveInternalMemoryFromTotalFlinkMemory(config, totalFlinkMemorySize);
 
-		return createTaskExecutorResourceSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
+		return createTaskExecutorProcessSpec(config, flinkInternalMemory, jvmMetaspaceAndOverhead);
 	}
 
 	private static JvmMetaspaceAndOverhead deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(
@@ -668,11 +668,11 @@ public class TaskExecutorResourceUtils {
 		return new CPUResource(cpuCores);
 	}
 
-	private static TaskExecutorResourceSpec createTaskExecutorResourceSpec(
+	private static TaskExecutorProcessSpec createTaskExecutorProcessSpec(
 			final Configuration config,
 			final FlinkInternalMemory flinkInternalMemory,
 			final JvmMetaspaceAndOverhead jvmMetaspaceAndOverhead) {
-		return new TaskExecutorResourceSpec(
+		return new TaskExecutorProcessSpec(
 			getCpuCores(config),
 			flinkInternalMemory.frameworkHeap,
 			flinkInternalMemory.frameworkOffHeap,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -47,7 +47,7 @@ public class MiniClusterConfiguration {
 
 	static final String SCHEDULER_TYPE_KEY = JobManagerOptions.SCHEDULER.key();
 	static final MemorySize DEFAULT_SHUFFLE_MEMORY_SIZE = MemorySize.parse("64m");
-	static final MemorySize DEFAULT_MANAGED_MEMORY_SIZE = MemorySize.parse("16m");
+	static final MemorySize DEFAULT_MANAGED_MEMORY_SIZE = MemorySize.parse("128m");
 
 	private final UnmodifiableConfiguration configuration;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -18,16 +18,14 @@
 
 package org.apache.flink.runtime.minicluster;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -46,8 +44,6 @@ public class MiniClusterConfiguration {
 	private static final Logger LOG = LoggerFactory.getLogger(MiniClusterConfiguration.class);
 
 	static final String SCHEDULER_TYPE_KEY = JobManagerOptions.SCHEDULER.key();
-	static final MemorySize DEFAULT_SHUFFLE_MEMORY_SIZE = MemorySize.parse("64m");
-	static final MemorySize DEFAULT_MANAGED_MEMORY_SIZE = MemorySize.parse("128m");
 
 	private final UnmodifiableConfiguration configuration;
 
@@ -86,31 +82,9 @@ public class MiniClusterConfiguration {
 			modifiedConfig.setString(JobManagerOptions.SCHEDULER, schedulerType);
 		}
 
-		adjustTaskManagerMemoryConfigurations(modifiedConfig);
+		TaskExecutorResourceUtils.adjustForLocalExecution(modifiedConfig);
 
 		return new UnmodifiableConfiguration(modifiedConfig);
-	}
-
-	@VisibleForTesting
-	static Configuration adjustTaskManagerMemoryConfigurations(final Configuration toBeModifiedConfiguration) {
-		if (!TaskExecutorProcessUtils.isTaskExecutorProcessResourceExplicitlyConfigured(toBeModifiedConfiguration)) {
-			// This does not affect the JVM heap size for local execution,
-			// we simply set it to pass the sanity checks in memory calculations
-			toBeModifiedConfiguration.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("100m"));
-		}
-
-		if (!TaskExecutorProcessUtils.isNetworkMemoryExplicitlyConfigured(toBeModifiedConfiguration)) {
-			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, DEFAULT_SHUFFLE_MEMORY_SIZE);
-			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
-			LOG.info("Network memory is not explicitly configured, use {} for local execution.", DEFAULT_SHUFFLE_MEMORY_SIZE);
-		}
-
-		if (!TaskExecutorProcessUtils.isManagedMemorySizeExplicitlyConfigured(toBeModifiedConfiguration)) {
-			toBeModifiedConfiguration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
-			LOG.info("Managed memory is not explicitly configured, use {} for local execution.", DEFAULT_MANAGED_MEMORY_SIZE);
-		}
-
-		return toBeModifiedConfiguration;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
@@ -93,19 +93,19 @@ public class MiniClusterConfiguration {
 
 	@VisibleForTesting
 	static Configuration adjustTaskManagerMemoryConfigurations(final Configuration toBeModifiedConfiguration) {
-		if (!TaskExecutorResourceUtils.isTaskExecutorResourceExplicitlyConfigured(toBeModifiedConfiguration)) {
+		if (!TaskExecutorProcessUtils.isTaskExecutorProcessResourceExplicitlyConfigured(toBeModifiedConfiguration)) {
 			// This does not affect the JVM heap size for local execution,
 			// we simply set it to pass the sanity checks in memory calculations
 			toBeModifiedConfiguration.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("100m"));
 		}
 
-		if (!TaskExecutorResourceUtils.isNetworkMemoryExplicitlyConfigured(toBeModifiedConfiguration)) {
+		if (!TaskExecutorProcessUtils.isNetworkMemoryExplicitlyConfigured(toBeModifiedConfiguration)) {
 			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, DEFAULT_SHUFFLE_MEMORY_SIZE);
 			toBeModifiedConfiguration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
 			LOG.info("Network memory is not explicitly configured, use {} for local execution.", DEFAULT_SHUFFLE_MEMORY_SIZE);
 		}
 
-		if (!TaskExecutorResourceUtils.isManagedMemorySizeExplicitlyConfigured(toBeModifiedConfiguration)) {
+		if (!TaskExecutorProcessUtils.isManagedMemorySizeExplicitlyConfigured(toBeModifiedConfiguration)) {
 			toBeModifiedConfiguration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
 			LOG.info("Managed memory is not explicitly configured, use {} for local execution.", DEFAULT_MANAGED_MEMORY_SIZE);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -52,7 +52,7 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 	protected final int numSlotsPerTaskManager;
 
-	protected final TaskExecutorResourceSpec taskExecutorResourceSpec;
+	protected final TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	protected final int defaultMemoryMB;
 
@@ -97,14 +97,14 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 		this.numSlotsPerTaskManager = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 		double defaultCpus = getCpuCores(flinkConfig);
-		this.taskExecutorResourceSpec = TaskExecutorResourceUtils
-			.newResourceSpecBuilder(flinkConfig)
+		this.taskExecutorProcessSpec = TaskExecutorProcessUtils
+			.newProcessSpecBuilder(flinkConfig)
 			.withCpuCores(defaultCpus)
 			.build();
-		this.defaultMemoryMB = taskExecutorResourceSpec.getTotalProcessMemorySize().getMebiBytes();
+		this.defaultMemoryMB = taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
 
-		this.resourceProfilesPerWorker = TaskExecutorResourceUtils
-			.createDefaultWorkerSlotProfiles(taskExecutorResourceSpec, numSlotsPerTaskManager);
+		this.resourceProfilesPerWorker = TaskExecutorProcessUtils
+			.createDefaultWorkerSlotProfiles(taskExecutorProcessSpec, numSlotsPerTaskManager);
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -67,7 +67,7 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 	}
 
 	public static Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
-		return TaskExecutorResourceUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
+		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			originalConfiguration, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.MemorySize;
 
 /**
- * Specification of resources for {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}.
+ * Specification of resources to use in running {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}.
  */
 public class TaskExecutorResourceSpec {
 	private final CPUResource cpuCores;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.MemorySize;
+
+/**
+ * Specification of resources used in running {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}.
+ */
+public class TaskExecutorResourceSpec {
+	private final CPUResource cpuCores;
+
+	private final MemorySize taskHeapSize;
+
+	private final MemorySize taskOffHeapSize;
+
+	private final MemorySize networkMemSize;
+
+	private final MemorySize managedMemorySize;
+
+	public TaskExecutorResourceSpec(
+			CPUResource cpuCores,
+			MemorySize taskHeapSize,
+			MemorySize taskOffHeapSize,
+			MemorySize networkMemSize,
+			MemorySize managedMemorySize) {
+		this.cpuCores = cpuCores;
+		this.taskHeapSize = taskHeapSize;
+		this.taskOffHeapSize = taskOffHeapSize;
+		this.networkMemSize = networkMemSize;
+		this.managedMemorySize = managedMemorySize;
+	}
+
+	public CPUResource getCpuCores() {
+		return cpuCores;
+	}
+
+	public MemorySize getTaskHeapSize() {
+		return taskHeapSize;
+	}
+
+	public MemorySize getTaskOffHeapSize() {
+		return taskOffHeapSize;
+	}
+
+	public MemorySize getNetworkMemSize() {
+		return networkMemSize;
+	}
+
+	public MemorySize getManagedMemorySize() {
+		return managedMemorySize;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceSpec.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.MemorySize;
 
 /**
- * Specification of resources used in running {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}.
+ * Specification of resources for {@link org.apache.flink.runtime.taskexecutor.TaskExecutor}.
  */
 public class TaskExecutorResourceSpec {
 	private final CPUResource cpuCores;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -87,7 +87,7 @@ public class TaskExecutorResourceUtils {
 
 	private static void checkConfigOptionIsSet(Configuration config, ConfigOption<?> option) {
 		if (!config.contains(option) && !option.hasDefaultValue()) {
-			throw new IllegalConfigurationException("Configuration option %s is not set", option);
+			throw new IllegalConfigurationException("The required configuration option %s is not set", option);
 		}
 	}
 
@@ -95,7 +95,7 @@ public class TaskExecutorResourceUtils {
 		if (!config.get(TaskManagerOptions.NETWORK_MEMORY_MIN).equals(config.get(TaskManagerOptions.NETWORK_MEMORY_MAX))) {
 			throw new IllegalConfigurationException(
 				"The network memory min (%s) and max (%s) mismatch, " +
-					"the network memory has to be fixed after task executor has started",
+					"the network memory has to be resolved and set to a fixed value before task executor starts",
 				config.get(TaskManagerOptions.NETWORK_MEMORY_MIN),
 				config.get(TaskManagerOptions.NETWORK_MEMORY_MAX));
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility class for {@link TaskExecutorResourceSpec} of running {@link TaskExecutor}.
+ */
+public class TaskExecutorResourceUtils {
+	private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorResourceUtils.class);
+
+	static final List<ConfigOption<?>> CONFIG_OPTIONS = Arrays.asList(
+		TaskManagerOptions.CPU_CORES,
+		TaskManagerOptions.TASK_HEAP_MEMORY,
+		TaskManagerOptions.TASK_OFF_HEAP_MEMORY,
+		TaskManagerOptions.NETWORK_MEMORY_MIN,
+		TaskManagerOptions.NETWORK_MEMORY_MAX,
+		TaskManagerOptions.MANAGED_MEMORY_SIZE
+	);
+
+	private static final List<ConfigOption<?>> UNUSED_CONFIG_OPTIONS = Arrays.asList(
+		TaskManagerOptions.TOTAL_PROCESS_MEMORY,
+		TaskManagerOptions.TOTAL_FLINK_MEMORY,
+		TaskManagerOptions.FRAMEWORK_HEAP_MEMORY,
+		TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY,
+		TaskManagerOptions.JVM_METASPACE,
+		TaskManagerOptions.JVM_OVERHEAD_MIN,
+		TaskManagerOptions.JVM_OVERHEAD_MAX,
+		TaskManagerOptions.JVM_OVERHEAD_FRACTION
+	);
+
+	static final MemorySize DEFAULT_SHUFFLE_MEMORY_SIZE = MemorySize.parse("64m");
+	static final MemorySize DEFAULT_MANAGED_MEMORY_SIZE = MemorySize.parse("128m");
+
+	private TaskExecutorResourceUtils() {}
+
+	static TaskExecutorResourceSpec resourceSpecFromConfig(Configuration config) {
+		try {
+			checkTaskExecutorResourceConfigSet(config);
+		} catch (IllegalConfigurationException e) {
+			throw new IllegalConfigurationException("Failed to create TaskExecutorResourceSpec", e);
+		}
+		return new TaskExecutorResourceSpec(
+			new CPUResource(config.getDouble(TaskManagerOptions.CPU_CORES)),
+			config.get(TaskManagerOptions.TASK_HEAP_MEMORY),
+			config.get(TaskManagerOptions.TASK_OFF_HEAP_MEMORY),
+			config.get(TaskManagerOptions.NETWORK_MEMORY_MIN),
+			config.get(TaskManagerOptions.MANAGED_MEMORY_SIZE)
+		);
+	}
+
+	private static void checkTaskExecutorResourceConfigSet(Configuration config) {
+		CONFIG_OPTIONS.forEach(option -> checkConfigOptionIsSet(config, option));
+		checkTaskExecutorNetworkConfigSet(config);
+	}
+
+	private static void checkTaskExecutorNetworkConfigSet(ReadableConfig config) {
+		if (!config.get(TaskManagerOptions.NETWORK_MEMORY_MIN).equals(config.get(TaskManagerOptions.NETWORK_MEMORY_MAX))) {
+			throw new IllegalConfigurationException(
+				"The network memory min (%s) and max (%s) mismatch, " +
+					"the network memory has to be fixed after task executor has started",
+				config.get(TaskManagerOptions.NETWORK_MEMORY_MIN),
+				config.get(TaskManagerOptions.NETWORK_MEMORY_MAX));
+		}
+	}
+
+	private static void checkConfigOptionIsSet(Configuration config, ConfigOption<?> option) {
+		if (!config.contains(option)) {
+			throw new IllegalConfigurationException("Configuration option %s is not set", option);
+		}
+	}
+
+	static ResourceProfile generateDefaultSlotResourceProfile(
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			int numberOfSlots) {
+		return ResourceProfile.newBuilder()
+			.setCpuCores(taskExecutorResourceSpec.getCpuCores().divide(numberOfSlots))
+			.setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize().divide(numberOfSlots))
+			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize().divide(numberOfSlots))
+			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize().divide(numberOfSlots))
+			.setNetworkMemory(taskExecutorResourceSpec.getNetworkMemSize().divide(numberOfSlots))
+			.build();
+	}
+
+	static ResourceProfile generateTotalAvailableResourceProfile(
+			TaskExecutorResourceSpec taskExecutorResourceSpec) {
+		return ResourceProfile.newBuilder()
+			.setCpuCores(taskExecutorResourceSpec.getCpuCores())
+			.setTaskHeapMemory(taskExecutorResourceSpec.getTaskHeapSize())
+			.setTaskOffHeapMemory(taskExecutorResourceSpec.getTaskOffHeapSize())
+			.setManagedMemory(taskExecutorResourceSpec.getManagedMemorySize())
+			.setNetworkMemory(taskExecutorResourceSpec.getNetworkMemSize())
+			.build();
+	}
+
+	@VisibleForTesting
+	public static TaskExecutorResourceSpec resourceSpecFromConfigForLocalExecution(Configuration config) {
+		return resourceSpecFromConfig(adjustForLocalExecution(config));
+	}
+
+	public static Configuration adjustForLocalExecution(Configuration config) {
+		UNUSED_CONFIG_OPTIONS.forEach(option -> warnOptionHasNoEffectIfSet(config, option));
+
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.MAX_VALUE);
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.TASK_OFF_HEAP_MEMORY, MemorySize.MAX_VALUE);
+		adjustNetworkMemoryForLocalExecution(config);
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.MANAGED_MEMORY_SIZE, DEFAULT_MANAGED_MEMORY_SIZE);
+
+		return config;
+	}
+
+	private static void adjustNetworkMemoryForLocalExecution(Configuration config) {
+		if (!config.contains(TaskManagerOptions.NETWORK_MEMORY_MIN) &&
+			config.contains(TaskManagerOptions.NETWORK_MEMORY_MAX)) {
+			config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, config.get(TaskManagerOptions.NETWORK_MEMORY_MAX));
+		}
+		if (!config.contains(TaskManagerOptions.NETWORK_MEMORY_MAX) &&
+			config.contains(TaskManagerOptions.NETWORK_MEMORY_MIN)) {
+			config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, config.get(TaskManagerOptions.NETWORK_MEMORY_MIN));
+		}
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.NETWORK_MEMORY_MIN, DEFAULT_SHUFFLE_MEMORY_SIZE);
+		setConfigOptionToDefaultIfNotSet(config, TaskManagerOptions.NETWORK_MEMORY_MAX, DEFAULT_SHUFFLE_MEMORY_SIZE);
+	}
+
+	private static void warnOptionHasNoEffectIfSet(Configuration config, ConfigOption<?> option) {
+		if (config.contains(option)) {
+			LOG.warn(
+				"The resource configuration option {} is set but it will have no effect for local execution, " +
+					"only the following options matter for the resource configuration: {}",
+				option,
+				UNUSED_CONFIG_OPTIONS);
+		}
+	}
+
+	private static <T> void setConfigOptionToDefaultIfNotSet(
+			Configuration config,
+			ConfigOption<T> option,
+			T defaultValue) {
+		if (!config.contains(option)) {
+			LOG.info(
+				"The configuration option {} required for local execution is not set, setting it to its default value {}",
+				option,
+				defaultValue);
+			config.set(option, defaultValue);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtils.java
@@ -85,6 +85,12 @@ public class TaskExecutorResourceUtils {
 		checkTaskExecutorNetworkConfigSet(config);
 	}
 
+	private static void checkConfigOptionIsSet(Configuration config, ConfigOption<?> option) {
+		if (!config.contains(option) && !option.hasDefaultValue()) {
+			throw new IllegalConfigurationException("Configuration option %s is not set", option);
+		}
+	}
+
 	private static void checkTaskExecutorNetworkConfigSet(ReadableConfig config) {
 		if (!config.get(TaskManagerOptions.NETWORK_MEMORY_MIN).equals(config.get(TaskManagerOptions.NETWORK_MEMORY_MAX))) {
 			throw new IllegalConfigurationException(
@@ -92,12 +98,6 @@ public class TaskExecutorResourceUtils {
 					"the network memory has to be fixed after task executor has started",
 				config.get(TaskManagerOptions.NETWORK_MEMORY_MIN),
 				config.get(TaskManagerOptions.NETWORK_MEMORY_MAX));
-		}
-	}
-
-	private static void checkConfigOptionIsSet(Configuration config, ConfigOption<?> option) {
-		if (!config.contains(option)) {
-			throw new IllegalConfigurationException("Configuration option %s is not set", option);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -27,8 +27,6 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
@@ -196,7 +194,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 	public static TaskManagerConfiguration fromConfiguration(
 			Configuration configuration,
-			TaskExecutorProcessSpec taskExecutorProcessSpec) {
+			TaskExecutorResourceSpec taskExecutorResourceSpec) {
 		int numberSlots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 
 		if (numberSlots == -1) {
@@ -279,8 +277,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 		return new TaskManagerConfiguration(
 			numberSlots,
-			TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberSlots),
-			TaskExecutorProcessUtils.generateTotalAvailableResourceProfile(taskExecutorProcessSpec),
+			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberSlots),
+			TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(taskExecutorResourceSpec),
 			tmpDirPaths,
 			timeout,
 			finiteRegistrationDuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerConfiguration.java
@@ -27,8 +27,8 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
@@ -196,7 +196,7 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 	public static TaskManagerConfiguration fromConfiguration(
 			Configuration configuration,
-			TaskExecutorResourceSpec taskExecutorResourceSpec) {
+			TaskExecutorProcessSpec taskExecutorProcessSpec) {
 		int numberSlots = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, 1);
 
 		if (numberSlots == -1) {
@@ -279,8 +279,8 @@ public class TaskManagerConfiguration implements TaskManagerRuntimeInfo {
 
 		return new TaskManagerConfiguration(
 			numberSlots,
-			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberSlots),
-			TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(taskExecutorResourceSpec),
+			TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberSlots),
+			TaskExecutorProcessUtils.generateTotalAvailableResourceProfile(taskExecutorProcessSpec),
 			tmpDirPaths,
 			timeout,
 			finiteRegistrationDuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -30,8 +30,6 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -355,8 +353,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
 
-		final TaskExecutorProcessSpec taskExecutorProcessSpec;
-		taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
+		final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =
 			TaskManagerServicesConfiguration.fromConfiguration(
@@ -364,7 +361,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 				resourceID,
 				remoteAddress,
 				localCommunicationOnly,
-				taskExecutorProcessSpec);
+				taskExecutorResourceSpec);
 
 		Tuple2<TaskManagerMetricGroup, MetricGroup> taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
 			metricRegistry,
@@ -378,7 +375,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			rpcService.getExecutor()); // TODO replace this later with some dedicated executor for io.
 
 		TaskManagerConfiguration taskManagerConfiguration =
-			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorProcessSpec);
+			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorResourceSpec);
 
 		String metricQueryServiceAddress = metricRegistry.getMetricQueryServiceGatewayRpcAddress();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -30,8 +30,8 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.blob.BlobCacheService;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -355,8 +355,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
 
-		final TaskExecutorResourceSpec taskExecutorResourceSpec;
-		taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+		final TaskExecutorProcessSpec taskExecutorProcessSpec;
+		taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
 
 		TaskManagerServicesConfiguration taskManagerServicesConfiguration =
 			TaskManagerServicesConfiguration.fromConfiguration(
@@ -364,7 +364,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 				resourceID,
 				remoteAddress,
 				localCommunicationOnly,
-				taskExecutorResourceSpec);
+				taskExecutorProcessSpec);
 
 		Tuple2<TaskManagerMetricGroup, MetricGroup> taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
 			metricRegistry,
@@ -378,7 +378,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			rpcService.getExecutor()); // TODO replace this later with some dedicated executor for io.
 
 		TaskManagerConfiguration taskManagerConfiguration =
-			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorResourceSpec);
+			TaskManagerConfiguration.fromConfiguration(configuration, taskExecutorProcessSpec);
 
 		String metricQueryServiceAddress = metricRegistry.getMetricQueryServiceGatewayRpcAddress();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -245,7 +243,7 @@ public class TaskManagerServices {
 
 		final TaskSlotTable<Task> taskSlotTable = createTaskSlotTable(
 			taskManagerServicesConfiguration.getNumberOfSlots(),
-			taskManagerServicesConfiguration.getTaskExecutorProcessSpec(),
+			taskManagerServicesConfiguration.getTaskExecutorResourceSpec(),
 			taskManagerServicesConfiguration.getTimerServiceShutdownTimeout(),
 			taskManagerServicesConfiguration.getPageSize());
 
@@ -282,7 +280,7 @@ public class TaskManagerServices {
 
 	private static TaskSlotTable<Task> createTaskSlotTable(
 			final int numberOfSlots,
-			final TaskExecutorProcessSpec taskExecutorProcessSpec,
+			final TaskExecutorResourceSpec taskExecutorResourceSpec,
 			final long timerServiceShutdownTimeout,
 			final int pageSize) {
 		final TimerService<AllocationID> timerService = new TimerService<>(
@@ -290,8 +288,8 @@ public class TaskManagerServices {
 			timerServiceShutdownTimeout);
 		return new TaskSlotTableImpl<>(
 			numberOfSlots,
-			TaskExecutorProcessUtils.generateTotalAvailableResourceProfile(taskExecutorProcessSpec),
-			TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberOfSlots),
+			TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(taskExecutorResourceSpec),
+			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots),
 			pageSize,
 			timerService);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -245,7 +245,7 @@ public class TaskManagerServices {
 
 		final TaskSlotTable<Task> taskSlotTable = createTaskSlotTable(
 			taskManagerServicesConfiguration.getNumberOfSlots(),
-			taskManagerServicesConfiguration.getTaskExecutorResourceSpec(),
+			taskManagerServicesConfiguration.getTaskExecutorProcessSpec(),
 			taskManagerServicesConfiguration.getTimerServiceShutdownTimeout(),
 			taskManagerServicesConfiguration.getPageSize());
 
@@ -282,7 +282,7 @@ public class TaskManagerServices {
 
 	private static TaskSlotTable<Task> createTaskSlotTable(
 			final int numberOfSlots,
-			final TaskExecutorResourceSpec taskExecutorResourceSpec,
+			final TaskExecutorProcessSpec taskExecutorProcessSpec,
 			final long timerServiceShutdownTimeout,
 			final int pageSize) {
 		final TimerService<AllocationID> timerService = new TimerService<>(
@@ -290,8 +290,8 @@ public class TaskManagerServices {
 			timerServiceShutdownTimeout);
 		return new TaskSlotTableImpl<>(
 			numberOfSlots,
-			TaskExecutorResourceUtils.generateTotalAvailableResourceProfile(taskExecutorResourceSpec),
-			TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(taskExecutorResourceSpec, numberOfSlots),
+			TaskExecutorProcessUtils.generateTotalAvailableResourceProfile(taskExecutorProcessSpec),
+			TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberOfSlots),
 			pageSize,
 			timerService);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -70,7 +70,7 @@ public class TaskManagerServicesConfiguration {
 
 	private Optional<Time> systemResourceMetricsProbingInterval;
 
-	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
+	private final TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	public TaskManagerServicesConfiguration(
 			Configuration configuration,
@@ -83,7 +83,7 @@ public class TaskManagerServicesConfiguration {
 			@Nullable QueryableStateConfiguration queryableStateConfig,
 			int numberOfSlots,
 			int pageSize,
-			TaskExecutorResourceSpec taskExecutorResourceSpec,
+			TaskExecutorProcessSpec taskExecutorProcessSpec,
 			long timerServiceShutdownTimeout,
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			Optional<Time> systemResourceMetricsProbingInterval) {
@@ -100,7 +100,7 @@ public class TaskManagerServicesConfiguration {
 
 		this.pageSize = pageSize;
 
-		this.taskExecutorResourceSpec = taskExecutorResourceSpec;
+		this.taskExecutorProcessSpec = taskExecutorProcessSpec;
 
 		checkArgument(timerServiceShutdownTimeout >= 0L, "The timer " +
 			"service shutdown timeout must be greater or equal to 0.");
@@ -155,16 +155,16 @@ public class TaskManagerServicesConfiguration {
 		return pageSize;
 	}
 
-	public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
-		return taskExecutorResourceSpec;
+	public TaskExecutorProcessSpec getTaskExecutorProcessSpec() {
+		return taskExecutorProcessSpec;
 	}
 
 	public MemorySize getNetworkMemorySize() {
-		return taskExecutorResourceSpec.getNetworkMemSize();
+		return taskExecutorProcessSpec.getNetworkMemSize();
 	}
 
 	public MemorySize getManagedMemorySize() {
-		return taskExecutorResourceSpec.getManagedMemorySize();
+		return taskExecutorProcessSpec.getManagedMemorySize();
 	}
 
 	long getTimerServiceShutdownTimeout() {
@@ -200,7 +200,7 @@ public class TaskManagerServicesConfiguration {
 			ResourceID resourceID,
 			InetAddress remoteAddress,
 			boolean localCommunicationOnly,
-			TaskExecutorResourceSpec taskExecutorResourceSpec) {
+			TaskExecutorProcessSpec taskExecutorProcessSpec) {
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 		String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
 		if (localStateRootDir.length == 0) {
@@ -227,7 +227,7 @@ public class TaskManagerServicesConfiguration {
 			queryableStateConfig,
 			ConfigurationParserUtils.getSlot(configuration),
 			ConfigurationParserUtils.getPageSize(configuration),
-			taskExecutorResourceSpec,
+			taskExecutorProcessSpec,
 			timerServiceShutdownTimeout,
 			retryingRegistrationConfiguration,
 			ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -70,7 +69,7 @@ public class TaskManagerServicesConfiguration {
 
 	private Optional<Time> systemResourceMetricsProbingInterval;
 
-	private final TaskExecutorProcessSpec taskExecutorProcessSpec;
+	private final TaskExecutorResourceSpec taskExecutorResourceSpec;
 
 	public TaskManagerServicesConfiguration(
 			Configuration configuration,
@@ -83,7 +82,7 @@ public class TaskManagerServicesConfiguration {
 			@Nullable QueryableStateConfiguration queryableStateConfig,
 			int numberOfSlots,
 			int pageSize,
-			TaskExecutorProcessSpec taskExecutorProcessSpec,
+			TaskExecutorResourceSpec taskExecutorResourceSpec,
 			long timerServiceShutdownTimeout,
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 			Optional<Time> systemResourceMetricsProbingInterval) {
@@ -100,7 +99,7 @@ public class TaskManagerServicesConfiguration {
 
 		this.pageSize = pageSize;
 
-		this.taskExecutorProcessSpec = taskExecutorProcessSpec;
+		this.taskExecutorResourceSpec = taskExecutorResourceSpec;
 
 		checkArgument(timerServiceShutdownTimeout >= 0L, "The timer " +
 			"service shutdown timeout must be greater or equal to 0.");
@@ -155,16 +154,16 @@ public class TaskManagerServicesConfiguration {
 		return pageSize;
 	}
 
-	public TaskExecutorProcessSpec getTaskExecutorProcessSpec() {
-		return taskExecutorProcessSpec;
+	public TaskExecutorResourceSpec getTaskExecutorResourceSpec() {
+		return taskExecutorResourceSpec;
 	}
 
 	public MemorySize getNetworkMemorySize() {
-		return taskExecutorProcessSpec.getNetworkMemSize();
+		return taskExecutorResourceSpec.getNetworkMemSize();
 	}
 
 	public MemorySize getManagedMemorySize() {
-		return taskExecutorProcessSpec.getManagedMemorySize();
+		return taskExecutorResourceSpec.getManagedMemorySize();
 	}
 
 	long getTimerServiceShutdownTimeout() {
@@ -200,7 +199,7 @@ public class TaskManagerServicesConfiguration {
 			ResourceID resourceID,
 			InetAddress remoteAddress,
 			boolean localCommunicationOnly,
-			TaskExecutorProcessSpec taskExecutorProcessSpec) {
+			TaskExecutorResourceSpec taskExecutorResourceSpec) {
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 		String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
 		if (localStateRootDir.length == 0) {
@@ -227,7 +226,7 @@ public class TaskManagerServicesConfiguration {
 			queryableStateConfig,
 			ConfigurationParserUtils.getSlot(configuration),
 			ConfigurationParserUtils.getPageSize(configuration),
-			taskExecutorProcessSpec,
+			taskExecutorResourceSpec,
 			timerServiceShutdownTimeout,
 			retryingRegistrationConfiguration,
 			ConfigurationUtils.getSystemResourceMetricsProbingInterval(configuration));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.util;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 
 import java.util.Arrays;
@@ -53,19 +53,19 @@ public class BashJavaUtils {
 
 	private static void getTmResourceDynamicConfigs(String[] args) throws Exception {
 		Configuration configuration = getConfigurationForStandaloneTaskManagers(args);
-		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
-		System.out.println(EXECUTION_PREFIX + TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec));
+		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
+		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
 	}
 
 	private static void getTmResourceJvmParams(String[] args) throws Exception {
 		Configuration configuration = getConfigurationForStandaloneTaskManagers(args);
-		TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
-		System.out.println(EXECUTION_PREFIX + TaskExecutorResourceUtils.generateJvmParametersStr(taskExecutorResourceSpec));
+		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
+		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateJvmParametersStr(taskExecutorProcessSpec));
 	}
 
 	private static Configuration getConfigurationForStandaloneTaskManagers(String[] args) throws Exception {
 		Configuration configuration = TaskManagerRunner.loadConfiguration(Arrays.copyOfRange(args, 1, args.length));
-		return TaskExecutorResourceUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
+		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			configuration, TaskManagerOptions.TOTAL_FLINK_MEMORY);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -149,7 +149,7 @@ public class BootstrapToolsTest extends TestLogger {
 	@Test
 	public void testGetTaskManagerShellCommand() {
 		final Configuration cfg = new Configuration();
-		final TaskExecutorResourceSpec taskExecutorResourceSpec = new TaskExecutorResourceSpec(
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = new TaskExecutorProcessSpec(
 			new CPUResource(1.0),
 			new MemorySize(0), // frameworkHeapSize
 			new MemorySize(0), // frameworkOffHeapSize
@@ -160,7 +160,7 @@ public class BootstrapToolsTest extends TestLogger {
 			new MemorySize(333), // jvmMetaspaceSize
 			new MemorySize(0)); // jvmOverheadSize
 		final ContaineredTaskManagerParameters containeredParams =
-			new ContaineredTaskManagerParameters(taskExecutorResourceSpec, 4, new HashMap<String, String>());
+			new ContaineredTaskManagerParameters(taskExecutorProcessSpec, 4, new HashMap<String, String>());
 
 		// no logging, with/out krb5
 		final String java = "$JAVA_HOME/bin/java";
@@ -174,7 +174,7 @@ public class BootstrapToolsTest extends TestLogger {
 			"-Dlog4j.configuration=file:./conf/log4j.properties"; // if set
 		final String mainClass =
 			"org.apache.flink.runtime.clusterframework.BootstrapToolsTest";
-		final String dynamicConfigs = TaskExecutorResourceUtils.generateDynamicConfigsStr(taskExecutorResourceSpec).trim();
+		final String dynamicConfigs = TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec).trim();
 		final String basicArgs = "--configDir ./conf";
 		final String mainArgs = "-Djobmanager.rpc.address=host1 -Dkey.a=v1";
 		final String args = dynamicConfigs + " " + basicArgs + " " + mainArgs;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterConfigurationTest.java
@@ -20,16 +20,12 @@ package org.apache.flink.runtime.minicluster;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for the {@link MiniClusterConfiguration}.
@@ -77,16 +73,5 @@ public class MiniClusterConfigurationTest extends TestLogger {
 		Assert.assertEquals(
 			JobManagerOptions.SCHEDULER.defaultValue(),
 			miniClusterConfiguration.getConfiguration().getString(JobManagerOptions.SCHEDULER));
-	}
-
-	@Test
-	public void testDefaultTaskExecutorMemoryConfiguration() {
-		final MiniClusterConfiguration miniClusterConfiguration = new MiniClusterConfiguration.Builder().build();
-		final Configuration actualConfiguration = miniClusterConfiguration.getConfiguration();
-		final Configuration expectedConfiguration = MiniClusterConfiguration.adjustTaskManagerMemoryConfigurations(new Configuration());
-
-		assertThat(actualConfiguration.get(TaskManagerOptions.NETWORK_MEMORY_MIN), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
-		assertThat(actualConfiguration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(MiniClusterConfiguration.DEFAULT_SHUFFLE_MEMORY_SIZE));
-		assertThat(actualConfiguration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE), is(MiniClusterConfiguration.DEFAULT_MANAGED_MEMORY_SIZE));
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -209,7 +209,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 	private TaskManagerServicesConfiguration createTaskManagerServiceConfiguration(
 			Configuration config) throws IOException {
 		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(TOTAL_FLINK_MEMORY_MB));
-		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils.resourceSpecFromConfig(config);
+		TaskExecutorProcessSpec spec = TaskExecutorProcessUtils.processSpecFromConfig(config);
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,
 			ResourceID.generate(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -21,15 +21,12 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServices;
 import org.apache.flink.runtime.taskexecutor.TaskManagerServicesConfiguration;
 import org.apache.flink.util.FileUtils;
@@ -208,14 +205,12 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
 	private TaskManagerServicesConfiguration createTaskManagerServiceConfiguration(
 			Configuration config) throws IOException {
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(TOTAL_FLINK_MEMORY_MB));
-		TaskExecutorProcessSpec spec = TaskExecutorProcessUtils.processSpecFromConfig(config);
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,
 			ResourceID.generate(),
 			InetAddress.getLocalHost(),
 			true,
-			spec);
+			TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(config));
 	}
 
 	private TaskManagerServices createTaskManagerServices(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -21,13 +21,10 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -437,11 +434,10 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 	private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices, TaskExecutorPartitionTracker partitionTracker, String metricQueryServiceAddress) throws IOException {
 		final Configuration configuration = new Configuration();
-		configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.parse("1g"));
 
 		return new TestingTaskExecutor(
 			RPC,
-			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorProcessUtils.processSpecFromConfig(configuration)),
+			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(configuration)),
 			haServices,
 			taskManagerServices,
 			new HeartbeatServices(10_000L, 30_000L),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.core.testutils.BlockerSync;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -441,7 +441,7 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
 
 		return new TestingTaskExecutor(
 			RPC,
-			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorResourceUtils.resourceSpecFromConfig(configuration)),
+			TaskManagerConfiguration.fromConfiguration(configuration, TaskExecutorProcessUtils.processSpecFromConfig(configuration)),
 			haServices,
 			taskManagerServices,
 			new HeartbeatServices(10_000L, 30_000L),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
@@ -78,8 +78,9 @@ public class TaskExecutorResourceUtilsTest extends TestLogger {
 		//noinspection unchecked
 		TaskExecutorResourceUtils.CONFIG_OPTIONS
 			.stream()
-			.filter(option -> option.equals(TaskManagerOptions.CPU_CORES))
-			.filter(option -> option.equals(optionToNotSet))
+			.filter(option -> !option.equals(TaskManagerOptions.CPU_CORES))
+			.filter(ConfigOption::hasDefaultValue)
+			.filter(option -> !option.equals(optionToNotSet))
 			.forEach(option -> configuration.set((ConfigOption<MemorySize>) option, MemorySize.ofMebiBytes(1)));
 
 		return configuration;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorResourceUtilsTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskexecutor;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.util.TestLogger;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+/** Test suite for {@link TaskExecutorResourceUtils}. */
+public class TaskExecutorResourceUtilsTest extends TestLogger {
+	@Test
+	public void testResourceSpecFromConfig() {
+		double cpuCores = 1.0;
+		MemorySize taskHeap = MemorySize.ofMebiBytes(1);
+		MemorySize taskOffHeap = MemorySize.ofMebiBytes(2);
+		MemorySize network = MemorySize.ofMebiBytes(3);
+		MemorySize managed = MemorySize.ofMebiBytes(4);
+
+		Configuration configuration = new Configuration();
+		configuration.set(TaskManagerOptions.CPU_CORES, cpuCores);
+		configuration.set(TaskManagerOptions.TASK_HEAP_MEMORY, taskHeap);
+		configuration.set(TaskManagerOptions.TASK_OFF_HEAP_MEMORY, taskOffHeap);
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, network);
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, network);
+		configuration.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, managed);
+
+		TaskExecutorResourceSpec resourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+
+		assertThat(resourceSpec.getCpuCores(), is(new CPUResource(cpuCores)));
+		assertThat(resourceSpec.getTaskHeapSize(), is(taskHeap));
+		assertThat(resourceSpec.getTaskOffHeapSize(), is(taskOffHeap));
+		assertThat(resourceSpec.getNetworkMemSize(), is(network));
+		assertThat(resourceSpec.getManagedMemorySize(), is(managed));
+	}
+
+	@Test
+	public void testResourceSpecFromConfigFailsIfRequiredOptionIsNotSet() {
+		TaskExecutorResourceUtils.CONFIG_OPTIONS.forEach(option -> {
+			try {
+				TaskExecutorResourceUtils.resourceSpecFromConfig(setAllRequiredOptionsExceptOne(option));
+				fail("should fail with " + IllegalConfigurationException.class.getSimpleName());
+			} catch (IllegalConfigurationException e) {
+				// expected
+			}
+		});
+	}
+
+	private static Configuration setAllRequiredOptionsExceptOne(ConfigOption<?> optionToNotSet) {
+		Configuration configuration = new Configuration();
+		if (!TaskManagerOptions.CPU_CORES.equals(optionToNotSet)) {
+			configuration.set(TaskManagerOptions.CPU_CORES, 1.0);
+		}
+
+		//noinspection unchecked
+		TaskExecutorResourceUtils.CONFIG_OPTIONS
+			.stream()
+			.filter(option -> option.equals(TaskManagerOptions.CPU_CORES))
+			.filter(option -> option.equals(optionToNotSet))
+			.forEach(option -> configuration.set((ConfigOption<MemorySize>) option, MemorySize.ofMebiBytes(1)));
+
+		return configuration;
+	}
+
+	@Test
+	public void testAdjustForLocalExecution() {
+		Configuration configuration = TaskExecutorResourceUtils.adjustForLocalExecution(new Configuration());
+
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MIN), is(TaskExecutorResourceUtils.DEFAULT_SHUFFLE_MEMORY_SIZE));
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(TaskExecutorResourceUtils.DEFAULT_SHUFFLE_MEMORY_SIZE));
+		assertThat(configuration.get(TaskManagerOptions.MANAGED_MEMORY_SIZE), is(TaskExecutorResourceUtils.DEFAULT_MANAGED_MEMORY_SIZE));
+	}
+
+	@Test
+	public void testNetworkMinAdjustForLocalExecutionIfMaxSet() {
+		MemorySize networkMemorySize = MemorySize.ofMebiBytes(1);
+		Configuration configuration = new Configuration();
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MAX, networkMemorySize);
+		TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
+
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MIN), is(networkMemorySize));
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(networkMemorySize));
+	}
+
+	@Test
+	public void testNetworkMaxAdjustForLocalExecutionIfMinSet() {
+		MemorySize networkMemorySize = MemorySize.ofMebiBytes(1);
+		Configuration configuration = new Configuration();
+		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, networkMemorySize);
+		TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
+
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MIN), is(networkMemorySize));
+		assertThat(configuration.get(TaskManagerOptions.NETWORK_MEMORY_MAX), is(networkMemorySize));
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -31,8 +31,8 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -180,7 +180,7 @@ public class TaskExecutorTest extends TestLogger {
 
 	public static final HeartbeatServices HEARTBEAT_SERVICES = new HeartbeatServices(1000L, 1000L);
 
-	private static final TaskExecutorResourceSpec TM_RESOURCE_SPEC = new TaskExecutorResourceSpec(
+	private static final TaskExecutorProcessSpec TM_RESOURCE_SPEC = new TaskExecutorProcessSpec(
 		new CPUResource(1.0),
 		MemorySize.parse("1m"),
 		MemorySize.parse("2m"),
@@ -1409,7 +1409,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
 			assertThat(registeredDefaultSlotResourceProfileFuture.get(),
-				equalTo(TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, numberOfSlots)));
+				equalTo(TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, numberOfSlots)));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -31,8 +31,6 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -180,16 +178,12 @@ public class TaskExecutorTest extends TestLogger {
 
 	public static final HeartbeatServices HEARTBEAT_SERVICES = new HeartbeatServices(1000L, 1000L);
 
-	private static final TaskExecutorProcessSpec TM_RESOURCE_SPEC = new TaskExecutorProcessSpec(
+	private static final TaskExecutorResourceSpec TM_RESOURCE_SPEC = new TaskExecutorResourceSpec(
 		new CPUResource(1.0),
 		MemorySize.parse("1m"),
 		MemorySize.parse("2m"),
 		MemorySize.parse("3m"),
-		MemorySize.parse("4m"),
-		MemorySize.parse("5m"),
-		MemorySize.parse("6m"),
-		MemorySize.parse("7m"),
-		MemorySize.parse("8m"));
+		MemorySize.parse("4m"));
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
@@ -1409,7 +1403,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(testingResourceManagerGateway.getAddress(), testingResourceManagerGateway.getFencingToken().toUUID());
 
 			assertThat(registeredDefaultSlotResourceProfileFuture.get(),
-				equalTo(TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, numberOfSlots)));
+				equalTo(TaskExecutorResourceUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, numberOfSlots)));
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -158,10 +158,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
 	//-----------------------------------------------------------------------------------------------
 
 	private static Configuration createFlinkConfiguration() {
-		final Configuration config = new Configuration();
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.ofMebiBytes(TOTAL_FLINK_MEMORY_MB));
-
-		return config;
+		return TaskExecutorResourceUtils.adjustForLocalExecution(new Configuration());
 	}
 
 	private static RpcService createRpcService() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.taskexecutor;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
@@ -89,8 +88,7 @@ public class TaskManagerRunnerTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		configuration.setString(JobManagerOptions.ADDRESS, "localhost");
 		configuration.setString(TaskManagerOptions.HOST, "localhost");
-		configuration.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
-		return configuration;
+		return TaskExecutorResourceUtils.adjustForLocalExecution(configuration);
 	}
 
 	private static TaskManagerRunner createTaskManagerRunner(final Configuration configuration) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -22,12 +22,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -196,11 +193,10 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 	@Nonnull
 	private TestingTaskExecutor createTaskExecutor(TaskManagerServices taskManagerServices, String metricQueryServiceAddress, Configuration configuration) {
 		final Configuration copiedConf = new Configuration(configuration);
-		copiedConf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
 
 		return new TestingTaskExecutor(
 			testingRpcService,
-			TaskManagerConfiguration.fromConfiguration(copiedConf, TaskExecutorProcessUtils.processSpecFromConfig(copiedConf)),
+			TaskManagerConfiguration.fromConfiguration(copiedConf, TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(copiedConf)),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -27,7 +27,7 @@ import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.blob.BlobCacheService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.Executors;
@@ -200,7 +200,7 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
 
 		return new TestingTaskExecutor(
 			testingRpcService,
-			TaskManagerConfiguration.fromConfiguration(copiedConf, TaskExecutorResourceUtils.resourceSpecFromConfig(copiedConf)),
+			TaskManagerConfiguration.fromConfiguration(copiedConf, TaskExecutorProcessUtils.processSpecFromConfig(copiedConf)),
 			haServices,
 			taskManagerServices,
 			heartbeatServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -173,7 +173,7 @@ public class JvmExitOnFatalErrorTest {
 				copiedConf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1024m"));
 
 				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration
-					.fromConfiguration(taskManagerConfig, TaskExecutorResourceUtils.resourceSpecFromConfig(copiedConf));
+					.fromConfiguration(taskManagerConfig, TaskExecutorProcessUtils.processSpecFromConfig(copiedConf));
 
 				final Executor executor = Executors.newCachedThreadPool();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/JvmExitOnFatalErrorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.util;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.io.InputSplit;
 import org.apache.flink.core.testutils.CommonTestUtils;
@@ -31,7 +30,6 @@ import org.apache.flink.runtime.blob.TransientBlobCache;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
@@ -62,6 +60,7 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.TaskStateManagerImpl;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.taskexecutor.KvStateService;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
@@ -170,10 +169,8 @@ public class JvmExitOnFatalErrorTest {
 				final ShuffleEnvironment<?, ?> shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();
 
 				final Configuration copiedConf = new Configuration(taskManagerConfig);
-				copiedConf.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1024m"));
-
 				final TaskManagerRuntimeInfo tmInfo = TaskManagerConfiguration
-					.fromConfiguration(taskManagerConfig, TaskExecutorProcessUtils.processSpecFromConfig(copiedConf));
+					.fromConfiguration(taskManagerConfig, TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(copiedConf));
 
 				final Executor executor = Executors.newCachedThreadPool();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/misc/SuccessAfterNetworkBuffersFailureITCase.java
@@ -27,7 +27,6 @@ import org.apache.flink.api.java.operators.IterativeDataSet;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.examples.java.clustering.KMeans;
 import org.apache.flink.examples.java.clustering.util.KMeansData;
@@ -68,7 +67,8 @@ public class SuccessAfterNetworkBuffersFailureITCase extends TestLogger {
 	private static Configuration getConfiguration() {
 		Configuration config = new Configuration();
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("80m"));
-		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 800);
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.ofMebiBytes(25L));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.ofMebiBytes(25L));
 		return config;
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -104,9 +103,11 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getAbsolutePath());
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
-		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
+		config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
+		config.set(TaskManagerOptions.CPU_CORES, 1.0);
 		config.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("512m"));
 
 		try (final StandaloneSessionClusterEntrypoint clusterEntrypoint = new StandaloneSessionClusterEntrypoint(config)) {
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -31,7 +31,6 @@ import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -248,9 +247,11 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 			zooKeeper.getConnectString(), zookeeperStoragePath.getPath());
 		// Task manager configuration
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
-		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("512m"));
+		config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
+		config.set(TaskManagerOptions.CPU_CORES, 1.0);
 
 		final RpcService rpcService = AkkaRpcServiceUtils.createRpcService("localhost", 0, config);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -33,7 +33,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -117,9 +116,11 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		config.setString(HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, zooKeeperResource.getConnectString());
 		config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, temporaryFolder.newFolder().getAbsolutePath());
 		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 2);
-		config.set(TaskManagerOptions.TOTAL_FLINK_MEMORY, MemorySize.parse("1g"));
 		config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("4m"));
-		config.setInteger(NettyShuffleEnvironmentOptions.NETWORK_NUM_BUFFERS, 100);
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MIN, MemorySize.parse("3200k"));
+		config.set(TaskManagerOptions.NETWORK_MEMORY_MAX, MemorySize.parse("3200k"));
+		config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
+		config.set(TaskManagerOptions.CPU_CORES, 1.0);
 		config.setInteger(RestOptions.PORT, 0);
 
 		final RpcService rpcService = AkkaRpcServiceUtils.createRpcService("localhost", 0, config);

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.hadoop.io.Text;
@@ -109,8 +109,8 @@ public class UtilsTest extends TestLogger {
 			hdfsDelegationTokenKind, service));
 		amCredentials.writeTokenStorageFile(new org.apache.hadoop.fs.Path(credentialFile.getAbsolutePath()), yarnConf);
 
-		TaskExecutorResourceSpec spec = TaskExecutorResourceUtils
-			.newResourceSpecBuilder(flinkConf)
+		TaskExecutorProcessSpec spec = TaskExecutorProcessUtils
+			.newProcessSpecBuilder(flinkConf)
 			.withTotalProcessMemory(MemorySize.parse("1g"))
 			.build();
 		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(spec, 1, new HashMap<>(1));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnConfigurationITCase.java
@@ -27,8 +27,8 @@ import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.RestClientConfiguration;
@@ -89,7 +89,7 @@ public class YarnConfigurationITCase extends YarnTestBase {
 			final int slotsPerTaskManager = 3;
 			configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, slotsPerTaskManager);
 
-			final TaskExecutorResourceSpec tmResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
+			final TaskExecutorProcessSpec tmResourceSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
 			final int masterMemory = 64;
 			final int taskManagerMemory = tmResourceSpec.getTotalProcessMemorySize().getMebiBytes();
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
-import org.apache.flink.runtime.clusterframework.TaskExecutorResourceUtils;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -165,7 +165,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		numPendingContainerRequests = 0;
 
 		this.webInterfaceUrl = webInterfaceUrl;
-		this.resource = Resource.newInstance(defaultMemoryMB, taskExecutorResourceSpec.getCpuCores().getValue().intValue());
+		this.resource = Resource.newInstance(defaultMemoryMB, taskExecutorProcessSpec.getCpuCores().getValue().intValue());
 	}
 
 	protected AMRMClientAsync<AMRMClient.ContainerRequest> createAndStartResourceManagerClient(
@@ -565,12 +565,12 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorResourceSpec, numSlotsPerTaskManager);
+				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec, numSlotsPerTaskManager);
 
 		log.info("TaskExecutor {} will be started on {} with {}.",
 			containerId,
 			host,
-			taskExecutorResourceSpec);
+			taskExecutorProcessSpec);
 
 		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 
@@ -600,7 +600,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	@Override
 	protected double getCpuCores(final Configuration configuration) {
 		int fallback = configuration.getInteger(YarnConfigOptions.VCORES);
-		double cpuCoresDouble = TaskExecutorResourceUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
+		double cpuCoresDouble = TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
 		@SuppressWarnings("NumericCastThatLosesPrecision")
 		long cpuCoresLong = Math.max((long) Math.ceil(cpuCoresDouble), 1L);
 		//noinspection FloatingPointEquality


### PR DESCRIPTION
## What is the purpose of the change

FLIP-49 calculates memory setup to start TM process. Atm, we reuse this logic to get necessary resource configuration options in running TM, although we do not need the full `TaskExecutorResourceSpec` which can be renamed to `TaskExecutorProcessSpec`.

In case of local execution in mini cluster, the TM process is started outside of Flink framework and nothing is pre-calculated. It means that any configured process or Flink memory size can make no sense and can be ignored then to make things simpler and more explicit. Also the result of FLIP-49 calculation can contradict to the default values and other derived FLIP-49 memory components are not used by TM internally anyways. If some necessary options are not set, we can set them to reasonable defaults. 

The configuration options required for running TM, which are expected to be calculated and set before its start, are the following (with defaults for local execution):

- cpu cores (potentially for FLIP-56, default: `Double.MAX_VALUE`)
- task heap memory (potentially for FLIP-56, default: `MemorySize.MAX_VALUE`)
- task off-heap memory (potentially for FLIP-56, default: `MemorySize.MAX_VALUE`)
- network memory (default: 64Mb)
- managed memory (default: 128Mb)

Additionally, we can refactor TM runner to not reuse current FLIP-49 computation but just check that the necessary options are set and create TaskExecutorResourceSpec which contains only them.

## Brief change log

  - Rename `TaskExecutorResourceSpec` to `TaskExecutorProcessSpec`
  - Introduce new `TaskExecutorResourceSpec` to use in running TM
  - Introduce new `TaskExecutorResourceUtils` to create new `TaskExecutorResourceSpec` from config
  - Set non-configured necessary options to defaults for local execution
  - Ignore other FLIP-49 options and warn if they are set for local execution
  - Adjust/Add unit tests

## Verifying this change

unit tests
