### PR TITLE
[FLINK-16234][tests] Fix unstable cases in StreamingJobGraphGeneratorTest

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -136,7 +136,7 @@ public class StreamGraph implements Pipeline {
 		vertexIDtoBrokerID = new HashMap<>();
 		vertexIDtoLoopTimeout  = new HashMap<>();
 		iterationSourceSinkPairs = new HashSet<>();
-		sources = new LinkedHashSet<>();
+		sources = new HashSet<>();
 		sinks = new HashSet<>();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -60,6 +60,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +136,7 @@ public class StreamGraph implements Pipeline {
 		vertexIDtoBrokerID = new HashMap<>();
 		vertexIDtoLoopTimeout  = new HashMap<>();
 		iterationSourceSinkPairs = new HashSet<>();
-		sources = new HashSet<>();
+		sources = new LinkedHashSet<>();
 		sinks = new HashSet<>();
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -60,7 +60,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -71,6 +71,7 @@ import javax.annotation.Nullable;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -785,19 +786,11 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 		assertEquals(4, verticesSorted.size());
 
-		JobVertex source1Vertex = null, source2Vertex = null, map1Vertex = null, map2Vertex= null;
-		for (int i = 0; i < 4; i++)
-		{
-			JobVertex vertex = verticesSorted.get(i);
-			if (vertex.getName().equals("Source: source1"))
-				source1Vertex = vertex;
-			if (vertex.getName().equals("Source: source2"))
-				source2Vertex = vertex;
-			if (vertex.getName().equals("map1"))
-				map1Vertex = vertex;
-			if (vertex.getName().equals("map2"))
-				map2Vertex = vertex;
-		}
+		final List<JobVertex> verticesMatched = getExpectedVerticesList(verticesSorted);
+		final JobVertex source1Vertex = verticesMatched.get(0);
+		final JobVertex source2Vertex = verticesMatched.get(1);
+		final JobVertex map1Vertex = verticesMatched.get(2);
+		final JobVertex map2Vertex = verticesMatched.get(3);
 
 		// all vertices should be in the same default slot sharing group
 		// except for map1 which has a specified slot sharing group
@@ -814,19 +807,11 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 		assertEquals(4, verticesSorted.size());
 
-		JobVertex source1Vertex = null, source2Vertex = null, map1Vertex = null, map2Vertex= null;
-		for (int i = 0; i < 4; i++)
-		{
-			JobVertex vertex = verticesSorted.get(i);
-			if (vertex.getName().equals("Source: source1"))
-				source1Vertex = vertex;
-			if (vertex.getName().equals("Source: source2"))
-				source2Vertex = vertex;
-			if (vertex.getName().equals("map1"))
-				map1Vertex = vertex;
-			if (vertex.getName().equals("map2"))
-				map2Vertex = vertex;
-		}
+		final List<JobVertex> verticesMatched = getExpectedVerticesList(verticesSorted);
+		final JobVertex source1Vertex = verticesMatched.get(0);
+		final JobVertex source2Vertex = verticesMatched.get(1);
+		final JobVertex map1Vertex = verticesMatched.get(2);
+		final JobVertex map2Vertex = verticesMatched.get(3);
 
 		// vertices in the same region should be in the same slot sharing group
 		assertSameSlotSharingGroup(source1Vertex, map1Vertex);
@@ -874,5 +859,18 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final Method setResourcesMethod = clazz.getDeclaredMethod("setResources", ResourceSpec.class);
 		setResourcesMethod.setAccessible(true);
 		return setResourcesMethod;
+	}
+
+	private List<JobVertex> getExpectedVerticesList(List<JobVertex> vertices) {
+		List<JobVertex> verticesMatched = new ArrayList<JobVertex>();
+		List<String> ExpectedOrder = Arrays.asList("source1", "source2", "map1", "map2");
+		for (int i = 0; i < ExpectedOrder.size(); i++) {
+			for (JobVertex vertex : vertices) {
+				if (vertex.getName().contains(ExpectedOrder.get(i))) {
+					verticesMatched.add(vertex);
+				}
+			}
+		}
+		return verticesMatched;
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -861,12 +861,12 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		return setResourcesMethod;
 	}
 
-	private List<JobVertex> getExpectedVerticesList(List<JobVertex> vertices) {
+	private static List<JobVertex> getExpectedVerticesList(List<JobVertex> vertices) {
 		List<JobVertex> verticesMatched = new ArrayList<JobVertex>();
-		List<String> ExpectedOrder = Arrays.asList("source1", "source2", "map1", "map2");
-		for (int i = 0; i < ExpectedOrder.size(); i++) {
+		List<String> expectedOrder = Arrays.asList("source1", "source2", "map1", "map2");
+		for (int i = 0; i < expectedOrder.size(); i++) {
 			for (JobVertex vertex : vertices) {
-				if (vertex.getName().contains(ExpectedOrder.get(i))) {
+				if (vertex.getName().contains(expectedOrder.get(i))) {
 					verticesMatched.add(vertex);
 				}
 			}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -785,10 +785,19 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 		assertEquals(4, verticesSorted.size());
 
-		final JobVertex source1Vertex = verticesSorted.get(0);
-		final JobVertex source2Vertex = verticesSorted.get(1);
-		final JobVertex map1Vertex = verticesSorted.get(2);
-		final JobVertex map2Vertex = verticesSorted.get(3);
+		JobVertex source1Vertex = null, source2Vertex = null, map1Vertex = null, map2Vertex= null;
+		for (int i = 0; i < 4; i++)
+		{
+			JobVertex vertex = verticesSorted.get(i);
+			if (vertex.getName().equals("Source: source1"))
+				source1Vertex = vertex;
+			if (vertex.getName().equals("Source: source2"))
+				source2Vertex = vertex;
+			if (vertex.getName().equals("map1"))
+				map1Vertex = vertex;
+			if (vertex.getName().equals("map2"))
+				map2Vertex = vertex;
+		}
 
 		// all vertices should be in the same default slot sharing group
 		// except for map1 which has a specified slot sharing group
@@ -805,10 +814,19 @@ public class StreamingJobGraphGeneratorTest extends TestLogger {
 		final List<JobVertex> verticesSorted = jobGraph.getVerticesSortedTopologicallyFromSources();
 		assertEquals(4, verticesSorted.size());
 
-		final JobVertex source1Vertex = verticesSorted.get(0);
-		final JobVertex source2Vertex = verticesSorted.get(1);
-		final JobVertex map1Vertex = verticesSorted.get(2);
-		final JobVertex map2Vertex = verticesSorted.get(3);
+		JobVertex source1Vertex = null, source2Vertex = null, map1Vertex = null, map2Vertex= null;
+		for (int i = 0; i < 4; i++)
+		{
+			JobVertex vertex = verticesSorted.get(i);
+			if (vertex.getName().equals("Source: source1"))
+				source1Vertex = vertex;
+			if (vertex.getName().equals("Source: source2"))
+				source2Vertex = vertex;
+			if (vertex.getName().equals("map1"))
+				map1Vertex = vertex;
+			if (vertex.getName().equals("map2"))
+				map2Vertex = vertex;
+		}
 
 		// vertices in the same region should be in the same slot sharing group
 		assertSameSlotSharingGroup(source1Vertex, map1Vertex);


### PR DESCRIPTION
This PR aims to solve the issue presented here: https://issues.apache.org/jira/browse/FLINK-16234
## What is the purpose of the change

The fix is to change the HashSet to LinkedHashSet to make the tests more stable.

## Verifying this change

This change is already covered by existing tests, and it can pass them successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:  don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
