### PR TITLE
[FLINK-16287][es][build] Remove Log4j2 relocation

### DIFF
--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -133,10 +133,6 @@ under the License.
 									<shadedPattern>org.apache.flink.elasticsearch6.shaded.org.elasticsearch</shadedPattern>
 								</relocation>
 								<relocation>
-									<pattern>org.apache.logging</pattern>
-									<shadedPattern>org.apache.flink.elasticsearch6.shaded.org.apache.logging</shadedPattern>
-								</relocation>
-								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
 									<shadedPattern>org.apache.flink.elasticsearch6.shaded.com.fasterxml.jackson</shadedPattern>
 								</relocation>


### PR DESCRIPTION
Log4j2 is no longer bundled in the jar since it is now bundled in flink-dist. The relocation is hence unnecessary and currently breaks the connector.