### PR TITLE
[FLINK-15840][table-planner-blink] ClassCastException is thrown when use tEnv.from for temp/catalog table

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterFactory.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverterFactory.java
@@ -23,6 +23,11 @@ import org.apache.calcite.rel.type.RelDataType;
 /**
  * Factory to create {@link SqlExprToRexConverter}.
  */
-public interface ToRexConverterFactory {
+public interface SqlExprToRexConverterFactory {
+
+	/**
+	 * Creates a new instance of {@link SqlExprToRexConverter} to convert SQL expression
+	 * to RexNode.
+	 */
 	SqlExprToRexConverter create(RelDataType tableRowType);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/ToRexConverterFactory.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/ToRexConverterFactory.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,26 +18,11 @@
 
 package org.apache.flink.table.planner.calcite;
 
-import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.type.RelDataType;
 
 /**
- * A ToRelContext impl that takes the context variables
- * used for sql expression transformation.
+ * Factory to create {@link SqlExprToRexConverter}.
  */
-public interface FlinkToRelContext extends RelOptTable.ToRelContext {
-
-	/**
-	 * Creates a new instance of {@link SqlExprToRexConverter} to convert sql statements
-	 * to {@link org.apache.calcite.rex.RexNode}.
-	 *
-	 * <p>See {@link org.apache.flink.table.planner.plan.schema.FlinkPreparingTableBase#toRel}
-	 * for details.
-	 */
-	SqlExprToRexConverter createSqlExprToRexConverter(RelDataType tableRowType);
-
-	/**
-	 * Creates a new instance of {@link FlinkRelBuilder} to build relational expressions.
-	 */
-	FlinkRelBuilder createRelBuilder();
+public interface ToRexConverterFactory {
+	SqlExprToRexConverter create(RelDataType tableRowType);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.FunctionCatalog;
 import org.apache.flink.table.planner.calcite.CalciteConfig;
 import org.apache.flink.table.planner.calcite.CalciteConfig$;
 import org.apache.flink.table.planner.calcite.CalciteParser;
+import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.calcite.FlinkContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
@@ -85,7 +86,7 @@ public class PlannerContext {
 	private final RelDataTypeSystem typeSystem = new FlinkTypeSystem();
 	private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(typeSystem);
 	private final TableConfig tableConfig;
-	private final FlinkContextImpl context;
+	private final FlinkContext context;
 	private final CalciteSchema rootSchema;
 	private final List<RelTraitDef> traitDefs;
 	private FrameworkConfig frameworkConfig;
@@ -103,11 +104,11 @@ public class PlannerContext {
 				tableConfig,
 				functionCatalog,
 				catalogManager,
-				t -> new SqlExprToRexConverterImpl(
+				rowType -> new SqlExprToRexConverterImpl(
 						checkNotNull(frameworkConfig),
 						checkNotNull(typeFactory),
 						checkNotNull(cluster),
-						t));
+						rowType));
 
 		this.rootSchema = rootSchema;
 		this.traitDefs = traitDefs;

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
@@ -43,6 +43,11 @@ trait FlinkContext extends Context {
     */
   def getCatalogManager: CatalogManager
 
+  /**
+    * Gets [[ToRexConverterFactory]] instance to convert sql expression to rex node.
+    */
+  def getToRexConverterFactory: ToRexConverterFactory
+
   override def unwrap[C](clazz: Class[C]): C = {
     if (clazz.isInstance(this)) clazz.cast(this) else null.asInstanceOf[C]
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContext.scala
@@ -44,9 +44,9 @@ trait FlinkContext extends Context {
   def getCatalogManager: CatalogManager
 
   /**
-    * Gets [[ToRexConverterFactory]] instance to convert sql expression to rex node.
+    * Gets [[SqlExprToRexConverterFactory]] instance to convert sql expression to rex node.
     */
-  def getToRexConverterFactory: ToRexConverterFactory
+  def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory
 
   override def unwrap[C](clazz: Class[C]): C = {
     if (clazz.isInstance(this)) clazz.cast(this) else null.asInstanceOf[C]

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
@@ -27,9 +27,13 @@ class FlinkContextImpl(
     catalogManager: CatalogManager)
   extends FlinkContext {
 
+  var toRexConverterFactory: ToRexConverterFactory = _
+
   override def getTableConfig: TableConfig = tableConfig
 
   override def getFunctionCatalog: FunctionCatalog = functionCatalog
 
   override def getCatalogManager: CatalogManager = catalogManager
+
+  override def getToRexConverterFactory: ToRexConverterFactory = toRexConverterFactory
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkContextImpl.scala
@@ -24,10 +24,9 @@ import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 class FlinkContextImpl(
     tableConfig: TableConfig,
     functionCatalog: FunctionCatalog,
-    catalogManager: CatalogManager)
+    catalogManager: CatalogManager,
+    toRexFactory: SqlExprToRexConverterFactory)
   extends FlinkContext {
-
-  var toRexConverterFactory: ToRexConverterFactory = _
 
   override def getTableConfig: TableConfig = tableConfig
 
@@ -35,5 +34,5 @@ class FlinkContextImpl(
 
   override def getCatalogManager: CatalogManager = catalogManager
 
-  override def getToRexConverterFactory: ToRexConverterFactory = toRexConverterFactory
+  override def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory = toRexFactory
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -160,13 +160,8 @@ class FlinkPlannerImpl(
   }
 
   /**
-    * Creates a new instance of [[SqlExprToRexConverter]] to convert SQL expression
-    * to RexNode.
+    * Creates a new instance of [[RelOptTable.ToRelContext]] for [[RelOptTable]].
     */
-  def createSqlExprToRexConverter(tableRowType: RelDataType): SqlExprToRexConverter = {
-    new SqlExprToRexConverterImpl(config, typeFactory, cluster, tableRowType)
-  }
-
   def createToRelContext(): RelOptTable.ToRelContext = new ToRelContextImpl
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -49,7 +49,7 @@ class FlinkPlannerImpl(
     config: FrameworkConfig,
     catalogReaderSupplier: JFunction[JBoolean, CalciteCatalogReader],
     typeFactory: FlinkTypeFactory,
-    cluster: RelOptCluster) extends FlinkToRelContext {
+    cluster: RelOptCluster) {
 
   val operatorTable: SqlOperatorTable = config.getOperatorTable
   val parser: CalciteParser = new CalciteParser(config.getParserConfig)
@@ -139,7 +139,7 @@ class FlinkPlannerImpl(
     try {
       assert(validatedSqlNode != null)
       val sqlToRelConverter: SqlToRelConverter = new SqlToRelConverter(
-        this,
+        createToRelContext(),
         sqlValidator,
         sqlValidator.getCatalogReader.unwrap(classOf[CalciteCatalogReader]),
         cluster,
@@ -167,31 +167,34 @@ class FlinkPlannerImpl(
     new SqlExprToRexConverterImpl(config, typeFactory, cluster, tableRowType)
   }
 
-  override def getCluster: RelOptCluster = cluster
+  def createToRelContext(): RelOptTable.ToRelContext = new ToRelContextImpl
 
-  override def expandView(
-      rowType: RelDataType,
-      queryString: String,
-      schemaPath: util.List[String],
-      viewPath: util.List[String])
+  /**
+    * Implements [[RelOptTable.ToRelContext]] interface for [[RelOptTable]] and
+    * [[org.apache.calcite.tools.Planner]].
+    */
+  class ToRelContextImpl extends RelOptTable.ToRelContext {
+
+    override def expandView(
+        rowType: RelDataType,
+        queryString: String,
+        schemaPath: util.List[String],
+        viewPath: util.List[String])
     : RelRoot = {
-    val parsed = parser.parse(queryString)
-    val originalReader = catalogReaderSupplier.apply(false)
-    val readerWithPathAdjusted = new FlinkCalciteCatalogReader(
-      originalReader.getRootSchema,
-      List(schemaPath, schemaPath.subList(0, 1)).asJava,
-      originalReader.getTypeFactory,
-      originalReader.getConfig
-    )
-    val validator = createSqlValidator(readerWithPathAdjusted)
-    val validated = validate(parsed, validator)
-    rel(validated, validator)
-  }
+      val parsed = parser.parse(queryString)
+      val originalReader = catalogReaderSupplier.apply(false)
+      val readerWithPathAdjusted = new FlinkCalciteCatalogReader(
+        originalReader.getRootSchema,
+        List(schemaPath, schemaPath.subList(0, 1)).asJava,
+        originalReader.getTypeFactory,
+        originalReader.getConfig
+      )
+      val validator = createSqlValidator(readerWithPathAdjusted)
+      val validated = validate(parsed, validator)
+      rel(validated, validator)
+    }
 
-  override def createRelBuilder(): FlinkRelBuilder = {
-    sqlToRelConverterConfig.getRelBuilderFactory
-      .create(cluster, null)
-      .asInstanceOf[FlinkRelBuilder]
+    override def getCluster: RelOptCluster = cluster
   }
 }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.optimize
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.planner.calcite.{FlinkContext, ToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecSink
 import org.apache.flink.table.planner.plan.optimize.program.{BatchOptimizeContext, FlinkBatchProgram}
@@ -80,12 +81,17 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
       .getOrElse(FlinkBatchProgram.buildProgram(config.getConfiguration))
     Preconditions.checkNotNull(programs)
 
+    val context = relNode.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
+
     programs.optimize(relNode, new BatchOptimizeContext {
       override def getTableConfig: TableConfig = config
 
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
+
+      override def getToRexConverterFactory: ToRexConverterFactory =
+        context.getToRexConverterFactory
     })
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/BatchCommonSubGraphBasedOptimizer.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.optimize
 
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
-import org.apache.flink.table.planner.calcite.{FlinkContext, ToRexConverterFactory}
+import org.apache.flink.table.planner.calcite.{FlinkContext, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecSink
 import org.apache.flink.table.planner.plan.optimize.program.{BatchOptimizeContext, FlinkBatchProgram}
@@ -90,8 +90,8 @@ class BatchCommonSubGraphBasedOptimizer(planner: BatchPlanner)
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
 
-      override def getToRexConverterFactory: ToRexConverterFactory =
-        context.getToRexConverterFactory
+      override def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory =
+        context.getSqlExprToRexConverterFactory
     })
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.optimize
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.planner.calcite.{FlinkContext, ToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.`trait`.{AccMode, AccModeTraitDef, MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode, UpdateAsRetractionTraitDef}
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
@@ -164,6 +165,8 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
       .getOrElse(FlinkStreamProgram.buildProgram(config.getConfiguration))
     Preconditions.checkNotNull(programs)
 
+    val context = relNode.getCluster.getPlanner.getContext.unwrap(classOf[FlinkContext])
+
     programs.optimize(relNode, new StreamOptimizeContext() {
 
       override def getTableConfig: TableConfig = config
@@ -171,6 +174,9 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
       override def getFunctionCatalog: FunctionCatalog = planner.functionCatalog
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
+
+      override def getToRexConverterFactory: ToRexConverterFactory =
+        context.getToRexConverterFactory
 
       override def getRexBuilder: RexBuilder = planner.getRelBuilder.getRexBuilder
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.optimize
 import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.api.config.ExecutionConfigOptions
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
-import org.apache.flink.table.planner.calcite.{FlinkContext, ToRexConverterFactory}
+import org.apache.flink.table.planner.calcite.{FlinkContext, SqlExprToRexConverterFactory}
 import org.apache.flink.table.planner.delegation.StreamPlanner
 import org.apache.flink.table.planner.plan.`trait`.{AccMode, AccModeTraitDef, MiniBatchInterval, MiniBatchIntervalTrait, MiniBatchIntervalTraitDef, MiniBatchMode, UpdateAsRetractionTraitDef}
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
@@ -175,8 +175,8 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
 
       override def getCatalogManager: CatalogManager = planner.catalogManager
 
-      override def getToRexConverterFactory: ToRexConverterFactory =
-        context.getToRexConverterFactory
+      override def getSqlExprToRexConverterFactory: SqlExprToRexConverterFactory =
+        context.getSqlExprToRexConverterFactory
 
       override def getRexBuilder: RexBuilder = planner.getRelBuilder.getRexBuilder
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -95,7 +95,7 @@ class CatalogSourceTable[T](
         .getPlanner
         .getContext
         .unwrap(classOf[FlinkContext])
-        .getToRexConverterFactory
+        .getSqlExprToRexConverterFactory
 
     // 2. push computed column project
     val fieldNames = rowType.getFieldNames.asScala

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
@@ -116,4 +116,29 @@ Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
 
     </Resource>
   </TestCase>
+  <TestCase name="testTableApiScanWithDDL">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+
+  <TestCase name="testTableApiScanWithTemporaryTable">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CsvTableSource(read fields: word)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+TableSourceScan(table=[[default_catalog, default_database, t1, source: [CsvTableSource(read fields: word)]]], fields=[word])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
@@ -56,62 +56,43 @@ TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [Tes
 
     </Resource>
   </TestCase>
-  <TestCase name="testDDLWithComputedColumn">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM t1]]>
 
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]])
-]]>
-
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
-+- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
-]]>
-
-    </Resource>
-  </TestCase>
   <TestCase name="testDDLWithWatermarkComputedColumn">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM t1]]>
+      <![CDATA[SELECT * FROM c_watermark_t]]>
 
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, c_watermark_t, source: [CollectionTableSource(a, b)]]])
 ]]>
 
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
-+- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, c_watermark_t, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
 
     </Resource>
   </TestCase>
   <TestCase name="testDDLWithComputedColumn">
     <Resource name="sql">
-      <![CDATA[SELECT * FROM t1]]>
+      <![CDATA[SELECT * FROM computed_column_t]]>
 
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)])
-+- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, computed_column_t, source: [CollectionTableSource(a, b)]]])
 ]]>
 
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
-+- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, computed_column_t, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
 
     </Resource>
