### PR TITLE
[FLINK-15905][runtime] Fix race condition between allocation and release of OpaqueMemoryResource

### DIFF
--- a/docs/_includes/generated/expert_high_availability_section.html
+++ b/docs/_includes/generated/expert_high_availability_section.html
@@ -12,7 +12,7 @@
             <td><h5>high-availability.jobmanager.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>
-            <td>Optional port (range) used by the job manager in high-availability mode.</td>
+            <td>The port (range) used by the Flink Master for its RPC connections in highly-available setups. In highly-available setups, this value is used instead of 'jobmanager.rpc.port'.A value of '0' means that a random free port is chosen. TaskManagers discover this port through the high-availability services (leader election), so a random port or a port range works without requiring any additional means of service discovery.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/high_availability_configuration.html
+++ b/docs/_includes/generated/high_availability_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>high-availability.jobmanager.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>
-            <td>Optional port (range) used by the job manager in high-availability mode.</td>
+            <td>The port (range) used by the Flink Master for its RPC connections in highly-available setups. In highly-available setups, this value is used instead of 'jobmanager.rpc.port'.A value of '0' means that a random free port is chosen. TaskManagers discover this port through the high-availability services (leader election), so a random port or a port range works without requiring any additional means of service discovery.</td>
         </tr>
         <tr>
             <td><h5>high-availability.storageDir</h5></td>

--- a/docs/ops/state/large_state_tuning.md
+++ b/docs/ops/state/large_state_tuning.md
@@ -92,27 +92,6 @@ the same time. For applications with large state in Flink, this often ties up to
 When a savepoint is manually triggered, it may be in process concurrently with an ongoing checkpoint.
 
 
