### PR TITLE
[FLINK-16118][table-planner-blink] Ignore order for FunctionITCase.testDynamicTableFunction

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -45,6 +45,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -588,11 +589,11 @@ public class FunctionITCase extends StreamingTestBase {
 
 	@Test
 	public void testDynamicTableFunction() throws Exception {
-		final List<Row> sinkData = Arrays.asList(
+		final Row[] sinkData = new Row[]{
 			Row.of("Test is a string"),
 			Row.of("42"),
 			Row.of((String) null)
-		);
+		};
 
 		TestCollectionTableFactory.reset();
 
@@ -608,7 +609,7 @@ public class FunctionITCase extends StreamingTestBase {
 			"SELECT CAST(T3.i AS STRING) FROM TABLE(DynamicTableFunction(CAST(NULL AS INT))) AS T3(i)");
 		tEnv().execute("Test Job");
 
-		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+		assertThat(TestCollectionTableFactory.getResult(), containsInAnyOrder(sinkData));
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes the test.

## Brief change log

See commit message.

## Verifying this change

This change is a trivial rework.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
