### PR TITLE
[FLINK-16060][task] Implement working StreamMultipleInputProcessor

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -42,8 +42,11 @@ public class MetricNames {
 	public static final String IO_NUM_BUFFERS_OUT_RATE = IO_NUM_BUFFERS_OUT + SUFFIX_RATE;
 
 	public static final String IO_CURRENT_INPUT_WATERMARK = "currentInputWatermark";
+	@Deprecated
 	public static final String IO_CURRENT_INPUT_1_WATERMARK = "currentInput1Watermark";
+	@Deprecated
 	public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
+	public static final String IO_CURRENT_INPUT_WATERMARK_PATERN = "currentInput%dWatermark";
 	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 
 	public static final String NUM_RUNNING_JOBS = "numRunningJobs";
@@ -64,4 +67,8 @@ public class MetricNames {
 
 	public static final String CHECKPOINT_ALIGNMENT_TIME = "checkpointAlignmentTime";
 	public static final String CHECKPOINT_START_DELAY_TIME = "checkpointStartDelayNanos";
+
+	public static String currentInputWatermarkName(int index) {
+		return String.format(IO_CURRENT_INPUT_WATERMARK_PATERN, index);
+	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/MultipleConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/MultipleConnectedStreams.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.datastream;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This is a very basic and rough stub for a class connecting multiple input {@link DataStream}s
+ * into one, using {@link MultipleInputStreamOperator}.
+ */
+@Experimental
+public class MultipleConnectedStreams {
+
+	protected final StreamExecutionEnvironment environment;
+
+	public MultipleConnectedStreams(StreamExecutionEnvironment env) {
+		this.environment = requireNonNull(env);
+	}
+
+	public StreamExecutionEnvironment getExecutionEnvironment() {
+		return environment;
+	}
+
+	public <OUT> SingleOutputStreamOperator<OUT> transform(MultipleInputTransformation<OUT> transform) {
+		return new SingleOutputStreamOperator<>(environment, transform);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamConfig.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Internal configuration for a {@link StreamOperator}. This is created and populated by the
@@ -73,8 +74,8 @@ public class StreamConfig implements Serializable {
 	private static final String ITERATION_ID = "iterationId";
 	private static final String OUTPUT_SELECTOR_WRAPPER = "outputSelectorWrapper";
 	private static final String BUFFER_TIMEOUT = "bufferTimeout";
-	private static final String TYPE_SERIALIZER_IN_1 = "typeSerializer_in_1";
-	private static final String TYPE_SERIALIZER_IN_2 = "typeSerializer_in_2";
+	private static final String TYPE_SERIALIZERS_IN_COUNT = "typeSerializer_in_count";
+	private static final String TYPE_SERIALIZERS_IN_PATTERN = "typeSerializer_in_%d";
 	private static final String TYPE_SERIALIZER_OUT_1 = "typeSerializer_out";
 	private static final String TYPE_SERIALIZER_SIDEOUT_PREFIX = "typeSerializer_sideout_";
 	private static final String ITERATON_WAIT = "iterationWait";
@@ -158,12 +159,11 @@ public class StreamConfig implements Serializable {
 		}
 	}
 
-	public void setTypeSerializerIn1(TypeSerializer<?> serializer) {
-		setTypeSerializer(TYPE_SERIALIZER_IN_1, serializer);
-	}
-
-	public void setTypeSerializerIn2(TypeSerializer<?> serializer) {
-		setTypeSerializer(TYPE_SERIALIZER_IN_2, serializer);
+	public void setTypeSerializersIn(TypeSerializer<?> ...serializers) {
+		config.setInteger(TYPE_SERIALIZERS_IN_COUNT, serializers.length);
+		for (int i = 0; i < serializers.length; i++) {
+			setTypeSerializer(String.format(TYPE_SERIALIZERS_IN_PATTERN, i), serializers[i]);
+		}
 	}
 
 	public void setTypeSerializerOut(TypeSerializer<?> serializer) {
@@ -174,19 +174,40 @@ public class StreamConfig implements Serializable {
 		setTypeSerializer(TYPE_SERIALIZER_SIDEOUT_PREFIX + outputTag.getId(), serializer);
 	}
 
+	@Deprecated
 	public <T> TypeSerializer<T> getTypeSerializerIn1(ClassLoader cl) {
-		try {
-			return InstantiationUtil.readObjectFromConfig(this.config, TYPE_SERIALIZER_IN_1, cl);
-		} catch (Exception e) {
-			throw new StreamTaskException("Could not instantiate serializer.", e);
-		}
+		return getTypeSerializerIn(0, cl);
 	}
 
+	@Deprecated
 	public <T> TypeSerializer<T> getTypeSerializerIn2(ClassLoader cl) {
+		return getTypeSerializerIn(1, cl);
+	}
+
+	public TypeSerializer<?>[] getTypeSerializersIn(ClassLoader cl) {
+		int typeSerializersCount = config.getInteger(TYPE_SERIALIZERS_IN_COUNT, -1);
+		checkState(
+			typeSerializersCount >= 0,
+			"Missing value for %s in the config? [%d]",
+			TYPE_SERIALIZERS_IN_COUNT,
+			typeSerializersCount);
+		TypeSerializer<?>[] typeSerializers = new TypeSerializer<?>[typeSerializersCount];
+		for (int i = 0; i < typeSerializers.length; i++) {
+			typeSerializers[i] = getTypeSerializerIn(i, cl);
+		}
+		return typeSerializers;
+	}
+
+	public <T> TypeSerializer<T> getTypeSerializerIn(int index, ClassLoader cl) {
 		try {
-			return InstantiationUtil.readObjectFromConfig(this.config, TYPE_SERIALIZER_IN_2, cl);
+			return InstantiationUtil.readObjectFromConfig(
+				this.config,
+				String.format(TYPE_SERIALIZERS_IN_PATTERN, index),
+				cl);
 		} catch (Exception e) {
-			throw new StreamTaskException("Could not instantiate serializer.", e);
+			throw new StreamTaskException(
+				String.format("Could not instantiate serializer for [%d] input.", index),
+				e);
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -282,11 +282,7 @@ public class StreamGraph implements Pipeline {
 			addNode(vertexID, slotSharingGroup, coLocationGroup, OneInputStreamTask.class, operatorFactory, operatorName);
 		}
 
-		TypeSerializer<IN> inSerializer = inTypeInfo != null && !(inTypeInfo instanceof MissingTypeInfo) ? inTypeInfo.createSerializer(executionConfig) : null;
-
-		TypeSerializer<OUT> outSerializer = outTypeInfo != null && !(outTypeInfo instanceof MissingTypeInfo) ? outTypeInfo.createSerializer(executionConfig) : null;
-
-		setSerializers(vertexID, inSerializer, null, outSerializer);
+		setSerializers(vertexID, createSerializer(inTypeInfo), null, createSerializer(outTypeInfo));
 
 		if (operatorFactory.isOutputTypeConfigurable() && outTypeInfo != null) {
 			// sets the output type which must be know at StreamGraph creation time
@@ -316,8 +312,7 @@ public class StreamGraph implements Pipeline {
 
 		addNode(vertexID, slotSharingGroup, coLocationGroup, vertexClass, taskOperatorFactory, operatorName);
 
-		TypeSerializer<OUT> outSerializer = (outTypeInfo != null) && !(outTypeInfo instanceof MissingTypeInfo) ?
-				outTypeInfo.createSerializer(executionConfig) : null;
+		TypeSerializer<OUT> outSerializer = createSerializer(outTypeInfo);
 
 		setSerializers(vertexID, in1TypeInfo.createSerializer(executionConfig), in2TypeInfo.createSerializer(executionConfig), outSerializer);
 
@@ -790,5 +785,10 @@ public class StreamGraph implements Pipeline {
 		catch (Exception e) {
 			throw new RuntimeException("JSON plan creation failed", e);
 		}
+	}
+
+	private <T> TypeSerializer<T> createSerializer(TypeInformation<T> typeInfo) {
+		return typeInfo != null && !(typeInfo instanceof MissingTypeInfo) ?
+			typeInfo.createSerializer(executionConfig) : null;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.cache.DistributedCache;
@@ -637,19 +638,24 @@ public class StreamGraph implements Pipeline {
 		return streamNodes.keySet();
 	}
 
+	@VisibleForTesting
 	public List<StreamEdge> getStreamEdges(int sourceId, int targetId) {
-
 		List<StreamEdge> result = new ArrayList<>();
 		for (StreamEdge edge : getStreamNode(sourceId).getOutEdges()) {
 			if (edge.getTargetId() == targetId) {
 				result.add(edge);
 			}
 		}
+		return result;
+	}
 
+	@VisibleForTesting
+	@Deprecated
+	public List<StreamEdge> getStreamEdgesOrThrow(int sourceId, int targetId) {
+		List<StreamEdge> result = getStreamEdges(sourceId, targetId);
 		if (result.isEmpty()) {
 			throw new RuntimeException("No such edge in stream graph: " + sourceId + " -> " + targetId);
 		}
-
 		return result;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -46,6 +46,7 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
 import org.apache.flink.streaming.api.transformations.SplitTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -742,6 +743,7 @@ public class StreamGraphGenerator {
 
 	private <OUT> Collection<Integer> transformMultipleInputTransform(MultipleInputTransformation<OUT> transform) {
 		checkArgument(!transform.getInputs().isEmpty(), "Empty inputs for MultipleInputTransformation. Did you forget to add inputs?");
+		MultipleInputSelectionHandler.checkSupportedInputCount(transform.getInputs().size());
 
 		List<Collection<Integer>> allInputIds = new ArrayList<>();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.api.operators.OutputFormatOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.transformations.CoFeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.FeedbackTransformation;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.PhysicalTransformation;
@@ -55,7 +56,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -251,6 +254,8 @@ public class StreamGraphGenerator {
 			transformedIds = transformOneInputTransform((OneInputTransformation<?, ?>) transform);
 		} else if (transform instanceof TwoInputTransformation<?, ?, ?>) {
 			transformedIds = transformTwoInputTransform((TwoInputTransformation<?, ?, ?>) transform);
+		} else if (transform instanceof MultipleInputTransformation<?>) {
+			transformedIds = transformMultipleInputTransform((MultipleInputTransformation<?>) transform);
 		} else if (transform instanceof SourceTransformation<?>) {
 			transformedIds = transformSource((SourceTransformation<?>) transform);
 		} else if (transform instanceof SinkTransformation<?>) {
@@ -730,6 +735,53 @@ public class StreamGraphGenerator {
 					transform.getId(),
 					2
 			);
+		}
+
+		return Collections.singleton(transform.getId());
+	}
+
+	private <OUT> Collection<Integer> transformMultipleInputTransform(MultipleInputTransformation<OUT> transform) {
+		checkArgument(!transform.getInputs().isEmpty(), "Empty inputs for MultipleInputTransformation. Did you forget to add inputs?");
+
+		List<Collection<Integer>> allInputIds = new ArrayList<>();
+
+		for (Transformation<?> input : transform.getInputs()) {
+			allInputIds.add(transform(input));
+		}
+
+		// the recursive call might have already transformed this
+		if (alreadyTransformed.containsKey(transform)) {
+			return alreadyTransformed.get(transform);
+		}
+
+		String slotSharingGroup = determineSlotSharingGroup(
+			transform.getSlotSharingGroup(),
+			allInputIds.stream()
+				.flatMap(Collection::stream)
+				.collect(Collectors.toList()));
+
+		streamGraph.addMultipleInputOperator(
+			transform.getId(),
+			slotSharingGroup,
+			transform.getCoLocationGroupKey(),
+			transform.getOperatorFactory(),
+			transform.getInputTypes(),
+			transform.getOutputType(),
+			transform.getName());
+
+		int parallelism = transform.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT ?
+			transform.getParallelism() : executionConfig.getParallelism();
+		streamGraph.setParallelism(transform.getId(), parallelism);
+		streamGraph.setMaxParallelism(transform.getId(), transform.getMaxParallelism());
+
+		for (int i = 0; i < allInputIds.size(); i++) {
+			Collection<Integer> inputIds = allInputIds.get(i);
+			for (Integer inputId: inputIds) {
+				streamGraph.addEdge(inputId,
+					transform.getId(),
+					i + 1
+				);
+			}
 		}
 
 		return Collections.singleton(transform.getId());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -37,6 +37,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * Class representing the operators in the streaming programs, with all their properties.
  */
@@ -65,8 +67,7 @@ public class StreamNode implements Serializable {
 
 	private transient StreamOperatorFactory<?> operatorFactory;
 	private List<OutputSelector<?>> outputSelectors;
-	private TypeSerializer<?> typeSerializerIn1;
-	private TypeSerializer<?> typeSerializerIn2;
+	private TypeSerializer<?>[] typeSerializersIn = new TypeSerializer[0];
 	private TypeSerializer<?> typeSerializerOut;
 
 	private List<StreamEdge> inEdges = new ArrayList<StreamEdge>();
@@ -235,20 +236,17 @@ public class StreamNode implements Serializable {
 		this.outputSelectors.add(outputSelector);
 	}
 
-	public TypeSerializer<?> getTypeSerializerIn1() {
-		return typeSerializerIn1;
+	public void setSerializersIn(TypeSerializer<?> ...typeSerializersIn) {
+		checkArgument(typeSerializersIn.length > 0);
+		this.typeSerializersIn = typeSerializersIn;
 	}
 
-	public void setSerializerIn1(TypeSerializer<?> typeSerializerIn1) {
-		this.typeSerializerIn1 = typeSerializerIn1;
+	public TypeSerializer<?>[] getTypeSerializersIn() {
+		return typeSerializersIn;
 	}
 
-	public TypeSerializer<?> getTypeSerializerIn2() {
-		return typeSerializerIn2;
-	}
-
-	public void setSerializerIn2(TypeSerializer<?> typeSerializerIn2) {
-		this.typeSerializerIn2 = typeSerializerIn2;
+	public TypeSerializer<?> getTypeSerializerIn(int index) {
+		return typeSerializersIn[index];
 	}
 
 	public TypeSerializer<?> getTypeSerializerOut() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -480,8 +480,7 @@ public class StreamingJobGraphGenerator {
 		config.setVertexID(vertexID);
 		config.setBufferTimeout(vertex.getBufferTimeout());
 
-		config.setTypeSerializerIn1(vertex.getTypeSerializerIn1());
-		config.setTypeSerializerIn2(vertex.getTypeSerializerIn2());
+		config.setTypeSerializersIn(vertex.getTypeSerializersIn());
 		config.setTypeSerializerOut(vertex.getTypeSerializerOut());
 
 		// iterate edges, find sideOutput edges create and save serializers for each outputTag type

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+/**
+ * {@link Input} interface used in {@link MultipleInputStreamOperator}.
+ */
+@PublicEvolving
+public interface Input<IN> {
+	/**
+	 * Processes one element that arrived on this input of the {@link MultipleInputStreamOperator}.
+	 * This method is guaranteed to not be called concurrently with other methods of the operator.
+	 */
+	void processElement(StreamRecord<IN> element) throws Exception;
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
@@ -113,6 +113,39 @@ public final class InputSelection implements Serializable {
 		throw new UnsupportedOperationException("Only two inputs are supported.");
 	}
 
+	/**
+	 * Fairly select one of the available inputs for reading.
+	 *
+	 * @param availableInputsMask The mask of all available inputs. Note -1 for this is interpreted
+	 *                            as all of the 32 inputs are available.
+	 * @param lastReadInputIndex The index of last read input.
+	 * @return the index of the input for reading or {@link InputSelection#NONE_AVAILABLE} (if
+	 *         {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
+	 */
+	public int fairSelectNextIndex(int availableInputsMask, int lastReadInputIndex) {
+		int selectionMask = (int) inputMask;
+		int combineMask = availableInputsMask & selectionMask;
+
+		if (combineMask == 0) {
+			return NONE_AVAILABLE;
+		}
+
+		int nextReadInputIndex = selectFirstBitRightFromNext(combineMask, lastReadInputIndex + 1);
+		if (nextReadInputIndex >= 0) {
+			return nextReadInputIndex;
+		}
+		return selectFirstBitRightFromNext(combineMask, 0);
+	}
+
+	private int selectFirstBitRightFromNext(int bits, int next) {
+		if (next >= 32) {
+			return NONE_AVAILABLE;
+		}
+		for (bits >>>= next; bits != 0 && (bits & 1) != 1; bits >>>= 1, next++) {
+		}
+		return bits != 0 ? next : NONE_AVAILABLE;
+	}
+
 	private static boolean isALLMaskOf2(long inputMask) {
 		return (3 & inputMask) == 3;
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InputSelection.java
@@ -27,6 +27,8 @@ import java.io.Serializable;
 @PublicEvolving
 public final class InputSelection implements Serializable {
 
+	public static final int NONE_AVAILABLE = -1;
+
 	private static final long serialVersionUID = 1L;
 
 	/**
@@ -88,13 +90,14 @@ public final class InputSelection implements Serializable {
 	/**
 	 * Fairly select one of the two inputs for reading. When {@code inputMask} includes two inputs and
 	 * both inputs are available, alternately select one of them. Otherwise, select the available one
-	 * of {@code inputMask}, or return -1 to indicate no input is selected.
+	 * of {@code inputMask}, or return {@link InputSelection#NONE_AVAILABLE} to indicate no input is
+	 * selected.
 	 *
 	 * <p>Note that this supports only two inputs for performance reasons.
 	 *
 	 * @param availableInputsMask The mask of all available inputs.
 	 * @param lastReadInputIndex The index of last read input.
-	 * @return the index of the input for reading or -1, and -1 indicates no input is selected (
+	 * @return the index of the input for reading or {@link InputSelection#NONE_AVAILABLE} (if
 	 *         {@code inputMask} is empty or the inputs in {@code inputMask} are unavailable).
 	 */
 	public int fairSelectNextIndexOutOf2(int availableInputsMask, int lastReadInputIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MultipleInputStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/MultipleInputStreamOperator.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.util.List;
+
+/**
+ * Interface for stream operators with multiple {@link Input}s.
+ */
+@PublicEvolving
+public interface MultipleInputStreamOperator<OUT> extends StreamOperator<OUT> {
+	List<Input> getInputs();
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This Transformation represents the application of a
+ * {@link org.apache.flink.streaming.api.operators.MultipleInputStreamOperator}
+ * to input {@code Transformations}. The result is again only one stream.
+ *
+ * @param <OUT> The type of the elements that result from this {@code MultipleInputTransformation}
+ */
+@Internal
+public class MultipleInputTransformation<OUT> extends PhysicalTransformation<OUT> {
+
+	private final List<Transformation<?>> inputs = new ArrayList<>();
+
+	private final StreamOperatorFactory<OUT> operatorFactory;
+
+	public MultipleInputTransformation(
+			String name,
+			StreamOperatorFactory<OUT> operatorFactory,
+			TypeInformation<OUT> outputType,
+			int parallelism) {
+		super(name, outputType, parallelism);
+		this.operatorFactory = operatorFactory;
+	}
+
+	public List<Transformation<?>> getInputs() {
+		return inputs;
+	}
+
+	/**
+	 * Returns the {@code TypeInformation} for the elements from the inputs.
+	 */
+	public List<TypeInformation<?>> getInputTypes() {
+		return inputs.stream()
+			.map(Transformation::getOutputType)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the {@code StreamOperatorFactory} of this Transformation.
+	 */
+	public StreamOperatorFactory<OUT> getOperatorFactory() {
+		return operatorFactory;
+	}
+
+	public void addInput(Transformation<?> input) {
+		inputs.add(input);
+	}
+
+	@Override
+	public Collection<Transformation<?>> getTransitivePredecessors() {
+		return inputs.stream()
+			.flatMap(input -> input.getTransitivePredecessors().stream())
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public final void setChainingStrategy(ChainingStrategy strategy) {
+		operatorFactory.setChainingStrategy(strategy);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
-import static org.apache.flink.util.Preconditions.checkState;
+import java.util.Arrays;
 
 /**
  * Utility for creating {@link CheckpointedInputGate} based on checkpoint mode
@@ -63,40 +63,53 @@ public class InputProcessorUtil {
 	public static CheckpointedInputGate[] createCheckpointedInputGatePair(
 			AbstractInvokable toNotifyOnCheckpoint,
 			CheckpointingMode checkpointMode,
-			InputGate inputGate1,
-			InputGate inputGate2,
 			Configuration taskManagerConfig,
 			TaskIOMetricGroup taskIOMetricGroup,
-			String taskName) {
+			String taskName,
+			InputGate ...inputGates) {
 
 		int pageSize = ConfigurationParserUtils.getPageSize(taskManagerConfig);
 
-		BufferStorage mainBufferStorage1 = createBufferStorage(
-			checkpointMode, pageSize, taskManagerConfig, taskName);
-		BufferStorage mainBufferStorage2 = createBufferStorage(
-			checkpointMode, pageSize, taskManagerConfig, taskName);
-		checkState(mainBufferStorage1.getMaxBufferedBytes() == mainBufferStorage2.getMaxBufferedBytes());
+		BufferStorage[] mainBufferStorages = new BufferStorage[inputGates.length];
+		for (int i = 0; i < inputGates.length; i++) {
+			mainBufferStorages[i] = createBufferStorage(
+				checkpointMode, pageSize, taskManagerConfig, taskName);
+		}
 
-		BufferStorage linkedBufferStorage1 = new LinkedBufferStorage(
-			mainBufferStorage1,
-			mainBufferStorage2,
-			mainBufferStorage1.getMaxBufferedBytes());
-		BufferStorage linkedBufferStorage2 = new LinkedBufferStorage(
-			mainBufferStorage2,
-			mainBufferStorage1,
-			mainBufferStorage1.getMaxBufferedBytes());
+		BufferStorage[] linkedBufferStorages = new BufferStorage[inputGates.length];
+
+		for (int i = 0; i < inputGates.length; i++) {
+			linkedBufferStorages[i] = new LinkedBufferStorage(
+				mainBufferStorages[i],
+				mainBufferStorages[i].getMaxBufferedBytes(),
+				copyBufferStoragesExceptOf(i, mainBufferStorages));
+		}
 
 		CheckpointBarrierHandler barrierHandler = createCheckpointBarrierHandler(
 			checkpointMode,
-			inputGate1.getNumberOfInputChannels() + inputGate2.getNumberOfInputChannels(),
+			Arrays.stream(inputGates).mapToInt(InputGate::getNumberOfInputChannels).sum(),
 			taskName,
 			toNotifyOnCheckpoint);
 		registerCheckpointMetrics(taskIOMetricGroup, barrierHandler);
 
-		return new CheckpointedInputGate[] {
-			new CheckpointedInputGate(inputGate1, linkedBufferStorage1, barrierHandler),
-			new CheckpointedInputGate(inputGate2, linkedBufferStorage2, barrierHandler, inputGate1.getNumberOfInputChannels())
-		};
+		CheckpointedInputGate[] checkpointedInputGates = new CheckpointedInputGate[inputGates.length];
+
+		int channelIndexOffset = 0;
+		for (int i = 0; i < inputGates.length; i++) {
+			checkpointedInputGates[i] = new CheckpointedInputGate(inputGates[i], linkedBufferStorages[i], barrierHandler, channelIndexOffset);
+			channelIndexOffset += inputGates[i].getNumberOfInputChannels();
+		}
+
+		return checkpointedInputGates;
+	}
+
+	private static BufferStorage[] copyBufferStoragesExceptOf(
+			int skipStorage,
+			BufferStorage[] bufferStorages) {
+		BufferStorage[] copy = new BufferStorage[bufferStorages.length - 1];
+		System.arraycopy(bufferStorages, 0, copy, 0, skipStorage);
+		System.arraycopy(bufferStorages, skipStorage + 1, copy, skipStorage, bufferStorages.length - skipStorage - 1);
+		return copy;
 	}
 
 	private static CheckpointBarrierHandler createCheckpointBarrierHandler(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * This handler is mainly used for selecting the next available input index
+ * in {@link StreamMultipleInputProcessor}.
+ */
+@Internal
+public class MultipleInputSelectionHandler {
+	public static final int MAX_SUPPORTED_INPUT_COUNT = Long.SIZE;
+
+	@Nullable
+	private final InputSelectable inputSelector;
+
+	private InputSelection inputSelection = InputSelection.ALL;
+
+	private final long allSelectedMask;
+
+	private long availableInputsMask;
+
+	private long notFinishedInputsMask;
+
+	public MultipleInputSelectionHandler(@Nullable InputSelectable inputSelectable, int inputCount) {
+		checkSupportedInputCount(inputCount);
+		this.inputSelector = inputSelectable;
+		this.allSelectedMask = (1 << inputCount) - 1;
+		this.availableInputsMask = allSelectedMask;
+		this.notFinishedInputsMask = allSelectedMask;
+	}
+
+	public static void checkSupportedInputCount(int inputCount) {
+		checkArgument(
+			inputCount <= MAX_SUPPORTED_INPUT_COUNT,
+			"Only up to %d inputs are supported at once, while encountered %d",
+			MAX_SUPPORTED_INPUT_COUNT,
+			inputCount);
+	}
+
+	public InputStatus updateStatus(InputStatus inputStatus, int inputIndex) throws IOException {
+		switch (inputStatus) {
+			case MORE_AVAILABLE:
+				checkState(checkBitMask(availableInputsMask, inputIndex));
+				return InputStatus.MORE_AVAILABLE;
+			case NOTHING_AVAILABLE:
+				availableInputsMask = unsetBitMask(availableInputsMask, inputIndex);
+				break;
+			case END_OF_INPUT:
+				notFinishedInputsMask = unsetBitMask(notFinishedInputsMask, inputIndex);
+				break;
+			default:
+				throw new UnsupportedOperationException("Unsupported inputStatus = " + inputStatus);
+		}
+		return calculateOverallStatus();
+	}
+
+	public InputStatus calculateOverallStatus() throws IOException {
+		if (areAllInputsFinished()) {
+			return InputStatus.END_OF_INPUT;
+		}
+
+		if (isAnyInputAvailable()) {
+			return InputStatus.MORE_AVAILABLE;
+		}
+		else {
+			long selectedNotFinishedInputMask = inputSelection.getInputMask() & notFinishedInputsMask;
+			if (selectedNotFinishedInputMask == 0) {
+				throw new IOException("Can not make a progress: all selected inputs are already finished");
+			}
+			return InputStatus.NOTHING_AVAILABLE;
+		}
+	}
+
+	void nextSelection() {
+		if (inputSelector == null) {
+			inputSelection = InputSelection.ALL;
+		} else {
+			inputSelection = inputSelector.nextSelection();
+		}
+	}
+
+	int selectNextInputIndex(int lastReadInputIndex) {
+		return inputSelection.fairSelectNextIndex(
+			availableInputsMask & notFinishedInputsMask,
+			lastReadInputIndex);
+	}
+
+	boolean shouldSetAvailableForAnotherInput() {
+		return availableInputsMask != allSelectedMask && inputSelection.areAllInputsSelected();
+	}
+
+	void setAvailableInput(int inputIndex) {
+		availableInputsMask = setBitMask(availableInputsMask, inputIndex);
+	}
+
+	void setUnavailableInput(int inputIndex) {
+		availableInputsMask = unsetBitMask(availableInputsMask, inputIndex);
+	}
+
+	boolean isAnyInputAvailable() {
+		return (inputSelection.getInputMask() & availableInputsMask & notFinishedInputsMask) != 0;
+	}
+
+	boolean areAllInputsSelected() {
+		return inputSelection.areAllInputsSelected();
+	}
+
+	boolean isInputSelected(int inputIndex) {
+		return inputSelection.isInputSelected(inputIndex + 1);
+	}
+
+	public boolean isInputFinished(int inputIndex) {
+		return !checkBitMask(notFinishedInputsMask, inputIndex);
+	}
+
+	public boolean areAllInputsFinished() {
+		return notFinishedInputsMask == 0;
+	}
+
+	long setBitMask(long mask, int inputIndex) {
+		return mask | 1L << inputIndex;
+	}
+
+	long unsetBitMask(long mask, int inputIndex) {
+		return mask & ~(1L << inputIndex);
+	}
+
+	boolean checkBitMask(long mask, int inputIndex) {
+		return (mask & (1L << inputIndex)) != 0;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StatusWatermarkValve;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
+import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.util.ExceptionUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Input processor for {@link MultipleInputStreamOperator}.
+ */
+@Internal
+public final class StreamMultipleInputProcessor implements StreamInputProcessor {
+
+	private final MultipleInputSelectionHandler inputSelectionHandler;
+
+	private final InputProcessor<?>[] inputProcessors;
+
+	private final OperatorChain<?, ?> operatorChain;
+
+	/**
+	 * Stream status for the two inputs. We need to keep track for determining when
+	 * to forward stream status changes downstream.
+	 */
+	private final StreamStatus[] streamStatuses;
+
+	private final Counter numRecordsIn;
+
+	/** Always try to read from the first input. */
+	private int lastReadInputIndex = 1;
+
+	private boolean isPrepared;
+
+	public StreamMultipleInputProcessor(
+			CheckpointedInputGate[] checkpointedInputGates,
+			TypeSerializer<?>[] inputSerializers,
+			IOManager ioManager,
+			StreamStatusMaintainer streamStatusMaintainer,
+			MultipleInputStreamOperator<?> streamOperator,
+			MultipleInputSelectionHandler inputSelectionHandler,
+			WatermarkGauge[] inputWatermarkGauges,
+			OperatorChain<?, ?> operatorChain,
+			Counter numRecordsIn) {
+
+		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
+
+		List<Input> inputs = streamOperator.getInputs();
+		int operatorsCount = inputs.size();
+
+		this.inputProcessors = new InputProcessor[operatorsCount];
+		this.streamStatuses = new StreamStatus[operatorsCount];
+		this.numRecordsIn = numRecordsIn;
+
+		for (int i = 0; i < operatorsCount; i++) {
+			StreamTaskNetworkOutput dataOutput = new StreamTaskNetworkOutput<>(
+				inputs.get(i),
+				streamStatusMaintainer,
+				inputWatermarkGauges[i],
+				i);
+
+			inputProcessors[i] = new InputProcessor(
+				dataOutput,
+				new StreamTaskNetworkInput<>(
+					checkpointedInputGates[i],
+					inputSerializers[i],
+					ioManager,
+					new StatusWatermarkValve(checkpointedInputGates[i].getNumberOfInputChannels(), dataOutput),
+					i));
+		}
+
+		this.operatorChain = checkNotNull(operatorChain);
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		if (inputSelectionHandler.areAllInputsSelected()) {
+			return isAnyInputAvailable();
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@Override
+	public InputStatus processInput() throws Exception {
+		int readingInputIndex;
+		if (isPrepared) {
+			readingInputIndex = selectNextReadingInputIndex();
+		} else {
+			// the preparations here are not placed in the constructor because all work in it
+			// must be executed after all operators are opened.
+			readingInputIndex = selectFirstReadingInputIndex();
+		}
+		if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
+			return InputStatus.NOTHING_AVAILABLE;
+		}
+
+		lastReadInputIndex = readingInputIndex;
+		InputStatus inputStatus = inputProcessors[readingInputIndex].processInput();
+		checkFinished(inputStatus, readingInputIndex);
+		return inputSelectionHandler.updateStatus(inputStatus, readingInputIndex);
+	}
+
+	private int selectFirstReadingInputIndex() {
+		// Note: the first call to nextSelection () on the operator must be made after this operator
+		// is opened to ensure that any changes about the input selection in its open()
+		// method take effect.
+		inputSelectionHandler.nextSelection();
+
+		isPrepared = true;
+
+		return selectNextReadingInputIndex();
+	}
+
+	private void checkFinished(InputStatus status, int inputIndex) throws Exception {
+		if (status == InputStatus.END_OF_INPUT) {
+			operatorChain.endHeadOperatorInput(getInputId(inputIndex));
+			inputSelectionHandler.nextSelection();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		IOException ex = null;
+		for (InputProcessor<?> input : inputProcessors) {
+			try {
+				input.close();
+			} catch (IOException e) {
+				ex = ExceptionUtils.firstOrSuppressed(e, ex);
+			}
+		}
+
+		if (ex != null) {
+			throw ex;
+		}
+	}
+
+	private int selectNextReadingInputIndex() {
+		if (!inputSelectionHandler.isAnyInputAvailable()) {
+			fullCheckAndSetAvailable();
+		}
+
+		int readingInputIndex = inputSelectionHandler.selectNextInputIndex(lastReadInputIndex);
+		if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
+			return InputSelection.NONE_AVAILABLE;
+		}
+
+		// to avoid starvation, if the input selection is ALL and availableInputsMask is not ALL,
+		// always try to check and set the availability of another input
+		if (inputSelectionHandler.shouldSetAvailableForAnotherInput()) {
+			fullCheckAndSetAvailable();
+		}
+
+		return readingInputIndex;
+	}
+
+	private void fullCheckAndSetAvailable() {
+		for (int i = 0; i < inputProcessors.length; i++) {
+			InputProcessor<?> inputProcessor = inputProcessors[i];
+			// TODO: isAvailable() can be a costly operation (checking volatile). If one of
+			// the input is constantly available and another is not, we will be checking this volatile
+			// once per every record. This might be optimized to only check once per processed NetworkBuffer
+			if (inputProcessor.networkInput.isApproximatelyAvailable() || inputProcessor.networkInput.isAvailable()) {
+				inputSelectionHandler.setAvailableInput(i);
+			}
+		}
+	}
+
+	private CompletableFuture<?> isAnyInputAvailable() {
+		if (inputSelectionHandler.isAnyInputAvailable() || inputSelectionHandler.areAllInputsFinished()) {
+			return AVAILABLE;
+		}
+		final CompletableFuture<?> anyInputAvailable = new CompletableFuture<>();
+		for (int i = 0; i < inputProcessors.length; i++) {
+			if (!inputSelectionHandler.isInputFinished(i)) {
+				inputProcessors[i].networkInput.getAvailableFuture().thenRun(() -> anyInputAvailable.complete(null));
+			}
+		}
+		return anyInputAvailable;
+	}
+
+	private int getInputId(int inputIndex) {
+		return inputIndex + 1;
+	}
+
+	private boolean allStreamStatusesAreIdle() {
+		for (StreamStatus streamStatus : streamStatuses) {
+			if (streamStatus.isActive()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private class InputProcessor<T> implements Closeable {
+		private final StreamTaskNetworkOutput<T> dataOutput;
+		private final StreamTaskNetworkInput<T> networkInput;
+
+		public InputProcessor(
+			StreamTaskNetworkOutput<T> dataOutput,
+			StreamTaskNetworkInput<T> networkInput) {
+			this.dataOutput = dataOutput;
+			this.networkInput = networkInput;
+		}
+
+		public InputStatus processInput() throws Exception {
+			return networkInput.emitNext(dataOutput);
+		}
+
+		public void close() throws IOException {
+			networkInput.close();
+		}
+	}
+
+	/**
+	 * The network data output implementation used for processing stream elements
+	 * from {@link StreamTaskNetworkInput} in two input selective processor.
+	 */
+	private class StreamTaskNetworkOutput<T> extends AbstractDataOutput<T> {
+		private final Input<T> input;
+
+		private final WatermarkGauge inputWatermarkGauge;
+
+		/** The input index to indicate how to process elements by two input operator. */
+		private final int inputIndex;
+
+		private StreamTaskNetworkOutput(
+				Input<T> input,
+				StreamStatusMaintainer streamStatusMaintainer,
+				WatermarkGauge inputWatermarkGauge,
+				int inputIndex) {
+			super(streamStatusMaintainer);
+
+			this.input = checkNotNull(input);
+			this.inputWatermarkGauge = checkNotNull(inputWatermarkGauge);
+			this.inputIndex = inputIndex;
+		}
+
+		@Override
+		public void emitRecord(StreamRecord<T> record) throws Exception {
+			//TODO: support keyed operators
+			//input.setKeyContextElement(record);
+			input.processElement(record);
+			numRecordsIn.inc();
+			inputSelectionHandler.nextSelection();
+		}
+
+		@Override
+		public void emitWatermark(Watermark watermark) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void emitStreamStatus(StreamStatus streamStatus) {
+			final StreamStatus anotherStreamStatus;
+
+			streamStatuses[inputIndex] = streamStatus;
+
+			// check if we need to toggle the task's stream status
+			if (!streamStatus.equals(streamStatusMaintainer.getStreamStatus())) {
+				if (streamStatus.isActive()) {
+					// we're no longer idle if at least one input has become active
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.ACTIVE);
+				} else if (allStreamStatusesAreIdle()) {
+					streamStatusMaintainer.toggleStreamStatus(StreamStatus.IDLE);
+				}
+			}
+		}
+
+		@Override
+		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
+import org.apache.flink.streaming.api.operators.InputSelection;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput.DataOutput;
@@ -160,12 +161,12 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		int readingInputIndex;
 		if (isPrepared) {
 			readingInputIndex = selectNextReadingInputIndex();
-			assert readingInputIndex != -1;
+			assert readingInputIndex != InputSelection.NONE_AVAILABLE;
 		} else {
 			// the preparations here are not placed in the constructor because all work in it
 			// must be executed after all operators are opened.
 			readingInputIndex = selectFirstReadingInputIndex();
-			if (readingInputIndex == -1) {
+			if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
 				return InputStatus.NOTHING_AVAILABLE;
 			}
 		}
@@ -244,8 +245,8 @@ public final class StreamTwoInputProcessor<IN1, IN2> implements StreamInputProce
 		checkInputSelectionAgainstIsFinished();
 
 		int readingInputIndex = inputSelectionHandler.selectNextInputIndex(lastReadInputIndex);
-		if (readingInputIndex == -1) {
-			return -1;
+		if (readingInputIndex == InputSelection.NONE_AVAILABLE) {
+			return InputSelection.NONE_AVAILABLE;
 		}
 
 		// to avoid starvation, if the input selection is ALL and availableInputsMask is not ALL,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
@@ -55,7 +55,7 @@ public class TwoInputSelectionHandler {
 	}
 
 	boolean shouldSetAvailableForAnotherInput() {
-		return availableInputsMask < 3 && inputSelection.isALLMaskOf2();
+		return availableInputsMask < 3 && inputSelection.areAllInputsSelected();
 	}
 
 	void setAvailableInput(int inputIndex) {
@@ -67,7 +67,7 @@ public class TwoInputSelectionHandler {
 	}
 
 	boolean areAllInputsSelected() {
-		return inputSelection.isALLMaskOf2();
+		return inputSelection.areAllInputsSelected();
 	}
 
 	boolean isFirstInputSelected() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/MinWatermarkGauge.java
@@ -20,21 +20,26 @@ package org.apache.flink.streaming.runtime.metrics;
 
 import org.apache.flink.metrics.Gauge;
 
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
- * A {@link Gauge} for exposing the minimum watermark of a {@link WatermarkGauge} pair.
+ * A {@link Gauge} for exposing the minimum watermark of chosen {@link WatermarkGauge}s.
  */
 public class MinWatermarkGauge implements Gauge<Long> {
+	private final WatermarkGauge[] watermarkGauges;
 
-	private WatermarkGauge watermarkGauge1;
-	private WatermarkGauge watermarkGauge2;
-
-	public MinWatermarkGauge(WatermarkGauge watermarkGauge1, WatermarkGauge watermarkGauge2) {
-		this.watermarkGauge1 = watermarkGauge1;
-		this.watermarkGauge2 = watermarkGauge2;
+	public MinWatermarkGauge(WatermarkGauge ...watermarkGauges) {
+		checkArgument(watermarkGauges.length > 0);
+		this.watermarkGauges = watermarkGauges;
 	}
 
 	@Override
 	public Long getValue() {
-		return Math.min(watermarkGauge1.getValue(), watermarkGauge2.getValue());
+		return Arrays.stream(watermarkGauges)
+			.mapToLong(WatermarkGauge::getValue)
+			.min()
+			.orElse(0);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -18,8 +18,27 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.operators.InputSelectable;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.runtime.io.CheckpointedInputGate;
+import org.apache.flink.streaming.runtime.io.InputGateUtil;
+import org.apache.flink.streaming.runtime.io.InputProcessorUtil;
+import org.apache.flink.streaming.runtime.io.MultipleInputSelectionHandler;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.metrics.MinWatermarkGauge;
+import org.apache.flink.streaming.runtime.metrics.WatermarkGauge;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A {@link StreamTask} for executing a {@link MultipleInputStreamOperator} and supporting
@@ -27,13 +46,78 @@ import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
  */
 @Internal
 public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputStreamOperator<OUT>> {
-
 	public MultipleInputStreamTask(Environment env) {
 		super(env);
 	}
 
 	@Override
 	public void init() throws Exception {
-		throw new UnsupportedOperationException();
+		StreamConfig configuration = getConfiguration();
+		ClassLoader userClassLoader = getUserCodeClassLoader();
+
+		TypeSerializer<?>[] inputDeserializers = configuration.getTypeSerializersIn(userClassLoader);
+
+		ArrayList<InputGate>[] inputLists = new ArrayList[inputDeserializers.length];
+		WatermarkGauge[] watermarkGauges = new WatermarkGauge[inputDeserializers.length];
+
+		for (int i = 0; i < inputDeserializers.length; i++) {
+			inputLists[i] = new ArrayList<>();
+			watermarkGauges[i] = new WatermarkGauge();
+			headOperator.getMetricGroup().gauge(MetricNames.currentInputWatermarkName(i), watermarkGauges[i]);
+		}
+
+		MinWatermarkGauge minInputWatermarkGauge = new MinWatermarkGauge(watermarkGauges);
+		headOperator.getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge);
+
+		List<StreamEdge> inEdges = configuration.getInPhysicalEdges(userClassLoader);
+		int numberOfInputs = configuration.getNumberOfInputs();
+
+		for (int i = 0; i < numberOfInputs; i++) {
+			int inputType = inEdges.get(i).getTypeNumber();
+			InputGate reader = getEnvironment().getInputGate(i);
+			inputLists[inputType - 1].add(reader);
+		}
+
+		createInputProcessor(inputLists, inputDeserializers, watermarkGauges);
+
+		// wrap watermark gauge since registered metrics must be unique
+		getEnvironment().getMetricGroup().gauge(MetricNames.IO_CURRENT_INPUT_WATERMARK, minInputWatermarkGauge::getValue);
+	}
+
+	protected void createInputProcessor(
+			Collection<InputGate>[] inputGates,
+			TypeSerializer<?>[] inputDeserializers,
+			WatermarkGauge[] inputWatermarkGauges) {
+		if (headOperator instanceof InputSelectable) {
+			throw new UnsupportedOperationException();
+		}
+		MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(
+			null,
+			inputGates.length);
+
+		InputGate[] unionedInputGates = new InputGate[inputGates.length];
+		for (int i = 0; i < inputGates.length; i++) {
+			unionedInputGates[i] = InputGateUtil.createInputGate(inputGates[i].toArray(new InputGate[0]));
+		}
+
+		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
+			this,
+			getConfiguration().getCheckpointMode(),
+			getEnvironment().getTaskManagerInfo().getConfiguration(),
+			getEnvironment().getMetricGroup().getIOMetricGroup(),
+			getTaskNameWithSubtaskAndId(),
+			unionedInputGates);
+		checkState(checkpointedInputGates.length == inputGates.length);
+
+		inputProcessor = new StreamMultipleInputProcessor(
+			checkpointedInputGates,
+			inputDeserializers,
+			getEnvironment().getIOManager(),
+			getStreamStatusMaintainer(),
+			headOperator,
+			selectionHandler,
+			inputWatermarkGauges,
+			operatorChain,
+			setupNumRecordsInCounter(headOperator));
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+
+/**
+ * A {@link StreamTask} for executing a {@link MultipleInputStreamOperator} and supporting
+ * the {@link MultipleInputStreamOperator} to select input for reading.
+ */
+@Internal
+public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputStreamOperator<OUT>> {
+
+	public MultipleInputStreamTask(Environment env) {
+		super(env);
+	}
+
+	@Override
+	public void init() throws Exception {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -414,7 +414,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
-	private void beforeInvoke() throws Exception {
+	protected void beforeInvoke() throws Exception {
 		disposedOperators = false;
 		LOG.debug("Initializing {}.", getName());
 
@@ -455,6 +455,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// registers a timer, that fires before the open() is called.
 			operatorChain.initializeStateAndOpenOperators();
 		});
+
+		isRunning = true;
 	}
 
 	@Override
@@ -468,7 +470,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			}
 
 			// let the task do its work
-			isRunning = true;
 			runMailboxLoop();
 
 			// if this left the run() method cleanly despite the fact that this was canceled,
@@ -484,11 +485,15 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
+	protected boolean runMailboxStep() throws Exception {
+		return mailboxProcessor.runMailboxStep();
+	}
+
 	private void runMailboxLoop() throws Exception {
 		mailboxProcessor.runMailboxLoop();
 	}
 
-	private void afterInvoke() throws Exception {
+	protected void afterInvoke() throws Exception {
 		LOG.debug("Finished task {}", getName());
 
 		final CompletableFuture<Void> timersFinishedFuture = new CompletableFuture<>();
@@ -527,7 +532,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		disposedOperators = true;
 	}
 
-	private void cleanUpInvoke() throws Exception {
+	protected void cleanUpInvoke() throws Exception {
 		// clean up everything we initialized
 		isRunning = false;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -330,7 +330,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * 2. Only input is unavailable.
 	 * 3. Only output is unavailable.
 	 */
-	private CompletableFuture<?> getInputOutputJointFuture(InputStatus status) {
+	@VisibleForTesting
+	CompletableFuture<?> getInputOutputJointFuture(InputStatus status) {
 		if (status == InputStatus.NOTHING_AVAILABLE && !recordWriter.isAvailable()) {
 			return CompletableFuture.allOf(inputProcessor.getAvailableFuture(), recordWriter.getAvailableFuture());
 		} else if (status == InputStatus.NOTHING_AVAILABLE) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -61,11 +61,11 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
 		CheckpointedInputGate[] checkpointedInputGates = InputProcessorUtil.createCheckpointedInputGatePair(
 			this,
 			getConfiguration().getCheckpointMode(),
-			unionedInputGate1,
-			unionedInputGate2,
 			getEnvironment().getTaskManagerInfo().getConfiguration(),
 			getEnvironment().getMetricGroup().getIOMetricGroup(),
-			getTaskNameWithSubtaskAndId());
+			getTaskNameWithSubtaskAndId(),
+			unionedInputGate1,
+			unionedInputGate2);
 		checkState(checkpointedInputGates.length == 2);
 
 		inputProcessor = new StreamTwoInputProcessor<>(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -183,9 +183,20 @@ public class MailboxProcessor implements Closeable {
 
 		final MailboxController defaultActionContext = new MailboxController(this);
 
-		while (processMail(localMailbox)) {
-			mailboxDefaultAction.runDefaultAction(defaultActionContext); // lock is acquired inside default action as needed
+		while (runMailboxStep(localMailbox, defaultActionContext)) {
 		}
+	}
+
+	public boolean runMailboxStep() throws Exception {
+		return runMailboxStep(mailbox, new MailboxController(this));
+	}
+
+	private boolean runMailboxStep(TaskMailbox localMailbox, MailboxController defaultActionContext) throws Exception {
+		if (processMail(localMailbox)) {
+			mailboxDefaultAction.runDefaultAction(defaultActionContext); // lock is acquired inside default action as needed
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -285,7 +296,8 @@ public class MailboxProcessor implements Closeable {
 		return suspendedDefaultAction != null;
 	}
 
-	protected boolean isMailboxLoopRunning() {
+	@VisibleForTesting
+	public boolean isMailboxLoopRunning() {
 		return mailboxLoopRunning;
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/StreamTestSingleInputGate.java
@@ -32,10 +32,8 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.Buffe
 import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel.BufferAndAvailabilityProvider;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.plugable.SerializationDelegate;
-import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
 
-import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -63,7 +61,7 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 	public StreamTestSingleInputGate(
 		int numInputChannels,
 		int bufferSize,
-		TypeSerializer<T> serializer) throws IOException, InterruptedException {
+		TypeSerializer<T> serializer) {
 		super(numInputChannels, false);
 
 		this.bufferSize = bufferSize;
@@ -78,15 +76,15 @@ public class StreamTestSingleInputGate<T> extends TestSingleInputGate {
 	}
 
 	@SuppressWarnings("unchecked")
-	private void setupInputChannels() throws IOException, InterruptedException {
+	private void setupInputChannels() {
 
 		for (int i = 0; i < numInputChannels; i++) {
 			final int channelIndex = i;
 			final RecordSerializer<SerializationDelegate<Object>> recordSerializer = new SpanningRecordSerializer<SerializationDelegate<Object>>();
 			final SerializationDelegate<Object> delegate = (SerializationDelegate<Object>) (SerializationDelegate<?>)
-				new SerializationDelegate<StreamElement>(new StreamElementSerializer<T>(serializer));
+				new SerializationDelegate<>(new StreamElementSerializer<T>(serializer));
 
-			inputQueues[channelIndex] = new ConcurrentLinkedQueue<InputValue<Object>>();
+			inputQueues[channelIndex] = new ConcurrentLinkedQueue<>();
 			inputChannels[channelIndex] = new TestInputChannel(inputGate, i);
 
 			final BufferAndAvailabilityProvider answer = () -> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -326,10 +326,10 @@ public class DataStreamTest extends TestLogger {
 		int id3 = createDownStreamId(group3);
 		int id4 = createDownStreamId(group4);
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id1)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id2)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id3)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), id4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), id1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), id2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), id3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), id4)));
 
 		assertTrue(isKeyed(group1));
 		assertTrue(isKeyed(group2));
@@ -347,10 +347,10 @@ public class DataStreamTest extends TestLogger {
 		int pid3 = createDownStreamId(partition3);
 		int pid4 = createDownStreamId(partition4);
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid1)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid2)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid3)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), pid4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), pid1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), pid2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), pid3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), pid4)));
 
 		assertTrue(isKeyed(partition1));
 		assertTrue(isKeyed(partition3));
@@ -373,9 +373,9 @@ public class DataStreamTest extends TestLogger {
 		int cid2 = createDownStreamId(customPartition3);
 		int cid3 = createDownStreamId(customPartition4);
 
-		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid1)));
-		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid2)));
-		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), cid3)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), cid1)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), cid2)));
+		assertTrue(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), cid3)));
 
 		assertFalse(isKeyed(customPartition1));
 		assertFalse(isKeyed(customPartition3));
@@ -397,20 +397,20 @@ public class DataStreamTest extends TestLogger {
 		ConnectedStreams<Tuple2<Long, Long>, Tuple2<Long, Long>> connectedGroup5 = connected.keyBy(new FirstSelector(), new FirstSelector());
 		Integer downStreamId5 = createDownStreamId(connectedGroup5);
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId1)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), downStreamId1)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(), downStreamId1)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId2)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), downStreamId2)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(), downStreamId2)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId3)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), downStreamId3)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(), downStreamId3)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId4)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), downStreamId4)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(), downStreamId4)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(), downStreamId5)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(), downStreamId5)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(), downStreamId5)));
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(), downStreamId5)));
 
 		assertTrue(isKeyed(connectedGroup1));
 		assertTrue(isKeyed(connectedGroup2));
