### PR TITLE
[FLINK-15994][Table-planner-blink]Support byte array argument for FROM_BASE64 function

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -910,6 +910,14 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     testSqlApi(
       "FROM_BASE64(CAST(x'6147567362473867643239796247513D' AS VARBINARY))",
       "hello world")
+
+    testSqlApi(
+      "FROM_BASE64(x'6147567362473867643239796247513D')",
+      "hello world")
+
+    testSqlApi(
+      "FROM_BASE64(f58)",
+      "你好")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -906,6 +906,10 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
       "FROM_BASE64('5L2g5aW9')",
       "你好"
     )
+
+    testSqlApi(
+      "FROM_BASE64(CAST(x'6147567362473867643239796247513D' AS VARBINARY))",
+      "hello world")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarTypesTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ScalarTypesTestBase.scala
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets
 abstract class ScalarTypesTestBase extends ExpressionTestBase {
 
   override def testData: Row = {
-    val testData = new Row(58)
+    val testData = new Row(59)
     testData.setField(0, "This is a test String.")
     testData.setField(1, true)
     testData.setField(2, 42.toByte)
@@ -90,6 +90,7 @@ abstract class ScalarTypesTestBase extends ExpressionTestBase {
     testData.setField(55, 1)
     testData.setField(56, 2)
     testData.setField(57, 1)
+    testData.setField(58, "5L2g5aW9".getBytes(StandardCharsets.UTF_8))
     testData
   }
 
@@ -152,6 +153,7 @@ abstract class ScalarTypesTestBase extends ExpressionTestBase {
       /* 54 */ Types.PRIMITIVE_ARRAY(Types.BYTE),
       /* 55 */ new GenericTypeInfo[Integer](classOf[Integer]),
       /* 56 */ new GenericTypeInfo[Integer](classOf[Integer]),
-      /* 57 */ new GenericTypeInfo[Integer](classOf[Integer]))
+      /* 57 */ new GenericTypeInfo[Integer](classOf[Integer]),
+      /* 58 */ Types.PRIMITIVE_ARRAY(Types.BYTE))
   }
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -1067,6 +1067,10 @@ public class SqlFunctionUtils {
 		return BinaryString.fromBytes(Base64.getDecoder().decode(bs.getBytes()));
 	}
 
+	public static BinaryString fromBase64(byte[] bytes) {
+		return BinaryString.fromBytes(Base64.getDecoder().decode(bytes));
+	}
+
 	public static String uuid(){
 		return UUID.randomUUID().toString();
 	}


### PR DESCRIPTION
## What is the purpose of the change

Support byte array arguments for FROM_BASE64 function

## Brief change log

Add byte array argument for FROM_BASE64 function

## Verifying this change

This change added tests and can be verified as follows:
Add test in ScalarFunctionsTest#testFromBase64

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
