### PR TITLE
[FLINK-15094] Use Unsafe to instantiate and construct DirectByteBuffer

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/HybridMemorySegment.java
@@ -26,11 +26,12 @@ import javax.annotation.Nullable;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
+
+import static org.apache.flink.core.memory.MemoryUtils.getByteBufferAddress;
 
 /**
  * This class represents a piece of memory managed by Flink.
@@ -74,7 +75,7 @@ public final class HybridMemorySegment extends MemorySegment {
 	  * @throws IllegalArgumentException Thrown, if the given ByteBuffer is not direct.
 	  */
 	HybridMemorySegment(@Nonnull ByteBuffer buffer, @Nullable Object owner, @Nullable Runnable cleaner) {
-		super(checkBufferAndGetAddress(buffer), buffer.capacity(), owner);
+		super(getByteBufferAddress(buffer), buffer.capacity(), owner);
 		this.offHeapBuffer = buffer;
 		this.cleaner = cleaner;
 	}
@@ -310,7 +311,7 @@ public final class HybridMemorySegment extends MemorySegment {
 
 		if (target.isDirect()) {
 			// copy to the target memory directly
-			final long targetPointer = getAddress(target) + targetOffset;
+			final long targetPointer = getByteBufferAddress(target) + targetOffset;
 			final long sourcePointer = address + offset;
 
 			if (sourcePointer <= addressLimit - numBytes) {
@@ -354,7 +355,7 @@ public final class HybridMemorySegment extends MemorySegment {
 
 		if (source.isDirect()) {
 			// copy to the target memory directly
-			final long sourcePointer = getAddress(source) + sourceOffset;
+			final long sourcePointer = getByteBufferAddress(source) + sourceOffset;
 			final long targetPointer = address + offset;
 
 			if (targetPointer <= addressLimit - numBytes) {
@@ -382,47 +383,5 @@ public final class HybridMemorySegment extends MemorySegment {
 				put(offset++, source.get());
 			}
 		}
-	}
-
-	// --------------------------------------------------------------------------------------------
-	//  Utilities for native memory accesses and checks
-	// --------------------------------------------------------------------------------------------
-
-	/**
-	 * The reflection fields with which we access the off-heap pointer from direct ByteBuffers.
-	 */
-	private static final Field ADDRESS_FIELD;
-
-	static {
-		try {
-			ADDRESS_FIELD = java.nio.Buffer.class.getDeclaredField("address");
-			ADDRESS_FIELD.setAccessible(true);
-		}
-		catch (Throwable t) {
-			throw new RuntimeException(
-					"Cannot initialize HybridMemorySegment: off-heap memory is incompatible with this JVM.", t);
-		}
-	}
-
-	private static long getAddress(ByteBuffer buffer) {
-		if (buffer == null) {
-			throw new NullPointerException("buffer is null");
-		}
-		try {
-			return (Long) ADDRESS_FIELD.get(buffer);
-		}
-		catch (Throwable t) {
-			throw new RuntimeException("Could not access direct byte buffer address.", t);
-		}
-	}
-
-	private static long checkBufferAndGetAddress(ByteBuffer buffer) {
-		if (buffer == null) {
-			throw new NullPointerException("buffer is null");
-		}
-		if (!buffer.isDirect()) {
-			throw new IllegalArgumentException("Can't initialize from non-direct ByteBuffer.");
-		}
-		return getAddress(buffer);
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -33,7 +33,7 @@ import java.nio.ByteOrder;
 public class MemoryUtils {
 
 	/** The "unsafe", which can be used to perform native memory accesses. */
-	@SuppressWarnings("restriction")
+	@SuppressWarnings({"restriction", "UseOfSunClasses"})
 	public static final sun.misc.Unsafe UNSAFE = getUnsafe();
 
 	/** The native byte order of the platform on which the system currently runs. */
@@ -50,7 +50,7 @@ public class MemoryUtils {
 		} catch (SecurityException e) {
 			throw new Error("Could not access the sun.misc.Unsafe handle, permission denied by security manager.", e);
 		} catch (NoSuchFieldException e) {
-			throw new Error("The static handle field in sun.misc.Unsafe was not found.");
+			throw new Error("The static handle field in sun.misc.Unsafe was not found.", e);
 		} catch (IllegalArgumentException e) {
 			throw new Error("Bug: Illegal argument reflection access for static field.", e);
 		} catch (IllegalAccessException e) {
@@ -64,7 +64,6 @@ public class MemoryUtils {
 	private MemoryUtils() {}
 
 	private static Constructor<? extends ByteBuffer> getDirectBufferPrivateConstructor() {
-		//noinspection OverlyBroadCatchBlock
 		try {
 			Constructor<? extends ByteBuffer> constructor =
 				ByteBuffer.allocateDirect(1).getClass().getDeclaredConstructor(long.class, int.class);
@@ -107,7 +106,6 @@ public class MemoryUtils {
 	 * @param address address of the unsafe memory to release
 	 * @return action to run to release the unsafe memory manually
 	 */
-	@SuppressWarnings("UseOfSunClasses")
 	static Runnable createMemoryGcCleaner(Object owner, long address) {
 		return JavaGcCleanerWrapper.create(owner, () -> releaseUnsafe(address));
 	}

--- a/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/core/memory/MemoryUtils.java
@@ -20,9 +20,10 @@ package org.apache.flink.core.memory;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.util.JavaGcCleanerWrapper;
+import org.apache.flink.util.Preconditions;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -39,7 +40,9 @@ public class MemoryUtils {
 	/** The native byte order of the platform on which the system currently runs. */
 	public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
 
-	private static final Constructor<?> DIRECT_BUFFER_CONSTRUCTOR = getDirectBufferPrivateConstructor();
+	private static final long BUFFER_ADDRESS_FIELD_OFFSET = getClassFieldOffset(Buffer.class, "address");
+	private static final long BUFFER_CAPACITY_FIELD_OFFSET = getClassFieldOffset(Buffer.class, "capacity");
+	private static final Class<?> DIRECT_BYTE_BUFFER_CLASS = getClassByName("java.nio.DirectByteBuffer");
 
 	@SuppressWarnings("restriction")
 	private static sun.misc.Unsafe getUnsafe() {
@@ -60,29 +63,27 @@ public class MemoryUtils {
 		}
 	}
 
-	/** Should not be instantiated. */
-	private MemoryUtils() {}
-
-	private static Constructor<? extends ByteBuffer> getDirectBufferPrivateConstructor() {
+	private static long getClassFieldOffset(@SuppressWarnings("SameParameterValue") Class<?> cl, String fieldName) {
 		try {
-			Constructor<? extends ByteBuffer> constructor =
-				ByteBuffer.allocateDirect(1).getClass().getDeclaredConstructor(long.class, int.class);
-			constructor.setAccessible(true);
-			return constructor;
-		} catch (NoSuchMethodException e) {
-			throw new Error(
-				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available.",
-				e);
+			return UNSAFE.objectFieldOffset(cl.getDeclaredField(fieldName));
 		} catch (SecurityException e) {
-			throw new Error(
-				"The private constructor java.nio.DirectByteBuffer.<init>(long, int) is not available, " +
-					"permission denied by security manager",
-				e);
+			throw new Error(getClassFieldOffsetErrorMessage(cl, fieldName) + ", permission denied by security manager.", e);
+		} catch (NoSuchFieldException e) {
+			throw new Error(getClassFieldOffsetErrorMessage(cl, fieldName), e);
 		} catch (Throwable t) {
-			throw new Error(
-				"Unclassified error while trying to access private constructor " +
-					"java.nio.DirectByteBuffer.<init>(long, int).",
-				t);
+			throw new Error(getClassFieldOffsetErrorMessage(cl, fieldName) + ", unclassified error", t);
+		}
+	}
+
+	private static String getClassFieldOffsetErrorMessage(Class<?> cl, String fieldName) {
+		return  "Could not get field '" + fieldName + "' offset in class '" + cl + "' for unsafe operations";
+	}
+
+	private static Class<?> getClassByName(@SuppressWarnings("SameParameterValue") String className) {
+		try {
+			return Class.forName(className);
+		} catch (ClassNotFoundException e) {
+			throw new Error("Could not find class '" + className + "' for unsafe operations.", e);
 		}
 	}
 
@@ -124,9 +125,32 @@ public class MemoryUtils {
 	static ByteBuffer wrapUnsafeMemoryWithByteBuffer(long address, int size) {
 		//noinspection OverlyBroadCatchBlock
 		try {
-			return (ByteBuffer) DIRECT_BUFFER_CONSTRUCTOR.newInstance(address, size);
+			ByteBuffer buffer = (ByteBuffer) UNSAFE.allocateInstance(DIRECT_BYTE_BUFFER_CLASS);
+			UNSAFE.putLong(buffer, BUFFER_ADDRESS_FIELD_OFFSET, address);
+			UNSAFE.putInt(buffer, BUFFER_CAPACITY_FIELD_OFFSET, size);
+			buffer.clear();
+			return buffer;
 		} catch (Throwable t) {
 			throw new Error("Failed to wrap unsafe off-heap memory with ByteBuffer", t);
 		}
 	}
+
+	/**
+	 * Get native memory address wrapped by the given {@link ByteBuffer}.
+	 *
+	 * @param buffer {@link ByteBuffer} which wraps the native memory address to get
+	 * @return native memory address wrapped by the given {@link ByteBuffer}
+	 */
+	static long getByteBufferAddress(ByteBuffer buffer) {
+		Preconditions.checkNotNull(buffer, "buffer is null");
+		Preconditions.checkArgument(buffer.isDirect(), "Can't get address of a non-direct ByteBuffer.");
+		try {
+			return UNSAFE.getLong(buffer, BUFFER_ADDRESS_FIELD_OFFSET);
+		} catch (Throwable t) {
+			throw new Error("Could not access direct byte buffer address field.", t);
+		}
+	}
+
+	/** Should not be instantiated. */
+	private MemoryUtils() {}
 }


### PR DESCRIPTION
## What is the purpose of the change

If we use reflection to create a DirectByteBuffer to wrap unsafe native memory allocations, it causes illegal access warnings in Java9+.

This PR changes this to use Unsafe to instantiate a DirectByteBuffer. The address and capacity fields are set by direct unsafe memory operations. Other fields are set by calling ByteBuffer#clear at the end.
Unsafe operations skips the illegal access verification and do not result in warnings. The same approach is used to get the address field.

This solution still relies on Unsafe which is about to be removed in future Java releases. If it is removed and we still do not want to contribute to direct memory by allocating native managed memory, we will have to find an alternative solution, like e.g. writing a custom native allocator and use JNI API to instantiate the wrapping DirectByteBuffer (NewDirectByteBuffer in C).

## Verifying this change

unit tests

