### PR TITLE
[FLINK-15942] Do not log huge/infinite cpu/memory resources in profiles

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -78,6 +78,12 @@ public class ResourceProfile implements Serializable {
 	/** A ResourceProfile describing zero resources. */
 	public static final ResourceProfile ZERO = newBuilder().build();
 
+	/** Maximum number of cpu cores to output in {@link #toString()}. */
+	static final BigDecimal MAX_CPU_CORE_NUMBER_TO_LOG = new BigDecimal(16384);
+
+	/** Maximum memory resource size to output in {@link #toString()}. */
+	static final MemorySize MAX_MEMORY_SIZE_TO_LOG = new MemorySize(1L << 50); // 1Pb
+
 	// ------------------------------------------------------------------------
 
 	/** How many cpu cores are needed. Can be null only if it is unknown. */
@@ -388,17 +394,28 @@ public class ResourceProfile implements Serializable {
 			return "ResourceProfile{ANY}";
 		}
 
-		final StringBuilder resources = new StringBuilder(extendedResources.size() * 10);
+		final StringBuilder extendedResourceStr = new StringBuilder(extendedResources.size() * 10);
 		for (Map.Entry<String, Resource> resource : extendedResources.entrySet()) {
-			resources.append(", ").append(resource.getKey()).append('=').append(resource.getValue().getValue());
+			extendedResourceStr.append(", ").append(resource.getKey()).append('=').append(resource.getValue().getValue());
 		}
-		return "ResourceProfile{" +
-			"cpuCores=" + cpuCores.getValue() +
-			", taskHeapMemory=" + taskHeapMemory.toHumanReadableString() +
-			", taskOffHeapMemory=" + taskOffHeapMemory.toHumanReadableString() +
-			", managedMemory=" + managedMemory.toHumanReadableString() +
-			", networkMemory=" + networkMemory.toHumanReadableString() + resources +
-			'}';
+		return "ResourceProfile{" + getResourceString() + extendedResourceStr + '}';
+	}
+
+	private String getResourceString() {
+		String resourceStr = cpuCores == null || cpuCores.getValue().compareTo(MAX_CPU_CORE_NUMBER_TO_LOG) > 0 ?
+			"" : "cpuCores=" + cpuCores.getValue();
+		resourceStr = addMemorySizeString(resourceStr, "taskHeapMemory", taskHeapMemory);
+		resourceStr = addMemorySizeString(resourceStr, "taskOffHeapMemory", taskOffHeapMemory);
+		resourceStr = addMemorySizeString(resourceStr, "managedMemory", managedMemory);
+		resourceStr = addMemorySizeString(resourceStr, "networkMemory", networkMemory);
+		return resourceStr;
+	}
+
+	private static String addMemorySizeString(String resourceStr, String name, MemorySize size) {
+		String comma = resourceStr.isEmpty() ? "" : ", ";
+		String memorySizeStr = size == null || size.compareTo(MAX_MEMORY_SIZE_TO_LOG) > 0 ?
+			"" : comma + name + '=' + size.toHumanReadableString();
+		return resourceStr + memorySizeStr;
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

In local execution mode, we assume that cpu and task memory of slots are infinite to match any requests. Those resources are configured to `Double/Long.MAX_VALUE` values in this case. These ridiculously huge numbers get logged as slot's `ResourceProfile` and can confuse users. As a quick fix, we do not output the values which exceed a certain huge threshold.

## Brief change log

Adjust `ResourceProfile#toString`.

## Verifying this change

unit tests