### PR TITLE
[FLINK-16202][sql] Support JSON_QUERY for blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1011,4 +1011,5 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlPostfixOperator IS_NOT_JSON_OBJECT = SqlStdOperatorTable.IS_NOT_JSON_OBJECT;
 	public static final SqlPostfixOperator IS_NOT_JSON_ARRAY = SqlStdOperatorTable.IS_NOT_JSON_ARRAY;
 	public static final SqlPostfixOperator IS_NOT_JSON_SCALAR = SqlStdOperatorTable.IS_NOT_JSON_SCALAR;
+	public static final SqlFunction JSON_QUERY = SqlStdOperatorTable.JSON_QUERY;
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -22,10 +22,12 @@ import org.apache.flink.table.dataformat.{Decimal, SqlTimestamp}
 import org.apache.flink.table.runtime.functions._
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.linq4j.tree.Types
-import org.apache.calcite.runtime.SqlFunctions
+import org.apache.calcite.runtime.{JsonFunctions, SqlFunctions}
 import java.lang.reflect.Method
 import java.lang.{Byte => JByte, Integer => JInteger, Long => JLong, Short => JShort}
 import java.util.TimeZone
+
+import org.apache.calcite.sql.{SqlJsonQueryEmptyOrErrorBehavior, SqlJsonQueryWrapperBehavior}
 
 object BuiltInMethods {
 
@@ -463,4 +465,9 @@ object BuiltInMethods {
 
   val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncate",
     classOf[SqlTimestamp], classOf[Int])
+
+  // JSON FUNCTIONS
+  val JSON_QUERY = Types.lookupMethod(classOf[JsonFunctions], "jsonQuery",
+    classOf[String], classOf[String], classOf[SqlJsonQueryWrapperBehavior],
+    classOf[SqlJsonQueryEmptyOrErrorBehavior], classOf[SqlJsonQueryEmptyOrErrorBehavior])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -801,6 +801,15 @@ object FunctionGenerator {
       new MethodCallGen(
         BuiltInMethod.IS_JSON_SCALAR.method)))
 
+  addSqlFunctionMethod(
+    JSON_QUERY,
+    Seq(VARCHAR, CHAR, RAW, RAW, RAW),
+    BuiltInMethods.JSON_QUERY)
+
+  addSqlFunctionMethod(
+    JSON_QUERY,
+    Seq(CHAR, CHAR, RAW, RAW, RAW),
+    BuiltInMethods.JSON_QUERY)
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.expressions
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.ValidationException
+import org.apache.flink.table.planner.codegen.CodeGenException
 import org.apache.flink.table.planner.expressions.utils.ExpressionTestBase
 import org.apache.flink.types.Row
 import org.junit.Assert.assertEquals
@@ -191,5 +192,14 @@ class JsonFunctionsTest extends ExpressionTestBase {
     testSqlApi("json_query(f8, 'strict $.name1' null on error)", "null")
     testSqlApi("json_query(f8, 'strict $' null on empty)", "{\"name\":\"flink\"}")
     testSqlApi("json_query(cast(f2 as varchar), 'lax $' null on empty)", "null")
+
+    // invalid input and path
+    testSqlApi("json_query('{]', 'invalid $.name')", "null")
+    testSqlApi("json_query('{]', '$.name')", "null")
+    testSqlApi("json_query(f8, 'invalid $.aa')", "null")
+    testSqlApi("json_query(f8, '$.aa')", "null")
+    // wrong field types
+    expectedException.expect(classOf[CodeGenException])
+    testSqlApi("json_query(f7, 'lax $' null on empty)", "{\"name\":\"flink\"}")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
@@ -125,4 +125,71 @@ class JsonFunctionsTest extends ExpressionTestBase {
     }
   }
 
+  @Test
+  def testJsonQuery(): Unit = {
+    // lax test
+    testSqlApi("json_query('{\"foo\":100}', 'lax $' null on empty)", "{\"foo\":100}")
+    testSqlApi("json_query('{\"foo\":100}', 'lax $' error on empty)", "{\"foo\":100}")
+    testSqlApi("json_query('{\"foo\":100}', 'lax $' empty array on empty)", "{\"foo\":100}");
+    testSqlApi("json_query('{\"foo\":100}', 'lax $' empty object on empty)", "{\"foo\":100}");
+    testSqlApi("json_query('{\"foo\":100}', 'lax $.foo' null on empty)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'lax $.foo' empty array on empty)", "[]");
+    testSqlApi("json_query('{\"foo\":100}', 'lax $.foo' empty object on empty)", "{}");
+
+    // path error test
+    testSqlApi("json_query('{\"foo\":100}', 'invalid $.foo' null on error)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'invalid $.foo' empty array on error)", "[]");
+    testSqlApi("json_query('{\"foo\":100}', 'invalid $.foo' empty object on error)", "{}");
+
+    // strict test
+    testSqlApi("json_query('{\"foo\":100}', 'strict $' null on empty)", "{\"foo\":100}");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $' error on empty)", "{\"foo\":100}");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $' empty array on error)", "{\"foo\":100}");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $' empty object on error)", "{\"foo\":100}");
+
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo1' null on error)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo1' empty array on error)", "[]");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo1' empty object on error)", "{}");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' null on error)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' empty array on error)", "[]");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' empty object on error)", "{}");
+
+    // array wrapper test
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' without wrapper)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' without array wrapper)", "null");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' with wrapper)", "[100]");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' with unconditional wrapper)", "[100]");
+    testSqlApi("json_query('{\"foo\":100}', 'strict $.foo' with conditional wrapper)", "[100]");
+    testSqlApi("json_query('{\"foo\":[100]}', 'strict $.foo' without wrapper)", "[100]");
+    testSqlApi("json_query('{\"foo\":[100]}', 'strict $.foo' without array wrapper)", "[100]");
+    testSqlApi("json_query('{\"foo\":[100]}', 'strict $.foo' with wrapper)", "[[100]]");
+    testSqlApi("json_query('{\"foo\":[100]}', 'strict $.foo' with unconditional wrapper)",
+      "[[100]]");
+    testSqlApi("json_query('{\"foo\":[100]}', 'strict $.foo' with conditional wrapper)", "[100]");
+
+    // without on err test
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' without wrapper null on error)", "null");
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' without wrapper empty array on error)", "[]");
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' without wrapper empty object on error)", "{}");
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' without wrapper null on error)", "null");
+
+    // with on err test
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' with wrapper null on error)", "[100]");
+    testSqlApi("json_query('{\"foo\":100}', " +
+      "'strict $.foo' with unconditional wrapper null on error)", "[100]");
+
+    // nulls
+    testSqlApi("json_query(cast(null as varchar), 'lax $')", "null")
+
+    testSqlApi("json_query(f8, 'lax $' null on empty)", "{\"name\":\"flink\"}")
+    testSqlApi("json_query(f8, 'invalid $.name' null on error)", "null")
+    testSqlApi("json_query(f8, 'strict $.name1' null on error)", "null")
+    testSqlApi("json_query(f8, 'strict $' null on empty)", "{\"name\":\"flink\"}")
+    testSqlApi("json_query(cast(f2 as varchar), 'lax $' null on empty)", "null")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Support `JSON_QUERY` function for blink planner

## Brief change log

*(for example:)*

- Introduce `JSON_QUERY` to `FlinkSqlOperatorTable`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `ScalarFunctionsTest.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)