### PR TITLE
[FLINK-16183][table-api] Make identifier parsing in Table API more lenient

### DIFF
--- a/docs/dev/table/common.md
+++ b/docs/dev/table/common.md
@@ -441,7 +441,6 @@ the current catalog and current database will be referred. Users can switch the 
 table API or SQL.
 
 Identifiers follow SQL requirements which means that they can be escaped with a backtick character (`` ` ``).
-Additionally all SQL reserved keywords must be escaped.
 
 <div class="codetabs" markdown="1">
 <div data-lang="java" markdown="1">
@@ -459,10 +458,6 @@ tableEnv.createTemporaryView("exampleView", table);
 // register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'other_database' 
 tableEnv.createTemporaryView("other_database.exampleView", table);
-
-// register the view named 'View' in the catalog named 'custom_catalog' in the
-// database named 'custom_database'. 'View' is a reserved keyword and must be escaped.  
-tableEnv.createTemporaryView("`View`", table);
 
 // register the view named 'example.View' in the catalog named 'custom_catalog'
 // in the database named 'custom_database' 
@@ -491,10 +486,6 @@ tableEnv.createTemporaryView("exampleView", table)
 // register the view named 'exampleView' in the catalog named 'custom_catalog'
 // in the database named 'other_database' 
 tableEnv.createTemporaryView("other_database.exampleView", table)
-
-// register the view named 'View' in the catalog named 'custom_catalog' in the
-// database named 'custom_database'. 'View' is a reserved keyword and must be escaped.  
-tableEnv.createTemporaryView("`View`", table)
 
 // register the view named 'example.View' in the catalog named 'custom_catalog'
 // in the database named 'custom_database' 

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -955,3 +955,97 @@ SqlTypeNameSpec ExtendedSqlRowTypeName() :
             unparseAsStandard);
     }
 }
+
+/**
+ * Those methods should not be used in SQL. They are good for parsing identifiers
+ * in Table API. The difference between those identifiers and CompoundIdentifer is
+ * that the Table API identifiers ignore any keywords. They are also strictly limited
+ * to three part identifiers. The quoting still works the same way.
+ */
+SqlIdentifier TableApiIdentifier() :
+{
+    final List<String> nameList = new ArrayList<String>();
+    final List<SqlParserPos> posList = new ArrayList<SqlParserPos>();
+}
+{
+    TableApiIdentifierSegment(nameList, posList)
+    (
+        LOOKAHEAD(2)
+        <DOT>
+        TableApiIdentifierSegment(nameList, posList)
+    )?
+    (
+        LOOKAHEAD(2)
+        <DOT>
+        TableApiIdentifierSegment(nameList, posList)
+    )?
+    <EOF>
+    {
+        SqlParserPos pos = SqlParserPos.sum(posList);
+        return new SqlIdentifier(nameList, null, pos, posList);
+    }
+}
+
+void TableApiIdentifierSegment(List<String> names, List<SqlParserPos> positions) :
+{
+    final String id;
+    char unicodeEscapeChar = BACKSLASH;
+    final SqlParserPos pos;
+    final Span span;
+}
+{
+    (
+        <QUOTED_IDENTIFIER> {
+            id = SqlParserUtil.strip(getToken(0).image, DQ, DQ, DQDQ,
+                quotedCasing);
+            pos = getPos().withQuoting(true);
+        }
+    |
+        <BACK_QUOTED_IDENTIFIER> {
+            id = SqlParserUtil.strip(getToken(0).image, "`", "`", "``",
+                quotedCasing);
+            pos = getPos().withQuoting(true);
+        }
+    |
+        <BRACKET_QUOTED_IDENTIFIER> {
+            id = SqlParserUtil.strip(getToken(0).image, "[", "]", "]]",
+                quotedCasing);
+            pos = getPos().withQuoting(true);
+        }
+    |
+        <UNICODE_QUOTED_IDENTIFIER> {
+            span = span();
+            String image = getToken(0).image;
+            image = image.substring(image.indexOf('"'));
+            image = SqlParserUtil.strip(image, DQ, DQ, DQDQ, quotedCasing);
+        }
+        [
+            <UESCAPE> <QUOTED_STRING> {
+                String s = SqlParserUtil.parseString(token.image);
+                unicodeEscapeChar = SqlParserUtil.checkUnicodeEscapeChar(s);
+            }
+        ]
+        {
+            pos = span.end(this).withQuoting(true);
+            SqlLiteral lit = SqlLiteral.createCharString(image, "UTF16", pos);
+            lit = lit.unescapeUnicode(unicodeEscapeChar);
+            id = lit.toValue();
+        }
+    |
+        {
+
+            id = getNextToken().image;
+            pos = getPos();
+        }
+    )
+    {
+        if (id.length() > this.identifierMaxLength) {
+            throw SqlUtil.newContextException(pos,
+                RESOURCE.identifierTooLong(id, this.identifierMaxLength));
+        }
+        names.add(id);
+        if (positions != null) {
+            positions.add(pos);
+        }
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -42,6 +42,9 @@ import static org.junit.Assert.assertThat;
 @RunWith(Parameterized.class)
 public class TableApiIdentifierParsingTest {
 
+	private static final String ANTHROPOS_IN_GREEK_IN_UNICODE = "#03B1#03BD#03B8#03C1#03C9#03C0#03BF#03C2";
+	private static final String ANTHROPOS_IN_GREEK = "ανθρωπος";
+
 	@Parameterized.Parameters(name = "Parsing: {0}. Expected identifier: {1}")
 	public static Object[][] parameters() {
 		return new Object[][] {
@@ -68,6 +71,26 @@ public class TableApiIdentifierParsingTest {
 			new Object[] {
 				"db.table",
 				asList("db", "table")
+			},
+
+			new Object[] {
+				"`ta``ble`",
+				singletonList("ta`ble")
+			},
+
+			new Object[] {
+				"`c``at`.`d``b`.`ta``ble`",
+				asList("c`at", "d`b", "ta`ble")
+			},
+
+			new Object[] {
+				"db.U&\"" + ANTHROPOS_IN_GREEK_IN_UNICODE + "\" UESCAPE '#'",
+				asList("db", ANTHROPOS_IN_GREEK)
+			},
+
+			new Object[] {
+				"db.ανθρωπος",
+				asList("db", ANTHROPOS_IN_GREEK)
 			}
 		};
 	}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/TableApiIdentifierParsingTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser;
