### PR TITLE
[FLINK-16164][build] Disable maven-site-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1699,6 +1699,18 @@ under the License.
 					</configuration>
 				</plugin>
 
+				<plugin>
+					<!-- Imherited from Apache parent, but not actually used. Disable to reduce noise. -->
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>attach-descriptor</id>
+							<phase>none</phase>
+						</execution>
+					</executions>
+				</plugin>
+
 				<!-- Disable certain plugins in Eclipse -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1700,7 +1700,7 @@ under the License.
 				</plugin>
 
 				<plugin>
-					<!-- Imherited from Apache parent, but not actually used. Disable to reduce noise. -->
+					<!-- Inherited from Apache parent, but not actually used. Disable to reduce noise. -->
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
 					<executions>


### PR DESCRIPTION
The maven-site-plugin can be used to generate a site for the project, like the sites used by various maven modules.
We inherit an execution for this plugin, but don't actually use it.

This PR disables the execution to remove some noise from the build.