### PR TITLE
[FLINK-15980] fix that the notFollowedBy in the end of GroupPattern may be ignored

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -245,15 +245,18 @@ public class NFACompiler {
 			List<Tuple2<IterativeCondition<T>, String>> notConditions = new ArrayList<>();
 
 			Pattern<T, ? extends T> previousPattern = currentPattern;
-			while (previousPattern.getPrevious() != null && (
-				previousPattern.getPrevious().getQuantifier().hasProperty(Quantifier.QuantifierProperty.OPTIONAL) ||
-				previousPattern.getPrevious().getQuantifier().getConsumingStrategy() == Quantifier.ConsumingStrategy.NOT_FOLLOW)) {
-
-				previousPattern = previousPattern.getPrevious();
+			while (previousPattern.getPrevious() != null) {
+				if (previousPattern.getPrevious() instanceof GroupPattern) {
+					previousPattern = ((GroupPattern) previousPattern.getPrevious()).getRawPattern();
+				} else {
+					previousPattern = previousPattern.getPrevious();
+				}
 
 				if (previousPattern.getQuantifier().getConsumingStrategy() == Quantifier.ConsumingStrategy.NOT_FOLLOW) {
 					final IterativeCondition<T> notCondition = getTakeCondition(previousPattern);
 					notConditions.add(Tuple2.of(notCondition, previousPattern.getName()));
+				} else if (!previousPattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.OPTIONAL)) {
+					break;
 				}
 			}
 			return notConditions;


### PR DESCRIPTION


## What is the purpose of the change

*This pull request fix that the notFollowedBy in the end of GroupPattern will be ignored when compiling.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test in NotPatternITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
