### PR TITLE
[FLINK-15914][tests] Fix the fragile tests caused by race condition of multiple threads

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -76,6 +76,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -808,17 +809,17 @@ public class OneInputStreamTaskTest extends TestLogger {
 		StreamConfig streamConfig = testHarness.getStreamConfig();
 		streamConfig.setStreamOperator(new TestOperator());
 
-		final Map<String, Metric> metrics = new HashMap<>();
+		final Map<String, Metric> metrics = new ConcurrentHashMap<>();
 		final TaskMetricGroup taskMetricGroup = new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
 		final StreamMockEnvironment environment = testHarness.createEnvironment();
 		environment.setTaskMetricGroup(taskMetricGroup);
 
 		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
 
 		assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
 		assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
 
-		testHarness.waitForTaskRunning();
 		testHarness.endInput();
 		testHarness.waitForTaskCompletion();
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -58,10 +58,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -641,17 +641,17 @@ public class TwoInputStreamTaskTest {
 		testHarness.setupOutputForSingletonOperatorChain();
 		streamConfig.setStreamOperator(coMapOperator);
 
-		final Map<String, Metric> metrics = new HashMap<>();
+		final Map<String, Metric> metrics = new ConcurrentHashMap<>();
 		final TaskMetricGroup taskMetricGroup = new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
 		final StreamMockEnvironment environment = testHarness.createEnvironment();
 		environment.setTaskMetricGroup(taskMetricGroup);
 
 		testHarness.invoke(environment);
+		testHarness.waitForTaskRunning();
 
 		assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
 		assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
 
-		testHarness.waitForTaskRunning();
 		testHarness.endInput();
 		testHarness.waitForTaskCompletion();
 	}


### PR DESCRIPTION
## What is the purpose of the change

*Fix the fragile tests caused by race condition of multiple threads*

## Brief change log

  - *Fix the `OneInputStreamTaskTest#testCheckpointBarrierMetrics`*
  - *Fix the `TwoInputStreamTaskTest#testCheckpointBarrierMetrics`*

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
