### PR TITLE
[FLINK-16130] [docs] Translate /ops/filesystems/common.zh.md into Chinese

### DIFF
--- a/docs/ops/filesystems/common.md
+++ b/docs/ops/filesystems/common.md
@@ -62,7 +62,7 @@ If the opening of the stream takes longer than `fs.<scheme>.limit.timeout`, the 
 
 To prevent inactive streams from taking up the full pool (preventing new connections to be opened), you can add an inactivity timeout which forcibly closes them if they do not read/write any bytes for at least that amount of time: `fs.<scheme>.limit.stream-timeout`. 
 
-Limit enforcment on a per TaskManager/file system basis.
+Limit enforcement on a per TaskManager/file system basis.
 Because file systems creation occurs per scheme and authority, different
 authorities have independent connection pools. For example `hdfs://myhdfs:50010/` and `hdfs://anotherhdfs:4399/` will have separate pools.
 

--- a/docs/ops/filesystems/common.zh.md
+++ b/docs/ops/filesystems/common.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Common Configurations"
+title: "通用配置"
 nav-parent_id: filesystems
 nav-pos: 0
 ---
@@ -22,48 +22,41 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Apache Flink provides several standard configuration settings that work across all file system implementations. 
+Apache Flink 提供了一些对所有文件系统均适用的基本配置。
 
 * This will be replaced by the TOC
 {:toc}
 
-## Default File System
+## 默认文件系统
 
-A default scheme (and authority) is used if paths to files do not explicitly specify a file system scheme (and authority).
+如果文件路径未明确指定文件系统的 scheme（和 authority），将会使用默认的 scheme（和 authority）：
 
 {% highlight yaml %}
 fs.default-scheme: <default-fs>
 {% endhighlight %}
 
-For example, if the default file system configured as `fs.default-scheme: hdfs://localhost:9000/`, then a file path of
-`/user/hugo/in.txt` is interpreted as `hdfs://localhost:9000/user/hugo/in.txt`.
+例如默认的文件系统配置为 `fs.default-scheme: hdfs://localhost:9000/`，则文件路径 `/user/hugo/in.txt` 将被处理为 `hdfs://localhost:9000/user/hugo/in.txt`。
 
-## Connection limiting
+## 连接限制
 
-You can limit the total number of connections that a file system can concurrently open which is useful when the file system cannot handle a large number
-of concurrent reads/writes or open connections at the same time.
+如果文件系统不能处理大量并发读/写操作或连接，可以为文件系统同时打开的总连接数设置上限。
 
-For example, small HDFS clusters with few RPC handlers can sometimes be overwhelmed by a large Flink job trying to build up many connections during a checkpoint.
+例如在一个大型 Flink 任务建立 checkpoint 时，具有少量 RPC handler 的小型 HDFS 集群可能会由于建立了过多的连接而过载。
 
-To limit a specific file system's connections, add the following entries to the Flink configuration. The file system to be limited is identified by
-its scheme.
+要限制文件系统的连接数，可将下列配置添加至 Flink 配置中。设置限制的文件系统由其 scheme 指定：
 
 {% highlight yaml %}
-fs.<scheme>.limit.total: (number, 0/-1 mean no limit)
-fs.<scheme>.limit.input: (number, 0/-1 mean no limit)
-fs.<scheme>.limit.output: (number, 0/-1 mean no limit)
-fs.<scheme>.limit.timeout: (milliseconds, 0 means infinite)
-fs.<scheme>.limit.stream-timeout: (milliseconds, 0 means infinite)
+fs.<scheme>.limit.total: (数量，0/-1 表示无限制)
+fs.<scheme>.limit.input: (数量，0/-1 表示无限制)
+fs.<scheme>.limit.output: (数量，0/-1 表示无限制)
+fs.<scheme>.limit.timeout: (毫秒，0 表示无穷)
+fs.<scheme>.limit.stream-timeout: (毫秒，0 表示无穷)
 {% endhighlight %}
 
-You can limit the number of input/output connections (streams) separately (`fs.<scheme>.limit.input` and `fs.<scheme>.limit.output`), as well as impose a limit on
-the total number of concurrent streams (`fs.<scheme>.limit.total`). If the file system tries to open more streams, the operation blocks until some streams close.
-If the opening of the stream takes longer than `fs.<scheme>.limit.timeout`, the stream opening fails.
+输入和输出连接（流）的数量可以分别进行限制（`fs.<scheme>.limit.input` 和 `fs.<scheme>.limit.output`），也可以限制并发流的总数（`fs.<scheme>.limit.total`）。如果文件系统尝试打开更多的流，操作将被阻塞直至某些流关闭。如果打开流的时间超过 `fs.<scheme>.limit.timeout`，则流打开失败。
 
-To prevent inactive streams from taking up the full pool (preventing new connections to be opened), you can add an inactivity timeout which forcibly closes them if they do not read/write any bytes for at least that amount of time: `fs.<scheme>.limit.stream-timeout`. 
+为避免不活动的流占满整个连接池（阻止新连接的建立），可以在配置中添加无活动超时时间，如果连接至少在 `fs.<scheme>.limit.stream-timeout` 时间内没有读/写操作，则连接会被强制关闭。
 
-Limit enforcment on a per TaskManager/file system basis.
-Because file systems creation occurs per scheme and authority, different
-authorities have independent connection pools. For example `hdfs://myhdfs:50010/` and `hdfs://anotherhdfs:4399/` will have separate pools.
+连接数是按每个 TaskManager/文件系统来进行限制的。因为文件系统的创建是按照 scheme 和 authority 进行的，所以不同的 authority 具有独立的连接池，例如 `hdfs://myhdfs:50010/` 和 `hdfs://anotherhdfs:4399/` 会有单独的连接池。
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request translates /ops/filesystems/common.zh.md into Chinese, and fixes a typo in corresponding English documentation.


## Brief change log

 - Translate /ops/filesystems/common.zh.md into Chinese
 - Fix a typo in /ops/filesystems/common.md


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
