### PR TITLE
[FLINK-15966][runtime] Capture callstacks for RPC ask() calls to improve exceptions.

### DIFF
--- a/docs/_includes/generated/akka_configuration.html
+++ b/docs/_includes/generated/akka_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>akka.ask.callstack</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If true, call stack for asynchronous asks are captured. That way, when an ask fails (for example times out), you get a proper exception, describing to the original method call and call site. Note that in case of having millions of concurrent RPC calls, this may add to the memory footprint.</td>
+        </tr>
+        <tr>
             <td><h5>akka.ask.timeout</h5></td>
             <td style="word-wrap: break-word;">"10 s"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/AkkaOptions.java
@@ -32,6 +32,18 @@ public class AkkaOptions {
 	/**
 	 * Timeout for akka ask calls.
 	 */
+	public static final ConfigOption<Boolean> CAPTURE_ASK_CALLSTACK = ConfigOptions
+		.key("akka.ask.callstack")
+		.booleanType()
+		.defaultValue(true)
+		.withDescription("If true, call stack for asynchronous asks are captured. That way, when an ask fails " +
+			"(for example times out), you get a proper exception, describing to the original method call and " +
+			"call site. Note that in case of having millions of concurrent RPC calls, this may add to the " +
+			"memory footprint.");
+
+	/**
+	 * Timeout for akka ask calls.
+	 */
 	public static final ConfigOption<String> ASK_TIMEOUT = ConfigOptions
 		.key("akka.ask.timeout")
 		.defaultValue("10 s")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -166,8 +166,6 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
 	/**
 	 * Triggers start of the rpc endpoint. This tells the underlying rpc server that the rpc endpoint is ready
 	 * to process remote procedure calls.
-	 *
-	 * @throws Exception indicating that something went wrong while starting the RPC endpoint
 	 */
 	public final void start() {
 		rpcServer.start();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaInvocationHandler.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
@@ -90,13 +91,16 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Nullable
 	private final CompletableFuture<Void> terminationFuture;
 
+	private final boolean captureAskCallStack;
+
 	AkkaInvocationHandler(
-			String address,
-			String hostname,
-			ActorRef rpcEndpoint,
-			Time timeout,
-			long maximumFramesize,
-			@Nullable CompletableFuture<Void> terminationFuture) {
+		String address,
+		String hostname,
+		ActorRef rpcEndpoint,
+		Time timeout,
+		long maximumFramesize,
+		@Nullable CompletableFuture<Void> terminationFuture,
+		boolean captureAskCallStack) {
 
 		this.address = Preconditions.checkNotNull(address);
 		this.hostname = Preconditions.checkNotNull(hostname);
@@ -105,6 +109,7 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 		this.timeout = Preconditions.checkNotNull(timeout);
 		this.maximumFramesize = maximumFramesize;
 		this.terminationFuture = terminationFuture;
+		this.captureAskCallStack = captureAskCallStack;
 	}
 
 	@Override
@@ -208,20 +213,20 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 
 			result = null;
 		} else {
-			// execute an asynchronous call
-			CompletableFuture<?> resultFuture = ask(rpcInvocation, futureTimeout);
+			// Capture the call stack. It is significantly faster to do that via an exception than
+			// via Thread.getStackTrace(), because exceptions lazily initialize the stack trace, initially only
+			// capture a lightweight native pointer, and convert that into the stack trace lazily when needed.
+			final Throwable callStackCapture = captureAskCallStack ? new Throwable() : null;
 
-			CompletableFuture<?> completableFuture = resultFuture.thenApply((Object o) -> {
-				if (o instanceof SerializedValue) {
-					try {
-						return  ((SerializedValue<?>) o).deserializeValue(getClass().getClassLoader());
-					} catch (IOException | ClassNotFoundException e) {
-						throw new CompletionException(
-							new RpcException("Could not deserialize the serialized payload of RPC method : "
-								+ methodName, e));
-					}
+			// execute an asynchronous call
+			final CompletableFuture<?> resultFuture = ask(rpcInvocation, futureTimeout);
+
+			final CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+			resultFuture.whenComplete((resultValue, failure) -> {
+				if (failure != null) {
+					completableFuture.completeExceptionally(resolveTimeoutException(failure, callStackCapture, method));
 				} else {
-					return o;
+					completableFuture.complete(deserializeValueIfNeeded(resultValue, method));
 				}
 			});
 
@@ -369,5 +374,34 @@ class AkkaInvocationHandler implements InvocationHandler, AkkaBasedEndpoint, Rpc
 	@Override
 	public CompletableFuture<Void> getTerminationFuture() {
 		return terminationFuture;
+	}
+
+	static Object deserializeValueIfNeeded(Object o, Method method) {
+		if (o instanceof SerializedValue) {
+			try {
+				return  ((SerializedValue<?>) o).deserializeValue(AkkaInvocationHandler.class.getClassLoader());
+			} catch (IOException | ClassNotFoundException e) {
+				throw new CompletionException(
+					new RpcException(
+						"Could not deserialize the serialized payload of RPC method : " + method.getName(), e));
+			}
+		} else {
+			return o;
+		}
+	}
+
+	static Throwable resolveTimeoutException(Throwable exception, @Nullable Throwable callStackCapture, Method method) {
+		if (callStackCapture == null || (!(exception instanceof akka.pattern.AskTimeoutException))) {
+			return exception;
+		}
+
+		final TimeoutException newException = new TimeoutException("Invocation of " + method + " timed out.");
+		newException.initCause(exception);
+
+		// remove the stack frames coming from the proxy interface invocation
+		final StackTraceElement[] stackTrace = callStackCapture.getStackTrace();
+		newException.setStackTrace(Arrays.copyOfRange(stackTrace, 3, stackTrace.length));
+
+		return newException;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -98,6 +98,8 @@ public class AkkaRpcService implements RpcService {
 	private final String address;
 	private final int port;
 
+	private final boolean captureAskCallstacks;
+
 	private final ScheduledExecutor internalScheduledExecutor;
 
 	private final CompletableFuture<Void> terminationFuture;
@@ -121,6 +123,8 @@ public class AkkaRpcService implements RpcService {
 		} else {
 			port = -1;
 		}
+
+		captureAskCallstacks = configuration.captureAskCallStack();
 
 		internalScheduledExecutor = new ActorSystemScheduledExecutorAdapter(actorSystem);
 
@@ -165,7 +169,8 @@ public class AkkaRpcService implements RpcService {
 					actorRef,
 					configuration.getTimeout(),
 					configuration.getMaximumFramesize(),
-					null);
+					null,
+					captureAskCallstacks);
 			});
 	}
 
@@ -185,7 +190,8 @@ public class AkkaRpcService implements RpcService {
 					configuration.getTimeout(),
 					configuration.getMaximumFramesize(),
 					null,
-					() -> fencingToken);
+					() -> fencingToken,
+					captureAskCallstacks);
 			});
 	}
 
