### PR TITLE
[FLINK-15990][table][python] Remove register source and sink in ConnectTableDescriptor

### DIFF
--- a/docs/ops/python_shell.md
+++ b/docs/ops/python_shell.md
@@ -82,7 +82,7 @@ The example below is a simple program in the Python shell:
 ...         .field("a", DataTypes.BIGINT())
 ...         .field("b", DataTypes.STRING())
 ...         .field("c", DataTypes.STRING()))\
-...     .register_table_sink("stream_sink")
+...     .create_temporary_table("stream_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("stream_sink")
 >>> st_env.execute("stream_job")
@@ -114,7 +114,7 @@ The example below is a simple program in the Python shell:
 ...         .field("a", DataTypes.BIGINT())
 ...         .field("b", DataTypes.STRING())
 ...         .field("c", DataTypes.STRING()))\
-...     .register_table_sink("batch_sink")
+...     .create_temporary_table("batch_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("batch_sink")
 >>> bt_env.execute("batch_job")

--- a/docs/ops/python_shell.zh.md
+++ b/docs/ops/python_shell.zh.md
@@ -81,7 +81,7 @@ bin/pyflink-shell.sh local
 ...         .field("a", DataTypes.BIGINT())
 ...         .field("b", DataTypes.STRING())
 ...         .field("c", DataTypes.STRING()))\
-...     .register_table_sink("stream_sink")
+...     .create_temporary_table("stream_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("stream_sink")
 >>> st_env.execute("stream_job")
@@ -113,7 +113,7 @@ bin/pyflink-shell.sh local
 ...         .field("a", DataTypes.BIGINT())
 ...         .field("b", DataTypes.STRING())
 ...         .field("c", DataTypes.STRING()))\
-...     .register_table_sink("batch_sink")
+...     .create_temporary_table("batch_sink")
 >>> t.select("a + 1, b, c")\
 ...     .insert_into("batch_sink")
 >>> bt_env.execute("batch_job")

--- a/flink-python/dev/pip_test_code.py
+++ b/flink-python/dev/pip_test_code.py
@@ -40,7 +40,7 @@ bt_env.connect(FileSystem().path(sink_path)) \
                  .field("a", DataTypes.BIGINT())
                  .field("b", DataTypes.STRING())
                  .field("c", DataTypes.STRING())) \
-    .register_table_sink("batch_sink")
+    .create_temporary_table("batch_sink")
 
 t.select("a + 1, b, c").insert_into("batch_sink")
 

--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -117,7 +117,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
     *                  .field("c", DataTypes.STRING())) \\
-    *     .register_table_sink("batch_sink")
+    *     .create_temporary_table("batch_sink")
     *
     * t.select("a + 1, b, c").insert_into("batch_sink")
     *
@@ -147,7 +147,7 @@ NOTE: Use the prebound Table Environment to implement batch or streaming Table p
     *                  .field("a", DataTypes.BIGINT())
     *                  .field("b", DataTypes.STRING())
     *                  .field("c", DataTypes.STRING())) \\
-    *     .register_table_sink("stream_sink")
+    *     .create_temporary_table("stream_sink")
     * 
     * t.select("a + 1, b, c").insert_into("stream_sink")
     *

--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -15,7 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-import warnings
 from abc import ABCMeta
 
 from py4j.java_gateway import get_method

--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -1286,50 +1286,6 @@ class ConnectTableDescriptor(Descriptor):
             self._j_connect_table_descriptor.withSchema(schema._j_schema)
         return self
 
