### PR TITLE
[FLINK-16013][core] Make complex type config options could be parsed correctly

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/StructuredOptionsSplitter.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StructuredOptionsSplitter.java
@@ -21,6 +21,7 @@ package org.apache.flink.configuration;
 import org.apache.flink.annotation.Internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -50,6 +51,36 @@ class StructuredOptionsSplitter {
 	static List<String> splitEscaped(String string, char delimiter) {
 		List<Token> tokens = tokenize(checkNotNull(string), delimiter);
 		return processTokens(tokens);
+	}
+
+	/**
+	 * Escapes the given string with single quotes, if the input string contains a double quote or any of the
+	 * given {@code charsToEscape}. Any single quotes in the input string will be escaped by doubling.
+	 *
+	 * <p>Given that the escapeChar is (;)
+	 *
+	 * <p>Examples:
+	 * <ul>
+	 *     <li>A,B,C,D => A,B,C,D</li>
+	 *     <li>A'B'C'D => 'A''B''C''D'</li>
+	 *     <li>A;BCD => 'A;BCD'</li>
+	 *     <li>AB"C"D => 'AB"C"D'</li>
+	 *     <li>AB'"D:B => 'AB''"D:B'</li>
+	 * </ul>
+	 *
+	 * @param string a string which needs to be escaped
+	 * @param charsToEscape escape chars for the escape conditions
+	 * @return escaped string by single quote
+	 */
+	static String escapeWithSingleQuote(String string, String... charsToEscape) {
+		boolean escape = Arrays.stream(charsToEscape).anyMatch(string::contains)
+			|| string.contains("\"") || string.contains("'");
+
+		if (escape) {
+			return "'" + string.replaceAll("'", "''") + "'";
+		}
+
+		return string;
 	}
 
 	private static List<String> processTokens(List<Token> tokens) {

--- a/flink-core/src/test/java/org/apache/flink/configuration/StructuredOptionsSplitterEscapeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/StructuredOptionsSplitterEscapeTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Tests for {@link StructuredOptionsSplitter#escapeWithSingleQuote}.
+ */
+@RunWith(Parameterized.class)
+public class StructuredOptionsSplitterEscapeTest {
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<TestSpec> getEncodeSpecs() {
+		return Arrays.asList(
+			TestSpec.encode("A,B,C,D", ";").expect("A,B,C,D"),
+			TestSpec.encode("A;BCD", ";").expect("'A;BCD'"),
+			TestSpec.encode("A'B'C'D", ";").expect("'A''B''C''D'"),
+			TestSpec.encode("AB\"C\"D", ";").expect("'AB\"C\"D'"),
+			TestSpec.encode("AB'\"D:B", ";").expect("'AB''\"D:B'"),
+
+			TestSpec.encode("A,B,C,D", ",").expect("'A,B,C,D'"),
+			TestSpec.encode("A;BCD", ",").expect("A;BCD"),
+			TestSpec.encode("AB\"C\"D", ",").expect("'AB\"C\"D'"),
+			TestSpec.encode("AB'\"D:B", ",").expect("'AB''\"D:B'"),
+
+			TestSpec.encode("A;B;C;D", ",", ":").expect("A;B;C;D"),
+			TestSpec.encode("A;B;C:D", ",", ":").expect("'A;B;C:D'")
+		);
+	}
+
+	@Parameterized.Parameter
+	public TestSpec testSpec;
+
+	@Test
+	public void testEscapeWithSingleQuote() {
+		String encoded = StructuredOptionsSplitter.escapeWithSingleQuote(
+			testSpec.getString(),
+			testSpec.getEscapeChars());
+		Assert.assertEquals(testSpec.getEncodedString(), encoded);
+	}
+
+	private static class TestSpec {
+		private final String string;
+		private final String[] escapeChars;
+		private String encodedString;
+
+		private TestSpec(String string, String... escapeChars) {
+			this.string = string;
+			this.escapeChars = escapeChars;
+		}
+
+		public static TestSpec encode(String string, String... escapeChars) {
+			return new TestSpec(string, escapeChars);
+		}
+
+		public TestSpec expect(String string) {
+			this.encodedString = string;
+			return this;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public String getEncodedString() {
+			return encodedString;
+		}
+
+		public String[] getEscapeChars() {
+			return escapeChars;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/BootstrapTools.java
@@ -288,11 +288,10 @@ public class BootstrapTools {
 	public static void writeConfiguration(Configuration cfg, File file) throws IOException {
 		try (FileWriter fwrt = new FileWriter(file);
 			PrintWriter out = new PrintWriter(fwrt)) {
-			for (String key : cfg.keySet()) {
-				String value = cfg.getString(key, null);
-				out.print(key);
+			for (Map.Entry<String, String> entry : cfg.toMap().entrySet()) {
+				out.print(entry.getKey());
 				out.print(": ");
-				out.println(value);
+				out.println(entry.getValue());
 			}
 		}
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, if a config option is List type and written to a flink-conf.yaml, it could not be parsed correctly when reloaded from yaml resource. The root cause is we use List#toString to save into the yaml resource. However, when we want to parse a List from a string, we use semicolon to split the value.

When the configuration value is List type, we need to convert it to a semicolon-separated string in `Configuration#toMap`. And If we want to write the configuration to a yaml file, `Configuration#toMap` should be used to get all the keys and values.


## Brief change log

* Convert list to semicolon-separated  string in `Configuration#toMap`


## Verifying this change

* The changes is covered by two new added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
