### PR TITLE
[FLINK-15964] [cep] fix getting event of previous stage in notFollowedBy may throw exception bug

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -685,6 +685,7 @@ public class NFA<T> {
 				final State<T> currentState = statesToCheck.pop();
 				for (StateTransition<T> transition : currentState.getStateTransitions()) {
 					if (transition.getAction() == StateTransitionAction.PROCEED &&
+							!transition.getTargetState().isStop() &&
 							checkFilterCondition(context, transition.getCondition(), event)) {
 						if (transition.getTargetState().isFinal()) {
 							return transition.getTargetState();

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.cep.nfa.sharedbuffer.SharedBuffer;
 import org.apache.flink.cep.nfa.sharedbuffer.SharedBufferAccessor;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.Quantifier;
-import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.cep.utils.NFATestHarness;
 import org.apache.flink.cep.utils.TestSharedBuffer;
@@ -2844,36 +2843,5 @@ public class NFAITCase extends TestLogger {
 			nfa.advanceTime(accessor, nfa.createInitialNFAState(), 2);
 			Mockito.verify(accessor, Mockito.times(1)).advanceTime(2);
 		}
-	}
-
-	/**
-	 * Test that can access the value of the previous stage directly in notFollowedBy.
-	 *
-	 * @see <a href="https://issues.apache.org/jira/browse/FLINK-15964">FLINK-15964</a>
-	 * @throws Exception
-	 */
-	@Test
-	public void testAccessPreviousStageInNotFollowedBy() throws Exception {
-		Pattern<Event, ?> pattern = Pattern.<Event>begin("start")
-				.notFollowedBy("not").where(new IterativeCondition<Event>() {
-					private static final long serialVersionUID = -4702359359303151881L;
-
-					@Override
-					public boolean filter(Event value, Context<Event> ctx) throws Exception {
-						return value.getName().equals(ctx.getEventsForPattern("start").iterator().next().getName());
-					}
-				}).followedBy("end");
-
-		Event a = new Event(40, "a", 1.0);
-		Event b = new Event(41, "b", 2.0);
-
-		List<StreamRecord<Event>> inputEvents = new ArrayList<>();
-		inputEvents.add(new StreamRecord<>(a, 1));
-		inputEvents.add(new StreamRecord<>(b, 2));
-
-		NFATestHarness nfaTestHarness = NFATestHarness.forPattern(pattern).build();
-		List<List<Event>> resultingPatterns = nfaTestHarness.feedRecords(inputEvents);
-
-		comparePatterns(resultingPatterns, Collections.singletonList(Lists.newArrayList(a, b)));
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

This pull request fixes the bug that when getting the events in previous stage in notFollowedBy, it may throw exceptions. 
For example:
```
Pattern.begin("a").notFollowedBy("b").where(new IterativeCondition<Event>() {
	@Override
	public boolean filter(Event value, Context<Event> ctx) throws Exception {
		return value.getName().equals(ctx.getEventsForPattern("a").iterator().next().getName());
	}
    }).followedBy(""c);
```
will throw exception at running.
## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in NFAITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
