### PR TITLE
[FLINK-16072][python] Optimize the performance of the write/read null mask

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -24,71 +24,74 @@ from apache_beam.coders.coder_impl import StreamCoderImpl
 from pyflink.table import Row
 
 
-def generate_null_mask_search_table():
-    """
-    Each bit of one byte represents if the column at the specified position is None or not, e.g.
-    0x84 represents the first column and the sixth column are None.
-    """
-    num = 256
-    null_mask = []
-    for b in range(num):
-        every_num_null_mask = [(b & 0x80) > 0, (b & 0x40) > 0, (b & 0x20) > 0, (b & 0x10) > 0,
-                               (b & 0x08) > 0, (b & 0x04) > 0, (b & 0x02) > 0, (b & 0x01) > 0]
-        null_mask.append(tuple(every_num_null_mask))
-
-    return tuple(null_mask)
-
-
 class FlattenRowCoderImpl(StreamCoderImpl):
-    null_mask_search_table = generate_null_mask_search_table()
-
-    null_byte_search_table = (0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01)
 
     def __init__(self, field_coders):
         self._field_coders = field_coders
         self._filed_count = len(field_coders)
-        self._complete_byte_num = self._filed_count // 8
-        self._leading_bytes_num = self._filed_count % 8
+        self._leading_complete_bytes_num = self._filed_count // 8
+        self._remaining_bits_num = self._filed_count % 8
+        self.null_mask_search_table = self.generate_null_mask_search_table()
+        self.null_byte_search_table = (0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01)
+
+    @staticmethod
+    def generate_null_mask_search_table():
+        """
+        Each bit of one byte represents if the column at the corresponding position is None or not,
+        e.g. 0x84 represents the first column and the sixth column are None.
+        """
+        null_mask = []
+        for b in range(256):
+            every_num_null_mask = [(b & 0x80) > 0, (b & 0x40) > 0, (b & 0x20) > 0, (b & 0x10) > 0,
+                                   (b & 0x08) > 0, (b & 0x04) > 0, (b & 0x02) > 0, (b & 0x01) > 0]
+            null_mask.append(tuple(every_num_null_mask))
+
+        return tuple(null_mask)
 
     def encode_to_stream(self, value, out_stream, nested):
         self.write_null_mask(value, out_stream)
+        field_coders = self._field_coders
         for i in range(self._filed_count):
             item = value[i]
             if item is not None:
