### PR TITLE
[FLINK-16222][runtime] Use plugins mechanism for initializing MetricReporters

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginLoader.java
@@ -20,7 +20,6 @@ package org.apache.flink.core.plugin;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.ArrayUtils;
-import org.apache.flink.util.ChildFirstClassLoader;
 import org.apache.flink.util.TemporaryClassLoaderContext;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -35,7 +34,7 @@ import java.util.ServiceLoader;
 
 /**
  * A {@link PluginLoader} is used by the {@link PluginManager} to load a single plugin. It is essentially a combination
- * of a {@link ChildFirstClassLoader} and {@link ServiceLoader}. This class can locate and load service implementations
+ * of a {@link PluginClassLoader} and {@link ServiceLoader}. This class can locate and load service implementations
  * from the plugin for a given SPI. The {@link PluginDescriptor}, which among other information contains the resource
  * URLs, is provided at construction.
  */
@@ -69,7 +68,7 @@ public class PluginLoader {
 	 * @param <P> Type of the requested plugin service.
 	 * @return An iterator of all implementations of the given service interface that could be loaded from the plugin.
 	 */
-	public <P extends Plugin> Iterator<P> load(Class<P> service) {
+	public <P> Iterator<P> load(Class<P> service) {
 		try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(pluginClassLoader)) {
 			return new ContextClassLoaderSettingIterator<>(
 				ServiceLoader.load(service, pluginClassLoader).iterator(),
@@ -83,7 +82,7 @@ public class PluginLoader {
 	 *
 	 * @param <P> type of the iterated plugin element.
 	 */
-	static class ContextClassLoaderSettingIterator<P extends Plugin> implements Iterator<P> {
+	static class ContextClassLoaderSettingIterator<P> implements Iterator<P> {
 
 		private final Iterator<P> delegate;
 		private final ClassLoader pluginClassLoader;

--- a/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
+++ b/flink-core/src/main/java/org/apache/flink/core/plugin/PluginManager.java
@@ -63,7 +63,7 @@ public class PluginManager {
 	 * @param <P> Type of the requested plugin service.
 	 * @return Iterator over all implementations of the given service that could be loaded from all known plugins.
 	 */
-	public <P extends Plugin> Iterator<P> load(Class<P> service) {
+	public <P> Iterator<P> load(Class<P> service) {
 		ArrayList<Iterator<P>> combinedIterators = new ArrayList<>(pluginDescriptors.size());
 		for (PluginDescriptor pluginDescriptor : pluginDescriptors) {
 			PluginLoader pluginLoader = PluginLoader.create(pluginDescriptor, parentClassLoader, alwaysParentFirstPatterns);

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.metrics.prometheus.tests;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.prometheus.PrometheusReporter;
+import org.apache.flink.metrics.prometheus.PrometheusReporterFactory;
 import org.apache.flink.tests.util.AutoClosableProcess;
 import org.apache.flink.tests.util.CommandLineWrapper;
 import org.apache.flink.tests.util.cache.DownloadCache;
@@ -46,15 +47,22 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.metrics.prometheus.tests.PrometheusReporterEndToEndITCase.TestParams.InstantiationType.FACTORY;
+import static org.apache.flink.metrics.prometheus.tests.PrometheusReporterEndToEndITCase.TestParams.InstantiationType.REFLECTION;
 import static org.apache.flink.tests.util.AutoClosableProcess.runBlocking;
 import static org.apache.flink.tests.util.AutoClosableProcess.runNonBlocking;
 
@@ -62,6 +70,7 @@ import static org.apache.flink.tests.util.AutoClosableProcess.runNonBlocking;
  * End-to-end test for the PrometheusReporter.
  */
 @Category(TravisGroup1.class)
+@RunWith(Parameterized.class)
 public class PrometheusReporterEndToEndITCase extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(PrometheusReporterEndToEndITCase.class);
@@ -70,6 +79,7 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 
 	private static final String PROMETHEUS_VERSION = "2.4.3";
 	private static final String PROMETHEUS_FILE_NAME;
+	private static final String PROMETHEUS_JAR_PREFIX = "flink-metrics-prometheus";
 
 	static {
 		final String base = "prometheus-" + PROMETHEUS_VERSION + '.';
@@ -114,13 +124,36 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 		Assume.assumeFalse("This test does not run on Windows.", OperatingSystem.isWindows());
 	}
 
+	@Parameterized.Parameters(name = "{index}: {0}")
+	public static Collection<TestParams> testParameters() {
+		return Arrays.asList(
+			TestParams.from("Jar in 'lib'",
+				builder -> builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.OPT, JarLocation.LIB),
+				REFLECTION),
+			TestParams.from("Jar in 'lib'",
+				builder -> builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.OPT, JarLocation.LIB),
+				FACTORY),
+			TestParams.from("Jar in 'plugins'",
+				builder -> builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.OPT, JarLocation.PLUGINS),
+				FACTORY),
+			TestParams.from("Jar in 'lib' and 'plugins'",
+				builder -> {
+					builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.OPT, JarLocation.LIB);
+					builder.copyJar(PROMETHEUS_JAR_PREFIX, JarLocation.OPT, JarLocation.PLUGINS);
+				},
+				FACTORY)
+		);
+	}
+
 	@Rule
-	public final FlinkResource dist = new LocalStandaloneFlinkResourceFactory()
-		.create(FlinkResourceSetup.builder()
-			.moveJar("flink-metrics-prometheus", JarLocation.OPT, JarLocation.LIB)
-			.addConfiguration(getFlinkConfig())
-			.build())
-		.get();
+	public final FlinkResource dist;
+
+	public PrometheusReporterEndToEndITCase(TestParams params) {
+		final FlinkResourceSetup.FlinkResourceSetupBuilder builder = FlinkResourceSetup.builder();
+		params.getBuilderSetup().accept(builder);
+		builder.addConfiguration(getFlinkConfig(params.getInstantiationType()));
+		dist = new LocalStandaloneFlinkResourceFactory().create(builder.build()).get();
+	}
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
@@ -128,11 +161,18 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 	@Rule
 	public final DownloadCache downloadCache = DownloadCache.get();
 
-	private static Configuration getFlinkConfig() {
+	private static Configuration getFlinkConfig(TestParams.InstantiationType instantiationType) {
 		final Configuration config = new Configuration();
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, PrometheusReporter.class.getCanonicalName());
-		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom.port", "9000-9100");
 
+		switch (instantiationType) {
+			case FACTORY:
+				config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, PrometheusReporterFactory.class.getName());
+				break;
+			case REFLECTION:
+				config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, PrometheusReporter.class.getCanonicalName());
+		}
+
+		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom.port", "9000-9100");
 		return config;
 	}
 
@@ -243,5 +283,39 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 			}
 		}
 		throw new AssertionError("Could not retrieve metric " + metric + " from Prometheus.", reportedException);
+	}
+
+	static class TestParams {
+		private final String jarLocationDescription;
+		private final Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup;
+		private final InstantiationType instantiationType;
+
+		private TestParams(String jarLocationDescription, Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup, InstantiationType instantiationType) {
+			this.jarLocationDescription = jarLocationDescription;
+			this.builderSetup = builderSetup;
+			this.instantiationType = instantiationType;
+		}
+
+		public static TestParams from(String jarLocationDesription, Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> builderSetup, InstantiationType instantiationType) {
+			return new TestParams(jarLocationDesription, builderSetup, instantiationType);
+		}
+
+		public Consumer<FlinkResourceSetup.FlinkResourceSetupBuilder> getBuilderSetup() {
+			return builderSetup;
+		}
+
+		public InstantiationType getInstantiationType() {
+			return instantiationType;
+		}
+
+		@Override
+		public String toString() {
+			return jarLocationDescription + ", instantiated via " + instantiationType.name().toLowerCase();
+		}
+
+		public enum InstantiationType {
+			REFLECTION,
+			FACTORY
+		}
 	}
 }

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosJobClusterEntrypoint.java
@@ -20,6 +20,7 @@ package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManagerFactory;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
@@ -70,8 +71,8 @@ public class MesosJobClusterEntrypoint extends JobClusterEntrypoint {
 	}
 
 	@Override
-	protected void initializeServices(Configuration config) throws Exception {
-		super.initializeServices(config);
+	protected void initializeServices(Configuration config, PluginManager pluginManager) throws Exception {
+		super.initializeServices(config, pluginManager);
 
 		final String hostname = config.getString(JobManagerOptions.ADDRESS);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosSessionClusterEntrypoint.java
@@ -20,6 +20,7 @@ package org.apache.flink.mesos.entrypoint;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.mesos.runtime.clusterframework.MesosResourceManagerFactory;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServices;
 import org.apache.flink.mesos.runtime.clusterframework.services.MesosServicesUtils;
@@ -67,8 +68,8 @@ public class MesosSessionClusterEntrypoint extends SessionClusterEntrypoint {
 	}
 
 	@Override
-	protected void initializeServices(Configuration config) throws Exception {
-		super.initializeServices(config);
+	protected void initializeServices(Configuration config, PluginManager pluginManager) throws Exception {
+		super.initializeServices(config, pluginManager);
 
 		final String hostname = config.getString(JobManagerOptions.ADDRESS);
 

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -21,6 +21,7 @@ package org.apache.flink.mesos.entrypoint;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.mesos.util.MesosUtils;
@@ -86,8 +87,10 @@ public class MesosTaskExecutorRunner {
 
 		final Map<String, String> envs = System.getenv();
 
+		final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+
 		// configure the filesystems
-		FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(configuration));
+		FileSystem.initialize(configuration, pluginManager);
 
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
@@ -103,7 +106,7 @@ public class MesosTaskExecutorRunner {
 
 		try {
 			SecurityUtils.getInstalledContext().runSecured(() -> {
-				TaskManagerRunner.runTaskManager(configuration, resourceId);
+				TaskManagerRunner.runTaskManager(configuration, resourceId, pluginManager);
 
 				return 0;
 			});

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.InstantiateViaFactory;
 import org.apache.flink.metrics.reporter.MetricReporter;
@@ -31,6 +32,8 @@ import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -125,7 +128,7 @@ public final class ReporterSetup {
 		return new ReporterSetup(reporterName, metricConfig, reporter);
 	}
 
-	public static List<ReporterSetup> fromConfiguration(final Configuration configuration) {
+	public static List<ReporterSetup> fromConfiguration(final Configuration configuration, @Nullable final PluginManager pluginManager) {
 		String includedReportersString = configuration.getString(MetricOptions.REPORTERS_LIST, "");
 
 		Set<String> namedReporters = findEnabledReportersInConfiguration(configuration, includedReportersString);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -721,7 +721,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	protected MetricRegistryImpl createMetricRegistry(Configuration config) {
 		return new MetricRegistryImpl(
 			MetricRegistryConfiguration.fromConfiguration(config),
-			ReporterSetup.fromConfiguration(config));
+			ReporterSetup.fromConfiguration(config, null));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -118,7 +119,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 	private boolean shutdown;
 
-	public TaskManagerRunner(Configuration configuration, ResourceID resourceId) throws Exception {
+	public TaskManagerRunner(Configuration configuration, ResourceID resourceId, PluginManager pluginManager) throws Exception {
 		this.configuration = checkNotNull(configuration);
 		this.resourceId = checkNotNull(resourceId);
 
@@ -139,7 +140,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		metricRegistry = new MetricRegistryImpl(
 			MetricRegistryConfiguration.fromConfiguration(configuration),
-			ReporterSetup.fromConfiguration(configuration));
+			ReporterSetup.fromConfiguration(configuration, pluginManager));
 
 		final RpcService metricQueryServiceRpcService = MetricUtils.startMetricsRpcService(configuration, rpcService.getAddress());
 		metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId);
@@ -307,8 +308,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		return GlobalConfiguration.loadConfiguration(clusterConfiguration.getConfigDir(), dynamicProperties);
 	}
 
-	public static void runTaskManager(Configuration configuration, ResourceID resourceId) throws Exception {
-		final TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, resourceId);
+	public static void runTaskManager(Configuration configuration, ResourceID resourceId, PluginManager pluginManager) throws Exception {
+		final TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, resourceId, pluginManager);
 
 		taskManagerRunner.start();
 	}
@@ -317,12 +318,13 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		try {
 			final Configuration configuration = loadConfiguration(args);
 
-			FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(configuration));
+			final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+			FileSystem.initialize(configuration, pluginManager);
 
 			SecurityUtils.install(new SecurityConfiguration(configuration));
 
 			SecurityUtils.getInstalledContext().runSecured(() -> {
-				runTaskManager(configuration, resourceID);
+				runTaskManager(configuration, resourceID, pluginManager);
 				return null;
 			});
 		} catch (Throwable t) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/MetricRegistryImplTest.java
@@ -280,7 +280,7 @@ public class MetricRegistryImplTest extends TestLogger {
 		config.setString(MetricOptions.SCOPE_DELIMITER, "_");
 		config.setString(MetricOptions.SCOPE_NAMING_TM, "A.B.C.D.E");
 
-		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config), ReporterSetup.fromConfiguration(config));
+		MetricRegistryImpl registry = new MetricRegistryImpl(MetricRegistryConfiguration.fromConfiguration(config), ReporterSetup.fromConfiguration(config, null));
 
 		TaskManagerMetricGroup tmGroup = new TaskManagerMetricGroup(registry, "host", "id");
 		assertEquals("A_B_C_D_E_name", tmGroup.getMetricIdentifier("name"));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/ReporterSetupTest.java
@@ -68,7 +68,7 @@ public class ReporterSetupTest extends TestLogger {
 
 		configureReporter1(config);
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		Assert.assertEquals(1, reporterSetups.size());
 
@@ -86,7 +86,7 @@ public class ReporterSetupTest extends TestLogger {
 		configureReporter1(config);
 		configureReporter2(config);
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		Assert.assertEquals(2, reporterSetups.size());
 
@@ -117,7 +117,7 @@ public class ReporterSetupTest extends TestLogger {
 
 		config.setString(MetricOptions.REPORTERS_LIST, "reporter2");
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		Assert.assertEquals(1, reporterSetups.size());
 
@@ -131,7 +131,7 @@ public class ReporterSetupTest extends TestLogger {
 
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "reporter1." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter1.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		Assert.assertEquals(1, reporterSetups.size());
 
@@ -151,7 +151,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter12.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test3." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, TestReporter13.class.getName());
 
-		List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(3, reporterSetups.size());
 
@@ -230,7 +230,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, TestReporterFactory.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_EXCLUDED_VARIABLES, excludedVariable1 + ";" + excludedVariable2);
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(1, reporterSetups.size());
 
@@ -247,7 +247,7 @@ public class ReporterSetupTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, TestReporterFactory.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(1, reporterSetups.size());
 
@@ -265,7 +265,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, InstantiationTypeTrackingTestReporterFactory.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, InstantiationTypeTrackingTestReporter.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(1, reporterSetups.size());
 
@@ -284,7 +284,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, TestReporterFactory.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "fail." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, FailingFactory.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(1, reporterSetups.size());
 	}
@@ -298,7 +298,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test1." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, InstantiationTypeTrackingTestReporterFactory.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test2." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, InstantiationTypeTrackingTestReporter.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(2, reporterSetups.size());
 
@@ -317,7 +317,7 @@ public class ReporterSetupTest extends TestLogger {
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_FACTORY_CLASS_SUFFIX, ConfigExposingReporterFactory.class.getName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test.arg", "hello");
 
-		ReporterSetup.fromConfiguration(config);
+		ReporterSetup.fromConfiguration(config, null);
 
 		Properties passedConfig = ConfigExposingReporterFactory.lastConfig;
 		assertEquals("hello", passedConfig.getProperty("arg"));
@@ -331,7 +331,7 @@ public class ReporterSetupTest extends TestLogger {
 		final Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "test." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, InstantiationTypeTrackingTestReporter2.class.getName());
 
-		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config);
+		final List<ReporterSetup> reporterSetups = ReporterSetup.fromConfiguration(config, null);
 
 		assertEquals(1, reporterSetups.size());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.taskexecutor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
 import org.apache.flink.util.TestLogger;
@@ -92,7 +94,8 @@ public class TaskManagerRunnerTest extends TestLogger {
 	}
 
 	private static TaskManagerRunner createTaskManagerRunner(final Configuration configuration) throws Exception {
-		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, ResourceID.generate());
+		final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, ResourceID.generate(), pluginManager);
 		taskManagerRunner.start();
 		return taskManagerRunner;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -27,6 +27,8 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
@@ -321,8 +323,9 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 			try {
 				final ParameterTool parameterTool = ParameterTool.fromArgs(args);
 				Configuration cfg = parameterTool.getConfiguration();
+				final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(cfg);
 
-				TaskManagerRunner.runTaskManager(cfg, ResourceID.generate());
+				TaskManagerRunner.runTaskManager(cfg, ResourceID.generate(), pluginManager);
 			}
 			catch (Throwable t) {
 				LOG.error("Failed to start TaskManager process", t);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -32,6 +32,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
@@ -269,9 +271,10 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 				config,
 				TestingUtils.defaultExecutor());
 
+			final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(config);
 			// Start the task manager process
 			for (int i = 0; i < numberOfTaskManagers; i++) {
-				taskManagerRunners[i] = new TaskManagerRunner(config, ResourceID.generate());
+				taskManagerRunners[i] = new TaskManagerRunner(config, ResourceID.generate(), pluginManager);
 				taskManagerRunners[i].start();
 			}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -92,7 +93,9 @@ public class YarnTaskExecutorRunner {
 
 			final Configuration configuration = TaskManagerRunner.loadConfiguration(args);
 
-			FileSystem.initialize(configuration, PluginUtils.createPluginManagerFromRootFolder(configuration));
+			final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+
+			FileSystem.initialize(configuration, pluginManager);
 
 			setupConfigurationAndInstallSecurityContext(configuration, currDir, ENV);
 
@@ -101,7 +104,7 @@ public class YarnTaskExecutorRunner {
 				"ContainerId variable %s not set", YarnResourceManager.ENV_FLINK_CONTAINER_ID);
 
 			SecurityUtils.getInstalledContext().runSecured((Callable<Void>) () -> {
-				TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId));
+				TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId), pluginManager);
 				return null;
 			});
 		}


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-11952](https://issues.apache.org/jira/browse/FLINK-11952) introduced Plugins mechanism into Flink. This PR makes it possible to benefit from using this new functionality during the MetricReporters initialization. Instead of placing MetricReporters JARs into`/libs`, it is now additionally possible (and encouraged) to convert them into plugins and use the `/plugins` folder for initialization via independent plugin classloaders.

Note that to enable this functionality, a bounded type of Plugin was removed from the PluginLoader/PluginManager methods. This removal did not affect any existing functionality, including FileSystems initialization. The adjustment was required for the following reason: `MetricReporter` interface, which is located in the `flink-metrics-core` module is currently not a `Plugin`. `Plugin` interface is located in `flink-core` and this module already has a depency on `flink-metrics-core`. This makes in impossible to mark `MetricReporter` as  `Plugin` without introducing a circular dependency. An  alternative approach could be extraction of the whole plugin classloading functionality out of `flink-core` into a separate module.

Another important consideration - current `PluginClassLoader` implementation uses parent-first initialization for classes, which start with Flink-native package prefixes, such as *org.apache.flink.*. Currently, metrics reporters shipped with Flink all have the same package prefix. This leads to the following situation: if there is a version of `PluginMetricFactory` for a particular reporter found in the /lib folder, JARs for this reporter in /plugins directory will effectively be ignored. The opposite priority might actually be desirable to improve user's experience when transitioning to plugins-based metrics initialization approach.

## Brief change log

  - `PluginManager`, already created for `FileSystems` initialization, is propagated from all Flink entrypoints into metrics reporters initializer
  - Reporters initializer (`ReporterSetup`) combines initialization via existing `ServiceLoader` approach with the new approach of loading plugins
- `PrometheusReporter` is adjusted to be compatible with the new plugins mechanism. Proper functioning is verified with the end-to-end tests

## Verifying this change

This change added tests and can be verified as follows:
  - Added integration tests for end-to-end tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)

