### PR TITLE
[FLINK-15897][python] Defer the deserialization of the Python UDF execution results

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -263,7 +263,7 @@ public abstract class AbstractPythonFunctionOperator<IN, OUT>
 	/**
 	 * Sends the execution results to the downstream operator.
 	 */
-	public abstract void emitResults();
+	public abstract void emitResults() throws IOException;
 
 	/**
 	 * Reserves the memory used by the Python worker from the MemoryManager. This makes sure that

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.runners.python.PythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.types.CRow;
 import org.apache.flink.table.runtime.types.CRowTypeInfo;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
@@ -38,13 +39,14 @@ import org.apache.flink.util.Collector;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 /**
  * The Python {@link ScalarFunction} operator for the legacy planner.
  */
 @Internal
-public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOperator<CRow, CRow, Row, Row> {
+public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOperator<CRow, CRow, Row> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -58,6 +60,11 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 	 */
 	private transient TypeSerializer<CRow> forwardedInputSerializer;
 
+	/**
+	 * The TypeSerializer for udf execution results.
+	 */
+	private transient TypeSerializer<Row> udfOutputTypeSerializer;
+
 	public PythonScalarFunctionOperator(
 		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
@@ -69,6 +76,7 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
 	public void open() throws Exception {
 		super.open();
 		this.cRowWrapper = new StreamRecordCRowWrappingCollector(output);
@@ -81,6 +89,7 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 				.map(TypeConversions::fromDataTypeToLegacyInfo)
 				.toArray(TypeInformation[]::new)));
 		forwardedInputSerializer = forwardedInputTypeInfo.createSerializer(getExecutionConfig());
+		udfOutputTypeSerializer = PythonTypeUtils.toFlinkTypeSerializer(udfOutputType);
 	}
 
 	@Override
@@ -99,18 +108,20 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 
 	@Override
 	@SuppressWarnings("ConstantConditions")
