### PR TITLE
[FLINK-15546][table-planner-blink] Fix obscure error message from Sca…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -1280,8 +1280,8 @@ object ScalarOperatorGens {
           | (INTERVAL_YEAR_MONTH, BIGINT) =>
       internalExprCasting(operand, targetType)
 
-    case (from, to) =>
-      throw new CodeGenException(s"Unsupported cast from '$from' to '$to'.")
+    case (_, _) =>
+      throw new CodeGenException(s"Unsupported cast from '${operand.resultType}' to '$targetType'.")
   }
 
   def generateIfElse(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/cast.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/cast.scala
@@ -38,7 +38,7 @@ case class Cast(child: PlannerExpression, resultType: TypeInformation[_])
       fromTypeInfoToLogicalType(resultType))) {
       ValidationSuccess
     } else {
-      ValidationFailure(s"Unsupported cast from ${child.resultType} to $resultType")
+      ValidationFailure(s"Unsupported cast from '${child.resultType}' to '$resultType'")
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
@@ -18,11 +18,10 @@
 
 package org.apache.flink.table.planner.expressions
 
-import org.apache.flink.table.api.DataTypes
+import org.apache.flink.table.api.{DataTypes, ValidationException}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.expressions.utils.RowTypeTestBase
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => gLocalTime}
-
 import org.junit.Test
 
 class RowTypeTest extends RowTypeTestBase {
@@ -129,4 +128,17 @@ class RowTypeTest extends RowTypeTestBase {
       "null"
     )
   }
+
+  @Test
+  def testUnsupportedCast(): Unit = {
+    expectedException.expect(classOf[ValidationException])
+    expectedException.expectMessage(
+      "Unsupported cast from Row(f0: String, f1: Boolean) to Long")
+
+    testTableApi(
+      'f5.cast(DataTypes.BIGINT()),
+      ""
+    )
+  }
+
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/RowTypeTest.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.table.api.{DataTypes, ValidationException}
 import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.codegen.CodeGenException
 import org.apache.flink.table.planner.expressions.utils.RowTypeTestBase
 import org.apache.flink.table.planner.utils.DateTimeTestUtil.{localDate, localDateTime, localTime => gLocalTime}
 import org.junit.Test
@@ -130,13 +131,25 @@ class RowTypeTest extends RowTypeTestBase {
   }
 
   @Test
-  def testUnsupportedCast(): Unit = {
+  def testUnsupportedCastTableApi(): Unit = {
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage(
-      "Unsupported cast from Row(f0: String, f1: Boolean) to Long")
+      "Unsupported cast from 'Row(f0: String, f1: Boolean)' to 'Long'")
 
     testTableApi(
       'f5.cast(DataTypes.BIGINT()),
+      ""
+    )
+  }
+
+  @Test
+  def testUnsupportedCastSqlApi(): Unit = {
+    expectedException.expect(classOf[CodeGenException])
+    expectedException.expectMessage(
+      "Unsupported cast from 'ROW<`f0` STRING, `f1` BOOLEAN>' to 'ROW<`f0` INT, `f1` STRING>'")
+
+    testSqlApi(
+      "CAST(f5 AS ROW<f0 INT, f1 STRING>)",
       ""
     )
   }


### PR DESCRIPTION
…larOperatorGens::generateCast


## What is the purpose of the change

ScalarOperatorGens::generateCast would produce obscure error message such as `Unsupported cast from 'ROW' to 'ROW'.` if we want cast one RowType to another.Users are unlikely to figure out what goes wrong from the above error message. Something like `Unsupported cast from 'ROW<DECIMAL(2,1), CHAR(3)>' to 'ROW<DOUBLE, VARCHAR(10)>' `will be more helpful. This PR would fix this.

## Brief change log

- 0396817 Use `LogicalType` instead of `LogicalTypeRoot` to produce clear error message.

## Verifying this change

This change added tests to verify

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
