### PR TITLE
[FLINK-16246][connector kinesis] Exclude AWS SDK MBean registry from Kinesis build

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -199,6 +199,14 @@ under the License.
 									<include>org.apache.httpcomponents:*</include>
 								</includes>
 							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>com/amazonaws/jmx/SdkMBeanRegistrySupport*</exclude>
+									</excludes>
+								</filter>
+							</filters>
 							<relocations combine.children="override">
 								<!-- DO NOT RELOCATE GUAVA IN THIS PACKAGE -->
 								<relocation>

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -98,6 +98,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
         EXIT_CODE=$(($EXIT_CODE+$?))
         check_shaded_artifacts_connector_elasticsearch 6
         EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_connector_kinesis
+        EXIT_CODE=$(($EXIT_CODE+$?))
     else
         echo "=============================================================================="
         echo "Previous build failure detected, skipping shaded dependency check."

--- a/tools/travis/shade.sh
+++ b/tools/travis/shade.sh
@@ -181,3 +181,19 @@ check_shaded_artifacts_connector_elasticsearch() {
 
 	return 0
 }
+
+# Check the Kinesis connectors' fat jars for illegal or missing classes
+check_shaded_artifacts_connector_kinesis() {
+	find flink-connectors/flink-connector-kinesis/target/flink-connector-kinesis*.jar ! -name "*-tests.jar" -exec jar tf {} \; > allClasses
+
+	FOUND_AWS_METRICS_REG=`cat allClasses | grep 'SdkMBeanRegistrySupport' | wc -l`
+	if [ "$FOUND_AWS_METRICS_REG" != "0" ]; then
+		echo "=============================================================================="
+		echo "Found SdkMBeanRegistrySupport in Kinesis jar"
+		echo "=============================================================================="
+		return 1
+	fi
+
+	return 0
+}
+

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -118,6 +118,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
         EXIT_CODE=$(($EXIT_CODE+$?))
         check_shaded_artifacts_connector_elasticsearch 6
         EXIT_CODE=$(($EXIT_CODE+$?))
+        check_shaded_artifacts_connector_kinesis
+        EXIT_CODE=$(($EXIT_CODE+$?))
     else
         echo "=============================================================================="
         echo "Previous build failure detected, skipping shaded dependency check."


### PR DESCRIPTION
## What is the purpose of the change

The AWS SDK always registers a MetricAdminMBean at the JMX MBean Server.
This allows users to turn on / off more detailed metrics via the JMX admin interface.

However, this registered bean keeps the user code classloader alive and thus causes a class leak.

Excluding the `com.amazonaws.jmx.SdkMBeanRegistrySupport` class from the connectors disables the default registration thus preventing the class leak. It should only disable that JMX metric admin interface and still allow users to manually configure/activate metrics for the AWS SDK.

## Brief change log

  - Exclude `com.amazonaws.jmx.SdkMBeanRegistrySupport` from Kinesis fat jar
  - Add a "shading check" in the build scripts to check whether the class is present in the shaded jar.

## Verifying this change

This change has self-contained tests.

To test the effectiveness of this, users would need to run a Flink session cluster on AWS and repeatedly submit/cancel a job that uses the Kinesis connector.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
