### PR TITLE
[FLINK-15785][travis][e2e] Rework E2E test activations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -279,7 +279,7 @@ jobs:
     # E2E profiles - Hadoop 2.8
     - if: type = cron
       stage: test
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -De2e-metrics -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - hadoop 2.8
     - if: type = cron
@@ -308,7 +308,7 @@ jobs:
       name: e2e - tpcds - hadoop 2.8
       # E2E profiles - Scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -De2e-metrics -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - scala 2.12
     - if: type = cron
@@ -337,7 +337,7 @@ jobs:
       name: e2e - tpcds - scala 2.12
       # E2E profiles - Hadoop-free
     - if: type = cron
-      env: PROFILE="-De2e-metrics -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
       script: ./tools/travis/nightly.sh split_misc_hadoopfree.sh
       name: e2e - misc
     - if: type = cron
@@ -368,7 +368,7 @@ jobs:
     - if: type = cron
       stage: test
       jdk: "openjdk11"
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -De2e-metrics -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - jdk11
     - if: type = cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ jobs:
       name: tests - legacy_scheduler
     - if: type in (pull_request, push)
       script: ./tools/travis_controller.sh misc
-      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Pe2e-pre-commit"
       name: misc
     - if: type in (pull_request, push)
       stage: cleanup
@@ -168,7 +168,7 @@ jobs:
       name: tests - hadoop 2.4.1
     - if: type = cron
       script: ./tools/travis_controller.sh misc
-      env: PROFILE="-Dhadoop.version=2.4.1 -Pskip-hive-tests"
+      env: PROFILE="-Dhadoop.version=2.4.1 -Pskip-hive-tests -Pe2e-pre-commit"
       name: misc - hadoop 2.4.1
     - if: type = cron
       stage: cleanup
@@ -208,7 +208,7 @@ jobs:
       name: tests - scala 2.12
     - if: type = cron
       script: ./tools/travis_controller.sh misc
-      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1 -Pe2e-pre-commit"
       name: misc - scala 2.12
     - if: type = cron
       stage: cleanup
@@ -261,7 +261,7 @@ jobs:
     - if: type = cron
       jdk: "openjdk11"
       script: ./tools/travis_controller.sh misc
-      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11"
+      env: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11 -Pe2e-pre-commit"
       name: misc
     - if: type = cron
       jdk: "openjdk11"
@@ -279,115 +279,115 @@ jobs:
     # E2E profiles - Hadoop 2.8
     - if: type = cron
       stage: test
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis1,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup2"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis2,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_ha.sh
       name: e2e - ha - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup3"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis3,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_sticky.sh
       name: e2e - sticky - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup4"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis4,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_checkpoints.sh
       name: e2e - checkpoints - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup5"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis5,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_container.sh
       name: e2e - container - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis6,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_heavy.sh
       name: e2e - heavy - hadoop 2.8
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis6,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_tpcds.sh
       name: e2e - tpcds - hadoop 2.8
       # E2E profiles - Scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis1,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup2"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis2,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_ha.sh
       name: e2e - ha - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup3"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis3,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_sticky.sh
       name: e2e - sticky - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup4"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis4,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_checkpoints.sh
       name: e2e - checkpoints - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup5"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis5,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_container.sh
       name: e2e - container - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis6,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_heavy.sh
       name: e2e - heavy - scala 2.12
     - if: type = cron
-      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dscala-2.12 -Pe2e-travis6,e2e-hadoop""
       script: ./tools/travis/nightly.sh split_tpcds.sh
       name: e2e - tpcds - scala 2.12
       # E2E profiles - Hadoop-free
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Pe2e-travis1"
       script: ./tools/travis/nightly.sh split_misc_hadoopfree.sh
       name: e2e - misc
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup2"
+      env: PROFILE="-Pe2e-travis2"
       script: ./tools/travis/nightly.sh split_ha.sh
       name: e2e - ha
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup3"
+      env: PROFILE="-Pe2e-travis3"
       script: ./tools/travis/nightly.sh split_sticky.sh
       name: e2e - sticky
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup4"
+      env: PROFILE="-Pe2e-travis4"
       script: ./tools/travis/nightly.sh split_checkpoints.sh
       name: e2e - checkpoints
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup5"
+      env: PROFILE="-Pe2e-travis5"
       script: ./tools/travis/nightly.sh split_container.sh without-hadoop
       name: e2e - container
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Pe2e-travis6"
       script: ./tools/travis/nightly.sh split_heavy.sh
       name: e2e - heavy
     - if: type = cron