@@ -434,29 +434,29 @@ public class DataStreamTest extends TestLogger {
 		ConnectedStreams<Tuple2<Long, Long>, Tuple2<Long, Long>> connectedPartition5 = connected.keyBy(new FirstSelector(), new FirstSelector());
 		Integer connectDownStreamId5 = createDownStreamId(connectedPartition5);
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(),
 				connectDownStreamId1)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(),
 				connectDownStreamId1)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(),
 				connectDownStreamId2)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(),
 				connectDownStreamId2)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(),
 				connectDownStreamId3)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(),
 				connectDownStreamId3)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(),
 				connectDownStreamId4)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(),
 				connectDownStreamId4)));
 
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId(),
 				connectDownStreamId5)));
-		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId(),
+		assertTrue(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId(),
 				connectDownStreamId5)));
 
 		assertTrue(isKeyed(connectedPartition1));
@@ -942,13 +942,13 @@ public class DataStreamTest extends TestLogger {
 		assertEquals(filterFunction, getFunctionForDataStream(unionFilter));
 
 		try {
-			getStreamGraph(env).getStreamEdges(map.getId(), unionFilter.getId());
+			getStreamGraph(env).getStreamEdgesOrThrow(map.getId(), unionFilter.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
 
 		try {
-			getStreamGraph(env).getStreamEdges(flatMap.getId(), unionFilter.getId());
+			getStreamGraph(env).getStreamEdgesOrThrow(flatMap.getId(), unionFilter.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
@@ -990,13 +990,13 @@ public class DataStreamTest extends TestLogger {
 		assertEquals(coMapper, getFunctionForDataStream(coMap));
 
 		try {
-			getStreamGraph(env).getStreamEdges(map.getId(), coMap.getId());
+			getStreamGraph(env).getStreamEdgesOrThrow(map.getId(), coMap.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}
 
 		try {
-			getStreamGraph(env).getStreamEdges(flatMap.getId(), coMap.getId());
+			getStreamGraph(env).getStreamEdgesOrThrow(flatMap.getId(), coMap.getId());
 		} catch (RuntimeException e) {
 			fail(e.getMessage());
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.assertTrue;
  * Tests for {@link InputSelection}.
  */
 public class InputSelectionTest {
-
 	@Test
 	public void testIsInputSelected() {
 		assertFalse(new Builder().build().isInputSelected(1));
@@ -43,13 +42,25 @@ public class InputSelectionTest {
 	}
 
 	@Test
-	public void testIsALLMaskOf2() {
-		assertTrue(InputSelection.ALL.isALLMaskOf2());
-		assertTrue(new Builder().select(1).select(2).build().isALLMaskOf2());
+	public void testInputSelectionNormalization() {
+		assertTrue(InputSelection.ALL.areAllInputsSelected());
 
-		assertFalse(InputSelection.FIRST.isALLMaskOf2());
-		assertFalse(InputSelection.SECOND.isALLMaskOf2());
-		assertFalse(new Builder().select(3).build().isALLMaskOf2());
+		assertFalse(new Builder().select(1).select(2).build().areAllInputsSelected());
+		assertTrue(new Builder().select(1).select(2).build(2).areAllInputsSelected());
+
+		assertFalse(new Builder().select(1).select(2).select(3).build().areAllInputsSelected());
+		assertTrue(new Builder().select(1).select(2).select(3).build(3).areAllInputsSelected());
+
+		assertFalse(new Builder().select(1).select(3).build().areAllInputsSelected());
+		assertFalse(new Builder().select(1).select(3).build(3).areAllInputsSelected());
+
+		assertFalse(InputSelection.FIRST.areAllInputsSelected());
+		assertFalse(InputSelection.SECOND.areAllInputsSelected());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInputSelectionNormalizationOverflow() {
+		new Builder().select(3).build(2);
 	}
 
 	@Test
@@ -76,14 +87,20 @@ public class InputSelectionTest {
 	}
 
 	@Test
-	public void testFairSelectNextIndex() {
+	public void testFairSelectNextIndexWithAllInputsSelected() {
 		assertEquals(1, InputSelection.ALL.fairSelectNextIndex(7, 0));
 		assertEquals(2, InputSelection.ALL.fairSelectNextIndex(7, 1));
 		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(7, 2));
 		assertEquals(1, InputSelection.ALL.fairSelectNextIndex(7, 0));
 		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.ALL.fairSelectNextIndex(0, 2));
 
+		assertEquals(11, InputSelection.ALL.fairSelectNextIndex(-1, 10));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 63));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 158));
+	}
 
+	@Test
+	public void testFairSelectNextIndexWithSomeInputsSelected() {
 		// combination of selection and availability is supposed to be 3, 5, 8:
 		InputSelection selection = new Builder().select(2).select(3).select(4).select(5).select(8).build();
 		int availableInputs = (int) new Builder().select(3).select(5).select(6).select(8).build().getInputMask();
@@ -99,10 +116,6 @@ public class InputSelectionTest {
 		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 8));
 		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 158));
 		assertEquals(InputSelection.NONE_AVAILABLE, selection.fairSelectNextIndex(0, 5));
-
-		assertEquals(11, InputSelection.ALL.fairSelectNextIndex(-1, 10));
-		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 31));
-		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 158));
 
 		assertEquals(InputSelection.NONE_AVAILABLE, new Builder().build().fairSelectNextIndex(-1, 5));
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
@@ -75,6 +75,38 @@ public class InputSelectionTest {
 		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.SECOND.fairSelectNextIndexOutOf2(0, 1));
 	}
 
