### PR TITLE
[FLINK-15975][flink-connectors] Making test assertion more stable

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
@@ -43,10 +43,13 @@ import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.HashMap;
 
 import static org.apache.flink.table.HiveVersionTestUtil.HIVE_110_OR_LATER;
 import static org.apache.flink.table.HiveVersionTestUtil.HIVE_120_OR_LATER;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -345,9 +348,7 @@ public class HiveGenericUDFTest {
 		Object[] result = (Object[]) udf2.eval(udf.eval(testInput));
 
 		assertEquals(3, result.length);
-		assertEquals("1", result[0]);
-		assertEquals("2", result[1]);
-		assertEquals("3", result[2]);
+		assertThat(Arrays.asList(result), containsInAnyOrder("1", "2", "3"));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

In this PR, we propose to fix [FLINK-15975] by making the test assertions more stable by considering any order of `result`.

## Brief change log
In `flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java`, we use one `assertEquals` instead of the last three `assertEquals` in `testMap`.
## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
