### PR TITLE
[FLINK-16190][e2e] Migrate tests to FlinkResource

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -23,7 +23,8 @@ import org.apache.flink.tests.util.categories.Hadoop;
 import org.apache.flink.tests.util.categories.TravisGroup1;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
-import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResource;
+import org.apache.flink.tests.util.flink.FlinkResourceSetup;
+import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResourceFactory;
 import org.apache.flink.tests.util.flink.SQLJobSubmission;
 import org.apache.flink.testutils.junit.FailsOnJava11;
 import org.apache.flink.util.FileUtils;
@@ -76,7 +77,9 @@ public class SQLClientKafkaITCase extends TestLogger {
 	}
 
 	@Rule
-	public final FlinkResource flink = new LocalStandaloneFlinkResource();
+	public final FlinkResource flink = new LocalStandaloneFlinkResourceFactory()
+		.create(FlinkResourceSetup.builder().build())
+		.get();
 
 	@Rule
 	public final KafkaResource kafka;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkDistribution.java
@@ -16,16 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.tests.util;
+package org.apache.flink.tests.util.flink;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
-import org.apache.flink.tests.util.flink.JarLocation;
-import org.apache.flink.tests.util.flink.JarMove;
-import org.apache.flink.tests.util.flink.JobSubmission;
-import org.apache.flink.tests.util.flink.SQLJobSubmission;
+import org.apache.flink.tests.util.AutoClosableProcess;
+import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExternalResource;
 
@@ -67,7 +65,7 @@ import java.util.stream.Stream;
 /**
  * A wrapper around a Flink distribution.
  */