-	public void emitResults() {
-		Row udfResult;
-		while ((udfResult = udfResultQueue.poll()) != null) {
+	public void emitResults() throws IOException {
+		byte[] rawUdfResult;
+		while ((rawUdfResult = udfResultQueue.poll()) != null) {
 			CRow input = forwardedInputQueue.poll();
 			cRowWrapper.setChange(input.change());
+			bais.setBuffer(rawUdfResult, 0, rawUdfResult.length);
+			Row udfResult = udfOutputTypeSerializer.deserialize(baisWrapper);
 			cRowWrapper.collect(Row.join(input.row(), udfResult));
 		}
 	}
 
 	@Override
 	public PythonFunctionRunner<Row> createPythonFunctionRunner(
-			FnDataReceiver<Row> resultReceiver,
+			FnDataReceiver<byte[]> resultReceiver,
 			PythonEnvironmentManager pythonEnvironmentManager) {
 		return new PythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonScalarFunctionRunner.java
@@ -49,10 +49,9 @@ import java.util.List;
  * Abstract {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
  *
  * @param <IN> Type of the input elements.
- * @param <OUT> Type of the execution results.
  */
 @Internal
-public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends AbstractPythonFunctionRunner<IN, OUT> {
+public abstract class AbstractPythonScalarFunctionRunner<IN> extends AbstractPythonFunctionRunner<IN> {
 
 	private static final String SCHEMA_CODER_URN = "flink:coder:schema:v1";
 	private static final String SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1";
@@ -76,7 +75,7 @@ public abstract class AbstractPythonScalarFunctionRunner<IN, OUT> extends Abstra
 
 	public AbstractPythonScalarFunctionRunner(
 		String taskName,
-		FnDataReceiver<OUT> resultReceiver,
+		FnDataReceiver<byte[]> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
@@ -35,11 +35,11 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
  * It takes {@link BaseRow} as the input and output type.
  */
 @Internal
-public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> {
+public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<BaseRow> {
 
 	public BaseRowPythonScalarFunctionRunner(
 		String taskName,
-		FnDataReceiver<BaseRow> resultReceiver,
+		FnDataReceiver<byte[]> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
@@ -51,11 +51,5 @@ public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunct
 	@SuppressWarnings("unchecked")
 	public BaseRowSerializer getInputTypeSerializer() {
 		return (BaseRowSerializer) PythonTypeUtils.toBlinkTypeSerializer(getInputType());
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public BaseRowSerializer getOutputTypeSerializer() {
-		return (BaseRowSerializer) PythonTypeUtils.toBlinkTypeSerializer(getOutputType());
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
@@ -35,11 +35,11 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
  * It takes {@link Row} as the input and output type.
  */
 @Internal
-public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<Row, Row> {
+public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<Row> {
 
 	public PythonScalarFunctionRunner(
 		String taskName,
-		FnDataReceiver<Row> resultReceiver,
+		FnDataReceiver<byte[]> resultReceiver,
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
@@ -51,11 +51,5 @@ public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunn
 	@SuppressWarnings("unchecked")
 	public RowSerializer getInputTypeSerializer() {
 		return (RowSerializer) PythonTypeUtils.toFlinkTypeSerializer(getInputType());
-	}
-
-	@Override
-	@SuppressWarnings("unchecked")
-	public RowSerializer getOutputTypeSerializer() {
-		return (RowSerializer) PythonTypeUtils.toFlinkTypeSerializer(getOutputType());
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/AbstractPythonScalarFunctionRunnerTest.java
@@ -29,11 +29,10 @@ import java.util.Collections;
  * Base class for PythonScalarFunctionRunner and BaseRowPythonScalarFunctionRunner test.
  *
  * @param <IN> Type of the input elements.
- * @param <OUT> Type of the output elements.
  */
-public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
+public abstract class AbstractPythonScalarFunctionRunnerTest<IN>  {
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createSingleUDFRunner() throws Exception {
+	AbstractPythonScalarFunctionRunner<IN> createSingleUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -44,7 +43,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, rowType, rowType);
 	}
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createMultipleUDFRunner() throws Exception {
+	AbstractPythonScalarFunctionRunner<IN> createMultipleUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -64,7 +63,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, inputType, outputType);
 	}
 
-	AbstractPythonScalarFunctionRunner<IN, OUT> createChainedUDFRunner() throws Exception {
+	AbstractPythonScalarFunctionRunner<IN> createChainedUDFRunner() throws Exception {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -102,7 +101,7 @@ public abstract class AbstractPythonScalarFunctionRunnerTest<IN, OUT>  {
 		return createPythonScalarFunctionRunner(pythonFunctionInfos, inputType, outputType);
 	}
 
-	public abstract AbstractPythonScalarFunctionRunner<IN, OUT> createPythonScalarFunctionRunner(
+	public abstract AbstractPythonScalarFunctionRunner<IN> createPythonScalarFunctionRunner(
 		PythonFunctionInfo[] pythonFunctionInfos, RowType inputType, RowType outputType) throws Exception;
 
 	/**

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonScalarFunctionRunnerTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -41,62 +40,47 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link BaseRowPythonScalarFunctionRunner}. These test that
  * the input data type and output data type are properly constructed.
  */
-public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFunctionRunnerTest<BaseRow, BaseRow> {
+public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFunctionRunnerTest<BaseRow> {
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForSingleUDF() throws Exception {
-		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createSingleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<BaseRow> runner = createSingleUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof BaseRowSerializer);
 
 		assertEquals(1, ((BaseRowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof BaseRowSerializer);
-		assertEquals(1, ((BaseRowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForMultipleUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createMultipleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<BaseRow> runner = createMultipleUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof BaseRowSerializer);
 
 		assertEquals(3, ((BaseRowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof BaseRowSerializer);
-		assertEquals(2, ((BaseRowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForChainedUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> runner = createChainedUDFRunner();
+		final AbstractPythonScalarFunctionRunner<BaseRow> runner = createChainedUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof BaseRowSerializer);
 
 		assertEquals(5, ((BaseRowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof BaseRowSerializer);
-		assertEquals(3, ((BaseRowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Override
-	public AbstractPythonScalarFunctionRunner<BaseRow, BaseRow> createPythonScalarFunctionRunner(
+	public AbstractPythonScalarFunctionRunner<BaseRow> createPythonScalarFunctionRunner(
 		final PythonFunctionInfo[] pythonFunctionInfos,
 		RowType inputType,
-		RowType outputType) throws IOException {
-		final FnDataReceiver<BaseRow> dummyReceiver = input -> {
+		RowType outputType) {
+		final FnDataReceiver<byte[]> dummyReceiver = input -> {
 			// ignore the execution results
 		};
 

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/PythonScalarFunctionRunnerTest.java
@@ -43,7 +43,6 @@ import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
 import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,59 +65,44 @@ import static org.mockito.Mockito.when;
  *     <li>The UDF proto is properly constructed</li>
  * </ul>
  */
-public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunctionRunnerTest<Row, Row> {
+public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunctionRunnerTest<Row> {
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForSingleUDF() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createSingleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createSingleUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof RowSerializer);
 
 		assertEquals(1, ((RowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof RowSerializer);
-		assertEquals(1, ((RowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForMultipleUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createMultipleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createMultipleUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof RowSerializer);
 
 		assertEquals(3, ((RowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof RowSerializer);
-		assertEquals(2, ((RowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Test
 	public void testInputOutputDataTypeConstructedProperlyForChainedUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createChainedUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createChainedUDFRunner();
 
 		// check input TypeSerializer
 		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
 		assertTrue(inputTypeSerializer instanceof RowSerializer);
 
 		assertEquals(5, ((RowSerializer) inputTypeSerializer).getArity());
-
-		// check output TypeSerializer
-		TypeSerializer outputTypeSerializer = runner.getOutputTypeSerializer();
-		assertTrue(outputTypeSerializer instanceof RowSerializer);
-		assertEquals(3, ((RowSerializer) outputTypeSerializer).getArity());
 	}
 
 	@Test
 	public void testUDFnProtoConstructedProperlyForSingleUDF() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createSingleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createSingleUDFRunner();
 
 		FlinkFnApi.UserDefinedFunctions udfs = runner.getUserDefinedFunctionsProto();
 		assertEquals(1, udfs.getUdfsCount());
@@ -130,7 +114,7 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 
 	@Test
 	public void testUDFProtoConstructedProperlyForMultipleUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createMultipleUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createMultipleUDFRunner();
 
 		FlinkFnApi.UserDefinedFunctions udfs = runner.getUserDefinedFunctionsProto();
 		assertEquals(2, udfs.getUdfsCount());
@@ -148,7 +132,7 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 
 	@Test
 	public void testUDFProtoConstructedProperlyForChainedUDFs() throws Exception {
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner = createChainedUDFRunner();
+		final AbstractPythonScalarFunctionRunner<Row> runner = createChainedUDFRunner();
 
 		FlinkFnApi.UserDefinedFunctions udfs = runner.getUserDefinedFunctionsProto();
 		assertEquals(3, udfs.getUdfsCount());
@@ -180,8 +164,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 	@Test
 	public void testPythonScalarFunctionRunner() throws Exception {
 		JobBundleFactory jobBundleFactorySpy = spy(JobBundleFactory.class);
-		FnDataReceiver<Row> resultReceiverSpy = spy(FnDataReceiver.class);
-		final AbstractPythonScalarFunctionRunner<Row, Row> runner =
+		FnDataReceiver<byte[]> resultReceiverSpy = spy(FnDataReceiver.class);
+		final AbstractPythonScalarFunctionRunner<Row> runner =
 			createUDFRunner(jobBundleFactorySpy, resultReceiverSpy);
 
 		StageBundleFactory stageBundleFactorySpy = spy(StageBundleFactory.class);
@@ -219,11 +203,11 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 	}
 
 	@Override
-	public AbstractPythonScalarFunctionRunner<Row, Row> createPythonScalarFunctionRunner(
+	public AbstractPythonScalarFunctionRunner<Row> createPythonScalarFunctionRunner(
 		final PythonFunctionInfo[] pythonFunctionInfos,
 		RowType inputType,
-		RowType outputType) throws IOException {
-		final FnDataReceiver<Row> dummyReceiver = input -> {
+		RowType outputType) {
+		final FnDataReceiver<byte[]> dummyReceiver = input -> {
 			// ignore the execution results
 		};
 
@@ -242,8 +226,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			outputType);
 	}
 
-	private AbstractPythonScalarFunctionRunner<Row, Row> createUDFRunner(
-		JobBundleFactory jobBundleFactory, FnDataReceiver<Row> receiver) throws IOException {
+	private AbstractPythonScalarFunctionRunner<Row> createUDFRunner(
+		JobBundleFactory jobBundleFactory, FnDataReceiver<byte[]> receiver) {
 		PythonFunctionInfo[] pythonFunctionInfos = new PythonFunctionInfo[] {
 			new PythonFunctionInfo(
 				DummyPythonFunction.INSTANCE,
@@ -274,7 +258,7 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 
 		PythonScalarFunctionRunnerTestHarness(
 			String taskName,
-			FnDataReceiver<Row> resultReceiver,
+			FnDataReceiver<byte[]> resultReceiver,
 			PythonFunctionInfo[] scalarFunctions,
 			PythonEnvironmentManager environmentManager,
 			RowType inputType, RowType outputType,
@@ -284,7 +268,7 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 		}
 
 		@Override
-		public JobBundleFactory createJobBundleFactory(Struct pipelineOptions) throws Exception {
+		public JobBundleFactory createJobBundleFactory(Struct pipelineOptions) {
 			return jobBundleFactory;
 		}
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.operators.python;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
@@ -29,6 +30,7 @@ import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -43,7 +45,7 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryrow;
  * Tests for {@link BaseRowPythonScalarFunctionOperator}.
  */
 public class BaseRowPythonScalarFunctionOperatorTest
-		extends PythonScalarFunctionOperatorTestBase<BaseRow, BaseRow, BaseRow, BaseRow> {
+		extends PythonScalarFunctionOperatorTestBase<BaseRow, BaseRow, BaseRow> {
 
 	private final BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(new TypeInformation[]{
 		Types.STRING,
@@ -52,7 +54,7 @@ public class BaseRowPythonScalarFunctionOperatorTest
 	});
 
 	@Override
-	public AbstractPythonScalarFunctionOperator<BaseRow, BaseRow, BaseRow, BaseRow> getTestOperator(
+	public AbstractPythonScalarFunctionOperator<BaseRow, BaseRow, BaseRow> getTestOperator(
 		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
@@ -104,7 +106,7 @@ public class BaseRowPythonScalarFunctionOperatorTest
 
 		@Override
 		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
-				FnDataReceiver<BaseRow> resultReceiver,
+				FnDataReceiver<byte[]> resultReceiver,
 				PythonEnvironmentManager pythonEnvironmentManager) {
 			return new PassThroughPythonFunctionRunner<BaseRow>(resultReceiver) {
 				@Override
@@ -112,6 +114,11 @@ public class BaseRowPythonScalarFunctionOperatorTest
 					BaseRow row = binaryrow(element.getLong(0));
 					row.setHeader(element.getHeader());
 					return row;
+				}
+
+				@Override
+				public TypeSerializer<BaseRow> getInputTypeSerializer() {
+					return PythonTypeUtils.toBlinkTypeSerializer(udfInputType);
 				}
 			};
 		}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.python;
 
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
@@ -26,6 +27,7 @@ import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.types.CRow;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
@@ -37,10 +39,10 @@ import java.util.Queue;
 /**
  * Tests for {@link PythonScalarFunctionOperator}.
  */
-public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperatorTestBase<CRow, CRow, Row, Row> {
+public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperatorTestBase<CRow, CRow, Row> {
 
 	@Override
-	public AbstractPythonScalarFunctionOperator<CRow, CRow, Row, Row> getTestOperator(
+	public AbstractPythonScalarFunctionOperator<CRow, CRow, Row> getTestOperator(
 		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,
@@ -80,12 +82,18 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 
 		@Override
 		public PythonFunctionRunner<Row> createPythonFunctionRunner(
-				FnDataReceiver<Row> resultReceiver,
+				FnDataReceiver<byte[]> resultReceiver,
 				PythonEnvironmentManager pythonEnvironmentManager) {
 			return new PassThroughPythonFunctionRunner<Row>(resultReceiver) {
 				@Override
 				public Row copy(Row element) {
 					return Row.copy(element);
+				}
+
+				@Override
+				@SuppressWarnings("unchecked")
+				public TypeSerializer<Row> getInputTypeSerializer() {
+					return PythonTypeUtils.toFlinkTypeSerializer(udfInputType);
 				}
 			};
 		}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperatorTestBase.java
@@ -58,9 +58,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  * @param <IN> Type of the input elements.
  * @param <OUT> Type of the output elements.
  * @param <UDFIN> Type of the UDF input type.
- * @param <UDFOUT> Type of the UDF input type.
  */
-public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOUT> {
+public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 
 	@Test
 	public void testRetractionFieldKept() throws Exception {
@@ -214,7 +213,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 			new RowType.RowField("f1", new VarCharType()),
 			new RowType.RowField("f2", new VarCharType()),
 			new RowType.RowField("f3", new BigIntType())));
-		AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> operator = getTestOperator(
+		AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN> operator = getTestOperator(
 			config,
 			new PythonFunctionInfo[] {
 				new PythonFunctionInfo(
@@ -233,7 +232,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN, UDFOU
 		return testHarness;
 	}
 
-	public abstract AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN, UDFOUT> getTestOperator(
+	public abstract AbstractPythonScalarFunctionOperator<IN, OUT, UDFIN> getTestOperator(
 		Configuration config,
 		PythonFunctionInfo[] scalarFunctions,
 		RowType inputType,


### PR DESCRIPTION
## What is the purpose of the change

*Currently, the Python UDF execution results are deserialized and then buffered in a collection when received from the Python worker. The deserialization could be deferred when sending the execution results to the downstream operator. That's to say, it buffers the serialized bytes instead of the deserialized Java objects in the buffer. This could reduce the memory footprint of the Java operator.*

## Brief change log

  - *Update AbstractPythonFunctionRunner to not deserialize the UDF execution results when received from the Python worker*
  - *The UDF execution results are deserialized in PythonScalarFunctionOperator when sending them out to the downstream operator*


## Verifying this change

This change is an improvement and is already covered by existing tests, such as *test_udf.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
