### PR TITLE
[FLINK-16053][python] Remove redundant metrics in PyFlink

### DIFF
--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -242,21 +242,18 @@ class ScalarFunctionOperation(Operation):
         self.scalar_function_runner.open()
 
     def setup(self):
-        with self.scoped_start_state:
-            super(ScalarFunctionOperation, self).setup()
-            self.scalar_function_runner.setup(self.receivers[0])
+        super(ScalarFunctionOperation, self).setup()
+        self.scalar_function_runner.setup(self.receivers[0])
 
     def start(self):
         with self.scoped_start_state:
             super(ScalarFunctionOperation, self).start()
 
     def process(self, o):
-        with self.scoped_process_state:
-            self.scalar_function_runner.process(o)
+        self.scalar_function_runner.process(o)
 
     def finish(self):
-        with self.scoped_finish_state:
-            super(ScalarFunctionOperation, self).finish()
+        super(ScalarFunctionOperation, self).finish()
 
     def needs_finalization(self):
         return False
@@ -265,8 +262,7 @@ class ScalarFunctionOperation(Operation):
         super(ScalarFunctionOperation, self).reset()
 
     def teardown(self):
-        with self.scoped_finish_state:
-            self.scalar_function_runner.close()
+        self.scalar_function_runner.close()
 
     def progress_metrics(self):
         metrics = super(ScalarFunctionOperation, self).progress_metrics()


### PR DESCRIPTION
## What is the purpose of the change

*We have recorded the metrics about how many elements it has processed in Python UDF. This kind of information is not necessary as there is also this kind of information in the Java operator. I have performed a simple test and find that removing it could improve the performance about 5% - 10%.*

## Brief change log

  - *Removes redundant metrics in PyFlink*

## Verifying this change

This change is a performance improvement work and have verified in my local environment. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
