### PR TITLE
FLINK-15744 Some TaskManager Task exceptions are logged as info

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -952,7 +952,7 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 			if (cause == null) {
 				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState);
 			} else {
-				LOG.info("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
+				LOG.warn("{} ({}) switched from {} to {}.", taskNameWithSubtask, executionId, currentState, newState, cause);
 			}
 
 			return true;


### PR DESCRIPTION
## What is the purpose of the change

The fundamental issue is that exceptions raised in the Task class are logged as log level info. This then requires retaining the log level at info level to be able to see these potentially important errors. However because the info level is intended for observation in some detail, the exceptions can be buried amongst the rest of the information.

The proposed change is to set the output from exceptions at warning level so that info level logging need not be set in order to observe any exceptions occurring in the task.

## Brief change log

Changed the log level to warn when exceptions occur in the Task

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
