### PR TITLE
[FLINK-15866][core]ClosureCleaner#getSuperClassOrInterfaceName throw NPE

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -225,6 +225,9 @@ public class ClosureCleaner {
 
 	private static String getSuperClassOrInterfaceName(Class<?> cls) {
 		Class<?> superclass = cls.getSuperclass();
+		if(superclass == null) {
+			return null;
+		}
 		if (superclass.getName().startsWith("org.apache.flink")) {
 			return superclass.getSimpleName();
 		} else {

--- a/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
@@ -231,6 +231,11 @@ public class ClosureCleanerTest {
 		Assert.assertEquals("text", writeReplace.getPayload().getRaw());
 		ClosureCleaner.clean(writeReplace, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
 	}
+
+	@Test(expected = InvalidProgramException.class)
+	public void testCleanedObjectClass() {
+		ClosureCleaner.clean(new Object(), ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+	}
 }
 
 class CustomMap implements MapFunction<Integer, Integer> {


### PR DESCRIPTION
Object type field was not implement Serializable, so checked it as unserialize object, and add check null before call superclass's method.