### PR TITLE
[FLINK-16012][runtime] Reduce the default number of buffers per channel from 2 to 1

### DIFF
--- a/docs/_includes/generated/all_taskmanager_network_section.html
+++ b/docs/_includes/generated/all_taskmanager_network_section.html
@@ -28,9 +28,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">2</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. By default, the minimum number of buffers is used to reduce the amount of data in flight which is useful for checkpoint in the case of back pressure. Together with the default 8 floating buffers, one buffer per channel should be enough for most cases. And one can increase it if there are any performance issues.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -40,9 +40,9 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
-            <td style="word-wrap: break-word;">2</td>
+            <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>
-            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+            <td>Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. By default, the minimum number of buffers is used to reduce the amount of data in flight which is useful for checkpoint in the case of back pressure. Together with the default 8 floating buffers, one buffer per channel should be enough for most cases. And one can increase it if there are any performance issues.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -140,16 +140,18 @@ public class NettyShuffleEnvironmentOptions {
 	/**
 	 * Number of network buffers to use for each outgoing/incoming channel (subpartition/input channel).
 	 *
-	 * <p>Reasoning: 1 buffer for in-flight data in the subpartition + 1 buffer for parallel serialization.
+	 * <p>Reasoning: using the minimum number of buffers to reduce the amount of data in flight which is
+	 * useful for checkpoint in the case of back pressure.
 	 */
 	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
 	public static final ConfigOption<Integer> NETWORK_BUFFERS_PER_CHANNEL =
 		key("taskmanager.network.memory.buffers-per-channel")
-			.defaultValue(2)
-			.withDescription("Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel)." +
-				"In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. It should be" +
-				" configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is" +
-				" for parallel serialization.");
+			.defaultValue(1)
+			.withDescription("Maximum number of network buffers to use for each outgoing/incoming channel (subpartition/input channel). " +
+				"In credit-based flow control mode, this indicates how many credits are exclusive in each input channel. By default, the" +
+				" minimum number of buffers is used to reduce the amount of data in flight which is useful for checkpoint in the case of" +
+				" back pressure. Together with the default 8 floating buffers, one buffer per channel should be enough for most cases. " +
+				"And one can increase it if there are any performance issues.");
 
 	/**
 	 * Number of extra network buffers to use for each outgoing/incoming gate (result partition/input gate).

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -45,7 +45,7 @@ public class NettyShuffleEnvironmentBuilder {
 
 	private int partitionRequestMaxBackoff;
 
-	private int networkBuffersPerChannel = 2;
+	private int networkBuffersPerChannel = 1;
 
 	private int floatingNetworkBuffersPerGate = 8;
 


### PR DESCRIPTION

## What is the purpose of the change

To speed up checkpoint in the case of back pressure, this commit tries to reduce the amount of data in flight by reducing the default number of buffers per channel from 2 to 1. Together with the default 8 floating buffers, one buffer per channel should be enough for most cases without performance regression. And one can increase it if there are any performance issues.


## Brief change log

  - Reduce the default number of buffers per channel from 2 to 1 and update document.


## Verifying this change

 - This change is already covered by existing tests.
 - Performance is verified by benchmarks.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