-                self._field_coders[i].encode_to_stream(item, out_stream, nested)
+                field_coders[i].encode_to_stream(item, out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
         null_mask = self.read_null_mask(in_stream)
-        return [None if null_mask[idx] else self._field_coders[idx].decode_from_stream(
+        field_coders = self._field_coders
+        return [None if null_mask[idx] else field_coders[idx].decode_from_stream(
             in_stream, nested) for idx in range(0, self._filed_count)]
 
     def write_null_mask(self, value, out_stream):
         field_pos = 0
-        for _ in range(self._complete_byte_num):
+        null_byte_search_table = self.null_byte_search_table
+        remaining_bits_num = self._remaining_bits_num
+        for _ in range(self._leading_complete_bytes_num):
             b = 0x00
             for i in range(0, 8):
                 if value[field_pos + i] is None:
-                    b |= FlattenRowCoderImpl.null_byte_search_table[i]
+                    b |= null_byte_search_table[i]
             field_pos += 8
             out_stream.write_byte(b)
 
-        if self._leading_bytes_num != 0:
+        if remaining_bits_num:
             b = 0x00
-            for i in range(self._leading_bytes_num):
+            for i in range(remaining_bits_num):
                 if value[field_pos + i] is None:
-                    b |= FlattenRowCoderImpl.null_byte_search_table[i]
+                    b |= null_byte_search_table[i]
             out_stream.write_byte(b)
 
     def read_null_mask(self, in_stream):
         null_mask = []
-        for _ in range(self._complete_byte_num):
+        null_mask_search_table = self.null_mask_search_table
+        remaining_bits_num = self._remaining_bits_num
+        for _ in range(self._leading_complete_bytes_num):
             b = in_stream.read_byte()
-            null_mask.extend(FlattenRowCoderImpl.null_mask_search_table[b])
+            null_mask.extend(null_mask_search_table[b])
 
-        if self._leading_bytes_num != 0:
+        if remaining_bits_num:
             b = in_stream.read_byte()
-            null_mask.extend(
-                FlattenRowCoderImpl.null_mask_search_table[b][0:self._leading_bytes_num])
+            null_mask.extend(null_mask_search_table[b][0:remaining_bits_num])
         return null_mask
 
     def __repr__(self):

--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -25,56 +25,331 @@ from pyflink.table import Row
 
 
 class FlattenRowCoderImpl(StreamCoderImpl):
+    null_mask_search_table = ((False, False, False, False, False, False, False, False),
+                              (False, False, False, False, False, False, False, True),
+                              (False, False, False, False, False, False, True, False),
+                              (False, False, False, False, False, False, True, True),
+                              (False, False, False, False, False, True, False, False),
+                              (False, False, False, False, False, True, False, True),
+                              (False, False, False, False, False, True, True, False),
+                              (False, False, False, False, False, True, True, True),
+                              (False, False, False, False, True, False, False, False),
+                              (False, False, False, False, True, False, False, True),
+                              (False, False, False, False, True, False, True, False),
+                              (False, False, False, False, True, False, True, True),
+                              (False, False, False, False, True, True, False, False),
+                              (False, False, False, False, True, True, False, True),
+                              (False, False, False, False, True, True, True, False),
+                              (False, False, False, False, True, True, True, True),
+                              (False, False, False, True, False, False, False, False),
+                              (False, False, False, True, False, False, False, True),
+                              (False, False, False, True, False, False, True, False),
+                              (False, False, False, True, False, False, True, True),
+                              (False, False, False, True, False, True, False, False),
+                              (False, False, False, True, False, True, False, True),
+                              (False, False, False, True, False, True, True, False),
+                              (False, False, False, True, False, True, True, True),
+                              (False, False, False, True, True, False, False, False),
+                              (False, False, False, True, True, False, False, True),
+                              (False, False, False, True, True, False, True, False),
+                              (False, False, False, True, True, False, True, True),
+                              (False, False, False, True, True, True, False, False),
+                              (False, False, False, True, True, True, False, True),
+                              (False, False, False, True, True, True, True, False),
+                              (False, False, False, True, True, True, True, True),
+                              (False, False, True, False, False, False, False, False),
+                              (False, False, True, False, False, False, False, True),
+                              (False, False, True, False, False, False, True, False),
+                              (False, False, True, False, False, False, True, True),
+                              (False, False, True, False, False, True, False, False),
+                              (False, False, True, False, False, True, False, True),
+                              (False, False, True, False, False, True, True, False),
+                              (False, False, True, False, False, True, True, True),
+                              (False, False, True, False, True, False, False, False),
+                              (False, False, True, False, True, False, False, True),
+                              (False, False, True, False, True, False, True, False),
+                              (False, False, True, False, True, False, True, True),
+                              (False, False, True, False, True, True, False, False),
+                              (False, False, True, False, True, True, False, True),
+                              (False, False, True, False, True, True, True, False),
+                              (False, False, True, False, True, True, True, True),
+                              (False, False, True, True, False, False, False, False),
+                              (False, False, True, True, False, False, False, True),
+                              (False, False, True, True, False, False, True, False),
+                              (False, False, True, True, False, False, True, True),
+                              (False, False, True, True, False, True, False, False),
+                              (False, False, True, True, False, True, False, True),
+                              (False, False, True, True, False, True, True, False),
+                              (False, False, True, True, False, True, True, True),
+                              (False, False, True, True, True, False, False, False),
+                              (False, False, True, True, True, False, False, True),
+                              (False, False, True, True, True, False, True, False),
+                              (False, False, True, True, True, False, True, True),
+                              (False, False, True, True, True, True, False, False),
+                              (False, False, True, True, True, True, False, True),
+                              (False, False, True, True, True, True, True, False),
+                              (False, False, True, True, True, True, True, True),
+                              (False, True, False, False, False, False, False, False),
+                              (False, True, False, False, False, False, False, True),
+                              (False, True, False, False, False, False, True, False),
+                              (False, True, False, False, False, False, True, True),
+                              (False, True, False, False, False, True, False, False),
+                              (False, True, False, False, False, True, False, True),
+                              (False, True, False, False, False, True, True, False),
+                              (False, True, False, False, False, True, True, True),
+                              (False, True, False, False, True, False, False, False),
+                              (False, True, False, False, True, False, False, True),
+                              (False, True, False, False, True, False, True, False),
+                              (False, True, False, False, True, False, True, True),
+                              (False, True, False, False, True, True, False, False),
+                              (False, True, False, False, True, True, False, True),
+                              (False, True, False, False, True, True, True, False),
+                              (False, True, False, False, True, True, True, True),
+                              (False, True, False, True, False, False, False, False),
+                              (False, True, False, True, False, False, False, True),
+                              (False, True, False, True, False, False, True, False),
+                              (False, True, False, True, False, False, True, True),
+                              (False, True, False, True, False, True, False, False),
+                              (False, True, False, True, False, True, False, True),
+                              (False, True, False, True, False, True, True, False),
+                              (False, True, False, True, False, True, True, True),
+                              (False, True, False, True, True, False, False, False),
+                              (False, True, False, True, True, False, False, True),
+                              (False, True, False, True, True, False, True, False),
+                              (False, True, False, True, True, False, True, True),
+                              (False, True, False, True, True, True, False, False),
+                              (False, True, False, True, True, True, False, True),
+                              (False, True, False, True, True, True, True, False),
+                              (False, True, False, True, True, True, True, True),
+                              (False, True, True, False, False, False, False, False),
+                              (False, True, True, False, False, False, False, True),
+                              (False, True, True, False, False, False, True, False),
+                              (False, True, True, False, False, False, True, True),
+                              (False, True, True, False, False, True, False, False),
+                              (False, True, True, False, False, True, False, True),
+                              (False, True, True, False, False, True, True, False),
+                              (False, True, True, False, False, True, True, True),
+                              (False, True, True, False, True, False, False, False),
+                              (False, True, True, False, True, False, False, True),
+                              (False, True, True, False, True, False, True, False),
+                              (False, True, True, False, True, False, True, True),
+                              (False, True, True, False, True, True, False, False),
+                              (False, True, True, False, True, True, False, True),
+                              (False, True, True, False, True, True, True, False),
+                              (False, True, True, False, True, True, True, True),
+                              (False, True, True, True, False, False, False, False),
+                              (False, True, True, True, False, False, False, True),
+                              (False, True, True, True, False, False, True, False),
+                              (False, True, True, True, False, False, True, True),
+                              (False, True, True, True, False, True, False, False),
+                              (False, True, True, True, False, True, False, True),
+                              (False, True, True, True, False, True, True, False),
+                              (False, True, True, True, False, True, True, True),
+                              (False, True, True, True, True, False, False, False),
+                              (False, True, True, True, True, False, False, True),
+                              (False, True, True, True, True, False, True, False),
+                              (False, True, True, True, True, False, True, True),
+                              (False, True, True, True, True, True, False, False),
+                              (False, True, True, True, True, True, False, True),
+                              (False, True, True, True, True, True, True, False),
+                              (False, True, True, True, True, True, True, True),
+                              (True, False, False, False, False, False, False, False),
+                              (True, False, False, False, False, False, False, True),
+                              (True, False, False, False, False, False, True, False),
+                              (True, False, False, False, False, False, True, True),
+                              (True, False, False, False, False, True, False, False),
+                              (True, False, False, False, False, True, False, True),
+                              (True, False, False, False, False, True, True, False),
+                              (True, False, False, False, False, True, True, True),
+                              (True, False, False, False, True, False, False, False),
+                              (True, False, False, False, True, False, False, True),
+                              (True, False, False, False, True, False, True, False),
+                              (True, False, False, False, True, False, True, True),
+                              (True, False, False, False, True, True, False, False),
+                              (True, False, False, False, True, True, False, True),
+                              (True, False, False, False, True, True, True, False),
+                              (True, False, False, False, True, True, True, True),
+                              (True, False, False, True, False, False, False, False),
+                              (True, False, False, True, False, False, False, True),
+                              (True, False, False, True, False, False, True, False),
+                              (True, False, False, True, False, False, True, True),
+                              (True, False, False, True, False, True, False, False),
+                              (True, False, False, True, False, True, False, True),
+                              (True, False, False, True, False, True, True, False),
+                              (True, False, False, True, False, True, True, True),
+                              (True, False, False, True, True, False, False, False),
+                              (True, False, False, True, True, False, False, True),
+                              (True, False, False, True, True, False, True, False),
+                              (True, False, False, True, True, False, True, True),
+                              (True, False, False, True, True, True, False, False),
+                              (True, False, False, True, True, True, False, True),
+                              (True, False, False, True, True, True, True, False),
+                              (True, False, False, True, True, True, True, True),
+                              (True, False, True, False, False, False, False, False),
+                              (True, False, True, False, False, False, False, True),
+                              (True, False, True, False, False, False, True, False),
+                              (True, False, True, False, False, False, True, True),
+                              (True, False, True, False, False, True, False, False),
+                              (True, False, True, False, False, True, False, True),
+                              (True, False, True, False, False, True, True, False),
+                              (True, False, True, False, False, True, True, True),
+                              (True, False, True, False, True, False, False, False),
+                              (True, False, True, False, True, False, False, True),
+                              (True, False, True, False, True, False, True, False),
+                              (True, False, True, False, True, False, True, True),
+                              (True, False, True, False, True, True, False, False),
+                              (True, False, True, False, True, True, False, True),
+                              (True, False, True, False, True, True, True, False),
+                              (True, False, True, False, True, True, True, True),
+                              (True, False, True, True, False, False, False, False),
+                              (True, False, True, True, False, False, False, True),
+                              (True, False, True, True, False, False, True, False),
+                              (True, False, True, True, False, False, True, True),
+                              (True, False, True, True, False, True, False, False),
+                              (True, False, True, True, False, True, False, True),
+                              (True, False, True, True, False, True, True, False),
+                              (True, False, True, True, False, True, True, True),
+                              (True, False, True, True, True, False, False, False),
+                              (True, False, True, True, True, False, False, True),
+                              (True, False, True, True, True, False, True, False),
+                              (True, False, True, True, True, False, True, True),
+                              (True, False, True, True, True, True, False, False),
+                              (True, False, True, True, True, True, False, True),
+                              (True, False, True, True, True, True, True, False),
+                              (True, False, True, True, True, True, True, True),
+                              (True, True, False, False, False, False, False, False),
+                              (True, True, False, False, False, False, False, True),
+                              (True, True, False, False, False, False, True, False),
+                              (True, True, False, False, False, False, True, True),
+                              (True, True, False, False, False, True, False, False),
+                              (True, True, False, False, False, True, False, True),
+                              (True, True, False, False, False, True, True, False),
+                              (True, True, False, False, False, True, True, True),
+                              (True, True, False, False, True, False, False, False),
+                              (True, True, False, False, True, False, False, True),
+                              (True, True, False, False, True, False, True, False),
+                              (True, True, False, False, True, False, True, True),
+                              (True, True, False, False, True, True, False, False),
+                              (True, True, False, False, True, True, False, True),
+                              (True, True, False, False, True, True, True, False),
+                              (True, True, False, False, True, True, True, True),
+                              (True, True, False, True, False, False, False, False),
+                              (True, True, False, True, False, False, False, True),
+                              (True, True, False, True, False, False, True, False),
+                              (True, True, False, True, False, False, True, True),
+                              (True, True, False, True, False, True, False, False),
+                              (True, True, False, True, False, True, False, True),
+                              (True, True, False, True, False, True, True, False),
+                              (True, True, False, True, False, True, True, True),
+                              (True, True, False, True, True, False, False, False),
+                              (True, True, False, True, True, False, False, True),
+                              (True, True, False, True, True, False, True, False),
+                              (True, True, False, True, True, False, True, True),
+                              (True, True, False, True, True, True, False, False),
+                              (True, True, False, True, True, True, False, True),
+                              (True, True, False, True, True, True, True, False),
+                              (True, True, False, True, True, True, True, True),
+                              (True, True, True, False, False, False, False, False),
+                              (True, True, True, False, False, False, False, True),
+                              (True, True, True, False, False, False, True, False),
+                              (True, True, True, False, False, False, True, True),
+                              (True, True, True, False, False, True, False, False),
+                              (True, True, True, False, False, True, False, True),
+                              (True, True, True, False, False, True, True, False),
+                              (True, True, True, False, False, True, True, True),
+                              (True, True, True, False, True, False, False, False),
+                              (True, True, True, False, True, False, False, True),
+                              (True, True, True, False, True, False, True, False),
+                              (True, True, True, False, True, False, True, True),
+                              (True, True, True, False, True, True, False, False),
+                              (True, True, True, False, True, True, False, True),
+                              (True, True, True, False, True, True, True, False),
+                              (True, True, True, False, True, True, True, True),
+                              (True, True, True, True, False, False, False, False),
+                              (True, True, True, True, False, False, False, True),
+                              (True, True, True, True, False, False, True, False),
+                              (True, True, True, True, False, False, True, True),
+                              (True, True, True, True, False, True, False, False),
+                              (True, True, True, True, False, True, False, True),
+                              (True, True, True, True, False, True, True, False),
+                              (True, True, True, True, False, True, True, True),
+                              (True, True, True, True, True, False, False, False),
+                              (True, True, True, True, True, False, False, True),
+                              (True, True, True, True, True, False, True, False),
+                              (True, True, True, True, True, False, True, True),
+                              (True, True, True, True, True, True, False, False),
+                              (True, True, True, True, True, True, False, True),
+                              (True, True, True, True, True, True, True, False),
+                              (True, True, True, True, True, True, True, True))
+
+    null_byte_search_table = (0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01)
 
     def __init__(self, field_coders):
         self._field_coders = field_coders
         self._filed_count = len(field_coders)
+        self._complete_byte_num = self._filed_count // 8
+        self._remaining_bit_num = self._filed_count % 8
 
     def encode_to_stream(self, value, out_stream, nested):
-        self.write_null_mask(value, out_stream)
+        self.write_null_mask(value, self._complete_byte_num, self._remaining_bit_num, out_stream)
         for i in range(self._filed_count):
-            if value[i] is not None:
-                self._field_coders[i].encode_to_stream(value[i], out_stream, nested)
+            item = value[i]
+            if item is not None:
+                self._field_coders[i].encode_to_stream(item, out_stream, nested)
 
     def decode_from_stream(self, in_stream, nested):
-        null_mask = self.read_null_mask(self._filed_count, in_stream)
+        null_mask = self.read_null_mask(self._complete_byte_num, self._remaining_bit_num, in_stream)
         return [None if null_mask[idx] else self._field_coders[idx].decode_from_stream(
             in_stream, nested) for idx in range(0, self._filed_count)]
 
     @staticmethod
-    def write_null_mask(value, out_stream):
+    def write_null_mask(value, complete_byte_num, remaining_bit_num, out_stream):
         field_pos = 0
-        field_count = len(value)
-        while field_pos < field_count:
+        for _ in range(complete_byte_num):
             b = 0x00
-            # set bits in byte
-            num_pos = min(8, field_count - field_pos)
-            byte_pos = 0
-            while byte_pos < num_pos:
-                b = b << 1
-                # set bit if field is null
-                if value[field_pos + byte_pos] is None:
-                    b |= 0x01
-                byte_pos += 1
-            field_pos += num_pos
-            # shift bits if last byte is not completely filled
-            b <<= (8 - byte_pos)
-            # write byte
+            if value[field_pos] is None:
+                b |= 0x80
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x40
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x20
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x10
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x08
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x04
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x02
+            field_pos += 1
+            if value[field_pos] is None:
+                b |= 0x01
+            field_pos += 1
+            out_stream.write_byte(b)
+
+        if remaining_bit_num != 0:
+            b = 0x00
+            for i in range(remaining_bit_num):
+                if value[field_pos + i] is None:
+                    b |= FlattenRowCoderImpl.null_byte_search_table[i]
             out_stream.write_byte(b)
 
     @staticmethod
-    def read_null_mask(field_count, in_stream):
+    def read_null_mask(complete_byte_num, remaining_bit_num, in_stream):
         null_mask = []
-        field_pos = 0
-        while field_pos < field_count:
+        for _ in range(complete_byte_num):
             b = in_stream.read_byte()
-            num_pos = min(8, field_count - field_pos)
-            byte_pos = 0
-            while byte_pos < num_pos:
-                null_mask.append((b & 0x80) > 0)
-                b = b << 1
-                byte_pos += 1
-            field_pos += num_pos
+            null_mask.extend(FlattenRowCoderImpl.null_mask_search_table[b])
+
+        if remaining_bit_num != 0:
+            b = in_stream.read_byte()
+            null_mask.extend(FlattenRowCoderImpl.null_mask_search_table[b][0:remaining_bit_num])
         return null_mask
 
     def __repr__(self):

--- a/flink-python/pyflink/fn_execution/tests/coders_test_common.py
+++ b/flink-python/pyflink/fn_execution/tests/coders_test_common.py
@@ -22,7 +22,7 @@ import unittest
 
 from pyflink.fn_execution.coders import BigIntCoder, TinyIntCoder, BooleanCoder, \
     SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder, \
-    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder
+    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder, FlattenRowCoder
 
 
 class CodersTest(unittest.TestCase):
@@ -112,6 +112,12 @@ class CodersTest(unittest.TestCase):
         decimal.getcontext().prec = 2
         self.check_coder(coder, decimal.Decimal('1.001'))
         self.assertEqual(decimal.getcontext().prec, 2)
+
+    def test_flatten_row_coder(self):
+        field_coder = BigIntCoder()
+        field_count = 10
+        coder = FlattenRowCoder([field_coder for _ in range(field_count)])
+        self.check_coder(coder, [None if i % 2 == 0 else i for i in range(field_count)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is the purpose of the change

*This pr optimize the performance of the write/read null mask*


## Brief change log

  - *The decode/encode/write_null_mask/read_mask in FlattenRowCoder*

## Verifying this change

This change added tests and can be verified as follows:

  - *It is a perforce improvement without extra function test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

## How does this patch test
### Test Code


    @udf(input_types=[DataTypes.INT(False)], result_type=DataTypes.INT(False))
    def inc(x):
        return x

    t_env.register_function("inc", inc)

    # num_rows = 100000000
    num_rows = 100000
    num_columns = 100

    select_list = ["inc(c%s)" % i for i in range(num_columns)]
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["c%s" % i for i in range(num_columns)],
            [DataTypes.INT(False)] * num_columns))

    t_env.from_table_source(MultiRowColumnTableSource(num_rows, num_columns)) \
        .select(','.join(select_list)) \
        .insert_into("sink")

    beg_time = time.time()
    t_env.execute("perf_test")
    print("consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
1000w,10                       |     262.01                          |   222.07
100w, 100                      |     161.12                           |   148.23
