### PR TITLE
[FLINK-16230][tests]Use LinkedHashSet instead of HashSet

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/testutils/DeeplyEqualsChecker.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/DeeplyEqualsChecker.java
@@ -24,7 +24,6 @@ import org.apache.flink.types.Row;
 
 import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -33,7 +32,6 @@ import java.util.function.BiFunction;
  * Deep equality checker for tests. It performs deep checks for objects which have no proper deepEquals methods like:
  * <ul>
  *     <li>{@link Tuple}s</li>
- *     <li>{@link Iterable}s</li>
  *     <li>Java arrays</li>
  *     <li>{@link Row}</li>
  *     <li>{@link Throwable}</li>
@@ -90,8 +88,6 @@ public class DeeplyEqualsChecker {
 	private boolean deepEquals0(Object e1, Object e2) {
 		if (e1.getClass().isArray() && e2.getClass().isArray()) {
 			return deepEqualsArray(e1, e2);
-		} else if (e1 instanceof Iterable && e2 instanceof Iterable) {
-			return deepEqualsIterable((Iterable) e1, (Iterable) e2);
 		} else if (e1 instanceof Tuple && e2 instanceof Tuple) {
 			return deepEqualsTuple((Tuple) e1, (Tuple) e2);
 		} else if (e1 instanceof Row && e2 instanceof Row) {
@@ -101,21 +97,6 @@ public class DeeplyEqualsChecker {
 		} else {
 			return e1.equals(e2);
 		}
-	}
-
-	private boolean deepEqualsIterable(Iterable i1, Iterable i2) {
-		Iterator s1 = i1.iterator();
-		Iterator s2 = i2.iterator();
-
-		while (s1.hasNext() && s2.hasNext()) {
-			Object l = s1.next();
-			Object r = s2.next();
-
-			if (!deepEquals(l, r)) {
-				return false;
-			}
-		}
-		return !s1.hasNext() && !s2.hasNext();
 	}
 
 	private boolean deepEqualsTuple(Tuple tuple1, Tuple tuple2) {


### PR DESCRIPTION
For background information, please refer to https://issues.apache.org/jira/browse/FLINK-16230

## What is the purpose of the change
The fix for the test is to use LinkedHashSet instead of HashSet so that the iteration order will be deterministic across different JVM versions or vendors, thus making the test more stable.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
