### PR TITLE
[FLINK-15701][Travis] Retries when uploading to transfer.sh fails

### DIFF
--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -43,6 +43,13 @@ MAX_NO_OUTPUT=${1:-300}
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20
 
+# Maximum times to retry uploading artifacts file to transfer.sh
+TRANSFER_UPLOAD_MAX_RETRIES=10
+
+# The delay between two retries to upload artifacts file to transfer.sh. The default exponential
+# backoff algorithm should be too long for the last several retries.
+TRANSFER_UPLOAD_RETRY_DELAY=15
+
 LOG4J_PROPERTIES=${HERE}/log4j-travis.properties
 
 PYTHON_TEST="./flink-python/dev/lint-python.sh"
@@ -133,7 +140,7 @@ upload_artifacts_s3() {
 
 	# upload to https://transfer.sh
 	echo "Uploading to transfer.sh"
-	curl --upload-file $ARTIFACTS_FILE --max-time 60 https://transfer.sh
+	curl --retry ${TRANSFER_UPLOAD_MAX_RETRIES} --retry-delay ${TRANSFER_UPLOAD_RETRY_DELAY} --upload-file $ARTIFACTS_FILE --max-time 60 https://transfer.sh
 }
 
 print_stacktraces () {


### PR DESCRIPTION
## What is the purpose of the change

When uploading the test detail outputs onto [transfer.sh](https://transfer.sh), occasionally we meet with the error `Could not save metadata`. The error makes the unstable tests might not be able to be located since the test logs are missing.

This PR tries to enable retrying if the uploading fails with curl's retrying support.


## Brief change log

- b60b8d03e20dc1c49acc48e69cfc73c6abba100d added retries when uploading fails.

## Verifying this change

  - Manually verified [the successful case](https://travis-ci.org/gaoyunhaii/flink/jobs/641905104) with transfer.sh and [ the fail case](https://travis-ci.org/gaoyunhaii/flink/jobs/641910891) with a simulated server.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**