### PR TITLE
[FLINK-15563] [table-planner] add FlinkCalcMergeRule to fix the optimization hangs until OOM

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
@@ -28,8 +28,11 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.utils.ParquetSchemaConverter;
 import org.apache.flink.formats.parquet.utils.TestUtil;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.expressions.EqualTo;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.GetCompositeField;
@@ -38,6 +41,8 @@ import org.apache.flink.table.expressions.ItemAt;
 import org.apache.flink.table.expressions.Literal;
 import org.apache.flink.table.expressions.PlannerResolvedFieldReference;
 import org.apache.flink.types.Row;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonMappingException;
 
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.parquet.avro.AvroSchemaConverter;
@@ -53,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.api.common.typeinfo.Types.STRING;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -60,6 +66,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test cases for {@link ParquetTableSource}.
@@ -214,6 +221,41 @@ public class ParquetTableSourceTest extends TestUtil {
 		FilterPredicate predicate = parquetIF.getPredicate();
 		// check predicate
 		assertEquals(expected, predicate);
+	}
+
+	@Test
+	public void testPushProjectAndFilter() {
+		// test for https://issues.apache.org/jira/browse/FLINK-15563
+
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env);
+
+		RowTypeInfo typeInfo = new RowTypeInfo(
+			new TypeInformation<?>[] { STRING, STRING, STRING },
+			new String[] { "log_id", "city", "log_from" });
+
+		ParquetTableSource tableSource = ParquetTableSource
+			.builder()
+			.forParquetSchema(ParquetSchemaConverter.toParquetType(typeInfo, false))
+			.path("/tmp/login_data")
+			.build();
+
+		tableEnv.registerTableSource("MyTable", tableSource);
+
+		Table t1 = tableEnv.sqlQuery("select log_id, city from MyTable where city = '274' ");
+		tableEnv.registerTable("t1", t1);
+
+		Table t2 = tableEnv.sqlQuery("select * from t1 where log_id='5927070661978133'");
+		try {
+			tableEnv.explain(t2);
+		} catch (Exception e) {
+			if (e instanceof JsonMappingException) {
+				// TODO remove this after fix the bug in PlanJsonParser
+				// the program can reach here to prove that the optimization does not hang until OOM
+			} else {
+				fail(e.getMessage());
+			}
+		}
 	}
 
 	private static Path createTestParquetFile() throws Exception {

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetTableSourceTest.java
@@ -250,7 +250,7 @@ public class ParquetTableSourceTest extends TestUtil {
 			tableEnv.explain(t2);
 		} catch (Exception e) {
 			if (e instanceof JsonMappingException) {
-				// TODO remove this after fix the bug in PlanJsonParser
+				// TODO remove this after https://issues.apache.org/jira/browse/FLINK-16315 is fixed
 				// the program can reach here to prove that the optimization does not hang until OOM
 			} else {
 				fail(e.getMessage());

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -114,7 +114,8 @@ object FlinkRuleSets {
     ProjectCalcMergeRule.INSTANCE,
     FilterToCalcRule.INSTANCE,
     ProjectToCalcRule.INSTANCE,
-    CalcMergeRule.INSTANCE,
+    FlinkCalcMergeRule.INSTANCE,
+//    CalcMergeRule.INSTANCE,
 
     // scan optimization
     PushProjectIntoTableSourceScanRule.INSTANCE,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/FlinkCalcMergeRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/FlinkCalcMergeRule.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.logical
+
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
+import org.apache.calcite.rel.core.{Calc, RelFactories}
+import org.apache.calcite.rex.{RexOver, RexProgramBuilder, RexUtil}
+import org.apache.calcite.tools.RelBuilderFactory
+
+import scala.collection.JavaConversions._
+
+/**
+  * This rule is copied from Calcite's [[org.apache.calcite.rel.rules.CalcMergeRule]].
+  *
+  * Modification:
+  * - Condition in the merged program will be simplified if it exists.
+  * - Don't merge calcs which contain non-deterministic expr
+  */
+
+/**
+  * Planner rule that merges a [[Calc]] onto a [[Calc]].
+  *
+  * <p>The resulting [[Calc]] has the same project list as the upper [[Calc]],
+  * but expressed in terms of the lower [[Calc]]'s inputs.
+  */
+class FlinkCalcMergeRule(relBuilderFactory: RelBuilderFactory) extends RelOptRule(
+  operand(classOf[Calc],
+    operand(classOf[Calc], any)),
+  relBuilderFactory,
+  "FlinkCalcMergeRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val topCalc: Calc = call.rel(0)
+    val bottomCalc: Calc = call.rel(1)
+
+    // Don't merge a calc which contains windowed aggregates onto a
+    // calc. That would effectively be pushing a windowed aggregate down
+    // through a filter.
+    val topProgram = topCalc.getProgram
+    if (RexOver.containsOver(topProgram)) {
+      return false
+    }
+
+    // Don't merge Calcs which contain non-deterministic expr
+    topProgram.getExprList.forall(RexUtil.isDeterministic) &&
+      bottomCalc.getProgram.getExprList.forall(RexUtil.isDeterministic)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val topCalc: Calc = call.rel(0)
+    val bottomCalc: Calc = call.rel(1)
+
+    val topProgram = topCalc.getProgram
+    val rexBuilder = topCalc.getCluster.getRexBuilder
+    // Merge the programs together.
+    val mergedProgram = RexProgramBuilder.mergePrograms(
+      topCalc.getProgram, bottomCalc.getProgram, rexBuilder)
+    require(mergedProgram.getOutputRowType eq topProgram.getOutputRowType)
+
+    val newMergedProgram = if (mergedProgram.getCondition != null) {
+      val condition = mergedProgram.expandLocalRef(mergedProgram.getCondition)
+      val simplifiedCondition = RexUtil.simplify(rexBuilder, condition)
+      if (simplifiedCondition.toString == condition.toString) {
+        mergedProgram
+      } else {
+        val programBuilder = RexProgramBuilder.forProgram(mergedProgram, rexBuilder, true)
+        programBuilder.clearCondition()
+        programBuilder.addCondition(simplifiedCondition)
+        programBuilder.getProgram(true)
+      }
+    } else {
+      mergedProgram
+    }
+
+    val newCalc = topCalc.copy(topCalc.getTraitSet, bottomCalc.getInput, newMergedProgram)
+    if (newCalc.getDigest == bottomCalc.getDigest) {
+      // newCalc is equivalent to bottomCalc,
+      // which means that topCalc
+      // must be trivial. Take it out of the game.
+      call.getPlanner.setImportance(topCalc, 0.0)
+    }
+    call.transformTo(newCalc)
+  }
+
+}
+
+object FlinkCalcMergeRule {
+  val INSTANCE = new FlinkCalcMergeRule(RelFactories.LOGICAL_BUILDER)
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/FlinkCalcMergeRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/FlinkCalcMergeRuleTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.PlannerConfig
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.calcite.CalciteConfigBuilder
+import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.plan.nodes.logical.{FlinkLogicalCalc, FlinkLogicalTableSourceScan}
+import org.apache.flink.table.plan.rules.logical.FlinkCalcMergeRule
+import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.table.utils.TableTestUtil.{streamTableNode, term, unaryNode}
+
+import org.apache.calcite.rel.rules.{FilterToCalcRule, ProjectToCalcRule}
+import org.apache.calcite.tools.RuleSets
+import org.junit.Test
+
+import java.util.Random
+
+class FlinkCalcMergeRuleTest extends TableTestBase {
+
+  private val util = streamTestUtil()
+  private val table = util.addTable[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+
+  // rewrite distinct aggregate
+  val cc: PlannerConfig = new CalciteConfigBuilder()
+    .replaceNormRuleSet(RuleSets.ofList())
+    .replaceLogicalOptRuleSet(RuleSets.ofList(
+      FilterToCalcRule.INSTANCE,
+      ProjectToCalcRule.INSTANCE,
+      FlinkCalcMergeRule.INSTANCE,
+      FlinkLogicalCalc.CONVERTER,
+      FlinkLogicalTableSourceScan.CONVERTER
+    ))
+    .build()
+  util.tableEnv.getConfig.setPlannerConfig(cc)
+
+  @Test
+  def testCalcMergeWithNonDeterministicExpr1(): Unit = {
+    util.addFunction("random_udf", new NonDeterministicUdf)
+    val sqlQuery = "SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10"
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(table),
+        term("select", "a", "random_udf(a) AS a1")
+      ),
+      term("select", "a", "a1"),
+      term("where", ">(a1, 10)")
+    )
+
+    util.verifySql(sqlQuery, expected)
+  }
+
+  @Test
+  def testCalcMergeWithNonDeterministicExpr2(): Unit = {
+    util.addFunction("random_udf", new NonDeterministicUdf)
+    val sqlQuery = "SELECT a FROM (SELECT a FROM MyTable) t WHERE random_udf(a) > 10"
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamCalc",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a")
+        ),
+        term("select", "a"),
+        term("where", ">(random_udf(a), 10)")
+      ),
+      term("select", "a")
+    )
+
+    util.verifySql(sqlQuery, expected)
+  }
+}
+
+/**
+  * Non-deterministic scalar function.
+  */
+class NonDeterministicUdf extends ScalarFunction {
+  private val random = new Random
+
+  def eval: Int = random.nextInt
+
+  def eval(v: Int): Int = v + random.nextInt
+
+  override def isDeterministic = false
+}


### PR DESCRIPTION
## What is the purpose of the change

*add FlinkCalcMergeRule to fix the optimization hangs until OOM when using ParquetTableSource.*


## Brief change log

  - *copy FlinkCalcMergeRule from blink planner to old planner*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added FlinkCalcMergeRuleTest to verify the plan*
  - *Extended ParquetTableSourceTest to reproduce the bug
mentioned in https://issues.apache.org/jira/browse/FLINK-15563. (Can't reproduce the bug in old planner module, so add this case in flink-parquet module)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
