### PR TITLE
[FLINK-16128][docs]Translate "Google Cloud PubSub" page into Chinese

### DIFF
--- a/docs/dev/connectors/pubsub.md
+++ b/docs/dev/connectors/pubsub.md
@@ -149,7 +149,7 @@ env.addSource(pubsubSource)
 
 There are several reasons why a message might be send multiple times, such as failure scenarios on Google PubSub's side.
 
-Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee at-least-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
+Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee at-least-once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
 
 For this reason it's recommended to have a (much) lower checkpoint interval than acknowledgement deadline.
 

--- a/docs/dev/connectors/pubsub.md
+++ b/docs/dev/connectors/pubsub.md
@@ -143,13 +143,13 @@ env.addSource(pubsubSource)
 </div>
 </div>
 
-### Atleast once guarantee
+### At least once guarantee
 
 #### SourceFunction
 
 There are several reasons why a message might be send multiple times, such as failure scenarios on Google PubSub's side.
 
-Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee Atleast-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
+Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee at-least-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
 
 For this reason it's recommended to have a (much) lower checkpoint interval than acknowledgement deadline.
 

--- a/docs/dev/connectors/pubsub.zh.md
+++ b/docs/dev/connectors/pubsub.zh.md
@@ -37,7 +37,7 @@ under the License.
 <b>注意</b>：此连接器最近才加到 Flink 里，还未接受广泛测试。
 </p>
 
-注意连接器目前还不是二进制发行版的一部分，添加依赖、打包配置以及集群运行信息请参考[这里]({{ site.baseurl }}/dev/projectsetup/dependencies.html)
+注意连接器目前还不是二进制发行版的一部分，添加依赖、打包配置以及集群运行信息请参考[这里]({{ site.baseurl }}/zh/dev/projectsetup/dependencies.html)
 
 ## Consuming or Producing PubSubMessages
 
@@ -135,7 +135,7 @@ env.addSource(pubsubSource)
 </div>
 </div>
 
-### 精确一次语义保证
+### 至少一次语义保证
 
 #### SourceFunction
 

