### PR TITLE
[FLINK-16161][hive] Statistics zero should be unknown in HiveCatalog

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -108,6 +108,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.catalog.config.CatalogConfig.FLINK_PROPERTY_PREFIX;
+import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveIntStat;
+import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveLongStat;
 import static org.apache.flink.table.filesystem.PartitionPathUtils.unescapePathName;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -1241,14 +1243,10 @@ public class HiveCatalog extends AbstractCatalog {
 	 * @return                whether need to update stats.
 	 */
 	private boolean statsChanged(CatalogTableStatistics newTableStats, Map<String, String> parameters) {
-		String oldRowCount = parameters.getOrDefault(StatsSetupConst.ROW_COUNT, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST);
-		String oldTotalSize = parameters.getOrDefault(StatsSetupConst.TOTAL_SIZE, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST);
-		String oldNumFiles = parameters.getOrDefault(StatsSetupConst.NUM_FILES, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST);
-		String oldRawDataSize = parameters.getOrDefault(StatsSetupConst.RAW_DATA_SIZE, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST);
-		return newTableStats.getRowCount() != Long.parseLong(oldRowCount)
-				|| newTableStats.getTotalSize() != Long.parseLong(oldTotalSize)
-				|| newTableStats.getFileCount() != Integer.parseInt(oldNumFiles)
-				|| newTableStats.getRawDataSize() != Long.parseLong(oldRawDataSize);
+		return newTableStats.getRowCount() != parsePositiveLongStat(parameters, StatsSetupConst.ROW_COUNT)
+				|| newTableStats.getTotalSize() != parsePositiveLongStat(parameters, StatsSetupConst.TOTAL_SIZE)
+				|| newTableStats.getFileCount() != parsePositiveIntStat(parameters, StatsSetupConst.NUM_FILES)
+				|| newTableStats.getRawDataSize() != parsePositiveLongStat(parameters, StatsSetupConst.NUM_FILES);
 	}
 
 	/**
@@ -1264,11 +1262,11 @@ public class HiveCatalog extends AbstractCatalog {
 	}
 
 	private static CatalogTableStatistics createCatalogTableStatistics(Map<String, String> parameters) {
-		long rowCount = Long.parseLong(parameters.getOrDefault(StatsSetupConst.ROW_COUNT, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST));
-		long totalSize = Long.parseLong(parameters.getOrDefault(StatsSetupConst.TOTAL_SIZE, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST));
-		int numFiles = Integer.parseInt(parameters.getOrDefault(StatsSetupConst.NUM_FILES, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST));
-		long rawDataSize = Long.parseLong(parameters.getOrDefault(StatsSetupConst.RAW_DATA_SIZE, HiveStatsUtil.DEFAULT_UNKNOWN_STATS_CONST));
-		return new CatalogTableStatistics(rowCount, numFiles, totalSize, rawDataSize);
+		return new CatalogTableStatistics(
+				parsePositiveLongStat(parameters, StatsSetupConst.ROW_COUNT),
+				parsePositiveIntStat(parameters, StatsSetupConst.NUM_FILES),
+				parsePositiveLongStat(parameters, StatsSetupConst.TOTAL_SIZE),
+				parsePositiveLongStat(parameters, StatsSetupConst.RAW_DATA_SIZE));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -63,7 +63,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class HiveStatsUtil {
 	private static final Logger LOG = LoggerFactory.getLogger(HiveStatsUtil.class);
 
-	public static final String DEFAULT_UNKNOWN_STATS_CONST = "-1";
+	private static final int DEFAULT_UNKNOWN_STATS_VALUE = -1;
 
 	private HiveStatsUtil() {}
 
@@ -291,5 +291,25 @@ public class HiveStatsUtil {
 		}
 		throw new CatalogException(String.format("Flink does not support converting ColumnStats '%s' for Hive column " +
 												"type '%s' yet", colStat, colType));
+	}
+
+	public static int parsePositiveIntStat(Map<String, String> parameters, String key) {
+		String value = parameters.get(key);
+		if (value == null) {
+			return DEFAULT_UNKNOWN_STATS_VALUE;
+		} else {
+			int v = Integer.parseInt(value);
+			return v > 0 ? v : DEFAULT_UNKNOWN_STATS_VALUE;
+		}
+	}
+
+	public static long parsePositiveLongStat(Map<String, String> parameters, String key) {
+		String value = parameters.get(key);
+		if (value == null) {
+			return DEFAULT_UNKNOWN_STATS_VALUE;
+		} else {
+			long v = Long.parseLong(value);
+			return v > 0 ? v : DEFAULT_UNKNOWN_STATS_VALUE;
+		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

In hive, treat statistics zero as unknown, but in Flink HiveCatalog, treat zero as real value.
This lead wrong inputs to CBO.
Previous discussed in https://github.com/apache/flink/pull/10380

## Brief change log

Fix in `HiveCatalog`. treat zero as unknown value.

## Verifying this change

`HiveCatalogHiveMetadataTest.testHiveStatistics`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)