### PR TITLE
[FLINK-13934][rest] Throw RestHandlerException instead of sending inline response

### DIFF
--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerStaticFileServerHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.webmonitor.history;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.rest.handler.router.Router;
 import org.apache.flink.runtime.webmonitor.utils.WebFrontendBootstrap;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.core.Is.is;
 
 /**
  * Tests for the HistoryServerStaticFileServerHandler.
@@ -57,28 +59,32 @@ public class HistoryServerStaticFileServerHandlerTest {
 		int port = webUI.getServerPort();
 		try {
 			// verify that 404 message is returned when requesting a non-existent file
-			String notFound404 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/hello");
-			Assert.assertThat(notFound404, containsString("not found"));
+			Tuple2<Integer, String> notFound404 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/hello");
+			Assert.assertThat(notFound404.f0, is(404));
+			Assert.assertThat(notFound404.f1, containsString("not found"));
 
 			// verify that a) a file can be loaded using the ClassLoader and b) that the HistoryServer
 			// index_hs.html is injected
-			String index = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/index.html");
-			Assert.assertThat(index, containsString("Apache Flink Web Dashboard"));
+			Tuple2<Integer, String> index = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/index.html");
+			Assert.assertThat(index.f0, is(200));
+			Assert.assertThat(index.f1, containsString("Apache Flink Web Dashboard"));
 
 			// verify that index.html is appended if the request path ends on '/'
-			String index2 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/");
+			Tuple2<Integer, String> index2 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/");
 			Assert.assertEquals(index, index2);
 
-			// verify that a 404 message is returned when requesting a directory
+			// verify that a 405 message is returned when requesting a directory
 			File dir = new File(webDir, "dir.json");
 			dir.mkdirs();
-			String dirNotFound404 = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/dir");
-			Assert.assertThat(dirNotFound404, containsString("not found"));
+			Tuple2<Integer, String> dirNotFound = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/dir");
+			Assert.assertThat(dirNotFound.f0, is(405));
+			Assert.assertThat(dirNotFound.f1, containsString("not found"));
 
-			// verify that a 404 message is returned when requesting a file outside the webDir
+			// verify that a 403 message is returned when requesting a file outside the webDir
 			tmp.newFile("secret");
-			String x = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/../secret");
-			Assert.assertThat(x, containsString("not found"));
+			Tuple2<Integer, String> dirOutsideDirectory = HistoryServerTest.getFromHTTP("http://localhost:" + port + "/../secret");
+			Assert.assertThat(dirOutsideDirectory.f0, is(403));
+			Assert.assertThat(dirOutsideDirectory.f1, containsString("Forbidden"));
 		} finally {
 			webUI.shutdown();
 		}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/history/HistoryServerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor.history;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HistoryServerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -244,14 +245,14 @@ public class HistoryServerTest extends TestLogger {
 	}
 
 	private static DashboardConfiguration getDashboardConfiguration(String baseUrl) throws Exception {
-		String response = getFromHTTP(baseUrl + DashboardConfigurationHeaders.INSTANCE.getTargetRestEndpointURL());
-		return OBJECT_MAPPER.readValue(response, DashboardConfiguration.class);
+		Tuple2<Integer, String> response = getFromHTTP(baseUrl + DashboardConfigurationHeaders.INSTANCE.getTargetRestEndpointURL());
+		return OBJECT_MAPPER.readValue(response.f1, DashboardConfiguration.class);
 
 	}
 
 	private static MultipleJobsDetails getJobsOverview(String baseUrl) throws Exception {
-		String response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);
-		return OBJECT_MAPPER.readValue(response, MultipleJobsDetails.class);
+		Tuple2<Integer, String> response = getFromHTTP(baseUrl + JobsOverviewHeaders.URL);
+		return OBJECT_MAPPER.readValue(response.f1, MultipleJobsDetails.class);
 	}
 
 	private static void runJob() throws Exception {
@@ -261,7 +262,7 @@ public class HistoryServerTest extends TestLogger {
 		env.execute();
 	}
 
-	static String getFromHTTP(String url) throws Exception {
+	static Tuple2<Integer, String> getFromHTTP(String url) throws Exception {
 		URL u = new URL(url);
 		HttpURLConnection connection = (HttpURLConnection) u.openConnection();
 		connection.setConnectTimeout(100000);
@@ -274,7 +275,7 @@ public class HistoryServerTest extends TestLogger {
 			is = connection.getInputStream();
 		}
 
-		return IOUtils.toString(is, connection.getContentEncoding() != null ? connection.getContentEncoding() : "UTF-8");
+		return Tuple2.of(connection.getResponseCode(), IOUtils.toString(is, connection.getContentEncoding() != null ? connection.getContentEncoding() : "UTF-8"));
 	}
 
 	private static String createLegacyArchive(Path directory) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/files/StaticFileServerHandler.java
@@ -27,7 +27,9 @@ package org.apache.flink.runtime.rest.handler.legacy.files;
  *****************************************************************************/
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.rest.NotFoundException;
 import org.apache.flink.runtime.rest.handler.LeaderRetrievalHandler;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.router.RoutedRequest;
 import org.apache.flink.runtime.rest.handler.util.HandlerUtils;
 import org.apache.flink.runtime.rest.handler.util.MimeTypes;
