### PR TITLE
[hotfix][table-common] Remove deprecated DataTypes.ANY(...)

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -561,14 +561,6 @@ public final class DataTypes {
 	}
 
 	/**
-	 * @deprecated Use {@link #RAW(Class, TypeSerializer)} instead.
-	 */
-	@Deprecated
-	public static <T> DataType ANY(Class<T> clazz, TypeSerializer<T> serializer) {
-		return RAW(clazz, serializer);
-	}
-
-	/**
 	 * Data type of an arbitrary serialized type backed by {@link TypeInformation}. This type is
 	 * a black box within the table ecosystem and is only deserialized at the edges.
 	 *
@@ -583,14 +575,6 @@ public final class DataTypes {
 	 */
 	public static <T> DataType RAW(TypeInformation<T> typeInformation) {
 		return new AtomicDataType(new TypeInformationRawType<>(typeInformation));
-	}
-
-	/**
-	 * @deprecated Use {@link #RAW(TypeInformation)} instead.
-	 */
-	@Deprecated
-	public static <T> DataType ANY(TypeInformation<T> typeInformation) {
-		return RAW(typeInformation);
 	}
 
 	// --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Removes the deprecated method. Due to a renaming. This method should not have been used by many users yet.

## Brief change log

Trivial change.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
