### PR TITLE
[FLINK-16004][build] Use correct parent

### DIFF
--- a/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
+++ b/flink-end-to-end-tests/flink-rocksdb-state-memory-control-test/pom.xml
@@ -21,10 +21,10 @@ under the License.
 		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<parent>
-		<artifactId>flink-parent</artifactId>
+		<artifactId>flink-end-to-end-tests</artifactId>
 		<groupId>org.apache.flink</groupId>
 		<version>1.11-SNAPSHOT</version>
-		<relativePath>../../pom.xml</relativePath>
+		<relativePath>..</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Adjusts the `flink-rocksdb-state-memory-control-test` pom to use `flink-end-to-end-tests` as a parent. 
This was likely just an oversight in the original PR and not intentional.

As a result the `flink-rocksdb-state-memory-control-test` will no longer be deployed.