### PR TITLE
[FLINK-16040][python] Change local import to global import

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -21,6 +21,8 @@ import decimal
 import struct
 from apache_beam.coders.coder_impl import StreamCoderImpl
 
+from pyflink.table import Row
+
 
 class RowCoderImpl(StreamCoderImpl):
 
@@ -34,7 +36,6 @@ class RowCoderImpl(StreamCoderImpl):
                 self._field_coders[i].encode_to_stream(value[i], out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
-        from pyflink.table import Row
         null_mask = self.read_null_mask(len(self._field_coders), in_stream)
         assert len(null_mask) == len(self._field_coders)
         return Row(*[None if null_mask[idx] else self._field_coders[idx].decode_from_stream(

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -26,6 +26,7 @@ from apache_beam.coders.coders import FastCoder
 
 from pyflink.fn_execution import coder_impl
 from pyflink.fn_execution import flink_fn_execution_pb2
+from pyflink.table import Row
 
 FLINK_SCHEMA_CODER_URN = "flink:coder:schema:v1"
 
@@ -51,7 +52,6 @@ class RowCoder(FastCoder):
         return all(c.is_deterministic() for c in self._field_coders)
 
     def to_type_hint(self):
-        from pyflink.table import Row
         return Row
 
     def __repr__(self):

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -19,12 +19,15 @@
 import datetime
 from abc import abstractmethod, ABCMeta
 
+import cloudpickle
+from apache_beam.runners.common import _OutputProcessor
 from apache_beam.runners.worker import operation_specs
 from apache_beam.runners.worker import bundle_processor
 from apache_beam.runners.worker.operations import Operation
 
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.serializers import PickleSerializer
+from pyflink.table import Row
 
 SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1"
 
@@ -179,7 +182,6 @@ def create_scalar_function_invoker(scalar_function_proto):
     :param scalar_function_proto: the proto representation of the Python :class:`ScalarFunction`
     :return: :class:`ScalarFunctionInvoker`.
     """
-    import cloudpickle
     scalar_function = cloudpickle.loads(scalar_function_proto.payload)
     return ScalarFunctionInvoker(scalar_function, scalar_function_proto.inputs)
 
@@ -203,7 +205,6 @@ class ScalarFunctionRunner(object):
         :param main_receivers: Receiver objects which is responsible for sending the execution
                                results back the the remote Java operator
         """
-        from apache_beam.runners.common import _OutputProcessor
         self.output_processor = _OutputProcessor(
             window_fn=None,
             main_receivers=main_receivers,
@@ -221,7 +222,6 @@ class ScalarFunctionRunner(object):
     def process(self, windowed_value):
         results = [invoker.invoke_eval(windowed_value.value) for invoker in
                    self.scalar_function_invokers]
-        from pyflink.table import Row
         result = Row(*results)
         # send the execution results back
         self.output_processor.process_outputs(windowed_value, [result])


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will change local import to global import*


## Brief change log

  - *change local import to global import*

## Verifying this change

This change added tests and can be verified as follows:

  - *tox test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## How was this patch tested?
### Test code:


    @udf(input_types=[DataTypes.INT(False)], result_type=DataTypes.INT(False))
    def inc(x):
        return x + 1
    t_env.register_function("inc", inc)
    #num_rows = 100000000
    num_rows = 10000000
    t_env.from_table_source(RangeTableSource(1, num_rows, 1)).alias("id") \
         .select("inc(id)") \
         .insert_into("sink")

    beg_time = time.time()
    t_env.execute("perf_test")
    print("consume time: " + str(time.time() - beg_time))
### config
python.fn-execution.bundle.size 3000
python.fn-execution.bundle.time 10000
pipeline.object-reuse True
### Test Result:
row number/Consume time( before)/Consume time (after)
100w           /   24.52s                    /  20.91s
1000w        /   173.56s                  /    150.93s