### PR TITLE
[FLINK-16041] Expand "popular" documentation sections by default

### DIFF
--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -101,6 +101,8 @@ level is determined by 'nav-pos'.
       {%- assign active = true -%}
     {%- elsif this.nav-id and active_nav_ids contains this.nav-id -%}
       {%- assign active = true -%}
+    {%- elsif this.always-expand -%}
+      {%- assign active = true -%}
     {%- else -%}
       {%- assign active = false -%}
     {%- endif -%}
@@ -117,7 +119,7 @@ level is determined by 'nav-pos'.
       {%- if children.size > 0 -%}
         {%- assign children = (children[0].items | sort: "nav-pos") -%}
         {%- capture collapse_target -%}"#collapse-{{ i }}" data-toggle="collapse"{%- if active -%} class="active"{%- endif -%}{%- endcapture -%}
-        {%- capture expand -%}{%- unless active -%} <i class="fa fa-caret-down pull-right" aria-hidden="true" style="padding-top: 4px"></i>{%- endunless -%}{%- endcapture %}
+        {%- capture expand -%}<i class="fa fa-caret-down pull-right" aria-hidden="true" style="padding-top: 4px"></i>{%- endcapture %}
 <li><a href={{ collapse_target }}>{{ title }}{{ expand }}</a><div class="collapse{% if active %} in{% endif %}" id="collapse-{{ i }}"><ul>
         {%- if this.nav-show_overview %}
 <li><a href={{ overview_target }}>

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -7,6 +7,7 @@ nav-parent_id: root
 layout: redirect
 redirect: /concepts/programming-model.html
 permalink: /concepts/index.html
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/concepts/index.zh.md
+++ b/docs/concepts/index.zh.md
@@ -7,6 +7,7 @@ nav-parent_id: root
 layout: redirect
 redirect: /concepts/programming-model.html
 permalink: /concepts/index.html
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/dev/best_practices.md
+++ b/docs/dev/best_practices.md
@@ -192,7 +192,7 @@ public class MyClass implements MapFunction {
 
 In all cases where classes are executed with a classpath created by a dependency manager such as Maven, Flink will pull log4j into the classpath.
 
-Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](./projectsetup/java_api_quickstart.html).
+Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](../getting-started/project-setup/java_api_quickstart.html).
 
 Change your projects `pom.xml` file like this:
 

--- a/docs/dev/best_practices.zh.md
+++ b/docs/dev/best_practices.zh.md
@@ -192,7 +192,7 @@ public class MyClass implements MapFunction {
 
 In all cases where classes are executed with a classpath created by a dependency manager such as Maven, Flink will pull log4j into the classpath.
 
-Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](./projectsetup/java_api_quickstart.html).
+Therefore, you will need to exclude log4j from Flink's dependencies. The following description will assume a Maven project created from a [Flink quickstart](../getting-started/project-setup/java_api_quickstart.html).
 
 Change your projects `pom.xml` file like this:
 

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -5,6 +5,7 @@ nav-title: '<i class="fa fa-code title maindish" aria-hidden="true"></i> Applica
 nav-parent_id: root
 nav-pos: 5
 section-break: true
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/dev/index.zh.md
+++ b/docs/dev/index.zh.md
@@ -5,6 +5,7 @@ nav-title: '<i class="fa fa-code title maindish" aria-hidden="true"></i> 应用�
 nav-parent_id: root
 nav-pos: 5
 section-break: true
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -6,6 +6,7 @@ nav-parent_id: root
 section-break: true
 nav-show_overview: true
 nav-pos: 1
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/index.zh.md
+++ b/docs/getting-started/index.zh.md
@@ -6,6 +6,7 @@ nav-parent_id: root
 section-break: true
 nav-show_overview: true
 nav-pos: 1
+always-expand: true
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/dependencies.md
+++ b/docs/getting-started/project-setup/dependencies.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuring Dependencies, Connectors, Libraries"
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 2
 ---
 <!--

--- a/docs/getting-started/project-setup/dependencies.zh.md
+++ b/docs/getting-started/project-setup/dependencies.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "配置依赖、连接器、类库"
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 2
 ---
 <!--