-    def register_table_sink(self, name):
-        """
-        Searches for the specified table sink, configures it accordingly, and registers it as
-        a table under the given name.
-
-        :param name: Table name to be registered in the table environment.
-        :return: This object.
-
-        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
-        """
-        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
-        self._j_connect_table_descriptor = self._j_connect_table_descriptor.registerTableSink(name)
-        return self
-
-    def register_table_source(self, name):
-        """
-        Searches for the specified table source, configures it accordingly, and registers it as
-        a table under the given name.
-
-        :param name: Table name to be registered in the table environment.
-        :return: This object.
-
-        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
-        """
-        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
-        self._j_connect_table_descriptor = \
-            self._j_connect_table_descriptor.registerTableSource(name)
-        return self
-
-    def register_table_source_and_sink(self, name):
-        """
-        Searches for the specified table source and sink, configures them accordingly, and
-        registers them as a table under the given name.
-
-        :param name: Table name to be registered in the table environment.
-        :return: This object.
-
-        .. note:: Deprecated in 1.10. Use :func:`create_temporary_table` instead.
-        """
-        warnings.warn("Deprecated in 1.10. Use create_temporary_table instead.", DeprecationWarning)
-        self._j_connect_table_descriptor = \
-            self._j_connect_table_descriptor.registerTableSourceAndSink(name)
-        return self
-
     def create_temporary_table(self, path):
         """
         Registers the table described by underlying properties in a given path.

--- a/flink-python/pyflink/table/examples/batch/word_count.py
+++ b/flink-python/pyflink/table/examples/batch/word_count.py
@@ -62,7 +62,7 @@ def word_count():
         .with_schema(Schema()
                      .field("word", DataTypes.STRING())
                      .field("count", DataTypes.BIGINT())) \
-        .register_table_sink("Results")
+        .create_temporary_table("Results")
 
     elements = [(word, 1) for word in content.split(" ")]
     t_env.from_elements(elements, ["word", "count"]) \

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -672,14 +672,14 @@ class TableEnvironment(object):
     @abstractmethod
     def connect(self, connector_descriptor):
         """
-        Creates a table source and/or table sink from a descriptor.
+        Creates a temporary table from a descriptor.
 
         Descriptors allow for declaring the communication to external systems in an
         implementation-agnostic way. The classpath is scanned for suitable table factories that
         match the desired configuration.
 
         The following example shows how to read from a connector using a JSON format and
-        registering a table source as "MyTable":
+        registering a temporary table as "MyTable":
 
         Example:
         ::
@@ -694,12 +694,12 @@ class TableEnvironment(object):
             ...                  .field("user-name", "VARCHAR")
             ...                  .from_origin_field("u_name")
             ...                  .field("count", "DECIMAL")) \\
-            ...     .register_table_source("MyTable")
+            ...     .create_temporary_table("MyTable")
 
         :param connector_descriptor: Connector descriptor describing the external system.
         :type connector_descriptor: pyflink.table.descriptors.ConnectorDescriptor
         :return: A :class:`~pyflink.table.descriptors.ConnectTableDescriptor` used to build the
-                 table source/sink.
+                 temporary table.
         :rtype: pyflink.table.descriptors.ConnectTableDescriptor
         """
         pass
@@ -1070,14 +1070,14 @@ class StreamTableEnvironment(TableEnvironment):
 
     def connect(self, connector_descriptor):
         """
-        Creates a table source and/or table sink from a descriptor.
+        Creates a temporary table from a descriptor.
 
         Descriptors allow for declaring the communication to external systems in an
         implementation-agnostic way. The classpath is scanned for suitable table factories that
         match the desired configuration.
 
         The following example shows how to read from a connector using a JSON format and
-        registering a table source as "MyTable":
+        registering a temporary table as "MyTable":
         ::
 
             >>> table_env \\
@@ -1090,12 +1090,12 @@ class StreamTableEnvironment(TableEnvironment):
             ...                  .field("user-name", "VARCHAR")
             ...                  .from_origin_field("u_name")
             ...                  .field("count", "DECIMAL")) \\
-            ...     .register_table_source("MyTable")
+            ...     .create_temporary_table("MyTable")
 
         :param connector_descriptor: Connector descriptor describing the external system.
         :type connector_descriptor: pyflink.table.descriptors.ConnectorDescriptor
-        :return: A :class:`~pyflink.table.descriptors.StreamTableDescriptor` used to build the table
-                 source/sink.
+        :return: A :class:`~pyflink.table.descriptors.StreamTableDescriptor` used to build the
+                 temporary table.
         :rtype: pyflink.table.descriptors.StreamTableDescriptor
         """
         return StreamTableDescriptor(
@@ -1189,14 +1189,14 @@ class BatchTableEnvironment(TableEnvironment):
 
     def connect(self, connector_descriptor):
         """
-        Creates a table source and/or table sink from a descriptor.
+        Creates a temporary table from a descriptor.
 
         Descriptors allow for declaring the communication to external systems in an
         implementation-agnostic way. The classpath is scanned for suitable table factories that
         match the desired configuration.
 
         The following example shows how to read from a connector using a JSON format and
