### PR TITLE
[hotfix] Stabilize python tests

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -98,10 +98,16 @@ jobs:
       path: $(CACHE_FLINK_DIR)
       artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
 
-  # recreate "build-target" symlink for python tests
-  - script: |
-      ln -snf $(CACHE_FLINK_DIR)/flink-dist/target/flink-*-SNAPSHOT-bin/flink-*-SNAPSHOT $(CACHE_FLINK_DIR)/build-target
-    displayName: Recreate 'build-target' symlink
+  # only for the python stage (which runs a full mvn install), download the cache
+  - task: Cache@2
+    condition: eq(variables['module'], 'python')
+    inputs:
+      key: $(CACHE_KEY)
+      restoreKeys: $(CACHE_FALLBACK_KEY)
+      path: $(MAVEN_CACHE_FOLDER)
+    continueOnError: true # continue the build even if the cache fails.
+    displayName: Cache Maven local repo
+    
   # Test
   - script: STAGE=test ${{parameters.environment}} ./tools/azure_controller.sh $(module)
     displayName: Test - $(module)

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -172,6 +172,14 @@ elif [ $STAGE != "$STAGE_CLEANUP" ]; then
         PY_MVN="${MVN// clean/}"
         PY_MVN="$PY_MVN -Drat.skip=true"
         ${PY_MVN}
+
+        if [ $EXIT_CODE != 0 ]; then
+            echo "=============================================================================="
+            echo "Compile error for python stage preparation. Exit code: $EXIT_CODE. Failing build"
+            echo "=============================================================================="
+            exit $EXIT_CODE
+        fi
+        
         echo "Done compiling ... "
     fi
 


### PR DESCRIPTION
These are some examples of failing python tests:
- https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5408&view=logs&j=dee070b7-d526-572b-39a4-ac3b24b600ee&t=b950229e-d858-5111-b60e-d71ec3d8da1d
- https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5409&view=logs&j=dee070b7-d526-572b-39a4-ac3b24b600ee&t=b950229e-d858-5111-b60e-d71ec3d8da1d
- https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5410&view=results
- https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5404&view=logs&j=dee070b7-d526-572b-39a4-ac3b24b600ee&t=b950229e-d858-5111-b60e-d71ec3d8da1d

They all have connection timeout errors:
```
INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13:04 min
[INFO] Finished at: 2020-02-21T12:23:36+00:00
[INFO] Final Memory: 265M/4463M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project flink-connector-elasticsearch7_2.11: Could not resolve dependencies for project org.apache.flink:flink-connector-elasticsearch7_2.11:jar:1.11-SNAPSHOT: Failed to collect dependencies at org.elasticsearch.client:elasticsearch-rest-high-level-client:jar:7.5.1 -> org.elasticsearch:elasticsearch:jar:7.5.1 -> org.apache.lucene:lucene-core:jar:8.3.0: Failed to read artifact descriptor for org.apache.lucene:lucene-core:jar:8.3.0: Could not transfer artifact org.apache.lucene:lucene-solr-grandparent:pom:8.3.0 from/to google-maven-central (https://maven-central-eu.storage-download.googleapis.com/maven2/): GET request of: org/apache/lucene/lucene-solr-grandparent/8.3.0/lucene-solr-grandparent-8.3.0.pom from google-maven-central failed: Connection reset -> [Help 1]
```

This hotfix introduces two mitigations:
a) we fail the build if maven fails
b) we use a cache for the python build, so that we don't have to excessively use the mirror