### PR TITLE
[FLINK-15920][build] Show thread names in logs by default

### DIFF
--- a/tools/log4j-travis.properties
+++ b/tools/log4j-travis.properties
@@ -23,7 +23,7 @@ log4j.rootLogger=INFO, file
 # -----------------------------------------------------------------------------
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
 
 # -----------------------------------------------------------------------------
 # File (use 'file')
@@ -32,7 +32,7 @@ log4j.appender.file=org.apache.log4j.FileAppender
 log4j.appender.file.file=${log.dir}/mvn-${mvn.forkNumber}.log
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
 
 # suppress the irrelevant (wrong) warnings from the netty channel handler
 log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR


### PR DESCRIPTION
## What is the purpose of the change

Having thread names in log lines make it much easier to understand from which task they come.
Enabling that by default on the CI setup helps with analyzing bugs and unstable tests.

This changes like layout from 
```
00:34:49,997 INFO  org.apache.flink.streaming.runtime.tasks.StreamTask - loading State ...
```
to
```
00:34:49,997 [MyWindow Operator (1/4)] INFO  org.apache.flink.streaming.runtime.tasks.StreamTask - loading State ...
```
