### PR TITLE
[FLINK-15836][k8s] Throw fatal error in KubernetesResourceManager when the pods watcher is closed with exception

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/FlinkKubeClient.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient;
 
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesPod;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesWatch;
 
 import java.util.List;
 import java.util.Map;
@@ -96,9 +97,10 @@ public interface FlinkKubeClient extends AutoCloseable {
 	 * Watch the pods selected by labels and do the {@link PodCallbackHandler}.
 	 *
 	 * @param labels labels to filter the pods to watch
-	 * @param callbackHandler {@link PodCallbackHandler} will be called when the watcher receive the corresponding events.
+	 * @param podCallbackHandler podCallbackHandler which reacts to pod events
+	 * @return Return a watch for pods. It needs to be closed after use.
 	 */
-	void watchPodsAndDoCallback(Map<String, String> labels, PodCallbackHandler callbackHandler);
+	KubernetesWatch watchPodsAndDoCallback(Map<String, String> labels, PodCallbackHandler podCallbackHandler);
 
 	/**
 	 * Callback handler for kubernetes pods.
@@ -112,6 +114,8 @@ public interface FlinkKubeClient extends AutoCloseable {
 		void onDeleted(List<KubernetesPod> pods);
 
 		void onError(List<KubernetesPod> pods);
+
+		void handleFatalError(Throwable throwable);
 	}
 
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcher.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+
+/**
+ * Watcher for pods in Kubernetes.
+ */
+public class KubernetesPodsWatcher implements Watcher<Pod> {
+
+	private static final Logger LOG = LoggerFactory.getLogger(KubernetesPodsWatcher.class);
+
+	private final FlinkKubeClient.PodCallbackHandler podsCallbackHandler;
+
+	public KubernetesPodsWatcher(FlinkKubeClient.PodCallbackHandler callbackHandler) {
+		this.podsCallbackHandler = callbackHandler;
+	}
+
+	@Override
+	public void eventReceived(Action action, Pod pod) {
+		LOG.debug("Received {} event for pod {}, details: {}", action, pod.getMetadata().getName(), pod.getStatus());
+		switch (action) {
+			case ADDED:
+				podsCallbackHandler.onAdded(Collections.singletonList(new KubernetesPod(pod)));
+				break;
+			case MODIFIED:
+				podsCallbackHandler.onModified(Collections.singletonList(new KubernetesPod(pod)));
+				break;
+			case ERROR:
+				podsCallbackHandler.onError(Collections.singletonList(new KubernetesPod(pod)));
+				break;
+			case DELETED:
+				podsCallbackHandler.onDeleted(Collections.singletonList(new KubernetesPod(pod)));
+				break;
+			default:
+				LOG.debug("Ignore handling {} event for pod {}", action, pod.getMetadata().getName());
+				break;
+		}
+	}
+
+	@Override
+	public void onClose(KubernetesClientException cause) {
+		// null means the watcher is closed by expected.
+		if (cause == null) {
+			LOG.info("The pods watcher is closing.");
+		} else {
+			podsCallbackHandler.handleFatalError(cause);
+		}
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesWatch.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesWatch.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import io.fabric8.kubernetes.client.Watch;
+
+/**
+ * Watch resource in Kubernetes.
+ */
+public class KubernetesWatch extends KubernetesResource<Watch> {
+
+	public KubernetesWatch(Watch watch) {
+		super(watch);
+	}
+
+	public void close() {
+		getInternalResource().close();
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcherTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesPodsWatcherTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.util.TestLogger;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link KubernetesPodsWatcher}.
+ */
+public class KubernetesPodsWatcherTest extends TestLogger {
+
+	private final List<KubernetesPod> podAddedList = new ArrayList<>();
+	private final List<KubernetesPod> podModifiedList = new ArrayList<>();
+	private final List<KubernetesPod> podDeletedList = new ArrayList<>();
+	private final List<KubernetesPod> podErrorList = new ArrayList<>();
+
+	@Test
+	public void testClosingWithNullException() {
+		final KubernetesPodsWatcher podsWatcher = new KubernetesPodsWatcher(
+			new TestingCallbackHandler(e -> Assert.fail("Should not reach here.")));
+		podsWatcher.onClose(null);
+	}
+
+	@Test
+	public void testClosingWithException() {
+		final AtomicBoolean called = new AtomicBoolean(false);
+		final KubernetesPodsWatcher podsWatcher = new KubernetesPodsWatcher(
+			new TestingCallbackHandler(e -> called.set(true)));
+		podsWatcher.onClose(new KubernetesClientException("exception"));
+		assertThat(called.get(), is(true));
+	}
+
+	@Test
+	public void testCallbackHandler() {
+		FlinkPod pod = new FlinkPod.Builder().build();
+		final KubernetesPodsWatcher podsWatcher = new KubernetesPodsWatcher(new TestingCallbackHandler(e -> {}));
+		podsWatcher.eventReceived(Watcher.Action.ADDED, pod.getPod());
+		podsWatcher.eventReceived(Watcher.Action.MODIFIED, pod.getPod());
+		podsWatcher.eventReceived(Watcher.Action.DELETED, pod.getPod());
+		podsWatcher.eventReceived(Watcher.Action.ERROR, pod.getPod());
+
+		assertThat(podAddedList.size(), is(1));
+		assertThat(podModifiedList.size(), is(1));
+		assertThat(podDeletedList.size(), is(1));
+		assertThat(podErrorList.size(), is(1));
+	}
+
+	private class TestingCallbackHandler implements FlinkKubeClient.PodCallbackHandler {
+
+		final Consumer<Throwable> consumer;
+
+		TestingCallbackHandler(Consumer<Throwable> consumer) {
+			this.consumer = consumer;
+		}
+
+		@Override
+		public void onAdded(List<KubernetesPod> pods) {
+			podAddedList.addAll(pods);
+		}
+
+		@Override
+		public void onModified(List<KubernetesPod> pods) {
+			podModifiedList.addAll(pods);
+		}
+
+		@Override
+		public void onDeleted(List<KubernetesPod> pods) {
+			podDeletedList.addAll(pods);
+		}
+
+		@Override
+		public void onError(List<KubernetesPod> pods) {
+			podErrorList.addAll(pods);
+		}
+
+		@Override
+		public void handleFatalError(Throwable throwable) {
+			consumer.accept(throwable);
+		}
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

As the discussion in the [PR](https://github.com/apache/flink/pull/10965#discussion_r373491974), if the watchReconnectLimit is configured by users via java properties or environment, the watch may be stopped and all the changes will not be processed properly. So we need to throw a fatal exception in KubernetesResourceManager when the old one is closed with exception.

 

> Why do we not create a new watcher in KubernetesResourceManager when the old one closed exceptionally？

After checking the WatchConnectionManager implementation in fabric8 kubernetes client, if the web socket closed exceptionally, it will check the reconnectLimit and schedule a reconnect if needed. And when reconnect successfully, the currentReconnectAttempt will reset to 0. By default, it will retry forever. When the users explicitly specify the reconnectLimit, we should respect it.

Another reason is the the web socket closed exceptionally is usually because of network problems or port abuse. In such situation, it is better to fail the jobmanager pod and retry in a new one.

Also this behavior is same with YARN implementation. If `AMRMClient` heartbeats with YARN ResourceManager failed(the ipc client has retried enough times), then `YarnResourceManager` will also call the `onFatalError`.


## Brief change log

* Spin off the `KubernetesPodsWatcher` from `Fabric8FlinkKubeClient`
* Throw fatal error in KubernetesResourceManager when the pod watcher is closed with exception


## Verifying this change
* Covered by new added unit test


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
