### PR TITLE
[FLINK-15579][table-planner-blink] Support UpsertStreamTableSink on Blink batch mode.

### DIFF
--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -18,13 +18,24 @@
 
 package org.apache.flink.api.java.io.jdbc;
 
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.io.CollectionInputFormat;
 import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.timestamps.AscendingTimestampExtractor;
+import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.sources.InputFormatTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
@@ -38,6 +49,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,6 +64,7 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 	public static final String DB_URL = "jdbc:derby:memory:upsert";
 	public static final String OUTPUT_TABLE1 = "upsertSink";
 	public static final String OUTPUT_TABLE2 = "appendSink";
+	public static final String OUTPUT_TABLE3 = "batchSink";
 
 	@Before
 	public void before() throws ClassNotFoundException, SQLException {
@@ -73,6 +86,10 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 					"num BIGINT NOT NULL DEFAULT 0," +
 					"ts TIMESTAMP)");
 
+			stat.executeUpdate("CREATE TABLE " + OUTPUT_TABLE3 + " (" +
+				"NAME VARCHAR(20) NOT NULL," +
+				"SCORE BIGINT NOT NULL DEFAULT 0)");
+
 			stat.executeUpdate("CREATE TABLE REAL_TABLE (real_data REAL)");
 		}
 	}
@@ -85,6 +102,7 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 			Statement stat = conn.createStatement()) {
 			stat.execute("DROP TABLE " + OUTPUT_TABLE1);
 			stat.execute("DROP TABLE " + OUTPUT_TABLE2);
+			stat.execute("DROP TABLE " + OUTPUT_TABLE3);
 			stat.execute("DROP TABLE REAL_TABLE");
 		}
 	}
@@ -210,5 +228,77 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 				Row.of(10, 4, Timestamp.valueOf("1970-01-01 00:00:00.01")),
 				Row.of(20, 6, Timestamp.valueOf("1970-01-01 00:00:00.02"))
 		}, DB_URL, OUTPUT_TABLE2, new String[]{"id", "num", "ts"});
+	}
+
+	@Test
+	public void testBatchUpsert() throws Exception {
+		StreamExecutionEnvironment bsEnv = StreamExecutionEnvironment.getExecutionEnvironment();
+		EnvironmentSettings bsSettings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+		StreamTableEnvironment bsTableEnv = StreamTableEnvironment.create(bsEnv, bsSettings);
+		RowTypeInfo rt = (RowTypeInfo) Types.ROW_NAMED(new String[]{"NAME", "SCORE"}, Types.STRING, Types.LONG);
+		Table source = bsTableEnv.fromTableSource(new CollectionTableSource(generateRecords(2), rt));
+		bsTableEnv.registerTable("sourceTable", source);
+		bsTableEnv.sqlUpdate(
+			"CREATE TABLE USER_RESULT(" +
+				"NAME VARCHAR," +
+				"SCORE BIGINT" +
+				") WITH ( " +
+				"'connector.type' = 'jdbc'," +
+				"'connector.url'='" + DB_URL + "'," +
+				"'connector.table' = '" + OUTPUT_TABLE3 + "'" +
+				")");
+
+		bsTableEnv.sqlUpdate("insert into USER_RESULT SELECT s.NAME, s.SCORE " +
+			"FROM sourceTable as s ");
+		bsTableEnv.execute("test");
+
+		check(new Row[] {
+			Row.of("a0", 0L),
+			Row.of("a1", 1L)
+		}, DB_URL, OUTPUT_TABLE3, new String[]{"NAME", "SCORE"});
+	}
+
+	private List<Row> generateRecords(int numRecords) {
+		int arity = 2;
+		List<Row> res = new ArrayList<>(numRecords);
+		for (long i = 0; i < numRecords; i++) {
+			Row row = new Row(arity);
+			row.setField(0, "a" + i);
+			row.setField(1, i);
+			res.add(row);
+		}
+		return res;
+	}
+
+	private static class CollectionTableSource extends InputFormatTableSource<Row> {
+
+		private final Collection<Row> data;
+		private final RowTypeInfo rowTypeInfo;
+
+		CollectionTableSource(Collection<Row> data, RowTypeInfo rowTypeInfo) {
+			this.data = data;
+			this.rowTypeInfo = rowTypeInfo;
+		}
+
+		@Override
+		public DataType getProducedDataType() {
+			return TypeConversions.fromLegacyInfoToDataType(rowTypeInfo);
+		}
+
+		@Override
+		public TypeInformation<Row> getReturnType() {
+			return rowTypeInfo;
+		}
+
+		@Override
+		public InputFormat<Row, ?> getInputFormat() {
+			return new CollectionInputFormat<>(data, rowTypeInfo.createSerializer(new ExecutionConfig()));
+		}
+
+		@Override
+		public TableSchema getTableSchema() {
+			return new TableSchema.Builder().fields(rowTypeInfo.getFieldNames(),
+				TypeConversions.fromLegacyInfoToDataType(rowTypeInfo.getFieldTypes())).build();
+		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
@@ -17,10 +17,9 @@
  */
 package org.apache.flink.table.planner.plan.utils
 
-import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
-
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.{RelNode, RelVisitor}
@@ -40,7 +39,7 @@ object UpdatingPlanChecker {
   /** Extracts the unique keys of the table produced by the plan. */
   def getUniqueKeyFields(
       relNode: RelNode,
-      planner: StreamPlanner,
+      planner: PlannerBase,
       sinkFieldNames: Array[String]): Option[Array[Array[String]]] = {
     val fmq = FlinkRelMetadataQuery.reuseOrCreate(planner.getRelBuilder.getCluster.getMetadataQuery)
     val uniqueKeys = fmq.getUniqueKeys(relNode)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Blink batch mode do not support jdbc sink right now . Becuse JDBCTableSourceSinkFactory.createStreamTableSink() create JDBCUpsertTableSink. But BatchExecSink can not work with UpsertStreamTableSink.

This PR made BatchExecSink just like StreamExecSink, let BatchExecSink support RetractStreamTableSink and UpsertStreamTableSink.


## Brief change log

  - RetractStreamTableSink and UpsertStreamTableSink translate to Transformation on BatchExecSink.translateToPlanInternal()


## Verifying this change

This change is already covered by existing tests, such as JDBCUpsertTableSinkITCase.testBatchUpsert().

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
