### PR TITLE
[FLINK-16026][python] Limits the avro-python3 version in Flink

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -224,7 +224,7 @@ run sdist.
         author_email='dev@flink.apache.org',
         python_requires='>=3.5',
         install_requires=['py4j==0.10.8.1', 'python-dateutil==2.8.0', 'apache-beam==2.19.0',
-                          'cloudpickle==1.2.2'],
+                          'cloudpickle==1.2.2', 'avro-python3>=1.8.1,<=1.9.1'],
         tests_require=['pytest==4.4.1'],
         description='Apache Flink Python API',
         long_description=long_description,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will limit the avro-python3 version in Flink*

## Brief change log

  - *limit the avro-python3 version*


## Verifying this change


This change added tests and can be verified as follows:

*tox test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
