### PR TITLE
[FLINK-16111][k8s] Fix Kubernetes deployment not respecting 'taskmanager.cpu.cores'.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -338,6 +339,6 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 
 	@Override
 	protected double getCpuCores(Configuration configuration) {
-		return flinkConfig.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, numSlotsPerTaskManager);
+		return TaskExecutorProcessUtils.getCpuCoresWithFallbackConfigOption(configuration, KubernetesConfigOptions.TASK_MANAGER_CPU);
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -80,6 +80,7 @@ import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -285,6 +286,33 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 				.map(e -> e.getMetadata().getName())
 				.collect(Collectors.toList()),
 			Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+	}
+
+	@Test
+	public void testGetCpuCoresCommonOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(resourceManager.getCpuCores(configuration), is(1.0));
+	}
+
+	@Test
+	public void testGetCpuCoresKubernetesOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(resourceManager.getCpuCores(configuration), is(2.0));
+	}
+
+	@Test
+	public void testGetCpuCoresNumSlots() {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(resourceManager.getCpuCores(configuration), is(3.0));
 	}
 
 	private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration) throws Exception {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -74,7 +74,7 @@ public class MesosTaskManagerParameters {
 		.withDescription(Description.builder().text("Disk space to assign to the Mesos workers in MB.").build());
 
 	public static final ConfigOption<Double> MESOS_RM_TASKS_CPUS =
-		key("mesos.resourcemanager.tasks.cpus")
+		key("mesos.resourcemanager.tasks.cpus").doubleType()
 		.defaultValue(0.0)
 		.withDescription("CPUs to assign to the Mesos workers.");
 
@@ -424,8 +424,7 @@ public class MesosTaskManagerParameters {
 	}
 
 	private static double getCpuCores(final Configuration configuration) {
-		double fallback = configuration.getDouble(MESOS_RM_TASKS_CPUS);
-		return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
+		return TaskExecutorProcessUtils.getCpuCoresWithFallbackConfigOption(configuration, MESOS_RM_TASKS_CPUS);
 	}
 
 	private static MemorySize getTotalProcessMemory(final Configuration configuration) {

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParametersTest.java
@@ -232,6 +232,8 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	public void testConfigCpuCores() {
 		Configuration config = getConfiguration();
 		config.setDouble(TaskManagerOptions.CPU_CORES, 1.5);
+		config.setDouble(MesosTaskManagerParameters.MESOS_RM_TASKS_CPUS, 2.5);
+		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(config);
 		assertThat(mesosTaskManagerParameters.cpus(), is(1.5));
 	}
@@ -240,6 +242,7 @@ public class MesosTaskManagerParametersTest extends TestLogger {
 	public void testLegacyConfigCpuCores() {
 		Configuration config = getConfiguration();
 		config.setDouble(MesosTaskManagerParameters.MESOS_RM_TASKS_CPUS, 1.5);
+		config.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 		MesosTaskManagerParameters mesosTaskManagerParameters = MesosTaskManagerParameters.create(config);
 		assertThat(mesosTaskManagerParameters.cpus(), is(1.5));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -644,6 +644,11 @@ public class TaskExecutorProcessUtils {
 		return getCpuCoresWithFallback(config, -1.0);
 	}
 
+	public static double getCpuCoresWithFallbackConfigOption(final Configuration config, ConfigOption<Double> fallbackOption) {
+		double fallbackValue = config.getDouble(fallbackOption);
+		return TaskExecutorProcessUtils.getCpuCoresWithFallback(config, fallbackValue).getValue().doubleValue();
+	}
+
 	public static CPUResource getCpuCoresWithFallback(final Configuration config, double fallback) {
 		final double cpuCores;
 		if (config.contains(TaskManagerOptions.CPU_CORES)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -640,15 +640,11 @@ public class TaskExecutorProcessUtils {
 		}
 	}
 
-	public static CPUResource getCpuCoresWithFallback(final Configuration config, double fallback) {
-		return getCpuCores(config, fallback);
-	}
-
 	private static CPUResource getCpuCores(final Configuration config) {
-		return getCpuCores(config, -1.0);
+		return getCpuCoresWithFallback(config, -1.0);
 	}
 
-	private static CPUResource getCpuCores(final Configuration config, double fallback) {
+	public static CPUResource getCpuCoresWithFallback(final Configuration config, double fallback) {
 		final double cpuCores;
 		if (config.contains(TaskManagerOptions.CPU_CORES)) {
 			cpuCores = config.getDouble(TaskManagerOptions.CPU_CORES);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -56,6 +57,7 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 
@@ -523,6 +525,59 @@ public class YarnResourceManagerTest extends TestLogger {
 				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT).releaseAssignedContainer(testingContainer.getId());
 				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT.times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));
 			});
+		}};
+	}
+
+	@Test
+	public void testGetCpuCoresCommonOption() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+		configuration.setInteger(YarnConfigOptions.VCORES, 2);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		new Context() {{
+			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(1.0)));
+		}};
+	}
+
+	@Test
+	public void testGetCpuCoresYarnOption() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(YarnConfigOptions.VCORES, 2);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		new Context() {{
+			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(2.0)));
+		}};
+	}
+
+	@Test
+	public void testGetCpuCoresNumSlots() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		new Context() {{
+			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(3.0)));
+		}};
+	}
+
+	@Test
+	public void testGetCpuRoundUp() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 0.5);
+
+		new Context() {{
+			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(1.0)));
+		}};
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testGetCpuExceedMaxInt() throws Exception {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
+
+		new Context() {{
+			resourceManager.getCpuCores(configuration);
 		}};
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This PR fix that Kubernetes deployment not respecting 'taskmanager.cpu.core'.
The expected behavior for cpu configuration is to fallback the cpu configuration with the following order:
1. common cpu config option ('taskmanager.cpu.core')
2. K8s/Yarn/Mesos config option ('kubernetes.taskmanager.cpu' for Kubernetes)
3. number of slots ('taskmanager.numberOfTaskSlots')

## Brief change log

- a43e139a4ffeeb06b00db4163e329dfcbfbb9f3b: Make Kubernetes to respect 'taskmanager.cpu.cores'.
- 9db123635d9b3142f3bf9b1b61347f7d46ca4890, c330e78bc64b398d2ff483ab3f996db3958ec2fd: Hotfixes for adding test cases validating the same behavior on Yarn/Mesos deployments.

## Verifying this change

This change added tests and can be verified as follows:
- Add test cases in `KubernetesResourceManagerTest`
- Add test cases in `YarnResourceManagerTest`
- Update existing test cases in `MesosTaskManagerParametersTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
