### PR TITLE
[FLINK-15914][checkpointing][metrics] Miss the barrier alignment metric for the case of two inputs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
@@ -66,6 +67,7 @@ public class InputProcessorUtil {
 			InputGate inputGate1,
 			InputGate inputGate2,
 			Configuration taskManagerConfig,
+			TaskIOMetricGroup taskIOMetricGroup,
 			String taskName) throws IOException {
 
 		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
@@ -90,6 +92,8 @@ public class InputProcessorUtil {
 			inputGate1.getNumberOfInputChannels() + inputGate2.getNumberOfInputChannels(),
 			taskName,
 			toNotifyOnCheckpoint);
+		taskIOMetricGroup.gauge("checkpointAlignmentTime", barrierHandler::getAlignmentDurationNanos);
+
 		return new CheckpointedInputGate[] {
 			new CheckpointedInputGate(inputGate1, linkedBufferStorage1, barrierHandler),
 			new CheckpointedInputGate(inputGate2, linkedBufferStorage2, barrierHandler, inputGate1.getNumberOfInputChannels())

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -66,6 +66,7 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 			unionedInputGate1,
 			unionedInputGate2,
 			getEnvironment().getTaskManagerInfo().getConfiguration(),
+			getEnvironment().getMetricGroup().getIOMetricGroup(),
 			getTaskNameWithSubtaskAndId());
 		checkState(checkpointedInputGates.length == 2);
 


### PR DESCRIPTION
## What is the purpose of the change

When the `StreamTwoInputSelectableProcessor` was introduced before, it was missing to add the barrier alignment metric in the constructor. But it does not cause problems then, because only `StreamTwoInputProcessor` works at that time.  After `StreamTwoInputProcessor` is replaced by `StreamTwoInputSelectableProcessor` as now, this bug is exposed and we will not see the barrier alignment metric for the case of two inputs.
    
The solution is to add this metric while constructing the `CheckpointBarrierHandler`.

## Brief change log

  - *Add the metric of barrier alignment while constructing the `CheckpointBarrierHandler`*

## Verifying this change

Via the job testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
