### PR TITLE
[FLINK-16000] Move "Project Build Setup" to "Getting Started" in documentation

### DIFF
--- a/docs/dev/best_practices.md
+++ b/docs/dev/best_practices.md
@@ -192,7 +192,7 @@ public class MyClass implements MapFunction {
 
 In all cases where classes are executed with a classpath created by a dependency manager such as Maven, Flink will pull log4j into the classpath.
 
-Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](./projectsetup/java_api_quickstart.html).
+Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](../getting-started/project-setup/java_api_quickstart.html).
 
 Change your projects `pom.xml` file like this:
 

--- a/docs/dev/best_practices.zh.md
+++ b/docs/dev/best_practices.zh.md
@@ -192,7 +192,7 @@ public class MyClass implements MapFunction {
 
 In all cases where classes are executed with a classpath created by a dependency manager such as Maven, Flink will pull log4j into the classpath.
 
-Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](./projectsetup/java_api_quickstart.html).
+Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](../getting-started/project-setup/java_api_quickstart.html).
 
 Change your projects `pom.xml` file like this:
 

--- a/docs/getting-started/docker-playgrounds/index.md
+++ b/docs/getting-started/docker-playgrounds/index.md
@@ -3,7 +3,7 @@ title: Docker Playgrounds
 nav-id: docker-playgrounds
 nav-title: '<i class="fa fa-ship title appetizer" aria-hidden="true"></i> Docker Playgrounds'
 nav-parent_id: getting-started
-nav-pos: 20
+nav-pos: 10
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/docker-playgrounds/index.md
+++ b/docs/getting-started/docker-playgrounds/index.md
@@ -1,7 +1,7 @@
 ---
 title: Docker Playgrounds
 nav-id: docker-playgrounds
-nav-title: '<i class="fa fa-ship title appetizer" aria-hidden="true"></i> Docker Playgrounds'
+nav-title: 'Docker Playgrounds'
 nav-parent_id: getting-started
 nav-pos: 10
 ---

--- a/docs/getting-started/docker-playgrounds/index.zh.md
+++ b/docs/getting-started/docker-playgrounds/index.zh.md
@@ -3,7 +3,7 @@ title: Docker Playgrounds
 nav-id: docker-playgrounds
 nav-title: '<i class="fa fa-ship title appetizer" aria-hidden="true"></i> Docker Playgrounds'
 nav-parent_id: getting-started
-nav-pos: 20
+nav-pos: 10
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/docker-playgrounds/index.zh.md
+++ b/docs/getting-started/docker-playgrounds/index.zh.md
@@ -1,7 +1,7 @@
 ---
 title: Docker Playgrounds
 nav-id: docker-playgrounds
-nav-title: '<i class="fa fa-ship title appetizer" aria-hidden="true"></i> Docker Playgrounds'
+nav-title: 'Docker Playgrounds'
 nav-parent_id: getting-started
 nav-pos: 10
 ---

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,7 +26,16 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-There are many ways to get started with Apache Flink. Which one is the best for you depends on your goal and prior experience.
+There are many ways to get started with Apache Flink. Which one is the best for
+you depends on your goal and prior experience:
+
+* take a look at the **Docker Playgrounds** for a docker-based introduction to
+  specific Flink concepts
+* explore on of the **Code Walkthroughs** if you want to get an end-to-end
+  introduction to using one of the Flink APIs
+* use **Project Setup** if you already know the basics of Flink but want to get a
+  project setup template for Java or Scala and need help setting up
+  dependencies
 
 ### Taking a first look at Flink
 

--- a/docs/getting-started/project-setup/dependencies.md
+++ b/docs/getting-started/project-setup/dependencies.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuring Dependencies, Connectors, Libraries"
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 2
 ---
 <!--

--- a/docs/getting-started/project-setup/dependencies.zh.md
+++ b/docs/getting-started/project-setup/dependencies.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "配置依赖、连接器、类库"
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 2
 ---
 <!--

--- a/docs/getting-started/project-setup/index.md
+++ b/docs/getting-started/project-setup/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Project Build Setup"
-nav-id: projectsetup
-nav-title: 'Project Build Setup'
-nav-parent_id: dev
-nav-pos: 0
+title: "Project Setup"
+nav-id: project-setup
+nav-title: 'Project Setup'
+nav-parent_id: getting-started
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/index.md
+++ b/docs/getting-started/project-setup/index.md
@@ -3,7 +3,7 @@ title: "Project Setup"
 nav-id: project-setup
 nav-title: 'Project Setup'
 nav-parent_id: getting-started
-nav-pos: 5
+nav-pos: 30
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/index.zh.md
+++ b/docs/getting-started/project-setup/index.zh.md
@@ -1,9 +1,9 @@
 ---
 title: "项目构建设置"
-nav-id: projectsetup
+nav-id: project-setup
 nav-title: '项目构建设置'
-nav-parent_id: dev
-nav-pos: 0
+nav-parent_id: getting-started
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/index.zh.md
+++ b/docs/getting-started/project-setup/index.zh.md
@@ -3,7 +3,7 @@ title: "项目构建设置"
 nav-id: project-setup
 nav-title: '项目构建设置'
 nav-parent_id: getting-started
