### PR TITLE
[FLINK-15982][e2e] Pick the right Flink version to fix the java quickstart test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -39,8 +39,6 @@ export TASK_SLOTS_PER_TM_HA=4
 
 echo "Flink dist directory: $FLINK_DIR"
 
-FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>/\1/p' | head -n 1)
-
 TEST_ROOT=`pwd -P`
 TEST_INFRA_DIR="$END_TO_END_DIR/test-scripts/"
 cd $TEST_INFRA_DIR

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -39,7 +39,7 @@ export TASK_SLOTS_PER_TM_HA=4
 
 echo "Flink dist directory: $FLINK_DIR"
 
-FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>/\1/p')
+FLINK_VERSION=$(cat ${END_TO_END_DIR}/pom.xml | sed -n 's/.*<version>\(.*\)<\/version>/\1/p' | head -n 1)
 
 TEST_ROOT=`pwd -P`
 TEST_INFRA_DIR="$END_TO_END_DIR/test-scripts/"

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -19,7 +19,7 @@
 
 source "${END_TO_END_DIR}"/test-scripts/common.sh
 
-FLINK_VERSION=$(mvn --file ${END_TO_END_DIR}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+export FLINK_VERSION=$(mvn --file ${END_TO_END_DIR}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
 
 #######################################
 # Prints the given description, runs the given test and prints how long the execution took.

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -19,6 +19,8 @@
 
 source "${END_TO_END_DIR}"/test-scripts/common.sh
 
+FLINK_VERSION=$(mvn --file ${END_TO_END_DIR}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+
 #######################################
 # Prints the given description, runs the given test and prints how long the execution took.
 # Arguments:
@@ -92,6 +94,8 @@ function post_test_validation {
         exit "${exit_code}"
     fi
 }
+
+
 
 # Shuts down cluster and reverts changes to cluster configs
 function cleanup_proc {


### PR DESCRIPTION
I know that calling `head -n 1` is not the most robust way.
[Multiline matching with sed](https://unix.stackexchange.com/questions/26284/how-can-i-use-sed-to-replace-a-multi-line-string) is fairly complicated. Using maven:
```
mvn --file ../pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout
```
takes roughly 4 seconds. The common.sh script is sourced in many scripts, this would slow down the test execution.


## Verifying this change

Run the "Quickstarts Java nightly end-to-end test"
