### PR TITLE
[FLINK-14818][benchmark] Fix receiving InputGate setup of StreamNetworkBenchmarkEnvironment.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -95,7 +95,7 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	// ------------------------------------------------------------------------
 
 	@Override
-	void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+	protected void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
 
 		boolean retriggerRequest = false;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -54,23 +54,23 @@ public class SingleInputGateFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(SingleInputGateFactory.class);
 
 	@Nonnull
-	private final ResourceID taskExecutorResourceId;
+	protected final ResourceID taskExecutorResourceId;
 
-	private final int partitionRequestInitialBackoff;
+	protected final int partitionRequestInitialBackoff;
 
-	private final int partitionRequestMaxBackoff;
-
-	@Nonnull
-	private final ConnectionManager connectionManager;
+	protected final int partitionRequestMaxBackoff;
 
 	@Nonnull
-	private final ResultPartitionManager partitionManager;
+	protected final ConnectionManager connectionManager;
 
 	@Nonnull
-	private final TaskEventPublisher taskEventPublisher;
+	protected final ResultPartitionManager partitionManager;
 
 	@Nonnull
-	private final NetworkBufferPool networkBufferPool;
+	protected final TaskEventPublisher taskEventPublisher;
+
+	@Nonnull
+	protected final NetworkBufferPool networkBufferPool;
 
 	private final int networkBuffersPerChannel;
 
@@ -198,7 +198,8 @@ public class SingleInputGateFactory {
 					metrics));
 	}
 
-	private InputChannel createKnownInputChannel(
+	@VisibleForTesting
+	protected InputChannel createKnownInputChannel(
 			SingleInputGate inputGate,
 			int index,
 			NettyShuffleDescriptor inputChannelDescriptor,
@@ -243,7 +244,10 @@ public class SingleInputGateFactory {
 		return () -> bufferPoolFactory.createBufferPool(0, floatingNetworkBuffersPerGate);
 	}
 
-	private static class ChannelStatistics {
+	/**
+	 * Statistics of input channels.
+	 */
+	protected static class ChannelStatistics {
 		int numLocalChannels;
 		int numRemoteChannels;
 		int numUnknownChannels;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.benchmark;
+
+import org.apache.flink.core.memory.MemorySegmentProvider;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.ConnectionManager;
+import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateFactory;
+import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
+import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
+
+import java.io.IOException;
+
+/**
+ * A benchmark-specific input gate factory which overrides the respective methods of creating
+ * {@link RemoteInputChannel} and {@link LocalInputChannel} for requesting specific subpartitions.
+ */
+public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
+
+	public SingleInputGateBenchmarkFactory(
+			ResourceID taskExecutorResourceId,
+			NettyShuffleEnvironmentConfiguration networkConfig,
+			ConnectionManager connectionManager,
+			ResultPartitionManager partitionManager,
+			TaskEventPublisher taskEventPublisher,
+			NetworkBufferPool networkBufferPool) {
+		super(
+			taskExecutorResourceId,
+			networkConfig,
+			connectionManager,
+			partitionManager,
+			taskEventPublisher,
+			networkBufferPool);
+	}
+
+	@Override
+	protected InputChannel createKnownInputChannel(
+			SingleInputGate inputGate,
+			int index,
+			NettyShuffleDescriptor inputChannelDescriptor,
+			SingleInputGateFactory.ChannelStatistics channelStatistics,
+			InputChannelMetrics metrics) {
+		ResultPartitionID partitionId = inputChannelDescriptor.getResultPartitionID();
+		if (inputChannelDescriptor.isLocalTo(taskExecutorResourceId)) {
+			return new TestLocalInputChannel(
+				inputGate,
+				index,
+				partitionId,
+				partitionManager,
+				taskEventPublisher,
+				partitionRequestInitialBackoff,
+				partitionRequestMaxBackoff,
+				metrics);
+		} else {
+			return new TestRemoteInputChannel(
+				inputGate,
+				index,
+				partitionId,
+				inputChannelDescriptor.getConnectionId(),
+				connectionManager,
+				partitionRequestInitialBackoff,
+				partitionRequestMaxBackoff,
+				metrics,
+				networkBufferPool);
+		}
+	}
+
+	/**
+	 * A {@link LocalInputChannel} which ignores the given subpartition index and uses channel index
+	 * instead when requesting subpartition.
+	 */
+	static class TestLocalInputChannel extends LocalInputChannel {
+
+		private final ResultPartitionID newPartitionID = new ResultPartitionID();
+
+		public TestLocalInputChannel(
+				SingleInputGate inputGate,
+				int channelIndex,
+				ResultPartitionID partitionId,
+				ResultPartitionManager partitionManager,
+				TaskEventPublisher taskEventPublisher,
+				int initialBackoff,
+				int maxBackoff,
+				InputChannelMetrics metrics) {
+			super(
+				inputGate,
+				channelIndex,
+				partitionId,
+				partitionManager,
+				taskEventPublisher,
+				initialBackoff,
+				maxBackoff,
+				metrics);
+		}
+
+		@Override
+		public void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+			super.requestSubpartition(channelIndex);
+		}
+
+		@Override
+		public ResultPartitionID getPartitionId() {
+			// the SingleInputGate assumes that all InputChannels are consuming different ResultPartition
+			// so can be distinguished by ResultPartitionID. However, the micro benchmark breaks this and
+			// all InputChannels in a SingleInputGate consume data from the same ResultPartition. To make
+			// it transparent to SingleInputGate, a new and unique ResultPartitionID is returned here
+			return newPartitionID;
+		}
+	}
+
+	/**
+	 * A {@link RemoteInputChannel} which ignores the given subpartition index and uses channel index
+	 * instead when requesting subpartition.
+	 */
+	static class TestRemoteInputChannel extends RemoteInputChannel {
+
+		private final ResultPartitionID newPartitionID = new ResultPartitionID();
+
+		public TestRemoteInputChannel(
+				SingleInputGate inputGate,
+				int channelIndex,
+				ResultPartitionID partitionId,
+				ConnectionID connectionId,
+				ConnectionManager connectionManager,
+				int initialBackOff,
+				int maxBackoff,
+				InputChannelMetrics metrics,
+				MemorySegmentProvider memorySegmentProvider) {
+			super(
+				inputGate,
+				channelIndex,
+				partitionId,
+				connectionId,
+				connectionManager,
+				initialBackOff,
+				maxBackoff,
+				metrics,
+				memorySegmentProvider);
+		}
+
+		@Override
+		public void requestSubpartition(int subpartitionIndex) throws IOException, InterruptedException {
+			super.requestSubpartition(channelIndex);
+		}
+
+		@Override
+		public ResultPartitionID getPartitionId() {
+			// the SingleInputGate assumes that all InputChannels are consuming different ResultPartition
+			// so can be distinguished by ResultPartitionID. However, the micro benchmark breaks this and
+			// all InputChannels in a SingleInputGate consume data from the same ResultPartition. To make
+			// it transparent to SingleInputGate, a new and unique ResultPartitionID is returned here
+			return newPartitionID;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

In network benchmark (for example 1000 channels benchmark with 4 record writers) StreamNetworkBenchmarkEnvironment#createInputGate creates 1000 input gates with 4 input channels each, which doesn't make much sense. It is expected that either having 4 receivers with single input gate with 1000 channels each, or a single receiver with 4 input gates, with 1000 channels each.


## Brief change log

  - The receiving InputGate setup logic of StreamNetworkBenchmarkEnvironment is changed

## Verifying this change

This change is already covered by existing tests, such as StreamNetworkThroughputBenchmarkTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
