### PR TITLE
[FLINK-15949][build] Harden jackson dependency constraints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,39 +400,10 @@ under the License.
 			</dependency>
 
 			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-
-			<!-- https://issues.apache.org/jira/browse/FLINK-15868 -->
-			<dependency>
-				<groupId>com.fasterxml.jackson.dataformat</groupId>
-				<artifactId>jackson-dataformat-cbor</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.dataformat</groupId>
-				<artifactId>jackson-dataformat-smile</artifactId>
-				<version>${jackson.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.fasterxml.jackson.dataformat</groupId>
-				<artifactId>jackson-dataformat-yaml</artifactId>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<type>pom</type>
+				<scope>import</scope>
 				<version>${jackson.version}</version>
 			</dependency>
 
@@ -1509,6 +1480,21 @@ under the License.
 								<requireJavaVersion>
 									<version>${java.version}</version>
 								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+					<execution>
+						<id>ban-unsafe-jackson</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<excludes>
+										<exclude>com.fasterxml.jackson*:*:(,2.10.0]</exclude>
+									</excludes>
+								</bannedDependencies>
 							</rules>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,24 @@ under the License.
 				<version>${jackson.version}</version>
 			</dependency>
 
+			<dependency>
+				<!-- re-branded javax.activation:javax.activation-api that is provided by flink-dist
+				 	(the package names are identical!) -->
+				<groupId>jakarta.activation</groupId>
+				<artifactId>jakarta.activation-api</artifactId>
+				<version>1.2.1</version>
+				<scope>provided</scope>
+			</dependency>
+
+			<dependency>
+				<!-- re-branded javax.xml.bind:jaxb-api that is provided by flink-dist
+					(the package names are identical!) -->
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
+				<version>2.3.2</version>
+				<scope>provided</scope>
+			</dependency>
+
 			<!-- For dependency convergence -->
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
Replaces the individual jackson dependency management entries with the jackson bom, and introduce an enforcer check to ban older jackson dependencies.
The bom import results in a dependency management entry for all existing jackson dependencies.

The bom import is done in the root pom.xml since around 50 modules have a transitive dependency on jackson, and that's a bit too many to place an individual import into each module.