-        registering a table source as "MyTable":
+        registering a temporary table as "MyTable":
         ::
 
             >>> table_env \\
@@ -1209,13 +1209,13 @@ class BatchTableEnvironment(TableEnvironment):
             ...                  .field("user-name", "VARCHAR")
             ...                  .from_origin_field("u_name")
             ...                  .field("count", "DECIMAL")) \\
-            ...     .register_table_source("MyTable")
+            ...     .create_temporary_table("MyTable")
 
         :param connector_descriptor: Connector descriptor describing the external system.
         :type connector_descriptor: pyflink.table.descriptors.ConnectorDescriptor
         :return: A :class:`~pyflink.table.descriptors.BatchTableDescriptor` or a
                  :class:`~pyflink.table.descriptors.StreamTableDescriptor` (for blink planner) used
-                 to build the table source/sink.
+                 to build the temporary table.
         :rtype: pyflink.table.descriptors.BatchTableDescriptor or
                 pyflink.table.descriptors.StreamTableDescriptor
         """

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -940,54 +940,7 @@ class AbstractTableDescriptorTests(object):
                     'connector.property-version': '1'}
         assert properties == expected
 
-    def test_register_table_source_and_register_table_sink(self):
-        self.env.set_parallelism(1)
-        source_path = os.path.join(self.tempdir + '/streaming.csv')
-        field_names = ["a", "b", "c"]
-        field_types = [DataTypes.INT(), DataTypes.STRING(), DataTypes.STRING()]
-        data = [(1, "Hi", "Hello"), (2, "Hello", "Hello")]
-        self.prepare_csv_source(source_path, data, field_types, field_names)
-        sink_path = os.path.join(self.tempdir + '/streaming2.csv')
-        if os.path.isfile(sink_path):
-            os.remove(sink_path)
-
-        t_env = self.t_env
-        # register_table_source
-        t_env.connect(FileSystem().path(source_path))\
-             .with_format(OldCsv()
-                          .field_delimiter(',')
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .with_schema(Schema()
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .create_temporary_table("source")
-
-        # register_table_sink
-        t_env.connect(FileSystem().path(sink_path))\
-             .with_format(OldCsv()
-                          .field_delimiter(',')
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .with_schema(Schema()
-                          .field("a", DataTypes.INT())
-                          .field("b", DataTypes.STRING())
-                          .field("c", DataTypes.STRING()))\
-             .create_temporary_table("sink")
-
-        t_env.scan("source") \
-             .select("a + 1, b, c") \
-             .insert_into("sink")
-        self.t_env.execute("test")
-
-        with open(sink_path, 'r') as f:
-            lines = f.read()
-            assert lines == '2,Hi,Hello\n' + '3,Hello,Hello\n'
-
-    def test_register_table_source_and_sink(self):
+    def test_register_temporary_table(self):
         self.env.set_parallelism(1)
         source_path = os.path.join(self.tempdir + '/streaming.csv')
         field_names = ["a", "b", "c"]

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -963,7 +963,7 @@ class AbstractTableDescriptorTests(object):
                           .field("a", DataTypes.INT())
                           .field("b", DataTypes.STRING())
                           .field("c", DataTypes.STRING()))\
-             .register_table_source("source")
+             .create_temporary_table("source")
 
         # register_table_sink
         t_env.connect(FileSystem().path(sink_path))\
@@ -976,7 +976,7 @@ class AbstractTableDescriptorTests(object):
                           .field("a", DataTypes.INT())
                           .field("b", DataTypes.STRING())
                           .field("c", DataTypes.STRING()))\
-             .register_table_sink("sink")
+             .create_temporary_table("sink")
 
         t_env.scan("source") \
              .select("a + 1, b, c") \
@@ -1009,7 +1009,7 @@ class AbstractTableDescriptorTests(object):
                           .field("a", DataTypes.INT())
                           .field("b", DataTypes.STRING())
                           .field("c", DataTypes.STRING()))\
-             .register_table_source_and_sink("source")
+             .create_temporary_table("source")
         t_env.connect(FileSystem().path(sink_path))\
              .with_format(OldCsv()
                           .field_delimiter(',')
@@ -1020,7 +1020,7 @@ class AbstractTableDescriptorTests(object):
                           .field("a", DataTypes.INT())
                           .field("b", DataTypes.STRING())
                           .field("c", DataTypes.STRING()))\
-             .register_table_source_and_sink("sink")
+             .create_temporary_table("sink")
         t_env.scan("source") \
              .select("a + 1, b, c") \
              .insert_into("sink")

--- a/flink-python/pyflink/table/tests/test_shell_example.py
+++ b/flink-python/pyflink/table/tests/test_shell_example.py
@@ -48,7 +48,7 @@ class ShellExampleTests(PyFlinkTestCase):
                          .field("a", DataTypes.BIGINT())
                          .field("b", DataTypes.STRING())
                          .field("c", DataTypes.STRING()))\
-            .register_table_sink("batch_sink")
+            .create_temporary_table("batch_sink")
 
         t.select("a + 1, b, c").insert_into("batch_sink")
 
@@ -84,7 +84,7 @@ class ShellExampleTests(PyFlinkTestCase):
                          .field("a", DataTypes.BIGINT())
                          .field("b", DataTypes.STRING())
                          .field("c", DataTypes.STRING()))\
-            .register_table_sink("stream_sink")
+            .create_temporary_table("stream_sink")
 
         t.select("a + 1, b, c").insert_into("stream_sink")
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
@@ -315,14 +315,14 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	void insertInto(Table table, BatchQueryConfig queryConfig, String sinkPath, String... sinkPathContinued);
 
 	/**
-	 * Creates a table source and/or table sink from a descriptor.
+	 * Creates a temporary table from a descriptor.
 	 *
 	 * <p>Descriptors allow for declaring the communication to external systems in an
 	 * implementation-agnostic way. The classpath is scanned for suitable table factories that match
 	 * the desired configuration.
 	 *
 	 * <p>The following example shows how to read from a connector using a JSON format and
-	 * registering a table source as "MyTable":
+	 * registering a temporary table as "MyTable":
 	 *
 	 * <pre>
 	 * {@code
@@ -339,7 +339,7 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 *     new Schema()
 	 *       .field("user-name", "VARCHAR").from("u_name")
 	 *       .field("count", "DECIMAL")
-	 *   .registerSource("MyTable")
+	 *   .createTemporaryTable("MyTable")
 	 * }
 	 * </pre>
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -462,14 +462,14 @@ public interface TableEnvironment {
 	void insertInto(String targetPath, Table table);
 
 	/**
-	 * Creates a table source and/or table sink from a descriptor.
+	 * Creates a temporary table from a descriptor.
 	 *
 	 * <p>Descriptors allow for declaring the communication to external systems in an
 	 * implementation-agnostic way. The classpath is scanned for suitable table factories that match
 	 * the desired configuration.
 	 *
 	 * <p>The following example shows how to read from a connector using a JSON format and
-	 * register a table source as "MyTable":
+	 * register a temporary table as "MyTable":
 	 *
 	 * <pre>
 	 * {@code
@@ -486,7 +486,7 @@ public interface TableEnvironment {
 	 *     new Schema()
 	 *       .field("user-name", "VARCHAR").from("u_name")
 	 *       .field("count", "DECIMAL")
-	 *   .registerSource("MyTable");
+	 *   .createTemporaryTable("MyTable");
 	 * }
 	 *</pre>
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/Registration.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/Registration.java
@@ -21,34 +21,12 @@ package org.apache.flink.table.api.internal;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.CatalogBaseTable;
-import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.table.sources.TableSource;
 
 /**
  * A way to register a table in a {@link TableEnvironment} that this descriptor originates from.
  */
 @Internal
 public interface Registration {
-	/**
-	 * Registers an external {@link TableSource} in this {@link TableEnvironment}'s catalog.
-	 * Registered tables can be referenced in SQL queries.
-	 *
-	 * @param name The name under which the {@link TableSource} is registered.
-	 * @param tableSource The {@link TableSource} to register.
-	 * @see TableEnvironment#registerTableSource(String, TableSource)
-	 */
-	void createTableSource(String name, TableSource<?> tableSource);
-
-	/**
-	 * Registers an external {@link TableSink} with already configured field names and field types in
-	 * this {@link TableEnvironment}'s catalog.
-	 * Registered sink tables can be referenced in SQL DML statements.
-	 *
-	 * @param name The name under which the {@link TableSink} is registered.
-	 * @param tableSink The configured {@link TableSink} to register.
-	 * @see TableEnvironment#registerTableSink(String, TableSink)
-	 */
-	void createTableSink(String name, TableSink<?> tableSink);
 
 	/**
 	 * Creates a temporary table in a given path.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -133,22 +133,13 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	 * Provides necessary methods for {@link ConnectTableDescriptor}.
 	 */
 	private final Registration registration = new Registration() {
+
 		@Override
 		public void createTemporaryTable(String path, CatalogBaseTable table) {
 			UnresolvedIdentifier unresolvedIdentifier = parser.parseIdentifier(path);
 			ObjectIdentifier objectIdentifier = catalogManager.qualifyIdentifier(
 				unresolvedIdentifier);
 			catalogManager.createTemporaryTable(table, objectIdentifier, false);
-		}
-
-		@Override
-		public void createTableSource(String name, TableSource<?> tableSource) {
-			registerTableSource(name, tableSource);
-		}
-
-		@Override
-		public void createTableSink(String name, TableSink<?> tableSink) {
-			registerTableSink(name, tableSink);
 		}
 	};
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/ConnectTableDescriptor.java
@@ -24,9 +24,6 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.internal.Registration;
 import org.apache.flink.table.catalog.CatalogTableImpl;
-import org.apache.flink.table.factories.TableFactoryUtil;
-import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -59,59 +56,6 @@ public abstract class ConnectTableDescriptor
 	public ConnectTableDescriptor withSchema(Schema schema) {
 		schemaDescriptor = Preconditions.checkNotNull(schema, "Schema must not be null.");
 		return this;
-	}
-
-	/**
-	 * Searches for the specified table source, configures it accordingly, and registers it as
-	 * a table under the given name.
-	 *
-	 * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists, it will
-	 * be inaccessible in the current session. To make the permanent object available again you can drop the
-	 * corresponding temporary object.
-	 *
-	 * @param name table name to be registered in the table environment
-	 * @deprecated use {@link #createTemporaryTable(String)}
-	 */
-	@Deprecated
-	public void registerTableSource(String name) {
-		Preconditions.checkNotNull(name);
-		TableSource<?> tableSource = TableFactoryUtil.findAndCreateTableSource(this);
-		registration.createTableSource(name, tableSource);
-	}
-
-	/**
-	 * Searches for the specified table sink, configures it accordingly, and registers it as
-	 * a table under the given name.
-	 *
-	 * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists, it will
-	 * be inaccessible in the current session. To make the permanent object available again you can drop the
-	 * corresponding temporary object.
-	 *
-	 * @param name table name to be registered in the table environment
-	 * @deprecated use {@link #createTemporaryTable(String)}
-	 */
-	@Deprecated
-	public void registerTableSink(String name) {
-		Preconditions.checkNotNull(name);
-		TableSink<?> tableSink = TableFactoryUtil.findAndCreateTableSink(this);
-		registration.createTableSink(name, tableSink);
-	}
-
-	/**
-	 * Searches for the specified table source and sink, configures them accordingly, and registers
-	 * them as a table under the given name.
-	 *
-	 * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists, it will
-	 * be inaccessible in the current session. To make the permanent object available again you can drop the
-	 * corresponding temporary object.
-	 *
-	 * @param name table name to be registered in the table environment
-	 * @deprecated use {@link #createTemporaryTable(String)}
-	 */
-	@Deprecated
-	public void registerTableSourceAndSink(String name) {
-		registerTableSource(name);
-		registerTableSink(name);
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/factories/TableFactoryUtil.java
@@ -22,7 +22,6 @@ import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.descriptors.Descriptor;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
 
@@ -33,14 +32,6 @@ import java.util.Optional;
  * Utility for dealing with {@link TableFactory} using the {@link TableFactoryService}.
  */
 public class TableFactoryUtil {
-
-	/**
-	 * Returns a table source matching the descriptor.
-	 */
-	public static <T> TableSource<T> findAndCreateTableSource(Descriptor descriptor) {
-		Map<String, String> properties = descriptor.toProperties();
-		return findAndCreateTableSource(properties);
-	}
 
 	/**
 	 * Returns a table source matching the properties.
@@ -54,14 +45,6 @@ public class TableFactoryUtil {
 		} catch (Throwable t) {
 			throw new TableException("findAndCreateTableSource failed.", t);
 		}
-	}
-
-	/**
-	 * Returns a table sink matching the descriptor.
-	 */
-	public static <T> TableSink<T> findAndCreateTableSink(Descriptor descriptor) {
-		Map<String, String> properties = descriptor.toProperties();
-		return findAndCreateTableSink(properties);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -49,7 +49,7 @@ public class TableEnvironmentTest {
 				.field("my_field_0", "INT")
 				.field("my_field_1", "BOOLEAN"))
 			.inAppendMode()
-			.registerTableSource("my_table");
+			.createTemporaryTable("my_table");
 
 		CatalogManager.TableLookupResult lookupResult = tableEnv.catalogManager.getTable(ObjectIdentifier.of(
 			EnvironmentSettings.DEFAULT_BUILTIN_CATALOG,

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.api;
 
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.descriptors.Schema;
 import org.apache.flink.table.utils.ConnectorDescriptorMock;
@@ -67,11 +66,5 @@ public class TableEnvironmentTest {
 					.field("my_field_0", DataTypes.INT())
 					.field("my_field_1", DataTypes.BOOLEAN())
 					.build()));
-
-		final ConnectorCatalogTable<?, ?> connectorCatalogTable = (ConnectorCatalogTable<?, ?>) table;
-
-		assertThat(
-			connectorCatalogTable.getTableSource().isPresent(),
-			equalTo(true));
 	}
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ParserMock.java
@@ -35,6 +35,6 @@ public class ParserMock implements Parser {
 
 	@Override
 	public UnresolvedIdentifier parseIdentifier(String identifier) {
-		return null;
+		return UnresolvedIdentifier.of(identifier);
 	}
 }

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -278,14 +278,14 @@ trait BatchTableEnvironment extends TableEnvironment {
   override def execute(jobName: String): JobExecutionResult
 
   /**
-    * Creates a table source and/or table sink from a descriptor.
+    * Creates a temporary table from a descriptor.
     *
     * Descriptors allow for declaring the communication to external systems in an
     * implementation-agnostic way. The classpath is scanned for suitable table factories that match
     * the desired configuration.
     *
     * The following example shows how to read from a connector using a JSON format and
-    * registering a table source as "MyTable":
+    * registering a temporary table as "MyTable":
     *
     * {{{
     *
@@ -301,7 +301,7 @@ trait BatchTableEnvironment extends TableEnvironment {
     *     new Schema()
     *       .field("user-name", "VARCHAR").from("u_name")
     *       .field("count", "DECIMAL")
-    *   .registerSource("MyTable")
+    *   .createTemporaryTable("MyTable")
     * }}}
     *
     * @param connectorDescriptor connector descriptor describing the external system

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -73,18 +73,11 @@ abstract class BatchTableEnvImpl(
    * Provides necessary methods for [[ConnectTableDescriptor]].
    */
   private val registration = new Registration() {
+
     override def createTemporaryTable(path: String, table: CatalogBaseTable): Unit = {
       val unresolvedIdentifier = parseIdentifier(path)
       val objectIdentifier = catalogManager.qualifyIdentifier(unresolvedIdentifier)
       catalogManager.createTemporaryTable(table, objectIdentifier, false)
-    }
-
-    override def createTableSource(name: String, tableSource: TableSource[_]): Unit = {
-      registerTableSource(name, tableSource)
-    }
-
-    override def createTableSink(name: String, tableSource: TableSink[_]): Unit = {
-      registerTableSink(name, tableSource)
     }
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/descriptors/TableDescriptorTest.scala
@@ -82,7 +82,7 @@ class TableDescriptorTest extends TableTestBase {
     }
 
     // tests the table factory discovery and thus validates the result automatically
-    descriptor.registerTableSourceAndSink("MyTable")
+    descriptor.createTemporaryTable("MyTable")
 
     val personArrayString = "ARRAY<LEGACY('STRUCTURED_TYPE', " +
       "'POJO<org.apache.flink.table.runtime.utils.CommonTestData$Person>')>"


### PR DESCRIPTION

## What is the purpose of the change

Remove deprecated methods in ConnectTableDescriptor.

Discuss thread: http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/DISCUSS-Remove-registration-of-TableSource-TableSink-in-Table-Env-and-ConnectTableDescriptor-td37270.html

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)