### PR TITLE
[FLINK-16281][Table SQL / Ecosystem] parameter 'maxRetryTimes' can not work in JDBCUpsertTableSink.

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/AppendOnlyWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/AppendOnlyWriter.java
@@ -57,9 +57,7 @@ public class AppendOnlyWriter implements JDBCWriter {
 	@Override
 	public void addRecord(Tuple2<Boolean, Row> record) {
 		checkArgument(record.f0, "Append mode can not receive retract/delete message.");
-		//deep copy, add record to buffer
-		Row row = Row.copy(record.f1);
-		cachedRows.add(row);
+		cachedRows.add(record.f1);
 	}
 
 	@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/AppendOnlyWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/AppendOnlyWriter.java
@@ -24,6 +24,8 @@ import org.apache.flink.types.Row;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.flink.api.java.io.jdbc.JDBCUtils.setRecordToStatement;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -38,6 +40,7 @@ public class AppendOnlyWriter implements JDBCWriter {
 	private final String insertSQL;
 	private final int[] fieldTypes;
 
+	private transient List<Tuple2<Boolean, Row>> rows;
 	private transient PreparedStatement statement;
 
 	public AppendOnlyWriter(String insertSQL, int[] fieldTypes) {
@@ -47,19 +50,26 @@ public class AppendOnlyWriter implements JDBCWriter {
 
 	@Override
 	public void open(Connection connection) throws SQLException {
+		this.rows = new ArrayList<>();
 		this.statement = connection.prepareStatement(insertSQL);
 	}
 
 	@Override
-	public void addRecord(Tuple2<Boolean, Row> record) throws SQLException {
+	public void addRecord(Tuple2<Boolean, Row> record) {
 		checkArgument(record.f0, "Append mode can not receive retract/delete message.");
-		setRecordToStatement(statement, fieldTypes, record.f1);
-		statement.addBatch();
+		rows.add(record);
 	}
 
 	@Override
 	public void executeBatch() throws SQLException {
-		statement.executeBatch();
+		if (rows.size() > 0) {
+			for (Tuple2<Boolean, Row> row : rows) {
+				setRecordToStatement(statement, fieldTypes, row.f1);
+				statement.addBatch();
+			}
+			statement.executeBatch();
+			rows.clear();
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/JDBCWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/JDBCWriter.java
@@ -38,7 +38,7 @@ public interface JDBCWriter extends Serializable {
 	/**
 	 * Add record to writer, the writer may cache the data.
 	 */
-	void addRecord(Tuple2<Boolean, Row> record) throws SQLException;
+	void addRecord(Tuple2<Boolean, Row> record);
 
 	/**
 	 * Submits a batch of commands to the database for execution.

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
@@ -48,8 +48,7 @@ public abstract class UpsertWriter implements JDBCWriter {
 		String tableName,
 		String[] fieldNames,
 		int[] fieldTypes,
-		String[] keyFields,
-		boolean objectReuse) {
+		String[] keyFields) {
 
 		checkNotNull(keyFields);
 
@@ -62,10 +61,10 @@ public abstract class UpsertWriter implements JDBCWriter {
 		Optional<String> upsertSQL = dialect.getUpsertStatement(tableName, fieldNames, keyFields);
 		return upsertSQL.map((Function<String, UpsertWriter>) sql ->
 				new UpsertWriterUsingUpsertStatement(
-						fieldTypes, pkFields, pkTypes, objectReuse, deleteSQL, sql))
+						fieldTypes, pkFields, pkTypes, deleteSQL, sql))
 				.orElseGet(() ->
 						new UpsertWriterUsingInsertUpdateStatement(
-								fieldTypes, pkFields, pkTypes, objectReuse, deleteSQL,
+								fieldTypes, pkFields, pkTypes, deleteSQL,
 								dialect.getRowExistsStatement(tableName, keyFields),
 								dialect.getInsertIntoStatement(tableName, fieldNames),
 								dialect.getUpdateStatement(tableName, fieldNames, keyFields)));
@@ -75,17 +74,15 @@ public abstract class UpsertWriter implements JDBCWriter {
 	final int[] pkTypes;
 	private final int[] pkFields;
 	private final String deleteSQL;
-	private final boolean objectReuse;
 
 	private transient Map<Row, Tuple2<Boolean, Row>> keyToRows;
 	private transient PreparedStatement deleteStatement;
 
-	private UpsertWriter(int[] fieldTypes, int[] pkFields, int[] pkTypes, String deleteSQL, boolean objectReuse) {
+	private UpsertWriter(int[] fieldTypes, int[] pkFields, int[] pkTypes, String deleteSQL) {
 		this.fieldTypes = fieldTypes;
 		this.pkFields = pkFields;
 		this.pkTypes = pkTypes;
 		this.deleteSQL = deleteSQL;
-		this.objectReuse = objectReuse;
 	}
 
 	@Override
@@ -95,10 +92,8 @@ public abstract class UpsertWriter implements JDBCWriter {
 	}
 
 	public void addRecord(Tuple2<Boolean, Row> record) {
-		// we don't need perform a deep copy, because jdbc field are immutable object.
-		Tuple2<Boolean, Row> tuple2 = objectReuse ? new Tuple2<>(record.f0, Row.copy(record.f1)) : record;
 		// add records to buffer
-		keyToRows.put(getPrimaryKey(tuple2.f1), tuple2);
+		keyToRows.put(getPrimaryKey(record.f1), record);
 	}
 
 	@Override
@@ -153,10 +148,9 @@ public abstract class UpsertWriter implements JDBCWriter {
 			int[] fieldTypes,
 			int[] pkFields,
 			int[] pkTypes,
-			boolean objectReuse,
 			String deleteSQL,
 			String upsertSQL) {
-			super(fieldTypes, pkFields, pkTypes, deleteSQL, objectReuse);
+			super(fieldTypes, pkFields, pkTypes, deleteSQL);
 			this.upsertSQL = upsertSQL;
 		}
 
@@ -202,12 +196,11 @@ public abstract class UpsertWriter implements JDBCWriter {
 			int[] fieldTypes,
 			int[] pkFields,
 			int[] pkTypes,
-			boolean objectReuse,
 			String deleteSQL,
 			String existSQL,
 			String insertSQL,
 			String updateSQL) {
-			super(fieldTypes, pkFields, pkTypes, deleteSQL, objectReuse);
+			super(fieldTypes, pkFields, pkTypes, deleteSQL);
 			this.existSQL = existSQL;
 			this.insertSQL = insertSQL;
 			this.updateSQL = updateSQL;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/writer/UpsertWriter.java
@@ -94,7 +94,7 @@ public abstract class UpsertWriter implements JDBCWriter {
 		this.deleteStatement = connection.prepareStatement(deleteSQL);
 	}
 
-	public void addRecord(Tuple2<Boolean, Row> record) throws SQLException {
+	public void addRecord(Tuple2<Boolean, Row> record) {
 		// we don't need perform a deep copy, because jdbc field are immutable object.
 		Tuple2<Boolean, Row> tuple2 = objectReuse ? new Tuple2<>(record.f0, Row.copy(record.f1)) : record;
 		// add records to buffer

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.java.io.jdbc.writer.AppendOnlyWriter;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.sql.BatchUpdateException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+
+import static org.apache.flink.api.java.io.jdbc.JDBCOutputFormatTest.toRow;
+import static org.mockito.Mockito.doReturn;
+
+/**
+ * Test for the {@link AppendOnlyWriter}.
+ */
+public class JDBCAppenOnlyWriterTest extends JDBCTestBase {
+	private JDBCUpsertOutputFormat format;
+	private String[] fieldNames;
+	private String[] keyFields;
+
+	@Before
+	public void setup() {
+		fieldNames = new String[]{"id", "title", "author", "price", "qty"};
+		keyFields = null;
+	}
+
+	@Test(expected = BatchUpdateException.class)
+	public void testMaxRetry() throws Exception {
+		format = JDBCUpsertOutputFormat.builder()
+			.setOptions(JDBCOptions.builder()
+				.setDBUrl(DB_URL)
+				.setTableName(OUTPUT_TABLE)
+				.build())
+			.setFieldNames(fieldNames)
+			.setKeyFields(keyFields)
+			.build();
+		RuntimeContext context = Mockito.mock(RuntimeContext.class);
+		ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
+		doReturn(config).when(context).getExecutionConfig();
+		doReturn(true).when(config).isObjectReuseEnabled();
+		format.setRuntimeContext(context);
+		format.open(0, 1);
+
+		// alter table schema to trigger retry logic after failure.
+		alterTable();
+		for (TestEntry entry : TEST_DATA) {
+			format.writeRecord(Tuple2.of(true, toRow(entry)));
+		}
+
+		// after retry default times, throws a BatchUpdateException.
+		format.flush();
+	}
+
+	private void alterTable() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (Connection conn = DriverManager.getConnection(DB_URL);
+			Statement stat = conn.createStatement()) {
+			stat.execute("ALTER  TABLE " + OUTPUT_TABLE + " DROP COLUMN " + fieldNames[1]);
+			stat.close();
+			conn.close();
+		}
+	}
+
+	@After
+	public void clear() throws Exception {
+		Class.forName(DRIVER_CLASS);
+		try (
+			Connection conn = DriverManager.getConnection(DB_URL);
+			Statement stat = conn.createStatement()) {
+			stat.execute("DELETE FROM " + OUTPUT_TABLE);
+
+			stat.close();
+			conn.close();
+		}
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
@@ -87,7 +87,11 @@ public class JDBCAppenOnlyWriterTest extends JDBCTestBase {
 	@After
 	public void clear() throws Exception {
 		if (format != null) {
-			format.close();
+			try {
+				format.close();
+			} catch (RuntimeException e) {
+				// ignore exception when close.
+			}
 		}
 		format = null;
 		Class.forName(DRIVER_CLASS);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppenOnlyWriterTest.java
@@ -40,14 +40,13 @@ import static org.mockito.Mockito.doReturn;
  * Test for the {@link AppendOnlyWriter}.
  */
 public class JDBCAppenOnlyWriterTest extends JDBCTestBase {
+
 	private JDBCUpsertOutputFormat format;
 	private String[] fieldNames;
-	private String[] keyFields;
 
 	@Before
 	public void setup() {
 		fieldNames = new String[]{"id", "title", "author", "price", "qty"};
-		keyFields = null;
 	}
 
 	@Test(expected = BatchUpdateException.class)
@@ -58,7 +57,7 @@ public class JDBCAppenOnlyWriterTest extends JDBCTestBase {
 				.setTableName(OUTPUT_TABLE)
 				.build())
 			.setFieldNames(fieldNames)
-			.setKeyFields(keyFields)
+			.setKeyFields(null)
 			.build();
 		RuntimeContext context = Mockito.mock(RuntimeContext.class);
 		ExecutionConfig config = Mockito.mock(ExecutionConfig.class);
@@ -82,21 +81,20 @@ public class JDBCAppenOnlyWriterTest extends JDBCTestBase {
 		try (Connection conn = DriverManager.getConnection(DB_URL);
 			Statement stat = conn.createStatement()) {
 			stat.execute("ALTER  TABLE " + OUTPUT_TABLE + " DROP COLUMN " + fieldNames[1]);
-			stat.close();
-			conn.close();
 		}
 	}
 
 	@After
 	public void clear() throws Exception {
+		if (format != null) {
+			format.close();
+		}
+		format = null;
 		Class.forName(DRIVER_CLASS);
 		try (
 			Connection conn = DriverManager.getConnection(DB_URL);
 			Statement stat = conn.createStatement()) {
 			stat.execute("DELETE FROM " + OUTPUT_TABLE);
-
-			stat.close();
-			conn.close();
 		}
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -53,7 +53,7 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 	public static final String DB_URL = "jdbc:derby:memory:upsert";
 	public static final String OUTPUT_TABLE1 = "upsertSink";
 	public static final String OUTPUT_TABLE2 = "appendSink";
-	public static final String NOT_EXISTS_TABLE = "notExistsTable";
+	public static final String NOT_EXISTS_TABLE = "notExistedTable";
 
 	@Before
 	public void before() throws ClassNotFoundException, SQLException {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -52,7 +52,6 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 	public static final String DB_URL = "jdbc:derby:memory:upsert";
 	public static final String OUTPUT_TABLE1 = "upsertSink";
 	public static final String OUTPUT_TABLE2 = "appendSink";
-	public static final String NOT_EXISTS_TABLE = "notExistedTable";
 
 	@Before
 	public void before() throws ClassNotFoundException, SQLException {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.java.tuple.Tuple4;
-import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -212,32 +211,5 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 				Row.of(10, 4, Timestamp.valueOf("1970-01-01 00:00:00.01")),
 				Row.of(20, 6, Timestamp.valueOf("1970-01-01 00:00:00.02"))
 		}, DB_URL, OUTPUT_TABLE2, new String[]{"id", "num", "ts"});
-	}
-
-	@Test(expected = JobExecutionException.class)
-	public void testTableNotExists() throws Exception {
-		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.getConfig().enableObjectReuse();
-		env.getConfig().setParallelism(1);
-		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
-
-		Table t = tEnv.fromDataStream(get4TupleDataStream(env), "id, num, text, ts");
-
-		tEnv.registerTable("T", t);
-
-		tEnv.sqlUpdate(
-			"CREATE TABLE upsertSink (" +
-				"  id INT," +
-				"  num BIGINT," +
-				"  ts TIMESTAMP(3)" +
-				") WITH (" +
-				"  'connector.type'='jdbc'," +
-				"  'connector.url'='" + DB_URL + "'," +
-				"  'connector.table'='" + NOT_EXISTS_TABLE + "'," +
-				"  'connector.write.max-retries'='3'" +
-				")");
-
-		tEnv.sqlUpdate("INSERT INTO upsertSink SELECT id, num, ts FROM T WHERE id IN (2, 10, 20)");
-		env.execute();
 	}
 }


### PR DESCRIPTION
parameter 'maxRetryTimes' can not work in JDBCUpsertTableSink.
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.

  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request fix 'maxRetryTimes' can not work properly in JDBCUpsertTableSink( only AppendOnlyWriter) .*


## Brief change log

  - *Cache data in AppendOnlyWriter for multiple call*
  - *Update executeBatch() in AppendOnlyWriter*


## Verifying this change

 Test exception will be thrown normally in JDBCUpsertTableSinkITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
