### PR TITLE
[FLINK-16261][table] Use type compatibility consistently to avoid casting

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/resolver/rules/ResolveCallByArgumentsRule.java
@@ -60,6 +60,7 @@ import java.util.stream.IntStream;
 
 import static java.util.Collections.singletonList;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
 import static org.apache.flink.table.types.utils.TypeConversions.fromDataTypeToLegacyInfo;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
@@ -231,7 +232,8 @@ final class ResolveCallByArgumentsRule implements ResolverRule {
 					final ResolvedExpression argument = resolvedArgs.get(pos);
 					final DataType argumentType = argument.getOutputDataType();
 					final DataType expectedType = inferenceResult.getExpectedArgumentTypes().get(pos);
-					if (!argumentType.equals(expectedType)) {
+
+					if (!supportsAvoidingCast(argumentType.getLogicalType(), expectedType.getLogicalType())) {
 						return resolutionContext
 							.postResolutionFactory()
 							.cast(argument, expectedType);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/AndArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/AndArgumentTypeStrategy.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
+
 /**
  * Strategy for inferring and validating an argument using a conjunction of multiple {@link ArgumentTypeStrategy}s
  * into one like {@code f(NUMERIC && LITERAL)}
@@ -72,7 +74,7 @@ public final class AndArgumentTypeStrategy implements ArgumentTypeStrategy {
 			}
 			final LogicalType inferredType = inferredDataType.get().getLogicalType();
 			// a more specific, casted argument type is available
-			if (!actualType.equals(inferredType) && !closestDataType.isPresent()) {
+			if (!supportsAvoidingCast(actualType, inferredType) && !closestDataType.isPresent()) {
 				closestDataType = inferredDataType;
 			}
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ExplicitArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ExplicitArgumentTypeStrategy.java
@@ -25,11 +25,13 @@ import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.inference.Signature.Argument;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.utils.LogicalTypeCasts;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Objects;
 import java.util.Optional;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsImplicitCast;
 
 /**
  * Strategy for an argument that corresponds to an explicitly defined type. Implicit casts will be
@@ -50,11 +52,11 @@ public final class ExplicitArgumentTypeStrategy implements ArgumentTypeStrategy 
 		final LogicalType actualType = callContext.getArgumentDataTypes().get(argumentPos).getLogicalType();
 		// if logical types match, we return the expected data type
 		// for ensuring the expected conversion class
-		if (expectedType.equals(actualType)) {
+		if (supportsAvoidingCast(actualType, expectedType)) {
 			return Optional.of(expectedDataType);
 		}
 		// type coercion
-		if (!LogicalTypeCasts.supportsImplicitCast(actualType, expectedType)) {
+		if (!supportsImplicitCast(actualType, expectedType)) {
 			if (throwOnFailure) {
 				throw callContext.newValidationError(
 					"Unsupported argument type. Expected type '%s' but actual type was '%s'.",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MappingTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/MappingTypeStrategy.java
@@ -31,9 +31,11 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
+
 /**
  * Type strategy that maps an {@link InputTypeStrategy} to a {@link TypeStrategy} if the input strategy
- * infers identical types.
+ * infers compatible types.
  */
 @Internal
 public final class MappingTypeStrategy implements TypeStrategy {
@@ -64,7 +66,7 @@ public final class MappingTypeStrategy implements TypeStrategy {
 			final List<LogicalType> inferredTypes = inferredDataTypes.get().stream()
 				.map(DataType::getLogicalType)
 				.collect(Collectors.toList());
-			if (actualTypes.equals(inferredTypes)) {
+			if (supportsAvoidingCast(actualTypes, inferredTypes)) {
 				return strategy.inferType(callContext);
 			}
 		}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OrArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OrArgumentTypeStrategy.java
@@ -33,6 +33,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
+
 /**
  * Strategy for inferring and validating an argument using a disjunction of multiple {@link ArgumentTypeStrategy}s
  * into one like {@code f(NUMERIC || STRING)}.
@@ -70,9 +72,9 @@ public final class OrArgumentTypeStrategy implements ArgumentTypeStrategy {
 				continue;
 			}
 			final LogicalType inferredType = inferredDataType.get().getLogicalType();
-			// argument type matches exactly
+			// argument type matches
 			// we prefer a strategy that does not require an implicit cast
-			if (actualType.equals(inferredType)) {
+			if (supportsAvoidingCast(actualType, inferredType)) {
 				return inferredDataType;
 			}
 			// argument type requires a more specific, casted type

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OrInputTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/OrInputTypeStrategy.java
@@ -37,6 +37,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
+
 /**
  * Strategy for inferring and validating the input using a disjunction of multiple {@link InputTypeStrategy}s
  * into one like {@code f(NUMERIC) || f(STRING)}.
@@ -121,8 +123,8 @@ public final class OrInputTypeStrategy implements InputTypeStrategy {
 			final List<LogicalType> inferredTypes = inferredDataTypes.get().stream()
 				.map(DataType::getLogicalType)
 				.collect(Collectors.toList());
-			// types match exactly
-			if (actualTypes.equals(inferredTypes)) {
+			// types match
+			if (supportsAvoidingCast(actualTypes, inferredTypes)) {
 				return inferredDataTypes;
 			}
 			// type matches with some casting
@@ -163,7 +165,7 @@ public final class OrInputTypeStrategy implements InputTypeStrategy {
 	/**
 	 * Returns the common minimum argument count or null if undefined.
 	 */
-	private @Nullable Integer commonMin(List<ArgumentCount> counts) {
+	private static @Nullable Integer commonMin(List<ArgumentCount> counts) {
 		// min=5, min=3, min=0           -> min=0
 		// min=5, min=3, min=0, min=null -> min=null
 		int commonMin = Integer.MAX_VALUE;
@@ -183,7 +185,7 @@ public final class OrInputTypeStrategy implements InputTypeStrategy {
 	/**
 	 * Returns the common maximum argument count or null if undefined.
 	 */
-	private @Nullable Integer commonMax(List<ArgumentCount> counts) {
+	private static @Nullable Integer commonMax(List<ArgumentCount> counts) {
 		// max=5, max=3, max=0           -> max=5
 		// max=5, max=3, max=0, max=null -> max=null
 		int commonMax = Integer.MIN_VALUE;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -24,6 +24,9 @@ import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,7 +69,9 @@ import static org.apache.flink.table.types.logical.LogicalTypeRoot.TIME_WITHOUT_
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.TINYINT;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARBINARY;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getLength;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.isSingleFieldInterval;
 
 /**
@@ -205,6 +210,43 @@ public final class LogicalTypeCasts {
 			.implicitFrom(INTERVAL_DAY_TIME)
 			.explicitFromFamily(EXACT_NUMERIC, CHARACTER_STRING)
 			.build();
+	}
+
+	/**
+	 * Returns whether the source type can be safely interpreted as the target type. This allows avoiding
+	 * casts by ignoring some logical properties. This is basically a relaxed {@link LogicalType#equals(Object)}.
+	 *
+	 * <p>In particular this means:
+	 *
+	 * <p>Atomic, non-string types (INT, BOOLEAN, ...) and user-defined structured types must be fully
+	 * equal (i.e. {@link LogicalType#equals(Object)}). However, a NOT NULL type can be stored in NULL
+	 * type but not vice versa.
+	 *
+	 * <p>Atomic, string types must be contained in the target type (e.g. CHAR(2) is contained in VARCHAR(3),
+	 * but VARCHAR(2) is not contained in CHAR(3)). Same for binary strings.
+	 *
+	 * <p>Constructed types (ARRAY, ROW, MAP, etc.) and user-defined distinct type must be of same kind
+	 * but ignore field names and other logical attributes. However, all the children types
+	 * ({@link LogicalType#getChildren()}) must be compatible.
+	 */
+	public static boolean supportsAvoidingCast(LogicalType sourceType, LogicalType targetType) {
+		final CastAvoidanceChecker checker = new CastAvoidanceChecker(sourceType);
+		return targetType.accept(checker);
+	}
+
+	/**
+	 * See {@link #supportsAvoidingCast(LogicalType, LogicalType)}.
+	 */
+	public static boolean supportsAvoidingCast(List<LogicalType> sourceTypes, List<LogicalType> targetTypes) {
+		if (sourceTypes.size() != targetTypes.size()) {
+			return false;
+		}
+		for (int i = 0; i < sourceTypes.size(); i++) {
+			if (!supportsAvoidingCast(sourceTypes.get(i), targetTypes.get(i))) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	/**
@@ -376,6 +418,79 @@ public final class LogicalTypeCasts {
 		void build() {
 			implicitCastingRules.put(targetType, implicitSourceTypes);
 			explicitCastingRules.put(targetType, explicitSourceTypes);
+		}
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Checks if a source type can safely be interpreted as the target type.
+	 */
+	private static class CastAvoidanceChecker extends LogicalTypeDefaultVisitor<Boolean> {
+
+		private final LogicalType sourceType;
+
+		private CastAvoidanceChecker(LogicalType sourceType) {
+			this.sourceType = sourceType;
+		}
+
+		@Override
+		public Boolean visit(VarCharType targetType) {
+			if (sourceType.isNullable() && !targetType.isNullable()) {
+				return false;
+			}
+			// CHAR and VARCHAR are very compatible within bounds
+			if ((hasRoot(sourceType, LogicalTypeRoot.CHAR) || hasRoot(sourceType, LogicalTypeRoot.VARCHAR)) &&
+					getLength(sourceType) <= targetType.getLength()) {
+				return true;
+			}
+			return defaultMethod(targetType);
+		}
+
+		@Override
+		public Boolean visit(VarBinaryType targetType) {
+			if (sourceType.isNullable() && !targetType.isNullable()) {
+				return false;
+			}
+			// BINARY and VARBINARY are very compatible within bounds
+			if ((hasRoot(sourceType, LogicalTypeRoot.BINARY) || hasRoot(sourceType, LogicalTypeRoot.VARBINARY)) &&
+					getLength(sourceType) <= targetType.getLength()) {
+				return true;
+			}
+			return defaultMethod(targetType);
+		}
+
+		@Override
+		public Boolean visit(StructuredType targetType) {
+			if (sourceType.isNullable() && !targetType.isNullable()) {
+				return false;
+			}
+			// structured types should be equal (modulo nullability)
+			return sourceType.equals(targetType) || sourceType.copy(true).equals(targetType);
+		}
+
+		@Override
+		protected Boolean defaultMethod(LogicalType targetType) {
+			// quick path
+			if (sourceType == targetType) {
+				return true;
+			}
+
+			if (sourceType.isNullable() && !targetType.isNullable() ||
+					sourceType.getClass() != targetType.getClass() || // TODO drop this line once we remove legacy types
+					sourceType.getTypeRoot() != targetType.getTypeRoot()) {
+				return false;
+			}
+
+			final List<LogicalType> sourceChildren = sourceType.getChildren();
+			final List<LogicalType> targetChildren = targetType.getChildren();
+			if (sourceChildren.isEmpty()) {
+				// handles all types that are not of family CONSTRUCTED or USER DEFINED
+				return sourceType.equals(targetType) || sourceType.copy(true).equals(targetType);
+			} else {
+				// handles all types of CONSTRUCTED family as well as distinct types
+				return supportsAvoidingCast(sourceChildren, targetChildren);
+			}
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -40,11 +40,8 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Utilities for checking {@link LogicalType} and avoiding a lot of type casting and repetitive work.
@@ -173,20 +170,6 @@ public final class LogicalTypeChecks {
 
 	public static boolean isSingleFieldInterval(LogicalType logicalType) {
 		return logicalType.accept(SINGLE_FIELD_INTERVAL_EXTRACTOR);
-	}
-
-	/**
-	 * Returns true if the two given types are compatible. Types are compatible is for atomic types
-	 * (VARCHAR, INT, BOOLEAN, etc..), they must be fully equal (i.e. {@link LogicalType#equals(Object)}),
-	 * for complex types (ARRAY, ROW, MAP, etc..), they must be in the same type but ignore field
-	 * names and other logical attributes, and all the children types ({@link LogicalType#getChildren()})
-	 * must be compatible too.
-	 */
-	public static boolean areTypesCompatible(LogicalType thisType, LogicalType thatType) {
-		checkNotNull(thisType);
-		checkNotNull(thatType);
-		TypeCompatibleVisitor visitor = new TypeCompatibleVisitor(thisType);
-		return thatType.accept(visitor);
 	}
 
 	private LogicalTypeChecks() {
@@ -373,49 +356,6 @@ public final class LogicalTypeChecks {
 					return true;
 				default:
 					return false;
-			}
-		}
-	}
-
-	private static class TypeCompatibleVisitor extends LogicalTypeDefaultVisitor<Boolean> {
-
-		private final LogicalType thisType;
-
-		private TypeCompatibleVisitor(LogicalType thisType) {
-			checkNotNull(thisType);
-			this.thisType = thisType;
-		}
-
-		@Override
-		protected Boolean defaultMethod(LogicalType thatType) {
-			checkNotNull(thatType);
-			if (thisType == thatType) {
-				return true;
-			}
-			if (thisType.getClass() != thatType.getClass() ||
-				thisType.isNullable() != thatType.isNullable() ||
-				thisType.getTypeRoot() != thatType.getTypeRoot()) {
-				return false;
-			}
-
-			List<LogicalType> thisChildren = thisType.getChildren();
-			List<LogicalType> thatChildren = thatType.getChildren();
-			if (thisChildren.size() != thatChildren.size()) {
-				return false;
-			}
-			if (thisChildren.isEmpty()) {
-				// if it is an atomic type, delegate to equals method.
-				return thisType.equals(thatType);
-			} else {
-				// if it is composite type, only need to check children types
-				for (int i = 0; i < thisChildren.size(); i++) {
-					LogicalType thisChild = thisChildren.get(i);
-					LogicalType thatChild = thatChildren.get(i);
-					if (!areTypesCompatible(thisChild, thatChild)) {
-						return false;
-					}
-				}
-				return true;
 			}
 		}
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast;
 import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasFamily;
 
 /**
@@ -247,7 +248,7 @@ public final class TypeMappingUtils {
 			LogicalType physicalFieldType,
 			LogicalType logicalFieldType,
 			Function<Throwable, ValidationException> exceptionSupplier) {
-		if (LogicalTypeChecks.areTypesCompatible(physicalFieldType, logicalFieldType)) {
+		if (supportsAvoidingCast(physicalFieldType, logicalFieldType)) {
 			return;
 		}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -89,6 +89,13 @@ public class InputTypeStrategiesTest {
 				.expectSignature("f(INT, BOOLEAN)")
 				.expectArgumentTypes(DataTypes.INT().bridgedTo(int.class), DataTypes.BOOLEAN()),
 
+			// explicit sequence with ROW ignoring field names
+			TestSpec
+				.forStrategy(explicitSequence(DataTypes.ROW(DataTypes.FIELD("expected", DataTypes.INT()))))
+				.calledWithArgumentTypes(DataTypes.ROW(DataTypes.FIELD("actual", DataTypes.INT())))
+				.expectSignature("f(ROW<`expected` INT>)")
+				.expectArgumentTypes(DataTypes.ROW(DataTypes.FIELD("expected", DataTypes.INT()))),
+
 			// invalid named sequence
 			TestSpec
 				.forStrategy(

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/TypeStrategiesTest.java
@@ -93,6 +93,13 @@ public class TypeStrategiesTest {
 				.inputTypes(DataTypes.INT(), DataTypes.STRING())
 				.expectDataType(DataTypes.BOOLEAN().bridgedTo(boolean.class)),
 
+			// (INT, CHAR(10)) -> BOOLEAN
+			// but avoiding casts (mapping actually expects STRING)
+			TestSpec
+				.forStrategy(createMappingTypeStrategy())
+				.inputTypes(DataTypes.INT(), DataTypes.CHAR(10))
+				.expectDataType(DataTypes.BOOLEAN().bridgedTo(boolean.class)),
+
 			// invalid mapping strategy
 			TestSpec
 				.forStrategy(createMappingTypeStrategy())

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/TableSinkUtils.scala
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.sinks
 
+import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
 import org.apache.flink.api.java.typeutils.{GenericTypeInfo, PojoTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
@@ -31,14 +32,14 @@ import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTy
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.types.DataType
-import org.apache.flink.table.types.inference.TypeTransformations.{legacyDecimalToDefaultDecimal, toNullable, legacyRawToTypeInfoRaw}
-import org.apache.flink.table.types.logical.utils.{LogicalTypeCasts, LogicalTypeChecks}
-import org.apache.flink.table.types.logical.{LegacyTypeInformationType, LogicalType, RowType, TypeInformationRawType}
+import org.apache.flink.table.types.inference.TypeTransformations.{legacyDecimalToDefaultDecimal, legacyRawToTypeInfoRaw, toNullable}
+import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.{supportsAvoidingCast, supportsImplicitCast}
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
+import org.apache.flink.table.types.logical.{LegacyTypeInformationType, RowType}
 import org.apache.flink.table.types.utils.DataTypeUtils
 import org.apache.flink.table.types.utils.TypeConversions.{fromLegacyInfoToDataType, fromLogicalToDataType}
 import org.apache.flink.table.utils.{TableSchemaUtils, TypeMappingUtils}
 import org.apache.flink.types.Row
-import org.apache.calcite.rel.RelNode
 
 import _root_.scala.collection.JavaConversions._
 
@@ -67,13 +68,10 @@ object TableSinkUtils {
       .transform(sinkSchema.toRowDataType, legacyDecimalToDefaultDecimal, legacyRawToTypeInfoRaw)
       .getLogicalType
       .asInstanceOf[RowType]
-    if (LogicalTypeCasts.supportsImplicitCast(queryLogicalType, sinkLogicalType)) {
+    if (supportsImplicitCast(queryLogicalType, sinkLogicalType)) {
       // the query can be written into sink
       // but we may need to add a cast project if the types are not compatible
-      if (LogicalTypeChecks.areTypesCompatible(
-          nullableLogicalType(queryLogicalType), nullableLogicalType(sinkLogicalType))) {
-        // types are compatible excepts nullable, do not need cast project
-        // we ignores nullable to avoid cast project as cast non-null to nullable is redundant
+      if (supportsAvoidingCast(queryLogicalType, sinkLogicalType)) {
         query
       } else {
         // otherwise, add a cast project
@@ -98,13 +96,6 @@ object TableSinkUtils {
           s"Query schema: $srcSchema\n" +
           s"Sink schema: $sinkSchema")
     }
-  }
-
-  /**
-    * Make the logical type nullable recursively.
-    */
-  private def nullableLogicalType(logicalType: LogicalType): LogicalType = {
-    DataTypeUtils.transform(fromLogicalToDataType(logicalType), toNullable).getLogicalType
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -453,13 +453,36 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData);
 
-		tEnv().sqlUpdate("CREATE TABLE TestTable(a INT NOT NULL, b BIGINT NOT NULL, c STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE TestTable(i INT NOT NULL, b BIGINT NOT NULL, s STRING) WITH ('connector' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("PrimitiveScalarFunction", PrimitiveScalarFunction.class);
-		tEnv().sqlUpdate("INSERT INTO TestTable SELECT a, PrimitiveScalarFunction(a, b, c), c FROM TestTable");
+		tEnv().sqlUpdate("INSERT INTO TestTable SELECT i, PrimitiveScalarFunction(i, b, s), s FROM TestTable");
 		tEnv().execute("Test Job");
 
 		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testRowScalarFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of(1, Row.of(1, "1")),
+			Row.of(2, Row.of(2, "2")),
+			Row.of(3, Row.of(3, "3"))
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate(
+			"CREATE TABLE TestTable(i INT, r ROW<i INT, s STRING>) " +
+			"WITH ('connector' = 'COLLECTION')");
+
+		tEnv().createTemporarySystemFunction("RowScalarFunction", RowScalarFunction.class);
+		// the names of the function input and r differ
+		tEnv().sqlUpdate("INSERT INTO TestTable SELECT i, RowScalarFunction(r) FROM TestTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sourceData));
 	}
 
 	@Test
@@ -684,6 +707,16 @@ public class FunctionITCase extends StreamingTestBase {
 	public static class PrimitiveScalarFunction extends ScalarFunction {
 		public long eval(int i, long l, String s) {
 			return i + l + s.length();
+		}
+	}
+
+	/**
+	 * Function that takes and returns rows.
+	 */
+	public static class RowScalarFunction extends ScalarFunction {
+		public @DataTypeHint("ROW<f0 INT, f1 STRING>") Row eval(
+				@DataTypeHint("ROW<f0 INT, f1 STRING>") Row row) {
+			return row;
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

In many cases, full type equality is not necessary. Especially when leaving the table ecosystem to sinks or UDFs a clear definition of "type compatibility" is important. This commit defines the type compatibility for all logical types to avoid unnecessary casting and less type inequality exceptions.

## Brief change log

- Clear definition of when to avoid casting
- All calls to LogicalType.equals() revisited
- Replaced by `LogicalTypeCasts.supportsAvoidingCasts`

## Verifying this change

Existing tests for type inference and `FunctionITCase` have been updated.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
