### PR TITLE
[FLINK-16011] fix the bug that within will not effect if not in the end of a pattern

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -43,6 +43,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 
@@ -129,7 +130,7 @@ public class NFACompiler {
 		private final Map<String, State<T>> stopStates = new HashMap<>();
 		private final List<State<T>> states = new ArrayList<>();
 
-		private long windowTime = 0;
+		private Optional<Long> windowTime;
 		private GroupPattern<T, ?> currentGroupPattern;
 		private Map<GroupPattern<T, ?>, Boolean> firstOfLoopMap = new HashMap<>();
 		private Pattern<T, ?> currentPattern;
@@ -140,6 +141,7 @@ public class NFACompiler {
 		NFAFactoryCompiler(final Pattern<T, ?> pattern) {
 			this.currentPattern = pattern;
 			afterMatchSkipStrategy = pattern.getAfterMatchSkipStrategy();
+			windowTime = Optional.empty();
 		}
 
 		/**
@@ -172,7 +174,7 @@ public class NFACompiler {
 		}
 
 		long getWindowTime() {
-			return windowTime;
+			return windowTime.orElse(0L);
 		}
 
 		/**
@@ -265,7 +267,7 @@ public class NFACompiler {
 		 */
 		private State<T> createEndingState() {
 			State<T> endState = createState(ENDING_STATE_NAME, State.StateType.Final);
-			windowTime = currentPattern.getWindowTime() != null ? currentPattern.getWindowTime().toMilliseconds() : 0L;
+			windowTime = Optional.ofNullable(currentPattern.getWindowTime()).map(Time::toMilliseconds);
 			return endState;
 		}
 
@@ -303,9 +305,9 @@ public class NFACompiler {
 				currentPattern = currentPattern.getPrevious();
 
 				final Time currentWindowTime = currentPattern.getWindowTime();
-				if (currentWindowTime != null && (windowTime == 0 || currentWindowTime.toMilliseconds() < windowTime)) {
+				if (currentWindowTime != null && currentWindowTime.toMilliseconds() < windowTime.orElse(Long.MAX_VALUE)) {
 					// the window time is the global minimum of all window times of each state
-					windowTime = currentWindowTime.toMilliseconds();
+					windowTime = Optional.of(currentWindowTime.toMilliseconds());
 				}
 			}
 			return lastSink;

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -303,7 +303,7 @@ public class NFACompiler {
 				currentPattern = currentPattern.getPrevious();
 
 				final Time currentWindowTime = currentPattern.getWindowTime();
-				if (currentWindowTime != null && currentWindowTime.toMilliseconds() < windowTime) {
+				if (currentWindowTime != null && (windowTime == 0 || currentWindowTime.toMilliseconds() < windowTime)) {
 					// the window time is the global minimum of all window times of each state
 					windowTime = currentWindowTime.toMilliseconds();
 				}

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.pattern.MalformedPatternException;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
+import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Sets;
@@ -237,5 +238,15 @@ public class NFACompilerTest extends TestLogger {
 		assertThat(NFACompiler.canProduceEmptyMatches(Pattern.begin("a")), is(false));
 		assertThat(NFACompiler.canProduceEmptyMatches(Pattern.begin("a").oneOrMore()), is(false));
 		assertThat(NFACompiler.canProduceEmptyMatches(Pattern.begin("a").oneOrMore().next("b").optional()), is(false));
+	}
+
+	@Test
+	public void testWindowTimeCorrectlySet() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").followedBy("middle").within(Time.seconds(10))
+				.followedBy("then").within(Time.seconds(20)).followedBy("end");
+
+		NFACompiler.NFAFactoryCompiler factory = new NFACompiler.NFAFactoryCompiler(pattern);
+		factory.compileFactory();
+		assertEquals(10000, factory.getWindowTime());
 	}
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/compiler/NFACompilerTest.java
@@ -245,8 +245,18 @@ public class NFACompilerTest extends TestLogger {
 		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").followedBy("middle").within(Time.seconds(10))
 				.followedBy("then").within(Time.seconds(20)).followedBy("end");
 
-		NFACompiler.NFAFactoryCompiler factory = new NFACompiler.NFAFactoryCompiler(pattern);
+		NFACompiler.NFAFactoryCompiler<Event> factory = new NFACompiler.NFAFactoryCompiler<>(pattern);
 		factory.compileFactory();
 		assertEquals(10000, factory.getWindowTime());
+	}
+
+	@Test
+	public void testMultipleWindowTimeWithZeroLength() {
+		Pattern<Event, ?> pattern = Pattern.<Event>begin("start").followedBy("middle").within(Time.seconds(10))
+			.followedBy("then").within(Time.seconds(0)).followedBy("end");
+
+		NFACompiler.NFAFactoryCompiler<Event> factory = new NFACompiler.NFAFactoryCompiler<>(pattern);
+		factory.compileFactory();
+		assertEquals(0, factory.getWindowTime());
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes the bug that In a CEP Pattern, if there is no within() in the end of a pattern, the within() will not effect.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test in NFACompilerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
