### PR TITLE
[FLINK-16113][table-planner-blink] ExpressionReducer shouldn't escape the reduced string value

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -138,8 +138,8 @@ class ExpressionReducer(
                SqlTypeName.MULTISET =>
             reducedValues.add(unreduced)
           case SqlTypeName.VARCHAR | SqlTypeName.CHAR =>
-            val escapeVarchar = StringEscapeUtils
-              .escapeJava(safeToString(reduced.getField(reducedIdx).asInstanceOf[BinaryString]))
+            val escapeVarchar = safeToString(
+              reduced.getField(reducedIdx).asInstanceOf[BinaryString])
             reducedValues.add(maySkipNullLiteralReduce(rexBuilder, escapeVarchar, unreduced))
             reducedIdx += 1
           case SqlTypeName.VARBINARY | SqlTypeName.BINARY =>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcTest.xml
@@ -69,6 +69,24 @@ Calc(select=[a, b, c], where=[OR(<(a, 10), >(a, 20))])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testFilterOnNonAsciiLiteral">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, c || TRIM(' 世界 ') FROM MyTable WHERE c = '你好']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], EXPR$3=[||($2, TRIM(FLAG(BOTH), _UTF-16LE' ', _UTF-16LE' 世界 '))])
++- LogicalFilter(condition=[=($2, _UTF-16LE'你好')])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, CAST(_UTF-16LE'你好':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS c, CAST(_UTF-16LE'你好世界':VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS EXPR$3], where=[=(c, _UTF-16LE'你好':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilterWithDateType">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/CalcTest.scala
@@ -80,6 +80,12 @@ class CalcTest extends TableTestBase {
   }
 
   @Test
+  def testFilterOnNonAsciiLiteral(): Unit = {
+    val sql = s"SELECT a, b, c, c || TRIM(' 世界 ') FROM MyTable WHERE c = '你好'"
+    util.verifyPlan(sql)
+  }
+
+  @Test
   def testNotIn(): Unit = {
     val sql = s"SELECT * FROM MyTable WHERE b NOT IN (1, 3, 4, 5, 6) OR c = 'xx'"
     util.verifyPlan(sql)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -284,21 +284,4 @@ class CalcITCase extends StreamingTestBase {
       assertEquals(expected, result)
     )
   }
-
-  @Test
-  def testFilterOnNonAsciiLiteral(): Unit = {
-    val data: Seq[(Int, Long, String)] = Seq(
-      (1, 1L, "你好"),
-      (2, 2L, "再见"),
-      (3, 2L, "你好"))
-    val t = env.fromCollection(data).toTable(tEnv, 'a, 'b, 'c)
-    tEnv.createTemporaryView("MyTable", t)
-    val sqlQuery = s"SELECT a, b, c, TRIM(' 世界 ') FROM MyTable WHERE c = '你好'"
-    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
-    val sink = new TestingAppendSink
-    result.addSink(sink)
-    env.execute()
-    val expected = Seq("1,1,你好,世界", "3,2,你好,世界")
-    assertEquals(expected.sorted, sink.getAppendResults.sorted)
-  }
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

ExpressionReducer shouldn't escape the reduced string value, the escaping should only happen in code generation, otherwise the output result is inccorect.

## Brief change log

Remove the escape string logic from `ExpressionReducer`.

## Verifying this change

Added a plan test and an integration test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
