### PR TITLE
[FLINK-15970][python] Optimize the Python UDF execution to only serialize the value

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -227,7 +227,6 @@ public abstract class AbstractPythonFunctionRunner<IN> implements PythonFunction
 		try {
 			baos.reset();
 			inputTypeSerializer.serialize(element, baosWrapper);
-			// TODO: support to use ValueOnlyWindowedValueCoder for better performance.
 			// Currently, FullWindowedValueCoder has to be used in Beam's portability framework.
 			mainInputReceiver.accept(WindowedValue.valueInGlobalWindow(baos.toByteArray()));
 		} catch (Throwable t) {

--- a/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/python/AbstractPythonFunctionRunner.java
@@ -227,7 +227,6 @@ public abstract class AbstractPythonFunctionRunner<IN> implements PythonFunction
 		try {
 			baos.reset();
 			inputTypeSerializer.serialize(element, baosWrapper);
-			// Currently, FullWindowedValueCoder has to be used in Beam's portability framework.
 			mainInputReceiver.accept(WindowedValue.valueInGlobalWindow(baos.toByteArray()));
 		} catch (Throwable t) {
 			throw new RuntimeException("Failed to process element when sending data to Python SDK harness.", t);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonStatelessFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonStatelessFunctionRunner.java
@@ -149,7 +149,7 @@ public abstract class AbstractPythonStatelessFunctionRunner<IN> extends Abstract
 			Collections.singletonList(
 				PipelineNode.pCollection(OUTPUT_ID, components.getPcollectionsOrThrow(OUTPUT_ID)));
 		return ImmutableExecutableStage.of(
-			components, createPythonExecutionEnvironment(), input, sideInputs, userStates, timers, transforms, outputs, createWireCoderSetting());
+			components, createPythonExecutionEnvironment(), input, sideInputs, userStates, timers, transforms, outputs, createValueOnlyWireCoderSetting());
 	}
 
 	FlinkFnApi.UserDefinedFunction getUserDefinedFunctionProto(PythonFunctionInfo pythonFunctionInfo) {
@@ -170,7 +170,7 @@ public abstract class AbstractPythonStatelessFunctionRunner<IN> extends Abstract
 		return builder.build();
 	}
 
-	private RunnerApi.WireCoderSetting createWireCoderSetting() throws IOException {
+	private RunnerApi.WireCoderSetting createValueOnlyWireCoderSetting() throws IOException {
 		WindowedValue<byte[]> value = WindowedValue.valueInGlobalWindow(new byte[0]);
 		Coder<? extends BoundedWindow> windowCoder = GlobalWindow.Coder.INSTANCE;
 		WindowedValue.FullWindowedValueCoder<byte[]> windowedValueCoder =


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will  optimize the Python UDF execution to only serialize the value*


## Brief change log

  - *Replace WindowedValueCoder with ParamWindowedValueCoder*

## Verifying this change

This change added tests and can be verified as follows:

  - *This is a PR with improved performance, so we don't need to add test in the source code*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
