### PR TITLE
[FLINK-16133] [docs] /ops/filesystems/azure.zh.md

### DIFF
--- a/docs/ops/filesystems/azure.md
+++ b/docs/ops/filesystems/azure.md
@@ -53,7 +53,7 @@ env.setStateBackend(new FsStateBackend("wasb://<your-container>@$<your-azure-acc
 
 ### Shaded Hadoop Azure Blob Storage file system
 
-To use `flink-azure-fs-hadoop,` copy the respective JAR file from the `opt` directory to the `plugins` directory of your Flink distribution before starting Flink, e.g.
+To use `flink-azure-fs-hadoop`, copy the respective JAR file from the `opt` directory to the `plugins` directory of your Flink distribution before starting Flink, e.g.
 
 {% highlight bash %}
 mkdir ./plugins/azure-fs-hadoop
@@ -74,7 +74,7 @@ in `flink-conf.yaml` via:
 fs.azure.account.key.<account_name>.blob.core.windows.net: <azure_storage_key>
 {% endhighlight %}
 
-Alternatively, the the filesystem can be configured to read the Azure Blob Storage key from an 
+Alternatively, the filesystem can be configured to read the Azure Blob Storage key from an 
 environment variable `AZURE_STORAGE_KEY` by setting the following configuration keys in 
 `flink-conf.yaml`.  
 

--- a/docs/ops/filesystems/azure.zh.md
+++ b/docs/ops/filesystems/azure.zh.md
@@ -1,6 +1,6 @@
 ---
 title: "Azure Blob 存储"
-nav-title: Azure Blob Storage
+nav-title: Azure Blob 存储
 nav-parent_id: filesystems
 nav-pos: 3
 ---

--- a/docs/ops/filesystems/azure.zh.md
+++ b/docs/ops/filesystems/azure.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure Blob Storage"
+title: "Azure Blob 存储"
 nav-title: Azure Blob Storage
 nav-parent_id: filesystems
 nav-pos: 3
@@ -23,60 +23,54 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-[Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/) is a Microsoft-managed service providing cloud storage for a variety of use cases.
-You can use Azure Blob Storage with Flink for **reading** and **writing data** as well in conjunction with the [streaming **state backends**]({{ site.baseurl }}/ops/state/state_backends.html)  
+[Azure Blob 存储](https://docs.microsoft.com/en-us/azure/storage/) 是一项由 Microsoft 管理的服务，能提供多种应用场景下的云存储。
+Azure Blob 存储可与 Flink 一起使用以**读取**和**写入数据**，以及与[流 State Backend]({{ site.baseurl }}/zh/ops/state/state_backends.html) 结合使用。
 
 * This will be replaced by the TOC
 {:toc}
 
-You can use Azure Blob Storage objects like regular files by specifying paths in the following format:
+通过以下格式指定路径，Azure Blob 存储对象可类似于普通文件使用：
 
 {% highlight plain %}
 wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>
 
-// SSL encrypted access
+// SSL 加密访问
 wasbs://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>
 {% endhighlight %}
 
-See below for how to use Azure Blob Storage in a Flink job:
+参见以下代码了解如何在 Flink 作业中使用 Azure Blob 存储：
 
 {% highlight java %}
-// Read from Azure Blob storage
+// 读取 Azure Blob 存储
 env.readTextFile("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>");
 
-// Write to Azure Blob storage
+// 写入 Azure Blob 存储
 stream.writeAsText("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>")
 
-// Use Azure Blob Storage as FsStatebackend
+// 将 Azure Blob 存储用作 FsStatebackend
 env.setStateBackend(new FsStateBackend("wasb://<your-container>@$<your-azure-account>.blob.core.windows.net/<object-path>"));
 {% endhighlight %}
 
-### Shaded Hadoop Azure Blob Storage file system
+### Shaded Hadoop Azure Blob 存储文件系统
 
-To use `flink-azure-fs-hadoop,` copy the respective JAR file from the `opt` directory to the `plugins` directory of your Flink distribution before starting Flink, e.g.
+为使用 flink-azure-fs-hadoop，在启动 Flink 之前，将对应的 JAR 文件从 opt 目录复制到 Flink 发行版中的 plugin 目录下的一个文件夹中，例如：
 
 {% highlight bash %}
 mkdir ./plugins/azure-fs-hadoop
 cp ./opt/flink-azure-fs-hadoop-{{ site.version }}.jar ./plugins/azure-fs-hadoop/
 {% endhighlight %}
 
-`flink-azure-fs-hadoop` registers default FileSystem wrappers for URIs with the *wasb://* and *wasbs://* (SSL encrypted access) scheme.
+`flink-azure-fs-hadoop` 为使用 *wasb://* 和 *wasbs://* (SSL 加密访问) 的 URI 注册了默认的文件系统包装器。
 
-### Credentials Configuration
-
-Hadoop's Azure Filesystem supports configuration of credentials via the Hadoop configuration as
-outlined in the [Hadoop Azure Blob Storage documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials).
-For convenience Flink forwards all Flink configurations with a key prefix of `fs.azure` to the
-Hadoop configuration of the filesystem. Consequentially, the azure blob storage key can be configured
-in `flink-conf.yaml` via:
+### 凭据配置
+Hadoop 的 Azure 文件系统支持通过 Hadoop 配置来配置凭据，如 [Hadoop Azure Blob Storage documentation](https://hadoop.apache.org/docs/current/hadoop-azure/index.html#Configuring_Credentials) 所述。
+为方便起见，Flink 将所有的 Flink 配置添加 `fs.azure` 键前缀后转发至文件系统的 Hadoop 配置中。因此，可通过以下方法在 `flink-conf.yaml` 中配置 Azure Blob 存储密钥：
 
 {% highlight yaml %}
 fs.azure.account.key.<account_name>.blob.core.windows.net: <azure_storage_key>
 {% endhighlight %}
 
-Alternatively, the the filesystem can be configured to read the Azure Blob Storage key from an
-environment variable `AZURE_STORAGE_KEY` by setting the following configuration keys in
-`flink-conf.yaml`.
+或者通过在 `flink-conf.yaml` 中设置以下配置键，将文件系统配置为从环境变量 `AZURE_STORAGE_KEY` 读取 Azure Blob 存储密钥：
 
 {% highlight yaml %}
 fs.azure.account.keyprovider.<account_name>.blob.core.windows.net: org.apache.flink.fs.azurefs.EnvironmentVariableKeyProvider


### PR DESCRIPTION
## What is the purpose of the change

This pull request translates /ops/filesystems/azure.zh.md into Chinese, and fixes a typo in the original English documentation.


## Brief change log

 - Translate /ops/filesystems/azure.zh.md into Chinese
 - Fix a typo in /ops/filesystems/azure.md


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