--- a/docs/getting-started/project-setup/index.md
+++ b/docs/getting-started/project-setup/index.md
@@ -1,9 +1,9 @@
 ---
-title: "Project Build Setup"
-nav-id: projectsetup
-nav-title: 'Project Build Setup'
-nav-parent_id: dev
-nav-pos: 0
+title: "Project Setup"
+nav-id: project-setup
+nav-title: 'Project Setup'
+nav-parent_id: getting-started
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/index.zh.md
+++ b/docs/getting-started/project-setup/index.zh.md
@@ -1,9 +1,9 @@
 ---
 title: "项目构建设置"
-nav-id: projectsetup
+nav-id: project-setup
 nav-title: '项目构建设置'
-nav-parent_id: dev
-nav-pos: 0
+nav-parent_id: getting-started
+nav-pos: 5
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/getting-started/project-setup/java_api_quickstart.md
+++ b/docs/getting-started/project-setup/java_api_quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: "Project Template for Java"
 nav-title: Project Template for Java
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 0
 ---
 <!--

--- a/docs/getting-started/project-setup/java_api_quickstart.zh.md
+++ b/docs/getting-started/project-setup/java_api_quickstart.zh.md
@@ -1,7 +1,7 @@
 ---
 title: "Java 项目模板"
 nav-title: Java 项目模板
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 0
 ---
 <!--

--- a/docs/getting-started/project-setup/scala_api_quickstart.md
+++ b/docs/getting-started/project-setup/scala_api_quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: "Project Template for Scala"
 nav-title: Project Template for Scala
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 1
 ---
 <!--

--- a/docs/getting-started/project-setup/scala_api_quickstart.zh.md
+++ b/docs/getting-started/project-setup/scala_api_quickstart.zh.md
@@ -1,7 +1,7 @@
 ---
 title: "Scala 项目模板"
 nav-title: Scala 项目模板
-nav-parent_id: projectsetup
+nav-parent_id: project-setup
 nav-pos: 1
 ---
 <!--

--- a/docs/redirects/projectsetup_dependencies.md
+++ b/docs/redirects/projectsetup_dependencies.md
@@ -1,0 +1,24 @@
+---
+title: "Configuring Dependencies, Connectors, Libraries"
+layout: redirect
+redirect: /getting-started/project-setup/dependencies.html
+permalink: /dev/projectsetup/dependencies.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_dependencies.zh.md
+++ b/docs/redirects/projectsetup_dependencies.zh.md
@@ -1,0 +1,24 @@
+---
+title: "配置依赖、连接器、类库"
+layout: redirect
+redirect: /getting-started/project-setup/dependencies.html
+permalink: /dev/projectsetup/dependencies.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_java_api_quickstart.md
+++ b/docs/redirects/projectsetup_java_api_quickstart.md
@@ -1,0 +1,24 @@
+---
+title: "Project Template for Java"
+layout: redirect
+redirect: /getting-started/project-setup/java_api_quickstart.html
+permalink: /dev/projectsetup/java_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_java_api_quickstart.zh.md
+++ b/docs/redirects/projectsetup_java_api_quickstart.zh.md
@@ -1,0 +1,24 @@
+---
+title: "Java 项目模板"
+layout: redirect
+redirect: /getting-started/project-setup/java_api_quickstart.html
+permalink: /dev/projectsetup/java_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_scala_api_quickstart.md
+++ b/docs/redirects/projectsetup_scala_api_quickstart.md
@@ -1,0 +1,24 @@
+---
+title: "Project Template for Scala"
+layout: redirect
+redirect: /getting-started/project-setup/scala_api_quickstart.html
+permalink: /dev/projectsetup/scala_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/redirects/projectsetup_scala_api_quickstart.zh.md
+++ b/docs/redirects/projectsetup_scala_api_quickstart.zh.md
@@ -1,0 +1,24 @@
+---
+title: "Scala 项目模板"
+layout: redirect
+redirect: /getting-started/project-setup/scala_api_quickstart.html
+permalink: /dev/projectsetup/scala_api_quickstart.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->


### PR DESCRIPTION
With this change, we expand the "Getting Started", "Concepts", and "Application Development" sections by default, thus making them more accessible/discoverable.