--- a/docs/dev/connectors/pubsub.zh.md
+++ b/docs/dev/connectors/pubsub.zh.md
@@ -23,9 +23,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-This connector provides a Source and Sink that can read from and write to
-[Google Cloud PubSub](https://cloud.google.com/pubsub). To use this connector, add the
-following dependency to your project:
+这个连接器可向 [Google Cloud PubSub](https://cloud.google.com/pubsub) 读取与写入数据。添加下面的依赖来使用此连接器:
 
 {% highlight xml %}
 <dependency>
@@ -39,24 +37,17 @@ following dependency to your project:
 <b>Note</b>: This connector has been added to Flink recently. It has not received widespread testing yet.
 </p>
 
-Note that the streaming connectors are currently not part of the binary
-distribution. See
-[here]({{ site.baseurl }}/dev/projectsetup/dependencies.html)
-for information about how to package the program with the libraries for
-cluster execution.
-
-
+注意连接器目前还不是二进制发行版的一部分，添加依赖、打包配置以及集群运行信息请参考[这里]({{ site.baseurl }}/dev/projectsetup/dependencies.html)
 
 ## Consuming or Producing PubSubMessages
 
-The connector provides a connectors for receiving and sending messages from and to Google PubSub.
-Google PubSub has an `at-least-once` guarantee and as such the connector delivers the same guarantees.
+连接器可以接收和发送 Google PubSub 的信息。和 Google PubSub 一样，这个连接器能够保证`至少一次`的语义。
 
 ### PubSub SourceFunction
 
-The class `PubSubSource` has a builder to create PubSubsources: `PubSubSource.newBuilder(...)`
+`PubSubSource` 类的对象由构建类来构建: `PubSubSource.newBuilder(...)`
 
-There are several optional methods to alter how the PubSubSource is created, the bare minimum is to provide a Google project, Pubsub subscription and a way to deserialize the PubSubMessages.
+除了 Google project，Pubsub subscription 和反序列化 PubSubMessage的方法是必须的，你有多种可选的方法来创建 PubSubSource。
 
 Example:
 
@@ -77,13 +68,13 @@ streamExecEnv.addSource(source);
 </div>
 </div>
 
-Currently the source functions [pulls](https://cloud.google.com/pubsub/docs/pull) messages from PubSub, [push endpoints](https://cloud.google.com/pubsub/docs/push) are not supported.
+当前还不支持 PubSub 的source functions [pulls](https://cloud.google.com/pubsub/docs/pull) messages和 [push endpoints](https://cloud.google.com/pubsub/docs/push)。
 
 ### PubSub Sink
 
-The class `PubSubSink` has a builder to create PubSubSinks. `PubSubSink.newBuilder(...)`
+`PubSubSink` 类的对象由构建类来构建: `PubSubSink.newBuilder(...)`
 
-This builder works in a similar way to the PubSubSource.
+构建类的使用方式与 PubSubSource 类似。
 
 Example:
 
@@ -106,17 +97,18 @@ dataStream.addSink(pubsubSink);
 
 ### Google Credentials
 
-Google uses [Credentials](https://cloud.google.com/docs/authentication/production) to authenticate and authorize applications so that they can use Google Cloud Platform resources (such as PubSub).
+应用程序需要使用 [Credentials](https://cloud.google.com/docs/authentication/production) 来通过认证和授权才能使用 Google Cloud Platform 的资源，例如PubSub。
 
-Both builders allow you to provide these credentials but by default the connectors will look for an environment variable: [GOOGLE_APPLICATION_CREDENTIALS](https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually) which should point to a file containing the credentials.
+上述的两个构建类都允许你提供 Credentials, 但是连接器默认会通过环境变量: [GOOGLE_APPLICATION_CREDENTIALS](https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually) 来获取 Credentials 的路径。
 
-If you want to provide Credentials manually, for instance if you read the Credentials yourself from an external system, you can use `PubSubSource.newBuilder(...).withCredentials(...)`.
+如果你想手动提供 Credentials，例如你想从外部系统读取 Credentials，你可以使用 `PubSubSource.newBuilder(...).withCredentials(...)`。
 
-### Integration testing
+### 集成测试
 
-When running integration tests you might not want to connect to PubSub directly but use a docker container to read and write to. (See: [PubSub testing locally](https://cloud.google.com/pubsub/docs/emulator))
+在集成测试的时候，如果你不想直接连 PubSub 而是想读取和写入一个 docker container，可以参照 [PubSub testing locally](https://cloud.google.com/pubsub/docs/emulator)。
 
-The following example shows how you would create a source to read messages from the emulator and send them back:
+下面的例子展示了如何使用 source 来从仿真器读取信息并发送回去：
+
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
 {% highlight java %}
@@ -143,22 +135,22 @@ env.addSource(pubsubSource)
 </div>
 </div>
 
-### Atleast once guarantee
+### 精确一次语义保证
 
 #### SourceFunction
 
-There are several reasons why a message might be send multiple times, such as failure scenarios on Google PubSub's side.
+有很多原因导致会一个信息会被多次发出，例如 Google PubSub 的故障。
 
-Another reason is when the acknowledgement deadline has passed. This is the time between receiving the message and between acknowledging the message. The PubSubSource will only acknowledge a message on successful checkpoints to guarantee Atleast-Once. This does mean if the time between successful checkpoints is larger than the acknowledgment deadline of your subscription messages will most likely be processed multiple times.
+另一个可能的原因是超过了确认的截止时间。这是收到信息的间隔和信息确认的间隔。PubSubSource 只有在信息被成功快照之后才会确认以保证至少一次的语义。这意味着，如果你的快照间隔大于信息确认的截止时间，那么你订阅的信息很有可能会被多次处理。
 
-For this reason it's recommended to have a (much) lower checkpoint interval than acknowledgement deadline.
+因此，我们建议把快照的间隔设置得比信息确认截止时间更短。
 
-See [PubSub](https://cloud.google.com/pubsub/docs/subscriber) for details on how to increase the acknowledgment deadline of your subscription.
+参照 [PubSub](https://cloud.google.com/pubsub/docs/subscriber) 来增加信息确认截止时间。
 
-Note: The metric `PubSubMessagesProcessedNotAcked` shows how many messages are waiting for the next checkpoint before they will be acknowledged.
+注意: `PubSubMessagesProcessedNotAcked` 显示了有多少信息正在等待下一个快照还没被确认。
 
 #### SinkFunction
 
-The sink function buffers messages that are to be send to PubSub for a short amount of time for performance reasons. Before each checkpoint this buffer is flushed and the checkpoint will not succeed unless the messages have been delivered to PubSub.
+Sink function 会把准备发到 PubSub 的信息短暂地缓存以提高性能。每次快照前，它会 flush 缓冲区，并且只有当所有信息成功发送到 PubSub 之后，快照才会成功完成。
 
 {% top %}

--- a/docs/dev/connectors/pubsub.zh.md
+++ b/docs/dev/connectors/pubsub.zh.md
@@ -34,7 +34,7 @@ under the License.
 {% endhighlight %}
 
 <p style="border-radius: 5px; padding: 5px" class="bg-danger">
-<b>Note</b>: This connector has been added to Flink recently. It has not received widespread testing yet.
+<b>注意</b>：此连接器最近才加到 Flink 里，还未接受广泛测试。
 </p>
 
 注意连接器目前还不是二进制发行版的一部分，添加依赖、打包配置以及集群运行信息请参考[这里]({{ site.baseurl }}/dev/projectsetup/dependencies.html)
@@ -47,7 +47,7 @@ under the License.
 
 `PubSubSource` 类的对象由构建类来构建: `PubSubSource.newBuilder(...)`
 
-除了 Google project，Pubsub subscription 和反序列化 PubSubMessage的方法是必须的，你有多种可选的方法来创建 PubSubSource。
+有多种可选的方法来创建 PubSubSource，但最低要求是要提供 Google Project、Pubsub 订阅和反序列化 PubSubMessages 的方法。
 
 Example:
 
@@ -68,7 +68,7 @@ streamExecEnv.addSource(source);
 </div>
 </div>
 
-当前还不支持 PubSub 的source functions [pulls](https://cloud.google.com/pubsub/docs/pull) messages和 [push endpoints](https://cloud.google.com/pubsub/docs/push)。
+当前还不支持 PubSub 的 source functions [pulls](https://cloud.google.com/pubsub/docs/pull) messages 和 [push endpoints](https://cloud.google.com/pubsub/docs/push)。
 
 ### PubSub Sink
 
@@ -97,7 +97,7 @@ dataStream.addSink(pubsubSink);
 
 ### Google Credentials
 
-应用程序需要使用 [Credentials](https://cloud.google.com/docs/authentication/production) 来通过认证和授权才能使用 Google Cloud Platform 的资源，例如PubSub。
+应用程序需要使用 [Credentials](https://cloud.google.com/docs/authentication/production) 来通过认证和授权才能使用 Google Cloud Platform 的资源，例如 PubSub。
 
 上述的两个构建类都允许你提供 Credentials, 但是连接器默认会通过环境变量: [GOOGLE_APPLICATION_CREDENTIALS](https://cloud.google.com/docs/authentication/production#obtaining_and_providing_service_account_credentials_manually) 来获取 Credentials 的路径。
 
@@ -141,16 +141,16 @@ env.addSource(pubsubSource)
 
 有很多原因导致会一个信息会被多次发出，例如 Google PubSub 的故障。
 
-另一个可能的原因是超过了确认的截止时间。这是收到信息的间隔和信息确认的间隔。PubSubSource 只有在信息被成功快照之后才会确认以保证至少一次的语义。这意味着，如果你的快照间隔大于信息确认的截止时间，那么你订阅的信息很有可能会被多次处理。
+另一个可能的原因是超过了确认的截止时间，即收到与确认信息之间的时间间隔。PubSubSource 只有在信息被成功快照之后才会确认以保证至少一次的语义。这意味着，如果你的快照间隔大于信息确认的截止时间，那么你订阅的信息很有可能会被多次处理。
 
 因此，我们建议把快照的间隔设置得比信息确认截止时间更短。
 
 参照 [PubSub](https://cloud.google.com/pubsub/docs/subscriber) 来增加信息确认截止时间。
 
-注意: `PubSubMessagesProcessedNotAcked` 显示了有多少信息正在等待下一个快照还没被确认。
+注意: `PubSubMessagesProcessedNotAcked` 显示了有多少信息正在等待下一个 checkpoint 还没被确认。
 
 #### SinkFunction
 
-Sink function 会把准备发到 PubSub 的信息短暂地缓存以提高性能。每次快照前，它会 flush 缓冲区，并且只有当所有信息成功发送到 PubSub 之后，快照才会成功完成。
+Sink function 会把准备发到 PubSub 的信息短暂地缓存以提高性能。每次 checkpoint 前，它会刷新缓冲区，并且只有当所有信息成功发送到 PubSub 之后，checkpoint 才会成功完成。
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request translates [Google Cloud PubSub](https://ci.apache.org/projects/flink/flink-docs-master/zh/dev/connectors/pubsub.html) page of connectors into Chinese


## Brief change log

- Translate the markdown file located at flink/docs/dev/connectors/pubsub.zh.md


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
