### PR TITLE
[FLINK-16057][runtime] chain ContinuousFileReaderOperator by default

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
@@ -34,7 +34,7 @@ import org.apache.flink.streaming.runtime.tasks.StreamTask;
  */
 public class ContinuousFileReaderOperatorFactory<OUT> implements YieldingOperatorFactory<OUT>, OneInputStreamOperatorFactory<TimestampedFileInputSplit, OUT> {
 
-	private ChainingStrategy strategy;
+	private ChainingStrategy strategy = ChainingStrategy.HEAD;
 	private final FileInputFormat<OUT> inputFormat;
 	private TypeInformation<OUT> type;
 	private ExecutionConfig executionConfig;


### PR DESCRIPTION
## What is the purpose of the change

*Use ChainingStrategy ALWAYS in ContinuousFileReaderOperatorFactory*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