-nav-pos: 5
+nav-pos: 30
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/java_api_quickstart.md
+++ b/docs/getting-started/project-setup/java_api_quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: "Project Template for Java"
 nav-title: Project Template for Java
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 0
 ---
 <!--

--- a/docs/getting-started/project-setup/java_api_quickstart.zh.md
+++ b/docs/getting-started/project-setup/java_api_quickstart.zh.md
@@ -1,7 +1,7 @@
 ---
 title: "Java 项目模板"
 nav-title: Java 项目模板
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 0
 ---
 <!--

--- a/docs/getting-started/project-setup/scala_api_quickstart.md
+++ b/docs/getting-started/project-setup/scala_api_quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: "Project Template for Scala"
 nav-title: Project Template for Scala
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 1
 ---
 <!--

--- a/docs/getting-started/project-setup/scala_api_quickstart.zh.md
+++ b/docs/getting-started/project-setup/scala_api_quickstart.zh.md
@@ -1,7 +1,7 @@
 ---
 title: "Scala 项目模板"
 nav-title: Scala 项目模板
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 1
 ---
 <!--

--- a/docs/getting-started/walkthroughs/index.md
+++ b/docs/getting-started/walkthroughs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Walkthroughs"
 nav-id: walkthroughs
-nav-title: '<i class="fa fa-bolt title appetizer" aria-hidden="true"></i> Code Walkthroughs'
+nav-title: 'Code Walkthroughs'
 nav-parent_id: getting-started
 nav-pos: 20
 ---

--- a/docs/getting-started/walkthroughs/index.md
+++ b/docs/getting-started/walkthroughs/index.md
@@ -3,7 +3,7 @@ title: "Code Walkthroughs"
 nav-id: walkthroughs
 nav-title: '<i class="fa fa-bolt title appetizer" aria-hidden="true"></i> Code Walkthroughs'
 nav-parent_id: getting-started
-nav-pos: 10
+nav-pos: 20
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/walkthroughs/index.zh.md
+++ b/docs/getting-started/walkthroughs/index.zh.md
@@ -1,7 +1,7 @@
 ---
 title: "Code Walkthroughs"
 nav-id: walkthroughs
-nav-title: '<i class="fa fa-bolt title appetizer" aria-hidden="true"></i> Code Walkthroughs'
+nav-title: 'Code Walkthroughs'
 nav-parent_id: getting-started
 nav-pos: 20
 ---

--- a/docs/getting-started/walkthroughs/index.zh.md
+++ b/docs/getting-started/walkthroughs/index.zh.md
@@ -3,7 +3,7 @@ title: "Code Walkthroughs"
 nav-id: walkthroughs
 nav-title: '<i class="fa fa-bolt title appetizer" aria-hidden="true"></i> Code Walkthroughs'
 nav-parent_id: getting-started
-nav-pos: 10
+nav-pos: 20
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/redirects/projectsetup_dependencies.md
+++ b/docs/redirects/projectsetup_dependencies.md
@@ -1,0 +1,24 @@
+---
+title: "Configuring Dependencies, Connectors, Libraries"
+layout: redirect
+redirect: /getting-started/project-setup/dependencies.html
+permalink: /dev/projectsetup/dependencies.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_dependencies.zh.md
+++ b/docs/redirects/projectsetup_dependencies.zh.md
@@ -1,0 +1,24 @@
+---
+title: "配置依赖、连接器、类库"
+layout: redirect
+redirect: /getting-started/project-setup/dependencies.html
+permalink: /dev/projectsetup/dependencies.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_java_api_quickstart.md
+++ b/docs/redirects/projectsetup_java_api_quickstart.md
@@ -1,0 +1,24 @@
+---
+title: "Project Template for Java"
+layout: redirect
+redirect: /getting-started/project-setup/java_api_quickstart.html
+permalink: /dev/projectsetup/java_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_java_api_quickstart.zh.md
+++ b/docs/redirects/projectsetup_java_api_quickstart.zh.md
@@ -1,0 +1,24 @@
+---
+title: "Java 项目模板"
+layout: redirect
+redirect: /getting-started/project-setup/java_api_quickstart.html
+permalink: /dev/projectsetup/java_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_scala_api_quickstart.md
+++ b/docs/redirects/projectsetup_scala_api_quickstart.md
@@ -1,0 +1,24 @@
+---
+title: "Project Template for Scala"
+layout: redirect
+redirect: /getting-started/project-setup/scala_api_quickstart.html
+permalink: /dev/projectsetup/scala_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_scala_api_quickstart.zh.md
+++ b/docs/redirects/projectsetup_scala_api_quickstart.zh.md
@@ -1,0 +1,24 @@
+---
+title: "Scala 项目模板"
+layout: redirect
+redirect: /getting-started/project-setup/scala_api_quickstart.html
+permalink: /dev/projectsetup/scala_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->


### PR DESCRIPTION
This is pretty much the first thing you have to do when programming with Flink, so it belongs in the "Getting Started" section, this is outlined in [FLIP-42](https://cwiki.apache.org/confluence/display/FLINK/FLIP-42%3A+Rework+Flink+Documentation).