+	@Test
+	public void testFairSelectNextIndex() {
+		assertEquals(1, InputSelection.ALL.fairSelectNextIndex(7, 0));
+		assertEquals(2, InputSelection.ALL.fairSelectNextIndex(7, 1));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(7, 2));
+		assertEquals(1, InputSelection.ALL.fairSelectNextIndex(7, 0));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.ALL.fairSelectNextIndex(0, 2));
+
+
+		// combination of selection and availability is supposed to be 3, 5, 8:
+		InputSelection selection = new Builder().select(2).select(3).select(4).select(5).select(8).build();
+		int availableInputs = (int) new Builder().select(3).select(5).select(6).select(8).build().getInputMask();
+
+		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 0));
+		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 1));
+		assertEquals(4, selection.fairSelectNextIndex(availableInputs, 2));
+		assertEquals(4, selection.fairSelectNextIndex(availableInputs, 3));
+		assertEquals(7, selection.fairSelectNextIndex(availableInputs, 4));
+		assertEquals(7, selection.fairSelectNextIndex(availableInputs, 5));
+		assertEquals(7, selection.fairSelectNextIndex(availableInputs, 6));
+		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 7));
+		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 8));
+		assertEquals(2, selection.fairSelectNextIndex(availableInputs, 158));
+		assertEquals(InputSelection.NONE_AVAILABLE, selection.fairSelectNextIndex(0, 5));
+
+		assertEquals(11, InputSelection.ALL.fairSelectNextIndex(-1, 10));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 31));
+		assertEquals(0, InputSelection.ALL.fairSelectNextIndex(-1, 158));
+
+		assertEquals(InputSelection.NONE_AVAILABLE, new Builder().build().fairSelectNextIndex(-1, 5));
+	}
+
 	@Test(expected = UnsupportedOperationException.class)
 	public void testUnsupportedFairSelectNextIndexOutOf2() {
 		InputSelection.ALL.fairSelectNextIndexOutOf2(7, 0);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InputSelectionTest.java
@@ -61,18 +61,18 @@ public class InputSelectionTest {
 		assertEquals(1, InputSelection.ALL.fairSelectNextIndexOutOf2(2, 1));
 		assertEquals(0, InputSelection.ALL.fairSelectNextIndexOutOf2(1, 0));
 		assertEquals(0, InputSelection.ALL.fairSelectNextIndexOutOf2(1, 1));
-		assertEquals(-1, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 0));
-		assertEquals(-1, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 1));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 0));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.ALL.fairSelectNextIndexOutOf2(0, 1));
 
 		assertEquals(0, InputSelection.FIRST.fairSelectNextIndexOutOf2(1, 0));
 		assertEquals(0, InputSelection.FIRST.fairSelectNextIndexOutOf2(3, 0));