-public final class FlinkDistribution implements ExternalResource {
+final class FlinkDistribution implements ExternalResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(FlinkDistribution.class);
 
@@ -86,7 +84,7 @@ public final class FlinkDistribution implements ExternalResource {
 
 	private Configuration defaultConfig;
 
-	public FlinkDistribution() {
+	FlinkDistribution() {
 		final String distDirProperty = System.getProperty("distDir");
 		if (distDirProperty == null) {
 			Assert.fail("The distDir property was not set. You can set it when running maven via -DdistDir=<path> .");

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResource.java
@@ -18,25 +18,19 @@
 
 package org.apache.flink.tests.util.flink;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.tests.util.util.FactoryUtils;
 import org.apache.flink.util.ExternalResource;
 
 import java.io.IOException;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 /**
  * Generic interface for interacting with Flink.
  */
 public interface FlinkResource extends ExternalResource {
-
-	/**
-	 * Adds the given configuration to the existing configuration of this resource. Entries in the existing configuration
-	 * will be overwritten.
-	 *
-	 * @param config config to add
-	 * @throws IOException
-	 */
-	void addConfiguration(Configuration config) throws IOException;
 
 	/**
 	 * Starts a cluster.
@@ -53,14 +47,34 @@ public interface FlinkResource extends ExternalResource {
 	ClusterController startCluster(int numTaskManagers) throws IOException;
 
 	/**
+	 * Searches the logs of all processes for the given pattern, and applies the given processor for every line for
+	 * which {@link Matcher#matches()} returned true.
+	 *
+	 * @param pattern pattern to search for
+	 * @param matchProcessor match processor
+	 * @return stream of matched strings
+	 */
+	Stream<String> searchAllLogs(Pattern pattern, Function<Matcher, String> matchProcessor) throws IOException;
+
+	/**
 	 * Returns the configured FlinkResource implementation, or a {@link LocalStandaloneFlinkResource} if none is configured.
 	 *
 	 * @return configured FlinkResource, or {@link LocalStandaloneFlinkResource} is none is configured
 	 */
 	static FlinkResource get() {
+		return get(FlinkResourceSetup.builder().build());
+	}
+
+	/**
+	 * Returns the configured FlinkResource implementation, or a {@link LocalStandaloneFlinkResource} if none is configured.
+	 *
+	 * @param setup setup instructions for the FlinkResource
+	 * @return configured FlinkResource, or {@link LocalStandaloneFlinkResource} is none is configured
+	 */
+	static FlinkResource get(FlinkResourceSetup setup) {
 		return FactoryUtils.loadAndInvokeFactory(
 			FlinkResourceFactory.class,
-			FlinkResourceFactory::create,
+			factory -> factory.create(setup),
 			LocalStandaloneFlinkResourceFactory::new);
 	}
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceFactory.java
@@ -30,7 +30,8 @@ public interface FlinkResourceFactory {
 	 * Returns a {@link FlinkResource} instance. If the instance could not be instantiated (for example, because a
 	 * mandatory parameter was missing), then an empty {@link Optional} should be returned.
 	 *
+	 * @param setup setup instructions for the FlinkResource
 	 * @return FlinkResource instance, or an empty Optional if the instance could not be instantiated
 	 */
-	Optional<FlinkResource> create();
+	Optional<FlinkResource> create(FlinkResourceSetup setup);
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceSetup.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/FlinkResourceSetup.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Setup instructions for a {@link FlinkResource}.
+ */
+public class FlinkResourceSetup {
+
+	@Nullable
+	private final Configuration config;
+	private final Collection<JarMove> jarMoveOperations;
+
+	private FlinkResourceSetup(@Nullable Configuration config, Collection<JarMove> jarMoveOperations) {
+		this.config = config;
+		this.jarMoveOperations = Preconditions.checkNotNull(jarMoveOperations);
+	}
+
+	public Optional<Configuration> getConfig() {
+		return Optional.ofNullable(config);
+	}
+
+	public Collection<JarMove> getJarMoveOperations() {
+		return jarMoveOperations;
+	}
+
+	public static FlinkResourceSetupBuilder builder() {
+		return new FlinkResourceSetupBuilder();
+	}
+
+	/**
+	 * Builder for {@link FlinkResourceSetup}.
+	 */
+	public static class FlinkResourceSetupBuilder {
+
+		private Configuration config;
+		private final Collection<JarMove> jarMoveOperations = new ArrayList<>();
+
+		private FlinkResourceSetupBuilder() {
+		}
+
+		public FlinkResourceSetupBuilder addConfiguration(Configuration config) {
+			this.config = config;
+			return this;
+		}
+
+		public FlinkResourceSetupBuilder moveJar(String jarNamePrefix, JarLocation source, JarLocation target) {
+			this.jarMoveOperations.add(new JarMove(jarNamePrefix, source, target));
+			return this;
+		}
+
+		public FlinkResourceSetup build() {
+			return new FlinkResourceSetup(config, Collections.unmodifiableCollection(jarMoveOperations));
+		}
+	}
+
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarLocation.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarLocation.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+/**
+ * Enum for specifying jar locations.
+ */
+public enum JarLocation {
+	LIB,
+	OPT,
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarMove.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarMove.java
@@ -20,7 +20,7 @@ package org.apache.flink.tests.util.flink;
 /**
  * Represents a move operation for a jar.
  */
-public class JarMove {
+class JarMove {
 
 	private final String jarNamePrefix;
 	private final JarLocation source;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarMove.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/JarMove.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.flink;
+
+/**
+ * Represents a move operation for a jar.
+ */
+public class JarMove {
+
+	private final String jarNamePrefix;
+	private final JarLocation source;
+	private final JarLocation target;
+
+	JarMove(String jarNamePrefix, JarLocation source, JarLocation target) {
+		this.jarNamePrefix = jarNamePrefix;
+		this.source = source;
+		this.target = target;
+	}
+
+	public String getJarNamePrefix() {
+		return jarNamePrefix;
+	}
+
+	public JarLocation getSource() {
+		return source;
+	}
+
+	public JarLocation getTarget() {
+		return target;
+	}
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
-import org.apache.flink.tests.util.FlinkDistribution;
 import org.apache.flink.util.ConfigurationException;
 
 import org.slf4j.Logger;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
@@ -30,8 +30,8 @@ public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceF
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneFlinkResourceFactory.class);
 
 	@Override
-	public Optional<FlinkResource> create() {
+	public Optional<FlinkResource> create(FlinkResourceSetup setup) {
 		LOG.info("Created {}.", LocalStandaloneFlinkResource.class.getSimpleName());
-		return Optional.of(new LocalStandaloneFlinkResource());
+		return Optional.of(new LocalStandaloneFlinkResource(setup));
 	}
 }

--- a/flink-end-to-end-tests/flink-metrics-availability-test/src/test/java/org/pache/flink/metrics/tests/MetricsAvailabilityITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-availability-test/src/test/java/org/pache/flink/metrics/tests/MetricsAvailabilityITCase.java
@@ -36,8 +36,11 @@ import org.apache.flink.runtime.rest.messages.job.metrics.TaskManagerMetricsMess
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
-import org.apache.flink.tests.util.FlinkDistribution;
 import org.apache.flink.tests.util.categories.TravisGroup1;
+import org.apache.flink.tests.util.flink.ClusterController;
+import org.apache.flink.tests.util.flink.FlinkResource;
+import org.apache.flink.tests.util.flink.FlinkResourceSetup;
+import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResourceFactory;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -72,7 +75,9 @@ public class MetricsAvailabilityITCase extends TestLogger {
 	private static final int PORT = 8081;
 
 	@Rule
-	public final FlinkDistribution dist = new FlinkDistribution();
+	public final FlinkResource dist = new LocalStandaloneFlinkResourceFactory()
+		.create(FlinkResourceSetup.builder().build())
+		.get();
 
 	@Nullable
 	private static ScheduledExecutorService scheduledExecutorService = null;
@@ -91,16 +96,16 @@ public class MetricsAvailabilityITCase extends TestLogger {
 
 	@Test
 	public void testReporter() throws Exception {
-		dist.startFlinkCluster();
+		try (ClusterController ignored = dist.startCluster(1)) {
+			final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), scheduledExecutorService);
 
-		final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), scheduledExecutorService);
+			checkJobManagerMetricAvailability(restClient);
 
-		checkJobManagerMetricAvailability(restClient);
+			final Collection<ResourceID> taskManagerIds = getTaskManagerIds(restClient);
 
-		final Collection<ResourceID> taskManagerIds = getTaskManagerIds(restClient);
-
-		for (final ResourceID taskManagerId : taskManagerIds) {
-			checkTaskManagerMetricAvailability(restClient, taskManagerId);
+			for (final ResourceID taskManagerId : taskManagerIds) {
+				checkTaskManagerMetricAvailability(restClient, taskManagerId);
+			}
 		}
 	}
 

--- a/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
+++ b/flink-end-to-end-tests/flink-metrics-reporter-prometheus-test/src/test/java/org/apache/flink/metrics/prometheus/tests/PrometheusReporterEndToEndITCase.java
@@ -23,9 +23,13 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.prometheus.PrometheusReporter;
 import org.apache.flink.tests.util.AutoClosableProcess;
 import org.apache.flink.tests.util.CommandLineWrapper;
-import org.apache.flink.tests.util.FlinkDistribution;
 import org.apache.flink.tests.util.cache.DownloadCache;
 import org.apache.flink.tests.util.categories.TravisGroup1;
+import org.apache.flink.tests.util.flink.ClusterController;
+import org.apache.flink.tests.util.flink.FlinkResource;
+import org.apache.flink.tests.util.flink.FlinkResourceSetup;
+import org.apache.flink.tests.util.flink.JarLocation;
+import org.apache.flink.tests.util.flink.LocalStandaloneFlinkResourceFactory;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.ProcessorArchitecture;
@@ -111,7 +115,12 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 	}
 
 	@Rule
-	public final FlinkDistribution dist = new FlinkDistribution();
+	public final FlinkResource dist = new LocalStandaloneFlinkResourceFactory()
+		.create(FlinkResourceSetup.builder()
+			.moveJar("flink-metrics-prometheus", JarLocation.OPT, JarLocation.LIB)
+			.addConfiguration(getFlinkConfig())
+			.build())
+		.get();
 
 	@Rule
 	public final TemporaryFolder tmp = new TemporaryFolder();
@@ -119,16 +128,16 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 	@Rule
 	public final DownloadCache downloadCache = DownloadCache.get();
 
-	@Test
-	public void testReporter() throws Exception {
-		dist.copyOptJarsToLib("flink-metrics-prometheus");
-
+	private static Configuration getFlinkConfig() {
 		final Configuration config = new Configuration();
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom." + ConfigConstants.METRICS_REPORTER_CLASS_SUFFIX, PrometheusReporter.class.getCanonicalName());
 		config.setString(ConfigConstants.METRICS_REPORTER_PREFIX + "prom.port", "9000-9100");
 
-		dist.appendConfiguration(config);
+		return config;
+	}
 
+	@Test
+	public void testReporter() throws Exception {
 		final Path tmpPrometheusDir = tmp.newFolder().toPath().resolve("prometheus");
 		final Path prometheusArchive = tmpPrometheusDir.resolve(PROMETHEUS_FILE_NAME + ".tar.gz");
 		final Path prometheusBinDir = tmpPrometheusDir.resolve(PROMETHEUS_FILE_NAME);
@@ -157,34 +166,35 @@ public class PrometheusReporterEndToEndITCase extends TestLogger {
 				.inPlace()
 				.build());
 
-		dist.startFlinkCluster();
+		try (ClusterController ignored = dist.startCluster(1)) {
 
-		final List<Integer> ports = dist
-			.searchAllLogs(LOG_REPORTER_PORT_PATTERN, matcher -> matcher.group(1))
-			.map(Integer::valueOf)
-			.collect(Collectors.toList());
+			final List<Integer> ports = dist
+				.searchAllLogs(LOG_REPORTER_PORT_PATTERN, matcher -> matcher.group(1))
+				.map(Integer::valueOf)
+				.collect(Collectors.toList());
 
-		final String scrapeTargets = ports.stream()
-			.map(port -> "'localhost:" + port + "'")
-			.collect(Collectors.joining(", "));
+			final String scrapeTargets = ports.stream()
+				.map(port -> "'localhost:" + port + "'")
+				.collect(Collectors.joining(", "));
 
-		LOG.info("Setting Prometheus scrape targets to {}.", scrapeTargets);
-		runBlocking(
-			CommandLineWrapper
-				.sed("s/\\(targets:\\).*/\\1 [" + scrapeTargets + "]/", prometheusConfig)
-				.inPlace()
-				.build());
+			LOG.info("Setting Prometheus scrape targets to {}.", scrapeTargets);
+			runBlocking(
+				CommandLineWrapper
+					.sed("s/\\(targets:\\).*/\\1 [" + scrapeTargets + "]/", prometheusConfig)
+					.inPlace()
+					.build());
 
-		LOG.info("Starting Prometheus server.");
-		try (AutoClosableProcess prometheus = runNonBlocking(
-			prometheusBinary.toAbsolutePath().toString(),
-			"--config.file=" + prometheusConfig.toAbsolutePath(),
-			"--storage.tsdb.path=" + prometheusBinDir.resolve("data").toAbsolutePath())) {
+			LOG.info("Starting Prometheus server.");
+			try (AutoClosableProcess prometheus = runNonBlocking(
+				prometheusBinary.toAbsolutePath().toString(),
+				"--config.file=" + prometheusConfig.toAbsolutePath(),
+				"--storage.tsdb.path=" + prometheusBinDir.resolve("data").toAbsolutePath())) {
 
-			final OkHttpClient client = new OkHttpClient();
+				final OkHttpClient client = new OkHttpClient();
 
-			checkMetricAvailability(client, "flink_jobmanager_numRegisteredTaskManagers");
-			checkMetricAvailability(client, "flink_taskmanager_Status_Network_TotalMemorySegments");
+				checkMetricAvailability(client, "flink_jobmanager_numRegisteredTaskManagers");
+				checkMetricAvailability(client, "flink_taskmanager_Status_Network_TotalMemorySegments");
+			}
 		}
 	}
 


### PR DESCRIPTION
Based on #11246.

Migrates existing java e2e tests from the `FlinkDistribution` to the `FlinkResource`.

Tests should only work against the `FlinkResource` API; the distribution class is more of a low-level construct.
Since the distribution exposed more functionality than the `FlinkResource` does we had to extend things slightly.
For mutating the distribution (like copying jars) a new `FlinkResourceSetup` class was introduced with which tests can define customization steps for a distribution.
The `FlinkResource` now also exposes a method for searching logs.
The existing `FlinkResource#addConfiguration` method has been removed as it is subsumed by the resource setup.