-      env: PROFILE="-DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Pe2e-travis6"
       script: ./tools/travis/nightly.sh split_tpcds.sh
       name: e2e - tpcds
     # E2E profiles - Java 11
     - if: type = cron
       stage: test
       jdk: "openjdk11"
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup1"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis1,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_misc.sh
       name: e2e - misc - jdk11
     - if: type = cron
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup2"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis2,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_ha.sh
       name: e2e - ha - jdk11
     - if: type = cron
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup3"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis3,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_sticky.sh
       name: e2e - sticky - jdk 11
     - if: type = cron
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup4"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis4,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_checkpoints.sh
       name: e2e - checkpoints - jdk 11
     - if: type = cron
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis6,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_heavy.sh
       name: e2e - heavy - jdk 11
     - if: type = cron
-      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -DincludeE2E=org.apache.flink.tests.util.categories.TravisGroup6"
+      env: PROFILE="-Djdk11 -Dinclude-hadoop -Dhadoop.version=2.8.3 -Pe2e-travis6,e2e-hadoop"
       script: ./tools/travis/nightly.sh split_tpcds.sh
       name: e2e - tpcds - jdk 11

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.tests.util.kafka;
 
 import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.tests.util.categories.Hadoop;
 import org.apache.flink.tests.util.categories.TravisGroup1;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
@@ -58,7 +59,7 @@ import java.util.Map;
  * End-to-end test for the kafka SQL connectors.
  */
 @RunWith(Parameterized.class)
-@Category(value = {TravisGroup1.class, FailsOnJava11.class})
+@Category(value = {TravisGroup1.class, FailsOnJava11.class, Hadoop.class})
 public class SQLClientKafkaITCase extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SQLClientKafkaITCase.class);

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -35,8 +35,20 @@ under the License.
 	<name>flink-end-to-end-tests</name>
 
 	<properties>
-		<includeE2E>org.apache.flink.tests.util.categories.Dummy</includeE2E>
-		<excludeE2E></excludeE2E>
+		<includeE2E/> <!-- keep this empty -->
+		<excludeE2E/> <!-- keep this empty -->
+		<!-- functions as a global exclude; required since an empty set of included groups implicitly includes all -->
+		<includeE2E.default>org.apache.flink.tests.util.categories.Dummy</includeE2E.default>
+		<!-- default inclusions / exclusions -->
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup1>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup1>
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup2>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup2>
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup3>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup3>
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup4>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup4>
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup5>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup5>
+		<e2e.include.org.apache.flink.tests.util.categories.TravisGroup6>false</e2e.include.org.apache.flink.tests.util.categories.TravisGroup6>
+		<e2e.include.org.apache.flink.tests.util.categories.PreCommit>false</e2e.include.org.apache.flink.tests.util.categories.PreCommit>
+		<e2e.exclude.org.apache.flink.tests.util.categories.Hadoop>true</e2e.exclude.org.apache.flink.tests.util.categories.Hadoop>
+		<e2e.exclude.org.apache.flink.testutils.junit.FailsOnJava11>true</e2e.exclude.org.apache.flink.testutils.junit.FailsOnJava11>
 	</properties>
 
 	<modules>
@@ -81,6 +93,67 @@ under the License.
 		<module>flink-tpcds-test</module>
 	</modules>
 
+	<profiles>
+		<profile>
+			<id>e2e-travis1</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup1>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup1>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-travis2</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup2>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup2>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-travis3</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup3>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup3>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-travis4</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup4>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup4>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-travis5</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup5>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup5>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-travis6</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.TravisGroup6>true</e2e.include.org.apache.flink.tests.util.categories.TravisGroup6>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-pre-commit</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.PreCommit>true</e2e.include.org.apache.flink.tests.util.categories.PreCommit>
+			</properties>
+		</profile>
+		<profile>
+			<id>e2e-hadoop</id>
+			<properties>
+				<e2e.include.org.apache.flink.tests.util.categories.Hadoop>true</e2e.include.org.apache.flink.tests.util.categories.Hadoop>
+				<e2e.exclude.org.apache.flink.tests.util.categories.Hadoop>false</e2e.exclude.org.apache.flink.tests.util.categories.Hadoop>
+			</properties>
+		</profile>
+		<profile>
+			<id>java11</id>
+			<activation>
+				<jdk>11</jdk>
+			</activation>
+			<properties>
+				<e2e.exclude.org.apache.flink.testutils.junit.FailsOnJava11>false</e2e.exclude.org.apache.flink.testutils.junit.FailsOnJava11>
+			</properties>
+		</profile>
+	</profiles>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -89,6 +162,66 @@ under the License.
 				<configuration>
 					<skip>true</skip>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.gmavenplus</groupId>
