### PR TITLE
[FLINK-16265][table][csv] CsvTableSourceFactoryBase should compare LogicalTypes instead of TableSchema

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -380,8 +380,8 @@ public class LocalExecutorITCase extends TestLogger {
 		final TableSchema actualTableSchema = executor.getTableSchema(sessionId, "TableNumber2");
 
 		final TableSchema expectedTableSchema = new TableSchema(
-			new String[]{"IntegerField2", "StringField2"},
-			new TypeInformation[]{Types.INT, Types.STRING});
+			new String[]{"IntegerField2", "StringField2", "TimestampField3"},
+			new TypeInformation[]{Types.INT, Types.STRING, Types.SQL_TIMESTAMP});
 
 		assertEquals(expectedTableSchema, actualTableSchema);
 		executor.closeSession(sessionId);

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-catalogs.yaml
@@ -56,6 +56,8 @@ tables:
         type: INT
       - name: StringField2
         type: VARCHAR
+      - name: TimestampField3
+        type: TIMESTAMP
     connector:
       type: filesystem
       path: "$VAR_SOURCE_PATH2"
@@ -66,6 +68,8 @@ tables:
           type: INT
         - name: StringField2
           type: VARCHAR
+        - name: TimestampField3
+          type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TestView2

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-defaults.yaml
@@ -56,6 +56,8 @@ tables:
         type: INT
       - name: StringField2
         type: VARCHAR
+      - name: TimestampField3
+        type: TIMESTAMP
     connector:
       type: filesystem
       path: "$VAR_SOURCE_PATH2"
@@ -66,6 +68,8 @@ tables:
           type: INT
         - name: StringField2
           type: VARCHAR
+        - name: TimestampField3
+          type: TIMESTAMP
       line-delimiter: "\n"
       comment-prefix: "#"
   - name: TableSourceSink

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -27,12 +27,15 @@ import org.apache.flink.table.descriptors.FormatDescriptorValidator;
 import org.apache.flink.table.descriptors.OldCsvValidator;
 import org.apache.flink.table.descriptors.SchemaValidator;
 import org.apache.flink.table.factories.TableFactory;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
@@ -123,7 +126,15 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 			TableSchema formatSchema = params.getTableSchema(FORMAT_FIELDS);
 			// the CsvTableSource needs some rework first
 			// for now the schema must be equal to the encoding
-			if (!formatSchema.equals(tableSchema)) {
+			// Ignore conversion classes in DataType
+			if (!Arrays
+					.stream(formatSchema.getFieldDataTypes())
+					.map(DataType::getLogicalType)
+					.collect(Collectors.toList())
+					.equals(Arrays
+							.stream(tableSchema.getFieldDataTypes())
+							.map(DataType::getLogicalType)
+							.collect(Collectors.toList()))) {
 				throw new TableException(
 					"Encodings that differ from the schema are not supported yet for CsvTableSources.");
 			}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/CsvTableSourceFactoryBase.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.descriptors.OldCsvValidator;
 import org.apache.flink.table.descriptors.SchemaValidator;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 
 import java.util.ArrayList;
@@ -127,14 +128,8 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 			// the CsvTableSource needs some rework first
 			// for now the schema must be equal to the encoding
 			// Ignore conversion classes in DataType
-			if (!Arrays
-					.stream(formatSchema.getFieldDataTypes())
-					.map(DataType::getLogicalType)
-					.collect(Collectors.toList())
-					.equals(Arrays
-							.stream(tableSchema.getFieldDataTypes())
-							.map(DataType::getLogicalType)
-							.collect(Collectors.toList()))) {
+			if (!getFieldLogicalTypes(formatSchema)
+					.equals(getFieldLogicalTypes(tableSchema))) {
 				throw new TableException(
 					"Encodings that differ from the schema are not supported yet for CsvTableSources.");
 			}
@@ -164,4 +159,10 @@ public abstract class CsvTableSourceFactoryBase implements TableFactory {
 		return csvTableSourceBuilder.build();
 	}
 
+	private static List<LogicalType> getFieldLogicalTypes(TableSchema schema) {
+		return Arrays
+				.stream(schema.getFieldDataTypes())
+				.map(DataType::getLogicalType)
+				.collect(Collectors.toList());
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

```
  - name: TableNumber2
    type: source
    $VAR_UPDATE_MODE
    schema:
      - name: IntegerField2
        type: INT
      - name: StringField2
        type: VARCHAR
      - name: TimestampField3
        type: TIMESTAMP
    connector:
      type: filesystem
      path: "$VAR_SOURCE_PATH2"
    format:
      type: csv
      fields:
        - name: IntegerField2
          type: INT
        - name: StringField2
          type: VARCHAR
        - name: TimestampField3
          type: TIMESTAMP
      line-delimiter: "\n"
      comment-prefix: "#"
```
Table like this will fail in SQL-CLI.
The root cause is we will convert the properties into CatalogTableImpl and then convert into properties again. The schema type properties will use new type systems then which is not equal to the legacy types due to conversion classes.

## Brief change log

We should avoid compare TableSchema in `CsvTableSourceFactoryBase.createTableSource`.

## Verifying this change

`LocalExecutorITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)