-		assertEquals(-1, InputSelection.FIRST.fairSelectNextIndexOutOf2(2, 0));
-		assertEquals(-1, InputSelection.FIRST.fairSelectNextIndexOutOf2(0, 0));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.FIRST.fairSelectNextIndexOutOf2(2, 0));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.FIRST.fairSelectNextIndexOutOf2(0, 0));
 
 		assertEquals(1, InputSelection.SECOND.fairSelectNextIndexOutOf2(2, 1));
 		assertEquals(1, InputSelection.SECOND.fairSelectNextIndexOutOf2(3, 1));
-		assertEquals(-1, InputSelection.SECOND.fairSelectNextIndexOutOf2(1, 1));
-		assertEquals(-1, InputSelection.SECOND.fairSelectNextIndexOutOf2(0, 1));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.SECOND.fairSelectNextIndexOutOf2(1, 1));
+		assertEquals(InputSelection.NONE_AVAILABLE, InputSelection.SECOND.fairSelectNextIndexOutOf2(0, 1));
 	}
 
 	@Test(expected = UnsupportedOperationException.class)

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/LinkedBufferStorageTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/LinkedBufferStorageTest.java
@@ -41,53 +41,63 @@ public class LinkedBufferStorageTest {
 
 	private CachedBufferStorage mainStorage;
 
-	private CachedBufferStorage linkedStorage;
+	private CachedBufferStorage linkedStorage1;
+
+	private CachedBufferStorage linkedStorage2;
 
 	private LinkedBufferStorage bufferStorage;
 
 	@Before
 	public void setUp() {
 		mainStorage = new CachedBufferStorage(PAGE_SIZE);
-		linkedStorage = new CachedBufferStorage(PAGE_SIZE);
+		linkedStorage1 = new CachedBufferStorage(PAGE_SIZE);
+		linkedStorage2 = new CachedBufferStorage(PAGE_SIZE);
 		bufferStorage = new LinkedBufferStorage(
 			mainStorage,
-			linkedStorage,
-			700);
+			700,
+			linkedStorage1,
+			linkedStorage2);
 	}
 
 	@After
 	public void tearDown() throws IOException {
 		bufferStorage.close();
 		mainStorage.close();
-		linkedStorage.close();
+		linkedStorage1.close();
+		linkedStorage2.close();
 	}
 
 	@Test
 	public void testBasicUsage() throws IOException {
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE + 0));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE + 0));
 		assertEquals(PAGE_SIZE, bufferStorage.getPendingBytes());
