### PR TITLE
[FLINK-15909][python][build] Supports releasing to PyPI for PyFlink for 1.9.

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -109,6 +109,9 @@ under the License.
 								</delete>
 								<delete file="${project.basedir}/lib/pyflink.zip"/>
 								<delete dir="${project.basedir}/target"/>
+								<delete dir="${project.basedir}/build"/>
+								<delete dir="${project.basedir}/dist"/>
+								<delete dir="${project.basedir}/apache_flink.egg-info"/>
 							</target>
 						</configuration>
 					</execution>

--- a/tools/releasing/create_binary_release.sh
+++ b/tools/releasing/create_binary_release.sh
@@ -90,9 +90,37 @@ make_binary_release() {
   cd ${FLINK_DIR}
 }
 
+make_python_release() {
+  cd flink-python/
+  python setup.py sdist
+  cd dist/
+  pyflink_actual_name=`echo *.tar.gz`
+  PYFLINK_VERSION=${RELEASE_VERSION/-SNAPSHOT/.dev0}
+  pyflink_release_name="apache-flink-${PYFLINK_VERSION}.tar.gz"
+
+  if [[ "$pyflink_actual_name" != "$pyflink_release_name" ]] ; then
+    echo -e "\033[31;1mThe file name of the python package: ${pyflink_actual_name} is not consistent with given release version: ${PYFLINK_VERSION}!\033[0m"
+    exit 1
+  fi
+
+  cp ${pyflink_actual_name} "${RELEASE_DIR}/${pyflink_release_name}"
+
+  cd ${RELEASE_DIR}
+
+  # Sign sha the tgz
+  if [ "$SKIP_GPG" == "false" ] ; then
+    gpg --armor --detach-sig "${pyflink_release_name}"
+  fi
+  $SHASUM "${pyflink_release_name}" > "${pyflink_release_name}.sha512"
+
+  cd ${FLINK_DIR}
+}
+
 if [ "$SCALA_VERSION" == "none" ]; then
   make_binary_release "2.12"
   make_binary_release "2.11"
+  make_python_release
 else
   make_binary_release "$SCALA_VERSION"
+  make_python_release
 fi

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -66,6 +66,10 @@ rsync -a \
   --exclude "CHANGELOG" --exclude ".github" --exclude "target" \
   --exclude ".idea" --exclude "*.iml" --exclude ".DS_Store" --exclude "build-target" \
   --exclude "docs/content" --exclude ".rubydeps" \
+  --exclude "flink-python/lib/pyflink.zip"  --exclude "flink-python/build" \
+  --exclude "flink-python/dist" --exclude "flink-python/apache_flink.egg-info" \
+  --exclude "flink-python/.tox" --exclude "flink-python/.cache" \
+  --exclude "flink-python/.pytest_cache" \
   . flink-$RELEASE_VERSION
 
 tar czf ${RELEASE_DIR}/flink-${RELEASE_VERSION}-src.tgz flink-$RELEASE_VERSION


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds PyPI release process into the subsequent release of 1.9.x. It is cherry-picked from https://github.com/apache/flink/pull/9496 .*

## Brief change log

  - *Add configuration in pom.xml to clean old files.*
  - *Add `make_python_release` function in `create_binary_release.sh`*
  - *Exclude unnecessary files when creating source release.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
