### PR TITLE
[FLINK-15941] [format-avro] RegistryAvroSerializationSchema registers schema on first message only

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/RegistryAvroSerializationSchema.java
@@ -78,8 +78,7 @@ public class RegistryAvroSerializationSchema<T> extends AvroSerializationSchema<
 				ByteArrayOutputStream outputStream = getOutputStream();
 				outputStream.reset();
 				Encoder encoder = getEncoder();
-				schemaCoderProvider.get()
-					.writeSchema(getSchema(), outputStream);
+				schemaCoder.writeSchema(getSchema(), outputStream);
 				getDatumWriter().write(object, encoder);
 				encoder.flush();
 				return outputStream.toByteArray();


### PR DESCRIPTION
  ## What is the purpose of the change

This pull request improves the RegistryAvroSerializationSchema class such that it will only attempt to register the schema with the Schema Registry on the first message. All subsequent messages will retrieve the schema id from the cache. 

## Brief change log

  - Update RegistryAvroSerializationSchema to utilize the same instance of SchemaCoder for each message so it can retrieve the schema id from the cache after initial registration.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