+		linkedStorage2.add(generateRandomBuffer(PAGE_SIZE + 1));
+		assertEquals(PAGE_SIZE * 2, bufferStorage.getPendingBytes());
+
 		assertTrue(bufferStorage.isEmpty());
 
-		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 1));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 2));
+		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 3));
 
 		assertTrue(bufferStorage.isEmpty());
 		assertPendingBytes();
 		assertRolledBytes();
 
 		assertTrue(bufferStorage.isEmpty());
-		assertTrue(linkedStorage.isEmpty());
+		assertTrue(linkedStorage1.isEmpty());
+		assertTrue(linkedStorage2.isEmpty());
 
 		bufferStorage.rollOver();
 
 		assertFalse(bufferStorage.isEmpty());
-		assertFalse(linkedStorage.isEmpty());
+		assertFalse(linkedStorage1.isEmpty());
+		assertFalse(linkedStorage2.isEmpty());
 
 		assertPendingBytes();
 		assertRolledBytes();
 
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE + 3));
-		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 4));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE + 4));
+		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 5));
 
 		assertPendingBytes();
 		assertRolledBytes();
@@ -96,17 +106,21 @@ public class LinkedBufferStorageTest {
 
 		assertPendingBytes();
 		assertRolledBytes();
-		
+
 		ArrayList<Integer> bufferSizes = drain(bufferStorage);
 
+		assertEquals(PAGE_SIZE + 5, (long) bufferSizes.get(0));
+		assertEquals(PAGE_SIZE + 2, (long) bufferSizes.get(1));
+		assertEquals(PAGE_SIZE + 3, (long) bufferSizes.get(2));
+
+		bufferSizes = drain(linkedStorage1);
+
 		assertEquals(PAGE_SIZE + 4, (long) bufferSizes.get(0));
-		assertEquals(PAGE_SIZE + 1, (long) bufferSizes.get(1));
-		assertEquals(PAGE_SIZE + 2, (long) bufferSizes.get(2));
-
-		bufferSizes = drain(linkedStorage);
-
-		assertEquals(PAGE_SIZE + 3, (long) bufferSizes.get(0));
 		assertEquals(PAGE_SIZE + 0, (long) bufferSizes.get(1));
+
+		bufferSizes = drain(linkedStorage2);
+
+		assertEquals(PAGE_SIZE + 1, (long) bufferSizes.get(0));
 
 		assertEquals(0, bufferStorage.getRolledBytes());
 		assertEquals(0, bufferStorage.getPendingBytes());
@@ -114,8 +128,8 @@ public class LinkedBufferStorageTest {
 
 	@Test
 	public void testPendingIsFull() throws IOException {
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE));
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
@@ -135,14 +149,14 @@ public class LinkedBufferStorageTest {
 	 */
 	//@Test
 	public void testRolledIsFull() throws IOException {
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE));
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.rollOver();
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.rollOver();
-		linkedStorage.add(generateRandomBuffer(PAGE_SIZE));
+		linkedStorage1.add(generateRandomBuffer(PAGE_SIZE));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 
 		assertFalse(bufferStorage.isFull());
@@ -153,11 +167,15 @@ public class LinkedBufferStorageTest {
 	}
 
 	private void assertPendingBytes() {
-		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
+		assertEquals(
+			mainStorage.getPendingBytes() + linkedStorage1.getPendingBytes() + linkedStorage2.getPendingBytes(),
+			bufferStorage.getPendingBytes());
 	}
 
 	private void assertRolledBytes() {
-		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
+		assertEquals(
+			mainStorage.getRolledBytes() + linkedStorage1.getRolledBytes() + linkedStorage2.getRolledBytes(),
+			bufferStorage.getRolledBytes());
 	}
 
 	private ArrayList<Integer> drain(BufferStorage bufferStorage) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/LinkedBufferStorageTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/LinkedBufferStorageTest.java
@@ -72,8 +72,8 @@ public class LinkedBufferStorageTest {
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 2));
 
 		assertTrue(bufferStorage.isEmpty());
-		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
-		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
+		assertPendingBytes();
+		assertRolledBytes();
 
 		assertTrue(bufferStorage.isEmpty());
 		assertTrue(linkedStorage.isEmpty());
@@ -83,20 +83,20 @@ public class LinkedBufferStorageTest {
 		assertFalse(bufferStorage.isEmpty());
 		assertFalse(linkedStorage.isEmpty());
 
-		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
-		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
+		assertPendingBytes();
+		assertRolledBytes();
 
 		linkedStorage.add(generateRandomBuffer(PAGE_SIZE + 3));
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE + 4));
 
-		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
-		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
+		assertPendingBytes();
+		assertRolledBytes();
 
 		bufferStorage.rollOver();
 
-		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
-		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
-
+		assertPendingBytes();
+		assertRolledBytes();
+		
 		ArrayList<Integer> bufferSizes = drain(bufferStorage);
 
 		assertEquals(PAGE_SIZE + 4, (long) bufferSizes.get(0));
