### PR TITLE
  [FLINK-15777][filesystem]Determine Hadoop version with fs classpath.

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -35,13 +35,13 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.apache.hadoop.util.VersionInfo;
+
+import javax.annotation.Nullable;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.time.Duration;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -55,7 +55,8 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 
 	private static final long LEASE_TIMEOUT = 100_000L;
 
-	private static Method truncateHandle;
+	@Nullable
+	private final Method truncateHandle;
 
 	private final FileSystem fs;
 
@@ -70,7 +71,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 			Path targetFile,
 			Path tempFile) throws IOException {
 
-		ensureTruncateInitialized();
+		truncateHandle = findTrunacteMethod(fs);
 
 		this.fs = checkNotNull(fs);
 		this.targetFile = checkNotNull(targetFile);
@@ -82,13 +83,13 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 			FileSystem fs,
 			HadoopFsRecoverable recoverable) throws IOException {
 
-		ensureTruncateInitialized();
+		truncateHandle = findTrunacteMethod(fs);
 
 		this.fs = checkNotNull(fs);
 		this.targetFile = checkNotNull(recoverable.targetFile());
 		this.tempFile = checkNotNull(recoverable.tempFile());
 
-		safelyTruncateFile(fs, tempFile, recoverable);
+		safelyTruncateFile(fs, tempFile, recoverable, truncateHandle);
 
 		out = fs.append(tempFile);
 
@@ -154,16 +155,15 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 	private static void safelyTruncateFile(
 			final FileSystem fileSystem,
 			final Path path,
-			final HadoopFsRecoverable recoverable) throws IOException {
-
-		ensureTruncateInitialized();
+			final HadoopFsRecoverable recoverable,
+			final Method truncateHandle) throws IOException {
 
 		waitUntilLeaseIsRevoked(fileSystem, path);
 
 		// truncate back and append
 		boolean truncated;
 		try {
-			truncated = truncate(fileSystem, path, recoverable.offset());
+			truncated = truncate(fileSystem, path, recoverable.offset(), truncateHandle);
 		} catch (Exception e) {
 			throw new IOException("Problem while truncating file: " + path, e);
 		}
@@ -175,44 +175,39 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 		}
 	}
 
