### PR TITLE
[FLINK-15833] Fix 'Kerberized YARN on Docker' e2e test 

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -88,11 +88,8 @@ run_test "Resuming Externalized Checkpoint after terminal failure (rocks, increm
 # Docker
 ################################################################################
 
-# Ignore these tests on Azure: In these tests, the TaskManagers are not starting on YARN, probably due to memory constraints.
-if [ -z "$TF_BUILD" ] ; then
-	run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
-	run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
-fi
+run_test "Running Kerberized YARN on Docker test (default input)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh"
+run_test "Running Kerberized YARN on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scripts/test_yarn_kerberos_docker.sh dummy-fs"
 
 ################################################################################
 # High Availability

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -79,9 +79,9 @@ function start_hadoop_cluster() {
             sleep 1
         fi
 
-        docker exec -it master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
-        nm_running=`docker exec -it master bash -c "yarn node -list" | grep RUNNING | wc -l`
-        docker exec -it master bash -c "kdestroy"
+        docker exec master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
+        nm_running=`docker exec master bash -c "yarn node -list" | grep RUNNING | wc -l`
+        docker exec master bash -c "kdestroy"
     done
 
     echo "We now have $nm_running NodeManagers up."
@@ -113,7 +113,7 @@ function start_hadoop_cluster_and_prepare_flink() {
     docker cp $FLINK_TARBALL_DIR/$FLINK_TARBALL master:/home/hadoop-user/
 
     # now, at least the container is ready
-    docker exec -it master bash -c "tar xzf /home/hadoop-user/$FLINK_TARBALL --directory /home/hadoop-user/"
+    docker exec master bash -c "tar xzf /home/hadoop-user/$FLINK_TARBALL --directory /home/hadoop-user/"
 
     # minimal Flink config, bebe
     FLINK_CONFIG=$(cat << END
@@ -123,10 +123,10 @@ slot.request.timeout: 120000
 containerized.heap-cutoff-min: 100
 END
 )
-    docker exec -it master bash -c "echo \"$FLINK_CONFIG\" > /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
+    docker exec master bash -c "echo \"$FLINK_CONFIG\" > /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
 
     echo "Flink config:"
-    docker exec -it master bash -c "cat /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
+    docker exec master bash -c "cat /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
 }
 
 function copy_and_show_logs {
@@ -141,18 +141,18 @@ function copy_and_show_logs {
     docker logs master
 
     echo "Flink logs:"
-    docker exec -it master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
-    docker exec -it master bash -c "yarn application -list -appStates ALL"
-    application_id=`docker exec -it master bash -c "yarn application -list -appStates ALL" | grep "Flink" | grep "cluster" | awk '{print \$1}'`
+    docker exec master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
+    docker exec master bash -c "yarn application -list -appStates ALL"
+    application_id=`docker exec master bash -c "yarn application -list -appStates ALL" | grep "Flink" | grep "cluster" | awk '{print \$1}'`
     echo "Application ID: $application_id"
-    docker exec -it master bash -c "yarn logs -applicationId $application_id"
-    docker exec -it master bash -c "kdestroy"
+    docker exec master bash -c "yarn logs -applicationId $application_id"
+    docker exec master bash -c "kdestroy"
 }
 
 function get_output {
-    docker exec -it master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
-        docker exec -it master bash -c "hdfs dfs -ls $1"
-        OUTPUT=$(docker exec -it master bash -c "hdfs dfs -cat $1")
-        docker exec -it master bash -c "kdestroy"
+    docker exec master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
+        docker exec master bash -c "hdfs dfs -ls $1"
+        OUTPUT=$(docker exec master bash -c "hdfs dfs -cat $1")
+        docker exec master bash -c "kdestroy"
         echo "$OUTPUT"
 }

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -48,7 +48,7 @@ OUTPUT_PATH=hdfs:///user/hadoop-user/wc-out-$RANDOM
 
 # it's important to run this with higher parallelism, otherwise we might risk that
 # JM and TM are on the same YARN node and that we therefore don't test the keytab shipping
-if docker exec -it master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+if docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
    /home/hadoop-user/$FLINK_DIRNAME/bin/flink run -m yarn-cluster -ys 1 -ytm 1000 -yjm 1000 -p 3 \
    -yD taskmanager.memory.jvm-metaspace.size=128m \
    /home/hadoop-user/$FLINK_DIRNAME/examples/streaming/WordCount.jar $INPUT_ARGS --output $OUTPUT_PATH";
@@ -70,13 +70,15 @@ for expected_result in ${EXPECTED_RESULT_LOG_CONTAINS[@]}; do
 done
 
 echo "Running Job without configured keytab, the exception you see below is expected"
-docker exec -it master bash -c "echo \"\" > /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
+docker exec master bash -c "echo \"\" > /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
 # verify that it doesn't work if we don't configure a keytab
-OUTPUT=$(docker exec -it master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
+docker exec master bash -c "export HADOOP_CLASSPATH=\`hadoop classpath\` && \
     /home/hadoop-user/$FLINK_DIRNAME/bin/flink run \
     -m yarn-cluster -ys 1 -ytm 1000 -yjm 1000 -p 3 \
     -yD taskmanager.memory.jvm-metaspace.size=128m \
-    /home/hadoop-user/$FLINK_DIRNAME/examples/streaming/WordCount.jar --output $OUTPUT_PATH")
+    /home/hadoop-user/$FLINK_DIRNAME/examples/streaming/WordCount.jar --output $OUTPUT_PATH" > stderrAndstdoutFile 2>&1
+OUTPUT=$(cat stderrAndstdoutFile)
+rm stderrAndstdoutFile
 echo "$OUTPUT"
 
 if [[ ! "$OUTPUT" =~ "Hadoop security with Kerberos is enabled but the login user does not have Kerberos credentials" ]]; then


### PR DESCRIPTION
## What is the purpose of the change

The Kerberized YARN on Docker tests did not pass on Azure Pipelines.

## Brief change log

Mostly removed the `-it` argument from docker exec. `-it` is meant to be used for interactive shell sessions, not in scripts on a CI system.
Because of the `-it` argument, the docker command printed `the input device is not a TTY` to the output. That's why some checks / assumptions in the scripts failed.



## Verifying this change
Run this end to end test locally: `FLINK_DIR=../build-target ./run-single-test.sh ./test-scripts/test_yarn_kerberos_docker.sh`

Check the output of this build job: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5309&view=logs&j=b1623ac9-0979-5b0d-2e5e-1377d695c991

## Does this pull request potentially affect one of the following parts:

only affects test scripts
  
## Documentation

only affects test scripts

