### PR TITLE
[FLINK-15913][python] Add Python TableFunction Runner and Operator in Blink planner

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonTableFunctionOperator.java
@@ -61,7 +61,10 @@ public abstract class AbstractPythonTableFunctionOperator<IN, OUT, UDTFIN>
 		JoinRelType joinType) {
 		super(config, inputType, outputType, udtfInputOffsets);
 		this.tableFunction = Preconditions.checkNotNull(tableFunction);
-		this.joinType = Preconditions.checkNotNull(joinType);
+		Preconditions.checkArgument(
+			joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT,
+			"The join type should be inner join or left join");
+		this.joinType = joinType;
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractPythonTableFunctionOperator.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.calcite.rel.core.JoinRelType;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,14 +47,21 @@ public abstract class AbstractPythonTableFunctionOperator<IN, OUT, UDTFIN>
 	 */
 	protected final PythonFunctionInfo tableFunction;
 
+	/**
+	 * The correlate join type.
+	 */
+	protected final JoinRelType joinType;
+
 	public AbstractPythonTableFunctionOperator(
 		Configuration config,
 		PythonFunctionInfo tableFunction,
 		RowType inputType,
 		RowType outputType,
-		int[] udtfInputOffsets) {
+		int[] udtfInputOffsets,
+		JoinRelType joinType) {
 		super(config, inputType, outputType, udtfInputOffsets);
 		this.tableFunction = Preconditions.checkNotNull(tableFunction);
+		this.joinType = Preconditions.checkNotNull(joinType);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/AbstractStatelessFunctionOperator.java
@@ -149,7 +149,7 @@ public abstract class AbstractStatelessFunctionOperator<IN, OUT, UDFIN>
 	 */
 	public abstract void bufferInput(IN input);
 
-	public abstract UDFIN getUdfInput(IN element);
+	public abstract UDFIN getFunctionInput(IN element);
 
 	public abstract PythonFunctionRunner<UDFIN> createPythonFunctionRunner(
 		FnDataReceiver<byte[]> resultReceiver,
@@ -185,7 +185,7 @@ public abstract class AbstractStatelessFunctionOperator<IN, OUT, UDFIN>
 
 		@Override
 		public void processElement(IN element) throws Exception {
-			pythonFunctionRunner.processElement(getUdfInput(element));
+			pythonFunctionRunner.processElement(getFunctionInput(element));
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonScalarFunctionOperator.java
@@ -108,7 +108,7 @@ public class BaseRowPythonScalarFunctionOperator
 	}
 
 	@Override
-	public BaseRow getUdfInput(BaseRow element) {
+	public BaseRow getFunctionInput(BaseRow element) {
 		return udfInputProjection.apply(element);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperator.java
@@ -106,7 +106,7 @@ public class BaseRowPythonTableFunctionOperator
 		// always copy the input BaseRow
 		BaseRow forwardedFields = forwardedInputSerializer.copy(input);
 		forwardedFields.setHeader(input.getHeader());
-		forwardedInputQueue.add(input);
+		forwardedInputQueue.add(forwardedFields);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperator.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.JoinedRow;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.planner.codegen.CodeGeneratorContext;
+import org.apache.flink.table.planner.codegen.ProjectionCodeGenerator;
+import org.apache.flink.table.runtime.generated.GeneratedProjection;
+import org.apache.flink.table.runtime.generated.Projection;
+import org.apache.flink.table.runtime.runners.python.BaseRowPythonTableFunctionRunner;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+
+import java.io.IOException;
+
+/**
+ * The Python {@link TableFunction} operator for the blink planner.
+ */
+@Internal
+public class BaseRowPythonTableFunctionOperator
+	extends AbstractPythonTableFunctionOperator<BaseRow, BaseRow, BaseRow> {
+
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The collector used to collect records.
+	 */
+	private transient StreamRecordBaseRowWrappingCollector baseRowWrapper;
+
+	/**
+	 * The JoinedRow reused holding the execution result.
+	 */
+	private transient JoinedRow reuseJoinedRow;
+
+	/**
+	 * The Projection which projects the udtf input fields from the input row.
+	 */
+	private transient Projection<BaseRow, BinaryRow> udtfInputProjection;
+
+	/**
+	 * The TypeSerializer for udtf execution results.
+	 */
+	private transient TypeSerializer<BaseRow> udtfOutputTypeSerializer;
+
+	public BaseRowPythonTableFunctionOperator(
+		Configuration config,
+		PythonFunctionInfo tableFunction,
+		RowType inputType,
+		RowType outputType,
+		int[] udtfInputOffsets) {
+		super(config, tableFunction, inputType, outputType, udtfInputOffsets);
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public void open() throws Exception {
+		super.open();
+		baseRowWrapper = new StreamRecordBaseRowWrappingCollector(output);
+		reuseJoinedRow = new JoinedRow();
+
+		udtfInputProjection = createUdtfInputProjection();
+		udtfOutputTypeSerializer = PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionOutputType);
+	}
+
+	@Override
+	public void bufferInput(BaseRow input) {
+		forwardedInputQueue.add(input);
+	}
+
+	@Override
+	public BaseRow getUdfInput(BaseRow element) {
+		return udtfInputProjection.apply(element);
+	}
+
+	@Override
+	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
+		FnDataReceiver<byte[]> resultReceiver,
+		PythonEnvironmentManager pythonEnvironmentManager) {
+		return new BaseRowPythonTableFunctionRunner(
+			getRuntimeContext().getTaskName(),
+			resultReceiver,
+			tableFunction,
+			pythonEnvironmentManager,
+			userDefinedFunctionInputType,
+			userDefinedFunctionOutputType);
+	}
+
+	private Projection<BaseRow, BinaryRow> createUdtfInputProjection() {
+		final GeneratedProjection generatedProjection = ProjectionCodeGenerator.generateProjection(
+			CodeGeneratorContext.apply(new TableConfig()),
+			"UdtfInputProjection",
+			inputType,
+			userDefinedFunctionInputType,
+			userDefinedFunctionInputOffsets);
+		// noinspection unchecked
+		return generatedProjection.newInstance(Thread.currentThread().getContextClassLoader());
+	}
+
+	@Override
+	public void emitResults() throws IOException {
+		BaseRow input = null;
+		byte[] rawUdtfResult;
+		while ((rawUdtfResult = userDefinedFunctionResultQueue.poll()) != null) {
+			if (input == null) {
+				input = forwardedInputQueue.poll();
+			}
+			boolean isFinishResult = isFinishResult(rawUdtfResult);
+			if (isFinishResult) {
+				input = forwardedInputQueue.poll();
+			}
+			if (input != null && !isFinishResult) {
+				reuseJoinedRow.setHeader(input.getHeader());
+				bais.setBuffer(rawUdtfResult, 0, rawUdtfResult.length);
+				BaseRow udtfResult = udtfOutputTypeSerializer.deserialize(baisWrapper);
+				baseRowWrapper.collect(reuseJoinedRow.replace(input, udtfResult));
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/PythonScalarFunctionOperator.java
@@ -100,7 +100,7 @@ public class PythonScalarFunctionOperator extends AbstractPythonScalarFunctionOp
 	}
 
 	@Override
-	public Row getUdfInput(CRow element) {
+	public Row getFunctionInput(CRow element) {
 		return Row.project(element.row(), userDefinedFunctionInputOffsets);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonScalarFunctionRunner.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
- * It takes {@link BaseRow} as the input and output type.
+ * It takes {@link BaseRow} as the input and outputs a byte array.
  */
 @Internal
 public class BaseRowPythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<BaseRow> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonTableFunctionRunner.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.runners.python;
+
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+
+/**
+ * A {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
+ * It takes {@link BaseRow} as the input and output type.
+ */
+public class BaseRowPythonTableFunctionRunner extends AbstractPythonTableFunctionRunner<BaseRow> {
+	public BaseRowPythonTableFunctionRunner(
+		String taskName,
+		FnDataReceiver<byte[]> resultReceiver,
+		PythonFunctionInfo tableFunction,
+		PythonEnvironmentManager environmentManager,
+		RowType inputType,
+		RowType outputType) {
+		super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType);
+	}
+
+	@Override
+	public BaseRowSerializer getInputTypeSerializer() {
+		return (BaseRowSerializer) PythonTypeUtils.toBlinkTypeSerializer(getInputType());
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/BaseRowPythonTableFunctionRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.runners.python;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -31,8 +32,9 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
- * It takes {@link BaseRow} as the input and output type.
+ * It takes {@link BaseRow} as the input and outputs a byte array.
  */
+@Internal
 public class BaseRowPythonTableFunctionRunner extends AbstractPythonTableFunctionRunner<BaseRow> {
 	public BaseRowPythonTableFunctionRunner(
 		String taskName,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonScalarFunctionRunner.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
- * It takes {@link Row} as the input and output type.
+ * It takes {@link Row} as the input and outputs a byte array.
  */
 @Internal
 public class PythonScalarFunctionRunner extends AbstractPythonScalarFunctionRunner<Row> {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/PythonTableFunctionRunner.java
@@ -33,7 +33,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
- * It takes {@link Row} as the input and output type.
+ * It takes {@link Row} as the input and outputs a byte array.
  */
 @Internal
 public class PythonTableFunctionRunner extends AbstractPythonTableFunctionRunner<Row> {

--- a/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonTableFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/functions/python/BaseRowPythonTableFunctionRunnerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.python;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.python.env.ProcessPythonEnvironmentManager;
+import org.apache.flink.python.env.PythonDependencyInfo;
+import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.runners.python.AbstractPythonTableFunctionRunner;
+import org.apache.flink.table.runtime.runners.python.BaseRowPythonTableFunctionRunner;
+import org.apache.flink.table.runtime.typeutils.serializers.python.BaseRowSerializer;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link BaseRowPythonTableFunctionRunner}. These test that
+ * the input data type and output data type are properly constructed.
+ */
+public class BaseRowPythonTableFunctionRunnerTest extends AbstractPythonTableFunctionRunnerTest<BaseRow> {
+
+	@Test
+	public void testInputOutputDataTypeConstructedProperlyForSingleUDTF() throws Exception {
+		final AbstractPythonTableFunctionRunner<BaseRow> runner = createUDTFRunner();
+
+		// check input TypeSerializer
+		TypeSerializer inputTypeSerializer = runner.getInputTypeSerializer();
+		assertTrue(inputTypeSerializer instanceof BaseRowSerializer);
+
+		assertEquals(1, ((BaseRowSerializer) inputTypeSerializer).getArity());
+	}
+
+	@Override
+	public AbstractPythonTableFunctionRunner<BaseRow> createPythonTableFunctionRunner(
+		PythonFunctionInfo pythonFunctionInfo,
+		RowType inputType,
+		RowType outputType) throws Exception {
+		final FnDataReceiver<byte[]> dummyReceiver = input -> {
+			// ignore the execution results
+		};
+
+		final PythonEnvironmentManager environmentManager =
+			new ProcessPythonEnvironmentManager(
+				new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), null),
+				new String[]{System.getProperty("java.io.tmpdir")},
+				new HashMap<>());
+
+		return new BaseRowPythonTableFunctionRunner(
+			"testPythonRunner",
+			dummyReceiver,
+			pythonFunctionInfo,
+			environmentManager,
+			inputType,
+			outputType);
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperatorTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.calcite.rel.core.JoinRelType;
 
 import java.util.Collection;
 
@@ -71,9 +72,10 @@ public class BaseRowPythonTableFunctionOperatorTest
 		PythonFunctionInfo tableFunction,
 		RowType inputType,
 		RowType outputType,
-		int[] udfInputOffsets) {
+		int[] udfInputOffsets,
+		JoinRelType joinRelType) {
 		return new BaseRowPassThroughPythonTableFunctionOperator(
-			config, tableFunction, inputType, outputType, udfInputOffsets);
+			config, tableFunction, inputType, outputType, udfInputOffsets, joinRelType);
 	}
 
 	private static class BaseRowPassThroughPythonTableFunctionOperator extends BaseRowPythonTableFunctionOperator {
@@ -83,8 +85,9 @@ public class BaseRowPythonTableFunctionOperatorTest
 			PythonFunctionInfo tableFunction,
 			RowType inputType,
 			RowType outputType,
-			int[] udfInputOffsets) {
-			super(config, tableFunction, inputType, outputType, udfInputOffsets);
+			int[] udfInputOffsets,
+			JoinRelType joinRelType) {
+			super(config, tableFunction, inputType, outputType, udfInputOffsets, joinRelType);
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/BaseRowPythonTableFunctionOperatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.python;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.PythonFunctionRunner;
+import org.apache.flink.python.env.PythonEnvironmentManager;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+
+import java.util.Collection;
+
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.baserow;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryrow;
+
+/**
+ * Tests for {@link BaseRowPythonTableFunctionOperator}.
+ */
+public class BaseRowPythonTableFunctionOperatorTest
+	extends PythonTableFunctionOperatorTestBase<BaseRow, BaseRow, BaseRow> {
+
+	private final BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(new TypeInformation[]{
+		Types.STRING,
+		Types.STRING,
+		Types.LONG,
+		Types.LONG
+	});
+
+	@Override
+	public BaseRow newRow(boolean accumulateMsg, Object... fields) {
+		if (accumulateMsg) {
+			return baserow(fields);
+		} else {
+			return BaseRowUtil.setRetract(baserow(fields));
+		}
+	}
+
+	@Override
+	public void assertOutputEquals(String message, Collection<Object> expected, Collection<Object> actual) {
+		assertor.assertOutputEquals(message, expected, actual);
+	}
+
+	@Override
+	public AbstractPythonTableFunctionOperator<BaseRow, BaseRow, BaseRow> getTestOperator(
+		Configuration config,
+		PythonFunctionInfo tableFunction,
+		RowType inputType,
+		RowType outputType,
+		int[] udfInputOffsets) {
+		return new BaseRowPassThroughPythonTableFunctionOperator(
+			config, tableFunction, inputType, outputType, udfInputOffsets);
+	}
+
+	private static class BaseRowPassThroughPythonTableFunctionOperator extends BaseRowPythonTableFunctionOperator {
+
+		BaseRowPassThroughPythonTableFunctionOperator(
+			Configuration config,
+			PythonFunctionInfo tableFunction,
+			RowType inputType,
+			RowType outputType,
+			int[] udfInputOffsets) {
+			super(config, tableFunction, inputType, outputType, udfInputOffsets);
+		}
+
+		@Override
+		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
+			FnDataReceiver<byte[]> resultReceiver,
+			PythonEnvironmentManager pythonEnvironmentManager) {
+			return new PassThroughPythonTableFunctionRunner<BaseRow>(resultReceiver) {
+				@Override
+				public BaseRow copy(BaseRow element) {
+					BaseRow row = binaryrow(element.getLong(0));
+					row.setHeader(element.getHeader());
+					return row;
+				}
+
+				@Override
+				@SuppressWarnings("unchecked")
+				public TypeSerializer<BaseRow> getInputTypeSerializer() {
+					return PythonTypeUtils.toBlinkTypeSerializer(userDefinedFunctionInputType);
+				}
+			};
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PassThroughPythonTableFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PassThroughPythonTableFunctionRunner.java
@@ -73,11 +73,16 @@ public abstract class PassThroughPythonTableFunctionRunner<IN> implements Python
 	public void finishBundle() throws Exception {
 		Preconditions.checkState(bundleStarted);
 		bundleStarted = false;
+		int num = 0;
 
 		for (IN element : bufferedElements) {
+			num++;
 			baos.reset();
 			getInputTypeSerializer().serialize(element, baosWrapper);
-			resultReceiver.accept(baos.toByteArray());
+			// test for left join
+			if (num != 6 && num != 8) {
+				resultReceiver.accept(baos.toByteArray());
+			}
 			resultReceiver.accept(new byte[]{0});
 		}
 		bufferedElements.clear();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/PythonTableFunctionOperatorTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.calcite.rel.core.JoinRelType;
 
 import java.util.Collection;
 import java.util.Queue;
@@ -44,9 +45,10 @@ public class PythonTableFunctionOperatorTest extends PythonTableFunctionOperator
 		PythonFunctionInfo tableFunction,
 		RowType inputType,
 		RowType outputType,
-		int[] udfInputOffsets) {
+		int[] udfInputOffsets,
+		JoinRelType joinRelType) {
 		return new PassThroughPythonTableFunctionOperator(
-			config, tableFunction, inputType, outputType, udfInputOffsets);
+			config, tableFunction, inputType, outputType, udfInputOffsets, joinRelType);
 	}
 
 	@Override
@@ -66,8 +68,9 @@ public class PythonTableFunctionOperatorTest extends PythonTableFunctionOperator
 			PythonFunctionInfo tableFunction,
 			RowType inputType,
 			RowType outputType,
-			int[] udfInputOffsets) {
-			super(config, tableFunction, inputType, outputType, udfInputOffsets);
+			int[] udfInputOffsets,
+			JoinRelType joinRelType) {
+			super(config, tableFunction, inputType, outputType, udfInputOffsets, joinRelType);
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request add Python Table Function Runner and Operator for executing Python user-defined table function in Blink Planner*


## Brief change log

  - *Add BaseRowPythonTableFunctionOperator*
  - *Add BaseRowPythonTableFunctionRunner*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add runner test in BaseRowPythonTableFunctionRunnerTest*
  - *Add operator test in BaseRowPythonTableFunctionOperatorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
