### PR TITLE
[FLINK-16129] [docs] Translate /ops/filesystems/index.zh.md

### DIFF
--- a/docs/ops/filesystems/index.zh.md
+++ b/docs/ops/filesystems/index.zh.md
@@ -24,7 +24,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Apache Flink 使用文件系统来消耗和持久化地存储数据，以处理应用结果以及容错与恢复。以下是一些最常用的文件系统：*本地存储*，*hadoop-compatible*，*Amazon S3*，*MapR FS*，*OpenStack Swift FS*，*阿里云 OSS* 和 *Azure Blob Storage*。
+Apache Flink 使用文件系统来消费和持久化地存储数据，以处理应用结果以及容错与恢复。以下是一些最常用的文件系统：*本地存储*，*hadoop-compatible*，*Amazon S3*，*MapR FS*，*OpenStack Swift FS*，*阿里云 OSS* 和 *Azure Blob Storage*。
 
 文件使用的文件系统通过其 URI Scheme 指定。例如 `file:///home/user/text.txt` 表示一个在本地文件系统中的文件，`hdfs://namenode:50010/data/user/text.txt` 表示一个在指定 HDFS 集群中的文件。
 

--- a/docs/ops/filesystems/index.zh.md
+++ b/docs/ops/filesystems/index.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "File Systems"
+title: "文件系统"
 nav-id: filesystems
 nav-parent_id: ops
 nav-show_overview: true
@@ -24,104 +24,82 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Apache Flink uses file systems to consume and persistently store data, both for the results of applications and for fault tolerance and recovery.
-These are some of most of the popular file systems, including *local*, *hadoop-compatible*, *Amazon S3*, *MapR FS*, *OpenStack Swift FS*, *Aliyun OSS* and *Azure Blob Storage*.
+Apache Flink 使用文件系统来消耗和持久化地存储数据，以处理应用结果以及容错与恢复。以下是一些最常用的文件系统：*本地存储*，*hadoop-compatible*，*Amazon S3*，*MapR FS*，*OpenStack Swift FS*，*阿里云 OSS* 和 *Azure Blob Storage*。
 
-The file system used for a particular file is determined by its URI scheme.
-For example, `file:///home/user/text.txt` refers to a file in the local file system, while `hdfs://namenode:50010/data/user/text.txt` is a file in a specific HDFS cluster.
+文件使用的文件系统通过其 URI Scheme 指定。例如 `file:///home/user/text.txt` 表示一个在本地文件系统中的文件，`hdfs://namenode:50010/data/user/text.txt` 表示一个在指定 HDFS 集群中的文件。
 
-File system instances are instantiated once per process and then cached/pooled, to avoid configuration overhead per stream creation and to enforce certain constraints, such as connection/stream limits.
+文件系统在每个进程实例化一次，然后进行缓存/池化，从而避免每次创建流时的配置开销，并强制执行特定的约束，如连接/流的限制。
 
 * This will be replaced by the TOC
 {:toc}
 
-## Local File System
+## 本地文件系统
 
-Flink has built-in support for the file system of the local machine, including any NFS or SAN drives mounted into that local file system.
-It can be used by default without additional configuration. Local files are referenced with the *file://* URI scheme.
+Flink 原生支持本地机器上的文件系统，包括任何挂载到本地文件系统的 NFS 或 SAN 驱动器，默认即可使用，无需额外配置。本地文件可通过 *file://* URI Scheme 引用。
 
-## Pluggable File Systems
+## 外部文件系统
 
-The Apache Flink project supports the following file systems:
+Apache Flink 支持下列文件系统：
+  - [**Amazon S3**](./s3.html) 对象存储由 `flink-s3-fs-presto` 和 `flink-s3-fs-hadoop` 两种替代实现提供支持。这两种实现都是独立的，没有依赖项。
 
-  - [**Amazon S3**](./s3.html) object storage is supported by two alternative implementations: `flink-s3-fs-presto` and `flink-s3-fs-hadoop`.
-  Both implementations are self-contained with no dependency footprint.
+  - **MapR FS** 文件系统适配器已在 Flink 的主发行版中通过 *maprfs://* URI Scheme 支持。MapR 库需要在 classpath 中指定（例如在 `lib` 目录中）。
 
-  - **MapR FS** file system adapter is already supported in the main Flink distribution under the *maprfs://* URI scheme.
-  You must provide the MapR libraries in the classpath (for example in `lib` directory).
+  - **OpenStack Swift FS** 由 `flink-swift-fs-hadoop` 支持，并通过 *swift://* URI scheme 使用。该实现基于 [Hadoop Project](https://hadoop.apache.org/)，但其是独立的，没有依赖项。
+  将 Flink 作为库使用时，使用该文件系统需要添加相应的 Maven 依赖项（`org.apache.flink:flink-swift-fs-hadoop:{{ site.version }}`）。
 
