### PR TITLE
Flink 15652

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.context</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The desired context from your K8s config file used to configure the K8s client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different K8s clusters/contexts.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -45,6 +45,12 @@
             <td>Kubernetes image pull policy. Valid values are Always, Never, and IfNotPresent. The default policy is IfNotPresent to avoid putting pressure to image repository.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.container.image.pull-secrets</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Comma separated list of the Kubernetes secrets used to access private image registries.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.entry.path</h5></td>
             <td style="word-wrap: break-word;">"/opt/flink/bin/kubernetes-entry.sh"</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -29,6 +29,14 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 @PublicEvolving
 public class KubernetesConfigOptions {
 
+	public static final ConfigOption<String> CONTEXT =
+		key("kubernetes.context")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("The desired context from your K8s config file used to configure the K8s client for " +
+			"interacting with the cluster. This could be helpful if one has multiple contexts configured and " +
+			"wants to administrate different Flink clusters on different K8s clusters/contexts.");
+
 	public static final ConfigOption<String> REST_SERVICE_EXPOSED_TYPE =
 		key("kubernetes.rest-service.exposed.type")
 		.stringType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -71,6 +71,12 @@ public class KubernetesConfigOptions {
 		.withDescription("Kubernetes image pull policy. Valid values are Always, Never, and IfNotPresent. " +
 			"The default policy is IfNotPresent to avoid putting pressure to image repository.");
 
+	public static final ConfigOption<String> CONTAINER_IMAGE_PULL_SECRETES =
+		key("kubernetes.container.image.pull-secretes")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Comma separated list of the Kubernetes secrets used to access private image registries.");
+
 	public static final ConfigOption<String> KUBE_CONFIG_FILE =
 		key("kubernetes.config.file")
 		.stringType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
@@ -42,18 +42,23 @@ public class KubeClientFactory {
 
 		final Config config;
 
+		final String kubeContext = flinkConfig.getString(KubernetesConfigOptions.CONTEXT);
+		if (kubeContext != null) {
+			LOG.info("Configuring K8S client using context {}.", kubeContext);
+		}
+
 		final String kubeConfigFile = flinkConfig.getString(KubernetesConfigOptions.KUBE_CONFIG_FILE);
 		if (kubeConfigFile != null) {
 			LOG.debug("Trying to load kubernetes config from file: {}.", kubeConfigFile);
 			try {
-				config = Config.fromKubeconfig(KubernetesUtils.getContentFromFile(kubeConfigFile));
+				config = Config.fromKubeconfig(kubeContext, KubernetesUtils.getContentFromFile(kubeConfigFile), null);
 			} catch (IOException e) {
 				throw new KubernetesClientException("Load kubernetes config failed.", e);
 			}
 		} else {
 			LOG.debug("Trying to load default kubernetes config.");
 			// Null means load from default context
-			config = Config.autoConfigure(null);
+			config = Config.autoConfigure(kubeContext);
 		}
 
 		final KubernetesClient client = new DefaultKubernetesClient(config);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkMasterDeploymentDecorator.java
@@ -38,6 +38,7 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -51,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.CONTAINER_IMAGE_PULL_SECRETES;
 import static org.apache.flink.kubernetes.utils.Constants.API_VERSION;
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.apache.flink.kubernetes.utils.Constants.POD_IP_FIELD_PATH;
@@ -97,10 +99,14 @@ public class FlinkMasterDeploymentDecorator extends Decorator<Deployment, Kubern
 		final Container container = createJobManagerContainer(flinkConfig, mainClass, hasLogback, hasLog4j, blobServerPort);
 
 		final String serviceAccount = flinkConfig.getString(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT);
+
+		final LocalObjectReference[] imagePullSecrets = KubernetesUtils.parseImagePullSecrets(flinkConfig.get(CONTAINER_IMAGE_PULL_SECRETES));
+
 		final PodSpec podSpec = new PodSpecBuilder()
 			.withServiceAccountName(serviceAccount)
 			.withVolumes(configMapVolume)
 			.withContainers(container)
+			.withImagePullSecrets(imagePullSecrets)
 			.build();
 
 		deployment.setSpec(new DeploymentSpecBuilder()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/TaskManagerPodDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/TaskManagerPodDecorator.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -39,6 +40,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.CONTAINER_IMAGE_PULL_SECRETES;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -79,9 +81,12 @@ public class TaskManagerPodDecorator extends Decorator<Pod, KubernetesPod> {
 
 		final Volume configMapVolume = KubernetesUtils.getConfigMapVolume(clusterId, hasLogback, hasLog4j);
 
+		final LocalObjectReference[] imagePullSecrets = KubernetesUtils.parseImagePullSecrets(flinkConfig.get(CONTAINER_IMAGE_PULL_SECRETES));
+
 		pod.setSpec(new PodSpecBuilder()
 			.withVolumes(configMapVolume)
 			.withContainers(createTaskManagerContainer(flinkConfig, hasLogback, hasLog4j, taskManagerRpcPort))
+			.withImagePullSecrets(imagePullSecrets)
 			.build());
 		return pod;
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.KeyToPath;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
@@ -48,6 +49,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -286,6 +288,21 @@ public class KubernetesUtils {
 			.addToLimits(Constants.RESOURCE_NAME_MEMORY, memQuantity)
 			.addToLimits(Constants.RESOURCE_NAME_CPU, cpuQuantity)
 			.build();
+	}
+
+	/**
+	 * Parses comma-separated list of imagePullSecrets into K8s-understandable format.
+	 */
+	public static LocalObjectReference[] parseImagePullSecrets(@Nullable String imagePullSecrets) {
+		if (imagePullSecrets == null) {
+			return new LocalObjectReference[0];
+		} else {
+			return Arrays.stream(imagePullSecrets.split(","))
+				.map(String::trim)
+				.filter(secret -> !secret.isEmpty())
+				.map(LocalObjectReference::new)
+				.toArray(LocalObjectReference[]::new);
+		}
 	}
 
 	private static String getJavaOpts(Configuration flinkConfig, ConfigOption<String> configOption) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesUtilsTest.java
@@ -34,13 +34,16 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.TestLogger;
 
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.stream.IntStream;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -237,6 +240,20 @@ public class KubernetesUtilsTest extends TestLogger {
 				e.getMessage(),
 				containsString(testingPort.key() + " should not be null."));
 		}
+	}
+
+	@Test
+	public void testParseImagePullSecrets() {
+		final LocalObjectReference[] noSecrets = KubernetesUtils.parseImagePullSecrets(null);
+		assertEquals(0, noSecrets.length);
+
+		final LocalObjectReference[] oneSecrete = KubernetesUtils.parseImagePullSecrets("s1");
+		assertTrue(oneSecrete.length == 1 && oneSecrete[0].getName().equals("s1"));
+
+		final LocalObjectReference[] commonSeparatedSecrets = KubernetesUtils.parseImagePullSecrets("s1, s2 , s3,, s4");
+		final String[] expectedSecrets = new String[]{"s1", "s2", "s3", "s4"};
+		assertEquals(4, commonSeparatedSecrets.length);
+		IntStream.range(0, 3).forEach(i -> assertEquals(expectedSecrets[i], commonSeparatedSecrets[i].getName()));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

It's likely that one would pull images from the private image registries, credentials can be passed with the Pod specification through the `imagePullSecrets` parameter,
which refers to the k8s secret by name. Implementation wise we expose a new configuration option to the users and then pass it along to the K8S.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
