### PR TITLE
[FLINK-15646][K8s]Configurable K8s context support.

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.context</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The desired context from your K8s config file used to configure the K8s client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different K8s clusters/contexts.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -12,7 +12,7 @@
             <td><h5>kubernetes.context</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The desired context from your K8s config file used to configure the K8s client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different K8s clusters/contexts.</td>
+            <td>The desired context from your Kubernetes config file used to configure the Kubernetes client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different Kubernetes clusters/contexts.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.cluster-id</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -29,6 +29,14 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 public class KubernetesConfigOptions {
 
+	public static final ConfigOption<String> CONTEXT =
+		key("kubernetes.context")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("The desired context from your K8s config file used to configure the K8s client for " +
+			"interacting with the cluster. This could be helpful if one has multiple contexts configured and " +
+			"wants to administrate different Flink clusters on different K8s clusters/contexts.");
+
 	public static final ConfigOption<String> REST_SERVICE_EXPOSED_TYPE =
 		key("kubernetes.rest-service.exposed.type")
 		.stringType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -33,9 +33,9 @@ public class KubernetesConfigOptions {
 		key("kubernetes.context")
 		.stringType()
 		.noDefaultValue()
-		.withDescription("The desired context from your K8s config file used to configure the K8s client for " +
-			"interacting with the cluster. This could be helpful if one has multiple contexts configured and " +
-			"wants to administrate different Flink clusters on different K8s clusters/contexts.");
+		.withDescription("The desired context from your Kubernetes config file used to configure the Kubernetes client " +
+			"for interacting with the cluster. This could be helpful if one has multiple contexts configured and " +
+			"wants to administrate different Flink clusters on different Kubernetes clusters/contexts.");
 
 	public static final ConfigOption<String> REST_SERVICE_EXPOSED_TYPE =
 		key("kubernetes.rest-service.exposed.type")

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
@@ -42,18 +42,23 @@ public class KubeClientFactory {
 
 		final Config config;
 
+		final String kubeContext = flinkConfig.getString(KubernetesConfigOptions.CONTEXT);
+		if (kubeContext != null) {
+			LOG.info("Configuring K8S client using context {}.", kubeContext);
+		}
+
 		final String kubeConfigFile = flinkConfig.getString(KubernetesConfigOptions.KUBE_CONFIG_FILE);
 		if (kubeConfigFile != null) {
 			LOG.debug("Trying to load kubernetes config from file: {}.", kubeConfigFile);
 			try {
-				config = Config.fromKubeconfig(KubernetesUtils.getContentFromFile(kubeConfigFile));
+				config = Config.fromKubeconfig(kubeContext, KubernetesUtils.getContentFromFile(kubeConfigFile), null);
 			} catch (IOException e) {
 				throw new KubernetesClientException("Load kubernetes config failed.", e);
 			}
 		} else {
 			LOG.debug("Trying to load default kubernetes config.");
 			// Null means load from default context
-			config = Config.autoConfigure(null);
+			config = Config.autoConfigure(kubeContext);
 		}
 
 		final KubernetesClient client = new DefaultKubernetesClient(config);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
@@ -44,19 +44,23 @@ public class KubeClientFactory {
 
 		final String kubeContext = flinkConfig.getString(KubernetesConfigOptions.CONTEXT);
 		if (kubeContext != null) {
-			LOG.info("Configuring K8S client using context {}.", kubeContext);
+			LOG.info("Configuring Kubernetes client using context {}.", kubeContext);
 		}
 
 		final String kubeConfigFile = flinkConfig.getString(KubernetesConfigOptions.KUBE_CONFIG_FILE);
 		if (kubeConfigFile != null) {
-			LOG.debug("Trying to load kubernetes config from file: {}.", kubeConfigFile);
+			LOG.debug("Trying to load Kubernetes config from file: {}.", kubeConfigFile);
 			try {
+				// If kubeContext is null, the default context in the kubeConfigFile will be used.
+				// Note: the third parameter kubeconfigPath is optional and is set to null. It is only used to rewrite
+				// relative tls asset paths inside kubeconfig when a file is passed, and in the case that the kubeconfig
+				// references some assets via relative paths.
 				config = Config.fromKubeconfig(kubeContext, KubernetesUtils.getContentFromFile(kubeConfigFile), null);
 			} catch (IOException e) {
-				throw new KubernetesClientException("Load kubernetes config failed.", e);
+				throw new KubernetesClientException("Load Kubernetes config failed.", e);
 			}
 		} else {
-			LOG.debug("Trying to load default kubernetes config.");
+			LOG.debug("Trying to load default Kubernetes config.");
 			// Null means load from default context
 			config = Config.autoConfigure(kubeContext);
 		}


### PR DESCRIPTION
## What is the purpose of the change

One would be forced to firstly use kubectl config use-context <context> to switch to the desired context if working with multiple K8S clusters or having multiple K8S "users" for interacting with the specified cluster,  so it is an important improvement to add an option(kubernetes.context) for configuring arbitrary contexts when deploying a Flink cluster. If that option is not specified, then the current context in the config file would be used.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
