### PR TITLE
[FLINK-15903][e2e] Make REST port configurable

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -48,6 +48,7 @@ cd $TEST_ROOT
 source "${TEST_INFRA_DIR}/common_utils.sh"
 
 NODENAME=${NODENAME:-`hostname -f`}
+NODEPORT=${NODEPORT:-8081}
 
 # REST_PROTOCOL and CURL_SSL_ARGS can be modified in common_ssl.sh if SSL is activated
 # they should be used in curl command to query Flink REST API
@@ -157,7 +158,7 @@ function create_ha_config() {
 
     # create the masters file (only one currently).
     # This must have all the masters to be used in HA.
-    echo "localhost:8081" > ${FLINK_DIR}/conf/masters
+    echo "localhost:${NODEPORT}" > ${FLINK_DIR}/conf/masters
 
     # then move on to create the flink-conf.yaml
     sed 's/^    //g' > ${FLINK_DIR}/conf/flink-conf.yaml << EOL
@@ -185,7 +186,7 @@ function create_ha_config() {
     # Web Frontend
     #==============================================================================
 
-    rest.port: 8081
+    rest.port: ${NODEPORT}
 
     queryable-state.server.ports: 9000-9009
     queryable-state.proxy.ports: 9010-9019
@@ -263,16 +264,18 @@ function wait_rest_endpoint_up {
     echo "Waiting for ${endpoint_name} REST endpoint to come up..."
     sleep 1
   done
-  echo "${endpoint_name} REST endpoint has not started within a timeout of ${TIMEOUT} sec"
+  echo "${endpoint_name} REST endpoint has not started on query url '${query_url}' within a timeout of ${TIMEOUT} sec"
   exit 1
 }
 
 function wait_dispatcher_running {
-  local query_url="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
+  local query_url="${REST_PROTOCOL}://${NODENAME}:${NODEPORT}/taskmanagers"
   wait_rest_endpoint_up "${query_url}" "Dispatcher" "\{\"taskmanagers\":\[.+\]\}"
 }
 
 function start_cluster {
+  echo "# Configuration appended by common.sh script for e2e tests" >> ${FLINK_DIR}/conf/flink-conf.yaml
+  echo "rest.port: ${NODEPORT}" >> ${FLINK_DIR}/conf/flink-conf.yaml
   "$FLINK_DIR"/bin/start-cluster.sh
   wait_dispatcher_running
 }
@@ -302,7 +305,7 @@ function start_and_wait_for_tm {
 }
 
 function query_running_tms {
-  local url="${REST_PROTOCOL}://${NODENAME}:8081/taskmanagers"
+  local url="${REST_PROTOCOL}://${NODENAME}:${NODEPORT}/taskmanagers"
   curl ${CURL_SSL_ARGS} -s "${url}"
 }
 
@@ -595,7 +598,7 @@ function get_job_metric {
   local job_id=$1
   local metric_name=$2
 
-  local json=$(curl ${CURL_SSL_ARGS} -s ${REST_PROTOCOL}://${NODENAME}:8081/jobs/${job_id}/metrics?get=${metric_name})
+  local json=$(curl ${CURL_SSL_ARGS} -s ${REST_PROTOCOL}://${NODENAME}:${NODEPORT}/jobs/${job_id}/metrics?get=${metric_name})
   local metric_value=$(echo ${json} | sed -n 's/.*"value":"\(.*\)".*/\1/p')
 
   echo ${metric_value}

--- a/flink-end-to-end-tests/test-scripts/common_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ha.sh
@@ -140,7 +140,7 @@ function ha_tm_watchdog() {
         # check how many successful checkpoints we have
         # and kill a TM only if the previous one already had some
 
-        local CHECKPOINTS=`curl -s "http://localhost:8081/jobs/${JOB_ID}/checkpoints" | cut -d ":" -f 6 | sed 's/,.*//'`
+        local CHECKPOINTS=`curl -s "http://localhost:${NODEPORT}/jobs/${JOB_ID}/checkpoints" | cut -d ":" -f 6 | sed 's/,.*//'`
 
         if [[ ${CHECKPOINTS} =~ '^[0-9]+$' ]] || [[ ${CHECKPOINTS} == "" ]]; then
 

--- a/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_mesos_docker.sh
@@ -59,7 +59,7 @@ function start_flink_cluster_with_mesos() {
     set_config_key "rest.address" "mesos-master"
 
     docker exec -itd mesos-master bash -c "${FLINK_DIR}/bin/mesos-appmaster.sh -Dmesos.master=mesos-master:5050"
-    wait_rest_endpoint_up "http://${NODENAME}:8081/taskmanagers" "Dispatcher" "\{\"taskmanagers\":\[.*\]\}"
+    wait_rest_endpoint_up "http://${NODENAME}:${NODEPORT}/taskmanagers" "Dispatcher" "\{\"taskmanagers\":\[.*\]\}"
     return 0
 }
 

--- a/flink-end-to-end-tests/test-scripts/container-scripts/job-cluster-job.yaml.template
+++ b/flink-end-to-end-tests/test-scripts/container-scripts/job-cluster-job.yaml.template
@@ -42,5 +42,5 @@ spec:
           name: blob
         - containerPort: 6125
           name: query
-        - containerPort: 8081
+        - containerPort: ${NODEPORT}
           name: ui

--- a/flink-end-to-end-tests/test-scripts/test_cli.sh
+++ b/flink-end-to-end-tests/test-scripts/test_cli.sh
@@ -85,7 +85,7 @@ if [ $EXIT_CODE == 0 ]; then
     printf "\n==============================================================================\n"
     printf "Test job launch with complex parameter set\n"
     printf "==============================================================================\n"
-    eval "$FLINK_DIR/bin/flink run -m localhost:8081 -p 4 -q \
+    eval "$FLINK_DIR/bin/flink run -m localhost:${NODEPORT} -p 4 -q \
       -c org.apache.flink.examples.java.wordcount.WordCount \
       $FLINK_DIR/examples/batch/WordCount.jar \
       --input file:///$FLINK_DIR/README.txt \

--- a/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_dataset.sh
@@ -84,7 +84,7 @@ function setup_and_start_cluster() {
     set_config_key "heartbeat.timeout" "10000"
 
     start_local_zk
-    start_ha_jm_watchdog 1 "StandaloneSessionClusterEntrypoint" start_jm_cmd "8081"
+    start_ha_jm_watchdog 1 "StandaloneSessionClusterEntrypoint" start_jm_cmd "${NODEPORT}"
     start_taskmanagers ${NUM_TASK_MANAGERS}
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -79,7 +79,7 @@ function run_ha_test() {
     wait_job_running ${JOB_ID}
 
     # start the watchdog that keeps the number of JMs stable
-    start_ha_jm_watchdog 1 "StandaloneSessionClusterEntrypoint" start_jm_cmd "8081"
+    start_ha_jm_watchdog 1 "StandaloneSessionClusterEntrypoint" start_jm_cmd "${NODEPORT}"
 
     sleep 5
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -25,6 +25,7 @@ export OUTPUT_VOLUME=${TEST_DATA_DIR}/out
 export OUTPUT_FILE=kubernetes_wc_out
 export FLINK_JOB_PARALLELISM=1
 export FLINK_JOB_ARGUMENTS='"--output", "/cache/kubernetes_wc_out"'
+export NODEPORT
 
 SUCCEEDED=1
 
@@ -48,7 +49,7 @@ cd "$END_TO_END_DIR"
 
 
 kubectl create -f ${KUBERNETES_MODULE_DIR}/job-cluster-service.yaml
-envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB} ${FLINK_JOB_PARALLELISM} ${FLINK_JOB_ARGUMENTS}' < ${CONTAINER_SCRIPTS}/job-cluster-job.yaml.template | kubectl create -f -
+envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB} ${FLINK_JOB_PARALLELISM} ${FLINK_JOB_ARGUMENTS} ${NODEPORT}' < ${CONTAINER_SCRIPTS}/job-cluster-job.yaml.template | kubectl create -f -
 envsubst '${FLINK_IMAGE_NAME} ${FLINK_JOB_PARALLELISM}' < ${CONTAINER_SCRIPTS}/task-manager-deployment.yaml.template | kubectl create -f -
 kubectl wait --for=condition=complete job/flink-job-cluster --timeout=1h
 kubectl cp `kubectl get pods | awk '/task-manager/ {print $1}'`:/cache/${OUTPUT_FILE} ${OUTPUT_VOLUME}/${OUTPUT_FILE}

--- a/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
+++ b/flink-end-to-end-tests/test-scripts/test_queryable_state_restart_tm.sh
@@ -154,7 +154,7 @@ function wait_for_number_of_checkpoints {
 
 function get_completed_number_of_checkpoints {
     local job_id=$1
-    local json_res=$(curl -s http://localhost:8081/jobs/${job_id}/checkpoints)
+    local json_res=$(curl -s http://localhost:${NODEPORT}/jobs/${job_id}/checkpoints)
 
     echo ${json_res}    | # {"counts":{"restored":0,"total":25,"in_progress":1,"completed":24,"failed":0} ...
         cut -d ":" -f 6 | # 24,"failed"


### PR DESCRIPTION
## Make REST port configurable in bash end-to-end tests.

Make the port used in the end to end test common scripts configurable.


## Verifying this change

```
NODEPORT=8082 FLINK_DIR=<put your flink build here> ./run-nightly-tests.sh
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / *no*)
  - The serializers: (yes / *no* / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / *no* / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / *no* / don't know)
  - The S3 file system connector: (yes / *no* / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (*not applicable* / docs / JavaDocs / not documented)
