### PR TITLE
[FLINK-16068][table-planner-blink] Fix computed column with escaped k…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -28,14 +28,16 @@ public interface SqlExprToRexConverter {
 	/**
 	 * Converts a SQL expression to a {@link RexNode} expression.
 	 *
-	 * @param expr It's caller's duty to ensure that the expression has been escaped correctly.
+	 * @param expr a SQL expression which must be quoted and expanded,
+	 *             e.g. "`my_catalog`.`my_database`.`my_udf`(`f0`) + 1".
 	 */
 	RexNode convertToRexNode(String expr);
 
 	/**
 	 * Converts an array of SQL expressions to an array of {@link RexNode} expressions.
 	 *
-	 * @param exprs It's caller's duty to ensure that the expression has been escaped correctly.
+	 * @param exprs SQL expressions which must be quoted and expanded,
+	 *              e.g. "`my_catalog`.`my_database`.`my_udf`(`f0`) + 1".
 	 */
 	RexNode[] convertToRexNodes(String[] exprs);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/SqlExprToRexConverter.java
@@ -27,11 +27,15 @@ public interface SqlExprToRexConverter {
 
 	/**
 	 * Converts a SQL expression to a {@link RexNode} expression.
+	 *
+	 * @param expr It's caller's duty to ensure that the expression has been escaped correctly.
 	 */
 	RexNode convertToRexNode(String expr);
 
 	/**
 	 * Converts an array of SQL expressions to an array of {@link RexNode} expressions.
+	 *
+	 * @param exprs It's caller's duty to ensure that the expression has been escaped correctly.
 	 */
 	RexNode[] convertToRexNodes(String[] exprs);
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -105,7 +105,7 @@ class CatalogSourceTable[T](
             if (columnExprs.contains(name)) {
               columnExprs(name)
             } else {
-              name
+              s"`$name`"
             }
           }.toArray
       val rexNodes = toRexFactory.create(newRelTable.getRowType).convertToRexNodes(fieldExprs)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -420,7 +420,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
       """
         |create table t1(
         |  a int,
-        |  b varchar,
+        |  `time` varchar,
         |  c as my_udf(a)
         |) with (
         |  'connector' = 'COLLECTION'
@@ -430,7 +430,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
       """
         |create table t2(
         |  a int,
-        |  b varchar,
+        |  `time` varchar,
         |  c int not null
         |) with (
         |  'connector' = 'COLLECTION'
@@ -439,56 +439,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     val query =
       """
         |insert into t2
-        |select t1.a, t1.b, t1.c from t1
-      """.stripMargin
-    tableEnv.sqlUpdate(sourceDDL)
-    tableEnv.sqlUpdate(sinkDDL)
-    tableEnv.sqlUpdate(query)
-    execJob("testJob")
-    assertEquals(expected.sorted, TestCollectionTableFactory.RESULT.sorted)
-  }
-
-  @Test
-  def testComputedColumnWithEscapedKeywordField(): Unit = {
-    val sourceData = List(
-      toRow(1, "1990-02-10 12:34:56"),
-      toRow(2, "2019-09-10 9:23:41"),
-      toRow(3, "2019-09-10 9:23:42"),
-      toRow(1, "2019-09-10 9:23:43"),
-      toRow(2, "2019-09-10 9:23:44")
-    )
-    val expected = List(
-      toRow(1, "1990-02-10 12:34:56", 1001),
-      toRow(2, "2019-09-10 9:23:41", 1002),
-      toRow(3, "2019-09-10 9:23:42", 1003),
-      toRow(1, "2019-09-10 9:23:43", 1001),
-      toRow(2, "2019-09-10 9:23:44", 1002)
-    )
-    TestCollectionTableFactory.initData(sourceData)
-    val sourceDDL =
-      """
-        |create table t1(
-        |  a int,
-        |  `time` varchar,
-        |  c as a + 1000
-        |) with (
-        |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val sinkDDL =
-      """
-        |create table t2(
-        |  a int,
-        |  `time` varchar,
-        |  c int
-        |) with (
-        |  'connector' = 'COLLECTION'
-        |)
-      """.stripMargin
-    val query =
-      """
-        |insert into t2
-        |select * from t1
+        |select t1.a, t1.`time`, t1.c from t1
       """.stripMargin
     tableEnv.sqlUpdate(sourceDDL)
     tableEnv.sqlUpdate(sinkDDL)


### PR DESCRIPTION
…eyword cannot work

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix a bug that computed column and escaped keyword cannot work together.

## Brief change log

- Add escape to field name in computed column.
- Add Java doc to `SqlExprToRexConverter` to remind others.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

- CatalogTableITCase. testComputedColumnWithEscapedKeywordField()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
