### PR TITLE
[FLINK-15584] Give nested data type of ROWs in ValidationException.

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/TableSinkUtils.scala
@@ -55,10 +55,10 @@ object TableSinkUtils {
 
       // format table and table sink schema strings
       val srcSchema = srcFieldNames.zip(srcFieldTypes)
-        .map { case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}" }
+        .map { case (n, t) => s"$n: $t" }
         .mkString("[", ", ", "]")
       val sinkSchema = sinkFieldNames.zip(sinkFieldTypes)
-        .map { case (n, t) => s"$n: ${t.getTypeClass.getSimpleName}" }
+        .map { case (n, t) => s"$n: $t" }
         .mkString("[", ", ", "]")
 
       throw new ValidationException(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/validation/InsertIntoValidationTest.scala
@@ -74,4 +74,22 @@ class InsertIntoValidationTest extends TableTestBase {
     // must fail because partial insert is not supported yet.
     util.tableEnv.sqlUpdate(sql)
   }
+
+  @Test
+  def testValidationExceptionMessage(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage("TableSink schema:    [a: Integer, b: Row" +
+      "(f0: Integer, f1: Integer, f2: Integer)]")
+    val util = batchTestUtil()
+    util.addTable[(Int, Long, String)]("sourceTable", 'a, 'b, 'c)
+    val fieldNames = Array("a", "b")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.INT, Types.ROW
+    (Types.INT, Types.INT, Types.INT))
+    val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
+    util.tableEnv.registerTableSink("targetTable", sink.configure(fieldNames,
+      fieldTypes))
+
+    val sql = "INSERT INTO targetTable SELECT a, b FROM sourceTable"
+
+    util.tableEnv.sqlUpdate(sql)}
 }


### PR DESCRIPTION
In 

INSERT INTO baz_sink
SELECT
  a,
  ROW(b, c)
FROM foo_source

Schema mismatch mistakes will not get proper detail level, yielding the following:

Caused by: org.apache.flink.table.api.ValidationException: Field types of query result and registered TableSink [baz_sink] do not match.
Query result schema: [a: Integer, EXPR$2: Row]
TableSink schema: [a: Integer, payload: Row]

Leaving the user with an opaque 'Row' type to debug.