### PR TITLE
[FLINK-16293][Kubernetes] Document using plugins in Kubernetes

### DIFF
--- a/docs/ops/deployment/docker.md
+++ b/docs/ops/deployment/docker.md
@@ -68,6 +68,37 @@ Therefore, one needs to build a dedicated container image for every job.
 The `flink-container` module contains a `build.sh` script which can be used to create such an image.
 Please see the [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) for more details. 
 
+## Using plugins
+As described in the [plugins]({{ site.baseurl }}/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+When running Flink from one of the provided Docker images by default no plugins have been activated.
+The simplest way to enable plugins is to modify the provided official Flink docker images by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your cluster.
+
+As an example assume you want to enable the [S3]({{ site.baseurl }}/ops/filesystems/s3.html) plugins in your installation.
+
+Create a Dockerfile with a content something like this: {% highlight dockerfile %}
+# On which specific version of Flink is this based?
+# Check https://hub.docker.com/_/flink?tab=tags for current options
+FROM flink:{{ site.version }}-scala_2.12
+
+# Install Flink S3 FS Presto plugin
+RUN mkdir /opt/flink/plugins/s3-fs-presto && cp /opt/flink/opt/flink-s3-fs-presto* /opt/flink/plugins/s3-fs-presto
+
+# Install Flink S3 FS Hadoop plugin
+RUN mkdir /opt/flink/plugins/s3-fs-hadoop && cp /opt/flink/opt/flink-s3-fs-hadoop* /opt/flink/plugins/s3-fs-hadoop
+{% endhighlight %}
+
+Then build and push that image to your registry
+{% highlight bash %}
+docker build -t docker.example.nl/flink:{{ site.version }}-scala_2.12-s3 .
+docker push     docker.example.nl/flink:{{ site.version }}-scala_2.12-s3
+{% endhighlight %}
+
+Now you can reference this image in your cluster deployment and the installed plugins are available for use.
+
 ## Flink with Docker Compose
 
 [Docker Compose](https://docs.docker.com/compose/) is a convenient way to run a

--- a/docs/ops/deployment/docker.zh.md
+++ b/docs/ops/deployment/docker.zh.md
@@ -68,6 +68,37 @@ Therefore, one needs to build a dedicated container image for every job.
 The `flink-container` module contains a `build.sh` script which can be used to create such an image.
 Please see the [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) for more details. 
 
+## Using plugins
+As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+When running Flink from one of the provided Docker images by default no plugins have been activated.
+The simplest way to enable plugins is to modify the provided official Flink docker images by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your cluster.
+
+As an example assume you want to enable the [S3]({{ site.baseurl }}/zh/ops/filesystems/s3.html) plugins in your installation.
+
+Create a Dockerfile with a content something like this: {% highlight dockerfile %}
+# On which specific version of Flink is this based?
+# Check https://hub.docker.com/_/flink?tab=tags for current options
+FROM flink:{{ site.version }}-scala_2.12
+
+# Install Flink S3 FS Presto plugin
+RUN mkdir /opt/flink/plugins/s3-fs-presto && cp /opt/flink/opt/flink-s3-fs-presto* /opt/flink/plugins/s3-fs-presto
+
+# Install Flink S3 FS Hadoop plugin
+RUN mkdir /opt/flink/plugins/s3-fs-hadoop && cp /opt/flink/opt/flink-s3-fs-hadoop* /opt/flink/plugins/s3-fs-hadoop
+{% endhighlight %}
+
+Then build and push that image to your registry
+{% highlight bash %}
+docker build -t docker.example.nl/flink:{{ site.version }}-scala_2.12-s3 .
+docker push     docker.example.nl/flink:{{ site.version }}-scala_2.12-s3
+{% endhighlight %}
+
+Now you can reference this image in your cluster deployment and then these plugins are available for use.
+
 ## Flink with Docker Compose
 
 [Docker Compose](https://docs.docker.com/compose/) is a convenient way to run a

--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -36,13 +36,13 @@ Please follow [Kubernetes' setup guide](https://kubernetes.io/docs/setup/) in or
 If you want to run Kubernetes locally, we recommend using [MiniKube](https://kubernetes.io/docs/setup/minikube/).
 
 <div class="alert alert-info" markdown="span">
-  <strong>Note:</strong> If using MiniKube please make sure to execute `minikube ssh 'sudo ip link set docker0 promisc on'` before deploying a Flink cluster. 
-  Otherwise Flink components are not able to self reference themselves through a Kubernetes service. 
+  <strong>Note:</strong> If using MiniKube please make sure to execute `minikube ssh 'sudo ip link set docker0 promisc on'` before deploying a Flink cluster.
+  Otherwise Flink components are not able to self reference themselves through a Kubernetes service.
 </div>
 
 ## Flink session cluster on Kubernetes
 
-A Flink session cluster is executed as a long-running Kubernetes Deployment. 
+A Flink session cluster is executed as a long-running Kubernetes Deployment.
 Note that you can run multiple Flink jobs on a session cluster.
 Each job needs to be submitted to the cluster after the cluster has been deployed.
 
@@ -91,15 +91,28 @@ In order to terminate the Flink session cluster, use `kubectl`:
 
 ## Flink job cluster on Kubernetes
 
-A Flink job cluster is a dedicated cluster which runs a single job. 
-The job is part of the image and, thus, there is no extra job submission needed. 
+A Flink job cluster is a dedicated cluster which runs a single job.
+The job is part of the image and, thus, there is no extra job submission needed.
 
 ### Creating the job-specific image
 
 The Flink job cluster image needs to contain the user code jars of the job for which the cluster is started.
 Therefore, one needs to build a dedicated container image for every job.
 Please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) to build the Docker image.
-    
+
+### Using plugins
+
+As described in the [plugins]({{ site.baseurl }}/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+The simplest way to enable plugins for use on Kubernetes is to modify the provided Flink docker image by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your Kubernetes cluster.
+
+How this can be done is described on the [Docker Setup]({{ site.baseurl }}/zh/ops/deployment/docker.html#using-plugins) page.
+
+With such an image created you can now start your Kubernetes based Flink cluster with image that was created.
+
 ### Deploy Flink job cluster on Kubernetes
 
 In order to deploy the a job cluster on Kubernetes please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/kubernetes/README.md#deploy-flink-job-cluster).

--- a/docs/ops/deployment/kubernetes.zh.md
+++ b/docs/ops/deployment/kubernetes.zh.md
@@ -100,6 +100,19 @@ The Flink job cluster image needs to contain the user code jars of the job for w
 Therefore, one needs to build a dedicated container image for every job.
 Please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/docker/README.md) to build the Docker image.
 
+### Using plugins
+
+As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+The simplest way to enable plugins for use on Kubernetes is to modify the provided Flink docker image by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your Kubernetes cluster.
+
+How this can be done is described on the [Docker Setup]({{ site.baseurl }}/zh/ops/deployment/docker.html#using-plugins) page.
+
+With such an image created you can now start your Kubernetes based Flink cluster with image that was created.
+
 ### Deploy Flink job cluster on Kubernetes
 
 In order to deploy the a job cluster on Kubernetes please follow these [instructions](https://github.com/apache/flink/blob/{{ site.github_branch }}/flink-container/kubernetes/README.md#deploy-flink-job-cluster).

--- a/docs/ops/deployment/native_kubernetes.md
+++ b/docs/ops/deployment/native_kubernetes.md
@@ -148,6 +148,32 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m
 
 If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process. 
 
+## Using plugins
+
+As described in the [plugins]({{ site.baseurl }}/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+The simplest way to enable plugins for use on Kubernetes is to modify the provided official Flink docker images by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your Kubernetes cluster.
+
+How this can be done is described on the [Docker Setup]({{ site.baseurl }}/ops/deployment/docker.html#using-plugins) page.
+
+With such an image created you can now start your Kubernetes based Flink session cluster with the additional parameter
+`kubernetes.container.image` which must specify the image that was created: `docker.example.nl/flink:{{ site.version }}-2.12-s3`
+
+Extending the above example command to start the session cluster makes it this:
+
+{% highlight bash %}
+./bin/kubernetes-session.sh \
+  -Dkubernetes.cluster-id=<ClusterId> \
+  -Dtaskmanager.memory.process.size=4096m \
+  -Dkubernetes.taskmanager.cpu=2 \
+  -Dtaskmanager.numberOfTaskSlots=4 \
+  -Dresourcemanager.taskmanager-timeout=3600000 \
+  -Dkubernetes.container.image=docker.example.nl/flink:{{ site.version }}-2.12-s3
+{% endhighlight %}
+
 ## Kubernetes concepts
 
 ### Namespaces

--- a/docs/ops/deployment/native_kubernetes.zh.md
+++ b/docs/ops/deployment/native_kubernetes.zh.md
@@ -148,6 +148,32 @@ appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m
 
 If the pod is running, you can use `kubectl exec -it <PodName> bash` to tunnel in and view the logs or debug the process. 
 
+## Using plugins
+
+As described in the [plugins]({{ site.baseurl }}/zh/ops/plugins.html) documentation page: in order to use plugins they must be
+copied to the correct location in the flink installation for them to work.
+
+The simplest way to enable plugins for use on Kubernetes is to modify the provided official Flink docker images by adding
+an additional layer. This does however assume you have a docker registry available where you can push images to and
+that is accessible by your Kubernetes cluster.
+
+How this can be done is described on the [Docker Setup]({{ site.baseurl }}/zh/ops/deployment/docker.html#using-plugins) page.
+
+With such an image created you can now start your Kubernetes based Flink session cluster with the additional parameter
+`kubernetes.container.image` which must specify the image that was created: `docker.example.nl/flink:{{ site.version }}-2.12-s3`
+
+Extending the above example command to start the session cluster makes it this:
+
+{% highlight bash %}
+./bin/kubernetes-session.sh \
+  -Dkubernetes.cluster-id=<ClusterId> \
+  -Dtaskmanager.memory.process.size=4096m \
+  -Dkubernetes.taskmanager.cpu=2 \
+  -Dtaskmanager.numberOfTaskSlots=4 \
+  -Dresourcemanager.taskmanager-timeout=3600000 \
+  -Dkubernetes.container.image=docker.example.nl/flink:{{ site.version }}-2.12-s3
+{% endhighlight %}
+
 ## Kubernetes concepts
 
 ### Namespaces

--- a/docs/ops/plugins.md
+++ b/docs/ops/plugins.md
@@ -70,7 +70,7 @@ possible across Flink core, plugins, and user code.
 
 ## File Systems
 
-All [file systems](filesystems/index) **except MapR** are pluggable. That means they can and should
+All [file systems](filesystems) **except MapR** are pluggable. That means they can and should
 be used as plugins. To use a pluggable file system, copy the corresponding JAR file from the `opt`
 directory to a directory under `plugins` directory of your Flink distribution before starting Flink,
 e.g.

--- a/docs/ops/plugins.zh.md
+++ b/docs/ops/plugins.zh.md
@@ -70,7 +70,7 @@ possible across Flink core, plugins, and user code.
 
 ## File Systems
 
-All [file systems](filesystems/index) **except MapR** are pluggable. That means they can and should
+All [file systems](filesystems) **except MapR** are pluggable. That means they can and should
 be used as plugins. To use a pluggable file system, copy the corresponding JAR file from the `opt`
 directory to a directory under `plugins` directory of your Flink distribution before starting Flink,
 e.g.


### PR DESCRIPTION
## What is the purpose of the change

* Document enabling plugins like S3 when running Flink natively on Kubernetes*

## Brief change log

* Only documentation*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
