### PR TITLE
[FLINK-15868][kinesis] Resolve version conflict between jackson-core and jackson-dataformat-cbor

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -92,6 +92,27 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		runElasticSearchSinkTest(SourceSinkDataTestKit::getJsonSinkFunction);
 	}
 
+	/**
+	 * Tests that the Elasticsearch sink works properly with cbor.
+	 */
+	public void runElasticsearchSinkCborTest() throws Exception {
+		runElasticSearchSinkTest(SourceSinkDataTestKit::getCborSinkFunction);
+	}
+
+	/**
+	 * Tests that the Elasticsearch sink works properly with smile.
+	 */
+	public void runElasticsearchSinkSmileTest() throws Exception {
+		runElasticSearchSinkTest(SourceSinkDataTestKit::getSmileSinkFunction);
+	}
+
+	/**
+	 * Tests that the Elasticsearch sink works properly with yaml.
+	 */
+	public void runElasticsearchSinkYamlTest() throws Exception {
+		runElasticSearchSinkTest(SourceSinkDataTestKit::getYamlSinkFunction);
+	}
+
 	private void runElasticSearchSinkTest(Function<String, ElasticsearchSinkFunction<Tuple2<Integer, String>>> functionFactory) throws Exception {
 		final String index = "elasticsearch-sink-test-index";
 

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.junit.Assert.fail;
 
@@ -85,9 +86,13 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 	}
 
 	/**
-	 * Tests that the Elasticsearch sink works properly.
+	 * Tests that the Elasticsearch sink works properly with json.
 	 */
 	public void runElasticsearchSinkTest() throws Exception {
+		runElasticSearchSinkTest(SourceSinkDataTestKit::getJsonSinkFunction);
+	}
+
+	private void runElasticSearchSinkTest(Function<String, ElasticsearchSinkFunction<Tuple2<Integer, String>>> functionFactory) throws Exception {
 		final String index = "elasticsearch-sink-test-index";
 
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -97,7 +102,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		source.addSink(createElasticsearchSinkForEmbeddedNode(
 				1,
 				CLUSTER_NAME,
-				new SourceSinkDataTestKit.TestElasticsearchSinkFunction(index)));
+				functionFactory.apply(index)));
 
 		env.execute("Elasticsearch Sink Test");
 
@@ -117,7 +122,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 					1,
 					CLUSTER_NAME,
 					null,
