### PR TITLE
[Hotfix]Add suffix L to WatermarkGeneratorCodeGenTest#testAscendingWatermark long type fields

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/WatermarkGeneratorCodeGenTest.scala
@@ -74,10 +74,10 @@ class WatermarkGeneratorCodeGenTest {
     val expected = List(
       JLong.valueOf(999L),
       null,
-      JLong.valueOf(2999),
-      JLong.valueOf(4999),
-      JLong.valueOf(3999),
-      JLong.valueOf(5999))
+      JLong.valueOf(2999L),
+      JLong.valueOf(4999L),
+      JLong.valueOf(3999L),
+      JLong.valueOf(5999L))
     assertEquals(expected, results)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Add suffix L to WatermarkGeneratorCodeGenTest#testAscendingWatermark long type fields

## Brief change log

Add suffix L to WatermarkGeneratorCodeGenTest#testAscendingWatermark long type fields

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
