### PR TITLE
[FLINK-15835][build][oss] Exclude hadoop-common

### DIFF
--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -60,6 +60,11 @@ under the License.
 					<groupId>com.aliyun.oss</groupId>
 					<artifactId>aliyun-oss-sdk</artifactId>
 				</exclusion>
+				<exclusion>
+					<!-- provided by flink-fs-hadoop-shaded -->
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-common</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
Adds an explicit exclusion for `hadoop-common` to `hadoop-aliyun`, since a trimmed-down version of this dependency is already supplied by `flink-fs-hadoop-shaded`.