### PR TITLE
[FLINK-15992][table] Fix classloader when finding TableFactory

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkFactoryBase.java
@@ -243,8 +243,7 @@ public abstract class ElasticsearchUpsertTableSinkFactoryBase implements StreamT
 		@SuppressWarnings("unchecked")
 		final SerializationSchemaFactory<Row> formatFactory = TableFactoryService.find(
 			SerializationSchemaFactory.class,
-			properties,
-			this.getClass().getClassLoader());
+			properties);
 		return formatFactory.createSerializationSchema(properties);
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryBase.java
@@ -280,8 +280,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		@SuppressWarnings("unchecked")
 		final DeserializationSchemaFactory<Row> formatFactory = TableFactoryService.find(
 			DeserializationSchemaFactory.class,
-			properties,
-			this.getClass().getClassLoader());
+			properties);
 		return formatFactory.createDeserializationSchema(properties);
 	}
 
@@ -289,8 +288,7 @@ public abstract class KafkaTableSourceSinkFactoryBase implements
 		@SuppressWarnings("unchecked")
 		final SerializationSchemaFactory<Row> formatFactory = TableFactoryService.find(
 			SerializationSchemaFactory.class,
-			properties,
-			this.getClass().getClassLoader());
+			properties);
 		return formatFactory.createSerializationSchema(properties);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes finding SerializationSchemaFactory with ClassLoader from `Thread.currentThread().getContextClassLoader()` rather than `this.getClass().getClassLoader()`.


## Brief change log

  - Remove ClassLoader parameter when invoking `TableFactoryService#find`, so it will use `Thread.currentThread().getContextClassLoader()` as default ClassLoader.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
