### PR TITLE
[FLINK-16139][runtime] Reset colocation constraints when restarting tasks in DefaultScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -67,6 +67,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmanager.PartitionProducerDisposedException;
+import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
@@ -320,8 +321,19 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	protected void resetForNewExecutions(final Collection<ExecutionVertexID> vertices) {
-		vertices.forEach(executionVertexId -> getExecutionVertex(executionVertexId)
-			.resetForNewExecution());
+		final Set<CoLocationGroup> colGroups = new HashSet<>();
+		vertices.forEach(executionVertexId -> {
+			final ExecutionVertex ev = getExecutionVertex(executionVertexId);
+
+			final CoLocationGroup cgroup = ev.getJobVertex().getCoLocationGroup();
+			if (cgroup != null && !colGroups.contains(cgroup)){
+				cgroup.resetConstraints();
+				colGroups.add(cgroup);
+			}
+
+			ev.resetForNewExecution();
+		});
+
 	}
 
 	protected void restoreState(final Set<ExecutionVertexID> vertices) throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ErrorInfo;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.executiongraph.failover.flip1.TestRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.executiongraph.utils.SimpleAckingTaskManagerGateway;
@@ -48,6 +49,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.NoResourceAvailableException;
+import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.VoidBackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.EagerSchedulingStrategy;
@@ -96,6 +99,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -670,6 +674,37 @@ public class DefaultSchedulerTest extends TestLogger {
 		final ErrorInfo failureInfo = scheduler.requestJob().getFailureInfo();
 		assertThat(failureInfo, is(notNullValue()));
 		assertThat(failureInfo.getExceptionAsString(), containsString(exceptionMessage));
+	}
+
+	@Test
+	public void coLocationConstraintIsResetOnTaskRecovery() {
+		final JobGraph jobGraph = nonParallelSourceSinkJobGraph();
+		final JobVertex source = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
+		final JobVertex sink = jobGraph.getVerticesSortedTopologicallyFromSources().get(1);
+
+		final SlotSharingGroup ssg = new SlotSharingGroup();
+		source.setSlotSharingGroup(ssg);
+		sink.setSlotSharingGroup(ssg);
+		sink.setStrictlyCoLocatedWith(source);
+
+		final JobID jobId = jobGraph.getJobID();
+		final DefaultScheduler scheduler = createSchedulerAndStartScheduling(jobGraph);
+
+		final ExecutionVertex sourceVertex = scheduler.getExecutionVertex(new ExecutionVertexID(source.getID(), 0));
+		final ExecutionAttemptID sourceAttemptId = sourceVertex.getCurrentExecutionAttempt().getAttemptId();
+		final ExecutionVertex sinkVertex = scheduler.getExecutionVertex(new ExecutionVertexID(sink.getID(), 0));
+		final ExecutionAttemptID sinkAttemptId = sinkVertex.getCurrentExecutionAttempt().getAttemptId();
+
+		// init the location constraint manually because the testExecutionSlotAllocator does not do it
+		sourceVertex.getLocationConstraint().setSlotRequestId(new SlotRequestId());
+		assertThat(sourceVertex.getLocationConstraint().getSlotRequestId(), is(notNullValue()));
+
+		final String exceptionMessage = "expected exception";
+		scheduler.updateTaskExecutionState(new TaskExecutionState(jobId, sourceAttemptId, ExecutionState.FAILED, new RuntimeException(exceptionMessage)));
+		scheduler.updateTaskExecutionState(new TaskExecutionState(jobId, sinkAttemptId, ExecutionState.CANCELED));
+		taskRestartExecutor.triggerScheduledTasks();
+
+		assertThat(sourceVertex.getLocationConstraint().getSlotRequestId(), is(nullValue()));
 	}
 
 	private static JobVertex createVertexWithAllInputConstraints(String name, int parallelism) {


### PR DESCRIPTION
## What is the purpose of the change

The colocation constraints are not reset on task recovery, which may lead to task recovery failures when allocating slots.
We should reset the colocation constraints before resetting vertices, just like what we do in the legacy scheduler.

## Brief change log

  - *Reset colocation constraints when restarting tasks in DefaultScheduler#resetForNewExecutions(...)*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added a unit test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
