### PR TITLE
[FLINK-16280][doc]Fix sample code errors in the documentation about elasticsearch connector.

### DIFF
--- a/docs/dev/connectors/elasticsearch.md
+++ b/docs/dev/connectors/elasticsearch.md
@@ -268,14 +268,14 @@ val esSinkBuilder = new ElasticsearchSink.Builder[String](
 esSinkBuilder.setBulkFlushMaxActions(1)
 
 // provide a RestClientFactory for custom configuration on the internally created REST client
-esSinkBuilder.setRestClientFactory(
-  restClientBuilder -> {
-    restClientBuilder.setDefaultHeaders(...)
-    restClientBuilder.setMaxRetryTimeoutMillis(...)
-    restClientBuilder.setPathPrefix(...)
-    restClientBuilder.setHttpClientConfigCallback(...)
+esSinkBuilder.setRestClientFactory(new RestClientFactory {
+  override def configureRestClientBuilder(restClientBuilder: RestClientBuilder): Unit = {
+       restClientBuilder.setDefaultHeaders(...)
+       restClientBuilder.setMaxRetryTimeoutMillis(...)
+       restClientBuilder.setPathPrefix(...)
+       restClientBuilder.setHttpClientConfigCallback(...)
   }
-)
+})
 
 // finally, build and add the sink to the job's pipeline
 input.addSink(esSinkBuilder.build)

--- a/docs/dev/connectors/elasticsearch.zh.md
+++ b/docs/dev/connectors/elasticsearch.zh.md
@@ -268,14 +268,14 @@ val esSinkBuilder = new ElasticsearchSink.Builder[String](
 esSinkBuilder.setBulkFlushMaxActions(1)
 
 // provide a RestClientFactory for custom configuration on the internally created REST client
-esSinkBuilder.setRestClientFactory(
-  restClientBuilder -> {
-    restClientBuilder.setDefaultHeaders(...)
-    restClientBuilder.setMaxRetryTimeoutMillis(...)
-    restClientBuilder.setPathPrefix(...)
-    restClientBuilder.setHttpClientConfigCallback(...)
+esSinkBuilder.setRestClientFactory(new RestClientFactory {
+  override def configureRestClientBuilder(restClientBuilder: RestClientBuilder): Unit = {
+       restClientBuilder.setDefaultHeaders(...)
+       restClientBuilder.setMaxRetryTimeoutMillis(...)
+       restClientBuilder.setPathPrefix(...)
+       restClientBuilder.setHttpClientConfigCallback(...)
   }
-)
+})
 
 // finally, build and add the sink to the job's pipeline
 input.addSink(esSinkBuilder.build)


### PR DESCRIPTION

## What is the purpose of the change

When I refer to the document for coding, I find that there is an error demonstration in scala code in the Elasticsearch connector section of the Flink document.

## Brief change log

before

```scala
esSinkBuilder.setRestClientFactory(
  restClientBuilder -> {
    restClientBuilder.setDefaultHeaders(...)
    restClientBuilder.setMaxRetryTimeoutMillis(...)
    restClientBuilder.setPathPrefix(...)
    restClientBuilder.setHttpClientConfigCallback(...)
  }
)
```

after

```scala
esSinkBuilder.setRestClientFactory(new RestClientFactory {
  override def configureRestClientBuilder(restClientBuilder: RestClientBuilder): Unit = {
       restClientBuilder.setDefaultHeaders(...)
       restClientBuilder.setMaxRetryTimeoutMillis(...)
       restClientBuilder.setPathPrefix(...)
       restClientBuilder.setHttpClientConfigCallback(...)
  }
})
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:(no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