-	private static void ensureTruncateInitialized() throws FlinkRuntimeException {
-		if (HadoopUtils.isMinHadoopVersion(2, 7) && truncateHandle == null) {
-			Method truncateMethod;
+	private static Method findTrunacteMethod(FileSystem fs) throws FlinkRuntimeException {
+		Method truncateMethod = null;
+		if (HadoopUtils.isMinHadoopVersion(fs.getClass().getClassLoader(), 2, 7)) {
 			try {
-				truncateMethod = FileSystem.class.getMethod("truncate", Path.class, long.class);
-			}
-			catch (NoSuchMethodException e) {
+				truncateMethod = fs.getClass().getMethod("truncate", Path.class, long.class);
+			} catch (NoSuchMethodException e) {
 				throw new FlinkRuntimeException("Could not find a public truncate method on the Hadoop File System.");
 			}
-
-			if (!Modifier.isPublic(truncateMethod.getModifiers())) {
-				throw new FlinkRuntimeException("Could not find a public truncate method on the Hadoop File System.");
-			}
-
-			truncateHandle = truncateMethod;
 		}
+
+		return truncateMethod;
 	}
 
-	private static boolean truncate(final FileSystem hadoopFs, final Path file, final long length) throws IOException {
-		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
-			throw new IllegalStateException("Truncation is not available in hadoop version < 2.7 , You are on Hadoop " + VersionInfo.getVersion());
+	private static boolean truncate(
+			final FileSystem hadoopFs,
+			final Path file,
+			final long length,
+			final Method truncateHandle) throws IOException {
+		if (truncateHandle == null) {
+			throw new IllegalStateException("Truncation is not available in hadoop version < 2.7 , the filesystem " +
+				"uses hadoop " + HadoopUtils.getHadoopVersion(hadoopFs.getClass().getClassLoader()));
 		}
 
-		if (truncateHandle != null) {
-			try {
-				return (Boolean) truncateHandle.invoke(hadoopFs, file, length);
-			}
-			catch (InvocationTargetException e) {
-				ExceptionUtils.rethrowIOException(e.getTargetException());
-			}
-			catch (Throwable t) {
-				throw new IOException(
-						"Truncation of file failed because of access/linking problems with Hadoop's truncate call. " +
-								"This is most likely a dependency conflict or class loading problem.");
-			}
+		try {
+			return (Boolean) truncateHandle.invoke(hadoopFs, file, length);
 		}
-		else {
-			throw new IllegalStateException("Truncation handle has not been initialized");
+		catch (InvocationTargetException e) {
+			ExceptionUtils.rethrowIOException(e.getTargetException());
+		}
+		catch (Throwable t) {
+			throw new IOException(
+					"Truncation of file failed because of access/linking problems with Hadoop's truncate call. " +
+							"This is most likely a dependency conflict or class loading problem.", t);
 		}
 		return false;
 	}
@@ -230,10 +225,12 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 
 		private final FileSystem fs;
 		private final HadoopFsRecoverable recoverable;
+		private final Method truncateHandle;
 
 		HadoopFsCommitter(FileSystem fs, HadoopFsRecoverable recoverable) {
 			this.fs = checkNotNull(fs);
 			this.recoverable = checkNotNull(recoverable);
+			this.truncateHandle = findTrunacteMethod(fs);
 		}
 
 		@Override
@@ -285,7 +282,7 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
 				if (srcStatus.getLen() > expectedLength) {
 					// can happen if we go from persist to recovering for commit directly
 					// truncate the trailing junk away
-					safelyTruncateFile(fs, src, recoverable);
+					safelyTruncateFile(fs, src, recoverable, truncateHandle);
 				}
 
 				// rename to final location (if it exists, overwrite it)

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -64,7 +64,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 
 		// Part of functionality depends on specific versions. We check these schemes and versions eagerly for
 		// better error messages.
-		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
+		if (!HadoopUtils.isMinHadoopVersion(fs.getClass().getClassLoader(), 2, 7)) {
 			LOG.warn("WARNING: You are running on hadoop version " + VersionInfo.getVersion() + "." +
 					" If your RollingPolicy does not roll on every checkpoint/savepoint, the StreamingFileSink will throw an exception upon recovery.");
 		}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopUtils.java
@@ -129,8 +129,8 @@ public class HadoopUtils {
 	/**
 	 * Checks if the Hadoop dependency is at least the given version.
 	 */
-	public static boolean isMinHadoopVersion(int major, int minor) throws FlinkRuntimeException {
-		final Tuple2<Integer, Integer> hadoopVersion = getMajorMinorBundledHadoopVersion();
+	public static boolean isMinHadoopVersion(ClassLoader classLoader, int major, int minor) throws FlinkRuntimeException {
+		final Tuple2<Integer, Integer> hadoopVersion = getMajorMinorBundledHadoopVersion(classLoader);
 		int maj = hadoopVersion.f0;
 		int min = hadoopVersion.f1;
 
@@ -140,16 +140,16 @@ public class HadoopUtils {
 	/**
 	 * Checks if the Hadoop dependency is at most the given version.
 	 */
-	public static boolean isMaxHadoopVersion(int major, int minor) throws FlinkRuntimeException {
-		final Tuple2<Integer, Integer> hadoopVersion = getMajorMinorBundledHadoopVersion();
+	public static boolean isMaxHadoopVersion(ClassLoader classLoader, int major, int minor) throws FlinkRuntimeException {
+		final Tuple2<Integer, Integer> hadoopVersion = getMajorMinorBundledHadoopVersion(classLoader);
 		int maj = hadoopVersion.f0;
 		int min = hadoopVersion.f1;
 
 		return maj < major || (maj == major && min < minor);
 	}
 
-	private static Tuple2<Integer, Integer> getMajorMinorBundledHadoopVersion() {
-		String versionString = VersionInfo.getVersion();
+	private static Tuple2<Integer, Integer> getMajorMinorBundledHadoopVersion(ClassLoader classLoader) {
+		String versionString = getHadoopVersion(classLoader);
 		String[] versionParts = versionString.split("\\.");
 
 		if (versionParts.length < 2) {
@@ -160,6 +160,14 @@ public class HadoopUtils {
 		int maj = Integer.parseInt(versionParts[0]);
 		int min = Integer.parseInt(versionParts[1]);
 		return Tuple2.of(maj, min);
+	}
+
+	public static String getHadoopVersion(final ClassLoader classLoader) {
+		try {
+			return (String) classLoader.loadClass(VersionInfo.class.getName()).getMethod("getVersion").invoke(null);
+		} catch (Exception e) {
+			throw new FlinkRuntimeException("Cannot find version of Hadoop", e);
+		}
 	}
 
 	/**

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest.java
@@ -64,7 +64,7 @@ public class HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest {
 
 	@BeforeClass
 	public static void testHadoopVersion() {
-		Assume.assumeTrue(HadoopUtils.isMaxHadoopVersion(2, 7));
+		Assume.assumeTrue(HadoopUtils.isMaxHadoopVersion(HadoopRecoverableWriter.class.getClassLoader(), 2, 7));
 	}
 
 	@BeforeClass

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterTest.java
@@ -51,7 +51,7 @@ public class HadoopRecoverableWriterTest extends AbstractRecoverableWriterTest {
 
 	@BeforeClass
 	public static void testHadoopVersion() {
-		Assume.assumeTrue(HadoopUtils.isMinHadoopVersion(2, 7));
+		Assume.assumeTrue(HadoopUtils.isMinHadoopVersion(HadoopRecoverableWriter.class.getClassLoader(), 2, 7));
 	}
 
 	@BeforeClass


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

FLINK-14170 introduced Hadoop version check to support older versions with limited functionality. However, the fix checks the Hadoop version of the system classloader and not of the plugin (of the actual used filesystem).

The version checks will fail when there is a Hadoop version in the classpath of Flink, independent of the bundled version of the filesystem.

On a recent EMR setup with lingering Hadoop 2.6 libraries, this mean that you cannot write to S3 with StreamingFileSink.

## Brief change log

- Make truncate handle non-static and receive it from actually used filesystem
- Use filesystem classloader for version checks

## Verifying this change

Not tested

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no /** don't know)
  - The S3 file system connector: (**yes** / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
