### PR TITLE
[FLINK-16186][es][tests] Reduce connect timeout to 5 seconds

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkTestBase.java
@@ -187,6 +187,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		try {
 			env.execute("Elasticsearch Sink Test");
 		} catch (JobExecutionException expectedException) {
+			// every ES version throws a different exception in case of timeouts, so don't bother asserting on the exception
 			// test passes
 			return;
 		}
@@ -201,6 +202,7 @@ public abstract class ElasticsearchSinkTestBase<C extends AutoCloseable, A> exte
 		Map<String, String> userConfig = new HashMap<>();
 		userConfig.put("cluster.name", clusterName);
 		userConfig.put(ElasticsearchSinkBase.CONFIG_KEY_BULK_FLUSH_MAX_ACTIONS, String.valueOf(bulkFlushMaxActions));
+		userConfig.put("transport.tcp.connect_timeout", "5s");
 
 		return userConfig;
 	}


### PR DESCRIPTION
Reduces the connect timeout to 5 seconds from the default 30 seconds to speed up test execution.