@@ -145,13 +126,13 @@ TableSourceScan(table=[[default_catalog, default_database, t1, source: [CsvTable
   <TestCase name="testTableApiScanWithWatermark">
     <Resource name="planBefore">
       <![CDATA[
-LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+LogicalTableScan(table=[[default_catalog, default_database, c_watermark_t, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
-+- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, c_watermark_t, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>
@@ -159,13 +140,13 @@ Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
   <TestCase name="testTableApiScanWithComputedColumn">
     <Resource name="planBefore">
       <![CDATA[
-LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+LogicalTableScan(table=[[default_catalog, default_database, computed_column_t, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
-+- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, computed_column_t, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.xml
@@ -141,4 +141,32 @@ TableSourceScan(table=[[default_catalog, default_database, t1, source: [CsvTable
 ]]>
     </Resource>
   </TestCase>
+
+  <TestCase name="testTableApiScanWithWatermark">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+
+  <TestCase name="testTableApiScanWithComputedColumn">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)], class: CatalogSourceTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -87,7 +87,7 @@ class AggCallSelectivityEstimatorTest {
     val moduleManager = mock(classOf[ModuleManager])
     val config = new TableConfig
     val functionCatalog = new FunctionCatalog(config, catalogManager, moduleManager)
-    val context = new FlinkContextImpl(new TableConfig, functionCatalog, catalogManager)
+    val context = new FlinkContextImpl(new TableConfig, functionCatalog, catalogManager, null)
     when(tableScan, "getCluster").thenReturn(cluster)
     when(cluster, "getRexBuilder").thenReturn(rexBuilder)
     when(cluster, "getTypeFactory").thenReturn(typeFactory)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimatorTest.scala
@@ -89,7 +89,8 @@ class SelectivityEstimatorTest {
     val catalogManager = CatalogManagerMocks.createEmptyCatalogManager()
     val moduleManager = mock(classOf[ModuleManager])
     val functionCatalog = new FunctionCatalog(tableConfig, catalogManager, moduleManager)
-    val context: FlinkContext = new FlinkContextImpl(tableConfig, functionCatalog, catalogManager)
+    val context: FlinkContext = new FlinkContextImpl(
+      tableConfig, functionCatalog, catalogManager, null)
     when(tableScan, "getCluster").thenReturn(cluster)
     when(cluster, "getRexBuilder").thenReturn(rexBuilder)
     when(cluster, "getPlanner").thenReturn(planner)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -66,10 +66,9 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.sql.parser.SqlParserPos
 import org.apache.calcite.sql.{SqlExplainLevel, SqlIntervalQualifier}
 import org.apache.commons.lang3.SystemUtils
-
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Rule
-import org.junit.rules.{ExpectedException, TestName}
+import org.junit.rules.{ExpectedException, TemporaryFolder, TestName}
 
 import _root_.java.math.{BigDecimal => JBigDecimal}
 import _root_.java.util
@@ -87,6 +86,11 @@ abstract class TableTestBase {
 
   // used for get test case method name
   val testName: TestName = new TestName
+
+  val _tempFolder = new TemporaryFolder
+
+  @Rule
+  def tempFolder: TemporaryFolder = _tempFolder
 
   @Rule
   def thrown: ExpectedException = expectedException


### PR DESCRIPTION
## What is the purpose of the change

`TableEnvironment.from/scan(string path)` cannot be used for all temporaryTable and CatalogTable (not DataStreamTable and ConnectorCatalogTable). Of course, it can be bypassed by `TableEnvironment.sqlQuery("select * from t")`, but `from/scan` are very important api of TableEnvironment and pure TableApi can't be used seriously.

## Brief change log

### Bug 1

The problem is that CatalogSourceTable.toRel wants to get the translator of the compute column. At present, CatalogSourceTable.toRe has two places to call:
1. The parser stage, which passes the correct compute column translator.
2. In the rule optimization stage, the correct compute column translator is not passed in the TableScanRule, so an error is reported.

There are three solutions:
1. Don't use ToRelContext to transfer the translators of compute column. Use FlinkContext to transfer so that we can get the correct translators of compute columns at any stage.
2. In CatalogSourceTable.toRel, when there is a compute column and the compute column translator cannot be obtained, an error is reported, and other cases pass normally. The disadvantage of this is that it is currently unable to support compute columns on TableApi.
3. @danny0405 suggestion, In the next version, separate the computed column and watermark translation to parser stage. But this need calcite interface modification too. No guarantee.

### Bug 2

Another bug is CatalogSourceTable need override explainSourceAsString. Otherwise hep rule optimizer can not distinguish CatalogSourceTable and TableSourceTable.

## Verifying this change

`TableScanTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)