### PR TITLE
[FLINK-15789][kubernetes] Do not wrap the InterruptedException and throw a different one in ActionWatcher.await

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -37,6 +37,7 @@ import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.TimeUtils;
+import org.apache.flink.util.function.FunctionUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -312,12 +313,13 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
 		final Duration timeout = TimeUtils.parseDuration(
 			flinkConfig.get(KubernetesConfigOptions.SERVICE_CREATE_TIMEOUT));
 
-		return CompletableFuture.supplyAsync(() -> {
-			final Service createdService = watcher.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
-			watchConnectionManager.close();
+		return CompletableFuture.supplyAsync(
+			FunctionUtils.uncheckedSupplier(() -> {
+				final Service createdService = watcher.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+				watchConnectionManager.close();
 
-			return new KubernetesService(this.flinkConfig, createdService);
-		});
+				return new KubernetesService(this.flinkConfig, createdService);
+			}));
 	}
 
 	private KubernetesService getService(String serviceName) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/ActionWatcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/ActionWatcher.java
@@ -53,14 +53,10 @@ public class ActionWatcher<T extends HasMetadata> implements Watcher<T> {
 	public void onClose(KubernetesClientException e) {
 	}
 
-	public T await(long amount, TimeUnit timeUnit) {
-		try {
-			if (this.latch.await(amount, timeUnit)) {
-				return this.reference.get();
-			} else {
-				throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
-			}
-		} catch (InterruptedException var5) {
+	public T await(long amount, TimeUnit timeUnit) throws InterruptedException {
+		if (this.latch.await(amount, timeUnit)) {
+			return this.reference.get();
+		} else {
 			throw new KubernetesClientTimeoutException(this.resource, amount, timeUnit);
 		}
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The ActionWatcher.await method should declare that it throws an InterruptedException instead of catching it, not resetting the interrupted flag and then throwing a different exception.


## Brief change log

* Throw InterruptedException in `ActionWatcher.await`


## Verifying this change

* All the tests should work well
* Manually starting a Flink cluster on K8s

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
