### PR TITLE
[FLINK-15993]/[FLINK-15997] Rework documentation 404 page

### DIFF
--- a/docs/404.md
+++ b/docs/404.md
@@ -21,6 +21,6 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<!--
-Force the 404 page to render
--->
+
+The page you are looking for has been moved. This could be because of a recent reorganization of the
+documentation. Redirecting to [Documentation Home Page]({{ site.baseurl }}/) in 5 seconds.

--- a/docs/_layouts/404_base.html
+++ b/docs/_layouts/404_base.html
@@ -20,9 +20,18 @@ under the License.
 <html lang="en-US">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=https:{{ site.stable_baseurl }}">
+    <noscript>
+      <meta http-equiv="refresh" content="5; url=https:{{ site.stable_baseurl }}">
+    </noscript>
     <script type="text/javascript">
-      window.location.href = "https:{{ site.stable_baseurl }}"
+      var documentationRootUrl = "https:{{ site.stable_baseurl }}";
+      var timeout = "5000";
+      window.onload = function() {
+        setTimeout(doRedirect, timeout);
+      }
+      function doRedirect() {
+        window.location.href = documentationRootUrl;
+      }
     </script>
     <title>404</title>
   </head>

--- a/docs/_layouts/404_base.html
+++ b/docs/_layouts/404_base.html
@@ -1,4 +1,6 @@
-<!DOCTYPE html>
+---
+layout: base
+---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -17,25 +19,21 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<html lang="en-US">
-  <head>
-    <meta charset="UTF-8">
-    <noscript>
-      <meta http-equiv="refresh" content="5; url=https:{{ site.stable_baseurl }}">
-    </noscript>
-    <script type="text/javascript">
-      var documentationRootUrl = "https:{{ site.stable_baseurl }}";
-      var timeout = "5000";
-      window.onload = function() {
-        setTimeout(doRedirect, timeout);
-      }
-      function doRedirect() {
-        window.location.href = documentationRootUrl;
-      }
-    </script>
-    <title>404</title>
-  </head>
-  <body>
-    <a href='https:{{ site.stable_baseurl }}'>Home</a>.
-  </body>
-</html>
+
+<noscript>
+  <meta http-equiv="refresh" content="5; url=https:{{ site.baseurl }}">
+</noscript>
+<script type="text/javascript">
+  var documentationRootUrl = "https:{{ site.baseurl }}";
+  var timeout = "5000";
+  window.onload = function() {
+    setTimeout(doRedirect, timeout);
+  }
+  function doRedirect() {
+    window.location.href = documentationRootUrl;
+  }
+</script>
+
+<h1>{{ page.title }}</h1>
+
+{{ content }}


### PR DESCRIPTION
Before, we would immediately redirect without the user knowing what's going on. Now we redirect after 5 seconds. This also adds explanatory text and makes the 404 page look like a regular documentation page, with sidenav and everything.