### PR TITLE
[FLINK-16182][table-api] Remove check against null types as a result of an input type inference

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -352,6 +352,14 @@ public class InputTypeStrategiesTest {
 				.expectSignature("f([<OUTPUT> | INT])")
 				.expectArgumentTypes(DataTypes.BOOLEAN()),
 
+			// surrounding info can not infer input type and does not help inferring a type
+			TestSpec
+				.forStrategy(explicitSequence(DataTypes.BOOLEAN()))
+				.surroundingStrategy(WILDCARD)
+				.calledWithArgumentTypes(DataTypes.NULL())
+				.expectSignature("f(BOOLEAN)")
+				.expectArgumentTypes(DataTypes.BOOLEAN()),
+
 			// surrounding function does not help inferring a type
 			TestSpec
 				.forStrategy(sequence(or(OUTPUT_IF_NULL, explicit(DataTypes.INT()))))


### PR DESCRIPTION
## What is the purpose of the change

It removes invalid check for null types as a result of an input type inference. Moreover it always fail for inferring output type based on surrounding info.


## Verifying this change
The behaviour in chained calls will be tested as part of FLINK-16033

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
