### PR TITLE
[FLINK-15487][table] Update code generation for new type inference

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -305,7 +305,7 @@ public final class DataTypeExtractor {
 			DataTypeTemplate template,
 			List<Type> typeHierarchy,
 			Type type) {
-		// byte arrays have higher priority than regular arrays
+		// prefer BYTES over ARRAY<TINYINT> for byte[]
 		if (type == byte[].class) {
 			return DataTypes.BYTES();
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -305,8 +305,12 @@ public final class DataTypeExtractor {
 			DataTypeTemplate template,
 			List<Type> typeHierarchy,
 			Type type) {
+		// byte arrays have higher priority than regular arrays
+		if (type == byte[].class) {
+			return DataTypes.BYTES();
+		}
 		// for T[]
-		if (type instanceof GenericArrayType) {
+		else if (type instanceof GenericArrayType) {
 			final GenericArrayType genericArray = (GenericArrayType) type;
 			return DataTypes.ARRAY(
 				extractDataTypeOrRaw(template, typeHierarchy, genericArray.getGenericComponentType()));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
@@ -465,6 +465,33 @@ public final class ExtractionUtils {
 		return currentClass == classCount;
 	}
 
+	/**
+	 * Creates a method signature string like {@code int eval(Integer, String)}.
+	 */
+	public static String createMethodSignatureString(
+			String methodName,
+			Class<?>[] parameters,
+			@Nullable Class<?> returnType) {
+		final StringBuilder builder = new StringBuilder();
+		if (returnType != null) {
+			builder.append(returnType.getName()).append(" ");
+		}
+		builder
+			.append(methodName)
+			.append(
+				Stream.of(parameters)
+					.map(parameter -> {
+						// in case we don't know the parameter at this location (i.e. for accumulators)
+						if (parameter == null) {
+							return "_";
+						} else {
+							return parameter.getName();
+						}
+					})
+					.collect(Collectors.joining(", ", "(", ")")));
+		return builder.toString();
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Parameter Extraction Utilities
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/ExtractionUtils.java
@@ -474,7 +474,7 @@ public final class ExtractionUtils {
 			@Nullable Class<?> returnType) {
 		final StringBuilder builder = new StringBuilder();
 		if (returnType != null) {
-			builder.append(returnType.getName()).append(" ");
+			builder.append(returnType.getCanonicalName()).append(" ");
 		}
 		builder
 			.append(methodName)
@@ -485,7 +485,7 @@ public final class ExtractionUtils {
 						if (parameter == null) {
 							return "_";
 						} else {
-							return parameter.getName();
+							return parameter.getCanonicalName();
 						}
 					})
 					.collect(Collectors.joining(", ", "(", ")")));

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInference.java
@@ -24,6 +24,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -135,6 +136,13 @@ public final class TypeInference {
 		}
 
 		/**
+		 * @see #namedArguments(List)
+		 */
+		public Builder namedArguments(String... argumentNames) {
+			return namedArguments(Arrays.asList(argumentNames));
+		}
+
+		/**
 		 * Sets the list of argument types for specifying a fixed, not overloaded, not vararg input
 		 * signature explicitly.
 		 *
@@ -145,6 +153,13 @@ public final class TypeInference {
 			this.typedArguments =
 				Preconditions.checkNotNull(argumentTypes, "List of argument types must not be null.");
 			return this;
+		}
+
+		/**
+		 * @see #typedArguments(List)
+		 */
+		public Builder typedArguments(DataType... argumentTypes) {
+			return typedArguments(Arrays.asList(argumentTypes));
 		}
 
 		/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeStrategies.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.strategies.ExplicitTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.MappingTypeStrategy;
 import org.apache.flink.table.types.inference.strategies.MissingTypeStrategy;
+import org.apache.flink.table.types.inference.strategies.UseArgumentTypeStrategy;
 
 import java.util.Map;
 
@@ -44,6 +45,13 @@ public final class TypeStrategies {
 	 */
 	public static TypeStrategy explicit(DataType dataType) {
 		return new ExplicitTypeStrategy(dataType);
+	}
+
+	/**
+	 * Type strategy that returns the n-th input argument.
+	 */
+	public static TypeStrategy argument(int pos) {
+		return new UseArgumentTypeStrategy(pos);
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/UseArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/UseArgumentTypeStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.inference.strategies;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategy;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Type strategy that returns the n-th input argument.
+ */
+@Internal
+public final class UseArgumentTypeStrategy implements TypeStrategy {
+
+	private final int pos;
+
+	public UseArgumentTypeStrategy(int pos) {
+		Preconditions.checkArgument(pos >= 0);
+		this.pos = pos;
+	}
+
+	@Override
+	public Optional<DataType> inferType(CallContext callContext) {
+		final List<DataType> argumentDataTypes = callContext.getArgumentDataTypes();
+		if (pos >= argumentDataTypes.size()) {
+			return Optional.empty();
+		}
+		return Optional.of(argumentDataTypes.get(pos));
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -19,10 +19,12 @@
 package org.apache.flink.table.types.utils;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.expressions.TableSymbol;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.extraction.DataTypeExtractor;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.types.Row;
 
@@ -34,6 +36,9 @@ import java.util.Optional;
 /**
  * Class-based data type extractor that supports extraction of clearly identifiable data types for
  * input and output conversion.
+ *
+ * <p>Note: In most of the cases, {@link DataTypeExtractor} is more useful as it also considers structured
+ * types and type variables possibly annotated with {@link DataTypeHint}.
  */
 @Internal
 public final class ClassDataTypeConverter {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/ClassDataTypeConverter.java
@@ -92,8 +92,8 @@ public final class ClassDataTypeConverter {
 	 */
 	@SuppressWarnings("unchecked")
 	public static Optional<DataType> extractDataType(Class<?> clazz) {
-		// byte arrays have higher priority than regular arrays
-		if (clazz.equals(byte[].class)) {
+		// prefer BYTES over ARRAY<TINYINT> for byte[]
+		if (clazz == byte[].class) {
 			return Optional.of(DataTypes.BYTES());
 		}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -77,10 +77,15 @@ public class DataTypeExtractorTest {
 	@Parameters
 	public static List<TestSpec> testData() {
 		return Arrays.asList(
-			// simple extraction
+			// simple extraction of INT
 			TestSpec
 				.forType(Integer.class)
 				.expectDataType(DataTypes.INT()),
+
+			// simple extraction of BYTES
+			TestSpec
+				.forType(byte[].class)
+				.expectDataType(DataTypes.BYTES()),
 
 			// extraction from hint conversion class
 			TestSpec

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -312,7 +312,17 @@ public class TypeInferenceExtractorTest {
 			// named arguments with overloaded function
 			TestSpec
 				.forScalarFunction(NamedArgumentsScalarFunction.class)
-				.expectNamedArguments("n")
+				.expectNamedArguments("n"),
+
+			// scalar function that takes an input
+			TestSpec
+				.forScalarFunction(InputGroupScalarFunction.class)
+				.expectNamedArguments("o")
+				.expectOutputMapping(
+					InputTypeStrategies.sequence(
+						new String[]{"o"},
+						new ArgumentTypeStrategy[]{InputTypeStrategies.ANY}),
+					TypeStrategies.explicit(DataTypes.STRING()))
 		);
 	}
 
@@ -705,6 +715,12 @@ public class TypeInferenceExtractorTest {
 
 		public Integer eval(@DataTypeHint("DECIMAL(10, 2)") Object n) {
 			return null;
+		}
+	}
+
+	private static class InputGroupScalarFunction extends ScalarFunction {
+		public String eval(@DataTypeHint(inputGroup = InputGroup.ANY) Object o) {
+			return o.toString();
 		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.table.types.inference.TypeStrategies.MISSING;
+import static org.apache.flink.table.types.inference.TypeStrategies.argument;
 import static org.apache.flink.table.types.inference.TypeStrategies.explicit;
 import static org.apache.flink.util.CoreMatchers.containsCause;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -67,6 +68,18 @@ public class TypeStrategiesTest {
 				.forStrategy(explicit(DataTypes.BIGINT()))
 				.inputTypes()
 				.expectDataType(DataTypes.BIGINT()),
+
+			// infer from input
+			TestSpec
+				.forStrategy(argument(0))
+				.inputTypes(DataTypes.INT(), DataTypes.STRING())
+				.expectDataType(DataTypes.INT()),
+
+			// infer from not existing input
+			TestSpec
+				.forStrategy(argument(0))
+				.inputTypes()
+				.expectErrorMessage("Could not infer an output type for the given arguments."),
 
 			// (INT, BOOLEAN) -> STRING
 			TestSpec

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/CallBindingCallContext.java
@@ -93,6 +93,9 @@ public final class CallBindingCallContext extends AbstractSqlCallContext {
 
 	@Override
 	public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
+		if (isArgumentNull(pos)) {
+			return Optional.empty();
+		}
 		try {
 			final SqlLiteral literal = SqlLiteral.unchain(adaptedArguments.get(pos));
 			return Optional.ofNullable(getLiteralValueAs(literal::getValueAs, clazz));

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/OperatorBindingCallContext.java
@@ -79,6 +79,9 @@ public final class OperatorBindingCallContext extends AbstractSqlCallContext {
 
 	@Override
 	public <T> Optional<T> getArgumentValue(int pos, Class<T> clazz) {
+		if (isArgumentNull(pos)) {
+			return Optional.empty();
+		}
 		try {
 			return Optional.ofNullable(
 				getLiteralValueAs(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -27,7 +27,7 @@ import org.apache.flink.table.planner.codegen.CodeGenUtils.{requireTemporal, req
 import org.apache.flink.table.planner.codegen.GenerateUtils._
 import org.apache.flink.table.planner.codegen.GeneratedExpression.{NEVER_NULL, NO_CODE}
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens._
-import org.apache.flink.table.planner.codegen.calls.{FunctionGenerator, ScalarFunctionCallGen, StringCallGen, TableFunctionCallGen}
+import org.apache.flink.table.planner.codegen.calls.{BridgingSqlFunctionCallGen, FunctionGenerator, ScalarFunctionCallGen, StringCallGen, TableFunctionCallGen}
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable._
 import org.apache.flink.table.planner.functions.sql.SqlThrowExceptionFunction
 import org.apache.flink.table.planner.functions.utils.{ScalarSqlFunction, TableSqlFunction}
@@ -41,6 +41,8 @@ import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.`type`.{ReturnTypes, SqlTypeName}
 import org.apache.calcite.util.TimestampString
+import org.apache.flink.table.functions.{ScalarFunction, UserDefinedFunction}
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction
 
 import scala.collection.JavaConversions._
 
@@ -482,7 +484,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
       case (o@_, _) => o.accept(this)
     }
 
-    generateCallExpression(ctx, call.getOperator, operands, resultType)
+    generateCallExpression(ctx, call, operands, resultType)
   }
 
   override def visitOver(over: RexOver): GeneratedExpression =
@@ -498,10 +500,10 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
 
   private def generateCallExpression(
       ctx: CodeGeneratorContext,
-      operator: SqlOperator,
+      call: RexCall,
       operands: Seq[GeneratedExpression],
       resultType: LogicalType): GeneratedExpression = {
-    operator match {
+    call.getOperator match {
       // arithmetic
       case PLUS if isNumeric(resultType) =>
         val left = operands.head
@@ -780,21 +782,25 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
           tsf.makeFunction(getOperandLiterals(operands), operands.map(_.resultType).toArray))
             .generate(ctx, operands, resultType)
 
+      case bf: BridgingSqlFunction if bf.getDefinition.isInstanceOf[ScalarFunction] =>
+        new BridgingSqlFunctionCallGen(call).generate(ctx, operands, resultType)
+
       // advanced scalar functions
       case sqlOperator: SqlOperator =>
-        StringCallGen.generateCallExpression(ctx, operator, operands, resultType).getOrElse {
-          FunctionGenerator
-            .getCallGenerator(
-              sqlOperator,
-              operands.map(expr => expr.resultType),
-              resultType)
-            .getOrElse(
-              throw new CodeGenException(s"Unsupported call: " +
-              s"$sqlOperator(${operands.map(_.resultType).mkString(", ")}) \n" +
-              s"If you think this function should be supported, " +
-              s"you can create an issue and start a discussion for it."))
-            .generate(ctx, operands, resultType)
-        }
+        StringCallGen.generateCallExpression(ctx, call.getOperator, operands, resultType)
+          .getOrElse {
+            FunctionGenerator
+              .getCallGenerator(
+                sqlOperator,
+                operands.map(expr => expr.resultType),
+                resultType)
+              .getOrElse(
+                throw new CodeGenException(s"Unsupported call: " +
+                s"$sqlOperator(${operands.map(_.resultType).mkString(", ")}) \n" +
+                s"If you think this function should be supported, " +
+                s"you can create an issue and start a discussion for it."))
+              .generate(ctx, operands, resultType)
+          }
 
       // unknown or invalid
       case call@_ =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -570,20 +570,20 @@ object GenerateUtils {
     * Wrapper types can autoboxed to their corresponding primitive type (Integer -> int).
     *
     * @param ctx code generator context which maintains various code statements.
-    * @param fieldType type of field
-    * @param fieldTerm expression term of field to be unboxed
-    * @param unboxingTerm unboxing/conversion term
+    * @param inputType type of field
+    * @param inputTerm expression term of field to be unboxed
+    * @param inputUnboxingTerm unboxing/conversion term
     * @return internal unboxed field representation
     */
   def generateInputFieldUnboxing(
       ctx: CodeGeneratorContext,
-      fieldType: LogicalType,
-      fieldTerm: String,
-      unboxingTerm: String)
+      inputType: LogicalType,
+      inputTerm: String,
+      inputUnboxingTerm: String)
     : GeneratedExpression = {
 
-    val resultTypeTerm = primitiveTypeTermForType(fieldType)
-    val defaultValue = primitiveDefaultValue(fieldType)
+    val resultTypeTerm = primitiveTypeTermForType(inputType)
+    val defaultValue = primitiveDefaultValue(inputType)
 
     val Seq(resultTerm, nullTerm) = ctx.addReusableLocalVariables(
       (resultTypeTerm, "result"),
@@ -591,19 +591,19 @@ object GenerateUtils {
 
     val wrappedCode = if (ctx.nullCheck) {
       s"""
-         |$nullTerm = $fieldTerm == null;
+         |$nullTerm = $inputTerm == null;
          |$resultTerm = $defaultValue;
          |if (!$nullTerm) {
-         |  $resultTerm = $unboxingTerm;
+         |  $resultTerm = $inputUnboxingTerm;
          |}
          |""".stripMargin.trim
     } else {
       s"""
-         |$resultTerm = $unboxingTerm;
+         |$resultTerm = $inputUnboxingTerm;
          |""".stripMargin.trim
     }
 
-    GeneratedExpression(resultTerm, nullTerm, wrappedCode, fieldType)
+    GeneratedExpression(resultTerm, nullTerm, wrappedCode, inputType)
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -572,12 +572,15 @@ object GenerateUtils {
     * @param ctx code generator context which maintains various code statements.
     * @param fieldType type of field
     * @param fieldTerm expression term of field to be unboxed
+    * @param unboxingTerm unboxing/conversion term
     * @return internal unboxed field representation
     */
   def generateInputFieldUnboxing(
       ctx: CodeGeneratorContext,
       fieldType: LogicalType,
-      fieldTerm: String): GeneratedExpression = {
+      fieldTerm: String,
+      unboxingTerm: String)
+    : GeneratedExpression = {
 
     val resultTypeTerm = primitiveTypeTermForType(fieldType)
     val defaultValue = primitiveDefaultValue(fieldType)
@@ -591,12 +594,12 @@ object GenerateUtils {
          |$nullTerm = $fieldTerm == null;
          |$resultTerm = $defaultValue;
          |if (!$nullTerm) {
-         |  $resultTerm = $fieldTerm;
+         |  $resultTerm = $unboxingTerm;
          |}
          |""".stripMargin.trim
     } else {
       s"""
-         |$resultTerm = $fieldTerm;
+         |$resultTerm = $unboxingTerm;
          |""".stripMargin.trim
     }
 
@@ -659,7 +662,7 @@ object GenerateUtils {
       case _ =>
         val fieldTypeTerm = boxedTypeTermForType(inputType)
         val inputCode = s"($fieldTypeTerm) $inputTerm"
-        generateInputFieldUnboxing(ctx, inputType, inputCode)
+        generateInputFieldUnboxing(ctx, inputType, inputCode, inputCode)
     }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -191,7 +191,7 @@ object LookupJoinCodeGenerator {
       .map { e =>
         val dataType = fromLogicalTypeToDataType(e.resultType)
         val bType = if (isExternalArgs) {
-          boxedTypeTermForExternalType(dataType)
+          typeTerm(dataType.getConversionClass)
         } else {
           boxedTypeTermForType(e.resultType)
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
@@ -103,7 +103,7 @@ class ImperativeAggCodeGen(
   } else {
     boxedTypeTermForType(fromDataTypeToLogicalType(externalAccType))
   }
-  val accTypeExternalTerm: String = boxedTypeTermForExternalType(externalAccType)
+  val accTypeExternalTerm: String = typeTerm(externalAccType.getConversionClass)
 
   val argTypes: Array[LogicalType] = {
     val types = inputTypes ++ constantExprs.map(_.resultType)
@@ -250,7 +250,7 @@ class ImperativeAggCodeGen(
 
   def getValue(generator: ExprCodeGenerator): GeneratedExpression = {
     val valueExternalTerm = newName("value_external")
-    val valueExternalTypeTerm = boxedTypeTermForExternalType(externalResultType)
+    val valueExternalTypeTerm = typeTerm(externalResultType.getConversionClass)
     val valueInternalTerm = newName("value_internal")
     val valueInternalTypeTerm = boxedTypeTermForType(internalResultType)
     val nullTerm = newName("valueIsNull")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/ImperativeAggCodeGen.scala
@@ -277,8 +277,7 @@ class ImperativeAggCodeGen(
       if (f >= inputTypes.length) {
         // index to constant
         val expr = constantExprs(f - inputTypes.length)
-        s"${expr.nullTerm} ? null : ${
-          genToExternal(ctx, externalInputTypes(index), expr.resultTerm)}"
+        genToExternalIfNeeded(ctx, externalInputTypes(index), expr)
       } else {
         // index to input field
         val inputRef = if (generator.input1Term.startsWith(DISTINCT_KEY_TERM)) {
@@ -297,8 +296,7 @@ class ImperativeAggCodeGen(
         var inputExpr = generator.generateExpression(inputRef.accept(rexNodeGen))
         if (inputFieldCopy) inputExpr = inputExpr.deepCopy(ctx)
         codes += inputExpr.code
-        val term = s"${genToExternal(ctx, externalInputTypes(index), inputExpr.resultTerm)}"
-        s"${inputExpr.nullTerm} ? null : $term"
+        genToExternalIfNeeded(ctx, externalInputTypes(index), inputExpr)
       }
     }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -625,8 +625,7 @@ object AggCodeGenHelper {
           agg, externalAccType, inputExprs.map(_.resultType))
         val parameters = inputExprs.zipWithIndex.map {
           case (expr, i) =>
-            s"${expr.nullTerm} ? null : " +
-                s"${ genToExternal(ctx, externalUDITypes(i), expr.resultTerm)}"
+            genToExternalIfNeeded(ctx, externalUDITypes(i), expr)
         }
 
         val javaTerm = boxedTypeTermForExternalType(externalAccType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -554,7 +554,7 @@ object AggCodeGenHelper {
         val singleIterableClass = classOf[SingleElementIterator[_]].getCanonicalName
 
         val externalAccT = getAccumulatorTypeOfAggregateFunction(agg)
-        val javaField = boxedTypeTermForExternalType(externalAccT)
+        val javaField = typeTerm(externalAccT.getConversionClass)
         val tmpAcc = newName("tmpAcc")
         s"""
            |final $singleIterableClass accIt$aggIndex = new  $singleIterableClass();
@@ -628,7 +628,7 @@ object AggCodeGenHelper {
             genToExternalIfNeeded(ctx, externalUDITypes(i), expr)
         }
 
-        val javaTerm = boxedTypeTermForExternalType(externalAccType)
+        val javaTerm = typeTerm(externalAccType.getConversionClass)
         val tmpAcc = newName("tmpAcc")
         val innerCode =
           s"""

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.codegen.calls
+import java.lang.reflect.Method
+import java.util.Collections
+
+import org.apache.calcite.rex.{RexCall, RexCallBinding}
+import org.apache.flink.table.functions.UserDefinedFunctionHelper.SCALAR_EVAL
+import org.apache.flink.table.functions.{ScalarFunction, TableFunction, UserDefinedFunction}
+import org.apache.flink.table.planner.codegen.CodeGenUtils.{genToExternalIfNeeded, genToInternalIfNeeded, typeTerm}
+import org.apache.flink.table.planner.codegen.{CodeGenException, CodeGeneratorContext, GeneratedExpression}
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction
+import org.apache.flink.table.planner.functions.inference.OperatorBindingCallContext
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
+import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.extraction.utils.ExtractionUtils
+import org.apache.flink.table.types.extraction.utils.ExtractionUtils.{createMethodSignatureString, isAssignable, isMethodInvokable, primitiveToWrapper}
+import org.apache.flink.table.types.inference.TypeInferenceUtil
+import org.apache.flink.table.types.logical.LogicalType
+
+/**
+ * Generates a call to a user-defined [[ScalarFunction]] or [[TableFunction]] (future work).
+ */
+class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
+
+  private val function: BridgingSqlFunction = call.getOperator.asInstanceOf[BridgingSqlFunction]
+  private val udf: UserDefinedFunction = function.getDefinition.asInstanceOf[UserDefinedFunction]
+
+  override def generate(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression],
+      returnType: LogicalType)
+    : GeneratedExpression = {
+
+    val inference = function.getTypeInference
+
+    // we could have implemented a dedicated code generation context but the closer we are to
+    // Calcite the more consistent is the type inference during the data type enrichment
+    val callContext = new OperatorBindingCallContext(
+      function.getDataTypeFactory,
+      udf,
+      RexCallBinding.create(
+        function.getTypeFactory,
+        call,
+        Collections.emptyList()))
+
+    // enrich argument types with conversion class
+    val adaptedCallContext = TypeInferenceUtil.adaptArguments(
+      inference,
+      callContext,
+      null)
+    val enrichedArgumentDataTypes = toScala(adaptedCallContext.getArgumentDataTypes)
+    verifyArgumentTypes(operands.map(_.resultType), enrichedArgumentDataTypes)
+
+    // enrich output types with conversion class
+    val enrichedOutputDataType = TypeInferenceUtil.inferOutputType(
+      adaptedCallContext,
+      inference.getOutputTypeStrategy)
+    verifyOutputType(returnType, enrichedOutputDataType)
+
+    // find runtime method and generate call
+    verifyImplementation(enrichedArgumentDataTypes, enrichedOutputDataType)
+    generateFunctionCall(ctx, operands, enrichedArgumentDataTypes, enrichedOutputDataType)
+  }
+
+  private def generateFunctionCall(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression],
+      argumentDataTypes: Seq[DataType],
+      outputDataType: DataType)
+    : GeneratedExpression = {
+
+    val functionTerm = ctx.addReusableFunction(udf)
+
+    // operand conversion
+    val externalOperands = prepareExternalOperands(ctx, operands, argumentDataTypes)
+    val externalOperandTerms = externalOperands.map(_.resultTerm).mkString(", ")
+
+    // result conversion
+    val externalResultClass = outputDataType.getConversionClass
+    val externalResultTypeTerm = typeTerm(externalResultClass)
+    // Janino does not fully support the JVM spec:
+    // boolean b = (boolean) f(); where f returns Object
+    // This is not supported and we need to box manually.
+    val externalResultClassBoxed = primitiveToWrapper(externalResultClass)
+    val externalResultCasting = if (externalResultClass == externalResultClassBoxed) {
+      s"($externalResultTypeTerm)"
+    } else {
+      s"($externalResultTypeTerm) (${typeTerm(externalResultClassBoxed)})"
+    }
+    val externalResultTerm = ctx.addReusableLocalVariable(externalResultTypeTerm, "externalResult")
+    val internalExpr = genToInternalIfNeeded(ctx, outputDataType, externalResultTerm)
+
+    // function call
+    internalExpr.copy(code =
+      s"""
+        |${externalOperands.map(_.code).mkString("\n")}
+        |$externalResultTerm = $externalResultCasting $functionTerm
+        |  .$SCALAR_EVAL($externalOperandTerms);
+        |${internalExpr.code}
+        |""".stripMargin)
+  }
+
+  private def prepareExternalOperands(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression],
+      argumentDataTypes: Seq[DataType])
+    : Seq[GeneratedExpression] = {
+    operands
+      .zip(argumentDataTypes)
+      .map { case (operand, dataType) =>
+        operand.copy(resultTerm = genToExternalIfNeeded(ctx, dataType, operand))
+      }
+  }
+
+  private def verifyArgumentTypes(
+      operandTypes: Seq[LogicalType],
+      enrichedDataTypes: Seq[DataType])
+    : Unit = {
+    val enrichedTypes = enrichedDataTypes.map(_.getLogicalType)
+    operandTypes.zip(enrichedTypes).foreach { case (operandType, enrichedType) =>
+      // check that the logical type has not changed during the enrichment
+      // a nullability mismatch is acceptable if the enriched type can handle it
+      if (operandType != enrichedType && operandType.copy(true) != enrichedType) {
+        throw new CodeGenException(
+          s"Mismatch of function's argument data type '$enrichedType' and actual " +
+            s"argument type '$operandType'.")
+      }
+    }
+    // the data type class can only partially verify the conversion class,
+    // now is the time for the final check
+    enrichedDataTypes.foreach(dataType => {
+      if (!dataType.getLogicalType.supportsOutputConversion(dataType.getConversionClass)) {
+        throw new CodeGenException(
+          s"Data type '$dataType' does not support an output conversion " +
+            s"to class '${dataType.getConversionClass}'.")
+      }
+    })
+  }
+
+  private def verifyOutputType(
+      outputType: LogicalType,
+      enrichedDataType: DataType)
+    : Unit = {
+    val enrichedType = enrichedDataType.getLogicalType
+    // check that the logical type has not changed during the enrichment
+    // a nullability mismatch is acceptable if the output type can handle it
+    if (outputType != enrichedType && outputType != enrichedType.copy(true)) {
+      throw new CodeGenException(
+        s"Mismatch of expected output data type '$outputType' and function's " +
+          s"output type '$enrichedType'.")
+    }
+    // the data type class can only partially verify the conversion class,
+    // now is the time for the final check
+    if (!enrichedType.supportsInputConversion(enrichedDataType.getConversionClass)) {
+      throw new CodeGenException(
+        s"Data type '$enrichedDataType' does not support an input conversion " +
+          s"to class '${enrichedDataType.getConversionClass}'.")
+    }
+  }
+
+  private def verifyImplementation(
+      argumentDataTypes: Seq[DataType],
+      outputDataType: DataType)
+    : Unit = {
+    val methods = toScala(ExtractionUtils.collectMethods(udf.getClass, SCALAR_EVAL))
+    val argumentClasses = argumentDataTypes.map(_.getConversionClass).toArray
+    val outputClass = outputDataType.getConversionClass
+    // verifies regular JVM calling semantics
+    def methodMatches(method: Method): Boolean = {
+      isMethodInvokable(method, argumentClasses: _*) &&
+        isAssignable(outputClass, method.getReturnType, true)
+    }
+    if (!methods.exists(methodMatches)) {
+      throw new CodeGenException(
+        s"Could not find an implementation method that matches the following signature: " +
+          s"${createMethodSignatureString(SCALAR_EVAL, argumentClasses, outputClass)}")
+    }
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
@@ -189,7 +189,8 @@ class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
     }
     if (!methods.exists(methodMatches)) {
       throw new CodeGenException(
-        s"Could not find an implementation method that matches the following signature: " +
+        s"Could not find an implementation method in class '${typeTerm(udf.getClass)}' for " +
+          s"function '$function' that matches the following signature: \n" +
           s"${createMethodSignatureString(SCALAR_EVAL, argumentClasses, outputClass)}")
     }
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter
 import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLogicalTypeToDataType
+import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.extraction.utils.ExtractionUtils
 import org.apache.flink.table.types.logical.LogicalType
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
@@ -107,7 +108,7 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
     val resultUnboxing = if (resultClass.isPrimitive) {
       GenerateUtils.generateNonNullField(returnType, resultTerm)
     } else {
-      GenerateUtils.generateInputFieldUnboxing(ctx, returnType, resultTerm)
+      GenerateUtils.generateInputFieldUnboxing(ctx, returnType, resultTerm, resultTerm)
     }
     resultUnboxing.copy(code =
       s"""
@@ -124,6 +125,17 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
     // get the expanded parameter types
     var paramClasses = getEvalMethodSignature(func, operands.map(_.resultType).toArray)
     prepareFunctionArgs(ctx, operands, paramClasses, func.getParameterTypes(paramClasses))
+  }
+
+  def genToInternalIfNeeded(
+      ctx: CodeGeneratorContext,
+      t: DataType,
+      term: String): String = {
+    if (isInternalClass(t)) {
+      s"(${boxedTypeTermForType(LogicalTypeDataTypeConverter.fromDataTypeToLogicalType(t))}) $term"
+    } else {
+      genToInternal(ctx, t, term)
+    }
   }
 
 }
@@ -161,10 +173,8 @@ object ScalarFunctionCallGen {
           } else {
             signatureTypes(i)
           }
-        val externalResultTerm = genToExternalIfNeeded(
-          ctx, signatureType, operandExpr.resultTerm)
-        val exprOrNull = s"${operandExpr.nullTerm} ? null : ($externalResultTerm)"
-        operandExpr.copy(resultTerm = exprOrNull)
+        val externalResultTerm = genToExternalIfNeeded(ctx, signatureType, operandExpr)
+        operandExpr.copy(resultTerm = externalResultTerm)
       }
     }
   }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -463,13 +463,15 @@ public class FunctionITCase extends StreamingTestBase {
 		final List<Row> sourceData = Arrays.asList(
 			Row.of(1, new byte[]{1, 2, 3}),
 			Row.of(2, new byte[]{2, 3, 4}),
-			Row.of(3, new byte[]{3, 4, 5})
+			Row.of(3, new byte[]{3, 4, 5}),
+			Row.of(null, null)
 		);
 
 		final List<Row> sinkData = Arrays.asList(
 			Row.of(1, "1+2012-12-12 12:12:12.123456789", "[1, 2, 3]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[1, 2, 3]"),
 			Row.of(2, "2+2012-12-12 12:12:12.123456789", "[2, 3, 4]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[2, 3, 4]"),
-			Row.of(3, "3+2012-12-12 12:12:12.123456789", "[3, 4, 5]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[3, 4, 5]")
+			Row.of(3, "3+2012-12-12 12:12:12.123456789", "[3, 4, 5]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[3, 4, 5]"),
+			Row.of(null, "null+2012-12-12 12:12:12.123456789", "null+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "null")
 		);
 
 		TestCollectionTableFactory.reset();
@@ -502,13 +504,15 @@ public class FunctionITCase extends StreamingTestBase {
 		final List<Row> sourceData = Arrays.asList(
 			Row.of(1),
 			Row.of(2),
-			Row.of(3)
+			Row.of(3),
+			Row.of((Integer) null)
 		);
 
 		final List<Row> sinkData = Arrays.asList(
 			Row.of(1, 1, 5),
 			Row.of(2, 2, 5),
-			Row.of(3, 3, 5)
+			Row.of(3, 3, 5),
+			Row.of(null, null, 5)
 		);
 
 		TestCollectionTableFactory.reset();
@@ -545,8 +549,9 @@ public class FunctionITCase extends StreamingTestBase {
 				e,
 				hasMessage(
 					equalTo(
-						"Could not find an implementation method that matches the following " +
-							"signature: java.lang.String eval(java.lang.String)")));
+						"Could not find an implementation method in class '" + CustomScalarFunction.class.getCanonicalName() +
+						"' for function 'CustomScalarFunction' that matches the following signature: \n" +
+						"java.lang.String eval(java.lang.String)")));
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -18,27 +18,37 @@
 
 package org.apache.flink.table.planner.runtime.stream.sql;
 
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.InputGroup;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.planner.codegen.CodeGenException;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
 import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.Row;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 /**
  * Tests for catalog and system in stream table environment.
@@ -400,7 +410,7 @@ public class FunctionITCase extends StreamingTestBase {
 		);
 
 		TestCollectionTableFactory.reset();
-		TestCollectionTableFactory.initData(sourceData, new ArrayList<>(), -1);
+		TestCollectionTableFactory.initData(sourceData);
 
 		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
 		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
@@ -420,5 +430,174 @@ public class FunctionITCase extends StreamingTestBase {
 
 		tEnv().sqlUpdate("drop table t1");
 		tEnv().sqlUpdate("drop table t2");
+	}
+
+	@Test
+	public void testPrimitiveScalarFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of(1, 1L, "-"),
+			Row.of(2, 2L, "--"),
+			Row.of(3, 3L, "---")
+		);
+
+		final List<Row> sinkData = Arrays.asList(
+			Row.of(1, 3L, "-"),
+			Row.of(2, 6L, "--"),
+			Row.of(3, 9L, "---")
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate("CREATE TABLE TestTable(a INT NOT NULL, b BIGINT NOT NULL, c STRING) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().createTemporarySystemFunction("PrimitiveScalarFunction", PrimitiveScalarFunction.class);
+		tEnv().sqlUpdate("INSERT INTO TestTable SELECT a, PrimitiveScalarFunction(a, b, c), c FROM TestTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testComplexScalarFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of(1, new byte[]{1, 2, 3}),
+			Row.of(2, new byte[]{2, 3, 4}),
+			Row.of(3, new byte[]{3, 4, 5})
+		);
+
+		final List<Row> sinkData = Arrays.asList(
+			Row.of(1, "1+2012-12-12 12:12:12.123456789", "[1, 2, 3]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[1, 2, 3]"),
+			Row.of(2, "2+2012-12-12 12:12:12.123456789", "[2, 3, 4]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[2, 3, 4]"),
+			Row.of(3, "3+2012-12-12 12:12:12.123456789", "[3, 4, 5]+2012-12-12 12:12:12.123456789", new BigDecimal("123.40"), "[3, 4, 5]")
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate(
+			"CREATE TABLE SourceTable(i INT, b BYTES) " +
+			"WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate(
+			"CREATE TABLE SinkTable(i INT, s1 STRING, s2 STRING, d DECIMAL(5, 2), s3 STRING) " +
+			"WITH ('connector' = 'COLLECTION')");
+
+		tEnv().createTemporarySystemFunction("ComplexScalarFunction", ComplexScalarFunction.class);
+		tEnv().sqlUpdate(
+			"INSERT INTO SinkTable " +
+			"SELECT " +
+			"  i, " +
+			"  ComplexScalarFunction(i, TIMESTAMP '2012-12-12 12:12:12.123456789'), " +
+			"  ComplexScalarFunction(b, TIMESTAMP '2012-12-12 12:12:12.123456789')," +
+			"  ComplexScalarFunction(), " +
+			"  ComplexScalarFunction(b) " +
+			"FROM SourceTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testCustomScalarFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of(1),
+			Row.of(2),
+			Row.of(3)
+		);
+
+		final List<Row> sinkData = Arrays.asList(
+			Row.of(1, 1, 5),
+			Row.of(2, 2, 5),
+			Row.of(3, 3, 5)
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate("CREATE TABLE SourceTable(i INT) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(i1 INT, i2 INT, i3 INT) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().createTemporarySystemFunction("CustomScalarFunction", CustomScalarFunction.class);
+		tEnv().sqlUpdate(
+			"INSERT INTO SinkTable " +
+			"SELECT " +
+			"  i, " +
+			"  CustomScalarFunction(i), " +
+			"  CustomScalarFunction(CAST(NULL AS INT), 5, i, i) " +
+			"FROM SourceTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testInvalidCustomScalarFunction() {
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().createTemporarySystemFunction("CustomScalarFunction", CustomScalarFunction.class);
+		try {
+			tEnv().sqlUpdate(
+				"INSERT INTO SinkTable " +
+				"SELECT CustomScalarFunction('test')");
+			fail();
+		} catch (CodeGenException e) {
+			assertThat(
+				e,
+				hasMessage(
+					equalTo(
+						"Could not find an implementation method that matches the following " +
+							"signature: java.lang.String eval(java.lang.String)")));
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test functions
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Function that takes and returns primitives.
+	 */
+	public static class PrimitiveScalarFunction extends ScalarFunction {
+		public long eval(int i, long l, String s) {
+			return i + l + s.length();
+		}
+	}
+
+	/**
+	 * Function that is overloaded and takes use of annotations.
+	 */
+	public static class ComplexScalarFunction extends ScalarFunction {
+		public String eval(@DataTypeHint(inputGroup = InputGroup.ANY) Object o, java.sql.Timestamp t) {
+			return EncodingUtils.objectToString(o) + "+" + t.toString();
+		}
+
+		public @DataTypeHint("DECIMAL(5, 2)") BigDecimal eval() {
+			return new BigDecimal("123.4"); // 1 digit is missing
+		}
+
+		public String eval(byte[] bytes) {
+			return Arrays.toString(bytes);
+		}
+	}
+
+	/**
+	 * Function that has a custom type inference that is broader than the actual implementation.
+	 */
+	public static class CustomScalarFunction extends ScalarFunction {
+		public Integer eval(Integer... args) {
+			for (Integer o : args) {
+				if (o != null) {
+					return o;
+				}
+			}
+			return null;
+		}
+
+		@Override
+		public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+			return TypeInference.newBuilder()
+				.outputTypeStrategy(TypeStrategies.argument(0))
+				.build();
+		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
@@ -97,6 +97,10 @@ object TestCollectionTableFactory {
   val RESULT = new JLinkedList[Row]()
   private var emitIntervalMS = -1L
 
+  def initData(sourceData: JList[Row]): Unit ={
+    initData(sourceData, List(), -1L)
+  }
+
   def initData(sourceData: JList[Row],
     dimData: JList[Row] = List(),
     emitInterval: Long = -1L): Unit ={
@@ -111,6 +115,8 @@ object TestCollectionTableFactory {
     DIM_DATA.clear()
     emitIntervalMS = -1L
   }
+
+  def getResult: util.List[Row] = RESULT
 
   def getCollectionSource(props: JMap[String, String]): CollectionTableSource = {
     val properties = new DescriptorProperties()


### PR DESCRIPTION
## What is the purpose of the change

This updates the code generation for the new type inference and thus completes FLINK-15487. Scala function work with the types supported by the planner. Tests added in this PR only test basic behavior. We will need more tests per data type. But this is a follow up issue.


## Brief change log

- Update the code generation
- Fix a couple of bugs and shortcomings

## Verifying this change

`FunctionITCase` tests the implementation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
