### PR TITLE
[FLINK-16180][runtime] Replace the nullable vertexExecution in ScheduledUnit with a non-null executionVertexId

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
@@ -18,23 +18,21 @@
 
 package org.apache.flink.runtime.jobmanager.scheduler;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.instance.SlotSharingGroupId;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
 /**
- * ScheduledUnit contains the information necessary to allocate a slot for the given
- * {@link JobVertexID}.
+ * ScheduledUnit contains the information necessary to allocate a slot for the given task.
  */
 public class ScheduledUnit {
 
-	@Nullable
-	private final Execution vertexExecution;
-
-	private final JobVertexID jobVertexId;
+	private final ExecutionVertexID executionVertexId;
 
 	@Nullable
 	private final SlotSharingGroupId slotSharingGroupId;
@@ -44,18 +42,16 @@ public class ScheduledUnit {
 
 	// --------------------------------------------------------------------------------------------
 
+	@VisibleForTesting
 	public ScheduledUnit(Execution task) {
 		this(
-			Preconditions.checkNotNull(task),
-			task.getVertex().getJobvertexId(),
-			null,
+			task,
 			null);
 	}
 
 	public ScheduledUnit(Execution task, @Nullable SlotSharingGroupId slotSharingGroupId) {
 		this(
-			Preconditions.checkNotNull(task),
-			task.getVertex().getJobvertexId(),
+			task,
 			slotSharingGroupId,
 			null);
 	}
@@ -65,31 +61,28 @@ public class ScheduledUnit {
 			@Nullable SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 		this(
-			Preconditions.checkNotNull(task),
-			task.getVertex().getJobvertexId(),
+			Preconditions.checkNotNull(task).getVertex().getID(),
 			slotSharingGroupId,
 			coLocationConstraint);
 	}
 
+	@VisibleForTesting
 	public ScheduledUnit(
 			JobVertexID jobVertexId,
 			@Nullable SlotSharingGroupId slotSharingGroupId,
 			@Nullable CoLocationConstraint coLocationConstraint) {
 		this(
-			null,
-			jobVertexId,
+			new ExecutionVertexID(jobVertexId, 0),
 			slotSharingGroupId,
 			coLocationConstraint);
 	}
 
 	public ScheduledUnit(
-		@Nullable Execution task,
-		JobVertexID jobVertexId,
-		@Nullable SlotSharingGroupId slotSharingGroupId,
-		@Nullable CoLocationConstraint coLocationConstraint) {
+			ExecutionVertexID executionVertexId,
+			@Nullable SlotSharingGroupId slotSharingGroupId,
+			@Nullable CoLocationConstraint coLocationConstraint) {
 
-		this.vertexExecution = task;
-		this.jobVertexId = Preconditions.checkNotNull(jobVertexId);
+		this.executionVertexId = Preconditions.checkNotNull(executionVertexId);
 		this.slotSharingGroupId = slotSharingGroupId;
 		this.coLocationConstraint = coLocationConstraint;
 
@@ -98,12 +91,11 @@ public class ScheduledUnit {
 	// --------------------------------------------------------------------------------------------
 
 	public JobVertexID getJobVertexId() {
-		return jobVertexId;
+		return executionVertexId.getJobVertexId();
 	}
 
-	@Nullable
-	public Execution getTaskToExecute() {
-		return vertexExecution;
+	public int getSubtaskIndex() {
+		return executionVertexId.getSubtaskIndex();
 	}
 
 	@Nullable
@@ -120,7 +112,7 @@ public class ScheduledUnit {
 
 	@Override
 	public String toString() {
-		return "{task=" + vertexExecution.getVertexWithAttempt() + ", sharingUnit=" + slotSharingGroupId +
+		return "{task=" + executionVertexId + ", sharingUnit=" + slotSharingGroupId +
 				", locationConstraint=" + coLocationConstraint + '}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/scheduler/ScheduledUnit.java
@@ -41,9 +41,9 @@ public class ScheduledUnit {
 
 	@Nullable
 	private final CoLocationConstraint coLocationConstraint;
-	
+
 	// --------------------------------------------------------------------------------------------
-	
+
 	public ScheduledUnit(Execution task) {
 		this(
 			Preconditions.checkNotNull(task),
@@ -51,7 +51,7 @@ public class ScheduledUnit {
 			null,
 			null);
 	}
-	
+
 	public ScheduledUnit(Execution task, @Nullable SlotSharingGroupId slotSharingGroupId) {
 		this(
 			Preconditions.checkNotNull(task),
@@ -59,7 +59,7 @@ public class ScheduledUnit {
 			slotSharingGroupId,
 			null);
 	}
-	
+
 	public ScheduledUnit(
 			Execution task,
 			@Nullable SlotSharingGroupId slotSharingGroupId,
@@ -96,7 +96,7 @@ public class ScheduledUnit {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	public JobVertexID getJobVertexId() {
 		return jobVertexId;
 	}
@@ -117,7 +117,7 @@ public class ScheduledUnit {
 	}
 
 	// --------------------------------------------------------------------------------------------
-	
+
 	@Override
 	public String toString() {
 		return "{task=" + vertexExecution.getVertexWithAttempt() + ", sharingUnit=" + slotSharingGroupId +

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SchedulerImpl.java
@@ -135,7 +135,7 @@ public class SchedulerImpl implements Scheduler {
 		ScheduledUnit scheduledUnit,
 		SlotProfile slotProfile,
 		@Nullable Time allocationTimeout) {
-		log.debug("Received slot request [{}] for task: {}", slotRequestId, scheduledUnit.getTaskToExecute());
+		log.debug("Received slot request [{}] for task: {}", slotRequestId, scheduledUnit.getJobVertexId());
 
 		componentMainThreadExecutor.assertRunningInMainThread();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionSlotAllocator.java
@@ -104,7 +104,7 @@ public class DefaultExecutionSlotAllocator implements ExecutionSlotAllocator {
 								slotProviderStrategy.allocateSlot(
 									slotRequestId,
 									new ScheduledUnit(
-										executionVertexId.getJobVertexId(),
+										executionVertexId,
 										slotSharingGroupId,
 										schedulingRequirements.getCoLocationConstraint()),
 									SlotProfile.priorAllocation(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ProgrammedSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ProgrammedSlotProvider.java
@@ -118,8 +118,8 @@ class ProgrammedSlotProvider implements Scheduler {
 			ScheduledUnit task,
 			SlotProfile slotProfile,
 			Time allocationTimeout) {
-		JobVertexID vertexId = task.getTaskToExecute().getVertex().getJobvertexId();
-		int subtask = task.getTaskToExecute().getParallelSubtaskIndex();
+		final JobVertexID vertexId = task.getJobVertexId();
+		final int subtask = task.getSubtaskIndex();
 
 		CompletableFuture<LogicalSlot>[] forTask = slotFutures.get(vertexId);
 		if (forTask != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/DummyScheduledUnit.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 public class DummyScheduledUnit extends ScheduledUnit {
 	public DummyScheduledUnit() {
 		super(
-			null,
 			new JobVertexID(),
 			null,
 			null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/scheduler/SchedulerTestUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import java.util.ArrayList;
@@ -48,10 +49,13 @@ public class SchedulerTestUtils {
 		ExecutionJobVertex executionJobVertex = mock(ExecutionJobVertex.class);
 
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
+
+		final JobVertexID jobVertexID = new JobVertexID();
+		when(vertex.getID()).thenReturn(new ExecutionVertexID(jobVertexID, 0));
 		when(vertex.getJobId()).thenReturn(new JobID());
 		when(vertex.toString()).thenReturn("TEST-VERTEX");
 		when(vertex.getJobVertex()).thenReturn(executionJobVertex);
-		when(vertex.getJobvertexId()).thenReturn(new JobVertexID());
+		when(vertex.getJobvertexId()).thenReturn(jobVertexID);
 
 		Execution execution = mock(Execution.class);
 		when(execution.getVertex()).thenReturn(vertex);
@@ -78,12 +82,14 @@ public class SchedulerTestUtils {
 		ExecutionJobVertex executionJobVertex = mock(ExecutionJobVertex.class);
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 
+		final JobVertexID jobVertexID = new JobVertexID();
+		when(vertex.getID()).thenReturn(new ExecutionVertexID(jobVertexID, 0));
 		when(vertex.getPreferredLocationsBasedOnInputs()).thenReturn(preferredLocationFutures);
 		when(vertex.getPreferredLocations()).thenReturn(preferredLocationFutures);
 		when(vertex.getJobId()).thenReturn(new JobID());
 		when(vertex.toString()).thenReturn("TEST-VERTEX");
 		when(vertex.getJobVertex()).thenReturn(executionJobVertex);
-		when(vertex.getJobvertexId()).thenReturn(new JobVertexID());
+		when(vertex.getJobvertexId()).thenReturn(jobVertexID);
 
 		Execution execution = mock(Execution.class);
 		when(execution.getVertex()).thenReturn(vertex);
@@ -97,6 +103,8 @@ public class SchedulerTestUtils {
 		ExecutionVertex vertex = mock(ExecutionVertex.class);
 
 		when(executionJobVertex.getSlotSharingGroup()).thenReturn(slotSharingGroup);
+
+		when(vertex.getID()).thenReturn(new ExecutionVertexID(jid, taskIndex));
 		when(vertex.getPreferredLocationsBasedOnInputs()).thenReturn(Collections.emptyList());
 		when(vertex.getJobId()).thenReturn(new JobID());
 		when(vertex.getJobvertexId()).thenReturn(jid);
@@ -132,6 +140,7 @@ public class SchedulerTestUtils {
 			preferredLocationFutures.add(CompletableFuture.completedFuture(location));
 		}
 
+		when(vertex.getID()).thenReturn(new ExecutionVertexID(jid, taskIndex));
 		when(vertex.getJobVertex()).thenReturn(executionJobVertex);
 		when(vertex.getPreferredLocationsBasedOnInputs()).thenReturn(preferredLocationFutures);
 		when(vertex.getJobId()).thenReturn(new JobID());


### PR DESCRIPTION
## What is the purpose of the change

ScheduledUnit#vertexExecution is nullable but ProgrammedSlotProvider requires it to be non-null to work. This makes ProgrammedSlotProvider not able to be used by new scheduler tests since vertexExecution is never set in the new scheduler code path. It blocks us from reworking tests which are based legacy scheduling to base on the new scheduler.

Thus I opened this PR to replace the nullable vertexExecution with a non-null executionVertexID.

It also naturally fixes 2 other issues:
1. The log printed in SchedulerImpl#allocateSlotInternal(...) can be broken since the vertexExecution can be null.
2. an NPE issue reported in FLINK-16145.

## Brief change log

See commits.

## Verifying this change

This change is already covered by existing tests, such as *ExecutionTests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
