### PR TITLE
[FLINK-16242][table-runtime-blink] Duplicate field serializers in BaseRowSerializer

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
@@ -77,7 +77,11 @@ public class BaseRowSerializer extends AbstractRowSerializer<BaseRow> {
 
 	@Override
 	public TypeSerializer<BaseRow> duplicate() {
-		return new BaseRowSerializer(types, fieldSerializers);
+		TypeSerializer<?>[] duplicateFieldSerializers = new TypeSerializer[fieldSerializers.length];
+		for (int i = 0; i < fieldSerializers.length; i++) {
+			duplicateFieldSerializers[i] = fieldSerializers[i].duplicate();
+		}
+		return new BaseRowSerializer(types, duplicateFieldSerializers);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializerTest.java
@@ -20,16 +20,21 @@ package org.apache.flink.table.runtime.typeutils;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.SerializerTestInstance;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryArray;
 import org.apache.flink.table.dataformat.BinaryArrayWriter;
+import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryMap;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
@@ -80,7 +85,8 @@ public class BaseRowSerializerTest extends SerializerTestInstance<BaseRow> {
 		return Arrays.asList(
 				testBaseRowSerializer(),
 				testLargeBaseRowSerializer(),
-				testBaseRowSerializerWithComplexTypes());
+				testBaseRowSerializerWithComplexTypes(),
+				testBaseRowSerializerWithKryo());
 	}
 
 	private static Object[] testBaseRowSerializer() {
@@ -157,6 +163,19 @@ public class BaseRowSerializerTest extends SerializerTestInstance<BaseRow> {
 
 		BaseRowSerializer serializer = typeInfo.createSerializer(new ExecutionConfig());
 		return new Object[] {serializer, data};
+	}
+
+	private static Object[] testBaseRowSerializerWithKryo() {
+		BinaryGenericSerializer<WrappedString> binaryGenericSerializer = new BinaryGenericSerializer<>(
+				new KryoSerializer<>(WrappedString.class, new ExecutionConfig()));
+		BaseRowSerializer serializer = new BaseRowSerializer(new LogicalType[]{
+				new RawType(BinaryGeneric.class, binaryGenericSerializer)},
+				new TypeSerializer[]{binaryGenericSerializer});
+
+		GenericRow row = new GenericRow(1);
+		row.setField(0, new BinaryGeneric<>(new WrappedString("a")));
+
+		return new Object[] {serializer, new GenericRow[]{row}};
 	}
 
 	// ----------------------------------------------------------------------------------------------
@@ -240,4 +259,17 @@ public class BaseRowSerializerTest extends SerializerTestInstance<BaseRow> {
 			checkDeepEquals(row, serializer.copy(row, new GenericRow(row.getArity() + 1)));
 		}
 	}
+
+	/**
+	 * Class used for concurrent testing with KryoSerializer.
+	 */
+	private static class WrappedString {
+
+		private final String content;
+
+		WrappedString(String content) {
+			this.content = content;
+		}
+	}
+
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix bug in duplicate() fucntion in #BaseRowSerializer

## Brief change log

Use duplicated field serializers in #BaseRowSerializer#duplicate()



## Verifying this change

Unit Testing. Without the bugfix, we can reproduce the concurrency error below:

```
java.lang.IllegalStateException: Concurrent access to KryoSerializer. Thread 1: Thread-11 , Thread 2: Thread-15

        at org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer.enterExclusiveThread(KryoSerializer.java:630)
        at org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer.serialize(KryoSerializer.java:285)
        at org.apache.flink.util.InstantiationUtil.serializeToByteArray(InstantiationUtil.java:526)
        at org.apache.flink.table.dataformat.BinaryGeneric.materialize(BinaryGeneric.java:49)
        at org.apache.flink.table.dataformat.LazyBinaryFormat.ensureMaterialized(LazyBinaryFormat.java:115)
        at org.apache.flink.table.dataformat.AbstractBinaryWriter.writeGeneric(AbstractBinaryWriter.java:124)
        at org.apache.flink.table.dataformat.BinaryWriter.write(BinaryWriter.java:138)
        at org.apache.flink.table.runtime.typeutils.BaseRowSerializer.toBinaryRow(BaseRowSerializer.java:192)
        at org.apache.flink.table.runtime.typeutils.BaseRowSerializer.serialize(BaseRowSerializer.java:95)
        at org.apache.flink.table.runtime.typeutils.BaseRowSerializer.serialize(BaseRowSerializer.java:50)
        at org.apache.flink.api.common.typeutils.SerializerTestBase$SerializerRunner.run(SerializerTestBase.java:577)
```

## Does this pull request potentially affect one of the following parts:
  - The serializers: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
