### PR TITLE
[FLINK-16231][hive][build] Add missing jdk.tools exclusion

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -665,6 +665,10 @@ under the License.
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
 				</exclusion>


### PR DESCRIPTION
Failed the build on Java 11 with Hive 2.x.y profiles.