-					new SourceSinkDataTestKit.TestElasticsearchSinkFunction("test"));
+					SourceSinkDataTestKit.getJsonSinkFunction("test"));
 		} catch (IllegalArgumentException | NullPointerException expectedException) {
 			// test passes
 			return;
@@ -135,7 +140,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 					1,
 					CLUSTER_NAME,
 					Collections.emptyList(),
-					new SourceSinkDataTestKit.TestElasticsearchSinkFunction("test"));
+					SourceSinkDataTestKit.getJsonSinkFunction("test"));
 		} catch (IllegalArgumentException expectedException) {
 			// test passes
 			return;
@@ -155,7 +160,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		source.addSink(createElasticsearchSinkForNode(
 				1,
 				"invalid-cluster-name",
-				new SourceSinkDataTestKit.TestElasticsearchSinkFunction("test"),
+				SourceSinkDataTestKit.getJsonSinkFunction("test"),
 				"123.123.123.123")); // incorrect ip address
 
 		try {

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -112,10 +112,6 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 	 * Tests that the Elasticsearch sink fails eagerly if the provided list of addresses is {@code null}.
 	 */
 	public void runNullAddressesTest() throws Exception {
-		Map<String, String> userConfig = new HashMap<>();
-		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		userConfig.put("cluster.name", CLUSTER_NAME);
-
 		try {
 			createElasticsearchSink(
 					1,
@@ -134,10 +130,6 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 	 * Tests that the Elasticsearch sink fails eagerly if the provided list of addresses is empty.
 	 */
 	public void runEmptyAddressesTest() throws Exception {
-		Map<String, String> userConfig = new HashMap<>();
-		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		userConfig.put("cluster.name", CLUSTER_NAME);
-
 		try {
 			createElasticsearchSink(
 					1,
@@ -159,10 +151,6 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStreamSource<Tuple2<Integer, String>> source = env.addSource(new SourceSinkDataTestKit.TestDataSourceFunction());
-
-		Map<String, String> userConfig = new HashMap<>();
-		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, "1");
-		userConfig.put("cluster.name", "invalid-cluster-name");
 
 		source.addSink(createElasticsearchSinkForNode(
 				1,

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
@@ -27,8 +27,12 @@ import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
 import org.junit.Assert;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -66,28 +70,35 @@ public class SourceSinkDataTestKit {
 		}
 	}
 
-	/**
-	 * A {@link ElasticsearchSinkFunction} that indexes each element it receives to a specified Elasticsearch index.
-	 */
-	public static class TestElasticsearchSinkFunction implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {
+	public static ElasticsearchSinkFunction<Tuple2<Integer, String>> getJsonSinkFunction(String index) {
+		return new TestElasticsearchSinkFunction(index, XContentFactory::jsonBuilder);
+	}
+
+	private static class TestElasticsearchSinkFunction implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {
 		private static final long serialVersionUID = 1L;
 
 		private final String index;
+		private final XContentBuilderProvider contentBuilderProvider;
 
 		/**
 		 * Create the sink function, specifying a target Elasticsearch index.
 		 *
 		 * @param index Name of the target Elasticsearch index.
 		 */
-		public TestElasticsearchSinkFunction(String index) {
+		public TestElasticsearchSinkFunction(String index, XContentBuilderProvider contentBuilderProvider) {
 			this.index = index;
+			this.contentBuilderProvider = contentBuilderProvider;
 		}
 
 		public IndexRequest createIndexRequest(Tuple2<Integer, String> element) {
-			Map<String, Object> json = new HashMap<>();
-			json.put(DATA_FIELD_NAME, element.f1);
+			Map<String, Object> document = new HashMap<>();
+			document.put(DATA_FIELD_NAME, element.f1);
 
-			return new IndexRequest(index, TYPE_NAME, element.f0.toString()).source(json);
+			try {
+				return new IndexRequest(index, TYPE_NAME, element.f0.toString()).source(contentBuilderProvider.getBuilder().map(document));
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
 		}
 
 		@Override
@@ -108,6 +119,11 @@ public class SourceSinkDataTestKit {
 			GetResponse response = client.get(new GetRequest(index, TYPE_NAME, Integer.toString(i))).actionGet();
 			Assert.assertEquals(DATA_PREFIX + i, response.getSource().get(DATA_FIELD_NAME));
 		}
+	}
+
+	@FunctionalInterface
+	private interface XContentBuilderProvider extends Serializable {
+		XContentBuilder getBuilder() throws IOException;
 	}
 
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/testutils/SourceSinkDataTestKit.java
@@ -70,8 +70,20 @@ public class SourceSinkDataTestKit {
 		}
 	}
 
+	public static ElasticsearchSinkFunction<Tuple2<Integer, String>> getCborSinkFunction(String index) {
+		return new TestElasticsearchSinkFunction(index, XContentFactory::cborBuilder);
+	}
+
 	public static ElasticsearchSinkFunction<Tuple2<Integer, String>> getJsonSinkFunction(String index) {
 		return new TestElasticsearchSinkFunction(index, XContentFactory::jsonBuilder);
+	}
+
+	public static ElasticsearchSinkFunction<Tuple2<Integer, String>> getSmileSinkFunction(String index) {
+		return new TestElasticsearchSinkFunction(index, XContentFactory::smileBuilder);
+	}
+
+	public static ElasticsearchSinkFunction<Tuple2<Integer, String>> getYamlSinkFunction(String index) {
+		return new TestElasticsearchSinkFunction(index, XContentFactory::yamlBuilder);
 	}
 
 	private static class TestElasticsearchSinkFunction implements ElasticsearchSinkFunction<Tuple2<Integer, String>> {

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.carrotsearch:hppc:0.7.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.6.6
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.6
 - com.google.guava:guava:18.0
 - com.ning:compress-lzf:1.0.2

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.6
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - com.google.guava:guava:18.0
 - com.ning:compress-lzf:1.0.2
 - com.spatial4j:spatial4j:0.5

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.carrotsearch:hppc:0.7.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.6
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.6.6
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.6
 - com.google.guava:guava:18.0

--- a/flink-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch2/src/test/java/org/apache/flink/streaming/connectors/elasticsearch2/ElasticsearchSinkITCase.java
@@ -42,6 +42,21 @@ public class ElasticsearchSinkITCase extends ElasticsearchSinkTestBase<Transport
 	}
 
 	@Test
+	public void testElasticsearchSinkWithCbor() throws Exception {
+		runElasticsearchSinkCborTest();
+	}
+
+	@Test
+	public void testElasticsearchSinkWithSmile() throws Exception {
+		runElasticsearchSinkSmileTest();
+	}
+
+	@Test
+	public void testElasticsearchSinkWithYaml() throws Exception {
+		runElasticsearchSinkYamlTest();
+	}
+
+	@Test
 	public void testNullAddresses() throws Exception {
 		runNullAddressesTest();
 	}

--- a/flink-connectors/flink-connector-elasticsearch5/pom.xml
+++ b/flink-connectors/flink-connector-elasticsearch5/pom.xml
@@ -40,6 +40,17 @@ under the License.
 		<elasticsearch.version>5.1.2</elasticsearch.version>
 	</properties>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- Bump version to 1.25 to make it work with Jackson dependencies (2.10.1) -->
+			<dependency>
+				<groupId>org.yaml</groupId>
+				<artifactId>snakeyaml</artifactId>
+				<version>1.25</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 
 		<!-- core dependencies -->

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.carrotsearch:hppc:0.7.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1
 - com.github.spullara.mustache.java:compiler:0.9.3

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.carrotsearch:hppc:0.7.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - com.github.spullara.mustache.java:compiler:0.9.3
 - com.tdunning:t-digest:3.0
 - commons-codec:commons-codec:1.10

--- a/flink-connectors/flink-connector-elasticsearch5/src/test/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/test/java/org/apache/flink/streaming/connectors/elasticsearch5/ElasticsearchSinkITCase.java
@@ -47,6 +47,21 @@ public class ElasticsearchSinkITCase extends ElasticsearchSinkTestBase<Transport
 	}
 
 	@Test
+	public void testElasticsearchSinkWithCbor() throws Exception {
+		runElasticsearchSinkCborTest();
+	}
+
+	@Test
+	public void testElasticsearchSinkWithSmile() throws Exception {
+		runElasticsearchSinkSmileTest();
+	}
+
+	@Test
+	public void testElasticsearchSinkWithYaml() throws Exception {
+		runElasticsearchSinkYamlTest();
+	}
+
+	@Test
 	public void testNullAddresses() throws Exception {
 		runNullAddressesTest();
 	}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/ElasticsearchSinkITCase.java
@@ -45,6 +45,11 @@ public class ElasticsearchSinkITCase extends ElasticsearchSinkTestBase<RestHighL
 	}
 
 	@Test
+	public void testElasticsearchSinkWithSmile() throws Exception {
+		runElasticsearchSinkSmileTest();
+	}
+
+	@Test
 	public void testNullAddresses() throws Exception {
 		runNullAddressesTest();
 	}

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/ElasticsearchSinkITCase.java
@@ -45,6 +45,11 @@ public class ElasticsearchSinkITCase extends ElasticsearchSinkTestBase<RestHighL
 	}
 
 	@Test
+	public void testElasticsearchSinkWithSmile() throws Exception {
+		runElasticsearchSinkSmileTest();
+	}
+
+	@Test
 	public void testNullAddresses() throws Exception {
 		runNullAddressesTest();
 	}

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.10
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.10
 - commons-codec:commons-codec:1.10

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.10
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.10
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.11
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.11
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.4

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.11
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.8.11
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.11
 - commons-codec:commons-codec:1.10

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:11.0.2
 - commons-beanutils:commons-beanutils:1.9.3

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -22,7 +22,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.woodstox:woodstox-core:5.0.3
 - com.google.guava:guava:21.0
 - io.airlift:configuration:0.153

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -9,7 +9,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.9
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
 - com.github.mifmif:generex:1.0.2
 - com.squareup.okhttp3:logging-interceptor:3.12.0
 - com.squareup.okhttp3:okhttp:3.12.1

--- a/flink-table/flink-table-planner-blink/pom.xml
+++ b/flink-table/flink-table-planner-blink/pom.xml
@@ -155,9 +155,9 @@ under the License.
 				[INFO] |  +- commons-codec:commons-codec:jar:1.10:compile
 				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.21.0:compile
 				[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1:compile
 				[INFO] |  +- com.google.guava:guava:jar:19.0:compile
 				[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.4.0:compile
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -57,17 +57,6 @@ under the License.
 				<artifactId>janino</artifactId>
 				<version>${janino.version}</version>
 			</dependency>
-			<!-- Common dependencies within calcite-core -->
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.9.6</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.9.6</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -153,9 +142,9 @@ under the License.
 				[INFO] |  +- org.apache.calcite.avatica:avatica-core:jar:1.15.0:compile
 				[INFO] |  +- org.apache.calcite:calcite-linq4j:jar:1.21.0:compile
 				[INFO] |  +- org.apache.commons:commons-lang3:jar:3.3.2:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.6:compile
-				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.6:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.10.1:compile
+				[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.10.1:compile
 				[INFO] |  +- com.google.guava:guava:jar:19.0:compile
 				[INFO] |  \- com.jayway.jsonpath:json-path:jar:2.4.0:compile
 

--- a/pom.xml
+++ b/pom.xml
@@ -418,6 +418,12 @@ under the License.
 				<version>${jackson.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-yaml</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,12 @@ under the License.
 				<version>${jackson.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-smile</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -390,19 +390,26 @@ under the License.
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.10.1</version>
+				<version>${jackson.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.10.1</version>
+				<version>${jackson.version}</version>
 			</dependency>
 
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.10.1</version>
+				<version>${jackson.version}</version>
+			</dependency>
+
+			<!-- https://issues.apache.org/jira/browse/FLINK-15868 -->
+			<dependency>
+				<groupId>com.fasterxml.jackson.dataformat</groupId>
+				<artifactId>jackson-dataformat-cbor</artifactId>
+				<version>${jackson.version}</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION

## What is the purpose of the change

For the Kinesis consumer to work, `jackson-core` and `jackson-dataformat-cbor` need to be at the same version. This change will ensure that users get the same version w/o having to override the `jackson-dataformat-cbor` dependency.

Note that the versions are consistent in https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.11.603 - the problem was introduced by the dependency management in Flink.

## Verifying this change

Run `mvn dependency:tree` on a downstream project and check that versions are same. Was also tested with the 1.10 RC1 with one of our internal deployments.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