-  - **OpenStack Swift FS** is supported by `flink-swift-fs-hadoop` and registered under the *swift://* URI scheme.
-  The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
-  To use it when using Flink as a library, add the respective maven dependency (`org.apache.flink:flink-swift-fs-hadoop:{{ site.version }}`).
-  
-  - **[Aliyun Object Storage Service](./oss.html)** is supported by `flink-oss-fs-hadoop` and registered under the *oss://* URI scheme.
-  The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
+  - **[阿里云对象存储](./oss.html)**由 `flink-oss-fs-hadoop` 支持，并通过 *oss://* URI scheme 使用。该实现基于 [Hadoop Project](https://hadoop.apache.org/)，但其是独立的，没有依赖项。
 
-  - **[Azure Blob Storage](./azure.html)** is supported by `flink-azure-fs-hadoop` and registered under the *wasb(s)://* URI schemes.
-  The implementation is based on the [Hadoop Project](https://hadoop.apache.org/) but is self-contained with no dependency footprint.
+  - **[Azure Blob Storage](./azure.html)** 由`flink-azure-fs-hadoop` 支持，并通过 *wasb(s)://* URI scheme 使用。该实现基于 [Hadoop Project](https://hadoop.apache.org/)，但其是独立的，没有依赖项。
 
-Except **MapR FS**, you can and should use any of them as [plugins](../plugins.html). 
+除 **MapR FS** 之外，上述文件系统可以并且需要作为[插件](../plugins.html)使用。
 
-To use a pluggable file systems, copy the corresponding JAR file from the `opt` directory to a directory under `plugins` directory
-of your Flink distribution before starting Flink, e.g.
+使用外部文件系统时，在启动 Flink 之前需将对应的 JAR 文件从 `opt` 目录复制到 Flink 发行版 `plugin` 目录下的某一文件夹中，例如：
 
 {% highlight bash %}
 mkdir ./plugins/s3-fs-hadoop
 cp ./opt/flink-s3-fs-hadoop-{{ site.version }}.jar ./plugins/s3-fs-hadoop/
 {% endhighlight %}
 
-<span class="label label-danger">Attention</span> The [plugin](../plugins.html) mechanism for file systems was introduced in Flink version `1.9` to
-support dedicated Java class loaders per plugin and to move away from the class shading mechanism.
-You can still use the provided file systems (or your own implementations) via the old mechanism by copying the corresponding
-JAR file into `lib` directory. However, **since 1.10, s3 plugins must be loaded through the plugin mechanism**; the old
-way no longer works as these plugins are not shaded anymore (or more specifically the classes are not relocated since 1.10).
+<span class="label label-danger">注意</span> 文件系统的[插件](../plugins.html)机制在 Flink 版本 1.9 中引入，以支持每个插件专有 Java 类加载器，并避免类隐藏机制。您仍然可以通过旧机制使用文件系统，即将对应的 JAR 文件复制到 `lib` 目录中，或使用您自己的实现方式，但是从版本 1.10 开始，**S3 插件必须通过插件机制加载**，因为这些插件不再被隐藏（版本 1.10 之后类不再被重定位），旧机制不再可用。
 
-It's encouraged to use the [plugins](../plugins.html)-based loading mechanism for file systems that support it. Loading file systems components from the `lib`
-directory will not supported in future Flink versions.
+尽可能通过基于[插件](../plugins.html)的加载机制使用支持的文件系统。未来的 Flink 版本将不再支持通过 `lib` 目录加载文件系统组件。
 
-## Adding a new pluggable File System implementation
+## 添加新的外部文件系统实现
 
-File systems are represented via the `org.apache.flink.core.fs.FileSystem` class, which captures the ways to access and modify files and objects in that file system.
+文件系统由类 `org.apache.flink.core.fs.FileSystem` 表示，该类定义了访问与修改文件系统中文件与对象的方法。
 
-To add a new file system:
+要添加一个新的文件系统：
 
-  - Add the File System implementation, which is a subclass of `org.apache.flink.core.fs.FileSystem`.
-  - Add a factory that instantiates that file system and declares the scheme under which the FileSystem is registered. This must be a subclass of `org.apache.flink.core.fs.FileSystemFactory`.
-  - Add a service entry. Create a file `META-INF/services/org.apache.flink.core.fs.FileSystemFactory` which contains the class name of your file system factory class
-  (see the [Java Service Loader docs](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) for more details).
+  - 添加文件系统实现，它应是 `org.apache.flink.core.fs.FileSystem` 的子类。
+  - 添加 Factory 类，以实例化该文件系统并声明文件系统所注册的 scheme, 它应是 `org.apache.flink.core.fs.FileSystemFactory` 的子类。
+  - 添加 Service Entry。创建文件 `META-INF/services/org.apache.flink.core.fs.FileSystemFactory`，文件中包含文件系统 Factory 类的类名。
+  （更多细节请查看 [Java Service Loader docs](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html)）
 
-During plugins discovery, the file system factory class will be loaded by a dedicated Java class loader to avoid class conflicts with other plugins and Flink components.
-The same class loader should be used during file system instantiation and the file system operation calls.
+在插件检索时，文件系统 Factory 类会由一个专用的 Java 类加载器加载，从而避免与其他类或 Flink 组件冲突。在文件系统实例化和文件系统调用时，应使用该类加载器。
 
-<span class="label label-warning">Warning</span> In practice, it means you should avoid using `Thread.currentThread().getContextClassLoader()` class loader
-in your implementation.
+<span class="label label-warning">警告</span> 实际上这表示您的实现应避免使用 `Thread.currentThread().getContextClassLoader()` 类加载器。
 
-## Hadoop File System (HDFS) and its other implementations
+## Hadoop 文件系统 (HDFS) 及其其他实现
 
-For all schemes where Flink cannot find a directly supported file system, it falls back to Hadoop.
-All Hadoop file systems are automatically available when `flink-runtime` and the Hadoop libraries are on the classpath.
-See also **[Hadoop Integration]({{ site.baseurl }}/ops/deployment/hadoop.html)**.
+所有 Flink 无法找到直接支持的文件系统均将回退为 Hadoop。
+当 `flink-runtime` 和 Hadoop 类包含在 classpath 中时，所有的 Hadoop 文件系统将自动可用。参见 **[Hadoop 集成]({{ site.baseurl }}/zh/../../s3.zh.mdops/deployment/hadoop.html)**。
 
-This way, Flink seamlessly supports all of Hadoop file systems implementing the `org.apache.hadoop.fs.FileSystem` interface,
-and all Hadoop-compatible file systems (HCFS).
-
-  - HDFS (tested)
-  - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector) (tested)
-  - [Alluxio](http://alluxio.org/) (tested, see configuration specifics below)
-  - [XtreemFS](http://www.xtreemfs.org/) (tested)
-  - FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html) (not tested)
-  - HAR (not tested)
+因此，Flink 无缝支持所有实现 `org.apache.hadoop.fs.FileSystem` 接口的 Hadoop 文件系统和所有兼容 Hadoop 的文件系统 (Hadoop-compatible file system, HCFS)：
+  - HDFS （已测试）
+  - [Google Cloud Storage Connector for Hadoop](https://cloud.google.com/hadoop/google-cloud-storage-connector)（已测试）
+  - [Alluxio](http://alluxio.org/)（已测试，参见下文的配置详细信息）
+  - [XtreemFS](http://www.xtreemfs.org/)（已测试）
+  - FTP via [Hftp](http://hadoop.apache.org/docs/r1.2.1/hftp.html)（未测试）
+  - HAR（未测试）
   - ...
 
-The Hadoop configuration has to have an entry for the required file system implementation in the `core-site.xml` file.
-See example for **[Alluxio]({{ site.baseurl }}/ops/filesystems/#alluxio)**.
+Hadoop 配置须在 `core-site.xml` 文件中包含所需文件系统的实现。可查看 **[Alluxio 的示例]({{ site.baseurl }}/zh/ops/filesystems/#alluxio)**。
 
-We recommend using Flink's built-in file systems unless required otherwise. Using a Hadoop File System directly may be required,
-for example, when using that file system for YARN's resource storage, via the `fs.defaultFS` configuration property in Hadoop's `core-site.xml`.
+除非有其他的需要，建议使用 Flink 内置的文件系统。在某些情况下，如通过配置 Hadoop `core-site.xml` 中的 `fs.defaultFS` 属性将文件系统作为 YARN 的资源存储时，可能需要直接使用 Hadoop 文件系统。
 
 ### Alluxio
 
-For Alluxio support add the following entry into the `core-site.xml` file:
+在 `core-site.xml` 文件中添加以下条目以支持 Alluxio：
 
 {% highlight xml %}
 <property>


### PR DESCRIPTION
## What is the purpose of the change

This pull request translates the overview part of the file system document into Chinese.


## Brief change log
 - Translate /ops/filesystems/index.zh.md into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
