### PR TITLE
[FLINK-15919][core][mem] MemoryManager shouldn't allow releasing more memory than reserved

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -266,30 +266,6 @@ public class MemoryManagerTest {
 	}
 
 	@Test
-	public void testMemoryReleaseMoreThanReserved() throws MemoryReservationException {
-		Object owner = new Object();
-		Object owner2 = new Object();
-		long totalHeapMemorySize = memoryManager.availableMemory(MemoryType.HEAP);
-		// to prevent memory size exceeding the maximum, reserve some memory from another owner.
-		memoryManager.reserveMemory(owner2, MemoryType.HEAP, PAGE_SIZE);
-
-		// test reserve once and release multiple times
-		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		long heapMemoryLeft = memoryManager.availableMemory(MemoryType.HEAP);
-		assertEquals("Memory leak happens", totalHeapMemorySize - PAGE_SIZE, heapMemoryLeft);
-
-		// test release more than the left reserved size
-		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE / 2);
-		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		heapMemoryLeft = memoryManager.availableMemory(MemoryType.HEAP);
-		assertEquals("Memory leak happens", totalHeapMemorySize - PAGE_SIZE, heapMemoryLeft);
-		memoryManager.releaseAllMemory(owner2, MemoryType.HEAP);
-	}
-
-	@Test
 	public void testCannotReserveBeyondTheLimit() throws MemoryReservationException {
 		Object owner = new Object();
 		memoryManager.reserveMemory(owner, MemoryType.OFF_HEAP, memoryManager.getMemorySizeByType(MemoryType.OFF_HEAP));
@@ -301,6 +277,41 @@ public class MemoryManagerTest {
 	public void testMemoryTooBigReservation() {
 		long size = memoryManager.getMemorySizeByType(MemoryType.HEAP) + PAGE_SIZE;
 		testCannotReserveAnymore(MemoryType.HEAP, size);
+	}
+
+	@Test
+	public void testMemoryReleaseMultipleTimes() throws MemoryReservationException {
+		Object owner = new Object();
+		Object owner2 = new Object();
+		int rounds = 5;
+		long totalHeapMemorySize = memoryManager.availableMemory(MemoryType.HEAP);
+		// to prevent memory size exceeding the maximum, reserve some memory from another owner.
+		memoryManager.reserveMemory(owner2, MemoryType.HEAP, PAGE_SIZE);
+
+		// reserve once and release multiple times
+		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		for (int i = 0; i < rounds; i++) {
+			memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		}
+		long heapMemoryLeft = memoryManager.availableMemory(MemoryType.HEAP);
+		assertEquals("Memory leak happens", totalHeapMemorySize - PAGE_SIZE, heapMemoryLeft);
+		memoryManager.releaseAllMemory(owner2, MemoryType.HEAP);
+	}
+
+	@Test
+	public void testMemoryReleaseMoreThanReserved() throws MemoryReservationException {
+		Object owner = new Object();
+		Object owner2 = new Object();
+		long totalHeapMemorySize = memoryManager.availableMemory(MemoryType.HEAP);
+		// to prevent memory size exceeding the maximum, reserve some memory from another owner.
+		memoryManager.reserveMemory(owner2, MemoryType.HEAP, PAGE_SIZE);
+
+		// release more than reserved size
+		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE * 2);
+		long heapMemoryLeft = memoryManager.availableMemory(MemoryType.HEAP);
+		assertEquals("Memory leak happens", totalHeapMemorySize - PAGE_SIZE, heapMemoryLeft);
+		memoryManager.releaseAllMemory(owner2, MemoryType.HEAP);
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -282,16 +282,14 @@ public class MemoryManagerTest {
 	public void testMemoryReleaseMultipleTimes() throws MemoryReservationException {
 		Object owner = new Object();
 		Object owner2 = new Object();
-		int rounds = 5;
 		long totalHeapMemorySize = memoryManager.availableMemory(MemoryType.HEAP);
-		// to prevent memory size exceeding the maximum, reserve some memory from another owner.
+		// to prevent memory size exceeding the limit, reserve some memory from another owner.
 		memoryManager.reserveMemory(owner2, MemoryType.HEAP, PAGE_SIZE);
 
-		// reserve once and release multiple times
+		// reserve once but release twice
 		memoryManager.reserveMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		for (int i = 0; i < rounds; i++) {
-			memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
-		}
+		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
+		memoryManager.releaseMemory(owner, MemoryType.HEAP, PAGE_SIZE);
 		long heapMemoryLeft = memoryManager.availableMemory(MemoryType.HEAP);
 		assertEquals("Memory leak happens", totalHeapMemorySize - PAGE_SIZE, heapMemoryLeft);
 		memoryManager.releaseAllMemory(owner2, MemoryType.HEAP);
@@ -302,7 +300,7 @@ public class MemoryManagerTest {
 		Object owner = new Object();
 		Object owner2 = new Object();
 		long totalHeapMemorySize = memoryManager.availableMemory(MemoryType.HEAP);
-		// to prevent memory size exceeding the maximum, reserve some memory from another owner.
+		// to prevent memory size exceeding the limit, reserve some memory from another owner.
 		memoryManager.reserveMemory(owner2, MemoryType.HEAP, PAGE_SIZE);
 
 		// release more than reserved size

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/memory/MemoryManagerTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**


### PR DESCRIPTION

## What is the purpose of the change

Currently `MemoryManager` allows to release more memory than the left reserved size and this PR aims at fixing the problem.


## Brief change log

Change the `MemoryManager.releaseMemory` method, recording the actual memory to release during the `reservedMemory` computation and use it for releasing `budgetByType`.


## Verifying this change

This change added a new `testMemoryReleaseMoreThanReserved` test in `MemoryManagerTest` to cover the issue case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
