### PR TITLE
[FLINK-15834] Set up nightly builds in Azure & various CI improvements

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,9 +32,11 @@
 
 resources:
   containers:
-  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
-  - container: flink-build-container
+  # Containers with Maven 3.2.5, SSL to have the same environment everywhere.
+  - container: flink-build-jdk8
     image: rmetzger/flink-ci:ubuntu-jdk8-amd64-2a765ab
+  - container: flink-build-jdk11
+    image: rmetzger/flink-ci:ubuntu-jdk11-amd64-2a765ab
 
 # See tools/azure-pipelines/jobs-template.yml for a short summary of the caching
 variables:
@@ -54,6 +56,5 @@ jobs:
       e2e_pool_definition:
         vmImage: 'ubuntu-16.04'
       environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
-
-
-
+      run_end_to_end: false
+      container: flink-build-jdk8

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -129,14 +129,23 @@ END
     docker exec master bash -c "cat /home/hadoop-user/$FLINK_DIRNAME/conf/flink-conf.yaml"
 }
 
-function copy_and_show_logs {
-    mkdir -p $TEST_DATA_DIR/logs
+function debug_copy_and_show_logs {
+    echo "Debugging failed YARN Docker test:"
+    echo "Currently running containers"
+    docker ps
+
+    echo "Currently running JVMs"
+    jps -v
+
     echo "Hadoop logs:"
-    docker cp master:/var/log/hadoop/* $TEST_DATA_DIR/logs/
-    for f in $TEST_DATA_DIR/logs/*; do
+    mkdir -p $TEST_DATA_DIR/logs
+    docker cp master:/var/log/hadoop/ $TEST_DATA_DIR/logs/
+    ls -lisah $TEST_DATA_DIR/logs/hadoop
+    for f in $TEST_DATA_DIR/logs/hadoop/*; do
         echo "$f:"
         cat $f
     done
+    
     echo "Docker logs:"
     docker logs master
 
@@ -144,6 +153,7 @@ function copy_and_show_logs {
     docker exec master bash -c "kinit -kt /home/hadoop-user/hadoop-user.keytab hadoop-user"
     docker exec master bash -c "yarn application -list -appStates ALL"
     application_id=`docker exec master bash -c "yarn application -list -appStates ALL" | grep "Flink" | grep "cluster" | awk '{print \$1}'`
+    
     echo "Application ID: $application_id"
     docker exec master bash -c "yarn logs -applicationId $application_id"
     docker exec master bash -c "kdestroy"

--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/yarn-site.xml
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/config/yarn-site.xml
@@ -183,4 +183,12 @@ under the License.
     <name>yarn.nodemanager.log-dirs</name>
     <value>file:///hadoop-data/nm-log-dirs</value>
   </property>
+  <!-- 
+    This allows running the tests also in low disk space environments. YARN is quite aggresive with 
+    blacklisting nodes on low memory: https://issues.apache.org/jira/browse/FLINK-16136
+  -->
+  <property>
+    <name>yarn.nodemanager.disk-health-checker.max-disk-utilization-per-disk-percentage</name>
+    <value>99</value>
+  </property>
 </configuration>

--- a/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
+++ b/flink-end-to-end-tests/test-scripts/queryable_state_base.sh
@@ -28,7 +28,7 @@ function get_queryable_state_server_ip {
     local ip=$(cat ${FLINK_DIR}/log/flink*taskexecutor*log \
         | grep "Started Queryable State Server" \
         | head -1 \
-        | awk '{split($11, a, "/"); split(a[2], b, ":"); print b[1]}')
+        | grep -Eo  "\.*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.*")
 
     printf "${ip} \n"
 }
@@ -38,7 +38,7 @@ function get_queryable_state_proxy_port {
     local port=$(cat ${FLINK_DIR}/log/flink*taskexecutor*log \
         | grep "Started Queryable State Proxy Server" \
         | head -1 \
-        | awk '{split($12, a, "/"); split(a[2], b, ":"); split(b[2], c, "."); print c[1]}')
+        | grep -Eo  "\.*\:([0-9]{3,5})\.*" | tr -d ":.")
 
     printf "${port} \n"
 }

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -57,14 +57,14 @@ then
     echo "$OUTPUT"
 else
     echo "Running the job failed."
-    copy_and_show_logs
+    debug_copy_and_show_logs
     exit 1
 fi
 
 for expected_result in ${EXPECTED_RESULT_LOG_CONTAINS[@]}; do
     if [[ ! "$OUTPUT" =~ $expected_result ]]; then
         echo "Output does not contain '$expected_result' as required"
-        copy_and_show_logs
+        debug_copy_and_show_logs
         exit 1
     fi
 done

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -21,11 +21,21 @@
 #  - custom triggered e2e tests
 #  - nightly builds
 
+schedules:
+- cron: "0 0 * * *"
+  displayName: nightly build
+  branches:
+    include:
+    - master
+  always: true # run even if there were no changes to the mentioned branches
+
 resources:
   containers:
-  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
-  - container: flink-build-container
+  # Containers with Maven 3.2.5, SSL to have the same environment everywhere.
+  - container: flink-build-jdk8
     image: rmetzger/flink-ci:ubuntu-jdk8-amd64-2a765ab
+  - container: flink-build-jdk11
+    image: rmetzger/flink-ci:ubuntu-jdk11-amd64-2a765ab
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository
@@ -37,7 +47,7 @@ variables:
 stages:
   # CI / PR triggered stage:
   - stage: ci_build
-    displayName: "CI Build (custom builders)"
+    displayName: "CI build (custom builders)"
     condition: not(eq(variables['Build.Reason'], in('Schedule', 'Manual')))
     jobs:
       - template: jobs-template.yml
@@ -48,3 +58,60 @@ stages:
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
           environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+          run_end_to_end: false
+          container: flink-build-jdk8
+  # Special stage for nightly builds:
+  - stage: cron_build
+    displayName: "Cron build"
+    dependsOn: [] # depending on an empty array makes the stages run in parallel
+    condition: or(eq(variables['Build.Reason'], 'Schedule'), eq(variables['MODE'], 'nightly'))
+    jobs:
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_hadoop241
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dhadoop.version=2.4.1 -Pskip-hive-tests"
+          run_end_to_end: true
+          container: flink-build-jdk8
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_scala212
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1"
+          run_end_to_end: true
+          container: flink-build-jdk8
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_jdk11
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11"
+          run_end_to_end: true
+          container: flink-build-jdk11
+      - template: jobs-template.yml
+        parameters:
+          stage_name: cron_build_hadoopfree
+          test_pool_definition:
+            name: Default
+          e2e_pool_definition:
+            vmImage: 'ubuntu-16.04'
+          environment: PROFILE=""
+          run_end_to_end: true
+          container: flink-build-jdk8
+      - job: docs_404_check # run on a MSFT provided machine
+        pool: 
+          vmImage: 'ubuntu-16.04'
+        steps:
+        - task: UseRubyVersion@0
+          inputs:
+            versionSpec: '= 2.4'
+            addToPath: true
+        - script: ./tools/travis/docs.sh

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -118,43 +118,11 @@ jobs:
     inputs:
       testResultsFormat: 'JUnit'
 
-- job: precommit_${{parameters.stage_name}}
-  dependsOn: compile_${{parameters.stage_name}}
-  condition: succeeded()
-  # We are not running this job on a container, but in a VM.
-  pool: ${{parameters.e2e_pool_definition}}
-  timeoutInMinutes: 240
-  cancelTimeoutInMinutes: 1
-  workspace:
-    clean: all
-  steps:
-    - task: Cache@2
-      inputs:
-        key: $(CACHE_KEY)
-        restoreKeys: $(CACHE_FALLBACK_KEY)
-        path: $(MAVEN_CACHE_FOLDER)
-      displayName: Cache Maven local repo
-      continueOnError: true
-    
-    # download artifacts
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        path: $(CACHE_FLINK_DIR)
-        artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
-    - script: |
-        echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
-        echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin;$(PATH)"
-      displayName: "Set to jdk11"
-      condition: eq('${{parameters.container}}', 'flink-build-jdk11')
-    - script: ./tools/travis/setup_maven.sh
-    - script: ${{parameters.environment}} ./tools/azure-pipelines/prepare_precommit.sh
-      displayName: prepare and build Flink
-    - script: FLINK_DIR=build-target ./flink-end-to-end-tests/run-pre-commit-tests.sh
-      displayName: Test - precommit 
 
 - job: e2e_${{parameters.stage_name}}
-  condition: or(eq(variables['MODE'], 'e2e'), eq(${{parameters.run_end_to_end}}, 'true'))
-  # We are not running this job on a container, but in a VM.
+  # uncomment below condition to run the e2e tests only on request.
+  #condition: or(eq(variables['MODE'], 'e2e'), eq(${{parameters.run_end_to_end}}, 'true'))
+  # We are running this in a separate pool
   pool: ${{parameters.e2e_pool_definition}}
   timeoutInMinutes: 240
   cancelTimeoutInMinutes: 1
@@ -177,6 +145,9 @@ jobs:
     - script: ./tools/azure-pipelines/setup_kubernetes.sh
     - script: M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH ${{parameters.environment}} STAGE=compile ./tools/azure_controller.sh compile
       displayName: Build
+    # TODO remove pre-commit tests script by adding the tests to the nightly script
+    - script: FLINK_DIR=build-target ./flink-end-to-end-tests/run-pre-commit-tests.sh
+      displayName: Test - precommit 
     - script: FLINK_DIR=`pwd`/build-target flink-end-to-end-tests/run-nightly-tests.sh
       displayName: Run nightly e2e tests
 

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -18,12 +18,14 @@ parameters:
   e2e_pool_definion: # defines the hardware pool for end-to-end test execution
   stage_name: # defines a unique identifier for all jobs in a stage (in case the jobs are added multiple times to a stage)
   environment: # defines environment variables for downstream scripts
+  run_end_to_end: # if set to 'true', the end to end tests will be executed
+  container: # the container name for the build
 
 jobs:
 - job: compile_${{parameters.stage_name}}
   condition: not(eq(variables['MODE'], 'e2e'))
   pool: ${{parameters.test_pool_definition}}
-  container: flink-build-container
+  container: ${{parameters.container}}
   timeoutInMinutes: 240
   cancelTimeoutInMinutes: 1
   workspace:
@@ -63,7 +65,7 @@ jobs:
   dependsOn: compile_${{parameters.stage_name}}
   condition: and(succeeded(), not(eq(variables['MODE'], 'e2e')))
   pool: ${{parameters.test_pool_definition}}
-  container: flink-build-container
+  container: ${{parameters.container}}
   timeoutInMinutes: 240
   cancelTimeoutInMinutes: 1
   workspace:
@@ -132,20 +134,26 @@ jobs:
         restoreKeys: $(CACHE_FALLBACK_KEY)
         path: $(MAVEN_CACHE_FOLDER)
       displayName: Cache Maven local repo
+      continueOnError: true
     
     # download artifacts
     - task: DownloadPipelineArtifact@2
       inputs:
         path: $(CACHE_FLINK_DIR)
         artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
+    - script: |
+        echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+        echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin;$(PATH)"
+      displayName: "Set to jdk11"
+      condition: eq('${{parameters.container}}', 'flink-build-jdk11')
     - script: ./tools/travis/setup_maven.sh
-    - script: ./tools/azure-pipelines/prepare_precommit.sh
+    - script: ${{parameters.environment}} ./tools/azure-pipelines/prepare_precommit.sh
       displayName: prepare and build Flink
     - script: FLINK_DIR=build-target ./flink-end-to-end-tests/run-pre-commit-tests.sh
       displayName: Test - precommit 
 
 - job: e2e_${{parameters.stage_name}}
-  condition: eq(variables['MODE'], 'e2e')
+  condition: or(eq(variables['MODE'], 'e2e'), eq(${{parameters.run_end_to_end}}, 'true'))
   # We are not running this job on a container, but in a VM.
   pool: ${{parameters.e2e_pool_definition}}
   timeoutInMinutes: 240
@@ -159,9 +167,15 @@ jobs:
         restoreKeys: $(CACHE_FALLBACK_KEY)
         path: $(MAVEN_CACHE_FOLDER)
       displayName: Cache Maven local repo
+      continueOnError: true
+    - script: |
+        echo "##vso[task.setvariable variable=JAVA_HOME]$(JAVA_HOME_11_X64)"
+        echo "##vso[task.setvariable variable=PATH]$(JAVA_HOME_11_X64)/bin;$(PATH)"
+      displayName: "Set to jdk11"
+      condition: eq('${{parameters.container}}', 'flink-build-jdk11')
     - script: ./tools/travis/setup_maven.sh
     - script: ./tools/azure-pipelines/setup_kubernetes.sh
-    - script: M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -De2e-metrics -Dmaven.wagon.http.pool=false" STAGE=compile ./tools/azure_controller.sh compile
+    - script: M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH ${{parameters.environment}} STAGE=compile ./tools/azure_controller.sh compile
       displayName: Build
     - script: FLINK_DIR=`pwd`/build-target flink-end-to-end-tests/run-nightly-tests.sh
       displayName: Run nightly e2e tests

--- a/tools/azure-pipelines/prepare_precommit.sh
+++ b/tools/azure-pipelines/prepare_precommit.sh
@@ -32,8 +32,17 @@ find . -type f -name '*.timestamp' | xargs touch
 export M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ 
 export PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH
 mvn -version
-mvn install --settings ./tools/azure-pipelines/google-mirror-settings.xml -DskipTests -Drat.skip
+MVN_CALL="mvn install --settings ./tools/azure-pipelines/google-mirror-settings.xml -DskipTests -Drat.skip $PROFILE"
+echo "Invoking Maven: '$MVN_CALL'"
+$MVN_CALL
+EXIT_CODE=$?
 
+if [ $EXIT_CODE != 0 ]; then
+	echo "=============================================================================="
+	echo "Build error. Exit code: $EXIT_CODE. Failing build"
+	echo "=============================================================================="
+	exit $EXIT_CODE
+fi
 
 chmod -R +x build-target
 chmod -R +x flink-end-to-end-tests

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -172,6 +172,7 @@ elif [ $STAGE != "$STAGE_CLEANUP" ]; then
         PY_MVN="${MVN// clean/}"
         PY_MVN="$PY_MVN -Drat.skip=true"
         ${PY_MVN}
+        EXIT_CODE=$?
 
         if [ $EXIT_CODE != 0 ]; then
             echo "=============================================================================="


### PR DESCRIPTION
## What is the purpose of the change

This change set up a nightly end to end test, testing special scenarios such as Java 11, hadoop 2.8 or scala 2.12.


## Brief change log

- Change the `build-apache-repo.yaml` to trigger the tests nightly (I left out release branches for now, as only master has the azure files present)
- change the `job-templates.yml` to build the end to end tests with every commit (pr, push builds). This is an experiment, as we might not have enough resources (but I believe we do).
I had two options for this: either transfer the build artifact from the compile phase into the e2e test job, or build there from scratch. I decided for the latter, as the build always takes 20 minutes. So in case the test machines are busy, but the azure provided machines are available, we'll start compiling right away.
The precommit tests are executed in this stage, before the end to end tests.

This change also fixes many issues with the end to end tests:
 
**Fix Kubernetes E2E tests**

Problem: Low disk space was causing K8s to mark the kubelet as "full disk", thus Flink did not schedule there.
Problem: Low disk space let the kublet delete unused docker images, including images generated for the test.

**Fix Kerberized YARN e2e test**

The problem was that YARN was decommissioning NodeManagers because of low disk space.

**Fix queryable state e2e test**

Problem: The logging pattern recently changed, that's why the extaction of port / ip failed


## Verifying this change

This nightly build failed only because of known issues (which also caused the travis nightly test to fail). I believe the structure / environment of the individual nightly tests is fine: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=5590&view=results


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)


