### PR TITLE
[FLINK-15872][javadoc] Remove unnessary javadocs in InputFormat

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/InputFormat.java
@@ -86,26 +86,12 @@ public interface InputFormat<OT, T extends InputSplit> extends InputSplitSource<
 	 * @return The base statistics for the input, or null, if not available.
 	 */
 	BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException;
-	
-	/**
-	 * Creates the different splits of the input that can be processed in parallel.
-	 * <p>
-	 * When this method is called, the input format it guaranteed to be configured.
-	 * 
-	 * @param minNumSplits The minimum desired number of splits. If fewer are created, some parallel
-	 *                     instances may remain idle.
-	 * @return The splits of this input that can be processed in parallel. 
-	 * 
-	 * @throws IOException Thrown, when the creation of the splits was erroneous.
-	 */
+
+	// --------------------------------------------------------------------------------------------
+
 	@Override
 	T[] createInputSplits(int minNumSplits) throws IOException;
-	
-	/**
-	 * Gets the type of the input splits that are processed by this input format.
-	 * 
-	 * @return The type of the input splits.
-	 */
+
 	@Override
 	InputSplitAssigner getInputSplitAssigner(T[] inputSplits);
 	


### PR DESCRIPTION
## What is the purpose of the change

InputFormat overrides methods from InputSplitSource with almost the same method signature, so there's no need for extra javadocs (and one of them is wrong).

## Brief change log

- Remove `InputFormat#getInputSplitAssigner(T[])`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
