### PR TITLE
[FLINK-15958][table-common] Introduce unresolved data types in API

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DataTypeFactoryImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/DataTypeFactoryImpl.java
@@ -24,7 +24,10 @@ import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.UnresolvedDataType;
 import org.apache.flink.table.types.extraction.DataTypeExtractor;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
@@ -34,7 +37,6 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
 
 import javax.annotation.Nullable;
 
-import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
@@ -61,19 +63,29 @@ final class DataTypeFactoryImpl implements DataTypeFactory {
 	}
 
 	@Override
-	public Optional<DataType> createDataType(String name) {
-		final LogicalType parsedType = LogicalTypeParser.parse(name, classLoader);
-		final LogicalType resolvedType = parsedType.accept(resolver);
-		return Optional.of(fromLogicalToDataType(resolvedType));
+	public <T extends AbstractDataType<T>> DataType createDataType(AbstractDataType<T> abstractDataType) {
+		if (abstractDataType instanceof DataType) {
+			return (DataType) abstractDataType;
+		} else if (abstractDataType instanceof UnresolvedDataType) {
+			return ((UnresolvedDataType) abstractDataType).toDataType(this);
+		}
+		throw new ValidationException("Unsupported abstract data type.");
 	}
 
 	@Override
-	public Optional<DataType> createDataType(UnresolvedIdentifier identifier) {
+	public DataType createDataType(String name) {
+		final LogicalType parsedType = LogicalTypeParser.parse(name, classLoader);
+		final LogicalType resolvedType = parsedType.accept(resolver);
+		return fromLogicalToDataType(resolvedType);
+	}
+
+	@Override
+	public DataType createDataType(UnresolvedIdentifier identifier) {
 		if (!identifier.getDatabaseName().isPresent()) {
 			return createDataType(identifier.getObjectName());
 		}
 		final LogicalType resolvedType = resolveType(identifier);
-		return Optional.of(fromLogicalToDataType(resolvedType));
+		return fromLogicalToDataType(resolvedType);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -22,11 +22,15 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.AtomicDataType;
 import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.UnresolvedDataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -46,6 +50,7 @@ import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -73,12 +78,82 @@ import java.util.stream.Stream;
  * A {@link DataType} can be used to declare input and/or output types of operations. This class
  * enumerates all pre-defined data types of the Table & SQL API.
  *
+ * <p>For convenience, this class also contains methods for creating {@link UnresolvedDataType}s that
+ * need to be resolved at later stages. This is in particular useful for more complex types that are
+ * expressed as {@link Class} (see {@link #of(Class)}) or types that need to be looked up in a catalog
+ * (see {@link #of(String)}).
+ *
  * <p>NOTE: Planners might not support every data type with the desired precision or parameter. Please
  * see the planner compatibility and limitations section in the website documentation before using a
  * data type.
  */
 @PublicEvolving
 public final class DataTypes {
+
+	/**
+	 * Creates an unresolved type that will be resolved to a {@link DataType} by analyzing the given
+	 * class later.
+	 *
+	 * <p>During the resolution, Java reflection is used which can be supported by {@link DataTypeHint}
+	 * annotations for nested, structured types.
+	 *
+	 * <p>It will throw an {@link ValidationException} in cases where the reflective extraction needs
+	 * more information or simply fails.
+	 *
+	 * <p>The following examples show how to use and enrich the extraction process:
+	 *
+	 * <pre>
+	 * {@code
+	 *   // returns INT
+	 *   of(Integer.class)
+	 *
+	 *   // returns TIMESTAMP(9)
+	 *   of(java.time.LocalDateTime.class)
+	 *
+	 *   // returns an anonymous, unregistered structured type
+	 *   // that is deeply integrated into the API compared to opaque RAW types
+	 *   class User {
+	 *
+	 *     // extract fields automatically
+	 *     public String name;
+	 *     public int age;
+	 *
+	 *     // enrich the extraction with precision information
+	 *     public @DataTypeHint("DECIMAL(10,2)") BigDecimal accountBalance;
+	 *
+	 *     // enrich the extraction with forcing using RAW types
+	 *     public @DataTypeHint(forceRawPattern = "scala.") Address address;
+	 *
+	 *     // enrich the extraction by specifying defaults
+	 *     public @DataTypeHint(defaultSecondPrecision = 3) Log log;
+	 *   }
+	 *   of(User.class)
+	 * }
+	 * </pre>
+	 *
+	 * <p>Note: In most of the cases, the {@link UnresolvedDataType} will be automatically resolved by
+	 * the API. At other locations, a {@link DataTypeFactory} is provided.
+	 */
+	public static UnresolvedDataType of(Class<?> unresolvedClass) {
+		return new UnresolvedDataType(
+			() -> String.format("'%s'", unresolvedClass.getName()),
+			(factory) -> factory.createDataType(unresolvedClass));
+	}
+
+	/**
+	 * Creates an unresolved type that will be resolved to a {@link DataType} by using a fully or partially
+	 * defined name.
+	 *
+	 * <p>It includes both built-in types (e.g. "INT") as well as user-defined types (e.g. "mycat.mydb.Money").
+	 *
+	 * <p>Note: In most of the cases, the {@link UnresolvedDataType} will be automatically resolved by
+	 * the API. At other locations, a {@link DataTypeFactory} is provided.
+	 */
+	public static UnresolvedDataType of(String unresolvedName) {
+		return new UnresolvedDataType(
+			() -> unresolvedName,
+			(factory) -> factory.createDataType(unresolvedName));
+	}
 
 	// we use SQL-like naming for data types and avoid Java keyword clashes
 	// CHECKSTYLE.OFF: MethodName
@@ -474,6 +549,25 @@ public final class DataTypes {
 	}
 
 	/**
+	 * Unresolved data type of an array of elements with same subtype.
+	 *
+	 * <p>Compared to the SQL standard, the maximum cardinality of an array cannot be specified but
+	 * is fixed at {@link Integer#MAX_VALUE}. Also, any valid type is supported as a subtype.
+	 *
+	 * <p>Note: Compared to {@link #ARRAY(DataType)}, this method produces an {@link UnresolvedDataType}.
+	 * In most of the cases, the {@link UnresolvedDataType} will be automatically resolved by the API. At
+	 * other locations, a {@link DataTypeFactory} is provided.
+	 *
+	 * @see ArrayType
+	 */
+	public static UnresolvedDataType ARRAY(UnresolvedDataType unresolvedElementDataType) {
+		Preconditions.checkNotNull(unresolvedElementDataType, "Element data type must not be null.");
+		return new UnresolvedDataType(
+			() -> String.format(ArrayType.FORMAT, unresolvedElementDataType),
+			factory -> ARRAY(factory.createDataType(unresolvedElementDataType)));
+	}
+
+	/**
 	 * Data type of a multiset (=bag). Unlike a set, it allows for multiple instances for each of its
 	 * elements with a common subtype. Each unique value (including {@code NULL}) is mapped to some
 	 * multiplicity.
@@ -486,6 +580,27 @@ public final class DataTypes {
 	public static DataType MULTISET(DataType elementDataType) {
 		Preconditions.checkNotNull(elementDataType, "Element data type must not be null.");
 		return new CollectionDataType(new MultisetType(elementDataType.getLogicalType()), elementDataType);
+	}
+
+	/**
+	 * Unresolved data type of a multiset (=bag). Unlike a set, it allows for multiple instances for each of its
+	 * elements with a common subtype. Each unique value (including {@code NULL}) is mapped to some
+	 * multiplicity.
+	 *
+	 * <p>There is no restriction of element types; it is the responsibility of the user to ensure
+	 * uniqueness.
+	 *
+	 * <p>Note: Compared to {@link #MULTISET(DataType)}, this method produces an {@link UnresolvedDataType}. In
+	 * most of the cases, the {@link UnresolvedDataType} will be automatically resolved by the API. At other
+	 * locations, a {@link DataTypeFactory} is provided.
+	 *
+	 * @see MultisetType
+	 */
+	public static UnresolvedDataType MULTISET(UnresolvedDataType unresolvedElementDataType) {
+		Preconditions.checkNotNull(unresolvedElementDataType, "Element data type must not be null.");
+		return new UnresolvedDataType(
+			() -> String.format(MultisetType.FORMAT, unresolvedElementDataType),
+			factory -> MULTISET(factory.createDataType(unresolvedElementDataType)));
 	}
 
 	/**
@@ -507,6 +622,27 @@ public final class DataTypes {
 	}
 
 	/**
+	 * Unresolved data type of an associative array that maps keys (including {@code NULL}) to values (including
+	 * {@code NULL}). A map cannot contain duplicate keys; each key can map to at most one value.
+	 *
+	 * <p>There is no restriction of key types; it is the responsibility of the user to ensure uniqueness.
+	 * The map type is an extension to the SQL standard.
+	 *
+	 * <p>Note: Compared to {@link #MAP(DataType, DataType)}, this method produces an {@link UnresolvedDataType}.
+	 * In most of the cases, the {@link UnresolvedDataType} will be automatically resolved by the API. At
+	 * other locations, a {@link DataTypeFactory} is provided.
+	 *
+	 * @see MapType
+	 */
+	public static UnresolvedDataType MAP(AbstractDataType<?> keyDataType, AbstractDataType<?> valueDataType) {
+		Preconditions.checkNotNull(keyDataType, "Key data type must not be null.");
+		Preconditions.checkNotNull(valueDataType, "Value data type must not be null.");
+		return new UnresolvedDataType(
+			() -> String.format(MapType.FORMAT, keyDataType, valueDataType),
+			factory -> MAP(factory.createDataType(keyDataType), factory.createDataType(valueDataType)));
+	}
+
+	/**
 	 * Data type of a sequence of fields. A field consists of a field name, field type, and an optional
 	 * description. The most specific type of a row of a table is a row type. In this case, each column
 	 * of the row corresponds to the field of the row type that has the same ordinal position as the
@@ -515,16 +651,62 @@ public final class DataTypes {
 	 * <p>Compared to the SQL standard, an optional field description simplifies the handling with
 	 * complex structures.
 	 *
+	 * <p>Use {@link #FIELD(String, DataType)} or {@link #FIELD(String, DataType, String)} to construct
+	 * fields.
+	 *
 	 * @see RowType
 	 */
 	public static DataType ROW(Field... fields) {
-		final List<RowType.RowField> logicalFields = Stream.of(fields)
+		final List<RowField> logicalFields = Stream.of(fields)
 			.map(f -> Preconditions.checkNotNull(f, "Field definition must not be null."))
-			.map(f -> new RowType.RowField(f.name, f.dataType.getLogicalType(), f.description))
+			.map(f -> new RowField(f.name, f.dataType.getLogicalType(), f.description))
 			.collect(Collectors.toList());
 		final Map<String, DataType> fieldDataTypes = Stream.of(fields)
 			.collect(Collectors.toMap(f -> f.name, f -> f.dataType));
 		return new FieldsDataType(new RowType(logicalFields), fieldDataTypes);
+	}
+
+	/**
+	 * Data type of a row type with no fields. It only exists for completeness.
+	 *
+	 * @see #ROW(Field...)
+	 */
+	public static DataType ROW() {
+		return ROW(new Field[0]);
+	}
+
+	/**
+	 * Unresolved data type of a sequence of fields. A field consists of a field name, field type, and
+	 * an optional description. The most specific type of a row of a table is a row type. In this case,
+	 * each column of the row corresponds to the field of the row type that has the same ordinal position
+	 * as the column.
+	 *
+	 * <p>Compared to the SQL standard, an optional field description simplifies the handling with
+	 * complex structures.
+	 *
+	 * <p>Use {@link #FIELD(String, UnresolvedDataType)} or {@link #FIELD(String, UnresolvedDataType, String)}
+	 * to construct fields.
+	 *
+	 * <p>Note: Compared to {@link #ROW(Field...)} )}, this method produces an {@link UnresolvedDataType}
+	 * with {@link UnresolvedField}s. In most of the cases, the {@link UnresolvedDataType} will be
+	 * automatically resolved by the API. At other locations, a {@link DataTypeFactory} is provided.
+	 *
+	 * @see RowType
+	 */
+	public static UnresolvedDataType ROW(AbstractField<?>... fields) {
+		Stream.of(fields)
+			.forEach(f -> Preconditions.checkNotNull(f, "Field definition must not be null."));
+		return new UnresolvedDataType(
+			() -> String.format(
+				RowType.FORMAT,
+				Stream.of(fields).map(Object::toString).collect(Collectors.joining(", "))),
+			factory -> {
+				final Field[] fieldsArray = Stream.of(fields)
+					.map(f -> new Field(f.name, factory.createDataType(f.dataType), f.description))
+					.toArray(Field[]::new);
+				return ROW(fieldsArray);
+			}
+		);
 	}
 
 	/**
@@ -548,8 +730,8 @@ public final class DataTypes {
 	 *
 	 * <p>The raw type is an extension to the SQL standard.
 	 *
-	 * <p>This method assumes that a {@link TypeSerializer} instance is present. Use {@link #RAW(TypeInformation)}
-	 * for generating a serializer from Flink's core type system automatically in subsequent layers.
+	 * <p>This method assumes that a {@link TypeSerializer} instance is present. Use {@link #RAW(Class)}
+	 * for automatically generating a serializer.
 	 *
 	 * @param clazz originating value class
 	 * @param serializer type serializer
@@ -558,6 +740,28 @@ public final class DataTypes {
 	 */
 	public static <T> DataType RAW(Class<T> clazz, TypeSerializer<T> serializer) {
 		return new AtomicDataType(new RawType<>(clazz, serializer));
+	}
+
+	/**
+	 * Unresolved data type of an arbitrary serialized type. This type is a black box within the table
+	 * ecosystem and is only deserialized at the edges.
+	 *
+	 * <p>The raw type is an extension to the SQL standard.
+	 *
+	 * <p>Compared to {@link #RAW(Class, TypeSerializer)}, this method produces an {@link UnresolvedDataType}
+	 * where no serializer is known and a generic serializer should be used. During the resolution, a
+	 * {@link DataTypes#RAW(Class, TypeSerializer)} with Flink's default RAW serializer is created and
+	 * automatically configured.
+	 *
+	 * <p>Note: In most of the cases, the {@link UnresolvedDataType} will be automatically resolved by
+	 * the API. At other locations, a {@link DataTypeFactory} is provided.
+	 *
+	 * @see RawType
+	 */
+	public static <T> UnresolvedDataType RAW(Class<T> clazz) {
+		return new UnresolvedDataType(
+			() -> String.format(RawType.FORMAT, clazz.getName(), "?"),
+			factory -> factory.createRawDataType(clazz));
 	}
 
 	/**
@@ -680,12 +884,40 @@ public final class DataTypes {
 			Preconditions.checkNotNull(description, "Field description must not be null."));
 	}
 
+	/**
+	 * Unresolved field definition with field name and data type.
+	 *
+	 * <p>Note: Compared to {@link #FIELD(String, DataType)}, this method produces an {@link UnresolvedField}
+	 * containing an {@link UnresolvedDataType}.
+	 */
+	public static UnresolvedField FIELD(String name, UnresolvedDataType unresolvedDataType) {
+		return new UnresolvedField(
+			Preconditions.checkNotNull(name, "Field name must not be null."),
+			Preconditions.checkNotNull(unresolvedDataType, "Field data type must not be null."),
+			null);
+	}
+
+	/**
+	 * Unresolved field definition with field name, unresolved data type, and a description.
+	 *
+	 * <p>Note: Compared to {@link #FIELD(String, DataType, String)}, this method produces an {@link UnresolvedField}
+	 * containing an {@link UnresolvedDataType}.
+	 */
+	public static UnresolvedField FIELD(String name, UnresolvedDataType unresolvedDataType, String description) {
+		return new UnresolvedField(
+			Preconditions.checkNotNull(name, "Field name must not be null."),
+			Preconditions.checkNotNull(unresolvedDataType, "Field data type must not be null."),
+			Preconditions.checkNotNull(description, "Field description must not be null."));
+	}
+
 	// --------------------------------------------------------------------------------------------
 	// Helper classes
 	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Helper class for defining the resolution of an interval.
+	 *
+	 * @see #INTERVAL(Resolution)
 	 */
 	public static final class Resolution {
 
@@ -790,17 +1022,22 @@ public final class DataTypes {
 	}
 
 	/**
-	 * Helper class for defining the field of a row or structured type.
+	 * Common helper class for resolved and unresolved fields of a row or structured type.
+	 *
+	 * @see #FIELD(String, DataType)
+	 * @see #FIELD(String, DataType, String)
+	 * @see #FIELD(String, UnresolvedDataType)
+	 * @see #FIELD(String, UnresolvedDataType, String)
 	 */
-	public static final class Field {
+	public static class AbstractField<T extends AbstractDataType<T>> {
 
-		private final String name;
+		protected final String name;
 
-		private final DataType dataType;
+		protected final T dataType;
 
-		private final @Nullable String description;
+		protected final @Nullable String description;
 
-		private Field(String name, DataType dataType, String description) {
+		private AbstractField(String name, T dataType, @Nullable String description) {
 			this.name = name;
 			this.dataType = dataType;
 			this.description = description;
@@ -810,12 +1047,55 @@ public final class DataTypes {
 			return name;
 		}
 
-		public DataType getDataType() {
+		public T getDataType() {
 			return dataType;
 		}
 
 		public Optional<String> getDescription() {
 			return Optional.ofNullable(description);
+		}
+
+		@Override
+		public String toString() {
+			if (description != null) {
+				return String.format(
+					RowField.FIELD_FORMAT_WITH_DESCRIPTION,
+					name,
+					dataType,
+					description);
+			}
+			return String.format(
+				RowField.FIELD_FORMAT_NO_DESCRIPTION,
+				name,
+				dataType);
+		}
+	}
+
+	/**
+	 * Helper class for defining the field of a row or structured type.
+	 *
+	 * @see #FIELD(String, DataType)
+	 * @see #FIELD(String, DataType, String)
+	 */
+	public static final class Field extends AbstractField<DataType> {
+
+		private Field(String name, DataType dataType, @Nullable String description) {
+			super(name, dataType, description);
+		}
+	}
+
+	/**
+	 * Helper class for defining the unresolved field of a row or structured type.
+	 *
+	 * <p>Compared to {@link Field}, an unresolved field contains an {@link UnresolvedDataType}.
+	 *
+	 * @see #FIELD(String, UnresolvedDataType)
+	 * @see #FIELD(String, UnresolvedDataType, String)
+	 */
+	public static final class UnresolvedField extends AbstractField<UnresolvedDataType> {
+
+		private UnresolvedField(String name, UnresolvedDataType unresolvedDataType, @Nullable String description) {
+			super(name, unresolvedDataType, description);
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DataTypeFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/DataTypeFactory.java
@@ -23,11 +23,11 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.UnresolvedDataType;
 import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.StructuredType;
-
-import java.util.Optional;
 
 /**
  * Factory for creating fully resolved data types that can be used for planning.
@@ -39,12 +39,20 @@ import java.util.Optional;
 public interface DataTypeFactory {
 
 	/**
+	 * Creates a type out of an {@link AbstractDataType}.
+	 *
+	 * <p>If the given type is already a {@link DataType}, the factory will return it unmodified. In
+	 * case of {@link UnresolvedDataType}, the factory will resolve it to a {@link DataType}.
+	 */
+	<T extends AbstractDataType<T>> DataType createDataType(AbstractDataType<T> abstractDataType);
+
+	/**
 	 * Creates a type by a fully or partially defined name.
 	 *
 	 * <p>The factory will parse and resolve the name of a type to a {@link DataType}. This includes
 	 * both built-in types as well as user-defined types (see {@link DistinctType} and {@link StructuredType}).
 	 */
-	Optional<DataType> createDataType(String name);
+	DataType createDataType(String name);
 
 	/**
 	 * Creates a type by a fully or partially defined identifier.
@@ -52,7 +60,7 @@ public interface DataTypeFactory {
 	 * <p>The factory will parse and resolve the name of a type to a {@link DataType}. This includes
 	 * both built-in types as well as user-defined types (see {@link DistinctType} and {@link StructuredType}).
 	 */
-	Optional<DataType> createDataType(UnresolvedIdentifier identifier);
+	DataType createDataType(UnresolvedIdentifier identifier);
 
 	/**
 	 * Creates a type by analyzing the given class.
@@ -63,36 +71,7 @@ public interface DataTypeFactory {
 	 * <p>It will throw an {@link ValidationException} in cases where the reflective extraction needs
 	 * more information or simply fails.
 	 *
-	 * <p>The following examples show how to use and enrich the extraction process:
-	 *
-	 * <pre>
-	 * {@code
-	 *   // returns INT
-	 *   createDataType(Integer.class)
-	 *
-	 *   // returns TIMESTAMP(9)
-	 *   createDataType(java.time.LocalDateTime.class)
-	 *
-	 *   // returns an anonymous, unregistered structured type
-	 *   // that is deeply integrated into the API compared to opaque RAW types
-	 *   class User {
-	 *
-	 *     // extract fields automatically
-	 *     public String name;
-	 *     public int age;
-	 *
-	 *     // enrich the extraction with precision information
-	 *     public @DataTypeHint("DECIMAL(10,2)") BigDecimal accountBalance;
-	 *
-	 *     // enrich the extraction with forcing using RAW types
-	 *     public @DataTypeHint(forceRawPattern = "scala.") Address address;
-	 *
-	 *     // enrich the extraction by specifying defaults
-	 *     public @DataTypeHint(defaultSecondPrecision = 3) Log log;
-	 *   }
-	 *   createDataType(User.class)
-	 * }
-	 * </pre>
+	 * <p>See {@link DataTypes#of(Class)} for further examples.
 	 */
 	<T> DataType createDataType(Class<T> clazz);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AbstractDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AbstractDataType.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.types.logical.LogicalType;
+
+/**
+ * Highest abstraction that describes the data type of a value in the table ecosystem. This class
+ * describes two kinds of data types:
+ *
+ * <p>Fully resolved data types that can be used directly to declare input and/or output types of
+ * operations. This kind is represented in subclasses of {@link DataType}.
+ *
+ * <p>Partially resolved data types that can be resolved to {@link DataType} but require a lookup in
+ * a catalog or configuration first. This kind is represented in subclasses of {@link UnresolvedDataType}.
+ *
+ * @param <T> kind of data type returned after mutation
+ */
+@PublicEvolving
+public interface AbstractDataType<T extends AbstractDataType<T>> {
+
+	/**
+	 * Adds a hint that null values are not expected in the data for this type.
+	 *
+	 * @return a new, reconfigured data type instance
+	 */
+	T notNull();
+
+	/**
+	 * Adds a hint that null values are expected in the data for this type (default behavior).
+	 *
+	 * <p>This method exists for explicit declaration of the default behavior or for invalidation of
+	 * a previous call to {@link #notNull()}.
+	 *
+	 * @return a new, reconfigured data type instance
+	 */
+	T nullable();
+
+	/**
+	 * Adds a hint that data should be represented using the given class when entering or leaving
+	 * the table ecosystem.
+	 *
+	 * <p>A supported conversion class depends on the logical type and its nullability property.
+	 *
+	 * <p>Please see the implementation of {@link LogicalType#supportsInputConversion(Class)},
+	 * {@link LogicalType#supportsOutputConversion(Class)}, or the documentation for more information
+	 * about supported conversions.
+	 *
+	 * @return a new, reconfigured data type instance
+	 */
+	T bridgedTo(Class<?> newConversionClass);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -50,7 +50,7 @@ import java.util.Objects;
  * @see DataTypes for a list of supported data types and instances of this class.
  */
 @PublicEvolving
-public abstract class DataType implements Serializable {
+public abstract class DataType implements AbstractDataType<DataType>, Serializable {
 
 	protected final LogicalType logicalType;
 
@@ -83,37 +83,6 @@ public abstract class DataType implements Serializable {
 	public Class<?> getConversionClass() {
 		return conversionClass;
 	}
-
-	/**
-	 * Adds a hint that null values are not expected in the data for this type.
-	 *
-	 * @return a new, reconfigured data type instance
-	 */
-	public abstract DataType notNull();
-
-	/**
-	 * Adds a hint that null values are expected in the data for this type (default behavior).
-	 *
-	 * <p>This method exists for explicit declaration of the default behavior or for invalidation of
-	 * a previous call to {@link #notNull()}.
-	 *
-	 * @return a new, reconfigured data type instance
-	 */
-	public abstract DataType nullable();
-
-	/**
-	 * Adds a hint that data should be represented using the given class when entering or leaving
-	 * the table ecosystem.
-	 *
-	 * <p>A supported conversion class depends on the logical type and its nullability property.
-	 *
-	 * <p>Please see the implementation of {@link LogicalType#supportsInputConversion(Class)},
-	 * {@link LogicalType#supportsOutputConversion(Class)}, or the documentation for more information
-	 * about supported conversions.
-	 *
-	 * @return a new, reconfigured data type instance
-	 */
-	public abstract DataType bridgedTo(Class<?> newConversionClass);
 
 	public abstract <R> R accept(DataTypeVisitor<R> visitor);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/UnresolvedDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/UnresolvedDataType.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import javax.annotation.Nullable;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Partially resolved data type that requires a lookup in a catalog or configuration before creating
+ * the corresponding {@link LogicalType}.
+ *
+ * <p>Users are able to influence the nullability and conversion class even if the actual {@link LogicalType}
+ * is not fully known yet. The information is stored and verified when resolving to {@link DataType}
+ * lazily.
+ */
+@PublicEvolving
+public final class UnresolvedDataType implements AbstractDataType<UnresolvedDataType> {
+
+	private static final String FORMAT = "[%s]"; // indicates that this is an unresolved type
+
+	private final @Nullable Boolean isNullable;
+
+	private final @Nullable Class<?> conversionClass;
+
+	private final Supplier<String> description;
+
+	private final Function<DataTypeFactory, DataType> resolutionFactory;
+
+	private UnresolvedDataType(
+			@Nullable Boolean isNullable,
+			@Nullable Class<?> conversionClass,
+			Supplier<String> description,
+			Function<DataTypeFactory, DataType> resolutionFactory) {
+		this.isNullable = isNullable;
+		this.conversionClass = conversionClass;
+		this.description = description;
+		this.resolutionFactory = resolutionFactory;
+	}
+
+	public UnresolvedDataType(
+			Supplier<String> description,
+			Function<DataTypeFactory, DataType> resolutionFactory) {
+		this(null, null, description, resolutionFactory);
+	}
+
+	/**
+	 * Converts this instance to a resolved {@link DataType} possibly enriched with additional
+	 * nullability and conversion class information.
+	 */
+	public DataType toDataType(DataTypeFactory factory) {
+		DataType resolvedDataType = resolutionFactory.apply(factory);
+		if (isNullable == Boolean.TRUE) {
+			resolvedDataType = resolvedDataType.nullable();
+		} else if (isNullable == Boolean.FALSE) {
+			resolvedDataType = resolvedDataType.notNull();
+		}
+		if (conversionClass != null) {
+			resolvedDataType = resolvedDataType.bridgedTo(conversionClass);
+		}
+		return resolvedDataType;
+	}
+
+	@Override
+	public UnresolvedDataType notNull() {
+		return new UnresolvedDataType(false, conversionClass, description, resolutionFactory);
+	}
+
+	@Override
+	public UnresolvedDataType nullable() {
+		return new UnresolvedDataType(true, conversionClass, description, resolutionFactory);
+	}
+
+	@Override
+	public UnresolvedDataType bridgedTo(Class<?> newConversionClass) {
+		return new UnresolvedDataType(isNullable, newConversionClass, description, resolutionFactory);
+	}
+
+	@Override
+	public String toString() {
+		return String.format(FORMAT, description.get());
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/DataTypeTemplate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/utils/DataTypeTemplate.java
@@ -35,7 +35,6 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.createRawType;
-import static org.apache.flink.table.types.extraction.utils.ExtractionUtils.extractionError;
 
 /**
  * Internal representation of a {@link DataTypeHint}.
@@ -315,14 +314,11 @@ public final class DataTypeTemplate {
 				return createRawType(typeFactory, template.rawSerializer, conversionClass);
 			}
 			// regular type that must be resolvable
-			return typeFactory.createDataType(typeName)
-				.map(dataType -> {
-					if (conversionClass != null) {
-						return dataType.bridgedTo(conversionClass);
-					}
-					return dataType;
-				})
-				.orElseThrow(() -> extractionError("Could not resolve type with name '%s'.", typeName));
+			final DataType resolvedDataType = typeFactory.createDataType(typeName);
+			if (conversionClass != null) {
+				return resolvedDataType.bridgedTo(conversionClass);
+			}
+			return resolvedDataType;
 		}
 		// extracted data type
 		else if (conversionClass != null) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ArrayType.java
@@ -38,7 +38,7 @@ import java.util.Set;
 @PublicEvolving
 public final class ArrayType extends LogicalType {
 
-	private static final String FORMAT = "ARRAY<%s>";
+	public static final String FORMAT = "ARRAY<%s>";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		"org.apache.flink.table.dataformat.BinaryArray");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MapType.java
@@ -40,7 +40,7 @@ import java.util.Set;
 @PublicEvolving
 public final class MapType extends LogicalType {
 
-	private static final String FORMAT = "MAP<%s, %s>";
+	public static final String FORMAT = "MAP<%s, %s>";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		Map.class.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/MultisetType.java
@@ -42,7 +42,7 @@ import java.util.Set;
 @PublicEvolving
 public final class MultisetType extends LogicalType {
 
-	private static final String FORMAT = "MULTISET<%s>";
+	public static final String FORMAT = "MULTISET<%s>";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		Map.class.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RawType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RawType.java
@@ -43,7 +43,7 @@ import java.util.Set;
 @PublicEvolving
 public final class RawType<T> extends LogicalType {
 
-	private static final String FORMAT = "RAW('%s', '%s')";
+	public static final String FORMAT = "RAW('%s', '%s')";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		byte[].class.getName(),

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/RowType.java
@@ -52,7 +52,7 @@ import static org.apache.flink.table.utils.EncodingUtils.escapeSingleQuotes;
 @PublicEvolving
 public final class RowType extends LogicalType {
 
-	private static final String FORMAT = "ROW<%s>";
+	public static final String FORMAT = "ROW<%s>";
 
 	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
 		Row.class.getName(),
@@ -65,9 +65,9 @@ public final class RowType extends LogicalType {
 	 */
 	public static final class RowField implements Serializable {
 
-		private static final String FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
+		public static final String FIELD_FORMAT_WITH_DESCRIPTION = "%s %s '%s'";
 
-		private static final String FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
+		public static final String FIELD_FORMAT_NO_DESCRIPTION = "%s %s";
 
 		private final String name;
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/DataTypesTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.types;
 
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.common.typeutils.base.VoidSerializer;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -49,6 +50,7 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType.YearMonthResolution;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.table.types.utils.LogicalTypeDataTypeConverter;
 import org.apache.flink.types.Row;
 
@@ -58,10 +60,13 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import javax.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.flink.table.api.DataTypes.ARRAY;
 import static org.apache.flink.table.api.DataTypes.BIGINT;
@@ -108,130 +113,343 @@ import static org.junit.Assert.assertThat;
 @RunWith(Parameterized.class)
 public class DataTypesTest {
 
-	@Parameters(name = "{index}: {0}=[Logical: {1}, Class: {2}]")
-	public static List<Object[]> dataTypes() {
+	@Parameters(name = "{index}: {0}")
+	public static List<TestSpec> testData() {
 		return Arrays.asList(
-			new Object[][]{
-				{CHAR(2), new CharType(2), String.class},
+			TestSpec
+				.forDataType(CHAR(2))
+				.expectLogicalType(new CharType(2))
+				.expectConversionClass(String.class),
 
-				{VARCHAR(2), new VarCharType(2), String.class},
+			TestSpec
+				.forDataType(VARCHAR(2))
+				.expectLogicalType(new VarCharType(2))
+				.expectConversionClass(String.class),
 
-				{STRING(), new VarCharType(VarCharType.MAX_LENGTH), String.class},
+			TestSpec
+				.forDataType(STRING())
+				.expectLogicalType(new VarCharType(VarCharType.MAX_LENGTH))
+				.expectConversionClass(String.class),
 
-				{BOOLEAN(), new BooleanType(), Boolean.class},
+			TestSpec
+				.forDataType(BOOLEAN())
+				.expectLogicalType(new BooleanType())
+				.expectConversionClass(Boolean.class),
 
-				{BINARY(42), new BinaryType(42), byte[].class},
+			TestSpec
+				.forDataType(BINARY(42))
+				.expectLogicalType(new BinaryType(42))
+				.expectConversionClass(byte[].class),
 
-				{VARBINARY(42), new VarBinaryType(42), byte[].class},
+			TestSpec
+				.forDataType(VARBINARY(42))
+				.expectLogicalType(new VarBinaryType(42))
+				.expectConversionClass(byte[].class),
 
-				{BYTES(), new VarBinaryType(VarBinaryType.MAX_LENGTH), byte[].class},
+			TestSpec
+				.forDataType(BYTES())
+				.expectLogicalType(new VarBinaryType(VarBinaryType.MAX_LENGTH))
+				.expectConversionClass(byte[].class),
 
-				{DECIMAL(10, 10), new DecimalType(10, 10), BigDecimal.class},
+			TestSpec
+				.forDataType(DECIMAL(10, 10))
+				.expectLogicalType(new DecimalType(10, 10))
+				.expectConversionClass(BigDecimal.class),
 
-				{TINYINT(), new TinyIntType(), Byte.class},
+			TestSpec
+				.forDataType(TINYINT())
+				.expectLogicalType(new TinyIntType())
+				.expectConversionClass(Byte.class),
 
-				{SMALLINT(), new SmallIntType(), Short.class},
+			TestSpec
+				.forDataType(SMALLINT())
+				.expectLogicalType(new SmallIntType())
+				.expectConversionClass(Short.class),
 
-				{INT(), new IntType(), Integer.class},
+			TestSpec
+				.forDataType(INT())
+				.expectLogicalType(new IntType())
+				.expectConversionClass(Integer.class),
 
-				{BIGINT(), new BigIntType(), Long.class},
+			TestSpec
+				.forDataType(BIGINT())
+				.expectLogicalType(new BigIntType())
+				.expectConversionClass(Long.class),
 
-				{FLOAT(), new FloatType(), Float.class},
+			TestSpec
+				.forDataType(FLOAT())
+				.expectLogicalType(new FloatType())
+				.expectConversionClass(Float.class),
 
-				{DOUBLE(), new DoubleType(), Double.class},
+			TestSpec
+				.forDataType(DOUBLE())
+				.expectLogicalType(new DoubleType())
+				.expectConversionClass(Double.class),
 
-				{DATE(), new DateType(), java.time.LocalDate.class},
+			TestSpec
+				.forDataType(DATE())
+				.expectLogicalType(new DateType())
+				.expectConversionClass(java.time.LocalDate.class),
 
-				{TIME(3), new TimeType(3), java.time.LocalTime.class},
+			TestSpec
+				.forDataType(TIME(3))
+				.expectLogicalType(new TimeType(3))
+				.expectConversionClass(java.time.LocalTime.class),
 
-				{TIME(), new TimeType(0), java.time.LocalTime.class},
+			TestSpec
+				.forDataType(TIME())
+				.expectLogicalType(new TimeType(0))
+				.expectConversionClass(java.time.LocalTime.class),
 
-				{TIMESTAMP(3), new TimestampType(3), java.time.LocalDateTime.class},
+			TestSpec
+				.forDataType(TIMESTAMP(3))
+				.expectLogicalType(new TimestampType(3))
+				.expectConversionClass(java.time.LocalDateTime.class),
 
-				{TIMESTAMP(), new TimestampType(6), java.time.LocalDateTime.class},
+			TestSpec
+				.forDataType(TIMESTAMP())
+				.expectLogicalType(new TimestampType(6))
+				.expectConversionClass(java.time.LocalDateTime.class),
 
-				{TIMESTAMP_WITH_TIME_ZONE(3),
-					new ZonedTimestampType(3),
-					java.time.OffsetDateTime.class},
+			TestSpec
+				.forDataType(TIMESTAMP_WITH_TIME_ZONE(3))
+				.expectLogicalType(new ZonedTimestampType(3))
+				.expectConversionClass(java.time.OffsetDateTime.class),
 
-				{TIMESTAMP_WITH_TIME_ZONE(),
-					new ZonedTimestampType(6),
-					java.time.OffsetDateTime.class},
+			TestSpec
+				.forDataType(TIMESTAMP_WITH_TIME_ZONE())
+				.expectLogicalType(new ZonedTimestampType(6))
+				.expectConversionClass(java.time.OffsetDateTime.class),
 
-				{TIMESTAMP_WITH_LOCAL_TIME_ZONE(3),
-					new LocalZonedTimestampType(3),
-					java.time.Instant.class},
+			TestSpec
+				.forDataType(TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))
+				.expectLogicalType(new LocalZonedTimestampType(3))
+				.expectConversionClass(java.time.Instant.class),
 
-				{TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
-					new LocalZonedTimestampType(6),
-					java.time.Instant.class},
+			TestSpec
+				.forDataType(TIMESTAMP_WITH_LOCAL_TIME_ZONE())
+				.expectLogicalType(new LocalZonedTimestampType(6))
+				.expectConversionClass(java.time.Instant.class),
 
-				{INTERVAL(MINUTE(), SECOND(3)),
-					new DayTimeIntervalType(MINUTE_TO_SECOND, DEFAULT_DAY_PRECISION, 3),
-					java.time.Duration.class},
+			TestSpec
+				.forDataType(INTERVAL(MINUTE(), SECOND(3)))
+				.expectLogicalType(new DayTimeIntervalType(MINUTE_TO_SECOND, DEFAULT_DAY_PRECISION, 3))
+				.expectConversionClass(java.time.Duration.class),
 
-				{INTERVAL(MONTH()),
-					new YearMonthIntervalType(YearMonthResolution.MONTH),
-					java.time.Period.class},
+			TestSpec
+				.forDataType(INTERVAL(MONTH()))
+				.expectLogicalType(new YearMonthIntervalType(YearMonthResolution.MONTH))
+				.expectConversionClass(java.time.Period.class),
 
-				{ARRAY(ARRAY(INT())),
-					new ArrayType(new ArrayType(new IntType())),
-					Integer[][].class},
+			TestSpec
+				.forDataType(ARRAY(ARRAY(INT())))
+				.expectLogicalType(new ArrayType(new ArrayType(new IntType())))
+				.expectConversionClass(Integer[][].class),
 
-				{MULTISET(MULTISET(INT())),
-					new MultisetType(new MultisetType(new IntType())),
-					Map.class},
+			TestSpec
+				.forDataType(MULTISET(MULTISET(INT())))
+				.expectLogicalType(new MultisetType(new MultisetType(new IntType())))
+				.expectConversionClass(Map.class),
 
-				{MAP(INT(), SMALLINT()),
-					new MapType(new IntType(), new SmallIntType()),
-					Map.class},
+			TestSpec
+				.forDataType(MAP(INT(), SMALLINT()))
+				.expectLogicalType(new MapType(new IntType(), new SmallIntType()))
+				.expectConversionClass(Map.class),
 
-				{ROW(FIELD("field1", CHAR(2)), FIELD("field2", BOOLEAN())),
-					new RowType(
+			TestSpec
+				.forDataType(ROW(FIELD("field1", CHAR(2)), FIELD("field2", BOOLEAN())))
+				.expectLogicalType(new RowType(
 						Arrays.asList(
 							new RowType.RowField("field1", new CharType(2)),
-							new RowType.RowField("field2", new BooleanType()))),
-					Row.class},
+							new RowType.RowField("field2", new BooleanType()))))
+				.expectConversionClass(Row.class),
 
-				{NULL(), new NullType(), Object.class},
+			TestSpec
+				.forDataType(NULL())
+				.expectLogicalType(new NullType())
+				.expectConversionClass(Object.class),
 
-				{RAW(Types.GENERIC(DataTypesTest.class)),
-					new TypeInformationRawType<>(Types.GENERIC(DataTypesTest.class)),
-					DataTypesTest.class},
+			TestSpec
+				.forDataType(RAW(Types.GENERIC(DataTypesTest.class)))
+				.expectLogicalType(new TypeInformationRawType<>(Types.GENERIC(DataTypesTest.class)))
+				.expectConversionClass(DataTypesTest.class),
 
-				{RAW(Void.class, VoidSerializer.INSTANCE),
-					new RawType<>(Void.class, VoidSerializer.INSTANCE),
-					Void.class}
-			}
+			TestSpec
+				.forDataType(RAW(Void.class, VoidSerializer.INSTANCE))
+				.expectLogicalType(new RawType<>(Void.class, VoidSerializer.INSTANCE))
+				.expectConversionClass(Void.class),
+
+			TestSpec
+				.forUnresolvedDataType(DataTypes.of("INT"))
+				.expectUnresolvedString("[INT]")
+				.lookupReturns(INT())
+				.expectLogicalType(new IntType()),
+
+			TestSpec
+				.forUnresolvedDataType(DataTypes.of(Integer.class))
+				.expectUnresolvedString("['java.lang.Integer']")
+				.expectResolvedDataType(INT()),
+
+			TestSpec
+				.forUnresolvedDataType(DataTypes.of(java.sql.Timestamp.class).notNull())
+				.expectUnresolvedString("['java.sql.Timestamp']")
+				.expectResolvedDataType(TIMESTAMP(9).notNull().bridgedTo(java.sql.Timestamp.class)),
+
+			TestSpec
+				.forUnresolvedDataType(
+					DataTypes.of(java.sql.Timestamp.class).bridgedTo(java.time.LocalDateTime.class))
+				.expectUnresolvedString("['java.sql.Timestamp']")
+				.expectResolvedDataType(TIMESTAMP(9).bridgedTo(java.time.LocalDateTime.class)),
+
+			TestSpec
+				.forUnresolvedDataType(MAP(DataTypes.of("INT"), DataTypes.of("STRING")))
+				.expectUnresolvedString("[MAP<[INT], [STRING]>]")
+				.expectResolvedDataType(MAP(DataTypes.INT(), DataTypes.STRING())),
+
+			TestSpec
+				.forUnresolvedDataType(MAP(DataTypes.of("INT"), STRING().notNull()))
+				.expectUnresolvedString("[MAP<[INT], STRING NOT NULL>]")
+				.expectResolvedDataType(MAP(INT(), STRING().notNull())),
+
+			TestSpec
+				.forUnresolvedDataType(MULTISET(DataTypes.of("STRING")))
+				.expectUnresolvedString("[MULTISET<[STRING]>]")
+				.expectResolvedDataType(MULTISET(DataTypes.STRING())),
+
+			TestSpec
+				.forUnresolvedDataType(ARRAY(DataTypes.of("STRING")))
+				.expectUnresolvedString("[ARRAY<[STRING]>]")
+				.expectResolvedDataType(ARRAY(DataTypes.STRING())),
+
+			TestSpec
+				.forUnresolvedDataType(
+					ARRAY(DataTypes.of("INT").notNull()).bridgedTo(int[].class))
+				.expectUnresolvedString("[ARRAY<[INT]>]")
+				.expectResolvedDataType(ARRAY(INT().notNull()).bridgedTo(int[].class)),
+
+			TestSpec
+				.forUnresolvedDataType(
+					ROW(FIELD("field1", DataTypes.of("CHAR(2)")), FIELD("field2", BOOLEAN())))
+				.expectUnresolvedString("[ROW<field1 [CHAR(2)], field2 BOOLEAN>]")
+				.expectResolvedDataType(ROW(FIELD("field1", CHAR(2)), FIELD("field2", BOOLEAN()))),
+
+			TestSpec
+				.forUnresolvedDataType(
+					ARRAY(
+						ROW(
+							FIELD("f0", DataTypes.of("ARRAY<INT>")),
+							FIELD("f1", ARRAY(INT())))))
+				.expectUnresolvedString("[ARRAY<[ROW<f0 [ARRAY<INT>], f1 ARRAY<INT>>]>]")
+				.expectResolvedDataType(
+					ARRAY(
+						ROW(
+							FIELD("f0", ARRAY(INT())),
+							FIELD("f1", ARRAY(INT()))))
+				),
+
+			TestSpec
+				.forUnresolvedDataType(RAW(Object.class))
+				.expectUnresolvedString("[RAW('java.lang.Object', '?')]")
+				.lookupReturns(DataTypes.RAW(new GenericTypeInfo<>(Object.class)))
+				.expectResolvedDataType(DataTypes.RAW(new GenericTypeInfo<>(Object.class)))
 		);
 	}
 
 	@Parameter
-	public DataType dataType;
-
-	@Parameter(1)
-	public LogicalType expectedLogicalType;
-
-	@Parameter(2)
-	public Class<?> expectedConversionClass;
+	public TestSpec testSpec;
 
 	@Test
 	public void testLogicalType() {
-		assertThat(dataType, hasLogicalType(expectedLogicalType));
+		if (testSpec.expectedLogicalType != null) {
+			final DataType dataType = testSpec.typeFactory.createDataType(testSpec.abstractDataType);
+
+			assertThat(dataType, hasLogicalType(testSpec.expectedLogicalType));
+
+			assertThat(toDataType(testSpec.expectedLogicalType), equalTo(dataType));
+
+			assertThat(toLogicalType(dataType), equalTo(testSpec.expectedLogicalType));
+		}
 	}
 
 	@Test
 	public void testConversionClass() {
-		assertThat(dataType, hasConversionClass(expectedConversionClass));
+		if (testSpec.expectedConversionClass != null) {
+			final DataType dataType = testSpec.typeFactory.createDataType(testSpec.abstractDataType);
+			assertThat(dataType, hasConversionClass(testSpec.expectedConversionClass));
+		}
 	}
 
 	@Test
-	public void testLogicalTypeToDataTypeConversion() {
-		assertThat(toDataType(expectedLogicalType), equalTo(dataType));
+	public void testUnresolvedString() {
+		if (testSpec.expectedUnresolvedString != null) {
+			assertThat(testSpec.abstractDataType.toString(), equalTo(testSpec.expectedUnresolvedString));
+		}
 	}
 
 	@Test
-	public void testDataTypeToLogicalTypeConversion() {
-		assertThat(toLogicalType(dataType), equalTo(expectedLogicalType));
+	public void testResolvedDataType() {
+		if (testSpec.expectedResolvedDataType != null) {
+			final DataType dataType = testSpec.typeFactory.createDataType(testSpec.abstractDataType);
+			assertThat(dataType, equalTo(testSpec.expectedResolvedDataType));
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private static class TestSpec {
+
+		private final DataTypeFactoryMock typeFactory = new DataTypeFactoryMock();
+
+		private final AbstractDataType<?> abstractDataType;
+
+		private @Nullable LogicalType expectedLogicalType;
+
+		private @Nullable Class<?> expectedConversionClass;
+
+		private @Nullable String expectedUnresolvedString;
+
+		private @Nullable DataType expectedResolvedDataType;
+
+		private TestSpec(AbstractDataType<?> abstractDataType) {
+			this.abstractDataType = abstractDataType;
+		}
+
+		static TestSpec forDataType(DataType dataType) {
+			return new TestSpec(dataType);
+		}
+
+		static TestSpec forUnresolvedDataType(UnresolvedDataType unresolvedDataType) {
+			return new TestSpec(unresolvedDataType);
+		}
+
+		TestSpec expectLogicalType(LogicalType expectedLogicalType) {
+			this.expectedLogicalType = expectedLogicalType;
+			return this;
+		}
+
+		TestSpec expectConversionClass(Class<?> expectedConversionClass) {
+			this.expectedConversionClass = expectedConversionClass;
+			return this;
+		}
+
+		TestSpec expectUnresolvedString(String expectedUnresolvedString) {
+			this.expectedUnresolvedString = expectedUnresolvedString;
+			return this;
+		}
+
+		TestSpec expectResolvedDataType(DataType expectedResolvedDataType) {
+			this.expectedResolvedDataType = expectedResolvedDataType;
+			return this;
+		}
+
+		TestSpec lookupReturns(DataType dataType) {
+			this.typeFactory.dataType = Optional.of(dataType);
+			return this;
+		}
+
+		@Override
+		public String toString() {
+			return abstractDataType.toString();
+		}
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.extraction.utils.DataTypeHintMock;
 import org.apache.flink.table.types.extraction.utils.DataTypeTemplate;
-import org.apache.flink.table.types.inference.utils.DataTypeFactoryMock;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
@@ -40,6 +39,7 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TypeInformationRawType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.types.Row;
 
 import org.hamcrest.Matcher;
@@ -402,16 +402,15 @@ public class DataTypeExtractorTest {
 	 */
 	static class TestSpec {
 
-		private final Function<DataTypeFactory, DataType> extractor;
+		private final DataTypeFactoryMock typeFactory = new DataTypeFactoryMock();
 
-		private DataTypeFactoryMock typeFactory;
+		private final Function<DataTypeFactory, DataType> extractor;
 
 		private @Nullable DataType expectedDataType;
 
 		private @Nullable String expectedErrorMessage;
 
 		private TestSpec(Function<DataTypeFactory, DataType> extractor) {
-			this.typeFactory = new DataTypeFactoryMock();
 			this.extractor = extractor;
 		}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/TypeInferenceExtractorTest.java
@@ -34,7 +34,7 @@ import org.apache.flink.table.types.inference.InputTypeStrategy;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.inference.TypeStrategy;
-import org.apache.flink.table.types.inference.utils.DataTypeFactoryMock;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 import org.apache.flink.types.Row;
 
 import org.hamcrest.Matcher;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -23,8 +23,8 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.utils.CallContextMock;
-import org.apache.flink.table.types.inference.utils.DataTypeFactoryMock;
 import org.apache.flink.table.types.inference.utils.FunctionDefinitionMock;
+import org.apache.flink.table.types.utils.DataTypeFactoryMock;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeFactoryMock.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeFactoryMock.java
@@ -16,14 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.types.inference.utils;
+package org.apache.flink.table.types.utils;
 
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.types.AbstractDataType;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.UnresolvedDataType;
 import org.apache.flink.table.types.extraction.DataTypeExtractor;
 import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
-import org.apache.flink.table.types.utils.TypeConversions;
 
 import java.util.Optional;
 
@@ -39,17 +41,28 @@ public class DataTypeFactoryMock implements DataTypeFactory {
 	public Optional<Class<?>> expectedClass = Optional.empty();
 
 	@Override
-	public Optional<DataType> createDataType(String name) {
-		return Optional.of(TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(name)));
+	public <T extends AbstractDataType<T>> DataType createDataType(AbstractDataType<T> abstractDataType) {
+		if (abstractDataType instanceof DataType) {
+			return (DataType) abstractDataType;
+		} else if (abstractDataType instanceof UnresolvedDataType) {
+			return ((UnresolvedDataType) abstractDataType).toDataType(this);
+		}
+		throw new IllegalStateException();
 	}
 
 	@Override
-	public Optional<DataType> createDataType(UnresolvedIdentifier identifier) {
-		return dataType;
+	public DataType createDataType(String name) {
+		return TypeConversions.fromLogicalToDataType(LogicalTypeParser.parse(name));
+	}
+
+	@Override
+	public DataType createDataType(UnresolvedIdentifier identifier) {
+		return dataType.orElseThrow(() -> new ValidationException("No type found."));
 	}
 
 	@Override
 	public <T> DataType createDataType(Class<T> clazz) {
+		expectedClass.ifPresent(expected -> assertEquals(expected, clazz));
 		return DataTypeExtractor.extractFromType(this, clazz);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

This introduces unresolved data types for class-based extraction, name-based resolution, and configuration-based RAW types. Unresolved types behave like regular data types but only after they have been resolved. Using unresolved data types in nested structures leads to further unresolved types. Thus, the usage of unresolved types is type-safe in API.

## Brief change log

- Introduction of `AbstractDataType` as the highest type of resolved and unresolved data types
- Introduction of `DataTypes.of()` for classes and names
- Helper classes and methods for constructing unresolved types type-safe

## Verifying this change

This change added tests and can be verified as follows:

- `DataTypesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
