### PR TITLE
[FLINK-15961][table-planner][table-planner-blink] Introduce Python Physical Correlate RelNodes which are containers for Python TableFunction

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCorrelateRule.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.batch;
+
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCorrelate;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
+import org.apache.flink.table.planner.plan.nodes.physical.batch.BatchExecPythonCorrelate;
+import org.apache.flink.table.planner.plan.utils.PythonUtil;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rex.RexNode;
+
+import scala.Option;
+import scala.Some;
+
+/**
+ * The physical rule is responsible for convert {@link FlinkLogicalCorrelate} to
+ * {@link BatchExecPythonCorrelate}.
+ */
+public class BatchExecPythonCorrelateRule extends ConverterRule {
+
+	public static final RelOptRule INSTANCE = new BatchExecPythonCorrelateRule();
+
+	private BatchExecPythonCorrelateRule() {
+		super(FlinkLogicalCorrelate.class, FlinkConventions.LOGICAL(), FlinkConventions.BATCH_PHYSICAL(),
+			"BatchExecPythonCorrelateRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		FlinkLogicalCorrelate join = call.rel(0);
+		RelNode right = ((RelSubset) join.getRight()).getOriginal();
+
+		if (right instanceof FlinkLogicalTableFunctionScan) {
+			// right node is a python table function
+			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
+			return PythonUtil.isPythonCall(scan.getCall());
+		} else if (right instanceof FlinkLogicalCalc) {
+			// a filter is pushed above the table function
+			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
+			RelSubset input = (RelSubset) calc.getInput();
+			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) input.getOriginal();
+			return PythonUtil.isPythonCall(scan.getCall());
+		}
+		return false;
+	}
+
+	@Override
+	public RelNode convert(RelNode relNode) {
+		BatchExecPythonCorrelateFactory factory = new BatchExecPythonCorrelateFactory(relNode);
+		return factory.convertToCorrelate();
+	}
+
+	/**
+	 * The factory is responsible to creating {@link BatchExecPythonCorrelate}.
+	 */
+	private static class BatchExecPythonCorrelateFactory {
+		private final RelNode correlateRel;
+		private final FlinkLogicalCorrelate correlate;
+		private final RelTraitSet traitSet;
+		private final RelNode convInput;
+		private final RelNode right;
+
+		BatchExecPythonCorrelateFactory(RelNode rel) {
+			this.correlateRel = rel;
+			this.correlate = (FlinkLogicalCorrelate) rel;
+			this.traitSet = rel.getTraitSet().replace(FlinkConventions.BATCH_PHYSICAL());
+			this.convInput = RelOptRule.convert(
+				correlate.getInput(0), FlinkConventions.BATCH_PHYSICAL());
+			this.right = correlate.getInput(1);
+		}
+
+		BatchExecPythonCorrelate convertToCorrelate() {
+			return convertToCorrelate(right, Option.empty());
+		}
+
+		private BatchExecPythonCorrelate convertToCorrelate(
+			RelNode relNode,
+			Option<RexNode> condition) {
+			if (relNode instanceof RelSubset) {
+				RelSubset rel = (RelSubset) relNode;
+				return convertToCorrelate(rel.getRelList().get(0), condition);
+			} else if (relNode instanceof FlinkLogicalCalc) {
+				FlinkLogicalCalc calc = (FlinkLogicalCalc) relNode;
+				return convertToCorrelate(
+					((RelSubset) calc.getInput()).getOriginal(),
+					Some.apply(calc.getProgram().expandLocalRef(calc.getProgram().getCondition())));
+			} else {
+				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) relNode;
+				return new BatchExecPythonCorrelate(
+					correlateRel.getCluster(),
+					traitSet,
+					convInput,
+					scan,
+					condition,
+					null,
+					correlateRel.getRowType(),
+					correlate.getJoinType());
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
@@ -67,8 +67,9 @@ public class StreamExecPythonCorrelateRule extends ConverterRule {
 		FlinkLogicalCorrelate correlate = call.rel(0);
 		RelNode right = ((RelSubset) correlate.getRight()).getOriginal();
 		if (right instanceof FlinkLogicalTableFunctionScan) {
-			// right node is a python table function
+			// right node is a table function
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
+			// return true if the table function is python table function
 			return PythonUtil.isPythonCall(scan.getCall());
 		} else if (right instanceof FlinkLogicalCalc) {
 			// a filter is pushed above the table function
@@ -84,17 +85,15 @@ public class StreamExecPythonCorrelateRule extends ConverterRule {
 	}
 
 	/**
-	 * The factory is responsible to creating {@link StreamExecPythonCorrelate}.
+	 * The factory is responsible for creating {@link StreamExecPythonCorrelate}.
 	 */
 	private static class StreamExecPythonCorrelateFactory {
-		private final RelNode correlateRel;
 		private final FlinkLogicalCorrelate correlate;
 		private final RelTraitSet traitSet;
 		private final RelNode convInput;
 		private final RelNode right;
 
 		StreamExecPythonCorrelateFactory(RelNode rel) {
-			this.correlateRel = rel;
 			this.correlate = (FlinkLogicalCorrelate) rel;
 			this.traitSet = rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
 			this.convInput = RelOptRule.convert(
@@ -122,13 +121,13 @@ public class StreamExecPythonCorrelateRule extends ConverterRule {
 			} else {
 				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) relNode;
 				return new StreamExecPythonCorrelate(
-					correlateRel.getCluster(),
+					correlate.getCluster(),
 					traitSet,
 					convInput,
 					null,
 					scan,
 					condition,
-					correlateRel.getRowType(),
+					correlate.getRowType(),
 					correlate.getJoinType());
 			}
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.physical.stream;
+
+import org.apache.flink.table.planner.plan.nodes.FlinkConventions;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCorrelate;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecPythonCorrelate;
+import org.apache.flink.table.planner.plan.utils.PythonUtil;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rex.RexNode;
+
+import scala.Option;
+import scala.Some;
+
+/**
+ * The physical rule is responsible for convert {@link FlinkLogicalCorrelate} to
+ * {@link StreamExecPythonCorrelate}.
+ */
+public class StreamExecPythonCorrelateRule extends ConverterRule {
+
+	public static final RelOptRule INSTANCE = new StreamExecPythonCorrelateRule();
+
+	private StreamExecPythonCorrelateRule() {
+		super(FlinkLogicalCorrelate.class, FlinkConventions.LOGICAL(), FlinkConventions.STREAM_PHYSICAL(),
+			"StreamExecPythonCorrelateRule");
+	}
+
+	// find only calc and table function
+	private boolean findTableFunction(FlinkLogicalCalc calc) {
+		RelNode child = ((RelSubset) calc.getInput()).getOriginal();
+		if (child instanceof FlinkLogicalTableFunctionScan) {
+			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) child;
+			return PythonUtil.isPythonCall(scan.getCall());
+		} else if (child instanceof FlinkLogicalCalc) {
+			FlinkLogicalCalc childCalc = (FlinkLogicalCalc) child;
+			return findTableFunction(childCalc);
+		}
+		return false;
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		FlinkLogicalCorrelate correlate = call.rel(0);
+		RelNode right = ((RelSubset) correlate.getRight()).getOriginal();
+		if (right instanceof FlinkLogicalTableFunctionScan) {
+			// right node is a python table function
+			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
+			return PythonUtil.isPythonCall(scan.getCall());
+		} else if (right instanceof FlinkLogicalCalc) {
+			// a filter is pushed above the table function
+			return findTableFunction((FlinkLogicalCalc) right);
+		}
+		return false;
+	}
+
+	@Override
+	public RelNode convert(RelNode relNode) {
+		StreamExecPythonCorrelateFactory factory = new StreamExecPythonCorrelateFactory(relNode);
+		return factory.convertToCorrelate();
+	}
+
+	/**
+	 * The factory is responsible to creating {@link StreamExecPythonCorrelate}.
+	 */
+	private static class StreamExecPythonCorrelateFactory {
+		private final RelNode correlateRel;
+		private final FlinkLogicalCorrelate correlate;
+		private final RelTraitSet traitSet;
+		private final RelNode convInput;
+		private final RelNode right;
+
+		StreamExecPythonCorrelateFactory(RelNode rel) {
+			this.correlateRel = rel;
+			this.correlate = (FlinkLogicalCorrelate) rel;
+			this.traitSet = rel.getTraitSet().replace(FlinkConventions.STREAM_PHYSICAL());
+			this.convInput = RelOptRule.convert(
+				correlate.getInput(0), FlinkConventions.STREAM_PHYSICAL());
+			this.right = correlate.getInput(1);
+		}
+
+		StreamExecPythonCorrelate convertToCorrelate() {
+			return convertToCorrelate(right, Option.empty());
+		}
+
+		private StreamExecPythonCorrelate convertToCorrelate(
+			RelNode relNode,
+			Option<RexNode> condition) {
+			if (relNode instanceof RelSubset) {
+				RelSubset rel = (RelSubset) relNode;
+				return convertToCorrelate(rel.getRelList().get(0), condition);
+			} else if (relNode instanceof FlinkLogicalCalc) {
+				FlinkLogicalCalc calc = (FlinkLogicalCalc) relNode;
+				RelNode tableScan = StreamExecCorrelateRule.getTableScan(calc);
+				FlinkLogicalCalc newCalc = StreamExecCorrelateRule.getMergedCalc(calc);
+				return convertToCorrelate(
+					tableScan,
+					Some.apply(newCalc.getProgram().expandLocalRef(newCalc.getProgram().getCondition())));
+			} else {
+				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) relNode;
+				return new StreamExecPythonCorrelate(
+					correlateRel.getCluster(),
+					traitSet,
+					convInput,
+					null,
+					scan,
+					condition,
+					correlateRel.getRowType(),
+					correlate.getJoinType());
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelate.scala
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**
-  * Batch physical RelNode for [[Correlate]] (Java user defined table function).
+  * Batch physical RelNode for [[Correlate]] (Java/Scala user defined table function).
   */
 class BatchExecCorrelate(
     cluster: RelOptCluster,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.batch
+
+import org.apache.flink.runtime.operators.DamBehavior
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.planner.delegation.BatchPlanner
+import org.apache.flink.table.planner.functions.utils.TableSqlFunction
+import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, TraitUtil}
+import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.planner.plan.utils.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.{Correlate, JoinRelType}
+import org.apache.calcite.rel.{RelCollationTraitDef, RelDistribution, RelFieldCollation, RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
+import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.util.mapping.{Mapping, MappingType, Mappings}
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Base Batch physical RelNode for [[Correlate]] (user defined table function).
+  */
+abstract class BatchExecCorrelateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    scan: FlinkLogicalTableFunctionScan,
+    condition: Option[RexNode],
+    projectProgram: Option[RexProgram],
+    outputRowType: RelDataType,
+    joinType: JoinRelType)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with BatchPhysicalRel
+  with BatchExecNode[BaseRow] {
+
+  require(joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT)
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    copy(traitSet, inputs.get(0), projectProgram, outputRowType)
+  }
+
+  /**
+    * Note: do not passing member 'child' because singleRel.replaceInput may update 'input' rel.
+    */
+  def copy(
+      traitSet: RelTraitSet,
+      child: RelNode,
+      projectProgram: Option[RexProgram],
+      outputType: RelDataType): RelNode
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val rexCall = scan.getCall.asInstanceOf[RexCall]
+    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
+    super.explainTerms(pw)
+      .item("invocation", scan.getCall)
+      .item("correlate", RelExplainUtil.correlateToString(
+        input.getRowType, rexCall, sqlFunction, getExpressionString))
+      .item("select", outputRowType.getFieldNames.mkString(","))
+      .item("rowType", outputRowType)
+      .item("joinType", joinType)
+      .itemIf("condition", condition.orNull, condition.isDefined)
+  }
+
+  override def satisfyTraits(requiredTraitSet: RelTraitSet): Option[RelNode] = {
+    val requiredDistribution = requiredTraitSet.getTrait(FlinkRelDistributionTraitDef.INSTANCE)
+    // Correlate could not provide broadcast distribution
+    if (requiredDistribution.getType == RelDistribution.Type.BROADCAST_DISTRIBUTED) {
+      return None
+    }
+
+    def getOutputInputMapping: Mapping = {
+      val inputFieldCnt = getInput.getRowType.getFieldCount
+      projectProgram match {
+        case Some(program) =>
+          val projects = program.getProjectList.map(program.expandLocalRef)
+          val mapping = Mappings.create(MappingType.INVERSE_FUNCTION, inputFieldCnt, projects.size)
+          projects.zipWithIndex.foreach {
+            case (project, index) =>
+              project match {
+                case inputRef: RexInputRef => mapping.set(inputRef.getIndex, index)
+                case call: RexCall if call.getKind == SqlKind.AS =>
+                  call.getOperands.head match {
+                    case inputRef: RexInputRef => mapping.set(inputRef.getIndex, index)
+                    case _ => // ignore
+                  }
+                case _ => // ignore
+              }
+          }
+          mapping.inverse()
+        case _ =>
+          val mapping = Mappings.create(MappingType.FUNCTION, inputFieldCnt, inputFieldCnt)
+          (0 until inputFieldCnt).foreach {
+            index => mapping.set(index, index)
+          }
+          mapping
+      }
+    }
+
+    val mapping = getOutputInputMapping
+    val appliedDistribution = requiredDistribution.apply(mapping)
+    // If both distribution and collation can be satisfied, satisfy both. If only distribution
+    // can be satisfied, only satisfy distribution. There is no possibility to only satisfy
+    // collation here except for there is no distribution requirement.
+    if ((!requiredDistribution.isTop) && (appliedDistribution eq FlinkRelDistribution.ANY)) {
+      return None
+    }
+
+    val requiredCollation = requiredTraitSet.getTrait(RelCollationTraitDef.INSTANCE)
+    val appliedCollation = TraitUtil.apply(requiredCollation, mapping)
+    // the required collation can be satisfied if field collations are not empty
+    // and the direction of each field collation is non-STRICTLY
+    val canSatisfyCollation = appliedCollation.getFieldCollations.nonEmpty &&
+      !appliedCollation.getFieldCollations.exists { c =>
+        (c.getDirection eq RelFieldCollation.Direction.STRICTLY_ASCENDING) ||
+          (c.getDirection eq RelFieldCollation.Direction.STRICTLY_DESCENDING)
+      }
+    // If required traits only contains collation requirements, but collation keys are not columns
+    // from input, then no need to satisfy required traits.
+    if ((appliedDistribution eq FlinkRelDistribution.ANY) && !canSatisfyCollation) {
+      return None
+    }
+
+    var inputRequiredTraits = getInput.getTraitSet
+    var providedTraits = getTraitSet
+    if (!appliedDistribution.isTop) {
+      inputRequiredTraits = inputRequiredTraits.replace(appliedDistribution)
+      providedTraits = providedTraits.replace(requiredDistribution)
+    }
+    if (canSatisfyCollation) {
+      inputRequiredTraits = inputRequiredTraits.replace(appliedCollation)
+      providedTraits = providedTraits.replace(requiredCollation)
+    }
+    val newInput = RelOptRule.convert(getInput, inputRequiredTraits)
+    Some(copy(providedTraits, Seq(newInput)))
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getDamBehavior: DamBehavior = DamBehavior.PIPELINED
+
+  override def getInputNodes: util.List[ExecNode[BatchPlanner, _]] =
+    getInputs.map(_.asInstanceOf[ExecNode[BatchPlanner, _]])
+
+  override def replaceInputNode(
+      ordinalInParent: Int,
+      newInputNode: ExecNode[BatchPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 import org.apache.flink.runtime.operators.DamBehavior
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.planner.delegation.BatchPlanner
-import org.apache.flink.table.planner.functions.utils.TableSqlFunction
 import org.apache.flink.table.planner.plan.`trait`.{FlinkRelDistribution, FlinkRelDistributionTraitDef, TraitUtil}
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
@@ -73,7 +72,6 @@ abstract class BatchExecCorrelateBase(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     val rexCall = scan.getCall.asInstanceOf[RexCall]
-    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
     super.explainTerms(pw)
       .item("invocation", scan.getCall)
       .item("correlate", RelExplainUtil.correlateToString(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecCorrelateBase.scala
@@ -77,7 +77,7 @@ abstract class BatchExecCorrelateBase(
     super.explainTerms(pw)
       .item("invocation", scan.getCall)
       .item("correlate", RelExplainUtil.correlateToString(
-        input.getRowType, rexCall, sqlFunction, getExpressionString))
+        input.getRowType, rexCall, getExpressionString))
       .item("select", outputRowType.getFieldNames.mkString(","))
       .item("rowType", outputRowType)
       .item("joinType", joinType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -68,6 +68,6 @@ class BatchExecPythonCorrelate(
 
   override protected def translateToPlanInternal(
       planner: BatchPlanner): Transformation[BaseRow] = {
-    throw new TableException("The implementation will be next commit.")
+    throw new TableException("The implementation will be FLINK-15972.")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -19,20 +19,19 @@ package org.apache.flink.table.planner.plan.nodes.physical.batch
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.dataformat.BaseRow
-import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CorrelateCodeGenerator}
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.{Correlate, JoinRelType}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
+import org.apache.flink.table.api.TableException
 
 /**
-  * Batch physical RelNode for [[Correlate]] (Java user defined table function).
+  * Batch physical RelNode for [[Correlate]] (Python user defined table function).
   */
-class BatchExecCorrelate(
+class BatchExecPythonCorrelate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
@@ -56,7 +55,7 @@ class BatchExecCorrelate(
       child: RelNode,
       projectProgram: Option[RexProgram],
       outputType: RelDataType): RelNode = {
-    new BatchExecCorrelate(
+    new BatchExecPythonCorrelate(
       cluster,
       traitSet,
       child,
@@ -69,25 +68,6 @@ class BatchExecCorrelate(
 
   override protected def translateToPlanInternal(
       planner: BatchPlanner): Transformation[BaseRow] = {
-    val config = planner.getTableConfig
-    val inputTransformation = getInputNodes.get(0).translateToPlan(planner)
-      .asInstanceOf[Transformation[BaseRow]]
-    val operatorCtx = CodeGeneratorContext(config)
-    CorrelateCodeGenerator.generateCorrelateTransformation(
-      config,
-      operatorCtx,
-      inputTransformation,
-      input.getRowType,
-      projectProgram,
-      scan,
-      condition,
-      outputRowType,
-      joinType,
-      inputTransformation.getParallelism,
-      retainHeader = false,
-      getExpressionString,
-      "BatchExecCorrelate",
-      getRelDetailedDescription)
+    throw new TableException("The implementation will be next commit.")
   }
-
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
@@ -17,61 +17,41 @@
  */
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
-import java.util
-
-import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
-import org.apache.calcite.rex.{RexCall, RexNode, RexProgram}
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CorrelateCodeGenerator}
 import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
-import org.apache.flink.table.planner.plan.utils.RelExplainUtil
 import org.apache.flink.table.runtime.operators.AbstractProcessStreamOperator
 
-import scala.collection.JavaConversions._
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**
-  * Flink RelNode which matches along with join a user defined table function.
+  * Flink RelNode which matches along with join a java user defined table function.
   */
 class StreamExecCorrelate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
-    val projectProgram: Option[RexProgram],
+    projectProgram: Option[RexProgram],
     scan: FlinkLogicalTableFunctionScan,
     condition: Option[RexNode],
     outputRowType: RelDataType,
     joinType: JoinRelType)
-  extends SingleRel(cluster, traitSet, inputRel)
-  with StreamPhysicalRel
-  with StreamExecNode[BaseRow] {
+  extends StreamExecCorrelateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    projectProgram,
+    scan,
+    condition,
+    outputRowType,
+    joinType) {
 
-  require(joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT)
-
-  override def producesUpdates: Boolean = false
-
-  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
-
-  override def consumesRetractions: Boolean = false
-
-  override def producesRetractions: Boolean = false
-
-  override def requireWatermark: Boolean = false
-
-  override def deriveRowType(): RelDataType = outputRowType
-
-  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    copy(traitSet, inputs.get(0), projectProgram, outputRowType)
-  }
-
-  /**
-    * Note: do not passing member 'child' because singleRel.replaceInput may update 'input' rel.
-    */
   def copy(
       traitSet: RelTraitSet,
       newChild: RelNode,
@@ -86,29 +66,6 @@ class StreamExecCorrelate(
       condition,
       outputType,
       joinType)
-  }
-
-  override def explainTerms(pw: RelWriter): RelWriter = {
-    val rexCall = scan.getCall.asInstanceOf[RexCall]
-    super.explainTerms(pw)
-      .item("invocation", scan.getCall)
-      .item("correlate", RelExplainUtil.correlateToString(
-        inputRel.getRowType, rexCall, getExpressionString))
-      .item("select", outputRowType.getFieldNames.mkString(","))
-      .item("rowType", outputRowType)
-      .item("joinType", joinType)
-      .itemIf("condition", condition.orNull, condition.isDefined)
-  }
-
-  //~ ExecNode methods -----------------------------------------------------------
-
-  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] =
-    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
-
-  override def replaceInputNode(
-      ordinalInParent: Int,
-      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
-    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
   }
 
   override protected def translateToPlanInternal(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelate.scala
@@ -31,7 +31,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexNode, RexProgram}
 
 /**
-  * Flink RelNode which matches along with join a java user defined table function.
+  * Flink RelNode which matches along with join a Java/Scala user defined table function.
   */
 class StreamExecCorrelate(
     cluster: RelOptCluster,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.table.dataformat.BaseRow
+import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.functions.utils.TableSqlFunction
+import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.planner.plan.utils.RelExplainUtil
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rex.{RexCall, RexNode, RexProgram}
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Base Flink RelNode which matches along with join a user defined table function.
+  */
+abstract class StreamExecCorrelateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    val projectProgram: Option[RexProgram],
+    scan: FlinkLogicalTableFunctionScan,
+    condition: Option[RexNode],
+    outputRowType: RelDataType,
+    joinType: JoinRelType)
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel
+  with StreamExecNode[BaseRow] {
+
+  require(joinType == JoinRelType.INNER || joinType == JoinRelType.LEFT)
+
+  override def producesUpdates: Boolean = false
+
+  override def needsUpdatesAsRetraction(input: RelNode): Boolean = false
+
+  override def consumesRetractions: Boolean = false
+
+  override def producesRetractions: Boolean = false
+
+  override def requireWatermark: Boolean = false
+
+  override def deriveRowType(): RelDataType = outputRowType
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    copy(traitSet, inputs.get(0), projectProgram, outputRowType)
+  }
+
+  /**
+    * Note: do not passing member 'child' because singleRel.replaceInput may update 'input' rel.
+    */
+  def copy(
+      traitSet: RelTraitSet,
+      newChild: RelNode,
+      projectProgram: Option[RexProgram],
+      outputType: RelDataType): RelNode
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val rexCall = scan.getCall.asInstanceOf[RexCall]
+    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
+    super.explainTerms(pw)
+      .item("invocation", scan.getCall)
+      .item("correlate", RelExplainUtil.correlateToString(
+        inputRel.getRowType, rexCall, sqlFunction, getExpressionString))
+      .item("select", outputRowType.getFieldNames.mkString(","))
+      .item("rowType", outputRowType)
+      .item("joinType", joinType)
+      .itemIf("condition", condition.orNull, condition.isDefined)
+  }
+
+  //~ ExecNode methods -----------------------------------------------------------
+
+  override def getInputNodes: util.List[ExecNode[StreamPlanner, _]] =
+    getInputs.map(_.asInstanceOf[ExecNode[StreamPlanner, _]])
+
+  override def replaceInputNode(
+      ordinalInParent: Int,
+      newInputNode: ExecNode[StreamPlanner, _]): Unit = {
+    replaceInput(ordinalInParent, newInputNode.asInstanceOf[RelNode])
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
@@ -83,7 +83,7 @@ abstract class StreamExecCorrelateBase(
     super.explainTerms(pw)
       .item("invocation", scan.getCall)
       .item("correlate", RelExplainUtil.correlateToString(
-        inputRel.getRowType, rexCall, sqlFunction, getExpressionString))
+        inputRel.getRowType, rexCall, getExpressionString))
       .item("select", outputRowType.getFieldNames.mkString(","))
       .item("rowType", outputRowType)
       .item("joinType", joinType)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecCorrelateBase.scala
@@ -19,7 +19,6 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.planner.delegation.StreamPlanner
-import org.apache.flink.table.planner.functions.utils.TableSqlFunction
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableFunctionScan
 import org.apache.flink.table.planner.plan.utils.RelExplainUtil
@@ -79,7 +78,6 @@ abstract class StreamExecCorrelateBase(
 
   override def explainTerms(pw: RelWriter): RelWriter = {
     val rexCall = scan.getCall.asInstanceOf[RexCall]
-    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
     super.explainTerms(pw)
       .item("invocation", scan.getCall)
       .item("correlate", RelExplainUtil.correlateToString(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -68,6 +68,6 @@ class StreamExecPythonCorrelate(
 
   override protected def translateToPlanInternal(
       planner: StreamPlanner): Transformation[BaseRow] = {
-    throw new TableException("The implementation will be next commit.")
+    throw new TableException("The implementation will be FLINK-15972.")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -415,6 +415,7 @@ object FlinkBatchRuleSets {
     // correlate
     BatchExecConstantTableFunctionScanRule.INSTANCE,
     BatchExecCorrelateRule.INSTANCE,
+    BatchExecPythonCorrelateRule.INSTANCE,
     // sink
     BatchExecSinkRule.INSTANCE
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -396,6 +396,7 @@ object FlinkStreamRuleSets {
     // correlate
     StreamExecConstantTableFunctionScanRule.INSTANCE,
     StreamExecCorrelateRule.INSTANCE,
+    StreamExecPythonCorrelateRule.INSTANCE,
     // sink
     StreamExecSinkRule.INSTANCE
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecCorrelateRule.scala
@@ -40,13 +40,17 @@ class BatchExecCorrelateRule extends ConverterRule(
     val right = join.getRight.asInstanceOf[RelSubset].getOriginal
 
     right match {
-      // right node is a java table function
+      // right node is a table function
+      // return true if it is a non python table function
       case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
       // a filter is pushed above the table function
+      // return true if it is a non python table function
       case calc: FlinkLogicalCalc =>
-        val scan = calc.getInput.asInstanceOf[RelSubset]
-          .getOriginal.asInstanceOf[FlinkLogicalTableFunctionScan]
-        PythonUtil.isNonPythonCall(scan.getCall)
+        calc.getInput.asInstanceOf[RelSubset].getOriginal match {
+          case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
+          case _ => false
+        }
+      case _ => false
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCorrelateRule.scala
@@ -52,7 +52,7 @@ class StreamExecCorrelateRule
     }
 
     right match {
-      // right node is a java table function
+      // right node is a table function
       case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
       // a filter is pushed above the table function
       case calc: FlinkLogicalCalc => findTableFunction(calc)
@@ -122,7 +122,7 @@ object StreamExecCorrelateRule {
     }
   }
 
-  def getTableScan(calc: FlinkLogicalCalc): RelNode = {
+  def getTableScan(calc: FlinkLogicalCalc): FlinkLogicalTableFunctionScan = {
     val child = calc.getInput.asInstanceOf[RelSubset].getOriginal
     child match {
       case scan: FlinkLogicalTableFunctionScan => scan

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCorrelateRule.scala
@@ -22,12 +22,13 @@ import org.apache.flink.table.api.TableException
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
 import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamExecCorrelate
-import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecCorrelateRule.getMergedCalc
+import org.apache.flink.table.planner.plan.rules.physical.stream.StreamExecCorrelateRule.{getMergedCalc, getTableScan}
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelTraitSet}
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.convert.ConverterRule
 import org.apache.calcite.rex.{RexNode, RexProgram, RexProgramBuilder}
+import org.apache.flink.table.planner.plan.utils.PythonUtil
 
 class StreamExecCorrelateRule
   extends ConverterRule(
@@ -44,15 +45,15 @@ class StreamExecCorrelateRule
     def findTableFunction(calc: FlinkLogicalCalc): Boolean = {
       val child = calc.getInput.asInstanceOf[RelSubset].getOriginal
       child match {
-        case scan: FlinkLogicalTableFunctionScan => true
+        case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
         case calc: FlinkLogicalCalc => findTableFunction(calc)
         case _ => false
       }
     }
 
     right match {
-      // right node is a table function
-      case _: FlinkLogicalTableFunctionScan => true
+      // right node is a java table function
+      case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
       // a filter is pushed above the table function
       case calc: FlinkLogicalCalc => findTableFunction(calc)
       case _ => false
@@ -65,16 +66,6 @@ class StreamExecCorrelateRule
     val convInput: RelNode = RelOptRule.convert(
       correlate.getInput(0), FlinkConventions.STREAM_PHYSICAL)
     val right: RelNode = correlate.getInput(1)
-
-
-    def getTableScan(calc: FlinkLogicalCalc): RelNode = {
-      val child = calc.getInput.asInstanceOf[RelSubset].getOriginal
-      child match {
-        case scan: FlinkLogicalTableFunctionScan => scan
-        case calc: FlinkLogicalCalc => getTableScan(calc)
-        case _ => throw new TableException("This must be a bug, could not find table scan")
-      }
-    }
 
     def convertToCorrelate(relNode: RelNode, condition: Option[RexNode]): StreamExecCorrelate = {
       relNode match {
@@ -128,6 +119,15 @@ object StreamExecCorrelateRule {
           .asInstanceOf[FlinkLogicalCalc]
       case _ =>
         calc
+    }
+  }
+
+  def getTableScan(calc: FlinkLogicalCalc): RelNode = {
+    val child = calc.getInput.asInstanceOf[RelSubset].getOriginal
+    child match {
+      case scan: FlinkLogicalTableFunctionScan => scan
+      case calc: FlinkLogicalCalc => getTableScan(calc)
+      case _ => throw new TableException("This must be a bug, could not find table scan")
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.utils
 
 import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.flink.table.functions.python.PythonFunction
-import org.apache.flink.table.planner.functions.utils.ScalarSqlFunction
+import org.apache.flink.table.planner.functions.utils.{ScalarSqlFunction, TableSqlFunction}
 
 import scala.collection.JavaConversions._
 
@@ -75,6 +75,7 @@ object PythonUtil {
       */
     private def isPythonRexCall(rexCall: RexCall): Boolean = rexCall.getOperator match {
       case sfc: ScalarSqlFunction => sfc.scalarFunction.isInstanceOf[PythonFunction]
+      case tfc: TableSqlFunction => tfc.udtf.isInstanceOf[PythonFunction]
       case _ => false
     }
 

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.xml
@@ -127,4 +127,19 @@ Calc(select=[c, s])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelatePythonTableFunction">
+    <Resource name="planBefore">
+	  <![CDATA[
+LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
+:- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
+]]>
+	</Resource>
+    <Resource name="planAfter">
+	  <![CDATA[
+PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], correlate=[table(PythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.xml
@@ -132,12 +132,12 @@ Calc(select=[c, s])
 	  <![CDATA[
 LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
 :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-+- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
++- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$MockPythonTableFunction$8c725e0df55184e548883d4b29709539($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
 ]]>
 	</Resource>
     <Resource name="planAfter">
 	  <![CDATA[
-PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], correlate=[table(PythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
+PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$MockPythonTableFunction$8c725e0df55184e548883d4b29709539($0, $1)], correlate=[table(MockPythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
 	</Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -206,4 +206,19 @@ Correlate(invocation=[org$apache$flink$table$planner$utils$PojoTableFunc$eb4ab6b
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCorrelatePythonTableFunction">
+    <Resource name="planBefore">
+	  <![CDATA[
+LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
+:- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
+]]>
+	  </Resource>
+    <Resource name="planAfter">
+	  <![CDATA[
+PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], correlate=[table(PythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.xml
@@ -211,12 +211,12 @@ Correlate(invocation=[org$apache$flink$table$planner$utils$PojoTableFunc$eb4ab6b
 	  <![CDATA[
 LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
 :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-+- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
++- LogicalTableFunctionScan(invocation=[org$apache$flink$table$planner$utils$MockPythonTableFunction$8c725e0df55184e548883d4b29709539($0, $1)], rowType=[RecordType(INTEGER x, INTEGER y)], elementType=[class [Ljava.lang.Object;])
 ]]>
 	  </Resource>
     <Resource name="planAfter">
 	  <![CDATA[
-PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$PythonTableFunction$d1618d261b132f94771c39fe2568b89a($0, $1)], correlate=[table(PythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
+PythonCorrelate(invocation=[org$apache$flink$table$planner$utils$MockPythonTableFunction$8c725e0df55184e548883d4b29709539($0, $1)], correlate=[table(MockPythonTableFunction(a,b))], select=[a,b,c,x,y], rowType=[RecordType(INTEGER a, INTEGER b, VARCHAR(2147483647) c, INTEGER x, INTEGER y)], joinType=[INNER])
 +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
 	</Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.scala
@@ -21,8 +21,7 @@ package org.apache.flink.table.planner.plan.batch.table
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram
-import org.apache.flink.table.planner.utils.{TableFunc0, TableFunc1, TableTestBase}
-
+import org.apache.flink.table.planner.utils.{PythonTableFunction, TableFunc0, TableFunc1, TableTestBase}
 import org.apache.calcite.rel.rules.{CalcMergeRule, FilterCalcMergeRule, ProjectCalcMergeRule}
 import org.apache.calcite.tools.RuleSets
 import org.junit.Test
@@ -114,6 +113,17 @@ class CorrelateTest extends TableTestBase {
       .where('e > 10)
       .where('e > 20)
       .select('c, 'd)
+
+    util.verifyPlan(result)
+  }
+
+  @Test
+  def testCorrelatePythonTableFunction(): Unit = {
+    val util = batchTestUtil()
+    val sourceTable = util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonTableFunction
+    util.addFunction("pyFunc", func)
+    val result = sourceTable.joinLateral(func('a, 'b) as('x, 'y))
 
     util.verifyPlan(result)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CorrelateTest.scala
@@ -21,7 +21,7 @@ package org.apache.flink.table.planner.plan.batch.table
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.plan.optimize.program.FlinkBatchProgram
-import org.apache.flink.table.planner.utils.{PythonTableFunction, TableFunc0, TableFunc1, TableTestBase}
+import org.apache.flink.table.planner.utils.{MockPythonTableFunction, TableFunc0, TableFunc1, TableTestBase}
 import org.apache.calcite.rel.rules.{CalcMergeRule, FilterCalcMergeRule, ProjectCalcMergeRule}
 import org.apache.calcite.tools.RuleSets
 import org.junit.Test
@@ -121,8 +121,7 @@ class CorrelateTest extends TableTestBase {
   def testCorrelatePythonTableFunction(): Unit = {
     val util = batchTestUtil()
     val sourceTable = util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
-    val func = new PythonTableFunction
-    util.addFunction("pyFunc", func)
+    val func = new MockPythonTableFunction
     val result = sourceTable.joinLateral(func('a, 'b) as('x, 'y))
 
     util.verifyPlan(result)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
@@ -21,8 +21,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.expressions.utils.Func13
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram
-import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, TableFunc0, TableFunc1, TableFunc2, TableTestBase}
-
+import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, PythonTableFunction, TableFunc0, TableFunc1, TableFunc2, TableTestBase}
 import org.apache.calcite.rel.rules.{CalcMergeRule, FilterCalcMergeRule, ProjectCalcMergeRule}
 import org.apache.calcite.tools.RuleSets
 import org.junit.Test
@@ -177,5 +176,16 @@ class CorrelateTest extends TableTestBase {
     val resultTable = sourceTable
       .flatMap(func2('f3))
     util.verifyPlan(resultTable)
+  }
+
+  @Test
+  def testCorrelatePythonTableFunction(): Unit = {
+    val util = streamTestUtil()
+    val sourceTable = util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonTableFunction
+    util.addFunction("pyFunc", func)
+    val result = sourceTable.joinLateral(func('a, 'b) as('x, 'y))
+
+    util.verifyPlan(result)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CorrelateTest.scala
@@ -21,7 +21,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.expressions.utils.Func13
 import org.apache.flink.table.planner.plan.optimize.program.FlinkStreamProgram
-import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, PythonTableFunction, TableFunc0, TableFunc1, TableFunc2, TableTestBase}
+import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, MockPythonTableFunction, TableFunc0, TableFunc1, TableFunc2, TableTestBase}
 import org.apache.calcite.rel.rules.{CalcMergeRule, FilterCalcMergeRule, ProjectCalcMergeRule}
 import org.apache.calcite.tools.RuleSets
 import org.junit.Test
@@ -182,8 +182,7 @@ class CorrelateTest extends TableTestBase {
   def testCorrelatePythonTableFunction(): Unit = {
     val util = streamTestUtil()
     val sourceTable = util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
-    val func = new PythonTableFunction
-    util.addFunction("pyFunc", func)
+    val func = new MockPythonTableFunction
     val result = sourceTable.joinLateral(func('a, 'b) as('x, 'y))
 
     util.verifyPlan(result)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple3
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala.typeutils.Types
 import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction, TableFunction}
 import org.apache.flink.types.Row
 
@@ -111,6 +112,25 @@ class TableFunc3(data: String, conf: Map[String, String]) extends TableFunction[
       }
     }
   }
+}
+
+class PythonTableFunction extends TableFunction[Row] with PythonFunction {
+
+  def eval(x: Int, y: Int): Unit = {
+    for (i <- 0 until y) {
+      val row = new Row(2)
+      row.setField(0, x)
+      row.setField(1, i * i)
+      collect(row)
+    }
+  }
+
+  override def getResultType: TypeInformation[Row] =
+    new RowTypeInfo(Types.INT, Types.INT)
+
+  override def getSerializedPythonFunction: Array[Byte] = Array[Byte](0)
+
+  override def getPythonEnv: PythonEnv = null
 }
 
 //TODO support dynamic type

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
@@ -114,16 +114,9 @@ class TableFunc3(data: String, conf: Map[String, String]) extends TableFunction[
   }
 }
 
-class PythonTableFunction extends TableFunction[Row] with PythonFunction {
+class MockPythonTableFunction extends TableFunction[Row] with PythonFunction {
 
-  def eval(x: Int, y: Int): Unit = {
-    for (i <- 0 until y) {
-      val row = new Row(2)
-      row.setField(0, x)
-      row.setField(1, i * i)
-      collect(row)
-    }
-  }
+  def eval(x: Int, y: Int) = ???
 
   override def getResultType: TypeInformation[Row] =
     new RowTypeInfo(Types.INT, Types.INT)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
@@ -63,7 +63,8 @@ public class DataStreamPythonCorrelateRule extends ConverterRule {
 		} else if (right instanceof FlinkLogicalCalc) {
 			// a filter is pushed above the table function
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
-			return PythonUtil.isPythonCall(CorrelateUtil.getTableFunctionScan(calc).get().getCall());
+			Option<FlinkLogicalTableFunctionScan> scan = CorrelateUtil.getTableFunctionScan(calc);
+			return scan.isDefined() && PythonUtil.isPythonCall(scan.get().getCall());
 		}
 		return false;
 	}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream;
+
+import org.apache.flink.table.plan.nodes.FlinkConventions;
+import org.apache.flink.table.plan.nodes.datastream.DataStreamPythonCorrelate;
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCorrelate;
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan;
+import org.apache.flink.table.plan.schema.RowSchema;
+import org.apache.flink.table.plan.util.CorrelateUtil;
+import org.apache.flink.table.plan.util.PythonUtil;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.plan.volcano.RelSubset;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rex.RexNode;
+
+import scala.Option;
+import scala.Some;
+
+/**
+ * The physical rule is responsible for convert {@link FlinkLogicalCorrelate} to
+ * {@link DataStreamPythonCorrelate}.
+ */
+public class DataStreamPythonCorrelateRule extends ConverterRule {
+
+	public static final RelOptRule INSTANCE = new DataStreamPythonCorrelateRule();
+
+	private DataStreamPythonCorrelateRule() {
+		super(FlinkLogicalCorrelate.class, FlinkConventions.LOGICAL(), FlinkConventions.DATASTREAM(),
+			"DataStreamPythonCorrelateRule");
+	}
+
+	@Override
+	public boolean matches(RelOptRuleCall call) {
+		FlinkLogicalCorrelate join = call.rel(0);
+		RelNode right = ((RelSubset) join.getRight()).getOriginal();
+
+		if (right instanceof FlinkLogicalTableFunctionScan) {
+			// right node is a python table function
+			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
+			return PythonUtil.isPythonCall(scan.getCall());
+		} else if (right instanceof FlinkLogicalCalc) {
+			// a filter is pushed above the table function
+			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
+			return PythonUtil.isPythonCall(CorrelateUtil.getTableFunctionScan(calc).get().getCall());
+		}
+		return false;
+	}
+
+	@Override
+	public RelNode convert(RelNode rel) {
+		DataStreamPythonCorrelateFactory factory = new DataStreamPythonCorrelateFactory(rel);
+		return factory.convertToCorrelate();
+	}
+
+	/**
+	 * The factory is responsible to creating {@link DataStreamPythonCorrelate}.
+	 */
+	private static class DataStreamPythonCorrelateFactory {
+		private final RelNode correlateRel;
+		private final FlinkLogicalCorrelate join;
+		private final RelTraitSet traitSet;
+		private final RelNode convInput;
+		private final RelNode right;
+
+		DataStreamPythonCorrelateFactory(RelNode rel) {
+			this.correlateRel = rel;
+			this.join = (FlinkLogicalCorrelate) rel;
+			this.traitSet = rel.getTraitSet().replace(FlinkConventions.DATASTREAM());
+			this.convInput = RelOptRule.convert(join.getInput(0), FlinkConventions.DATASTREAM());
+			this.right = join.getInput(1);
+		}
+
+		DataStreamPythonCorrelate convertToCorrelate() {
+			return convertToCorrelate(right, Option.empty());
+		}
+
+		private DataStreamPythonCorrelate convertToCorrelate(
+			RelNode relNode,
+			Option<RexNode> condition) {
+			if (relNode instanceof RelSubset) {
+				RelSubset rel = (RelSubset) relNode;
+				return convertToCorrelate(rel.getRelList().get(0), condition);
+			} else if (relNode instanceof FlinkLogicalCalc) {
+				FlinkLogicalCalc calc = (FlinkLogicalCalc) relNode;
+				FlinkLogicalTableFunctionScan tableScan = CorrelateUtil.getTableFunctionScan(calc).get();
+				FlinkLogicalCalc newCalc = CorrelateUtil.getMergedCalc(calc);
+				return convertToCorrelate(
+					tableScan,
+					Some.apply(newCalc.getProgram().expandLocalRef(newCalc.getProgram().getCondition())));
+			} else {
+				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) relNode;
+				return new DataStreamPythonCorrelate(
+					relNode.getCluster(),
+					traitSet,
+					new RowSchema(convInput.getRowType()),
+					convInput,
+					scan,
+					condition,
+					new RowSchema(correlateRel.getRowType()),
+					new RowSchema(join.getRowType()),
+					join.getJoinType(),
+					"DataStreamPythonCorrelateRule");
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelate.scala
@@ -34,7 +34,7 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex.{RexCall, RexNode}
 
 /**
-  * Flink RelNode which matches along with join a user defined table function.
+  * Flink RelNode which matches along with join a Java/Scala user defined table function.
   */
 class DataStreamCorrelate(
     cluster: RelOptCluster,
@@ -55,9 +55,7 @@ class DataStreamCorrelate(
     scan,
     condition,
     schema,
-    joinSchema,
-    joinType,
-    ruleDescription) {
+    joinType) {
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamCorrelate(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelateBase.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.{RexCall, RexNode}
+import org.apache.flink.table.functions.utils.TableSqlFunction
+import org.apache.flink.table.plan.nodes.CommonCorrelate
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.plan.schema.RowSchema
+
+/**
+  * Base RelNode for data stream correlate.
+  */
+abstract class DataStreamCorrelateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputSchema: RowSchema,
+    input: RelNode,
+    scan: FlinkLogicalTableFunctionScan,
+    condition: Option[RexNode],
+    schema: RowSchema,
+    joinSchema: RowSchema,
+    joinType: JoinRelType,
+    ruleDescription: String)
+  extends SingleRel(cluster, traitSet, input)
+  with CommonCorrelate
+  with DataStreamRel {
+
+  override def deriveRowType() = schema.relDataType
+
+  override def toString: String = {
+    val rexCall = scan.getCall.asInstanceOf[RexCall]
+    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
+    correlateToString(inputSchema.relDataType, rexCall, sqlFunction, getExpressionString)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    val rexCall = scan.getCall.asInstanceOf[RexCall]
+    val sqlFunction = rexCall.getOperator.asInstanceOf[TableSqlFunction]
+    super.explainTerms(pw)
+      .item("invocation", scan.getCall)
+      .item("correlate", correlateToString(
+        inputSchema.relDataType,
+        rexCall, sqlFunction,
+        getExpressionString))
+      .item("select", selectToString(schema.relDataType))
+      .item("rowType", schema.relDataType)
+      .item("joinType", joinType)
+      .itemIf("condition", condition.orNull, condition.isDefined)
+  }
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamCorrelateBase.scala
@@ -37,9 +37,7 @@ abstract class DataStreamCorrelateBase(
     scan: FlinkLogicalTableFunctionScan,
     condition: Option[RexNode],
     schema: RowSchema,
-    joinSchema: RowSchema,
-    joinType: JoinRelType,
-    ruleDescription: String)
+    joinType: JoinRelType)
   extends SingleRel(cluster, traitSet, input)
   with CommonCorrelate
   with DataStreamRel {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.core.JoinRelType
+import org.apache.calcite.rex.RexNode
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{StreamQueryConfig, TableException}
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalTableFunctionScan
+import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.planner.StreamPlanner
+import org.apache.flink.table.runtime.types.CRow
+
+/**
+  * Flink RelNode which matches along with join a python user defined table function.
+  */
+class DataStreamPythonCorrelate(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputSchema: RowSchema,
+    input: RelNode,
+    scan: FlinkLogicalTableFunctionScan,
+    condition: Option[RexNode],
+    schema: RowSchema,
+    joinSchema: RowSchema,
+    joinType: JoinRelType,
+    ruleDescription: String)
+  extends DataStreamCorrelateBase(
+    cluster,
+    traitSet,
+    inputSchema,
+    input,
+    scan,
+    condition,
+    schema,
+    joinSchema,
+    joinType,
+    ruleDescription) {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new DataStreamPythonCorrelate(
+      cluster,
+      traitSet,
+      inputSchema,
+      inputs.get(0),
+      scan,
+      condition,
+      schema,
+      joinSchema,
+      joinType,
+      ruleDescription)
+  }
+
+  override def translateToPlan(
+      planner: StreamPlanner,
+      queryConfig: StreamQueryConfig): DataStream[CRow] = {
+    throw new TableException("The implementation will be next commit.")
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.table.runtime.types.CRow
 
 /**
-  * Flink RelNode which matches along with join a python user defined table function.
+  * Flink RelNode which matches along with join a Python user defined table function.
   */
 class DataStreamPythonCorrelate(
     cluster: RelOptCluster,
@@ -50,9 +50,7 @@ class DataStreamPythonCorrelate(
     scan,
     condition,
     schema,
-    joinSchema,
-    joinType,
-    ruleDescription) {
+    joinType) {
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
     new DataStreamPythonCorrelate(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -251,7 +251,8 @@ object FlinkRuleSets {
     DataStreamMatchRule.INSTANCE,
     DataStreamTableAggregateRule.INSTANCE,
     DataStreamGroupWindowTableAggregateRule.INSTANCE,
-    DataStreamPythonCalcRule.INSTANCE
+    DataStreamPythonCalcRule.INSTANCE,
+    DataStreamPythonCorrelateRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCorrelateRule.scala
@@ -40,11 +40,14 @@ class DataStreamCorrelateRule
     val right = join.getRight.asInstanceOf[RelSubset].getOriginal
 
     right match {
-      // right node is a java table function
+      // right node is a table function
+      // return true if right node is a non python table function
       case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
       // a filter is pushed above the table function
+      // return true if the table function is non python table function.
       case calc: FlinkLogicalCalc =>
-        PythonUtil.isNonPythonCall(CorrelateUtil.getTableFunctionScan(calc).get.getCall)
+        val scan = CorrelateUtil.getTableFunctionScan(calc)
+        scan.isDefined && PythonUtil.isNonPythonCall(scan.get.getCall)
       case _ => false
     }
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCorrelateRule.scala
@@ -26,7 +26,7 @@ import org.apache.flink.table.plan.nodes.FlinkConventions
 import org.apache.flink.table.plan.nodes.datastream.DataStreamCorrelate
 import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalCorrelate, FlinkLogicalTableFunctionScan}
 import org.apache.flink.table.plan.schema.RowSchema
-import org.apache.flink.table.plan.util.CorrelateUtil
+import org.apache.flink.table.plan.util.{CorrelateUtil, PythonUtil}
 
 class DataStreamCorrelateRule
   extends ConverterRule(
@@ -40,10 +40,11 @@ class DataStreamCorrelateRule
     val right = join.getRight.asInstanceOf[RelSubset].getOriginal
 
     right match {
-      // right node is a table function
-      case scan: FlinkLogicalTableFunctionScan => true
+      // right node is a java table function
+      case scan: FlinkLogicalTableFunctionScan => PythonUtil.isNonPythonCall(scan.getCall)
       // a filter is pushed above the table function
-      case calc: FlinkLogicalCalc if CorrelateUtil.getTableFunctionScan(calc).isDefined => true
+      case calc: FlinkLogicalCalc =>
+        PythonUtil.isNonPythonCall(CorrelateUtil.getTableFunctionScan(calc).get.getCall)
       case _ => false
     }
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/PythonUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/PythonUtil.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.plan.util
 
 import org.apache.calcite.rex.{RexCall, RexNode}
 import org.apache.flink.table.functions.python.PythonFunction
-import org.apache.flink.table.functions.utils.ScalarSqlFunction
+import org.apache.flink.table.functions.utils.{ScalarSqlFunction, TableSqlFunction}
 
 import scala.collection.JavaConversions._
 
@@ -74,6 +74,7 @@ object PythonUtil {
       */
     private def isPythonRexCall(rexCall: RexCall): Boolean = rexCall.getOperator match {
       case sfc: ScalarSqlFunction => sfc.getScalarFunction.isInstanceOf[PythonFunction]
+      case tfc: TableSqlFunction => tfc.getTableFunction.isInstanceOf[PythonFunction]
       case _ => false
     }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
@@ -370,7 +370,7 @@ class CorrelateTest extends TableTestBase {
   def testCorrelatePythonTableFunction(): Unit = {
     val util = streamTestUtil()
     val table = util.addTable[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
-    val func = new PythonTableFunction()
+    val func = new MockPythonTableFunction
 
     val resultTable = table.joinLateral(func('a, 'b) as('x, 'y))
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CorrelateTest.scala
@@ -365,4 +365,25 @@ class CorrelateTest extends TableTestBase {
 
     util.verifyTable(resultTable, expected)
   }
+
+  @Test
+  def testCorrelatePythonTableFunction(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
+    val func = new PythonTableFunction()
+
+    val resultTable = table.joinLateral(func('a, 'b) as('x, 'y))
+
+    val expected = unaryNode(
+      "DataStreamPythonCorrelate",
+      streamTableNode(table),
+      term("invocation", s"${func.functionIdentifier}($$0, $$1)"),
+      term("correlate", s"table(${func.getClass.getSimpleName}(a, b))"),
+      term("select", "a, b, c, x, y"),
+      term("rowType",
+           "RecordType(INTEGER a, INTEGER b, INTEGER c, INTEGER x, INTEGER y)"),
+      term("joinType", "INNER")
+      )
+    util.verifyTable(resultTable, expected)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.tuple.Tuple3
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.{Types, ValidationException}
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.functions.{FunctionContext, TableFunction}
 import org.apache.flink.types.Row
 import org.junit.Assert
@@ -170,6 +171,25 @@ class PojoUser() {
     this.name = name
     this.age = age
   }
+}
+
+class PythonTableFunction extends TableFunction[Row] with PythonFunction {
+
+  def eval(x: Int, y: Int): Unit = {
+    for (i <- 0 until y) {
+      val row = new Row(2)
+      row.setField(0, x)
+      row.setField(1, i * i)
+      collect(row)
+    }
+  }
+
+  override def getResultType: TypeInformation[Row] =
+    new RowTypeInfo(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO)
+
+  override def getSerializedPythonFunction: Array[Byte] = Array[Byte](0)
+
+  override def getPythonEnv: PythonEnv = null
 }
 
 // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/UserDefinedTableFunctions.scala
@@ -173,16 +173,9 @@ class PojoUser() {
   }
 }
 
-class PythonTableFunction extends TableFunction[Row] with PythonFunction {
+class MockPythonTableFunction extends TableFunction[Row] with PythonFunction {
 
-  def eval(x: Int, y: Int): Unit = {
-    for (i <- 0 until y) {
-      val row = new Row(2)
-      row.setField(0, x)
-      row.setField(1, i * i)
-      collect(row)
-    }
-  }
+  def eval(x: Int, y: Int) = ???
 
   override def getResultType: TypeInformation[Row] =
     new RowTypeInfo(BasicTypeInfo.INT_TYPE_INFO, BasicTypeInfo.INT_TYPE_INFO)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduce Python Physical Correlate RelNodes which are containers for Python TableFunction*

## Brief change log

  - *Add Physical Python Correlate Rule `BatchExecPythonCorrelateRule` ,`StreamExecPythonCorrelateRule` and `DataStreamPythonCorrelateRule`*
  - *Add Physical Python Correlate Node `DataStreamPythonCorrelate`, `StreamExecPythonCorrelate` and `BatchExecPythonCorrelate`*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added ut case testCorrelatePythonTableFunction*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