+				<artifactId>gmavenplus-plugin</artifactId>
+				<version>1.8.1</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.groovy</groupId>
+						<artifactId>groovy-all</artifactId>
+						<version>2.5.9</version>
+						<scope>runtime</scope>
+						<type>pom</type>
+					</dependency>
+				</dependencies>
+				<executions>
+					<execution>
+						<id>merge-categories</id>
+						<phase>initialize</phase>
+						<goals>
+							<goal>execute</goal>
+						</goals>
+						<configuration>
+							<scripts>
+								<script>
+									<![CDATA[
+									def categorySearcher = { String propertyPrefix ->
+										project.properties.entrySet().stream()
+											.filter { p -> p.getKey().startsWith(propertyPrefix) }
+											.filter { p -> p.getValue().toBoolean() }
+											.map { p -> p.getKey() }
+											.map { p -> p.substring(propertyPrefix.size(), p.size()) }
+											.toList()
+									}
+
+									def includes = categorySearcher('e2e.include.')
+									// allow overrides from the command-line
+									if (!project.properties.includeE2E.isEmpty()) {
+										includes.add(project.properties.includeE2E)
+									}
+									if (includes.size() > 0) {
+										project.properties.includeE2E = includes.join(',')
+									} else {
+										project.properties.includeE2E = project.properties.'includeE2E.default'
+									}
+
+									def excludes = categorySearcher('e2e.exclude.')
+									// allow overrides from the command-line
+									if (!project.properties.excludeE2E.isEmpty()) {
+										excludes.add(project.properties.excludeE2E)
+									}
+									project.properties.excludeE2E = excludes.join(',')
+
+									println "includes: " + project.properties.includeE2E
+									println "excludes: " + project.properties.excludeE2E
+									]]>
+								</script>
+							</scripts>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -69,7 +69,7 @@ e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml
 
 MVN_COMPILE="mvn $MVN_COMMON_OPTIONS $MVN_COMPILE_OPTIONS $PROFILE $MVN_COMPILE_MODULES install"
 MVN_TEST="mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE $MVN_TEST_MODULES verify"
-MVN_E2E="mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE -DincludeE2E="org.apache.flink.tests.util.categories.PreCommit" -pl ${e2e_modules},flink-dist verify"
+MVN_E2E="mvn $MVN_COMMON_OPTIONS $MVN_TEST_OPTIONS $PROFILE -pl ${e2e_modules},flink-dist verify"
 
 MVN_PID="${ARTIFACTS_DIR}/watchdog.mvn.pid"
 MVN_EXIT="${ARTIFACTS_DIR}/watchdog.mvn.exit"


### PR DESCRIPTION
This PR reworks the activation logic for java end-to-end tests.

Introduces a new framework for specifying category inclusions/exclusions in `flink-end-to-end-tests`, that is capable of automatically aggregating properties across profiles.
Inclusions are defined by setting the `e2e.include.<category-class>`, conversely exclusions by setting `e2e.exclude.<category-class>`. The value of the property is a boolean that controls whether the inclusion/exclusions is enabled or not.
A groovy script searches for all properties matching the naming scheme, extracts the category class, aggregates inclusions/exclusions and sets the appropriate properties.

The script also prints the final inclusions/exclusions; I'd recommend trying it out and specifying different profile sets to see how it behaves.

**Background**: Maven does not really support combining categories. The surefire-plugin only accepts values like `catA,catB`, instead of a list where individual items have their own XML element. This implies that in order to combine category definitions one would have to concatenate the current value with some other value, i.e., do `categories = categories + "hello"`. Maven doesn't support this however since it is a recursive definition of a property.

The following is a listing of every problem and how it was addressed:

1) **travis activations are spread out over multiple files (.travis.yml, travis_watchdoh.sh)**
They are now consolidated in .travis.yml. While this does introduce some redundancy it is still preferable because .travis.yml is the most visible travis file, and it is easier to mvoe the pre-commit activation around.
2) **setting multiple categories in .travis.yml is incredibly verbose**
Each category now has their dedicated profile in `flink-end-to-end-tests` that set the appropriate category. This is significantly more concise and provides an abstraction of the specific categories used. (In other words, we can modify things at will without breaking setups)
3) **hadoop tests are not excluded by default**
Now disabled by default.
4) **hadoop exclusions aren't setup (causing FLINK-15685)** 
Are now setup.
5) **automatic java11 exclusion is prone to not working as intended**
There is now a dedicated java11 profile in `flink-end-to-end-tests` to ensure the java11 exclusions is always applied.