@@ -247,7 +253,8 @@ public class AkkaRpcService implements RpcService {
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
 				terminationFuture,
-				((FencedRpcEndpoint<?>) rpcEndpoint)::getFencingToken);
+				((FencedRpcEndpoint<?>) rpcEndpoint)::getFencingToken,
+				captureAskCallstacks);
 
 			implementedRpcGateways.add(FencedMainThreadExecutable.class);
 		} else {
@@ -257,7 +264,8 @@ public class AkkaRpcService implements RpcService {
 				actorRef,
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
-				terminationFuture);
+				terminationFuture,
+				captureAskCallstacks);
 		}
 
 		// Rather than using the System ClassLoader directly, we derive the ClassLoader
@@ -285,7 +293,8 @@ public class AkkaRpcService implements RpcService {
 				configuration.getTimeout(),
 				configuration.getMaximumFramesize(),
 				null,
-				() -> fencingToken);
+				() -> fencingToken,
+				captureAskCallstacks);
 
 			// Rather than using the System ClassLoader directly, we derive the ClassLoader
 			// from this class . That works better in cases where Flink runs embedded and all Flink

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceConfiguration.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.rpc.akka;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.akka.AkkaUtils;
 
@@ -38,11 +39,19 @@ public class AkkaRpcServiceConfiguration {
 
 	private final long maximumFramesize;
 
-	public AkkaRpcServiceConfiguration(@Nonnull Configuration configuration, @Nonnull Time timeout, long maximumFramesize) {
+	private final boolean captureAskCallStack;
+
+	public AkkaRpcServiceConfiguration(
+			@Nonnull Configuration configuration,
+			@Nonnull Time timeout,
+			long maximumFramesize,
+			boolean captureAskCallStack) {
+
 		checkArgument(maximumFramesize > 0L, "Maximum framesize must be positive.");
 		this.configuration = configuration;
 		this.timeout = timeout;
 		this.maximumFramesize = maximumFramesize;
+		this.captureAskCallStack = captureAskCallStack;
 	}
 
 	@Nonnull
@@ -59,12 +68,18 @@ public class AkkaRpcServiceConfiguration {
 		return maximumFramesize;
 	}
 
+	public boolean captureAskCallStack() {
+		return captureAskCallStack;
+	}
+
 	public static AkkaRpcServiceConfiguration fromConfiguration(Configuration configuration) {
 		final Time timeout = AkkaUtils.getTimeoutAsTime(configuration);
 
 		final long maximumFramesize = AkkaRpcServiceUtils.extractMaximumFramesize(configuration);
 
-		return new AkkaRpcServiceConfiguration(configuration, timeout, maximumFramesize);
+		final boolean captureAskCallStacks = configuration.get(AkkaOptions.CAPTURE_ASK_CALLSTACK);
+
+		return new AkkaRpcServiceConfiguration(configuration, timeout, maximumFramesize, captureAskCallStacks);
 	}
 
 	public static AkkaRpcServiceConfiguration defaultConfiguration() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/FencedAkkaInvocationHandler.java
@@ -61,8 +61,9 @@ public class FencedAkkaInvocationHandler<F extends Serializable> extends AkkaInv
 			Time timeout,
 			long maximumFramesize,
 			@Nullable CompletableFuture<Void> terminationFuture,
-			Supplier<F> fencingTokenSupplier) {
-		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture);
+			Supplier<F> fencingTokenSupplier,
+			boolean captureAskCallStacks) {
+		super(address, hostname, rpcEndpoint, timeout, maximumFramesize, terminationFuture, captureAskCallStacks);
 
 		this.fencingTokenSupplier = Preconditions.checkNotNull(fencingTokenSupplier);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteRpcInvocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/messages/RemoteRpcInvocation.java
@@ -29,8 +29,8 @@ import java.io.Serializable;
 /**
  * Remote rpc invocation message which is used when the actor communication is remote and, thus, the
  * message has to be serialized.
- * <p>
- * In order to fail fast and report an appropriate error message to the user, the method name, the
+ *
+ * <p>In order to fail fast and report an appropriate error message to the user, the method name, the
  * parameter types and the arguments are eagerly serialized. In case the invocation call
  * contains a non-serializable object, then an {@link IOException} is thrown.
  */
@@ -138,7 +138,7 @@ public class RemoteRpcInvocation implements RpcInvocation, Serializable {
 	// -------------------------------------------------------------------
 
 	/**
-	 * Wrapper class for the method invocation information
+	 * Wrapper class for the method invocation information.
 	 */
 	private static final class MethodInvocation implements Serializable {
 		private static final long serialVersionUID = 9187962608946082519L;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -51,7 +51,6 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
-import akka.pattern.AskTimeoutException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -63,9 +62,11 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -249,7 +250,9 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				firstFuture.get();
 				fail("Should have failed because connection to taskmanager is delayed beyond timeout");
 			} catch (Exception e) {
-				assertThat(ExceptionUtils.stripExecutionException(e), instanceOf(AskTimeoutException.class));
+				final Throwable cause = ExceptionUtils.stripExecutionException(e);
+				assertThat(cause, instanceOf(TimeoutException.class));
+				assertThat(cause.getMessage(), containsString("ResourceManagerGateway.registerTaskExecutor"));
 			}
 
 			startConnection.await();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/TimeoutCallStackTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rpc.RpcEndpoint;
+import org.apache.flink.runtime.rpc.RpcGateway;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.util.IOUtils;
+
+import akka.actor.ActorSystem;
+import akka.actor.Terminated;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests that ask timeouts report the call stack of the calling function.
+ */
+public class TimeoutCallStackTest {
+
+	private static ActorSystem actorSystem;
+	private static RpcService rpcService;
+
+	private final List<RpcEndpoint> endpointsToStop = new ArrayList<>();
+
+	@BeforeClass
+	public static void setup() {
+		actorSystem = AkkaUtils.createDefaultActorSystem();
+		rpcService = new AkkaRpcService(actorSystem, AkkaRpcServiceConfiguration.defaultConfiguration());
+	}
+
+	@AfterClass
+	public static void teardown() throws Exception {
+
+		final CompletableFuture<Void> rpcTerminationFuture = rpcService.stopService();
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = FutureUtils.toJava(actorSystem.terminate());
+
+		FutureUtils
+			.waitForAll(Arrays.asList(rpcTerminationFuture, actorSystemTerminationFuture))
+			.get(10_000, TimeUnit.MILLISECONDS);
+	}
+
+	@After
+	public void stopTestEndpoints() {
+		endpointsToStop.forEach(IOUtils::closeQuietly);
+	}
+
+	@Test
+	public void testTimeoutException() throws Exception {
+		final TestingGateway gateway = createTestingGateway();
+
+		final CompletableFuture<Void> future = gateway.callThatTimesOut(Time.milliseconds(1));
+
+		Throwable failureCause = null;
+		try {
+			future.get();
+			fail("test buggy: the call should never have completed");
+		} catch (ExecutionException e) {
+			failureCause = e.getCause();
+		}
+
+		assertThat(failureCause, instanceOf(TimeoutException.class));
+		assertThat(failureCause.getMessage(), containsString("callThatTimesOut"));
+		assertThat(failureCause.getStackTrace()[0].getMethodName(), equalTo("testTimeoutException"));
+	}
+
+	// ------------------------------------------------------------------------
+	//  setup helpers
+	// ------------------------------------------------------------------------
+
+	private TestingGateway createTestingGateway() throws Exception {
+		final TestingRpcEndpoint endpoint = new TestingRpcEndpoint(rpcService, "test_name");
+		endpointsToStop.add(endpoint);
+		endpoint.start();
+
+		return rpcService.connect(endpoint.getAddress(), TestingGateway.class).get();
+	}
+
+	// ------------------------------------------------------------------------
+	//  testing mocks / stubs
+	// ------------------------------------------------------------------------
+
+	private interface TestingGateway extends RpcGateway {
+
+		CompletableFuture<Void> callThatTimesOut(@RpcTimeout Time timeout);
+	}
+
+	private static final class TestingRpcEndpoint extends RpcEndpoint implements TestingGateway {
+
+		TestingRpcEndpoint(RpcService rpcService, String endpointId) {
+			super(rpcService, endpointId);
+		}
+
+		@Override
+		public CompletableFuture<Void> callThatTimesOut(@RpcTimeout Time timeout) {
+			// return a future that never completes, so the call is guaranteed to time out
+			return new CompletableFuture<>();
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This change preserves the call stack from the invocation of RPC ask() calls. When the call fails, this allows us to add a meaningful exception pointing to the original call site, rather than having just some weird stack trace from akka.

*Note:* While it is possible to do this for all types of ask() failures, this PR uses this approach for now only for timeouts.

Former exception message and stack trace:
```
akka.pattern.AskTimeoutException: Ask timed out on [Actor[akka://flink/user/test_name#-585757974]] after [1 ms]. Message of type [org.apache.flink.runtime.rpc.messages.LocalRpcInvocation]. A typical reason for `AskTimeoutException` is that the recipient actor didn't send a reply.
	at akka.pattern.PromiseActorRef$$anonfun$2.apply(AskSupport.scala:635)
	at akka.pattern.PromiseActorRef$$anonfun$2.apply(AskSupport.scala:635)
	at akka.pattern.PromiseActorRef$$anonfun$1.apply$mcV$sp(AskSupport.scala:648)
	at akka.actor.Scheduler$$anon$4.run(Scheduler.scala:205)
	at scala.concurrent.Future$InternalCallbackExecutor$.unbatchedExecute(Future.scala:601)
	at scala.concurrent.BatchingExecutor$class.execute(BatchingExecutor.scala:109)
	at scala.concurrent.Future$InternalCallbackExecutor$.execute(Future.scala:599)
	at akka.actor.LightArrayRevolverScheduler$TaskHolder.executeTask(LightArrayRevolverScheduler.scala:328)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.executeBucket$1(LightArrayRevolverScheduler.scala:279)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.nextTick(LightArrayRevolverScheduler.scala:283)
	at akka.actor.LightArrayRevolverScheduler$$anon$4.run(LightArrayRevolverScheduler.scala:235)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
New exceptions and stack trace:
```
java.util.concurrent.TimeoutException: Invocation of java.util.concurrent.CompletableFuture org.apache.flink.runtime.rpc.akka.TimeoutCallStackTest$TestingGateway.callThatTimesOut(org.apache.flink.api.common.time.Time) timed out.
	at org.apache.flink.runtime.rpc.akka.TimeoutCallStackTest.testTimeoutException(TimeoutCallStackTest.java:87)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	...
```

## Brief change log

  - Add a new config option `akka.ask.callstack` (default: true)
  - Capture call stack at call site
  - Replace exception on timeout

## Verifying this change

You can verify this with any Flink deployment where something times out, for example deploy/cancel calls when a TaskManager is killed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **config docs**