@@ -47,7 +49,6 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpChunkedInp
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.LastHttpContent;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedFile;
@@ -70,7 +71,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
-import java.util.Map;
 import java.util.TimeZone;
 
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders.Names.CACHE_CONTROL;
@@ -143,14 +143,23 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 			requestPath = routedRequest.getPath();
 		}
 
-		respondToRequest(channelHandlerContext, request, requestPath);
+		try {
+			respondToRequest(channelHandlerContext, request, requestPath);
+		} catch (RestHandlerException rhe) {
+			HandlerUtils.sendErrorResponse(
+				channelHandlerContext,
+				routedRequest.getRequest(),
+				new ErrorResponseBody(rhe.getMessage()),
+				rhe.getHttpResponseStatus(),
+				responseHeaders);
+		}
 	}
 
 	/**
 	 * Response when running with leading JobManager.
 	 */
 	private void respondToRequest(ChannelHandlerContext ctx, HttpRequest request, String requestPath)
-			throws IOException, ParseException, URISyntaxException {
+			throws IOException, ParseException, URISyntaxException, RestHandlerException {
 
 		// convert to absolute path
 		final File file = new File(rootPath, requestPath);
@@ -187,19 +196,13 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 				} finally {
 					if (!success) {
 						logger.debug("Unable to load requested file {} from classloader", requestPath);
-						HandlerUtils.sendErrorResponse(
-							ctx,
-							request,
-							new ErrorResponseBody(String.format("Unable to load requested file %s.", requestPath)),
-							NOT_FOUND,
-							responseHeaders);
-						return;
+						throw new NotFoundException(String.format("Unable to load requested file %s.", requestPath));
 					}
 				}
 			}
 		}
 
-		checkFileValidity(file, rootPath, ctx, request, responseHeaders, logger);
+		checkFileValidity(file, rootPath, logger);
 
 		// cache validation
 		final String ifModifiedSince = request.headers().get(IF_MODIFIED_SINCE);
@@ -234,13 +237,7 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 			if (logger.isDebugEnabled()) {
 				logger.debug("Could not find file {}.", file.getAbsolutePath());
 			}
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("File not found."),
-				HttpResponseStatus.NOT_FOUND,
-				responseHeaders);
-			return;
+			throw new NotFoundException("File not found.");
 		}
 
 		try {
@@ -279,12 +276,7 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 		} catch (Exception e) {
 			raf.close();
 			logger.error("Failed to serve file.", e);
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("Internal server error."),
-				INTERNAL_SERVER_ERROR,
-				responseHeaders);
+			throw new RestHandlerException("Internal server error.", INTERNAL_SERVER_ERROR);
 		}
 	}
 
@@ -365,45 +357,33 @@ public class StaticFileServerHandler<T extends RestfulGateway> extends LeaderRet
 		response.headers().set(CONTENT_TYPE, mimeFinal);
 	}
 
-	public static void checkFileValidity(File file, File rootPath, ChannelHandlerContext ctx, HttpRequest request, Map<String, String> responseHeaders, Logger logger) throws IOException {
+	/**
+	 * Checks various conditions for file access.
+	 * If all checks pass this method returns, and processing of the request may continue.
+	 * If any check fails this method throws a {@link RestHandlerException}, and further processing of the request
+	 * must be limited to sending an error response.
+	 */
+	public static void checkFileValidity(File file, File rootPath, Logger logger) throws IOException, RestHandlerException {
 		// this check must be done first to prevent probing for arbitrary files
 		if (!file.getCanonicalFile().toPath().startsWith(rootPath.toPath())) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Requested path {} points outside the root directory.", file.getAbsolutePath());
 			}
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("Forbidden."),
-				FORBIDDEN,
-				responseHeaders);
-			return;
+			throw new RestHandlerException("Forbidden.", FORBIDDEN);
 		}
 
 		if (!file.exists() || file.isHidden()) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Requested path {} cannot be found.", file.getAbsolutePath());
 			}
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("File not found."),
-				NOT_FOUND,
-				responseHeaders);
-			return;
+			throw new RestHandlerException("File not found.", NOT_FOUND);
 		}
 
 		if (file.isDirectory() || !file.isFile()) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Requested path {} does not point to a file.", file.getAbsolutePath());
 			}
-			HandlerUtils.sendErrorResponse(
-				ctx,
-				request,
-				new ErrorResponseBody("File not found."),
-				METHOD_NOT_ALLOWED,
-				responseHeaders);
-			return;
+			throw new RestHandlerException("File not found.", METHOD_NOT_ALLOWED);
 		}
 	}
 }


### PR DESCRIPTION
The `StaticFileServerHandlers` so far used a different approach to error-handling as other REST handlers, as they were sending response directly (and returning afterwards), instead of throwing a `RestHandlerException` that is processed higher up the stack.
This approach is both more noisy and increases the risk of introducing bugs during refactorings, since you cannot just take a block of error handling code and move it into a separate method, since you're then missing the return.

This exact problem has occurred when I introduced the `checkFileValidity()` method. Currently the handlers continue processing even if one check failed, leading to inconsistent responses.

This PR adjusts the error handling in these handlers accordingly, and adjust the `HistoryServerStaticFileServerHandlerTest` to check for the correct error messages, and strenghtens the assertions by also verifying the response codes.
