### PR TITLE
[FLINK-15902][python][doc] Improve the Python API doc adding the version an API introduced

### DIFF
--- a/flink-python/pyflink/__init__.py
+++ b/flink-python/pyflink/__init__.py
@@ -21,3 +21,19 @@ if sys.version_info < (3, 5):
     raise RuntimeError(
         'Python versions prior to 3.5 are not supported for PyFlink [' +
         str(sys.version_info) + '].')
+
+
+def since(version):
+    """
+    A decorator that annotates a function to append the version the function was added.
+    """
+    import re
+    indent_p = re.compile(r'\n( +)')
+
+    def deco(f):
+        original_doc = f.__doc__ or ""
+        indents = indent_p.findall(original_doc)
+        indent = ' ' * (min(len(indent) for indent in indents) if indents else 0)
+        f.__doc__ = original_doc.rstrip() + "\n\n%s.. versionadded:: %s" % (indent, version)
+        return f
+    return deco

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -18,6 +18,7 @@
 
 from py4j.java_gateway import java_import
 
+from pyflink import since
 from pyflink.java_gateway import get_gateway
 from pyflink.table.table_schema import TableSchema
 
@@ -789,6 +790,7 @@ class CatalogFunction(object):
         else:
             return None
 
+    @since("1.10.0")
     def is_generic(self):
         """
         Whether or not is the function a flink UDF.
@@ -797,6 +799,7 @@ class CatalogFunction(object):
         """
         return self._j_catalog_function.isGeneric()
 
+    @since("1.10.0")
     def get_function_language(self):
         """
         Get the language used for the function definition.

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -18,6 +18,7 @@
 
 from py4j.compat import long
 
+from pyflink import since
 from pyflink.common import Configuration
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.java_gateway import get_gateway
@@ -276,6 +277,7 @@ class TableConfig(object):
         """
         self._j_table_config.setSqlDialect(SqlDialect._to_j_sql_dialect(sql_dialect))
 
+    @since("1.10.0")
     def set_python_executable(self, python_exec):
         """
         Sets the path of the python interpreter which is used to execute the python udf workers.
@@ -313,6 +315,7 @@ class TableConfig(object):
         """
         self.get_configuration().set_string(DependencyManager.PYTHON_EXEC, python_exec)
 
+    @since("1.10.0")
     def get_python_executable(self):
         """
         Gets the path of the python interpreter which is used to execute the python udf workers.

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -293,8 +293,9 @@ class TableEnvironment(object):
         :param table: The Table to write to the sink.
         :type table: pyflink.table.Table
 
-        .. versionadded:: 1.10.0
-            The *table* parameter.
+        .. versionchanged:: 1.10.0
+            The signature is changed, e.g. the parameter *table_path_continued* was removed and
+            the parameter *target_path* is moved before the parameter *table*.
         """
         self._j_tenv.insertInto(target_path, table._j_table)
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -22,6 +22,7 @@ from abc import ABCMeta, abstractmethod
 
 from py4j.java_gateway import get_java_class, get_method
 
+from pyflink import since
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table.catalog import Catalog
@@ -235,6 +236,7 @@ class TableEnvironment(object):
         j_table = self._j_tenv.scan(j_table_paths)
         return Table(j_table)
 
+    @since("1.10.0")
     def from_path(self, path):
         """
         Reads a registered table and returns the resulting :class:`~pyflink.table.Table`.
@@ -288,8 +290,11 @@ class TableEnvironment(object):
         :param target_path: The path of the registered :class:`~pyflink.table.TableSink` to which
                             the :class:`~pyflink.table.Table` is written.
         :type target_path: str
-        :param table: table The Table to write to the sink.
+        :param table: The Table to write to the sink.
         :type table: pyflink.table.Table
+
+        .. versionadded:: 1.10.0
+            The *table* parameter.
         """
         self._j_tenv.insertInto(target_path, table._j_table)
 
@@ -303,6 +308,7 @@ class TableEnvironment(object):
         j_catalog_name_array = self._j_tenv.listCatalogs()
         return [item for item in j_catalog_name_array]
 
+    @since("1.10.0")
     def list_modules(self):
         """
         Gets the names of all modules registered in this environment.
@@ -343,6 +349,7 @@ class TableEnvironment(object):
         j_udf_name_array = self._j_tenv.listUserDefinedFunctions()
         return [item for item in j_udf_name_array]
 
+    @since("1.10.0")
     def list_functions(self):
         """
         Gets the names of all functions in this environment.
@@ -353,6 +360,7 @@ class TableEnvironment(object):
         j_function_name_array = self._j_tenv.listFunctions()
         return [item for item in j_function_name_array]
 
+    @since("1.10.0")
     def list_temporary_tables(self):
         """
         Gets the names of all temporary tables and views available in the current namespace
@@ -367,6 +375,7 @@ class TableEnvironment(object):
         j_table_name_array = self._j_tenv.listTemporaryTables()
         return [item for item in j_table_name_array]
 
+    @since("1.10.0")
     def list_temporary_views(self):
         """
         Gets the names of all temporary views available in the current namespace (the current
@@ -381,6 +390,7 @@ class TableEnvironment(object):
         j_view_name_array = self._j_tenv.listTemporaryViews()
         return [item for item in j_view_name_array]
 
+    @since("1.10.0")
     def drop_temporary_table(self, table_path):
         """
         Drops a temporary table registered in the given path.
@@ -395,6 +405,7 @@ class TableEnvironment(object):
         """
         return self._j_tenv.dropTemporaryTable(table_path)
 
+    @since("1.10.0")
     def drop_temporary_view(self, view_path):
         """
         Drops a temporary view registered in the given path.
@@ -715,6 +726,7 @@ class TableEnvironment(object):
             .loadClass(function_class_name).newInstance()
         self._j_tenv.registerFunction(name, java_function)
 
+    @since("1.10.0")
     def register_function(self, name, function):
         """
         Registers a python user-defined function under a unique name. Replaces already existing
@@ -746,6 +758,7 @@ class TableEnvironment(object):
         self._j_tenv.registerFunction(name, function._judf(self._is_blink_planner,
                                                            self.get_config()._j_table_config))
 
+    @since("1.10.0")
     def create_temporary_view(self, view_path, table):
         """
         Registers a :class:`~pyflink.table.Table` API object as a temporary view similar to SQL
@@ -764,6 +777,7 @@ class TableEnvironment(object):
         """
         self._j_tenv.createTemporaryView(view_path, table._j_table)
 
+    @since("1.10.0")
     def add_python_file(self, file_path):
         """
         Adds a python dependency which could be python files, python packages or
@@ -775,6 +789,7 @@ class TableEnvironment(object):
         """
         self._dependency_manager.add_python_file(file_path)
 
+    @since("1.10.0")
     def set_python_requirements(self, requirements_file_path, requirements_cache_dir=None):
         """
         Specifies a requirements.txt file which defines the third-party dependencies.
@@ -812,6 +827,7 @@ class TableEnvironment(object):
         self._dependency_manager.set_python_requirements(requirements_file_path,
                                                          requirements_cache_dir)
 
+    @since("1.10.0")
     def add_python_archive(self, archive_path, target_dir=None):
         """
         Adds a python archive file. The file will be extracted to the working directory of


### PR DESCRIPTION

## What is the purpose of the change

*Currently it's not possible to know in which version a Python API is added. This information is very useful for users and this PR will address this problem.*

## Brief change log

  - *Add a since decorator*
  - *Add since decorator for the the APIs introduced in 1.10*

## Verifying this change

This change is a documentation work without any test coverage and have checked the Python doc manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
