### PR TITLE
 [FLINK-16033][table-api] Expose catalog lookup function calls in Scala's expression dsl.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -162,7 +162,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 		this.parser = planner.getParser();
 		this.operationTreeBuilder = OperationTreeBuilder.create(
 			tableConfig,
-			functionCatalog,
+			functionCatalog.asLookup(parser::parseIdentifier),
 			catalogManager.getDataTypeFactory(),
 			path -> {
 				try {
@@ -1012,6 +1012,6 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			this,
 			tableOperation,
 			operationTreeBuilder,
-			functionCatalog);
+			functionCatalog.asLookup(parser::parseIdentifier));
 	}
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionLookup.java
@@ -35,6 +35,11 @@ import java.util.Optional;
 public interface FunctionLookup {
 
 	/**
+	 * Lookup a function by function identifier. The identifier is parsed The lookup is case insensitive.
+	 */
+	Optional<Result> lookupFunction(String stringIdentifier);
+
+	/**
 	 * Lookup a function by function identifier. The lookup is case insensitive.
 	 */
 	Optional<Result> lookupFunction(UnresolvedIdentifier identifier);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/LookupCallResolver.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/LookupCallResolver.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.expressions.resolver;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.FunctionLookup;
-import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.LookupCallExpression;
 import org.apache.flink.table.expressions.UnresolvedCallExpression;
@@ -45,7 +44,7 @@ public class LookupCallResolver extends ApiExpressionDefaultVisitor<Expression> 
 	}
 
 	public Expression visit(LookupCallExpression lookupCall) {
-		final FunctionLookup.Result result = functionLookup.lookupFunction(UnresolvedIdentifier.of(lookupCall.getUnresolvedName()))
+		final FunctionLookup.Result result = functionLookup.lookupFunction(lookupCall.getUnresolvedName())
 			.orElseThrow(() -> new ValidationException("Undefined function: " + lookupCall.getUnresolvedName()));
 
 		return unresolvedCall(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/OverWindowResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/OverWindowResolverRule.java
@@ -80,13 +80,12 @@ final class OverWindowResolverRule implements ResolverRule {
 
 				newArgs.addAll(referenceWindow.getPartitionBy());
 
-				return unresolvedCall(unresolvedCall.getFunctionDefinition(), newArgs.toArray(new Expression[0]));
+				return unresolvedCall.replaceArgs(newArgs);
 			} else {
-				return unresolvedCall(
-					unresolvedCall.getFunctionDefinition(),
+				return unresolvedCall.replaceArgs(
 					unresolvedCall.getChildren().stream()
 						.map(expr -> expr.accept(this))
-						.toArray(Expression[]::new));
+						.collect(Collectors.toList()));
 			}
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ReferenceResolverRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ReferenceResolverRule.java
@@ -56,12 +56,12 @@ final class ReferenceResolverRule implements ResolverRule {
 
 		@Override
 		public Expression visit(UnresolvedCallExpression unresolvedCall) {
-			final Expression[] resolvedArgs = unresolvedCall.getChildren()
+			final List<Expression> resolvedArgs = unresolvedCall.getChildren()
 				.stream()
 				.map(expr -> expr.accept(this))
-				.toArray(Expression[]::new);
+				.collect(Collectors.toList());
 
-			return unresolvedCall(unresolvedCall.getFunctionDefinition(), resolvedArgs);
+			return unresolvedCall.replaceArgs(resolvedArgs);
 		}
 
 		@Override
@@ -79,11 +79,9 @@ final class ReferenceResolverRule implements ResolverRule {
 		private ValidationException failForField(UnresolvedReferenceExpression fieldReference) {
 			return new ValidationException(format("Cannot resolve field [%s], input field list:[%s].",
 				fieldReference.getName(),
-				String.join(
-					", ",
-					resolutionContext.referenceLookup().getAllInputFields()
-						.stream().map(FieldReferenceExpression::getName)
-						.collect(Collectors.toList())))
+				resolutionContext.referenceLookup().getAllInputFields()
+					.stream().map(FieldReferenceExpression::getName)
+					.collect(Collectors.joining(", ")))
 			);
 		}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationExpressionsUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationExpressionsUtils.java
@@ -180,11 +180,11 @@ public class OperationExpressionsUtils {
 				return unresolvedRef(properties.get(unresolvedCall));
 			}
 
-			final Expression[] args = unresolvedCall.getChildren()
+			final List<Expression> args = unresolvedCall.getChildren()
 				.stream()
 				.map(c -> c.accept(this))
-				.toArray(Expression[]::new);
-			return unresolvedCall(unresolvedCall.getFunctionDefinition(), args);
+				.collect(Collectors.toList());
+			return unresolvedCall.replaceArgs(args);
 		}
 
 		@Override

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/expressionDsl.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/expressionDsl.scala
@@ -1258,6 +1258,37 @@ trait ImplicitExpressionConversions {
   }
 
   // ----------------------------------------------------------------------------------------------
+  // Function calls
+  // ----------------------------------------------------------------------------------------------
+
+  /**
+   * A call to a function that will be looked up in a catalog. There are two kinds of functions:
+   *
+   *  - System functions - which are identified with one part names
+   *  - Catalog functions - which are identified always with three parts names
+   *    (catalog, database, function)
+   *
+   * Moreover each function can either be a temporary function or permanent one
+   * (which is stored in a catalog).
+   *
+   * Based on those two properties, the resolution order for looking up a function based on
+   * the provided path is as follows:
+   *
+   *  - Temporary system function
+   *  - System function
+   *  - Temporary catalog function
+   *  - Catalog function
+   *
+   * @see TableEnvironment#useCatalog(String)
+   * @see TableEnvironment#useDatabase(String)
+   * @see TableEnvironment#createTemporaryFunction
+   * @see TableEnvironment#createTemporarySystemFunction
+   */
+  def call(path: String, params: Expression*): Expression = {
+    lookupCall(path, params: _*)
+  }
+
+  // ----------------------------------------------------------------------------------------------
   // Implicit expressions in prefix notation
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/CallExpressionResolver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.expressions;
 
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.UnresolvedCallExpression;
@@ -45,7 +46,9 @@ public class CallExpressionResolver {
 		this.resolver = ExpressionResolver.resolverFor(
 				context.getTableConfig(),
 				name -> Optional.empty(),
-				context.getFunctionCatalog(),
+				context.getFunctionCatalog().asLookup(str -> {
+					throw new TableException("We should not need to lookup any expressions at this point");
+				}),
 				context.getCatalogManager().getDataTypeFactory())
 			.build();
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
@@ -58,7 +58,6 @@ class FlinkRelBuilder(
   require(context != null)
 
   private val toRelNodeConverter = {
-    val functionCatalog = context.unwrap(classOf[FlinkContext]).getFunctionCatalog
     new QueryOperationConverter(this)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkRelBuilder.scala
@@ -59,7 +59,7 @@ class FlinkRelBuilder(
 
   private val toRelNodeConverter = {
     val functionCatalog = context.unwrap(classOf[FlinkContext]).getFunctionCatalog
-    new QueryOperationConverter(this, functionCatalog)
+    new QueryOperationConverter(this)
   }
 
   private val expandFactory: ExpandFactory = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/ExpressionBridge.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/ExpressionBridge.scala
@@ -18,24 +18,15 @@
 
 package org.apache.flink.table.planner.expressions
 
-import org.apache.flink.table.catalog.FunctionLookup
-import org.apache.flink.table.expressions.resolver.LookupCallResolver
 import org.apache.flink.table.expressions.{Expression, ExpressionVisitor}
 
 /**
   * Bridges between API [[Expression]]s (for both Java and Scala) and final expression stack.
   */
-class ExpressionBridge[E <: Expression](
-    functionCatalog: FunctionLookup,
-    finalVisitor: ExpressionVisitor[E]) {
-
-  private val callResolver = new LookupCallResolver(functionCatalog)
+class ExpressionBridge[E <: Expression](finalVisitor: ExpressionVisitor[E]) {
 
   def bridge(expression: Expression): E = {
-    // resolve calls
-    val resolvedExpressionTree = expression.accept(callResolver)
-
     // convert to final expressions
-    resolvedExpressionTree.accept(finalVisitor)
+    expression.accept(finalVisitor)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CalcTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/table/CalcTest.xml
@@ -221,7 +221,7 @@ Calc(select=[a, b])
   <TestCase name="testSelectFunction">
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(_c0=[org$apache$flink$table$planner$plan$batch$table$CalcTest$MyHashCode$$1945176195778b1bff1a30c41ce16445($2)], b=[$1])
+LogicalProject(_c0=[hashCode($2)], b=[$1])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.xml
@@ -19,7 +19,7 @@ limitations under the License.
   <TestCase name="testAddColumns">
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], d=[org$apache$flink$table$planner$plan$stream$table$TestFunc$$0a129e109ff5f69f562e719e8997109e($0, $1)])
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[TestFunc($0, $1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(a, b, c)]]])
 ]]>
     </Resource>
@@ -166,7 +166,7 @@ Correlate(invocation=[org$apache$flink$table$planner$utils$TableFunc0$9f62966fe1
   <TestCase name="testOver">
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(c=[$2], mycount=[AS(org$apache$flink$table$planner$utils$CountAggFunction$0586d822ebc97b1e30641334ee46f6e9($1) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'mycount')], wAvg=[AS(org$apache$flink$table$planner$plan$utils$JavaUserDefinedAggFunctions$WeightedAvg$dedb224c126f1b27ca3cdc51d8bf0ff6($0, $1) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'wAvg')], countDist=[AS(org$apache$flink$table$planner$plan$utils$JavaUserDefinedAggFunctions$CountDistinct$76641b169cd6e1a0f10b94c70cd16334($0) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'countDist')])
+LogicalProject(c=[$2], mycount=[AS(countFun($1) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'mycount')], wAvg=[AS(weightAvgFun($0, $1) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'wAvg')], countDist=[AS(countDist($0) OVER (PARTITION BY $2 ORDER BY $3 NULLS FIRST ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW), _UTF-16LE'countDist')])
 +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
 ]]>
     </Resource>
@@ -196,7 +196,7 @@ Calc(select=[a AS d, b])
   <TestCase name="testStar">
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(_c0=[org$apache$flink$table$planner$plan$stream$table$TestFunc$$0a129e109ff5f69f562e719e8997109e($0, $1)])
+LogicalProject(_c0=[TestFunc($0, $1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, Table1, source: [TestTableSource(double, long)]]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.scala
@@ -40,7 +40,7 @@ class ColumnFunctionsTest extends TableTestBase {
     val t = util.addTableSource[(Double, Long)]('double, 'long)
 
    util.addFunction("TestFunc", TestFunc)
-    val tab1 = t.select(TestFunc(withColumns('*)))
+    val tab1 = t.select(call("TestFunc", withColumns('*)))
     val tab2 = t.select("TestFunc(withColumns(*))")
     verifyTableEquals(tab1, tab2)
     util.verifyPlan(tab1)
@@ -171,9 +171,9 @@ class ColumnFunctionsTest extends TableTestBase {
       .window(
         Over partitionBy withColumns('c) orderBy 'proctime preceding UNBOUNDED_ROW as 'w)
       .select('c,
-        countFun(withColumns('b)) over 'w as 'mycount,
-        weightAvgFun(withColumns('a to 'b)) over 'w as 'wAvg,
-        countDist('a) over 'w as 'countDist)
+        call("countFun", withColumns('b)) over 'w as 'mycount,
+        call("weightAvgFun", withColumns('a to 'b)) over 'w as 'wAvg,
+        call("countDist", 'a) over 'w as 'countDist)
       .select('c, 'mycount, 'wAvg, 'countDist)
 
     val tab2 = table
@@ -194,7 +194,7 @@ class ColumnFunctionsTest extends TableTestBase {
     val t = util.addTableSource[(Double, Long, String)]('a, 'b, 'c)
 
    util.addFunction("TestFunc", TestFunc)
-    val tab1 = t.addColumns(TestFunc(withColumns('a, 'b)) as 'd)
+    val tab1 = t.addColumns(call("TestFunc", withColumns('a, 'b)) as 'd)
     val tab2 = t.addColumns("TestFunc(withColumns(a, b)) as d")
     verifyTableEquals(tab1, tab2)
     util.verifyPlan(tab1)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CalcStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CalcStringExpressionTest.scala
@@ -176,7 +176,7 @@ class CalcStringExpressionTest extends TableTestBase {
     util.tableEnv.registerFunction("func", Func23)
 
     val t1 = t.map("func(a, b, c)")
-    val t2 = t.map(Func23('a, 'b, 'c))
+    val t2 = t.map(call("func", 'a, 'b, 'c))
 
     verifyTableEquals(t1, t2)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/OverWindowStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/OverWindowStringExpressionTest.scala
@@ -40,7 +40,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over partitionBy 'a orderBy 'rowtime preceding UNBOUNDED_ROW as 'w)
-      .select('a, 'b.sum over 'w as 'cnt, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w as 'cnt, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.partitionBy("a").orderBy("rowtime").preceding("unbounded_row").as("w"))
       .select("a, SUM(b) OVER w as cnt, weightAvgFun(a, b) over w as myCnt")
@@ -59,7 +59,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over orderBy 'rowtime preceding UNBOUNDED_ROW following CURRENT_ROW as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.orderBy("rowtime").preceding("unbounded_row").following("current_row").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -78,7 +78,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over partitionBy('a, 'd) orderBy 'rowtime preceding 10.rows as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.partitionBy("a, d").orderBy("rowtime").preceding("10.rows").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -97,7 +97,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over orderBy 'rowtime preceding 10.rows following CURRENT_ROW as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.orderBy("rowtime").preceding("10.rows").following("current_row").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -116,7 +116,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over partitionBy 'a orderBy 'rowtime preceding UNBOUNDED_RANGE as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.partitionBy("a").orderBy("rowtime").preceding("unbounded_range").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -135,7 +135,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over orderBy 'rowtime preceding UNBOUNDED_RANGE following CURRENT_RANGE as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(
         Over.orderBy("rowtime").preceding("unbounded_range").following("current_range").as("w"))
@@ -160,7 +160,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over orderBy 'proctime preceding UNBOUNDED_RANGE following CURRENT_RANGE as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(
         Over.orderBy("proctime").preceding("unbounded_range").following("current_range").as("w"))
@@ -185,7 +185,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over partitionBy('a, 'c) orderBy 'rowtime preceding 10.minutes as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.partitionBy("a, c").orderBy("rowtime").preceding("10.minutes").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -204,7 +204,7 @@ class OverWindowStringExpressionTest extends TableTestBase {
 
     val resScala = t
       .window(Over orderBy 'rowtime preceding 4.hours following CURRENT_RANGE as 'w)
-      .select('a, 'b.sum over 'w, weightAvgFun('a, 'b) over 'w as 'myCnt)
+      .select('a, 'b.sum over 'w, call("weightAvgFun", 'a, 'b) over 'w as 'myCnt)
     val resJava = t
       .window(Over.orderBy("rowtime").preceding("4.hours").following("current_range").as("w"))
       .select("a, SUM(b) OVER w, weightAvgFun(a, b) over w as myCnt")
@@ -227,10 +227,10 @@ class OverWindowStringExpressionTest extends TableTestBase {
       .window(Over partitionBy 'a orderBy 'rowtime preceding UNBOUNDED_ROW as 'w)
       .select(
         array('a.sum over 'w, 'a.count over 'w),
-        plusOne('b.sum over 'w as 'wsum) as 'd,
+        call("plusOne", 'b.sum over 'w as 'wsum) as 'd,
         ('a.count over 'w).exp(),
-        (weightedAvg('a, 'b) over 'w) + 1,
-        "AVG:".toExpr + (weightedAvg('a, 'b) over 'w))
+        (call("weightedAvg", 'a, 'b) over 'w) + 1,
+        "AVG:".toExpr + (call("weightedAvg", 'a, 'b) over 'w))
 
     val resJava = t
       .window(Over.partitionBy("a").orderBy("rowtime").preceding("unbounded_row").as("w"))

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
@@ -37,8 +37,8 @@ class TableAggregateStringExpressionTest extends TableTestBase {
 
     // Expression / Scala API
     val resScala = t
-      .flatAggregate(top3('a))
-      .select(Func0('f0) as 'a, 'f1 as 'b)
+      .flatAggregate(call("top3", 'a))
+      .select(call("Func0", 'f0) as 'a, 'f1 as 'b)
 
     // String / Java API
     val resJava = t
@@ -60,8 +60,8 @@ class TableAggregateStringExpressionTest extends TableTestBase {
     // Expression / Scala API
     val resScala = t
       .groupBy('b % 5)
-      .flatAggregate(top3('a))
-      .select(Func0('f0) as 'a, 'f1 as 'b)
+      .flatAggregate(call("top3", 'a))
+      .select(call("Func0", 'f0) as 'a, 'f1 as 'b)
 
     // String / Java API
     val resJava = t

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/RexNodeExtractorTest.scala
@@ -62,9 +62,7 @@ class RexNodeExtractorTest extends RexNodeTestBase {
     moduleManager)
 
   private val expressionBridge: ExpressionBridge[PlannerExpression] =
-    new ExpressionBridge[PlannerExpression](
-      functionCatalog,
-      PlannerExpressionConverter.INSTANCE)
+    new ExpressionBridge[PlannerExpression](PlannerExpressionConverter.INSTANCE)
 
   @Test
   def testExtractRefInputFields(): Unit = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/ExpressionBridge.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/ExpressionBridge.scala
@@ -18,23 +18,12 @@
 
 package org.apache.flink.table.expressions
 
-import org.apache.flink.table.catalog.FunctionLookup
-import org.apache.flink.table.expressions.resolver.LookupCallResolver
-
 /**
   * Bridges between API [[Expression]]s (for both Java and Scala) and final expression stack.
   */
-class ExpressionBridge[E <: Expression](
-    functionCatalog: FunctionLookup,
-    finalVisitor: ExpressionVisitor[E]) {
-
-  private val callResolver = new LookupCallResolver(functionCatalog)
-
+class ExpressionBridge[E <: Expression](finalVisitor: ExpressionVisitor[E]) {
   def bridge(expression: Expression): E = {
-    // resolve calls
-    val resolvedExpressionTree = expression.accept(callResolver)
-
     // convert to final expressions
-    resolvedExpressionTree.accept(finalVisitor)
+    expression.accept(finalVisitor)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/util/RexProgramExtractor.scala
@@ -18,12 +18,6 @@
 
 package org.apache.flink.table.plan.util
 
-import java.sql.{Date, Time, Timestamp}
-import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.rex._
-import org.apache.calcite.sql.fun.SqlStdOperatorTable
-import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
-import org.apache.calcite.util.{DateString, TimeString, TimestampString}
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo}
 import org.apache.flink.table.api.TableException
 import org.apache.flink.table.calcite.FlinkTypeFactory
@@ -32,7 +26,15 @@ import org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall
 import org.apache.flink.table.expressions._
 import org.apache.flink.table.util.JavaScalaConversionUtil
 import org.apache.flink.util.Preconditions
+
+import org.apache.calcite.plan.RelOptUtil
+import org.apache.calcite.rex._
+import org.apache.calcite.sql.fun.SqlStdOperatorTable
+import org.apache.calcite.sql.{SqlFunction, SqlPostfixOperator}
+import org.apache.calcite.util.{DateString, TimeString, TimestampString}
 import org.slf4j.{Logger, LoggerFactory}
+
+import java.sql.{Date, Time, Timestamp}
 
 import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
@@ -276,7 +278,6 @@ class RexNodeToExpressionConverter(
   private def lookupFunction(name: String, operands: Seq[Expression]): Option[Expression] = {
     // TODO we assume only planner expression as a temporary solution to keep the old interfaces
     val expressionBridge = new ExpressionBridge[PlannerExpression](
-      functionCatalog,
       PlannerExpressionConverter.INSTANCE)
     JavaScalaConversionUtil.toScala(functionCatalog.lookupFunction(UnresolvedIdentifier.of(name)))
       .flatMap(result =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -80,7 +80,7 @@ class StreamPlanner(
 
   // temporary bridge between API and planner
   private val expressionBridge: ExpressionBridge[PlannerExpression] =
-    new ExpressionBridge[PlannerExpression](functionCatalog, PlannerExpressionConverter.INSTANCE)
+    new ExpressionBridge[PlannerExpression](PlannerExpressionConverter.INSTANCE)
 
   private val planningConfigurationBuilder: PlanningConfigurationBuilder =
     new PlanningConfigurationBuilder(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -96,8 +96,7 @@ public class SqlToOperationConverterTest {
 		new PlanningConfigurationBuilder(tableConfig,
 			functionCatalog,
 			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, tableConfig, false)),
-			new ExpressionBridge<>(functionCatalog,
-				PlannerExpressionConverter.INSTANCE()));
+			new ExpressionBridge<>(PlannerExpressionConverter.INSTANCE()));
 
 	@Rule
 	public ExpectedException expectedEx = ExpectedException.none();

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/AggregateTest.scala
@@ -31,8 +31,9 @@ import org.apache.flink.table.delegation.{Executor, Planner}
 import org.apache.flink.table.functions.{AggregateFunction, AggregateFunctionDefinition}
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.utils.TableTestUtil.{streamTableNode, term, unaryNode}
-import org.apache.flink.table.utils.{CatalogManagerMocks, StreamTableTestUtil, TableTestBase}
+import org.apache.flink.table.utils.{CatalogManagerMocks, PlannerMock, StreamTableTestUtil, TableTestBase}
 import org.apache.flink.types.Row
+
 import org.junit.Assert.{assertEquals, assertTrue}
 import org.junit.Test
 import org.mockito.Mockito
@@ -77,7 +78,7 @@ class AggregateTest extends TableTestBase {
       functionCatalog,
       config,
       Mockito.mock(classOf[StreamExecutionEnvironment]),
-      Mockito.mock(classOf[Planner]),
+      new PlannerMock,
       Mockito.mock(classOf[Executor]),
       true
     )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RexProgramExtractorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/RexProgramExtractorTest.scala
@@ -18,8 +18,13 @@
 
 package org.apache.flink.table.plan
 
-import java.math.BigDecimal
-import java.sql.{Date, Time, Timestamp}
+import org.apache.flink.table.api.TableConfig
+import org.apache.flink.table.catalog.FunctionCatalog
+import org.apache.flink.table.expressions._
+import org.apache.flink.table.module.ModuleManager
+import org.apache.flink.table.plan.util.{RexNodeToExpressionConverter, RexProgramExtractor}
+import org.apache.flink.table.utils.CatalogManagerMocks
+import org.apache.flink.table.utils.InputTypeBuilder.inputOf
 
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rex._
@@ -28,16 +33,12 @@ import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, INTEGER, VARCHAR}
 import org.apache.calcite.sql.fun.SqlStdOperatorTable
 import org.apache.calcite.util.{DateString, TimeString, TimestampString}
-import org.apache.flink.table.api.TableConfig
-import org.apache.flink.table.catalog.FunctionCatalog
-import org.apache.flink.table.expressions._
-import org.apache.flink.table.module.ModuleManager
-import org.apache.flink.table.plan.util.{RexNodeToExpressionConverter, RexProgramExtractor}
-import org.apache.flink.table.utils.CatalogManagerMocks
-import org.apache.flink.table.utils.InputTypeBuilder.inputOf
 import org.hamcrest.CoreMatchers.is
 import org.junit.Assert.{assertArrayEquals, assertEquals, assertThat}
 import org.junit.Test
+
+import java.math.BigDecimal
+import java.sql.{Date, Time, Timestamp}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -50,9 +51,7 @@ class RexProgramExtractorTest extends RexProgramTestBase {
     new ModuleManager
   )
   private val expressionBridge: ExpressionBridge[PlannerExpression] =
-    new ExpressionBridge[PlannerExpression](
-      functionCatalog,
-      PlannerExpressionConverter.INSTANCE)
+    new ExpressionBridge[PlannerExpression](PlannerExpressionConverter.INSTANCE)
 
   @Test
   def testExtractRefInputFields(): Unit = {


### PR DESCRIPTION
## What is the purpose of the change

First of all it fixes the fact that we were loosing function identifier within the expression resolution stack.

Second of all it lets users use catalog functions in scala's expression DSL.

It is based on #11156

## Verifying this change

This change is already covered by existing tests, which were also updated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
