### PR TITLE
[FLINK-16071][python] Optimize the cost of the get item of the Row

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -23,6 +23,7 @@ import datetime
 import decimal
 from apache_beam.coders import Coder
 from apache_beam.coders.coders import FastCoder
+from apache_beam.typehints import typehints
 
 from pyflink.fn_execution import coder_impl
 from pyflink.fn_execution import flink_fn_execution_pb2
@@ -31,31 +32,31 @@ from pyflink.table import Row
 FLINK_SCHEMA_CODER_URN = "flink:coder:schema:v1"
 
 
-__all__ = ['RowCoder', 'BigIntCoder', 'TinyIntCoder', 'BooleanCoder',
+__all__ = ['FlattenRowCoder', 'RowCoder', 'BigIntCoder', 'TinyIntCoder', 'BooleanCoder',
            'SmallIntCoder', 'IntCoder', 'FloatCoder', 'DoubleCoder',
            'BinaryCoder', 'CharCoder', 'DateCoder', 'TimeCoder',
            'TimestampCoder', 'ArrayCoder', 'MapCoder', 'DecimalCoder']
 
 
-class RowCoder(FastCoder):
+class FlattenRowCoder(FastCoder):
     """
-    Coder for Row.
+    Coder for Row. The result of decode will be list for the performance.
     """
 
     def __init__(self, field_coders):
         self._field_coders = field_coders
 
     def _create_impl(self):
-        return coder_impl.RowCoderImpl([c.get_impl() for c in self._field_coders])
+        return coder_impl.FlattenRowCoderImpl([c.get_impl() for c in self._field_coders])
 
     def is_deterministic(self):
         return all(c.is_deterministic() for c in self._field_coders)
 
     def to_type_hint(self):
-        return Row
+        return typehints.List
 
     def __repr__(self):
-        return 'RowCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
+        return 'FlattenRowCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
 
     def __eq__(self, other):
         return (self.__class__ == other.__class__
@@ -68,6 +69,24 @@ class RowCoder(FastCoder):
 
     def __hash__(self):
         return hash(self._field_coders)
+
+
+class RowCoder(FlattenRowCoder):
+    """
+    Coder for Row.
+    """
+
+    def __init__(self, field_coders):
+        super(RowCoder, self).__init__(field_coders)
+
+    def _create_impl(self):
+        return coder_impl.RowCoderImpl([c.get_impl() for c in self._field_coders])
+
+    def to_type_hint(self):
+        return Row
+
+    def __repr__(self):
+        return 'RowCoder[%s]' % ', '.join(str(c) for c in self._field_coders)
 
 
 class CollectionCoder(FastCoder):
@@ -319,7 +338,7 @@ class TimestampCoder(DeterministicCoder):
 
 @Coder.register_urn(FLINK_SCHEMA_CODER_URN, flink_fn_execution_pb2.Schema)
 def _pickle_from_runner_api_parameter(schema_proto, unused_components, unused_context):
-    return RowCoder([from_proto(f.type) for f in schema_proto.fields])
+    return FlattenRowCoder([from_proto(f.type) for f in schema_proto.fields])
 
 
 type_name = flink_fn_execution_pb2.Schema.TypeName

--- a/flink-python/pyflink/fn_execution/operations.py
+++ b/flink-python/pyflink/fn_execution/operations.py
@@ -27,7 +27,6 @@ from apache_beam.runners.worker.operations import Operation
 
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.serializers import PickleSerializer
-from pyflink.table import Row
 
 SCALAR_FUNCTION_URN = "flink:transform:scalar_function:v1"
 
@@ -222,9 +221,8 @@ class ScalarFunctionRunner(object):
     def process(self, windowed_value):
         results = [invoker.invoke_eval(windowed_value.value) for invoker in
                    self.scalar_function_invokers]
-        result = Row(*results)
         # send the execution results back
-        self.output_processor.process_outputs(windowed_value, [result])
+        self.output_processor.process_outputs(windowed_value, [results])
 
 
 class ScalarFunctionOperation(Operation):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Optimize the cost of the get item of the Row in Python UDF*


## Brief change log 

  - *Using FlattenRowCoder in Python UDF*

## Verifying this change

This change added tests and can be verified as follows:

  - *It is the perforce improvements without function test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## How does this patch test
### Test Code


    @udf(input_types=[DataTypes.INT(False)], result_type=DataTypes.INT(False))
    def inc(x):
        return x

    t_env.register_function("inc", inc)

    # num_rows = 100000000
    num_rows = 100000
    num_columns = 100

    select_list = ["inc(c%s)" % i for i in range(num_columns)]
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["c%s" % i for i in range(num_columns)],
            [DataTypes.INT(False)] * num_columns))

    t_env.from_table_source(MultiRowColumnTableSource(num_rows, num_columns)) \
        .select(','.join(select_list)) \
        .insert_into("sink")

    beg_time = time.time()
    t_env.execute("perf_test")
    print("consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
10w, 100                         |    53.32s                           |   22.18s
100w,10                          |    55.88s                           |   33.85s
