### PR TITLE
[FLINK-16172][build] Add baseline set of allowed unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1676,6 +1676,34 @@ under the License.
 							<version>1.11.1</version>
 						</dependency>
 					</dependencies>
+					<configuration>
+						<ignoredUnusedDeclaredDependencies combine.children="append">
+							<!-- build dependency, required for shading; does not contain any classes -->
+							<dependency>org.apache.flink:force-shading</dependency>
+							<!-- compile dependencies; defined in root pom for brevity -->
+							<dependency>com.google.code.findbugs:jsr305</dependency>
+							<dependency>org.scala-lang:scala-compiler</dependency>
+							<!-- logging dependencies; defined in root pom for brevity
+									some modules may not use any logging, but that's not a problem
+									implementations are loaded via reflection and are always detected as unused -->
+							<dependency>org.slf4j:slf4j-api</dependency>
+							<!-- log4j1 -->
+							<dependency>log4j:log4j</dependency>
+							<dependency>org.slf4j:slf4j-log4j12</dependency>
+							<!-- log4j2 -->
+							<dependency>org.apache.logging.log4j:log4j-slf4j-impl</dependency>
+							<dependency>org.apache.logging.log4j:log4j-api</dependency>
+							<dependency>org.apache.logging.log4j:log4j-core</dependency>
+							<dependency>org.apache.logging.log4j:log4j-1.2-api</dependency>
+							<!-- test dependencies; defined in root pom for brevity -->
+							<dependency>org.apache.flink:flink-test-utils-junit</dependency>
+							<dependency>junit:junit</dependency>
+							<dependency>org.mockito:mockito-core</dependency>
+							<dependency>org.powermock:powermock-api-mockito2</dependency>
+							<dependency>org.powermock:powermock-module-junit4</dependency>
+							<dependency>org.hamcrest:hamcrest-all</dependency>
+						</ignoredUnusedDeclaredDependencies>
+					</configuration>
 				</plugin>
 
 				<!-- Pin the version of the maven shade plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -1677,6 +1677,16 @@ under the License.
 						</dependency>
 					</dependencies>
 					<configuration>
+						<ignoredUsedUndeclaredDependencies combine.children="append">
+							<!-- allow using transitive Flink dependencies for brevity -->
+							<dependency>org.apache.flink:*</dependency>
+							<!-- False positive since we use hamcrest-all -->
+							<dependency>org.hamcrest:hamcrest-core</dependency>
+							<!-- transitive powermock test dependencies; excluded for brevity -->
+							<dependency>org.powermock:powermock-core</dependency>
+							<dependency>org.powermock:powermock-reflect</dependency>
+							<dependency>org.powermock:powermock-api-support</dependency>
+						</ignoredUsedUndeclaredDependencies>
 						<ignoredUnusedDeclaredDependencies combine.children="append">
 							<!-- build dependency, required for shading; does not contain any classes -->
 							<dependency>org.apache.flink:force-shading</dependency>


### PR DESCRIPTION
Add a baseline of dependencies that we allow to be unused, along with a set of dependencies that we allowed to be used without a declared dependencies.

The purpose here is to ease the analysis of unused dependencies by excluding non-critical dependencies.

You can compare the difference by running `mvn dependency:analyze` before and after this change.