### PR TITLE
[FLINK-15811][task] report CancelTaskException from SourceStreamTask

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/StreamSourceOperatorWatermarksTest.java
@@ -107,7 +107,9 @@ public class StreamSourceOperatorWatermarksTest {
 			testHarness.waitForTaskCompletion();
 			fail("should throw an exception");
 		} catch (Throwable t) {
-			assertTrue(ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent());
+			if (!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
+				throw t;
+			}
 		}
 		assertTrue(testHarness.getOutput().isEmpty());
 	}
@@ -120,11 +122,13 @@ public class StreamSourceOperatorWatermarksTest {
 		testHarness.invoke();
 		testHarness.waitForTaskRunning();
 		Thread.sleep(200);
-		testHarness.getTask().cancel(); // cancel task
+		testHarness.getTask().cancel();
 		try {
 			testHarness.waitForTaskCompletion();
 		} catch (Throwable t) {
-			assertTrue(ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent());
+			if (!ExceptionUtils.findThrowable(t, CancelTaskException.class).isPresent()) {
+				throw t;
+			}
 		}
 		assertTrue(testHarness.getOutput().isEmpty());
 	}


### PR DESCRIPTION
## What is the purpose of the change

`SourceStreamTask` has it's own thread and on `cancel()` it interrupts this thread.
When the thread completes the failure if any is reported via mailbox to the upstream `Task`.

So on cancel it reports `InterruptedException`.
But the contract (or common practice) of `AbstractInvokable` is to throw `CancelTaskException`.

In PR `SourceStreamTask` reports `CancelTaskException` if it was cancelled.


## Verifying this change

This change is already covered by existing tests, such as `StreamSourceOperatorWatermarksTest#testNoMaxWatermarkOnAsyncCancel`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