+
+import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
+import org.apache.flink.sql.parser.impl.ParseException;
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance;
+
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.util.SourceStringReader;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for parsing a Table API specific SqlIdentifier.
+ */
+@RunWith(Parameterized.class)
+public class TableApiIdentifierParsingTest {
+
+	@Parameterized.Parameters(name = "Parsing: {0}. Expected identifier: {1}")
+	public static Object[][] parameters() {
+		return new Object[][] {
+			new Object[] {
+				"array",
+				singletonList("array")
+			},
+
+			new Object[] {
+				"table",
+				singletonList("table")
+			},
+
+			new Object[] {
+				"cat.db.array",
+				asList("cat", "db", "array")
+			},
+
+			new Object[] {
+				"`cat.db`.table",
+				asList("cat.db", "table")
+			},
+
+			new Object[] {
+				"db.table",
+				asList("db", "table")
+			}
+		};
+	}
+
+	@Parameterized.Parameter
+	public String stringIdentifier;
+
+	@Parameterized.Parameter(1)
+	public List<String> expectedParsedIdentifier;
+
+	@Test
+	public void testTableApiIdentifierParsing() throws ParseException {
+		FlinkSqlParserImpl parser = createFlinkParser(stringIdentifier);
+
+		SqlIdentifier sqlIdentifier = parser.TableApiIdentifier();
+		assertThat(sqlIdentifier.names, equalTo(expectedParsedIdentifier));
+	}
+
+	private FlinkSqlParserImpl createFlinkParser(String expr) {
+		SourceStringReader reader = new SourceStringReader(expr);
+		FlinkSqlParserImpl parser = (FlinkSqlParserImpl) FlinkSqlParserImpl.FACTORY.getParser(reader);
+		parser.setTabSize(1);
+		parser.setUnquotedCasing(Lex.JAVA.unquotedCasing);
+		parser.setQuotedCasing(Lex.JAVA.quotedCasing);
+		parser.setIdentifierMaxLength(256);
+		parser.setConformance(FlinkSqlConformance.DEFAULT);
+		parser.switchTo("BTID");
+
+		return parser;
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -50,13 +50,12 @@ import java.util.Optional;
  *     <li>Offering further configuration options.</li>
  * </ul>
  *
- * <p>The path in methods such as {@link #createTemporaryView(String, Table)} should be a proper SQL identifier.
- * The syntax is following [[catalog-name.]database-name.]object-name, where the catalog name and database are
- * optional. For path resolution see {@link #useCatalog(String)} and {@link #useDatabase(String)}. All keywords
- * or other special characters need to be escaped.
+ * <p>The syntax for path in methods such as {@link #createTemporaryView(String, Table)}is following
+ * [[catalog-name.]database-name.]object-name, where the catalog name and database are optional.
+ * For path resolution see {@link #useCatalog(String)} and {@link #useDatabase(String)}.
  *
- * <p>Example: `cat.1`.`db`.`Table` resolves to an object named 'Table' (table is a reserved keyword, thus must
- * be escaped) in a catalog named 'cat.1' and database named 'db'.
+ * <p>Example: `cat.1`.`db`.`Table` resolves to an object named 'Table' in a catalog named 'cat.1' and
+ * database named 'db'.
  *
  * <p>Note: This environment is meant for pure table programs. If you would like to convert from or to
  * other Flink APIs, it might be necessary to use one of the available language-specific table environments
@@ -419,11 +418,11 @@ public interface TableEnvironment {
 	 * }
 	 * </pre>
 	 *
-	 * <p>Reading a table from a registered catalog with escaping. ({@code Table} is a reserved keyword).
-	 * Dots in e.g. a database name also must be escaped.
+	 * <p>Reading a table from a registered catalog with escaping.
+	 * Dots in e.g. a database name must be escaped.
 	 * <pre>
 	 * {@code
-	 *   Table tab = tableEnv.from("catalogName.`db.Name`.`Table`");
+	 *   Table tab = tableEnv.from("catalogName.`db.Name`.Table");
 	 * }
 	 * </pre>
 	 *

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/CalciteParser.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/CalciteParser.java
@@ -27,6 +27,8 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.util.SourceStringReader;
 
+import java.io.Reader;
+
 /**
  * Thin wrapper around {@link SqlParser} that does exception conversion and {@link SqlNode} casting.
  */
@@ -69,6 +71,12 @@ public class CalciteParser {
 		}
 	}
 
+	/**
+	 * Equivalent to {@link SqlParser#create(Reader, SqlParser.Config)}. The only
+	 * difference is we do not wrap the {@link FlinkSqlParserImpl} with {@link SqlParser}.
+	 *
+	 * <p>It is so that we can access specific parsing methods not accessible through the {@code SqlParser}.
+	 */
 	private FlinkSqlParserImpl createFlinkParser(String expr) {
 		SourceStringReader reader = new SourceStringReader(expr);
 		FlinkSqlParserImpl parser = (FlinkSqlParserImpl) config.parserFactory().getParser(reader);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/CalciteParser.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/calcite/CalciteParser.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.planner.calcite;
 
+import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 import org.apache.flink.table.api.SqlParserException;
 
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.util.SourceStringReader;
 
 /**
  * Thin wrapper around {@link SqlParser} that does exception conversion and {@link SqlNode} casting.
@@ -60,12 +62,33 @@ public class CalciteParser {
 	 */
 	public SqlIdentifier parseIdentifier(String identifier) {
 		try {
-			SqlParser parser = SqlParser.create(identifier, config);
-			SqlNode sqlNode = parser.parseExpression();
-			return (SqlIdentifier) sqlNode;
+			return createFlinkParser(identifier).TableApiIdentifier();
 		} catch (Exception e) {
 			throw new SqlParserException(String.format(
-				"Invalid SQL identifier %s. All SQL keywords must be escaped.", identifier));
+				"Invalid SQL identifier %s.", identifier));
 		}
+	}
+
+	private FlinkSqlParserImpl createFlinkParser(String expr) {
+		SourceStringReader reader = new SourceStringReader(expr);
+		FlinkSqlParserImpl parser = (FlinkSqlParserImpl) config.parserFactory().getParser(reader);
+		parser.setTabSize(1);
+		parser.setQuotedCasing(config.quotedCasing());
+		parser.setUnquotedCasing(config.unquotedCasing());
+		parser.setIdentifierMaxLength(config.identifierMaxLength());
+		parser.setConformance(config.conformance());
+		switch (config.quoting()) {
+			case DOUBLE_QUOTE:
+				parser.switchTo("DQID");
+				break;
+			case BACK_TICK:
+				parser.switchTo("BTID");
+				break;
+			case BRACKET:
+				parser.switchTo("DEFAULT");
+				break;
+		}
+
+		return parser;
 	}
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/calcite/CalciteParser.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/calcite/CalciteParser.java
@@ -27,6 +27,8 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.util.SourceStringReader;
 
+import java.io.Reader;
+
 /**
  * Thin wrapper around {@link SqlParser} that does exception conversion and {@link SqlNode} casting.
  */
@@ -69,6 +71,12 @@ public class CalciteParser {
 		}
 	}
 
+	/**
+	 * Equivalent to {@link SqlParser#create(Reader, SqlParser.Config)}. The only
+	 * difference is we do not wrap the {@link FlinkSqlParserImpl} with {@link SqlParser}.
+	 *
+	 * <p>It is so that we can access specific parsing methods not accessible through the {@code SqlParser}.
+	 */
 	private FlinkSqlParserImpl createFlinkParser(String expr) {
 		SourceStringReader reader = new SourceStringReader(expr);
 		FlinkSqlParserImpl parser = (FlinkSqlParserImpl) config.parserFactory().getParser(reader);


### PR DESCRIPTION
## What is the purpose of the change

It improves the experience of Table API users as they do not need to escape SQL keywords. Some of the sql keywords might be a commonly used names in Table API (e.g. "table" for Table names). It also lets us support parsing identifiers coming from Java's ExpressionParser (e.g. for a string array(...) it produces a lookup call with an "array" identifier which should be parsed).

## Verifying this change

This change added tests :
* org.apache.flink.sql.parser.TableApiIdentifierParsingTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented)