@@ -150,6 +150,14 @@ public class LinkedBufferStorageTest {
 		bufferStorage.add(generateRandomBuffer(PAGE_SIZE));
 
 		assertTrue(bufferStorage.isFull());
+	}
+
+	private void assertPendingBytes() {
+		assertEquals(mainStorage.getPendingBytes() + linkedStorage.getPendingBytes(), bufferStorage.getPendingBytes());
+	}
+
+	private void assertRolledBytes() {
+		assertEquals(mainStorage.getRolledBytes() + linkedStorage.getRolledBytes(), bufferStorage.getRolledBytes());
 	}
 
 	private ArrayList<Integer> drain(BufferStorage bufferStorage) throws IOException {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.streaming.api.functions.co.CoMapFunction;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.co.CoStreamMap;
+import org.apache.flink.streaming.runtime.io.InputStatus;
+import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestBoundedMultipleInputOperator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link MultipleInputStreamTask}. Theses tests implicitly also test the
+ * {@link StreamMultipleInputProcessor}.
+ */
+public class MultipleInputStreamTaskTest {
+
+	/**
+	 * This test verifies that open() and close() are correctly called. This test also verifies
+	 * that timestamps of emitted elements are correct. {@link CoStreamMap} assigns the input
+	 * timestamp to emitted elements.
+	 */
+	@Test
+	public void testOpenCloseAndTimestamps() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.INT_TYPE_INFO)
+				.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
+				.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperator())
+				.build()) {
+
+			long initialTime = 0L;
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			testHarness.processElement(new StreamRecord<>("Hello", initialTime + 1), 0);
+			expectedOutput.add(new StreamRecord<>("Hello", initialTime + 1));
+			testHarness.processElement(new StreamRecord<>(1337, initialTime + 2), 1);
+			expectedOutput.add(new StreamRecord<>("1337", initialTime + 2));
+			testHarness.processElement(new StreamRecord<>(42.44d, initialTime + 3), 2);
+			expectedOutput.add(new StreamRecord<>("42.44", initialTime + 3));
+
+			testHarness.endInput();
+			testHarness.waitForTaskCompletion();
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+		}
+	}
+
+	/**
+	 * This test verifies that checkpoint barriers are correctly forwarded.
+	 */
+	@Test
+	public void testCheckpointBarriers() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO, 2)
+				.addInput(BasicTypeInfo.INT_TYPE_INFO, 2)
+				.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, 2)
+				.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperator())
+				.build()) {
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+			long initialTime = 0L;
+
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 0);
+
+			// This element should be buffered since we received a checkpoint barrier on this input
+			testHarness.processElement(new StreamRecord<>("Hello-0-0", initialTime), 0, 0);
+			// This one should go through
+			testHarness.processElement(new StreamRecord<>("Ciao-0-0", initialTime), 0, 1);
+			expectedOutput.add(new StreamRecord<>("Ciao-0-0", initialTime));
+
+			// These elements should be forwarded, since we did not yet receive a checkpoint barrier
+			// on that input, only add to same input, otherwise we would not know the ordering
+			// of the output since the Task might read the inputs in any order
+			testHarness.processElement(new StreamRecord<>(11, initialTime), 1, 1);
+			testHarness.processElement(new StreamRecord<>(1.0d, initialTime), 2, 0);
+			expectedOutput.add(new StreamRecord<>("11", initialTime));
+			expectedOutput.add(new StreamRecord<>("1.0", initialTime));
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 1);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 0);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 1);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 0);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 1);
+
+			// now we should see the barrier and after that the buffered elements
+			expectedOutput.add(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()));
+			expectedOutput.add(new StreamRecord<>("Hello-0-0", initialTime));
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+		}
+	}
+
+	/**
+	 * This test verifies that checkpoint barriers and barrier buffers work correctly with
+	 * concurrent checkpoint barriers where one checkpoint is "overtaking" another checkpoint, i.e.
+	 * some inputs receive barriers from an earlier checkpoint, thereby blocking,
+	 * then all inputs receive barriers from a later checkpoint.
+	 */
+	@Test
+	public void testOvertakingCheckpointBarriers() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO, 2)
+				.addInput(BasicTypeInfo.INT_TYPE_INFO, 2)
+				.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, 2)
+				.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperator())
+				.build()) {
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+			long initialTime = 0L;
+
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 0);
+
+			// These elements should be buffered until we receive barriers from
+			// all inputs
+			testHarness.processElement(new StreamRecord<>("Hello-0-0", initialTime), 0, 0);
+			testHarness.processElement(new StreamRecord<>("Ciao-0-0", initialTime), 0, 0);
+
+			// These elements should be forwarded, since we did not yet receive a checkpoint barrier
+			// on that input, only add to same input, otherwise we would not know the ordering
+			// of the output since the Task might read the inputs in any order
+			testHarness.processElement(new StreamRecord<>("Witam-0-1", initialTime), 0, 1);
+			testHarness.processElement(new StreamRecord<>(42, initialTime), 1, 1);
+			testHarness.processElement(new StreamRecord<>(1.0d, initialTime), 2, 1);
+			expectedOutput.add(new StreamRecord<>("Witam-0-1", initialTime));
+			expectedOutput.add(new StreamRecord<>("42", initialTime));
+			expectedOutput.add(new StreamRecord<>("1.0", initialTime));
+
+			// we should not yet see the barrier, only the two elements from non-blocked input
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// Now give a later barrier to all inputs, this should unblock the first channel,
+			// thereby allowing the two blocked elements through
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 0);
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 1);
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 0);
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 1);
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 0);
+			testHarness.processEvent(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 1);
+
+			expectedOutput.add(new CancelCheckpointMarker(0));
+			expectedOutput.add(new StreamRecord<>("Hello-0-0", initialTime));
+			expectedOutput.add(new StreamRecord<>("Ciao-0-0", initialTime));
+			expectedOutput.add(new CheckpointBarrier(1, 1, CheckpointOptions.forCheckpointWithDefaultLocation()));
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// Then give the earlier barrier, these should be ignored
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 0, 1);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 0);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 1, 1);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 0);
+			testHarness.processEvent(new CheckpointBarrier(0, 0, CheckpointOptions.forCheckpointWithDefaultLocation()), 2, 1);
+
+			testHarness.waitForTaskCompletion();
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+		}
+	}
+
+	@Test
+	public void testOperatorMetricReuse() throws Exception {
+
+		TaskMetricGroup taskMetricGroup = new UnregisteredMetricGroups.UnregisteredTaskMetricGroup() {
+			@Override
+			public OperatorMetricGroup getOrAddOperator(OperatorID operatorID, String name) {
+				return new OperatorMetricGroup(NoOpMetricRegistry.INSTANCE, this, operatorID, name);
+			}
+		};
+
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.setupOperatorChain(new DuplicatingOperator())
+				.chain(new OneInputStreamTaskTest.DuplicatingOperator(), BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+				.chain(new OneInputStreamTaskTest.DuplicatingOperator(), BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+				.finish()
+				.setTaskMetricGroup(taskMetricGroup)
+				.build()) {
+			Counter numRecordsInCounter = taskMetricGroup.getIOMetricGroup().getNumRecordsInCounter();
+			Counter numRecordsOutCounter = taskMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
+
+			int numRecords1 = 5;
+			int numRecords2 = 3;
+			int numRecords3 = 2;
+			for (int x = 0; x < numRecords1; x++) {
+				testHarness.processElement(new StreamRecord<>("hello"), 0, 0);
+			}
+			for (int x = 0; x < numRecords2; x++) {
+				testHarness.processElement(new StreamRecord<>("hello"), 1, 0);
+			}
+			for (int x = 0; x < numRecords3; x++) {
+				testHarness.processElement(new StreamRecord<>("hello"), 2, 0);
+			}
+
+			int totalRecords = numRecords1 + numRecords2 + numRecords3;
+			assertEquals(totalRecords, numRecordsInCounter.getCount());
+			assertEquals((totalRecords) * 2 * 2 * 2, numRecordsOutCounter.getCount());
+			testHarness.waitForTaskCompletion();
+		}
+	}
+
+	static class DuplicatingOperator extends AbstractStreamOperator<String>
+		implements MultipleInputStreamOperator<String> {
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(new DuplicatingInput(), new DuplicatingInput(), new DuplicatingInput());
+		}
+
+		class DuplicatingInput implements Input<String> {
+			@Override
+			public void processElement(StreamRecord<String> element) throws Exception {
+				output.collect(element);
+				output.collect(element);
+			}
+		}
+	}
+
+	@Test
+	public void testClosingAllOperatorsOnChainProperly() throws Exception {
+		StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.setupOperatorChain(new TestBoundedMultipleInputOperator("Operator0"))
+				.chain(new TestBoundedOneInputStreamOperator("Operator1"), BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+				.finish()
+				.build();
+
+		ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+		try {
+			testHarness.processElement(new StreamRecord<>("Hello-1"), 0);
+			testHarness.endInput(0);
+			testHarness.process();
+
+			testHarness.processElement(new StreamRecord<>("Hello-2"), 1);
+			testHarness.processElement(new StreamRecord<>("Hello-3"), 2);
+			testHarness.endInput(1);
+			testHarness.process();
+			testHarness.endInput(2);
+			testHarness.process();
+			assertEquals(
+				true,
+				testHarness.getStreamTask().getInputOutputJointFuture(InputStatus.NOTHING_AVAILABLE).isDone());
+
+			testHarness.waitForTaskCompletion();
+		}
+		finally {
+			testHarness.close();
+		}
+
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-1]: End of input"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-3]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-2]: End of input"));
+		expectedOutput.add(new StreamRecord<>("[Operator0-3]: End of input"));
+		expectedOutput.add(new StreamRecord<>("[Operator0]: Bye"));
+		expectedOutput.add(new StreamRecord<>("[Operator1]: End of input"));
+		expectedOutput.add(new StreamRecord<>("[Operator1]: Bye"));
+
+		assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+	}
+
+	@Test
+	public void testInputFairness() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperator())
+					.build()) {
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			testHarness.setAutoProcess(false);
+			testHarness.processElement(new StreamRecord<>("0"), 0);
+			testHarness.processElement(new StreamRecord<>("1"), 0);
+			testHarness.processElement(new StreamRecord<>("2"), 0);
+			testHarness.processElement(new StreamRecord<>("3"), 0);
+
+			testHarness.processElement(new StreamRecord<>("0"), 2);
+			testHarness.processElement(new StreamRecord<>("1"), 2);
+
+			testHarness.process();
+
+			// We do not know which of the input will be picked first, but we are expecting them
+			// to alternate
+			// NOTE: the behaviour of alternation once per record is not part of any contract.
+			// Task is just expected to not starve any of the inputs, it just happens to be
+			// currently implemented in truly "fair" fashion. That means this test might need
+			// to be adjusted if logic changes.
+			expectedOutput.add(new StreamRecord<>("0"));
+			expectedOutput.add(new StreamRecord<>("0"));
+			expectedOutput.add(new StreamRecord<>("1"));
+			expectedOutput.add(new StreamRecord<>("1"));
+			expectedOutput.add(new StreamRecord<>("2"));
+			expectedOutput.add(new StreamRecord<>("3"));
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+		}
+	}
+
+	// This must only be used in one test, otherwise the static fields will be changed
+	// by several tests concurrently
+	private static class MapToStringMultipleInputOperator
+			extends AbstractStreamOperator<String> implements MultipleInputStreamOperator<String> {
+		private static final long serialVersionUID = 1L;
+
+		private boolean openCalled;
+		private boolean closeCalled;
+
+		@Override
+		public void open() throws Exception {
+			super.open();
+			if (closeCalled) {
+				Assert.fail("Close called before open.");
+			}
+			openCalled = true;
+		}
+
+		@Override
+		public void close() throws Exception {
+			super.close();
+			if (!openCalled) {
+				Assert.fail("Open was not called before close.");
+			}
+			closeCalled = true;
+		}
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new MapToStringInput<String>(),
+				new MapToStringInput<Integer>(),
+				new MapToStringInput<Double>());
+		}
+
+		public boolean wasCloseCalled() {
+			return closeCalled;
+		}
+
+		public class MapToStringInput<T> implements Input<T> {
+			@Override
+			public void processElement(StreamRecord<T> element) throws Exception {
+				if (!openCalled) {
+					Assert.fail("Open was not called before run.");
+				}
+				if (element.hasTimestamp()) {
+					output.collect(new StreamRecord<>(element.getValue().toString(), element.getTimestamp()));
+				}
+				else {
+					output.collect(new StreamRecord<>(element.getValue().toString()));
+				}
+			}
+		}
+	}
+
+	private static class IdentityMap implements CoMapFunction<String, Integer, String> {
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public String map1(String value) {
+			return value;
+		}
+
+		@Override
+		public String map2(Integer value) {
+
+			return value.toString();
+		}
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Builder to create a {@link StreamTaskMailboxTestHarness} to test {@link MultipleInputStreamTask}.
+ */
+public class MultipleInputStreamTaskTestHarnessBuilder<OUT> extends StreamTaskMailboxTestHarnessBuilder<OUT> {
+
+	private final ArrayList<TypeSerializer<?>> inputSerializers = new ArrayList<>();
+	private final ArrayList<Integer> inputChannelsPerGate = new ArrayList<>();
+
+	public MultipleInputStreamTaskTestHarnessBuilder(
+			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+			TypeInformation<OUT> outputType) {
+		super(taskFactory, outputType);
+	}
+
+	public MultipleInputStreamTaskTestHarnessBuilder<OUT> addInput(TypeInformation<?> inputType) {
+		return addInput(inputType, 1);
+	}
+
+	public MultipleInputStreamTaskTestHarnessBuilder<OUT> addInput(TypeInformation<?> inputType, int inputChannels) {
+		inputSerializers.add(inputType.createSerializer(executionConfig));
+		inputChannelsPerGate.add(inputChannels);
+		return this;
+	}
+
+	@Override
+	protected void initializeInputs(StreamMockEnvironment streamMockEnvironment) {
+		inputGates = new StreamTestSingleInputGate[inputSerializers.size()];
+		List<StreamEdge> inPhysicalEdges = new LinkedList<>();
+
+		StreamOperator<?> dummyOperator = new AbstractStreamOperator<Object>() {
+			private static final long serialVersionUID = 1L;
+		};
+
+		StreamNode sourceVertexDummy = new StreamNode(0, "default group", null, dummyOperator, "source dummy", new LinkedList<>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(1, "default group", null, dummyOperator, "target dummy", new LinkedList<>(), SourceStreamTask.class);
+
+		for (int i = 0; i < inputSerializers.size(); i++) {
+			TypeSerializer<?> inputSerializer = inputSerializers.get(i);
+			inputGates[i] = new StreamTestSingleInputGate<>(
+					inputChannelsPerGate.get(i),
+					bufferSize,
+					inputSerializer);
+
+			StreamEdge streamEdge = new StreamEdge(
+				sourceVertexDummy,
+				targetVertexDummy,
+				i + 1,
+				new LinkedList<>(),
+				new BroadcastPartitioner<>(),
+				null);
+
+			inPhysicalEdges.add(streamEdge);
+			streamMockEnvironment.addInputGate(inputGates[i].getInputGate());
+		}
+
+		streamConfig.setInPhysicalEdges(inPhysicalEdges);
+		streamConfig.setNumberOfInputs(inputGates.length);
+		streamConfig.setTypeSerializersIn(inputSerializers.toArray(new TypeSerializer[inputSerializers.size()]));
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -133,7 +133,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 		}
 
 		streamConfig.setNumberOfInputs(1);
-		streamConfig.setTypeSerializerIn1(inputSerializer);
+		streamConfig.setTypeSerializersIn(inputSerializer);
 	}
 
 	public <K> void configureForKeyedStream(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.function.Function;
 
 
@@ -121,7 +120,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	}
 
 	@Override
-	protected void initializeInputs() throws IOException, InterruptedException {
+	protected void initializeInputs() {
 		inputGates = new StreamTestSingleInputGate[numInputGates];
 
 		for (int i = 0; i < numInputGates; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -121,7 +121,7 @@ public class StreamConfigChainer {
 		tailConfig = new StreamConfig(new Configuration());
 		tailConfig.setStreamOperatorFactory(checkNotNull(operatorFactory));
 		tailConfig.setOperatorID(checkNotNull(operatorID));
-		tailConfig.setTypeSerializerIn1(inputSerializer);
+		tailConfig.setTypeSerializersIn(inputSerializer);
 		tailConfig.setTypeSerializerOut(outputSerializer);
 		if (createKeyedStateBackend) {
 			// used to test multiple stateful operators chained in a single task.

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -42,7 +42,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Helper class to build StreamConfig for chain of operators.
  */
-public class StreamConfigChainer {
+public class StreamConfigChainer<OWNER> {
+	private final OWNER owner;
 	private final StreamConfig headConfig;
 	private final Map<Integer, StreamConfig> chainedConfigs = new HashMap<>();
 	private final long bufferTimeout;
@@ -50,7 +51,8 @@ public class StreamConfigChainer {
 	private StreamConfig tailConfig;
 	private int chainIndex = 0;
 
-	StreamConfigChainer(OperatorID headOperatorID, StreamConfig headConfig) {
+	StreamConfigChainer(OperatorID headOperatorID, StreamConfig headConfig, OWNER owner) {
+		this.owner = checkNotNull(owner);
 		this.headConfig = checkNotNull(headConfig);
 		this.tailConfig = checkNotNull(headConfig);
 		this.bufferTimeout = headConfig.getBufferTimeout();
@@ -65,7 +67,7 @@ public class StreamConfigChainer {
 		headConfig.setBufferTimeout(bufferTimeout);
 	}
 
-	public <T> StreamConfigChainer chain(
+	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<T, T> operator,
 			TypeSerializer<T> typeSerializer,
@@ -73,21 +75,33 @@ public class StreamConfigChainer {
 		return chain(operatorID, operator, typeSerializer, typeSerializer, createKeyedStateBackend);
 	}
 
-	public <T> StreamConfigChainer chain(
+	public <T> StreamConfigChainer<OWNER> chain(
+			OneInputStreamOperator<T, T> operator,
+			TypeSerializer<T> typeSerializer) {
+		return chain(new OperatorID(), operator, typeSerializer);
+	}
+
+	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<T, T> operator,
 			TypeSerializer<T> typeSerializer) {
 		return chain(operatorID, operator, typeSerializer, typeSerializer, false);
 	}
 
-	public <T> StreamConfigChainer chain(
+	public <T> StreamConfigChainer<OWNER> chain(
+			OneInputStreamOperatorFactory<T, T> operatorFactory,
+			TypeSerializer<T> typeSerializer) {
+		return chain(new OperatorID(), operatorFactory, typeSerializer);
+	}
+
+	public <T> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperatorFactory<T, T> operatorFactory,
 			TypeSerializer<T> typeSerializer) {
 		return chain(operatorID, operatorFactory, typeSerializer, typeSerializer, false);
 	}
 
-	private <IN, OUT> StreamConfigChainer chain(
+	private <IN, OUT> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			OneInputStreamOperator<IN, OUT> operator,
 			TypeSerializer<IN> inputSerializer,
@@ -101,7 +115,7 @@ public class StreamConfigChainer {
 			createKeyedStateBackend);
 	}
 
-	public <IN, OUT> StreamConfigChainer chain(
+	public <IN, OUT> StreamConfigChainer<OWNER> chain(
 			OperatorID operatorID,
 			StreamOperatorFactory<OUT> operatorFactory,
 			TypeSerializer<IN> inputSerializer,
@@ -135,7 +149,7 @@ public class StreamConfigChainer {
 		return this;
 	}
 
-	public void finish() {
+	public OWNER finish() {
 		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
 		outEdgesInOrder.add(
 			new StreamEdge(
@@ -153,5 +167,7 @@ public class StreamConfigChainer {
 		tailConfig.setNonChainedOutputs(outEdgesInOrder);
 		headConfig.setTransitiveChainedTaskConfigs(chainedConfigs);
 		headConfig.setOutEdgesInOrder(outEdgesInOrder);
+
+		return owner;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.memory.MemoryManager;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+
+import java.util.Collections;
+import java.util.Queue;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test harness for testing a {@link StreamTask}.
+ *
+ * <p>This mock Invokable provides the task with a basic runtime context and allows pushing elements
+ * and watermarks into the task. {@link #getOutput()} can be used to get the emitted elements
+ * and events. You are free to modify the retrieved list.
+ */
+public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
+	protected final StreamTask<OUT, ?> streamTask;
+	protected final StreamMockEnvironment streamMockEnvironment;
+	protected TestTaskStateManager taskStateManager;
+	protected final Queue<Object> outputList;
+	protected final StreamTestSingleInputGate[] inputGates;
+	protected final boolean[] inputGateEnded;
+
+	private boolean autoProcess = true;
+
+	StreamTaskMailboxTestHarness(
+			StreamTask<OUT, ?> streamTask,
+			Queue<Object> outputList,
+			LocalRecoveryConfig localRecoveryConfig,
+			StreamTestSingleInputGate[] inputGates,
+			StreamMockEnvironment streamMockEnvironment) {
+		this.streamTask = checkNotNull(streamTask);
+		this.taskStateManager = new TestTaskStateManager(checkNotNull(localRecoveryConfig));
+		this.inputGates = checkNotNull(inputGates);
+		this.outputList = checkNotNull(outputList);
+		this.streamMockEnvironment = checkNotNull(streamMockEnvironment);
+		this.inputGateEnded = new boolean[inputGates.length];
+	}
+
+	public TestTaskStateManager getTaskStateManager() {
+		return taskStateManager;
+	}
+
+	public void setTaskStateSnapshot(long checkpointId, TaskStateSnapshot taskStateSnapshot) {
+		taskStateManager.setReportedCheckpointId(checkpointId);
+		taskStateManager.setJobManagerTaskStateSnapshotsByCheckpointId(
+			Collections.singletonMap(checkpointId, taskStateSnapshot));
+	}
+
+	public StreamTask<OUT, ?> getStreamTask() {
+		return streamTask;
+	}
+
+	/**
+	 * Get all the output from the task. This contains StreamRecords and Events interleaved. Use
+	 * {@link org.apache.flink.streaming.util.TestHarnessUtil#getRawElementsFromOutput(java.util.Queue)}}
+	 * to extract only the StreamRecords.
+	 */
+	public Queue<Object> getOutput() {
+		return outputList;
+	}
+
+	@SuppressWarnings("unchecked")
+	public void processElement(Object element) throws Exception {
+		processElement(element, 0);
+	}
+
+	@SuppressWarnings("unchecked")
+	public void processElement(Object element, int inputGate) throws Exception {
+		processElement(element, inputGate, 0);
+	}
+
+	@SuppressWarnings("unchecked")
+	public void processElement(Object element, int inputGate, int channel) throws Exception {
+		inputGates[inputGate].sendElement(element, channel);
+		maybeProcess();
+	}
+
+	public void processEvent(AbstractEvent event) throws Exception {
+		processEvent(event, 0, 0);
+	}
+
+	public void processEvent(AbstractEvent event, int inputGate, int channel) throws Exception {
+		inputGates[inputGate].sendEvent(event, channel);
+		maybeProcess();
+	}
+
+	private void maybeProcess() throws Exception {
+		if (autoProcess) {
+			process();
+		}
+	}
+
+	public void process() throws Exception {
+		while (streamTask.inputProcessor.isAvailable() && streamTask.mailboxProcessor.isMailboxLoopRunning()) {
+			streamTask.runMailboxStep();
+		}
+	}
+
+	public void endInput() {
+		for (int i = 0; i < inputGates.length; i++) {
+			endInput(i);
+		}
+	}
+
+	public void endInput(int inputIndex) {
+		if (!inputGateEnded[inputIndex]) {
+			inputGates[inputIndex].endInput();
+			inputGateEnded[inputIndex] = true;
+		}
+	}
+
+	public void waitForTaskCompletion() throws Exception {
+		endInput();
+		while (streamTask.runMailboxStep()) {
+		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		streamTask.cancel();
+
+		streamTask.afterInvoke();
+		streamTask.cleanUpInvoke();
+
+		streamMockEnvironment.getIOManager().close();
+		MemoryManager memMan = this.streamMockEnvironment.getMemoryManager();
+		if (memMan != null) {
+			assertTrue("Memory Manager managed memory was not completely freed.", memMan.verifyEmpty());
+			memMan.shutdown();
+		}
+	}
+
+	public void setAutoProcess(boolean autoProcess) {
+		this.autoProcess = autoProcess;
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -102,7 +102,11 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 	}
 
 	public void processEvent(AbstractEvent event) throws Exception {
-		processEvent(event, 0, 0);
+		processEvent(event, 0);
+	}
+
+	public void processEvent(AbstractEvent event, int inputGate) throws Exception {
+		processEvent(event, inputGate, 0);
 	}
 
 	public void processEvent(AbstractEvent event, int inputGate, int channel) throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.state.LocalRecoveryConfig;
+import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.collector.selector.OutputSelector;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.graph.StreamEdge;
+import org.apache.flink.streaming.api.graph.StreamNode;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.function.Function;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Builder class for {@link StreamTaskMailboxTestHarness}.
+ */
+public abstract class StreamTaskMailboxTestHarnessBuilder<OUT> {
+	protected final Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory;
+	protected final TypeSerializer<OUT> outputSerializer;
+	protected final ExecutionConfig executionConfig = new ExecutionConfig();
+
+	protected long memorySize = 1024 * 1024;
+	protected int bufferSize = 1024;
+	protected long bufferTimeout = 0;
+	protected Configuration jobConfig = new Configuration();
+	protected Configuration taskConfig = new Configuration();
+	protected StreamConfig streamConfig = new StreamConfig(taskConfig);
+	protected LocalRecoveryConfig localRecoveryConfig = TestLocalRecoveryConfig.disabled();
+	@Nullable
+	protected StreamTestSingleInputGate[] inputGates;
+	protected TaskMetricGroup taskMetricGroup = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
+
+	private boolean setupCalled = false;
+
+	public StreamTaskMailboxTestHarnessBuilder(
+			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+			TypeInformation<OUT> outputType) {
+		this.taskFactory = checkNotNull(taskFactory);
+		outputSerializer = outputType.createSerializer(executionConfig);
+	}
+
+	public StreamTaskMailboxTestHarness<OUT> build() throws Exception {
+		streamConfig.setBufferTimeout(bufferTimeout);
+
+		TestTaskStateManager taskStateManager = new TestTaskStateManager(localRecoveryConfig);
+
+		StreamMockEnvironment streamMockEnvironment = new StreamMockEnvironment(
+			jobConfig,
+			taskConfig,
+			executionConfig,
+			memorySize,
+			new MockInputSplitProvider(),
+			bufferSize,
+			taskStateManager);
+
+		initializeInputs(streamMockEnvironment);
+
+		checkState(inputGates != null, "InputGates hasn't been initialised");
+
+		StreamElementSerializer<OUT> outputStreamRecordSerializer = new StreamElementSerializer<>(outputSerializer);
+
+		Queue<Object> outputList = new ArrayDeque<>();
+		streamMockEnvironment.addOutput(outputList, outputStreamRecordSerializer);
+		streamMockEnvironment.setTaskMetricGroup(taskMetricGroup);
+
+		StreamTask<OUT, ?> task = taskFactory.apply(streamMockEnvironment);
+		task.beforeInvoke();
+
+		return new StreamTaskMailboxTestHarness<>(
+			task,
+			outputList,
+			localRecoveryConfig,
+			inputGates,
+			streamMockEnvironment);
+	}
+
+	protected abstract void initializeInputs(StreamMockEnvironment streamMockEnvironment);
+
+	public StreamTaskMailboxTestHarnessBuilder<OUT> setupOutputForSingletonOperatorChain(StreamOperator<?> operator) {
+		return setupOutputForSingletonOperatorChain(SimpleOperatorFactory.of(operator));
+	}
+
+	/**
+	 * Users of the test harness can call this utility method to setup the stream config
+	 * if there will only be a single operator to be tested. The method will setup the
+	 * outgoing network connection for the operator.
+	 *
+	 * <p>For more advanced test cases such as testing chains of multiple operators with the harness,
+	 * please manually configure the stream config.
+	 */
+	public StreamTaskMailboxTestHarnessBuilder<OUT> setupOutputForSingletonOperatorChain(StreamOperatorFactory<?> factory) {
+		checkState(!setupCalled, "This harness was already setup.");
+		setupCalled = true;
+		streamConfig.setChainStart();
+		streamConfig.setTimeCharacteristic(TimeCharacteristic.EventTime);
+		streamConfig.setOutputSelectors(Collections.<OutputSelector<?>>emptyList());
+		streamConfig.setNumberOfOutputs(1);
+		streamConfig.setTypeSerializerOut(outputSerializer);
+		streamConfig.setVertexID(0);
+		streamConfig.setOperatorID(new OperatorID(4711L, 123L));
+
+		StreamOperator<OUT> dummyOperator = new AbstractStreamOperator<OUT>() {
+			private static final long serialVersionUID = 1L;
+		};
+
+		List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
+		StreamNode sourceVertexDummy = new StreamNode(0, "group", null, dummyOperator, "source dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+		StreamNode targetVertexDummy = new StreamNode(1, "group", null, dummyOperator, "target dummy", new LinkedList<OutputSelector<?>>(), SourceStreamTask.class);
+
+		outEdgesInOrder.add(new StreamEdge(sourceVertexDummy, targetVertexDummy, 0, new LinkedList<String>(), new BroadcastPartitioner<Object>(), null /* output tag */));
+
+		streamConfig.setOutEdgesInOrder(outEdgesInOrder);
+		streamConfig.setNonChainedOutputs(outEdgesInOrder);
+
+		streamConfig.setStreamOperatorFactory(factory);
+		streamConfig.setOperatorID(new OperatorID());
+
+		return this;
+	}
+
+	public StreamConfigChainer<StreamTaskMailboxTestHarnessBuilder<OUT>> setupOperatorChain(StreamOperator<?> headOperator) {
+		return setupOperatorChain(new OperatorID(), headOperator);
+	}
+
+	public StreamConfigChainer<StreamTaskMailboxTestHarnessBuilder<OUT>> setupOperatorChain(OperatorID headOperatorId, StreamOperator<?> headOperator) {
+		return setupOperatorChain(headOperatorId, SimpleOperatorFactory.of(headOperator));
+	}
+
+	public StreamConfigChainer<StreamTaskMailboxTestHarnessBuilder<OUT>> setupOperatorChain(StreamOperatorFactory<?> headOperatorFactory) {
+		return setupOperatorChain(new OperatorID(), headOperatorFactory);
+	}
+
+	public StreamConfigChainer<StreamTaskMailboxTestHarnessBuilder<OUT>> setupOperatorChain(OperatorID headOperatorId, StreamOperatorFactory<?> headOperatorFactory) {
+		checkState(!setupCalled, "This harness was already setup.");
+		setupCalled = true;
+		streamConfig.setStreamOperatorFactory(headOperatorFactory);
+		return new StreamConfigChainer<>(headOperatorId, streamConfig, this);
+	}
+
+	public StreamTaskMailboxTestHarnessBuilder<OUT> setTaskMetricGroup(TaskMetricGroup taskMetricGroup) {
+		this.taskMetricGroup = taskMetricGroup;
+		return this;
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -941,7 +941,7 @@ public class StreamTaskTest extends TestLogger {
 		streamConfig.setStreamOperatorFactory(new UnusedOperatorFactory());
 
 		// Make sure that there is some output edge in the config so that some RecordWriter is created
-		StreamConfigChainer cfg = new StreamConfigChainer(new OperatorID(42, 42), streamConfig);
+		StreamConfigChainer cfg = new StreamConfigChainer(new OperatorID(42, 42), streamConfig, this);
 		cfg.chain(
 			new OperatorID(44, 44),
 			new UnusedOperatorFactory(),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -80,7 +80,10 @@ import static org.apache.flink.util.Preconditions.checkState;
  * <p>After setting up everything the Task can be invoked using {@link #invoke()}. This will start
  * a new Thread to execute the Task. Use {@link #waitForTaskCompletion()} to wait for the Task
  * thread to finish.
+ *
+ * <p>This class id deprecated because of it's threading model. Please use {@link StreamTaskMailboxTestHarness}
  */
+@Deprecated
 public class StreamTaskTestHarness<OUT> {
 
 	public static final int DEFAULT_MEMORY_MANAGER_SIZE = 1024 * 1024;
@@ -422,16 +425,16 @@ public class StreamTaskTestHarness<OUT> {
 		inputGates[gateIndex].sendEvent(EndOfPartitionEvent.INSTANCE, channelIndex);
 	}
 
-	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, StreamOperator<?> headOperator) {
+	public StreamConfigChainer<StreamTaskTestHarness<OUT>> setupOperatorChain(OperatorID headOperatorId, StreamOperator<?> headOperator) {
 		return setupOperatorChain(headOperatorId, SimpleOperatorFactory.of(headOperator));
 	}
 
-	public StreamConfigChainer setupOperatorChain(OperatorID headOperatorId, StreamOperatorFactory<?> headOperatorFactory) {
+	public StreamConfigChainer<StreamTaskTestHarness<OUT>> setupOperatorChain(OperatorID headOperatorId, StreamOperatorFactory<?> headOperatorFactory) {
 		Preconditions.checkState(!setupCalled, "This harness was already setup.");
 		setupCalled = true;
 		StreamConfig streamConfig = getStreamConfig();
 		streamConfig.setStreamOperatorFactory(headOperatorFactory);
-		return new StreamConfigChainer(headOperatorId, streamConfig);
+		return new StreamConfigChainer(headOperatorId, streamConfig, this);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -28,7 +28,6 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 
-import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
@@ -102,7 +101,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 	}
 
 	@Override
-	protected void initializeInputs() throws IOException, InterruptedException {
+	protected void initializeInputs() {
 
 		inputGates = new StreamTestSingleInputGate[numInputGates];
 		List<StreamEdge> inPhysicalEdges = new LinkedList<>();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -158,8 +158,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 
 		streamConfig.setInPhysicalEdges(inPhysicalEdges);
 		streamConfig.setNumberOfInputs(numInputGates);
-		streamConfig.setTypeSerializerIn1(inputSerializer1);
-		streamConfig.setTypeSerializerIn2(inputSerializer2);
+		streamConfig.setTypeSerializersIn(inputSerializer1, inputSerializer2);
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -47,7 +47,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 			TypeSerializer<IN> typeSerializerIn) throws Exception {
 		this(operator, 1, 1, 0);
 
-		config.setTypeSerializerIn1(Preconditions.checkNotNull(typeSerializerIn));
+		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
 	public OneInputStreamOperatorTestHarness(
@@ -59,7 +59,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 		OperatorID operatorID) throws Exception {
 		this(operator, maxParallelism, parallelism, subtaskIndex, operatorID);
 
-		config.setTypeSerializerIn1(Preconditions.checkNotNull(typeSerializerIn));
+		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
 	public OneInputStreamOperatorTestHarness(
@@ -68,7 +68,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 		MockEnvironment environment) throws Exception {
 		this(operator, environment);
 
-		config.setTypeSerializerIn1(Preconditions.checkNotNull(typeSerializerIn));
+		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
 	public OneInputStreamOperatorTestHarness(OneInputStreamOperator<IN, OUT> operator) throws Exception {
@@ -108,7 +108,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 			MockEnvironment environment) throws Exception {
 		this(factory, environment);
 
-		config.setTypeSerializerIn1(Preconditions.checkNotNull(typeSerializerIn));
+		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
 	public OneInputStreamOperatorTestHarness(
@@ -122,7 +122,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 			TypeSerializer<IN> typeSerializerIn) throws Exception {
 		this(factory, 1, 1, 0);
 
-		config.setTypeSerializerIn1(Preconditions.checkNotNull(typeSerializerIn));
+		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
 	public OneInputStreamOperatorTestHarness(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedMultipleInputOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedMultipleInputOperator.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A test operator class implementing {@link BoundedMultiInput}.
+ */
+public class TestBoundedMultipleInputOperator extends AbstractStreamOperator<String>
+	implements MultipleInputStreamOperator<String>, BoundedMultiInput {
+
+	private static final long serialVersionUID = 1L;
+
+	private final String name;
+
+	public TestBoundedMultipleInputOperator(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public List<Input> getInputs() {
+		return Arrays.asList(
+			new TestInput(1),
+			new TestInput(2),
+			new TestInput(3)
+		);
+	}
+
+	@Override
+	public void endInput(int inputId) {
+		output.collect(new StreamRecord<>("[" + name + "-" + inputId + "]: End of input"));
+	}
+
+	@Override
+	public void close() throws Exception {
+		output.collect(new StreamRecord<>("[" + name + "]: Bye"));
+		super.close();
+	}
+
+	class TestInput implements Input<String> {
+		private final int inputIndex;
+
+		public TestInput(int inputIndex) {
+			this.inputIndex = inputIndex;
+		}
+
+		@Override
+		public void processElement(StreamRecord<String> element) throws Exception {
+			output.collect(element.replace("[" + name + "-" + inputIndex + "]: " + element.getValue()));
+		}
+	}
+}

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/DataStreamTest.scala
@@ -117,10 +117,10 @@ class DataStreamTest extends AbstractTestBase {
     val gid2 = createDownStreamId(group2)
     val gid3 = createDownStreamId(group3)
     val gid4 = createDownStreamId(group4)
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid1)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid2)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid3)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, gid4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, gid1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, gid2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, gid3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, gid4)))
 
     //Testing DataStream partitioning
     val partition1: DataStream[_] = src1.keyBy(0)
@@ -133,10 +133,10 @@ class DataStreamTest extends AbstractTestBase {
     val pid3 = createDownStreamId(partition3)
     val pid4 = createDownStreamId(partition4)
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid1)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid2)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid3)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, pid4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, pid1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, pid2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, pid3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, pid4)))
 
     // Testing DataStream custom partitioning
     val longPartitioner: Partitioner[Long] = new Partitioner[Long] {
@@ -153,9 +153,9 @@ class DataStreamTest extends AbstractTestBase {
     val cpid1 = createDownStreamId(customPartition1)
     val cpid2 = createDownStreamId(customPartition3)
     val cpid3 = createDownStreamId(customPartition4)
-    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid1)))
-    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid2)))
-    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, cpid3)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, cpid1)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, cpid2)))
+    assert(isCustomPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, cpid3)))
 
     //Testing ConnectedStreams grouping
     val connectedGroup1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
@@ -174,20 +174,20 @@ class DataStreamTest extends AbstractTestBase {
     val connectedGroup5: ConnectedStreams[_, _] = connected.keyBy(x => x._1, x => x._1)
     val downStreamId5: Integer = createDownStreamId(connectedGroup5)
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId1)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId1)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId1)))
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId2)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId2)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId2)))
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId3)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId3)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId3)))
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId4)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId4)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId4)))
 
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, downStreamId5)))
-    assert(isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, downStreamId5)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, downStreamId5)))
+    assert(isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, downStreamId5)))
 
     //Testing ConnectedStreams partitioning
     val connectedPartition1: ConnectedStreams[_, _] = connected.keyBy(0, 0)
