### PR TITLE
[FLINK-16265][table] Use LogicalType to equals in TableSchema

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -380,8 +380,8 @@ public class LocalExecutorITCase extends TestLogger {
 		final TableSchema actualTableSchema = executor.getTableSchema(sessionId, "TableNumber2");
 
 		final TableSchema expectedTableSchema = new TableSchema(
-			new String[]{"IntegerField2", "StringField2"},
-			new TypeInformation[]{Types.INT, Types.STRING});
+			new String[]{"IntegerField2", "StringField2", "TimestampField3"},
+			new TypeInformation[]{Types.INT, Types.STRING, Types.SQL_TIMESTAMP});
 
 		assertEquals(expectedTableSchema, actualTableSchema);
 		executor.closeSession(sessionId);

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
@@ -56,6 +56,8 @@ tables:
         type: INT
       - name: StringField2
         type: VARCHAR
+      - name: TimestampField3
+        type: TIMESTAMP
     connector:
       type: filesystem
       path: "$VAR_SOURCE_PATH2"
@@ -66,6 +68,8 @@ tables:
           type: INT
         - name: StringField2
           type: VARCHAR
+        - name: TimestampField3
+          type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TestView2

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -56,6 +56,8 @@ tables:
         type: INT
       - name: StringField2
         type: VARCHAR
+      - name: TimestampField3
+        type: TIMESTAMP
     connector:
       type: filesystem
       path: "$VAR_SOURCE_PATH2"
@@ -66,6 +68,8 @@ tables:
           type: INT
         - name: StringField2
           type: VARCHAR
+        - name: TimestampField3
+          type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TableSourceSink

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableColumn.java
@@ -93,13 +93,13 @@ public class TableColumn {
 		}
 		TableColumn that = (TableColumn) o;
 		return Objects.equals(this.name, that.name)
-			&& Objects.equals(this.type, that.type)
+			&& Objects.equals(this.type.getLogicalType(), that.type.getLogicalType())
 			&& Objects.equals(this.expr, that.expr);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.name, this.type, this.expr);
+		return Objects.hash(this.name, this.type.getLogicalType(), this.expr);
 	}
 
 	//~ Getter/Setter ----------------------------------------------------------


### PR DESCRIPTION

## What is the purpose of the change

```
  - name: TableNumber2
    type: source
    $VAR_UPDATE_MODE
    schema:
      - name: IntegerField2
        type: INT
      - name: StringField2
        type: VARCHAR
      - name: TimestampField3
        type: TIMESTAMP
    connector:
      type: filesystem
      path: "$VAR_SOURCE_PATH2"
    format:
      type: csv
      fields:
        - name: IntegerField2
          type: INT
        - name: StringField2
          type: VARCHAR
        - name: TimestampField3
          type: TIMESTAMP
      line-delimiter: "\n"
      comment-prefix: "#"
```
Table like this will fail in SQL-CLI.
The root cause is we will convert the properties into CatalogTableImpl and then convert into properties again. The schema type properties will use new type systems then which is not equal to the legacy types.

## Brief change log

I think the fix we can do could be comparing LogicalType in TableSchema.equals/hashCode instead of DataType with conversion classes.

## Verifying this change

`LocalExecutorITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)