### PR TITLE
[FLINK-15794][Kubernetes] Generate the Kubernetes default image version

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -34,9 +34,9 @@
         </tr>
         <tr>
             <td><h5>kubernetes.container.image</h5></td>
-            <td style="word-wrap: break-word;">"flink:latest"</td>
+            <td style="word-wrap: break-word;">The default value depends on the actually running version. In general it looks like "flink:&lt;FLINK_VERSION&gt;-scala_&lt;SCALA_VERSION&gt;"</td>
             <td>String</td>
-            <td>Image to use for Flink containers.</td>
+            <td>Image to use for Flink containers. The specified image must be based upon the same Apache Flink and Scala versions as used by the application. Visit https://hub.docker.com/_/flink?tab=tags for the images provided by the Flink project.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-policy</h5></td>

--- a/docs/ops/deployment/docker.md
+++ b/docs/ops/deployment/docker.md
@@ -46,6 +46,11 @@ For example, you can use the following aliases:
 * `flink:latest` → `flink:<latest-flink>-scala_<latest-scala>`
 * `flink:1.11` → `flink:1.11.<latest-flink-1.11>-scala_2.11`
 
+<span class="label label-info">Note</span> It is recommended to always use an explicit version tag of the docker image that specifies both the needed Flink and Scala
+versions (for example `flink:1.11-scala_2.12`).
+This will avoid some class conflicts that can occur if the Flink and/or Scala versions used in the application are different
+from the versions provided by the docker image.
+
 <span class="label label-info">Note</span> Prior to Flink 1.5 version, Hadoop dependencies were always bundled with Flink.
 You can see that certain tags include the version of Hadoop, e.g. (e.g. `-hadoop28`).
 Beginning with Flink 1.5, image tags that omit the Hadoop version correspond to Hadoop-free releases of Flink

--- a/docs/ops/deployment/docker.zh.md
+++ b/docs/ops/deployment/docker.zh.md
@@ -46,6 +46,11 @@ For example, you can use the following aliases:
 * `flink:latest` → `flink:<latest-flink>-scala_<latest-scala>`
 * `flink:1.11` → `flink:1.11.<latest-flink-1.11>-scala_2.11`
 
+<span class="label label-info">Note</span>It is recommended to always use an explicit version tag of the docker image that specifies both the needed Flink and Scala
+versions (for example `flink:1.11-scala_2.12`).
+This will avoid some class conflicts that can occur if the Flink and/or Scala versions used in the application are different
+from the versions provided by the docker image.
+
 <span class="label label-info">Note</span> Prior to Flink 1.5 version, Hadoop dependencies were always bundled with Flink.
 You can see that certain tags include the version of Hadoop, e.g. (e.g. `-hadoop28`).
 Beginning with Flink 1.5, image tags that omit the Hadoop version correspond to Hadoop-free releases of Flink

--- a/docs/ops/deployment/kubernetes.md
+++ b/docs/ops/deployment/kubernetes.md
@@ -262,7 +262,7 @@ spec:
     spec:
       containers:
       - name: jobmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["jobmanager"]
         ports:
         - containerPort: 6123
@@ -314,7 +314,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["taskmanager"]
         ports:
         - containerPort: 6122
@@ -363,7 +363,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: jobmanager
-          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
           env:
           args: ["standalone-job", "--job-classname", "com.job.ClassName", ["--job-id", "<job id>",] ["--fromSavepoint", "/path/to/savepoint", ["--allowNonRestoredState",]] [job arguments]]
           ports:
@@ -421,7 +421,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         env:
         args: ["taskmanager"]
         ports:

--- a/docs/ops/deployment/kubernetes.zh.md
+++ b/docs/ops/deployment/kubernetes.zh.md
@@ -262,7 +262,7 @@ spec:
     spec:
       containers:
       - name: jobmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["jobmanager"]
         ports:
         - containerPort: 6123
@@ -314,7 +314,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         args: ["taskmanager"]
         ports:
         - containerPort: 6122
@@ -363,7 +363,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: jobmanager
-          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+          image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
           env:
           args: ["standalone-job", "--job-classname", "com.job.ClassName", ["--job-id", "<job id>",] ["--fromSavepoint", "/path/to/savepoint", ["--allowNonRestoredState",]] [job arguments]]
           ports:
@@ -421,7 +421,7 @@ spec:
     spec:
       containers:
       - name: taskmanager
