### PR TITLE
[FLINK-16179][hive] Use configuration from TableFactory in hive connector

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.OutputFormatTableSink;
 import org.apache.flink.table.sinks.TableSink;
-import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -71,17 +71,14 @@ public class HiveTableFactory
 		boolean isGeneric = Boolean.parseBoolean(table.getProperties().get(CatalogConfig.IS_GENERIC));
 
 		if (!isGeneric) {
-			return createHiveTableSource(context.getObjectIdentifier().toObjectPath(), table);
+			return new HiveTableSource(
+					new JobConf(hiveConf),
+					context.getConfiguration(),
+					context.getObjectIdentifier().toObjectPath(),
+					table);
 		} else {
 			return TableFactoryUtil.findAndCreateTableSource(context);
 		}
-	}
-
-	/**
-	 * Creates and configures a {@link StreamTableSource} using the given {@link CatalogTable}.
-	 */
-	private StreamTableSource<BaseRow> createHiveTableSource(ObjectPath tablePath, CatalogTable table) {
-		return new HiveTableSource(new JobConf(hiveConf), tablePath, table);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -411,7 +411,7 @@ public class HiveTableSourceTest {
 	}
 
 	@Test
-	public void testVectorReaderSwitch() throws Exception {
+	public void testSourceConfig() throws Exception {
 		// vector reader not available for 1.x and we're not testing orc for 2.0.x
 		Assume.assumeTrue(HiveVersionTestUtil.HIVE_210_OR_LATER);
 		Map<String, String> env = System.getenv();

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -428,7 +428,6 @@ public class HiveTableSourceTest {
 	}
 
 	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {
-		ObjectPath tablePath = new ObjectPath("db1", "src");
 		HiveTableFactory tableFactorySpy = spy((HiveTableFactory) hiveCatalog.getTableFactory().get());
 
 		doAnswer(invocation -> {
@@ -467,13 +466,13 @@ public class HiveTableSourceTest {
 		private final boolean inferParallelism;
 
 		TestConfigSource(
-				JobConf hiveConf,
+				JobConf jobConf,
 				ReadableConfig flinkConf,
 				ObjectPath tablePath,
 				CatalogTable catalogTable,
 				boolean fallbackMR,
 				boolean inferParallelism) {
-			super(hiveConf, flinkConf, tablePath, catalogTable);
+			super(jobConf, flinkConf, tablePath, catalogTable);
 			this.fallbackMR = fallbackMR;
 			this.inferParallelism = inferParallelism;
 		}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -19,18 +19,16 @@
 package org.apache.flink.connectors.hive;
 
 import org.apache.flink.api.dag.Transformation;
-import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.connectors.hive.read.HiveMapredSplitReader;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
-import org.apache.flink.connectors.hive.read.HiveTableInputSplit;
-import org.apache.flink.connectors.hive.read.HiveVectorizedOrcSplitReader;
-import org.apache.flink.runtime.clusterframework.BootstrapTools;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableUtils;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -40,13 +38,13 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.FileUtils;
 
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.annotations.HiveSQL;
@@ -63,11 +61,8 @@ import org.junit.runner.RunWith;
 
 import javax.annotation.Nullable;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +74,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
@@ -423,36 +419,39 @@ public class HiveTableSourceTest {
 		try {
 			hiveShell.execute("create table db1.src (x int,y string) stored as orc");
 			hiveShell.execute("insert into db1.src values (1,'a'),(2,'b')");
-			testVectorReader(true);
-			testVectorReader(false);
+			testSourceConfig(true, true);
+			testSourceConfig(false, false);
 		} finally {
 			TestBaseUtils.setEnv(env);
 			hiveShell.execute("drop database db1 cascade");
 		}
 	}
 
-	private void testVectorReader(boolean fallback) throws Exception {
-		File tmpDir = Files.createTempDirectory(null).toFile();
-		Runtime.getRuntime().addShutdownHook(new Thread(() -> FileUtils.deleteDirectoryQuietly(tmpDir)));
-
-		File flinkConf = new File(tmpDir, GlobalConfiguration.FLINK_CONF_FILENAME);
-		Configuration conf = new Configuration();
-		conf.setBoolean(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, fallback);
-		BootstrapTools.writeConfiguration(conf, flinkConf);
-		Map<String, String> map = new HashMap<>(System.getenv());
-		map.put(ConfigConstants.ENV_FLINK_CONF_DIR, tmpDir.getAbsolutePath());
-		TestBaseUtils.setEnv(map);
-
+	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {
 		ObjectPath tablePath = new ObjectPath("db1", "src");
-		CatalogTable catalogTable = (CatalogTable) hiveCatalog.getTable(tablePath);
-
 		HiveTableFactory tableFactorySpy = spy((HiveTableFactory) hiveCatalog.getTableFactory().get());
-		doReturn(new TestVectorReaderSource(new JobConf(hiveCatalog.getHiveConf()), tablePath, catalogTable))
-				.when(tableFactorySpy).createTableSource(any(TableSourceFactory.Context.class));
+
+		doAnswer(invocation -> {
+			TableSourceFactory.Context context = invocation.getArgument(0);
+			return new TestConfigSource(
+					new JobConf(hiveCatalog.getHiveConf()),
+					context.getConfiguration(),
+					context.getObjectIdentifier().toObjectPath(),
+					context.getTable(),
+					fallbackMR,
+					inferParallelism);
+		}).when(tableFactorySpy).createTableSource(any(TableSourceFactory.Context.class));
+
 		HiveCatalog catalogSpy = spy(hiveCatalog);
 		doReturn(Optional.of(tableFactorySpy)).when(catalogSpy).getTableFactory();
 
 		TableEnvironment tableEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
+		tableEnv.getConfig().getConfiguration().setBoolean(
+				HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, fallbackMR);
+		tableEnv.getConfig().getConfiguration().setBoolean(
+				HiveOptions.TABLE_EXEC_HIVE_INFER_SOURCE_PARALLELISM, inferParallelism);
+		tableEnv.getConfig().getConfiguration().setInteger(
+				ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 2);
 		tableEnv.registerCatalog(catalogSpy.getName(), catalogSpy);
 		tableEnv.useCatalog(catalogSpy.getName());
 
@@ -460,39 +459,39 @@ public class HiveTableSourceTest {
 		assertEquals("[1,a, 2,b]", results.toString());
 	}
 
-	// A sub-class of HiveTableSource to test vector reader switch.
-	private static class TestVectorReaderSource extends HiveTableSource {
-		private final JobConf jobConf;
-		private final CatalogTable catalogTable;
+	/**
+	 * A sub-class of HiveTableSource to test vector reader switch.
+	 */
+	private static class TestConfigSource extends HiveTableSource {
+		private final boolean fallbackMR;
+		private final boolean inferParallelism;
 
-		TestVectorReaderSource(JobConf jobConf, ObjectPath tablePath, CatalogTable catalogTable) {
-			super(jobConf, tablePath, catalogTable);
-			this.jobConf = jobConf;
-			this.catalogTable = catalogTable;
+		TestConfigSource(
+				JobConf hiveConf,
+				ReadableConfig flinkConf,
+				ObjectPath tablePath,
+				CatalogTable catalogTable,
+				boolean fallbackMR,
+				boolean inferParallelism) {
+			super(hiveConf, flinkConf, tablePath, catalogTable);
+			this.fallbackMR = fallbackMR;
+			this.inferParallelism = inferParallelism;
 		}
 
 		@Override
-		HiveTableInputFormat getInputFormat(List<HiveTablePartition> allHivePartitions, boolean useMapRedReader) {
-			return new TestVectorReaderInputFormat(
-					jobConf, catalogTable, allHivePartitions, null, -1, hiveCatalog.getHiveVersion(), useMapRedReader);
-		}
-	}
-
-	// A sub-class of HiveTableInputFormat to test vector reader switch.
-	private static class TestVectorReaderInputFormat extends HiveTableInputFormat {
-
-		private static final long serialVersionUID = 1L;
-
-		TestVectorReaderInputFormat(JobConf jobConf, CatalogTable catalogTable, List<HiveTablePartition> partitions,
-				int[] projectedFields, long limit, String hiveVersion, boolean useMapRedReader) {
-			super(jobConf, catalogTable, partitions, projectedFields, limit, hiveVersion, useMapRedReader);
+		public DataStream<BaseRow> getDataStream(StreamExecutionEnvironment execEnv) {
+			DataStreamSource<BaseRow> dataStream = (DataStreamSource<BaseRow>) super.getDataStream(execEnv);
+			int parallelism = dataStream.getTransformation().getParallelism();
+			assertEquals(inferParallelism ? 1 : 2, parallelism);
+			return dataStream;
 		}
 
 		@Override
-		public void open(HiveTableInputSplit split) throws IOException {
-			super.open(split);
-			boolean fallback = GlobalConfiguration.loadConfiguration().getBoolean(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER);
-			assertTrue((fallback && reader instanceof HiveMapredSplitReader) || (!fallback && reader instanceof HiveVectorizedOrcSplitReader));
+		HiveTableInputFormat getInputFormat(
+				List<HiveTablePartition> allHivePartitions,
+				boolean useMapRedReader) {
+			assertEquals(useMapRedReader, fallbackMR);
+			return super.getInputFormat(allHivePartitions, useMapRedReader);
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

Now HiveOptions is used for GlobalConfiguration.loadConfiguration() .
It is not natural for table, we should use configuration from TableFactory to enable table config.

## Brief change log

Modify `HiveTableSource` to read config from `TableSourceFactory.Context`.

## Verifying this change

`HiveTableSourceTest.testSourceConfig`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)