### PR TITLE
[FLINK-16168][build] Add build-debug profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -892,6 +892,42 @@ under the License.
 		</profile>
 
 		<profile>
+			<id>debug-build</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-help-plugin</artifactId>
+						<!-- Executing this for the parent module prints the profiles for all modules -->
+						<inherited>false</inherited>
+						<executions>
+							<execution>
+								<id>print-active-profiles</id>
+								<goals>
+									<goal>active-profiles</goal>
+								</goals>
+								<phase>validate</phase>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-dependency-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>print-dependencies</id>
+								<goals>
+									<goal>tree</goal>
+								</goals>
+								<phase>validate</phase>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
+		<profile>
 			<id>fast</id>
 			<activation>
 				<property>


### PR DESCRIPTION
Adds a `debug-build` profile for convenience that prints a dependency tree and shows active profiles.