### PR TITLE
[FLINK-16136][yarn][tests] Increase disk space limit for all YARN tests

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -188,6 +188,7 @@ public abstract class YarnTestBase extends TestLogger {
 		YARN_CONFIGURATION.setInt(YarnConfiguration.NM_VCORES, 666); // memory is overwritten in the MiniYARNCluster.
 		// so we have to change the number of cores for testing.
 		YARN_CONFIGURATION.setInt(YarnConfiguration.RM_AM_EXPIRY_INTERVAL_MS, 20000); // 20 seconds expiry (to ensure we properly heartbeat with YARN).
+		YARN_CONFIGURATION.setFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, 99.0F);
 	}
 
 	public static void populateYarnSecureConfigurations(Configuration conf, String principal, String keytab) {


### PR DESCRIPTION
## What is the purpose of the change

- Increase test stability by requiring less free disk space (the azure agents have large disks, but little free space (proportionally))


## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

This code only affects the testing infrastructure.

## Documentation

  - Does this pull request introduce a new feature? (yes / *no*)
  - If yes, how is the feature documented? (not applicable)
