### PR TITLE
[FLINK-7727] [REST] Improve error handling in StaticFileServerHandlers

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandler.java
@@ -171,25 +171,7 @@ public class HistoryServerStaticFileServerHandler extends SimpleChannelInboundHa
 			}
 		}
 
-		if (!file.exists() || file.isHidden() || file.isDirectory() || !file.isFile()) {
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("File not found."),
-				NOT_FOUND,
-				Collections.emptyMap());
-			return;
-		}
-
-		if (!file.getCanonicalFile().toPath().startsWith(rootPath.toPath())) {
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("File not found."),
-				NOT_FOUND,
-				Collections.emptyMap());
-			return;
-		}
+		StaticFileServerHandler.checkFileValidity(file, rootPath, ctx, request, Collections.emptyMap(), LOG);
 
 		// cache validation
 		final String ifModifiedSince = request.headers().get(IF_MODIFIED_SINCE);
@@ -220,6 +202,9 @@ public class HistoryServerStaticFileServerHandler extends SimpleChannelInboundHa
 		try {
 			raf = new RandomAccessFile(file, "r");
 		} catch (FileNotFoundException e) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Could not find file {}.", file.getAbsolutePath());
+			}
 			HandlerUtils.sendErrorResponse(
 				ctx,
 				request,


### PR DESCRIPTION
Adjusts the error handling in the `StaticFileServerHandlers` to
a) prevent probing of file existence outside of web directory,
b) return METHOD_NOT_ALLOWED when the requested resource is not a file,
c) log errors.

These changes are in part for security purposes (a), but mostly to ease debugging.