### PR TITLE
[FLINK-15143][doc] Create documents for FLIP-49.

### DIFF
--- a/docs/concepts/glossary.md
+++ b/docs/concepts/glossary.md
@@ -150,6 +150,10 @@ Node of a [Physical Graph](#physical-graph). A task is the basic unit of work, w
 Flink's runtime. Tasks encapsulate exactly one parallel instance of an
 [Operator](#operator) or [Operator Chain](#operator-chain).
 
+#### TaskExecutor
+
+see [Flink TaskManager](#flink-taskmanager)
+
 #### Flink TaskManager
 
 TaskManagers are the worker processes of a [Flink Cluster](#flink-cluster). [Tasks](#task) are

--- a/docs/concepts/glossary.zh.md
+++ b/docs/concepts/glossary.zh.md
@@ -107,6 +107,10 @@ Sub-Task 是负责处理数据流 [Partition](#partition) 的 [Task](#task)。"S
 
 Task 是 [Physical Graph](#physical-graph) 的节点。它是基本的工作单元，由 Flink 的 runtime 来执行。Task 正好封装了一个 [Operator](#operator) 或者 [Operator Chain](#operator-chain) 的 *parallel instance*。 
 
+#### TaskExecutor
+
+见 [Flink TaskManager](#flink-taskmanager)。
+
 #### Flink TaskManager
 
 TaskManager 是 [Flink Cluster](#flink-cluster) 的工作进程。[Task](#task) 被调度到 TaskManager 上执行。TaskManager 相互通信，只为在后续的 Task 之间交换数据。

--- a/docs/fig/tm_memory_model.svg
+++ b/docs/fig/tm_memory_model.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xl="http://www.w3.org/1999/xlink" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="280 101 412 415" width="412" height="415">
+  <defs>
+    <font-face font-family="Helvetica Neue" font-size="16" panose-1="2 0 5 3 0 0 0 2 0 4" units-per-em="1000" underline-position="-100" underline-thickness="50" slope="0" x-height="517" cap-height="714" ascent="951.9958" descent="-212.99744" font-weight="400">
+      <font-face-src>
+        <font-face-name name="HelveticaNeue"/>
+      </font-face-src>
+    </font-face>
+  </defs>
+  <metadata> Produced by OmniGraffle 7.12.1 
+    <dc:date>2020-01-28 04:08:49 +0000</dc:date>
+  </metadata>
+  <g id="TE_Memory" stroke="none" stroke-opacity="1" fill="none" fill-opacity="1" stroke-dasharray="none">
+    <title>TE Memory</title>
+    <g id="TE_Memory: 图层 1">
+      <title>图层 1</title>
+      <g id="Graphic_13">
+        <rect x="280.875" y="101.5" width="282.25" height="414" fill="white"/>
+        <rect x="280.875" y="101.5" width="282.25" height="414" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(285.875 106.5)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="75.669" y="15">Process Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_2">
+        <rect x="292.75" y="134" width="257" height="285.5" fill="#ccc"/>
+        <rect x="292.75" y="134" width="257" height="285.5" stroke="gray" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+        <text transform="translate(297.75 139)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="75.188" y="15">Flink Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_4">
+        <rect x="305.25" y="291.5268" width="233.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(310.25 299.31622)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="28.886" y="15">Task Off-Heap Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_7">
+        <rect x="305.25" y="168.44637" width="233.5" height="34.026815" fill="#80ffff"/>
+        <text transform="translate(310.25 176.23578)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="18.702" y="15">Framework Heap Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_8">
+        <rect x="305.25" y="250.5" width="233.5" height="34.026815" fill="#80ffff"/>
+        <text transform="translate(310.25 258.2894)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="42.694" y="15">Task Heap Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_9">
+        <rect x="293.25" y="428" width="255.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(298.25 435.7894)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="64.806" y="15">JVM Metaspace</tspan>
+        </text>
+      </g>
+      <g id="Graphic_11">
+        <rect x="305.25" y="333.55363" width="232.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(310.25 341.34304)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="49.618" y="15">Network Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_12">
+        <rect x="294.25" y="471.0268" width="255.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(299.25 478.8162)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="69.694" y="15">JVM Overhead</tspan>
+        </text>
+      </g>
+      <g id="Graphic_15">
+        <rect x="600.5" y="471.0268" width="91" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(605.5 478.8162)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.58" y="15">Off-Heap</tspan>
+        </text>
+      </g>
+      <g id="Graphic_16">
+        <rect x="600.5" y="428" width="91" height="34.026815" fill="#80ffff"/>
+        <text transform="translate(605.5 435.7894)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="7.748" y="15">On-Heap</tspan>
+        </text>
+      </g>
+      <g id="Graphic_17">
+        <rect x="305.25" y="209.47319" width="233.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(310.25 217.2626)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="4.894" y="15">Framework Off-Heap Memory</tspan>
+        </text>
+      </g>
+      <g id="Graphic_18">
+        <rect x="304.75" y="376.0134" width="232.5" height="34.026815" fill="#ffff80"/>
+        <text transform="translate(309.75 383.8028)" fill="black">
+          <tspan font-family="Helvetica Neue" font-size="16" font-weight="400" fill="black" x="46.042" y="15">Managed Memory</tspan>
+        </text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/internals/memory_model.md
+++ b/docs/internals/memory_model.md
@@ -1,0 +1,183 @@
+---
+title: "Task Executor Memory Model"
+nav-parent_id: internals
+nav-pos: 11
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+
+* Replaced by the TOC
+{:toc}
+
+# Memory Breakdown
+
+Flink breaks memory usages of a TaskExecutor process down to the following components.
+- **Framework Heap Memory** - JVM heap memory reserved for TaskExecutor framework.
+- **Framework Off-Heap Memory** - Direct and native memory reserved for TaskExecutor framework.
+- **Task Heap Memory** - JVM heap memory reserved for [tasks]({{ site.baseurl }}/concepts/glossary.html#task).
+- **Task Off-Heap Memory** - Direct and native memory reserved for tasks.
+- **Network Memory** - Direct memory reserved for ShuffleEnvironment (e.g., network buffers).
+- **Managed Memory** - Native memory managed by the Flink MemoryManager, reserved for sorting, hash tables, caching of intermediate results and [RocksDB state backend]({{ site.baseurl }}/ops/state/state_backends.html#the-rocksdbstatebackend).
+- **JVM Metaspace** - JVM metaspace size.
+- **JVM Overhead** - Native memory reserved for other JVM overheads, e.g., thread stacks, code cache, garbage collection space.
+
+For simplicity when configuring Flink, the term **Process Memory** refers to the total memory usage of a TaskExecutor, and **Flink Memory** refers to that excluding JVM Metaspace and JVM Overhead.
+
+<div style="text-align: center;">
+<img src="{{ site.baseurl }}/fig/tm_memory_model.svg" alt="Task Executor Memory Model" height="400px" style="text-align: center;"/>
+</div>
+
+Note: There’s no isolation between Framework Heap Memory and Task Heap Memory, neither between Framework Off-Heap Memory and Task Off-Heap Memory.
+The separation of the framework and task memory is in preparation for dynamic slot allocation, an upcoming feature that will allow task memory to be allocated to slots while framework memory will not.
+
+# Memory Configuration
+
+For all types of deployments, except for local execution, Flink requires either of the following three (combination of) memory sizes to be explicitly configured.
+- Task Heap Memory and Managed Memory
+- Flink Memory
+- Process Memory
+
+Note: Explicitly configuring more than one of the above three (combination of) memory sizes is not recommended.
+It may lead to deployment failures due to potential memory configuration conflicts.
+
+The following memory components will always be explicitly configured.
+If no configuration changes are made the following default values will be used.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Memory Component</th>
+      <th class="text-left" style="width: 60%">Configuration Option</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Framework Heap Memory</td>
+      <td>‘taskmanager.memory.framework.heap.size’ (default 128MB)</td>
+    </tr>
+    <tr>
+      <td>Framework Off-Heap Memory</td>
+      <td>‘taskmanager.memory.framework.off-heap.size’ (default 128MB)</td>
+    </tr>
+    <tr>
+      <td>Task Off-Heap Memory</td>
+      <td>‘taskmanager.memory.task.off-heap.size’ (default 0)</td>
+    </tr>
+    <tr>
+      <td>JVM Metaspace</td>
+      <td>‘taskmanager.memory.jvm-metaspace.size’ (default 96MB)</td>
+    </tr>
+  </tbody>
+</table>
+
+The following components will always be allocated memory within a specified range and targeting a specific amount, specified as a fraction of total memory, on a best effort basis.
+If the ranges and fractions are not explicitly specified by the user, the following default values will be used.
+Note that the fractions may not always be respected even if explicitly configured.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 25%">Memory Component</th>
+      <th class="text-left" style="width: 50%">Configuration Option</th>
+      <th class="text-left" style="width: 25%">Base of Fraction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3">Network Memory</td>
+      <td>‘taskmanager.memory.network.min’ (default 64MB)</td>
+      <td rowspan="3">Flink Memory</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.network.max’ (default 1GB)</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.network.fraction’’ (default 0.1)</td>
+    </tr>
+    <tr>
+      <td rowspan="3">JVM Overhead</td>
+      <td>‘taskmanager.memory.jvm-overhead.min’ (default 192MB)</td>
+      <td rowspan="3">Process Memory</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.jvm-overhead.max’ (default 1GB)</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.jvm-overhead.fraction’ (default 0.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+Imagine Flink Memory is 1000MB and Network Memory is configured to be in the range of 64MB to 1GB with a fraction of 0.08.
+In this case, Flink will attempt to allocate 80MB for Network Memory but guarantee the runtime amount is within the range of 64MB to 1GB.  
+
+The size of Managed Memory can either be configured directly (‘taskmanager.memory.managed.size’), or derived to make up the configured fraction (‘taskmanager.memory.managed.fraction’) of Flink Memory.
+If both size and fraction are explicitly specified by user, the size will be used.
+If neither of size and fraction is explicitly configured, it will be derived with the default fraction (0.4).
+
+The size of Task Heap Memory can be configured directly (‘taskmanager.memory.task.heap.size’).
+If not explicitly specified by user, it will use whatever left in Flink Memory after sizes of other memory components are decided.
+
+Users can also directly configure the size of Process Memory (‘taskmanager.memory.process.size’) or Flink Memory (‘taskmanager.memory.flink.size’).
+Flink will then automatically derive the memory component sizes.
+
+Note: All the explicitly configured sizes, default sizes (if a default absolute size exists), min/max constraints and the Managed Memory fraction (if the size is not specified) will be respected (excluding Network Memory and JVM Overhead fractions).
+Flink cannot be deployed and exceptions will be thrown on conflictions.
+
+## Memory Configuration for Local Execution
+
+In local execution environments, all TaskExecutors run in the same JVM process that the program is executed.
+Therefore, the configuration cannot affect the JVM heap size, direct memory/metaspace limits, and the overall memory reserved for the process.
+In other words, configurations on the following memory components will not take effect.
+- Framework Heap Memory
+- Framework Off-Heap Memory
+- Task Heap Memory
+- Task Off-Heap Memory
+- JVM Metaspace
+- JVM Overhead
+
+Unless explicitly configured, Flink will internally set the sizes of Network Memory and Managed Memory to 64MB and 16MB respectively, for the purpose of trying out Flink locally with less memory consumption. 
+
+# JVM Parameters
+Flink explicitly sets the following memory related JVM parameters for TaskExecutor processes, w.r.t. the configured / derived memory component sizes.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 30%">JVM Parameters</th>
+      <th class="text-left" style="width: 70%">Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>-Xmx / -Xms</td>
+      <td>Framework Heap Memory + Task Heap Memory</td>
+    </tr>
+    <tr>
+      <td>-XX:MaxDirectMemorySize</td>
+      <td>Framework Off-Heap Memory + Task Off-Heap Memory + Network Memory</td>
+    </tr>
+    <tr>
+      <td>-XX:MaxMetaspaceSize</td>
+      <td>JVM Metaspace</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/internals/memory_model.md
+++ b/docs/internals/memory_model.md
@@ -23,7 +23,7 @@ under the License.
 -->
 
 This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
-Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html).
+Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html) and [migration guidelines]({{ site.baseurl }}/ops/memory-config/migration_guide.html).
 
 * Replaced by the TOC
 {:toc}

--- a/docs/internals/memory_model.md
+++ b/docs/internals/memory_model.md
@@ -23,6 +23,7 @@ under the License.
 -->
 
 This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html).
 
 * Replaced by the TOC
 {:toc}

--- a/docs/internals/memory_model.zh.md
+++ b/docs/internals/memory_model.zh.md
@@ -23,7 +23,7 @@ under the License.
 -->
 
 This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
-Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html).
+Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html) and [migration guidelines]({{ site.baseurl }}/ops/memory-config/migration_guide.html).
 
 * Replaced by the TOC
 {:toc}

--- a/docs/internals/memory_model.zh.md
+++ b/docs/internals/memory_model.zh.md
@@ -23,6 +23,7 @@ under the License.
 -->
 
 This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+Guidelines on how to configure memory usages with this model can be found in [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html).
 
 * Replaced by the TOC
 {:toc}

--- a/docs/internals/memory_model.zh.md
+++ b/docs/internals/memory_model.zh.md
@@ -1,0 +1,183 @@
+---
+title: "Task Executor 内存模型"
+nav-parent_id: internals
+nav-pos: 11
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document describes the memory model of Flink [TaskExecutor]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+
+* Replaced by the TOC
+{:toc}
+
+# Memory Breakdown
+
+Flink breaks memory usages of a TaskExecutor process down to the following components.
+- **Framework Heap Memory** - JVM heap memory reserved for TaskExecutor framework.
+- **Framework Off-Heap Memory** - Direct and native memory reserved for TaskExecutor framework.
+- **Task Heap Memory** - JVM heap memory reserved for [tasks]({{ site.baseurl }}/concepts/glossary.html#task).
+- **Task Off-Heap Memory** - Direct and native memory reserved for tasks.
+- **Network Memory** - Direct memory reserved for ShuffleEnvironment (e.g., network buffers).
+- **Managed Memory** - Native memory managed by the Flink MemoryManager, reserved for sorting, hash tables, caching of intermediate results and [RocksDB state backend]({{ site.baseurl }}/ops/state/state_backends.html#the-rocksdbstatebackend).
+- **JVM Metaspace** - JVM metaspace size.
+- **JVM Overhead** - Native memory reserved for other JVM overheads, e.g., thread stacks, code cache, garbage collection space.
+
+For simplicity when configuring Flink, the term **Process Memory** refers to the total memory usage of a TaskExecutor, and **Flink Memory** refers to that excluding JVM Metaspace and JVM Overhead.
+
+<div style="text-align: center;">
+<img src="{{ site.baseurl }}/fig/tm_memory_model.svg" alt="Task Executor Memory Model" height="400px" style="text-align: center;"/>
+</div>
+
+Note: There’s no isolation between Framework Heap Memory and Task Heap Memory, neither between Framework Off-Heap Memory and Task Off-Heap Memory.
+The separation of the framework and task memory is in preparation for dynamic slot allocation, an upcoming feature that will allow task memory to be allocated to slots while framework memory will not.
+
+# Memory Configuration
+
+For all types of deployments, except for local execution, Flink requires either of the following three (combination of) memory sizes to be explicitly configured.
+- Task Heap Memory and Managed Memory
+- Flink Memory
+- Process Memory
+
+Note: Explicitly configuring more than one of the above three (combination of) memory sizes is not recommended.
+It may lead to deployment failures due to potential memory configuration conflicts.
+
+The following memory components will always be explicitly configured.
+If no configuration changes are made the following default values will be used.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 40%">Memory Component</th>
+      <th class="text-left" style="width: 60%">Configuration Option</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Framework Heap Memory</td>
+      <td>‘taskmanager.memory.framework.heap.size’ (default 128MB)</td>
+    </tr>
+    <tr>
+      <td>Framework Off-Heap Memory</td>
+      <td>‘taskmanager.memory.framework.off-heap.size’ (default 128MB)</td>
+    </tr>
+    <tr>
+      <td>Task Off-Heap Memory</td>
+      <td>‘taskmanager.memory.task.off-heap.size’ (default 0)</td>
+    </tr>
+    <tr>
+      <td>JVM Metaspace</td>
+      <td>‘taskmanager.memory.jvm-metaspace.size’ (default 96MB)</td>
+    </tr>
+  </tbody>
+</table>
+
+The following components will always be allocated memory within a specified range and targeting a specific amount, specified as a fraction of total memory, on a best effort basis.
+If the ranges and fractions are not explicitly specified by the user, the following default values will be used.
+Note that the fractions may not always be respected even if explicitly configured.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 25%">Memory Component</th>
+      <th class="text-left" style="width: 50%">Configuration Option</th>
+      <th class="text-left" style="width: 25%">Base of Fraction</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="3">Network Memory</td>
+      <td>‘taskmanager.memory.network.min’ (default 64MB)</td>
+      <td rowspan="3">Flink Memory</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.network.max’ (default 1GB)</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.network.fraction’’ (default 0.1)</td>
+    </tr>
+    <tr>
+      <td rowspan="3">JVM Overhead</td>
+      <td>‘taskmanager.memory.jvm-overhead.min’ (default 192MB)</td>
+      <td rowspan="3">Process Memory</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.jvm-overhead.max’ (default 1GB)</td>
+    </tr>
+    <tr>
+      <td>‘taskmanager.memory.jvm-overhead.fraction’ (default 0.1)</td>
+    </tr>
+  </tbody>
+</table>
+
+Imagine Flink Memory is 1000MB and Network Memory is configured to be in the range of 64MB to 1GB with a fraction of 0.08.
+In this case, Flink will attempt to allocate 80MB for Network Memory but guarantee the runtime amount is within the range of 64MB to 1GB.  
+
+The size of Managed Memory can either be configured directly (‘taskmanager.memory.managed.size’), or derived to make up the configured fraction (‘taskmanager.memory.managed.fraction’) of Flink Memory.
+If both size and fraction are explicitly specified by user, the size will be used.
+If neither of size and fraction is explicitly configured, it will be derived with the default fraction (0.4).
+
+The size of Task Heap Memory can be configured directly (‘taskmanager.memory.task.heap.size’).
+If not explicitly specified by user, it will use whatever left in Flink Memory after sizes of other memory components are decided.
+
+Users can also directly configure the size of Process Memory (‘taskmanager.memory.process.size’) or Flink Memory (‘taskmanager.memory.flink.size’).
+Flink will then automatically derive the memory component sizes.
+
+Note: All the explicitly configured sizes, default sizes (if a default absolute size exists), min/max constraints and the Managed Memory fraction (if the size is not specified) will be respected (excluding Network Memory and JVM Overhead fractions).
+Flink cannot be deployed and exceptions will be thrown on conflictions.
+
+## Memory Configuration for Local Execution
+
+In local execution environments, all TaskExecutors run in the same JVM process that the program is executed.
+Therefore, the configuration cannot affect the JVM heap size, direct memory/metaspace limits, and the overall memory reserved for the process.
+In other words, configurations on the following memory components will not take effect.
+- Framework Heap Memory
+- Framework Off-Heap Memory
+- Task Heap Memory
+- Task Off-Heap Memory
+- JVM Metaspace
+- JVM Overhead
+
+Unless explicitly configured, Flink will internally set the sizes of Network Memory and Managed Memory to 64MB and 16MB respectively, for the purpose of trying out Flink locally with less memory consumption. 
+
+# JVM Parameters
+Flink explicitly sets the following memory related JVM parameters for TaskExecutor processes, w.r.t. the configured / derived memory component sizes.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 30%">JVM Parameters</th>
+      <th class="text-left" style="width: 70%">Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>-Xmx / -Xms</td>
+      <td>Framework Heap Memory + Task Heap Memory</td>
+    </tr>
+    <tr>
+      <td>-XX:MaxDirectMemorySize</td>
+      <td>Framework Off-Heap Memory + Task Off-Heap Memory + Network Memory</td>
+    </tr>
+    <tr>
+      <td>-XX:MaxMetaspaceSize</td>
+      <td>JVM Metaspace</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/ops/memory-config/config_guide.md
+++ b/docs/ops/memory-config/config_guide.md
@@ -1,0 +1,91 @@
+---
+title: "Configuration Guidelines"
+nav-title: Configuration Guidelines
+nav-parent_id: ops_mem_config
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in complian
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document gives guidelines on how to configure memory usages of Flink [TaskExecutors]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+Please refer to [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) for basic concepts and corresponding configuration options.
+
+* toc
+{:toc}
+
+The easiest way to configure Flink TaskExecutor memory is to specify Process Memory and let Flink decide how to allocate memory to each of the components.
+This should work for most use cases.
+
+If you are less concerned with overall memory consumption, you can specify Flink Memory instead of Process Memory, to focus more on the performance-critical memory setting.
+For containerized deployments, Flink will request containers with derived Process Memory, thus, the containers will have more memory than the configured Flink Memory.
+
+*Tips: It is not recommended to configure Process Memory and Flink Memory at the same time, which may easily cause conflicts.*
+
+While setting Process / Flink Memory, users can also customize whatever detailed memory components they want to.
+E.g., one can explicitly specify Process Memory and Managed Memory sizes at the same time.
+Flink will automatically adjust the other memory components to fit in the explicit configurations, as long as there is no conflict.
+
+*Tips: If both Task Heap Memory and Managed Memory sizes are explicitly configured, it is recommended to unset Process Memory and Flink Memory to avoid potential conflicts.*
+
+*Tips: The absolute size of Network Memory and JVM Overhead can be specified by setting the min/max constraints to the same value.*
+
+For streaming jobs with MemoryStateBackend or FsStateBackend, there should not be any usage of Managed Memory.
+Therefore, it is recommended to set Managed Memory size/fraction to 0 for better memory utilization.
+
+For streaming jobs with RocksDBStateBackend, it is recommended to reserve enough Managed Memory for RockDB.
+Otherwise, the Process Memory could be exceeded.
+On containerized deployments, TaskExecutors could be killed due to exceeding memory limits.
+The RocksDB state backend includes a feature to limit total memory consumption, please look [here]({{ site.baseurl }}/ops/state/state_backends.html#state-backend-rocksdb-memory-managed) for more details.
+
+## Trouble Shootings
+
+### IllegalConfigurationException
+
+If you see an `IllegalConfigurationException` thrown from `TaskExecutorResourceUtils`, it usually indicates that there’s either an invalid configuration value (e.g., negative memory size, a fraction that is greater than 1, etc.) or conflicting configurations.
+Details on the problem and suggested solution should be found in the exception message.
+
+### OutOfMemoryError: Java heap space
+
+The exception usually indicates that JVM heap is not large enough for your workload.
+You can try to increase the JVM heap size by configuring larger Framework Heap Memory or Task Heap Memory.
+
+Note: If Task Heap Memory is not explicitly configured, but rather derived from the remaining of Flink Memory, increasing Framework Heap Memory alone may not change the JVM heap size but only result in Task Heap Memory.
+You will need to either also increase the Process Memory / Flink Memory, or explicitly configure the Task Heap Memory.
+
+### OutOfMemoryError: Direct buffer memory
+
+The exception usually indicates that JVM max direct memory limit is configured too small.
+You can try to increase the JVM max direct memory limit by increasing Framework Off-Heap Memory or Task Off-Heap Memory.
+
+Note: Despite that Network Memory also uses JVM direct memory, it is guaranteed by Flink to always allocated the configured size.
+Therefore, resizing Network Memory will not help on this exception.
+
+### OutOfMemoryError: Metaspace
+
+The exception usually indicates that JVM max metaspace limit is configured too small.
+You can try to increase the JVM max metaspace limit by increasing JVM Metaspace.
+
+### IOException: Insufficient number of network buffers
+
+The exception usually indicates that Network Memory is not configured with enough size.
+
+### Container Memory Exceeded
+
+If a TaskExecutor memory usage exceeds its container on Yarn/Mesos/Kubernetes, this usually indicates that Flink did not reserve enough native memory.
+The memory exceeding can be observed either from external monitoring systems or error messages if containers get killed due to this issue.

--- a/docs/ops/memory-config/config_guide.md
+++ b/docs/ops/memory-config/config_guide.md
@@ -25,6 +25,7 @@ under the License.
 
 This document gives guidelines on how to configure memory usages of Flink [TaskExecutors]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
 Please refer to [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) for basic concepts and corresponding configuration options.
+Guidelines on how to migrate memory configurations from a previous version (Flink 1.9 and below) could be found in [migration guidelines]({{ site.baseurl }}/ops/memory-config/migration_guide.html).
 
 * toc
 {:toc}

--- a/docs/ops/memory-config/config_guide.zh.md
+++ b/docs/ops/memory-config/config_guide.zh.md
@@ -1,0 +1,91 @@
+---
+title: "配置指南"
+nav-title: 配置指南
+nav-parent_id: ops_mem_config
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in complian
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document gives guidelines on how to configure memory usages of Flink [TaskExecutors]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
+Please refer to [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) for basic concepts and corresponding configuration options.
+
+* toc
+{:toc}
+
+The easiest way to configure Flink TaskExecutor memory is to specify Process Memory and let Flink decide how to allocate memory to each of the components.
+This should work for most use cases.
+
+If you are less concerned with overall memory consumption, you can specify Flink Memory instead of Process Memory, to focus more on the performance-critical memory setting.
+For containerized deployments, Flink will request containers with derived Process Memory, thus, the containers will have more memory than the configured Flink Memory.
+
+*Tips: It is not recommended to configure Process Memory and Flink Memory at the same time, which may easily cause conflicts.*
+
+While setting Process / Flink Memory, users can also customize whatever detailed memory components they want to.
+E.g., one can explicitly specify Process Memory and Managed Memory sizes at the same time.
+Flink will automatically adjust the other memory components to fit in the explicit configurations, as long as there is no conflict.
+
+*Tips: If both Task Heap Memory and Managed Memory sizes are explicitly configured, it is recommended to unset Process Memory and Flink Memory to avoid potential conflicts.*
+
+*Tips: The absolute size of Network Memory and JVM Overhead can be specified by setting the min/max constraints to the same value.*
+
+For streaming jobs with MemoryStateBackend or FsStateBackend, there should not be any usage of Managed Memory.
+Therefore, it is recommended to set Managed Memory size/fraction to 0 for better memory utilization.
+
+For streaming jobs with RocksDBStateBackend, it is recommended to reserve enough Managed Memory for RockDB.
+Otherwise, the Process Memory could be exceeded.
+On containerized deployments, TaskExecutors could be killed due to exceeding memory limits.
+The RocksDB state backend includes a feature to limit total memory consumption, please look [here]({{ site.baseurl }}/ops/state/state_backends.html#state-backend-rocksdb-memory-managed) for more details.
+
+## Trouble Shootings
+
+### IllegalConfigurationException
+
+If you see an `IllegalConfigurationException` thrown from `TaskExecutorResourceUtils`, it usually indicates that there’s either an invalid configuration value (e.g., negative memory size, a fraction that is greater than 1, etc.) or conflicting configurations.
+Details on the problem and suggested solution should be found in the exception message.
+
+### OutOfMemoryError: Java heap space
+
+The exception usually indicates that JVM heap is not large enough for your workload.
+You can try to increase the JVM heap size by configuring larger Framework Heap Memory or Task Heap Memory.
+
+Note: If Task Heap Memory is not explicitly configured, but rather derived from the remaining of Flink Memory, increasing Framework Heap Memory alone may not change the JVM heap size but only result in Task Heap Memory.
+You will need to either also increase the Process Memory / Flink Memory, or explicitly configure the Task Heap Memory.
+
+### OutOfMemoryError: Direct buffer memory
+
+The exception usually indicates that JVM max direct memory limit is configured too small.
+You can try to increase the JVM max direct memory limit by increasing Framework Off-Heap Memory or Task Off-Heap Memory.
+
+Note: Despite that Network Memory also uses JVM direct memory, it is guaranteed by Flink to always allocated the configured size.
+Therefore, resizing Network Memory will not help on this exception.
+
+### OutOfMemoryError: Metaspace
+
+The exception usually indicates that JVM max metaspace limit is configured too small.
+You can try to increase the JVM max metaspace limit by increasing JVM Metaspace.
+
+### IOException: Insufficient number of network buffers
+
+The exception usually indicates that Network Memory is not configured with enough size.
+
+### Container Memory Exceeded
+
+If a TaskExecutor memory usage exceeds its container on Yarn/Mesos/Kubernetes, this usually indicates that Flink did not reserve enough native memory.
+The memory exceeding can be observed either from external monitoring systems or error messages if containers get killed due to this issue.

--- a/docs/ops/memory-config/config_guide.zh.md
+++ b/docs/ops/memory-config/config_guide.zh.md
@@ -25,6 +25,7 @@ under the License.
 
 This document gives guidelines on how to configure memory usages of Flink [TaskExecutors]({{ site.baseurl }}/concepts/glossary.html#taskexecutor).
 Please refer to [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) for basic concepts and corresponding configuration options.
+Guidelines on how to migrate memory configurations from a previous version (Flink 1.9 and below) could be found in [migration guidelines]({{ site.baseurl }}/ops/memory-config/migration_guide.html).
 
 * toc
 {:toc}

--- a/docs/ops/memory-config/index.md
+++ b/docs/ops/memory-config/index.md
@@ -1,0 +1,24 @@
+---
+nav-title: 'Memory Configuration'
+nav-id: ops_mem_config
+nav-parent_id: ops
+nav-pos: 16
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/ops/memory-config/index.zh.md
+++ b/docs/ops/memory-config/index.zh.md
@@ -1,0 +1,24 @@
+---
+nav-title: '内存配置'
+nav-id: ops_mem_config
+nav-parent_id: ops
+nav-pos: 16
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/ops/memory-config/migration_guide.md
+++ b/docs/ops/memory-config/migration_guide.md
@@ -1,0 +1,130 @@
+---
+title: "Migration Guidelines"
+nav-title: Migration Guidelines
+nav-parent_id: ops_mem_config
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in complian
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document gives guidelines on how to migrate memory configurations from a previous version (Flink 1.9 and below), to the current [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) (Flink 1.10 and above).
+Please refer to [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html) for new jobs that are not migrated from previous versions.
+
+* toc
+{:toc}
+
+## Changes to be Noticed
+
+### Managed Memory
+
+Managed Memory is now always off-heap.
+The configuration option ‘taskmanager.memory.off-heap’ has been removed.
+In addition, the off-heap Managed Memory now uses native memory rather than direct memory, which means it is no longer accounted for in JVM max direct memory limits.
+
+Managed Memory is always lazily allocated now and the configuration option ‘taskmanager.memory.preallocate’ has been removed.
+
+RocksDBStatebackend now uses Managed Memory.
+
+### Container Cut Off Memory
+
+For the containerized deployments, TaskExecutors no long have cut-off memory.
+The configuration options ‘containerized.heap-cutoff-ratio’ and ‘containerized.heap-cutoff-min’ do not affect TaskExecutors now.
+
+The JobManager still does have container cut off memory and the configuration options work the same way as before.
+
+### Configuration Options
+
+The table below lists all the deprecated and removed TaskExecutor memory configuration options.
+For the deprecated options, the table also shows which new option it will be interpreted as if used.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 50%">Deprecated / Removed Option</th>
+      <th class="text-left" style="width: 50%">Interpreted as New Option</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">taskmanager.heap.size</td>
+      <td>Standalone: taskmanager.memory.flink.size</td>
+    </tr>
+    <tr>
+      <td>Containerized: taskmanager.memory.process.size</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.fraction</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.off-heap</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.preallocate</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.size</td>
+      <td>taskmanager.memory.managed.size</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.fraction</td>
+      <td>taskmanager.memory.network.fraction</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.max</td>
+      <td>taskmanager.memory.network.max</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.min</td>
+      <td>taskmanager.memory.network.min</td>
+    </tr>
+  </tbody>
+</table>
+
+Note: If ‘taskmanager.heap.size’ is configured, it will be interpreted differently on standalone and containerized deployments (Yarm/Mesos/Kubernetes).
+The configured size will be set to Flink Memory on standalone deployment, and Process Memory on containerized deployments.
+This aligns with the previous behaviors.
+
+Note: A new configuration option ‘taskmanager.memory.managed.fraction’ is introduced.
+However, it is not equivalent with the removed option ‘taskmanager.memory.fraction’, and should not directly use the value previously configured for the removed fraction.
+To be specific, the new option defines the fraction of Flink Memory that should be reserved for Managed Memory, while the old option defines the fraction of total memory (‘taskmanager.heap.size’) mius network memory (and container cut off memory on containerized deployments) for Managed Memory.
+
+### Out-of-Box Configurations
+
+In the default ‘flink-conf.yaml’, ‘taskmanager.heap.size’ is replaced by ‘taskmanager.memory.process.size’, with the value increased from 1024MB to 1568MB.
+
+As an integrated outcome of making Managed Memory always off-heap, increasing default Process Memory size, and removing container cut off memory, Flink’s out-of-box configuration now results in different overall and component individual memory sizes on TaskExecutors.
+Performance regression could be observed in some scenarios.
+
+A detailed comparison of out-of-box overall and component individual memory sizes before and after FLIP-49 can be found in the [calculation spreadsheet](https://docs.google.com/spreadsheets/d/1mJaMkMPfDJJ-w6nMXALYmTc4XxiV30P5U7DzgwLkSoE/edit?usp=sharing).
+
+## Migration Tips
+
+- Use the [calculation spreadsheet](https://docs.google.com/spreadsheets/d/1mJaMkMPfDJJ-w6nMXALYmTc4XxiV30P5U7DzgwLkSoE/edit?usp=sharing) to get the overall and individual component memory sizes from the old configuration.
+- To have the same overall memory size, one can try to set the previous configured value of ‘taskmanager.heap.size’ to Flink Memory on standalone deployment, and to Process Memory on containerized deployments.
+- To have the same JVM heap size, one can try to configure Framework Heap Memory and Task Heap Memory, so that these two added together have the size of previous JVM heap size.
+- Managed Memory
+  - For streaming jobs, they should not use managed memory in the previous model. If managed memory was configured non-zero, off-heap and not preallocated (reserving for some other off-heap memory usages), one could try to configure this memory to Framework Off-Heap Memory or Task Off-Heap Memory if MemoryStateBackend or FsStateBackend is used, or keep it for Managed Memory if RocksDBStateBackend is used. Otherwise, it is recommended to simply configure the Managed Memory size to 0.
+  - For batch jobs, it is recommended to keep the same size of Managed Memory.
+- For Network Memory, the configuration options are not changed a lot. However, one should be aware that the same configured values do not necessarily lead to the same size of Network Memory, due to the base of Network Memory fraction could be different.
+- Container cut off memory (on containerized deployments only)
+  - For streaming jobs with RocksDBStateBackend, it is recommended to configure the majority of previous container cut off memory to Managed Memory, leaving only the default JVM Metaspace and JVM Overhead.
+  - For other jobs not using RocksDBStateBackend, it is recommended to configure the majority of previous container cut off memory to JVM Overhead, leaving only the default JVM Metaspace. None of the container cut off memory should go to Managed Memory in these use cases.

--- a/docs/ops/memory-config/migration_guide.zh.md
+++ b/docs/ops/memory-config/migration_guide.zh.md
@@ -1,0 +1,130 @@
+---
+title: "迁移指南"
+nav-title: 迁移指南
+nav-parent_id: ops_mem_config
+nav-pos: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in complian
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+This document gives guidelines on how to migrate memory configurations from a previous version (Flink 1.9 and below), to the current [TaskExecutors memory model]({{ site.baseurl }}/internals/memory_model.html) (Flink 1.10 and above).
+Please refer to [configuration guidelines]({{ site.baseurl }}/ops/memory-config/config_guide.html) for new jobs that are not migrated from previous versions.
+
+* toc
+{:toc}
+
+## Changes to be Noticed
+
+### Managed Memory
+
+Managed Memory is now always off-heap.
+The configuration option ‘taskmanager.memory.off-heap’ has been removed.
+In addition, the off-heap Managed Memory now uses native memory rather than direct memory, which means it is no longer accounted for in JVM max direct memory limits.
+
+Managed Memory is always lazily allocated now and the configuration option ‘taskmanager.memory.preallocate’ has been removed.
+
+RocksDBStatebackend now uses Managed Memory.
+
+### Container Cut Off Memory
+
+For the containerized deployments, TaskExecutors no long have cut-off memory.
+The configuration options ‘containerized.heap-cutoff-ratio’ and ‘containerized.heap-cutoff-min’ do not affect TaskExecutors now.
+
+The JobManager still does have container cut off memory and the configuration options work the same way as before.
+
+### Configuration Options
+
+The table below lists all the deprecated and removed TaskExecutor memory configuration options.
+For the deprecated options, the table also shows which new option it will be interpreted as if used.
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th class="text-left" style="width: 50%">Deprecated / Removed Option</th>
+      <th class="text-left" style="width: 50%">Interpreted as New Option</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="2">taskmanager.heap.size</td>
+      <td>Standalone: taskmanager.memory.flink.size</td>
+    </tr>
+    <tr>
+      <td>Containerized: taskmanager.memory.process.size</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.fraction</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.off-heap</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.preallocate</td>
+      <td>none</td>
+    </tr>
+    <tr>
+      <td>taskmanager.memory.size</td>
+      <td>taskmanager.memory.managed.size</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.fraction</td>
+      <td>taskmanager.memory.network.fraction</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.max</td>
+      <td>taskmanager.memory.network.max</td>
+    </tr>
+    <tr>
+      <td>taskmanager.network.memory.min</td>
+      <td>taskmanager.memory.network.min</td>
+    </tr>
+  </tbody>
+</table>
+
+Note: If ‘taskmanager.heap.size’ is configured, it will be interpreted differently on standalone and containerized deployments (Yarm/Mesos/Kubernetes).
+The configured size will be set to Flink Memory on standalone deployment, and Process Memory on containerized deployments.
+This aligns with the previous behaviors.
+
+Note: A new configuration option ‘taskmanager.memory.managed.fraction’ is introduced.
+However, it is not equivalent with the removed option ‘taskmanager.memory.fraction’, and should not directly use the value previously configured for the removed fraction.
+To be specific, the new option defines the fraction of Flink Memory that should be reserved for Managed Memory, while the old option defines the fraction of total memory (‘taskmanager.heap.size’) mius network memory (and container cut off memory on containerized deployments) for Managed Memory.
+
+### Out-of-Box Configurations
+
+In the default ‘flink-conf.yaml’, ‘taskmanager.heap.size’ is replaced by ‘taskmanager.memory.process.size’, with the value increased from 1024MB to 1568MB.
+
+As an integrated outcome of making Managed Memory always off-heap, increasing default Process Memory size, and removing container cut off memory, Flink’s out-of-box configuration now results in different overall and component individual memory sizes on TaskExecutors.
+Performance regression could be observed in some scenarios.
+
+A detailed comparison of out-of-box overall and component individual memory sizes before and after FLIP-49 can be found in the [calculation spreadsheet](https://docs.google.com/spreadsheets/d/1mJaMkMPfDJJ-w6nMXALYmTc4XxiV30P5U7DzgwLkSoE/edit?usp=sharing).
+
+## Migration Tips
+
+- Use the [calculation spreadsheet](https://docs.google.com/spreadsheets/d/1mJaMkMPfDJJ-w6nMXALYmTc4XxiV30P5U7DzgwLkSoE/edit?usp=sharing) to get the overall and individual component memory sizes from the old configuration.
+- To have the same overall memory size, one can try to set the previous configured value of ‘taskmanager.heap.size’ to Flink Memory on standalone deployment, and to Process Memory on containerized deployments.
+- To have the same JVM heap size, one can try to configure Framework Heap Memory and Task Heap Memory, so that these two added together have the size of previous JVM heap size.
+- Managed Memory
+  - For streaming jobs, they should not use managed memory in the previous model. If managed memory was configured non-zero, off-heap and not preallocated (reserving for some other off-heap memory usages), one could try to configure this memory to Framework Off-Heap Memory or Task Off-Heap Memory if MemoryStateBackend or FsStateBackend is used, or keep it for Managed Memory if RocksDBStateBackend is used. Otherwise, it is recommended to simply configure the Managed Memory size to 0.
+  - For batch jobs, it is recommended to keep the same size of Managed Memory.
+- For Network Memory, the configuration options are not changed a lot. However, one should be aware that the same configured values do not necessarily lead to the same size of Network Memory, due to the base of Network Memory fraction could be different.
+- Container cut off memory (on containerized deployments only)
+  - For streaming jobs with RocksDBStateBackend, it is recommended to configure the majority of previous container cut off memory to Managed Memory, leaving only the default JVM Metaspace and JVM Overhead.
+  - For other jobs not using RocksDBStateBackend, it is recommended to configure the majority of previous container cut off memory to JVM Overhead, leaving only the default JVM Metaspace. None of the container cut off memory should go to Managed Memory in these use cases.


### PR DESCRIPTION
## What is the purpose of the change

This PR adds documents for FLIP-49.

## Brief change log

- Add "Internals -> Task Executor Memory Model"
- Add "Deployment & Operations -> Memory Configuration -> Configuration Guidelines"
- Add "Deployment & Operations -> Memory Configuration -> Migration Guidelines"
