### PR TITLE
[FLINK-15838] Dangling CountDownLatch.await(timeout)

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/AbstractCloseableRegistryTest.java
@@ -240,7 +240,7 @@ public abstract class AbstractCloseableRegistryTest<C extends Closeable, T> {
 		 * Causes the current thread to wait until {@link #close()} is called.
 		 */
 		public void awaitClose(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
-			closeCalledLatch.await(timeout, timeUnit);
+			assertTrue(closeCalledLatch.await(timeout, timeUnit));
 		}
 	}
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -66,6 +66,8 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.junit.Assert.assertTrue;
+
 /**
  * Tests for the HistoryServer.
  */
@@ -142,7 +144,7 @@ public class HistoryServerTest extends TestLogger {
 		try {
 			hs.start();
 			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS));
 
 			Assert.assertEquals(numJobs + numLegacyJobs, getJobsOverview(baseUrl).getJobs().size());
 
@@ -193,7 +195,7 @@ public class HistoryServerTest extends TestLogger {
 		try {
 			hs.start();
 			String baseUrl = "http://localhost:" + hs.getWebPort();
-			numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedArchivedJobs.await(10L, TimeUnit.SECONDS));
 
 			Collection<JobDetails> jobs = getJobsOverview(baseUrl).getJobs();
 			Assert.assertEquals(numJobs, jobs.size());
@@ -207,7 +209,7 @@ public class HistoryServerTest extends TestLogger {
 			// delete one archive from jm
 			Files.deleteIfExists(jmDirectory.toPath().resolve(jobIdToDelete));
 
-			numExpectedExpiredJobs.await(10L, TimeUnit.SECONDS);
+			assertTrue(numExpectedExpiredJobs.await(10L, TimeUnit.SECONDS));
 
 			// check that archive is present in hs
 			Collection<JobDetails> jobsAfterDeletion = getJobsOverview(baseUrl).getJobs();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java
@@ -2402,7 +2402,7 @@ public abstract class AbstractByteBufTest extends TestLogger {
                 }
             }).start();
         }
-        latch.await(10, TimeUnit.SECONDS);
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
         barrier.await(5, TimeUnit.SECONDS);
         buffer.release();
     }
@@ -2457,7 +2457,7 @@ public abstract class AbstractByteBufTest extends TestLogger {
                 }
             }).start();
         }
-        latch.await(10, TimeUnit.SECONDS);
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
         barrier.await(5, TimeUnit.SECONDS);
         buffer.release();
     }
@@ -2512,7 +2512,7 @@ public abstract class AbstractByteBufTest extends TestLogger {
                 }
             }).start();
         }
-        latch.await(10, TimeUnit.SECONDS);
+		assertTrue(latch.await(10, TimeUnit.SECONDS));
         barrier.await(5, TimeUnit.SECONDS);
         assertNull(cause.get());
         buffer.release();

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -182,8 +182,10 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 		}
 
 		// wait until we restart at least 2 times and until we see at least 10 checkpoints.
-		numberOfRestarts.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
-		checkpointsToWaitFor.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+		assertTrue(numberOfRestarts.await(deadline.timeLeft().toMillis(),
+			TimeUnit.MILLISECONDS));
+		assertTrue(checkpointsToWaitFor.await(deadline.timeLeft().toMillis(),
+			TimeUnit.MILLISECONDS));
 
 		// verifying that we actually received a synchronous checkpoint
 		assertTrue(syncSavepointId.get() > 0);
@@ -287,7 +289,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 				null));
 
 		ClientUtils.submitJob(clusterClient, jobGraph);
-		invokeLatch.await(60, TimeUnit.SECONDS);
+		assertTrue(invokeLatch.await(60, TimeUnit.SECONDS));
 		waitForJob();
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTriggerSavepointITCase.java
@@ -62,6 +62,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link org.apache.flink.runtime.jobmaster.JobMaster#triggerSavepoint(String, boolean, Time)}.
@@ -114,7 +115,7 @@ public class JobMasterTriggerSavepointITCase extends AbstractTestBase {
 			null));
 
 		ClientUtils.submitJob(clusterClient, jobGraph);
-		invokeLatch.await(60, TimeUnit.SECONDS);
+		assertTrue(invokeLatch.await(60, TimeUnit.SECONDS));
 		waitForJob();
 	}
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/RescalingITCase.java
@@ -82,6 +82,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test savepoint rescaling.
@@ -193,7 +194,7 @@ public class RescalingITCase extends TestLogger {
 			ClientUtils.submitJob(client, jobGraph);
 
 			// wait til the sources have emitted numberElements for each key and completed a checkpoint
-			SubtaskIndexFlatMapper.workCompletedLatch.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertTrue(SubtaskIndexFlatMapper.workCompletedLatch.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 			// verify the current state
 
@@ -337,7 +338,7 @@ public class RescalingITCase extends TestLogger {
 			ClientUtils.submitJob(client, jobGraph);
 
 			// wait til the sources have emitted numberElements for each key and completed a checkpoint
-			SubtaskIndexFlatMapper.workCompletedLatch.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertTrue(SubtaskIndexFlatMapper.workCompletedLatch.await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 			// verify the current state
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SavepointITCase.java
@@ -436,7 +436,7 @@ public class SavepointITCase extends TestLogger {
 			JobID jobID = submissionResult.getJobID();
 
 			// wait for the Tasks to be ready
-			StatefulCounter.getProgressLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertTrue(StatefulCounter.getProgressLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 			savepointPath = client.triggerSavepoint(jobID, null).get();
 			LOG.info("Retrieved savepoint: " + savepointPath + ".");
@@ -484,10 +484,10 @@ public class SavepointITCase extends TestLogger {
 			// Submit the job
 			ClientUtils.submitJob(client, modifiedJobGraph);
 			// Await state is restored
-			StatefulCounter.getRestoreLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertTrue(StatefulCounter.getRestoreLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 
 			// Await some progress after restore
-			StatefulCounter.getProgressLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS);
+			assertTrue(StatefulCounter.getProgressLatch().await(deadline.timeLeft().toMillis(), TimeUnit.MILLISECONDS));
 		} finally {
 			cluster.after();
 		}


### PR DESCRIPTION
There are 16 occurrences in the codebase (all in test code) when the result of CountDownLatch.await(timeout, TimeUnit) is not checked. It's like not checking the result of File.delete(). The common fix is to wrap CDL.await() call into assertTrue().