@@ -209,38 +209,38 @@ class DataStreamTest extends AbstractTestBase {
     val connectDownStreamId5: Integer = createDownStreamId(connectedPartition5)
 
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId1))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId1))
     )
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId1))
-    )
-
-    assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId2))
-    )
-    assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId2))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, connectDownStreamId1))
     )
 
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId3))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId2))
     )
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId3))
-    )
-
-    assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId4))
-    )
-    assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId4))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, connectDownStreamId2))
     )
 
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src1.getId, connectDownStreamId5))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId3))
     )
     assert(
-      isPartitioned(getStreamGraph(env).getStreamEdges(src2.getId, connectDownStreamId5))
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, connectDownStreamId3))
+    )
+
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId4))
+    )
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, connectDownStreamId4))
+    )
+
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src1.getId, connectDownStreamId5))
+    )
+    assert(
+      isPartitioned(getStreamGraph(env).getStreamEdgesOrThrow(src2.getId, connectDownStreamId5))
     )
   }
 
@@ -541,7 +541,7 @@ class DataStreamTest extends AbstractTestBase {
         (in, state: Option[Long]) => (false, None))
    
     try {
-      getStreamGraph(env).getStreamEdges(map.getId, unionFilter.getId)
+      getStreamGraph(env).getStreamEdgesOrThrow(map.getId, unionFilter.getId)
     }
     catch {
       case e: Throwable => {
@@ -550,7 +550,7 @@ class DataStreamTest extends AbstractTestBase {
     }
 
     try {
-      getStreamGraph(env).getStreamEdges(flatMap.getId, unionFilter.getId)
+      getStreamGraph(env).getStreamEdgesOrThrow(flatMap.getId, unionFilter.getId)
     }
     catch {
       case e: Throwable => {
@@ -577,11 +577,11 @@ class DataStreamTest extends AbstractTestBase {
     val select = split.select("a")
     val sink = select.print()
     val splitEdge =
-      getStreamGraph(env).getStreamEdges(unionFilter.getId, sink.getTransformation.getId)
+      getStreamGraph(env).getStreamEdgesOrThrow(unionFilter.getId, sink.getTransformation.getId)
     assert("a" == splitEdge.get(0).getSelectedNames.get(0))
 
     val sinkWithIdentifier = select.print("identifier")
-    val newSplitEdge = getStreamGraph(env).getStreamEdges(
+    val newSplitEdge = getStreamGraph(env).getStreamEdgesOrThrow(
       unionFilter.getId,
       sinkWithIdentifier.getTransformation.getId)
     assert("a" == newSplitEdge.get(0).getSelectedNames.get(0))
@@ -608,7 +608,7 @@ class DataStreamTest extends AbstractTestBase {
     assert(coMapFunction == getFunctionForDataStream(coMap))
 
     try {
-      getStreamGraph(env).getStreamEdges(fold.getId, coMap.getId)
+      getStreamGraph(env).getStreamEdgesOrThrow(fold.getId, coMap.getId)
     }
     catch {
       case e: Throwable => {
@@ -616,7 +616,7 @@ class DataStreamTest extends AbstractTestBase {
       }
     }
     try {
-      getStreamGraph(env).getStreamEdges(flatMap.getId, coMap.getId)
+      getStreamGraph(env).getStreamEdgesOrThrow(flatMap.getId, coMap.getId)
     }
     catch {
       case e: Throwable => {
@@ -634,31 +634,31 @@ class DataStreamTest extends AbstractTestBase {
     val broadcast = src.broadcast
     val broadcastSink = broadcast.print()
     val broadcastPartitioner = getStreamGraph(env)
-      .getStreamEdges(src.getId, broadcastSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdgesOrThrow(src.getId, broadcastSink.getTransformation.getId).get(0).getPartitioner
     assert(broadcastPartitioner.isInstanceOf[BroadcastPartitioner[_]])
 
     val shuffle: DataStream[Long] = src.shuffle
     val shuffleSink = shuffle.print()
     val shufflePartitioner = getStreamGraph(env)
-      .getStreamEdges(src.getId, shuffleSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdgesOrThrow(src.getId, shuffleSink.getTransformation.getId).get(0).getPartitioner
     assert(shufflePartitioner.isInstanceOf[ShufflePartitioner[_]])
 
     val forward: DataStream[Long] = src.forward
     val forwardSink = forward.print()
     val forwardPartitioner = getStreamGraph(env)
-      .getStreamEdges(src.getId, forwardSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdgesOrThrow(src.getId, forwardSink.getTransformation.getId).get(0).getPartitioner
     assert(forwardPartitioner.isInstanceOf[ForwardPartitioner[_]])
 
     val rebalance: DataStream[Long] = src.rebalance
     val rebalanceSink = rebalance.print()
     val rebalancePartitioner = getStreamGraph(env)
-      .getStreamEdges(src.getId, rebalanceSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdgesOrThrow(src.getId, rebalanceSink.getTransformation.getId).get(0).getPartitioner
     assert(rebalancePartitioner.isInstanceOf[RebalancePartitioner[_]])
 
     val global: DataStream[Long] = src.global
     val globalSink = global.print()
     val globalPartitioner = getStreamGraph(env)
-      .getStreamEdges(src.getId, globalSink.getTransformation.getId).get(0).getPartitioner
+      .getStreamEdgesOrThrow(src.getId, globalSink.getTransformation.getId).get(0).getPartitioner
     assert(globalPartitioner.isInstanceOf[GlobalPartitioner[_]])
   }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.streaming.runtime;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.test.streaming.runtime.util.TestListResultSink;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Integration tests for {@link MultipleInputStreamOperator}.
+ */
+@SuppressWarnings("serial")
+public class MultipleInputITCase extends AbstractTestBase {
+	@Test
+	public void test() throws Exception {
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+
+		TestListResultSink<Long> resultSink = new TestListResultSink<>();
+
+		DataStream<Integer> source1 = env.fromElements(1, 10);
+		DataStream<Long> source2 = env.fromElements(2L, 11L);
+		DataStream<String> source3 = env.fromElements("42", "44");
+
+		MultipleInputTransformation<Long> transform = new MultipleInputTransformation<>(
+			"My Operator",
+			new SumAllInputOperatorFactory(),
+			BasicTypeInfo.LONG_TYPE_INFO,
+			1);
+
+		transform.addInput(source1.getTransformation());
+		transform.addInput(source2.getTransformation());
+		transform.addInput(source3.getTransformation());
+
+		env.addOperator(transform);
+
+		new MultipleConnectedStreams(env)
+			.transform(transform)
+			.addSink(resultSink);
+
+		env.execute();
+
+		List<Long> result = resultSink.getResult();
+		Collections.sort(result);
+		long actualSum = result.get(result.size() - 1);
+		assertEquals(1 + 10 + 2 + 11 + 42 + 44, actualSum);
+	}
+
+	/**
+	 * 3 input operator that sums all of it inputs.
+	 * TODO: provide non {@link SetupableStreamOperator} variant of {@link AbstractStreamOperator}?
+	 * TODO: provide non {@link AbstractStreamOperator} seems to pre-override processWatermark1/2 and other
+	 * methods that are not defined there?
+	 */
+	public static class SumAllInputOperator extends AbstractStreamOperator<Long> implements MultipleInputStreamOperator<Long> {
+		private long sum;
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new SumInput<Integer>(),
+				new SumInput<Long>(),
+				new SumInput<String>());
+		}
+
+		/**
+		 * Summing input for {@link SumAllInputOperator}.
+		 */
+		public class SumInput<T> implements Input<T> {
+			@Override
+			public void processElement(StreamRecord<T> element) throws Exception {
+				sum += Long.valueOf(element.getValue().toString());
+				output.collect(new StreamRecord<>(sum));
+			}
+		}
+	}
+
+	/**
+	 * Factory for {@link SumAllInputOperator}.
+	 */
+	public static class SumAllInputOperatorFactory implements StreamOperatorFactory<Long> {
+		private ChainingStrategy chainingStrategy;
+
+		@Override
+		public <T extends StreamOperator<Long>> T createStreamOperator(
+				StreamTask<?, ?> containingTask,
+				StreamConfig config,
+				Output<StreamRecord<Long>> output) {
+			SumAllInputOperator sumAllInputOperator = new SumAllInputOperator();
+			sumAllInputOperator.setup(containingTask, config, output);
+			return (T) sumAllInputOperator;
+		}
+
+		@Override
+		public void setChainingStrategy(ChainingStrategy chainingStrategy) {
+			this.chainingStrategy = chainingStrategy;
+		}
+
+		@Override
+		public ChainingStrategy getChainingStrategy() {
+			return chainingStrategy;
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a basic support for multiple input operators and relevant interfaces.

This doesn't fully support input selection, watermarks, latency markers and keyed context yet.

## Verifying this change

This change adds couple of new test classes, most importantly `MultipleInputStreamTaskTest`
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
