### PR TITLE
[FLINK-16147][Flink-Table-Common] WatermarkSepc#toString contain watermarkExprOutputType field

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/WatermarkSpec.java
@@ -92,7 +92,9 @@ public class WatermarkSpec {
 
 	@Override
 	public String toString() {
-		return "rowtime: '" + rowtimeAttribute + '\'' +
-			", watermark: '" + watermarkExpressionString + '\'';
+		return "WatermarkSpec{rowtime: '" + rowtimeAttribute + '\'' +
+			", watermark: '" + watermarkExpressionString + '\'' +
+			", outputType: '" + watermarkExprOutputType + '\'' +
+			"}";
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change
WatermarkSepc#toString method include watermarkExprOutputType field

## Brief change log
Add watermarkExprOutputType and 'WatermarkSpec{}' around WatermarkSepc#toString method.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
