### PR TITLE
[FLINK-15768] [Client/Job Submission] Consolidate executor related cl…

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -16,40 +16,39 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment;
+package org.apache.flink.client.deployment.executors;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.dag.Pipeline;
-import org.apache.flink.client.cli.ExecutionConfigAccessor;
+import org.apache.flink.client.deployment.ClusterClientFactory;
+import org.apache.flink.client.deployment.ClusterClientJobClientAdapter;
+import org.apache.flink.client.deployment.ClusterDescriptor;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nonnull;
 
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * An abstract {@link PipelineExecutor} used to execute {@link Pipeline pipelines} on dedicated (per-job) clusters.
+ * An abstract {@link PipelineExecutor} used to execute {@link Pipeline pipelines} on an existing (session) cluster.
  *
  * @param <ClusterID> the type of the id of the cluster.
  * @param <ClientFactory> the type of the {@link ClusterClientFactory} used to create/retrieve a client to the target cluster.
  */
 @Internal
-public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends ClusterClientFactory<ClusterID>> implements PipelineExecutor {
-
-	private static final Logger LOG = LoggerFactory.getLogger(AbstractJobClusterExecutor.class);
+public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends ClusterClientFactory<ClusterID>> implements PipelineExecutor {
 
 	private final ClientFactory clusterClientFactory;
 
-	public AbstractJobClusterExecutor(@Nonnull final ClientFactory clusterClientFactory) {
+	public AbstractSessionClusterExecutor(@Nonnull final ClientFactory clusterClientFactory) {
 		this.clusterClientFactory = checkNotNull(clusterClientFactory);
 	}
 
@@ -58,16 +57,17 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 		final JobGraph jobGraph = ExecutorUtils.getJobGraph(pipeline, configuration);
 
 		try (final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(configuration)) {
-			final ExecutionConfigAccessor configAccessor = ExecutionConfigAccessor.fromConfiguration(configuration);
+			final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);
+			checkState(clusterID != null);
 
-			final ClusterSpecification clusterSpecification = clusterClientFactory.getClusterSpecification(configuration);
-
-			final ClusterClientProvider<ClusterID> clusterClientProvider = clusterDescriptor
-					.deployJobCluster(clusterSpecification, jobGraph, configAccessor.getDetachedMode());
-			LOG.info("Job has been submitted with JobID " + jobGraph.getJobID());
-
-			return CompletableFuture.completedFuture(
-					new ClusterClientJobClientAdapter<>(clusterClientProvider, jobGraph.getJobID()));
+			final ClusterClientProvider<ClusterID> clusterClientProvider = clusterDescriptor.retrieve(clusterID);
+			ClusterClient<ClusterID> clusterClient = clusterClientProvider.getClusterClient();
+			return clusterClient
+					.submitJob(jobGraph)
+					.thenApplyAsync(jobID -> (JobClient) new ClusterClientJobClientAdapter<>(
+							clusterClientProvider,
+							jobID))
+					.whenComplete((ignored1, ignored2) -> clusterClient.close());
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/ExecutorUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/ExecutorUtils.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.client.deployment;
+package org.apache.flink.client.deployment.executors;
 
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/RemoteExecutor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.deployment.executors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.AbstractSessionClusterExecutor;
 import org.apache.flink.client.deployment.StandaloneClientFactory;
 import org.apache.flink.client.deployment.StandaloneClusterId;
 import org.apache.flink.core.execution.PipelineExecutor;

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
@@ -19,7 +19,7 @@
 package org.apache.flink.kubernetes.executors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.AbstractSessionClusterExecutor;
+import org.apache.flink.client.deployment.executors.AbstractSessionClusterExecutor;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnJobClusterExecutor.java
@@ -19,7 +19,7 @@
 package org.apache.flink.yarn.executors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.AbstractJobClusterExecutor;
+import org.apache.flink.client.deployment.executors.AbstractJobClusterExecutor;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.yarn.YarnClusterClientFactory;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/executors/YarnSessionClusterExecutor.java
@@ -19,7 +19,7 @@
 package org.apache.flink.yarn.executors;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.client.deployment.AbstractSessionClusterExecutor;
+import org.apache.flink.client.deployment.executors.AbstractSessionClusterExecutor;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.yarn.YarnClusterClientFactory;
 


### PR DESCRIPTION
## What is the purpose of the change

Consolidate executor related classes into the same module that underneath of org.apache.flink.client.deployment.exectuors.


## Brief change log
  - Move classes into org.apache.flink.client.deployment.exectuors package.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
