### PR TITLE
[FLINK-15791][k8s] Use explicit I/O Executor for asynchronous operations in Fabric8FlinkKubeClient

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.client.async.thread-pool-size</h5></td>
+            <td style="word-wrap: break-word;">4</td>
+            <td>Integer</td>
+            <td>Number of threads in FlinkKubeClient to process all asynchronous operations.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.cluster-id</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -97,7 +97,13 @@ public class KubernetesConfigOptions {
 		.withDescription("Timeout used for creating the service. The timeout value requires a time-unit " +
 			"specifier (ms/s/min/h/d).");
 
-  	// ---------------------------------------------------------------------------------
+	public static final ConfigOption<Integer> CLIENT_ASYNC_THREAD_POOL_SIZE =
+		key("kubernetes.client.async.thread-pool-size")
+		.intType()
+		.defaultValue(4)
+		.withDescription("Number of threads in FlinkKubeClient to process all asynchronous operations.");
+
+	// ---------------------------------------------------------------------------------
 	// The following config options could be overridden by KubernetesCliOptions.
 	// ---------------------------------------------------------------------------------
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
@@ -35,7 +34,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.Test;
 
 import java.util.List;
@@ -62,7 +60,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 		assertEquals(CLUSTER_ID + "." + NAMESPACE, FLINK_CONFIG.getString(JobManagerOptions.ADDRESS));
 		assertEquals(MOCK_SERVICE_ID, FLINK_CONFIG.getString(KubernetesConfigOptionsInternal.SERVICE_ID));
 
-		final KubernetesClient kubeClient = server.getClient();
 		final ServiceList serviceList = kubeClient.services().list();
 		assertEquals(2, serviceList.getItems().size());
 		assertEquals(CLUSTER_ID, serviceList.getItems().get(0).getMetadata().getName());
@@ -97,7 +94,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 
 		final ClusterClient<String> clusterClient = deploySessionCluster();
 
-		final KubernetesClient kubeClient = server.getClient();
 		final Container jmContainer = kubeClient
 			.apps()
 			.deployments()
@@ -121,7 +117,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 
 	@Test
 	public void testKillCluster() throws Exception {
-		final FlinkKubeClient flinkKubeClient = getFabric8FlinkKubeClient();
 		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(FLINK_CONFIG, flinkKubeClient);
 
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
@@ -129,7 +124,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 
 		descriptor.deploySessionCluster(clusterSpecification);
 
-		final KubernetesClient kubeClient = server.getClient();
 		assertEquals(2, kubeClient.services().list().getItems().size());
 
 		descriptor.killCluster(CLUSTER_ID);
@@ -143,7 +137,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesTestBase {
 	}
 
 	private ClusterClient<String> deploySessionCluster() throws ClusterDeploymentException {
-		final FlinkKubeClient flinkKubeClient = getFabric8FlinkKubeClient();
 		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(FLINK_CONFIG, flinkKubeClient);
 
 		final ClusterClient<String> clusterClient = descriptor

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -43,6 +43,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceStatusBuilder;
 import io.fabric8.kubernetes.api.model.WatchEvent;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -68,6 +69,10 @@ public class KubernetesTestBase extends TestLogger {
 	public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
 	private File flinkConfDir;
+
+	protected FlinkKubeClient flinkKubeClient;
+
+	protected KubernetesClient kubeClient;
 
 	protected static final String NAMESPACE = "test";
 
@@ -106,21 +111,25 @@ public class KubernetesTestBase extends TestLogger {
 		map.put(ConfigConstants.ENV_FLINK_CONF_DIR, flinkConfDir.toString());
 		TestBaseUtils.setEnv(map);
 
+		flinkKubeClient = getFabric8FlinkKubeClient();
+		kubeClient = getKubeClient();
+
 		// Set mock requests.
 		mockInternalServiceActionWatch();
 		mockRestServiceActionWatcher(CLUSTER_ID);
 		mockGetRestService(CLUSTER_ID, MOCK_SERVICE_HOST_NAME, MOCK_SERVICE_IP);
 	}
 
-	protected FlinkKubeClient getFabric8FlinkKubeClient(){
-		return getFabric8FlinkKubeClient(FLINK_CONFIG);
+	@After
+	public void tearDown() throws Exception {
+		flinkKubeClient.close();
 	}
 
-	protected FlinkKubeClient getFabric8FlinkKubeClient(Configuration flinkConfig){
-		return new Fabric8FlinkKubeClient(flinkConfig, server.getClient().inNamespace(NAMESPACE));
+	private FlinkKubeClient getFabric8FlinkKubeClient(){
+		return new Fabric8FlinkKubeClient(FLINK_CONFIG, server.getClient().inNamespace(NAMESPACE));
 	}
 
-	protected KubernetesClient getKubeClient() {
+	private KubernetesClient getKubeClient() {
 		return server.getClient().inNamespace(NAMESPACE);
 	}
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8ClientTest.java
@@ -33,13 +33,10 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.hamcrest.Matchers;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -57,17 +54,6 @@ import static org.junit.Assert.assertTrue;
  * Tests for Fabric implementation of {@link FlinkKubeClient}.
  */
 public class Fabric8ClientTest extends KubernetesTestBase {
-
-	private FlinkKubeClient flinkKubeClient;
-
-	private KubernetesClient kubeClient;
-
-	@Before
-	public void setUp() throws IOException {
-		super.setUp();
-		flinkKubeClient = getFabric8FlinkKubeClient();
-		kubeClient = getKubeClient();
-	}
 
 	@Test
 	public void testCreateConfigMap() throws Exception {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

We should not use the ForkJoinPool#commonPool() in order to run asynchronous operations in the Fabric8FlinkKubeClient as it is done here. Since we don't know which other component is using this pool, it can be quite dangerous to use it as there might be congestion.

Instead, I propose to provide an explicit I/O Executor which is used for running asynchronous operations.

This PR is based on #10970.


## Brief change log

* Use explicit I/O Executor for asynchronous operations in Fabric8FlinkKubeClient


## Verifying this change

* All the tests should work well
* Manually starting a Flink cluster on K8s

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
