### PR TITLE
[Flink-15873] [cep] fix matches result not returned when existing earlier partial matches

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -377,12 +377,12 @@ public class NFA<T> {
 			nfaState.setStateChanged();
 			nfaState.getCompletedMatches().poll();
 			List<Map<String, List<EventId>>> matchedResult =
-					sharedBufferAccessor.extractPatterns(earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
+				sharedBufferAccessor.extractPatterns(earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
 
 			afterMatchSkipStrategy.prune(
-					nfaState.getCompletedMatches(),
-					matchedResult,
-					sharedBufferAccessor);
+				nfaState.getCompletedMatches(),
+				matchedResult,
+				sharedBufferAccessor);
 
 			result.add(sharedBufferAccessor.materializeMatch(matchedResult.get(0)));
 			sharedBufferAccessor.releaseNode(earliestMatch.getPreviousBufferEntry());

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -630,7 +630,10 @@ class MatchRecognizeITCase(backend: StateBackendMode) extends StreamingWithState
     result.addSink(sink)
     env.execute()
 
-    val expected = mutable.MutableList("1,5,0,null,2,3,3.4,8", "9,4,0,null,3,4,3.2,12")
+    val expected = mutable.MutableList(
+      "1,5,0,null,2,3,3.4,8",
+      "3,2,0,null,2,4,0.4,7",
+      "9,4,0,null,3,4,3.2,12")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/MatchRecognizeITCase.scala
@@ -588,7 +588,10 @@ class MatchRecognizeITCase extends StreamingWithStateTestBase {
     result.addSink(new StreamITCase.StringSink[Row])
     env.execute()
 
-    val expected = mutable.MutableList("1,5,0,null,2,3,3.4,8", "9,4,0,null,3,4,3.2,12")
+    val expected = mutable.MutableList(
+      "1,5,0,null,2,3,3.4,8",
+      "3,2,0,null,2,4,0.4,7",
+      "9,4,0,null,3,4,3.2,12")
     assertEquals(expected.sorted, StreamITCase.testResults.sorted)
   }
 


### PR DESCRIPTION

## What is the purpose of the change

*(This pull request fixes the bug that matches result may not be returned when existing earlier partial matches in a pattern configured with skip strategy.)*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in NFAITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