-## Tuning Network Buffers
-
-Before Flink 1.3, an increased number of network buffers also caused increased checkpointing times since
-keeping more in-flight data meant that checkpoint barriers got delayed. Since Flink 1.3, the
-number of network buffers used per outgoing/incoming channel is limited and thus network buffers
-may be configured without affecting checkpoint times
-(see [network buffer configuration](../config.html#configuring-the-network-buffers)).
-
-## Asynchronous Checkpointing
-
-When state is *asynchronously* snapshotted, the checkpoints scale better than when the state is *synchronously* snapshotted.
-Especially in more complex streaming applications with multiple joins, co-functions, or windows, this may have a profound
-impact.
-
-For state to be snapshotted asynchronsously, you need to use a state backend which supports asynchronous snapshotting.
-Starting from Flink 1.3, both RocksDB-based as well as heap-based state backends (`filesystem`) support asynchronous
-snapshotting and use it by default. This applies to both managed operator state as well as managed keyed state (incl. timers state).
-
-<span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state.
-Other state like keyed state is still snapshotted asynchronously. Please note that this is not a regression from previous versions and will be resolved with `FLINK-10026`.*
-
 ## Tuning RocksDB
 
 The state storage workhorse of many large scale Flink streaming applications is the *RocksDB State Backend*.

--- a/docs/ops/state/large_state_tuning.zh.md
+++ b/docs/ops/state/large_state_tuning.zh.md
@@ -92,27 +92,6 @@ the same time. For applications with large state in Flink, this often ties up to
 When a savepoint is manually triggered, it may be in process concurrently with an ongoing checkpoint.
 
 
-## Tuning Network Buffers
-
-Before Flink 1.3, an increased number of network buffers also caused increased checkpointing times since
-keeping more in-flight data meant that checkpoint barriers got delayed. Since Flink 1.3, the
-number of network buffers used per outgoing/incoming channel is limited and thus network buffers
-may be configured without affecting checkpoint times
-(see [network buffer configuration](../config.html#configuring-the-network-buffers)).
-
-## Asynchronous Checkpointing
-
-When state is *asynchronously* snapshotted, the checkpoints scale better than when the state is *synchronously* snapshotted.
-Especially in more complex streaming applications with multiple joins, co-functions, or windows, this may have a profound
-impact.
-
-For state to be snapshotted asynchronsously, you need to use a state backend which supports asynchronous snapshotting.
-Starting from Flink 1.3, both RocksDB-based as well as heap-based state backends (`filesystem`) support asynchronous
-snapshotting and use it by default. This applies to both managed operator state as well as managed keyed state (incl. timers state).
-
-<span class="label label-info">Note</span> *The combination RocksDB state backend with heap-based timers currently does NOT support asynchronous snapshots for the timers state.
-Other state like keyed state is still snapshotted asynchronously. Please note that this is not a regression from previous versions and will be resolved with `FLINK-10026`.*
-
 ## Tuning RocksDB
 
 The state storage workhorse of many large scale Flink streaming applications is the *RocksDB State Backend*.

--- a/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/HighAvailabilityOptions.java
@@ -79,9 +79,15 @@ public class HighAvailabilityOptions {
 	@Documentation.Section(Documentation.Sections.EXPERT_HIGH_AVAILABILITY)
 	public static final ConfigOption<String> HA_JOB_MANAGER_PORT_RANGE =
 			key("high-availability.jobmanager.port")
+			.stringType()
 			.defaultValue("0")
 			.withDeprecatedKeys("recovery.jobmanager.port")
-			.withDescription("Optional port (range) used by the job manager in high-availability mode.");
+			.withDescription(
+					"The port (range) used by the Flink Master for its RPC connections in highly-available setups. " +
+					"In highly-available setups, this value is used instead of '" + JobManagerOptions.PORT.key() + "'." +
+					"A value of '0' means that a random free port is chosen. TaskManagers discover this port through " +
+					"the high-availability services (leader election), so a random port or a port range works " +
+					"without requiring any additional means of service discovery.");
 
 	// ------------------------------------------------------------------------
 	//  ZooKeeper Options

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/TaskInformation.java
@@ -32,22 +32,22 @@ public class TaskInformation implements Serializable {
 
 	private static final long serialVersionUID = -9006218793155953789L;
 
-	/** Job vertex id of the associated job vertex */
+	/** Job vertex id of the associated job vertex. */
 	private final JobVertexID jobVertexId;
 
-	/** Name of the task */
+	/** Name of the task. */
 	private final String taskName;
 
-	/** The number of subtasks for this operator */
+	/** The number of subtasks for this operator. */
 	private final int numberOfSubtasks;
 
-	/** The maximum parallelism == number of key groups */
+	/** The maximum parallelism == number of key groups. */
 	private final int maxNumberOfSubtasks;
 
-	/** Class name of the invokable to run */
+	/** Class name of the invokable to run. */
 	private final String invokableClassName;
 
-	/** Configuration for the task */
+	/** Configuration for the task. */
 	private final Configuration taskConfiguration;
 
 	public TaskInformation(
@@ -59,8 +59,8 @@ public class TaskInformation implements Serializable {
 			Configuration taskConfiguration) {
 		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
 		this.taskName = Preconditions.checkNotNull(taskName);
-		this.numberOfSubtasks = Preconditions.checkNotNull(numberOfSubtasks);
-		this.maxNumberOfSubtasks = Preconditions.checkNotNull(maxNumberOfSubtasks);
+		this.numberOfSubtasks = numberOfSubtasks;
+		this.maxNumberOfSubtasks = maxNumberOfSubtasks;
 		this.invokableClassName = Preconditions.checkNotNull(invokableClassName);
 		this.taskConfiguration = Preconditions.checkNotNull(taskConfiguration);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/memory/MemoryManager.java
@@ -50,6 +50,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateOffHeapUnsafeMemory;
 import static org.apache.flink.core.memory.MemorySegmentFactory.allocateUnpooledSegment;
@@ -567,6 +568,13 @@ public class MemoryManager {
 	 *
 	 * <p>The OpaqueMemoryResource object returned from this method must be closed once not used any further.
 	 * Once all acquisitions have closed the object, the resource itself is closed.
+	 *
+	 * <p><b>Important:</b> The failure semantics are as follows: If the memory manager fails to reserve
+	 * the memory, the external resource initializer will not be called. If an exception is thrown when the
+	 * opaque resource is closed (last lease is released), the memory manager will still un-reserve the
+	 * memory to make sure its own accounting is clean. The exception will need to be handled by the caller of
+	 * {@link OpaqueMemoryResource#close()}. For example, if this indicates that native memory was not released
+	 * and the process might thus have a memory leak, the caller can decide to kill the process as a result.
 	 */
 	public <T extends AutoCloseable> OpaqueMemoryResource<T> getSharedMemoryResourceForManagedMemory(
 			String type,
@@ -576,7 +584,9 @@ public class MemoryManager {
 		// if we need to allocate the resource (no shared resource allocated, yet), this would be the size to use
 		final long numBytes = computeMemorySize(fractionToInitializeWith);
 
-		// the initializer attempt to reserve the memory before actual initialization
+		// initializer and releaser as functions that are pushed into the SharedResources,
+		// so that the SharedResources can decide in (thread-safely execute) when initialization
+		// and release should happen
 		final LongFunctionWithException<T, Exception> reserveAndInitialize = (size) -> {
 			try {
 				reserveMemory(type, MemoryType.OFF_HEAP, size);
@@ -587,6 +597,8 @@ public class MemoryManager {
 
 			return initializer.apply(size);
 		};
+
+		final Consumer<Long> releaser = (size) -> releaseMemory(type, MemoryType.OFF_HEAP, size);
 
 		// This object identifies the lease in this request. It is used only to identify the release operation.
 		// Using the object to represent the lease is a bit nicer safer than just using a reference counter.
@@ -599,12 +611,7 @@ public class MemoryManager {
 		// someone else before with a different value for fraction (should not happen in practice, though).
 		final long size = resource.size();
 
-		final ThrowingRunnable<Exception> disposer = () -> {
-				final boolean allDisposed = sharedResources.release(type, leaseHolder);
-				if (allDisposed) {
-					releaseMemory(type, MemoryType.OFF_HEAP, size);
-				}
-			};
+		final ThrowingRunnable<Exception> disposer = () -> sharedResources.release(type, leaseHolder, releaser);
 
 		return new OpaqueMemoryResource<>(resource.resourceHandle(), size, disposer);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerSharedResourcesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerSharedResourcesTest.java
@@ -117,6 +117,7 @@ public class MemoryManagerSharedResourcesTest {
 		resource1.close();
 
 		assertFalse(resource1.getResourceHandle().closed);
+		assertFalse(memoryManager.verifyEmpty());
 	}
 
 	@Test
@@ -132,6 +133,7 @@ public class MemoryManagerSharedResourcesTest {
 		resource2.close();
 
 		assertTrue(resource1.getResourceHandle().closed);
+		assertTrue(memoryManager.verifyEmpty());
 	}
 
 	@Test
@@ -145,6 +147,7 @@ public class MemoryManagerSharedResourcesTest {
 		resource1.close();
 
 		assertFalse(resource1.getResourceHandle().closed);
+		assertFalse(memoryManager.verifyEmpty());
 	}
 
 	@Test
@@ -160,6 +163,7 @@ public class MemoryManagerSharedResourcesTest {
 
 		assertTrue(resource1.getResourceHandle().closed);
 		assertTrue(resource2.getResourceHandle().closed);
+		assertTrue(memoryManager.verifyEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes the race condition when releasing `OpaqueMemoryResource`between the following lines: 
```java
final boolean allDisposed = sharedResources.release(type, leaseHolder);
if (allDisposed) {
	releaseMemory(type, MemoryType.OFF_HEAP, size);
}
```
  - The shared resource release happens under lock
  - Releasing the memory to the memory manager is outside the lock
  - Another thread can find the resource released, but the memory not yet returned

The solution is to push the memory release (via a lambda) into the `sharedResources` such that the release also happens under the lock.

## Verifying this change

This extends the existing unit tests.
Thread safety is not verified in unit tests, as this is not easily possible.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