-        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest{% endif %}
+        image: flink:{% if site.is_stable %}{{site.version}}-scala{{site.scala_version_suffix}}{% else %}latest # The 'latest' tag contains the latest released version of Flink for a specific Scala version. Do not use the 'latest' tag in production as it will break your setup automatically when a new version is released.{% endif %}
         env:
         args: ["taskmanager"]
         ports:

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -19,8 +19,10 @@
 package org.apache.flink.kubernetes.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ExternalResourceOptions;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import java.util.List;
 import java.util.Map;
@@ -137,11 +139,17 @@ public class KubernetesConfigOptions {
 		.withDescription("The cluster-id, which should be no more than 45 characters, is used for identifying " +
 			"a unique Flink cluster. If not set, the client will automatically generate it with a random ID.");
 
+	// The default container image that ties to the exact needed versions of both Flink and Scala.
+	public static final String DEFAULT_CONTAINER_IMAGE = "flink:" + EnvironmentInformation.getVersion() + "-scala_" + EnvironmentInformation.getScalaVersion();
+
+	@Documentation.OverrideDefault("The default value depends on the actually running version. In general it looks like \"flink:<FLINK_VERSION>-scala_<SCALA_VERSION>\"")
 	public static final ConfigOption<String> CONTAINER_IMAGE =
 		key("kubernetes.container.image")
 		.stringType()
-		.defaultValue("flink:latest")
-		.withDescription("Image to use for Flink containers.");
+		.defaultValue(DEFAULT_CONTAINER_IMAGE)
+		.withDescription("Image to use for Flink containers. " +
+			"The specified image must be based upon the same Apache Flink and Scala versions as used by the application. " +
+			"Visit https://hub.docker.com/_/flink?tab=tags for the images provided by the Flink project.");
 
 	/**
 	 * The following config options need to be set according to the image.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.ExternalResourceOptions;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
@@ -139,14 +140,11 @@ public class KubernetesConfigOptions {
 		.withDescription("The cluster-id, which should be no more than 45 characters, is used for identifying " +
 			"a unique Flink cluster. If not set, the client will automatically generate it with a random ID.");
 
-	// The default container image that ties to the exact needed versions of both Flink and Scala.
-	public static final String DEFAULT_CONTAINER_IMAGE = "flink:" + EnvironmentInformation.getVersion() + "-scala_" + EnvironmentInformation.getScalaVersion();
-
 	@Documentation.OverrideDefault("The default value depends on the actually running version. In general it looks like \"flink:<FLINK_VERSION>-scala_<SCALA_VERSION>\"")
 	public static final ConfigOption<String> CONTAINER_IMAGE =
 		key("kubernetes.container.image")
 		.stringType()
-		.defaultValue(DEFAULT_CONTAINER_IMAGE)
+		.defaultValue(getDefaultFlinkImage())
 		.withDescription("Image to use for Flink containers. " +
 			"The specified image must be based upon the same Apache Flink and Scala versions as used by the application. " +
 			"Visit https://hub.docker.com/_/flink?tab=tags for the images provided by the Flink project.");
@@ -236,6 +234,13 @@ public class KubernetesConfigOptions {
 			.noDefaultValue()
 			.withDescription("If configured, Flink will add \"resources.limits.<config-key>\" and \"resources.requests.<config-key>\" " +
 				"to the main container of TaskExecutor and set the value to the value of " + ExternalResourceOptions.EXTERNAL_RESOURCE_AMOUNT.key() + ".");
+
+	private static String getDefaultFlinkImage() {
+		// The default container image that ties to the exact needed versions of both Flink and Scala.
+		boolean snapshot = EnvironmentInformation.getVersion().toLowerCase(Locale.ENGLISH).contains("snapshot");
+		String tag = snapshot ? "latest" : EnvironmentInformation.getVersion() + "-scala_" + EnvironmentInformation.getScalaVersion();
+		return "flink:" + tag;
+	}
 
 	/**
 	 * The flink rest service exposed type.


### PR DESCRIPTION
## What is the purpose of the change

The default image used by Kubernetes is `flink:latest` which causes version compatibility problems if the latest it not exactly the same as what you are using.
This change generates the exact version id of the image (i.e. no longer `latest`).

## Brief change log

- Generate the project and scala versions into a simple Java class.
- Use this generated code to define the docker image tag and related documentation.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This changes only the default value.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no, only build plugins
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes, by default a different image tag is pulled.
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
