### PR TITLE
[FLINK-15995][Table-planner-blink] Change TO_BASE64 sql operator defination

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -574,9 +574,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlFunction TO_BASE64 = new SqlFunction(
 		"TO_BASE64",
 		SqlKind.OTHER_FUNCTION,
-		VARCHAR_2000_NULLABLE,
+		ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE),
 		null,
-		OperandTypes.ANY,
+		OperandTypes.family(SqlTypeFamily.STRING),
 		SqlFunctionCategory.STRING);
 
 	public static final SqlFunction FROM_BASE64 = new SqlFunction(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/validation/ScalarFunctionsValidationTest.scala
@@ -261,4 +261,14 @@ class ScalarFunctionsValidationTest extends ScalarTypesTestBase {
       "IF(f7 > 5, f0, f1)",
       "FAIL")
   }
+
+  @Test
+  def testInvalidToBase64(): Unit = {
+    //test TO_BASE64(INTEGER)
+    thrown.expect(classOf[ValidationException])
+    thrown.expectMessage("Cannot apply 'TO_BASE64' to arguments of type 'TO_BASE64(<INTEGER>)'")
+    testSqlApi(
+      "TO_BASE64(11)",
+      "FAIL")
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change
Change TO_BASE64 sql operator defination

## Brief change log
1.  Change SqlTypeFamily.ANY to OperandTypes.family(SqlTypeFamily.STRING)
2. Change VARCHAR_2000_NULLABLE  to ReturnTypes.cascade(ReturnTypes.explicit(SqlTypeName.VARCHAR), SqlTypeTransforms.TO_NULLABLE) to align with legency planner


## Verifying this change
This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
