### PR TITLE
[FLINK-10918][rocks-db-backend] Fix incremental checkpoints on Windows.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -51,6 +51,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -94,6 +95,17 @@ public final class FileUtils {
 	public static void writeCompletely(WritableByteChannel channel, ByteBuffer src) throws IOException {
 		while (src.hasRemaining()) {
 			channel.write(src);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Lists the given directory in a resource-leak-safe way.
+	 */
+	public static java.nio.file.Path[] listDirectory(java.nio.file.Path directory) throws IOException {
+		try (Stream<java.nio.file.Path> stream = Files.list(directory)) {
+			return stream.toArray(java.nio.file.Path[]::new);
 		}
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FileUtils.java
@@ -76,7 +76,7 @@ public final class FileUtils {
 
 	/**
 	 * The maximum size of array to allocate for reading. See
-	 * {@link java.nio.file.Files#MAX_BUFFER_SIZE} for more.
+	 * {@code MAX_BUFFER_SIZE} in {@link java.nio.file.Files} for more.
 	 */
 	private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/SnapshotDirectoryTest.java
@@ -18,10 +18,7 @@
 
 package org.apache.flink.runtime.state;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.AfterClass;
@@ -32,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -61,7 +59,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File folderRoot = temporaryFolder.getRoot();
 		File newFolder = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 		File innerNewFolder = new File(newFolder, String.valueOf(UUID.randomUUID()));
-		Path path = new Path(innerNewFolder.toURI());
+		Path path = innerNewFolder.toPath();
 
 		Assert.assertFalse(newFolder.isDirectory());
 		Assert.assertFalse(innerNewFolder.isDirectory());
@@ -85,7 +83,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File folderA = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 
 		Assert.assertFalse(folderA.isDirectory());
-		Path path = new Path(folderA.toURI());
+		Path path = folderA.toPath();
 		SnapshotDirectory snapshotDirectory = SnapshotDirectory.permanent(path);
 		Assert.assertFalse(snapshotDirectory.exists());
 		Assert.assertTrue(folderA.mkdirs());
@@ -106,14 +104,13 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File file = new File(folderA, "test.txt");
 		Assert.assertTrue(file.createNewFile());
 
-		Path path = new Path(folderA.toURI());
-		FileSystem fileSystem = path.getFileSystem();
+		Path path = folderA.toPath();
 		SnapshotDirectory snapshotDirectory = SnapshotDirectory.permanent(path);
 		Assert.assertTrue(snapshotDirectory.exists());
 
 		Assert.assertEquals(
-			Arrays.toString(fileSystem.listStatus(path)),
-			Arrays.toString(snapshotDirectory.listStatus()));
+			Arrays.toString(FileUtils.listDirectory(path)),
+			Arrays.toString(snapshotDirectory.listDirectory()));
 	}
 
 	/**
@@ -125,7 +122,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File folderRoot = temporaryFolder.getRoot();
 		File folderA = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 		Assert.assertTrue(folderA.mkdirs());
-		Path folderAPath = new Path(folderA.toURI());
+		Path folderAPath = folderA.toPath();
 
 		SnapshotDirectory snapshotDirectory = SnapshotDirectory.permanent(folderAPath);
 
@@ -160,7 +157,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		Assert.assertTrue(folderB.mkdirs());
 		File file = new File(folderA, "test.txt");
 		Assert.assertTrue(file.createNewFile());
-		Path folderAPath = new Path(folderA.toURI());
+		Path folderAPath = folderA.toPath();
 		SnapshotDirectory snapshotDirectory = SnapshotDirectory.permanent(folderAPath);
 		Assert.assertTrue(snapshotDirectory.cleanup());
 		Assert.assertFalse(folderA.isDirectory());
@@ -181,7 +178,7 @@ public class SnapshotDirectoryTest extends TestLogger {
 		File folderRoot = temporaryFolder.getRoot();
 		File folderA = new File(folderRoot, String.valueOf(UUID.randomUUID()));
 		Assert.assertTrue(folderA.mkdirs());
-		Path pathA = new Path(folderA.toURI());
+		Path pathA = folderA.toPath();
 		SnapshotDirectory snapshotDirectory = SnapshotDirectory.permanent(pathA);
 		Assert.assertFalse(snapshotDirectory.isSnapshotCompleted());
 		Assert.assertNotNull(snapshotDirectory.completeSnapshotAndGetHandle());
@@ -207,29 +204,4 @@ public class SnapshotDirectoryTest extends TestLogger {
 		Assert.assertTrue(tmpSnapshotDirectory.cleanup());
 		Assert.assertFalse(folder.exists());
 	}
-
-	/**
-	 * Tests that we always use the local file system even if we have specified a different default
-	 * file system. See FLINK-12042.
-	 */
-	@Test
-	public void testLocalFileSystemIsUsedForTemporary() throws Exception {
-		// ensure that snapshot directory will always use the local file system instead of the default file system
-		Configuration configuration = new Configuration();
-		configuration.setString(CoreOptions.DEFAULT_FILESYSTEM_SCHEME, "nonexistfs:///");
-		FileSystem.initialize(configuration);
-
-		final File folderRoot = temporaryFolder.getRoot();
-
-		try {
-			File folderB = new File(folderRoot, String.valueOf(UUID.randomUUID()));
-			// only pass the path and leave the scheme missing
-			SnapshotDirectory snapshotDirectoryB = SnapshotDirectory.temporary(folderB);
-			Assert.assertEquals(snapshotDirectoryB.getFileSystem(), FileSystem.getLocalFileSystem());
-		} finally {
-			// restore the FileSystem configuration
-			FileSystem.initialize(new Configuration());
-		}
-	}
-
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSnapshotTransformerTest.java
@@ -21,13 +21,13 @@ package org.apache.flink.runtime.state;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory;
 import org.apache.flink.runtime.state.internal.InternalListState;
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.runtime.state.internal.InternalValueState;
-import org.apache.flink.api.common.typeutils.SingleThreadAccessCheckingTypeSerializer;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.util.StringUtils;
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloader.java
@@ -19,9 +19,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FSDataOutputStream;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
@@ -31,6 +28,10 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class RocksDBStateDownloader extends RocksDBStateDataTransfer {
 			StateHandleID stateHandleID = entry.getKey();
 			StreamStateHandle remoteFileHandle = entry.getValue();
 
-			Path path = new Path(restoreInstancePath, stateHandleID.toString());
+			Path path = restoreInstancePath.resolve(stateHandleID.toString());
 
 			runnables.add(ThrowingRunnable.unchecked(
 				() -> downloadDataForStateHandle(path, remoteFileHandle, closeableRegistry)));
@@ -120,14 +121,14 @@ public class RocksDBStateDownloader extends RocksDBStateDataTransfer {
 		CloseableRegistry closeableRegistry) throws IOException {
 
 		FSDataInputStream inputStream = null;
-		FSDataOutputStream outputStream = null;
+		OutputStream outputStream = null;
 
 		try {
-			FileSystem restoreFileSystem = restoreFilePath.getFileSystem();
 			inputStream = remoteFileHandle.openInputStream();
 			closeableRegistry.registerCloseable(inputStream);
 
-			outputStream = restoreFileSystem.create(restoreFilePath, FileSystem.WriteMode.OVERWRITE);
+			Files.createDirectories(restoreFilePath.getParent());
+			outputStream = Files.newOutputStream(restoreFilePath, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
 			closeableRegistry.registerCloseable(outputStream);
 
 			byte[] buffer = new byte[8 * 1024];

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
@@ -19,9 +19,6 @@
 package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointedStateScope;
@@ -35,6 +32,9 @@ import org.apache.flink.util.function.CheckedSupplier;
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -107,14 +107,14 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
 		Path filePath,
 		CheckpointStreamFactory checkpointStreamFactory,
 		CloseableRegistry closeableRegistry) throws IOException {
-		FSDataInputStream inputStream = null;
+
+		InputStream inputStream = null;
 		CheckpointStreamFactory.CheckpointStateOutputStream outputStream = null;
 
 		try {
 			final byte[] buffer = new byte[READ_BUFFER_SIZE];
 
-			FileSystem backupFileSystem = filePath.getFileSystem();
-			inputStream = backupFileSystem.open(filePath);
+			inputStream = Files.newInputStream(filePath);
 			closeableRegistry.registerCloseable(inputStream);
 
 			outputStream = checkpointStreamFactory

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/restore/RocksDBIncrementalRestoreOperation.java
@@ -28,10 +28,6 @@ import org.apache.flink.contrib.streaming.state.RocksDBWriteBatchWrapper;
 import org.apache.flink.contrib.streaming.state.RocksIteratorWrapper;
 import org.apache.flink.contrib.streaming.state.ttl.RocksDbTtlCompactFiltersManager;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.FileStatus;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.metrics.MetricGroup;
@@ -48,6 +44,7 @@ import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateSerializerProvider;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
 
 import org.rocksdb.ColumnFamilyDescriptor;
@@ -64,7 +61,10 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -187,9 +187,8 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 	}
 
 	private void restoreFromRemoteState(IncrementalRemoteKeyedStateHandle stateHandle) throws Exception {
-		final Path tmpRestoreInstancePath = new Path(
-			instanceBasePath.getAbsolutePath(),
-			UUID.randomUUID().toString()); // used as restore source for IncrementalRemoteKeyedStateHandle
+		// used as restore source for IncrementalRemoteKeyedStateHandle
+		final Path tmpRestoreInstancePath = instanceBasePath.getAbsoluteFile().toPath().resolve(UUID.randomUUID().toString());
 		try {
 			restoreFromLocalState(
 				transferRemoteStateToLocalDirectory(tmpRestoreInstancePath, stateHandle));
@@ -246,10 +245,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 
 	private void cleanUpPathQuietly(@Nonnull Path path) {
 		try {
-			FileSystem fileSystem = path.getFileSystem();
-			if (fileSystem.exists(path)) {
-				fileSystem.delete(path, true);
-			}
+			FileUtils.deleteDirectory(path.toFile());
 		} catch (IOException ex) {
 			LOG.warn("Failed to clean up path " + path, ex);
 		}
@@ -296,7 +292,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 					", but found " + rawStateHandle.getClass());
 			}
 
-			Path temporaryRestoreInstancePath = new Path(instanceBasePath.getAbsolutePath() + UUID.randomUUID().toString());
+			Path temporaryRestoreInstancePath = instanceBasePath.getAbsoluteFile().toPath().resolve(UUID.randomUUID().toString());
 			try (RestoredDBInstance tmpRestoreDBInfo = restoreDBInstanceFromStateHandle(
 				(IncrementalRemoteKeyedStateHandle) rawStateHandle,
 				temporaryRestoreInstancePath);
@@ -427,7 +423,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 			new ArrayList<>(stateMetaInfoSnapshots.size() + 1);
 
 		RocksDB restoreDb = RocksDBOperationUtils.openDB(
-			temporaryRestoreInstancePath.getPath(),
+			temporaryRestoreInstancePath.toString(),
 			columnFamilyDescriptors,
 			columnFamilyHandles,
 			RocksDBOperationUtils.createColumnFamilyOptions(columnFamilyOptionsFactory, "default"),
@@ -461,26 +457,18 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 	 * a local state.
 	 */
 	private void restoreInstanceDirectoryFromPath(Path source, String instanceRocksDBPath) throws IOException {
+		final Path instanceRocksDBDirectory = Paths.get(instanceRocksDBPath);
+		final Path[] files = FileUtils.listDirectory(source);
 
-		FileSystem fileSystem = source.getFileSystem();
-
-		final FileStatus[] fileStatuses = fileSystem.listStatus(source);
-
-		if (fileStatuses == null) {
-			throw new IOException("Cannot list file statues. Directory " + source + " does not exist.");
-		}
-
-		for (FileStatus fileStatus : fileStatuses) {
-			final Path filePath = fileStatus.getPath();
-			final String fileName = filePath.getName();
-			File restoreFile = new File(source.getPath(), fileName);
-			File targetFile = new File(instanceRocksDBPath, fileName);
+		for (Path file : files) {
+			final String fileName = file.getFileName().toString();
+			final Path targetFile = instanceRocksDBDirectory.resolve(fileName);
 			if (fileName.endsWith(SST_FILE_SUFFIX)) {
 				// hardlink'ing the immutable sst-files.
-				Files.createLink(targetFile.toPath(), restoreFile.toPath());
+				Files.createLink(targetFile, file);
 			} else {
 				// true copy for all other files.
-				Files.copy(restoreFile.toPath(), targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+				Files.copy(file, targetFile, StandardCopyOption.REPLACE_EXISTING);
 			}
 		}
 	}
@@ -490,7 +478,7 @@ public class RocksDBIncrementalRestoreOperation<K> extends AbstractRocksDBRestor
 	 */
 	private KeyedBackendSerializationProxy<K> readMetaData(StreamStateHandle metaStateHandle) throws Exception {
 
-		FSDataInputStream inputStream = null;
+		InputStream inputStream = null;
 
 		try {
 			inputStream = metaStateHandle.openInputStream();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateDownloaderTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.contrib.streaming.state;
 
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.FSDataInputStream;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.StateHandleID;
@@ -34,6 +33,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -91,7 +91,7 @@ public class RocksDBStateDownloaderTest extends TestLogger {
 		try (RocksDBStateDownloader rocksDBStateDownloader = new RocksDBStateDownloader(5)) {
 			rocksDBStateDownloader.transferAllStateDataToDirectory(
 				incrementalKeyedStateHandle,
-				new Path(temporaryFolder.newFolder().toURI()),
+				temporaryFolder.newFolder().toPath(),
 				new CloseableRegistry());
 			fail();
 		} catch (Exception e) {
@@ -133,13 +133,13 @@ public class RocksDBStateDownloaderTest extends TestLogger {
 				privateStates,
 				handles.get(0));
 
-		Path dstPath = new Path(temporaryFolder.newFolder().toURI());
+		Path dstPath = temporaryFolder.newFolder().toPath();
 		try (RocksDBStateDownloader rocksDBStateDownloader = new RocksDBStateDownloader(5)) {
 			rocksDBStateDownloader.transferAllStateDataToDirectory(incrementalKeyedStateHandle, dstPath, new CloseableRegistry());
 		}
 
 		for (int i = 0; i < contentNum; ++i) {
-			assertStateContentEqual(contents[i], new Path(dstPath, String.format("sharedState%d", i)));
+			assertStateContentEqual(contents[i], dstPath.resolve(String.format("sharedState%d", i)));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This solves the bug that Paths are handled wrong on Windows, breaking incremental checkpoints.
The bug manifests in errors like
```
org.rocksdb.RocksDBException: Unexpected error for: /C:/Users/ewens/AppData/Local/Temp/... ...-77c716fd2ade/chk-682375462378: The filename, directory name, or volume label syntax is incorrect.
```

The bug was caused by wrong path handling logic on Windows. RocksDB's initial native checkpoint (flush/hardlink) needs to go lo the local filesystem anyways, so we can directly use local path class for that, which does not suffer from cross-platform escaping issues.

## Brief change log

  - Replace use of `org.apache.flink.core.fs.Path` with `java.nio.file.Path` in RocksDB incremental checkpoint classes. 

## Verifying this change

This change is already covered by the tests for RocksDB checkpointing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
