### PR TITLE
[FLINK-15797][k8s] Reduce log noise of Fabric8FlinkKubeClient

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -278,7 +278,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
 			@Override
 			public void onClose(KubernetesClientException e) {
-				LOG.debug("The pods watcher is closing.", e);
+				LOG.error("The pods watcher is closing.", e);
 			}
 		};
 		this.internalClient.pods().withLabels(labels).watch(watcher);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -123,7 +123,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 			configMap = c.decorate(configMap);
 		}
 
-		LOG.info("Create config map with data size {}", configMap.getInternalResource().getData().size());
+		LOG.debug("Create config map with data size {}", configMap.getInternalResource().getData().size());
 		this.internalClient.configMaps().create(configMap.getInternalResource());
 	}
 
@@ -146,7 +146,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 		}
 
 		deployment = new FlinkMasterDeploymentDecorator(clusterSpecification).decorate(deployment);
-		LOG.info("Create Flink Master deployment with spec: {}", deployment.getInternalResource().getSpec());
+
+		LOG.debug("Create Flink Master deployment with spec: {}", deployment.getInternalResource().getSpec());
 
 		this.internalClient
 			.apps()
@@ -164,7 +165,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 		}
 
 		pod = new TaskManagerPodDecorator(parameter).decorate(pod);
-		LOG.info("Create TaskManager pod with spec: {}", pod.getInternalResource().getSpec().toString());
+
+		LOG.debug("Create TaskManager pod with spec: {}", pod.getInternalResource().getSpec());
 
 		this.internalClient.pods().inNamespace(this.nameSpace).create(pod.getInternalResource());
 	}
@@ -234,7 +236,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 
 	@Override
 	public void handleException(Exception e) {
-		LOG.error("Encounter Kubernetes Exception.", e);
+		LOG.error("A Kubernetes exception occurred.", e);
 	}
 
 	@Override
@@ -254,7 +256,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 		final Watcher<Pod> watcher = new Watcher<Pod>() {
 			@Override
 			public void eventReceived(Action action, Pod pod) {
-				LOG.info("Received {} event for pod {}, details: {}", action, pod.getMetadata().getName(), pod.getStatus());
+				LOG.debug("Received {} event for pod {}, details: {}", action, pod.getMetadata().getName(), pod.getStatus());
 				switch (action) {
 					case ADDED:
 						callbackHandler.onAdded(Collections.singletonList(new KubernetesPod(flinkConfig, pod)));
@@ -269,14 +271,14 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 						callbackHandler.onDeleted(Collections.singletonList(new KubernetesPod(flinkConfig, pod)));
 						break;
 					default:
-						LOG.info("Skip handling {} event for pod {}", action, pod.getMetadata().getName());
+						LOG.debug("Ignore handling {} event for pod {}", action, pod.getMetadata().getName());
 						break;
 				}
 			}
 
 			@Override
 			public void onClose(KubernetesClientException e) {
-				LOG.error("Pods watcher onClose", e);
+				LOG.debug("The pods watcher is closing.", e);
 			}
 		};
 		this.internalClient.pods().withLabels(labels).watch(watcher);
@@ -295,7 +297,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 			kubernetesService = d.decorate(kubernetesService);
 		}
 
-		LOG.info("Create service with spec: {}", kubernetesService.getInternalResource().getSpec());
+		LOG.debug("Create service {} with spec: {}", serviceName, kubernetesService.getInternalResource().getSpec());
 
 		this.internalClient.services().create(kubernetesService.getInternalResource());
 


### PR DESCRIPTION
## What is the purpose of the change

This commit reduces the log noise of the Fabric8FlinkKubeClient by changing the log level
from info to debug.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
