### PR TITLE
[FLINK-16307][e2e] Use start-cluster.sh instead of manually building cluster

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/FlinkDistribution.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/FlinkDistribution.java
@@ -48,6 +48,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -286,6 +287,10 @@ public final class FlinkDistribution implements ExternalResource {
 			.collect(Collectors.toList());
 
 		Files.write(conf.resolve("flink-conf.yaml"), configurationLines);
+	}
+
+	public void setTaskExecutorHosts(Collection<String> taskExecutorHosts) throws IOException {
+		Files.write(conf.resolve("slaves"), taskExecutorHosts);
 	}
 
 	public Stream<String> searchAllLogs(Pattern pattern, Function<Matcher, String> matchProcessor) throws IOException {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -35,12 +35,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 /**
  * Flink resource that start local standalone clusters.
@@ -73,7 +72,7 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 
 	@Override
 	public ClusterController startCluster(int numTaskManagers) throws IOException {
-		distribution.setTaskExecutorHosts(IntStream.range(0, numTaskManagers).mapToObj(i -> "localhost").collect(Collectors.toList()));
+		distribution.setTaskExecutorHosts(Collections.nCopies(numTaskManagers, "localhost"));
 		distribution.startFlinkCluster();
 
 		try (final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), Executors.directExecutor())) {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -39,6 +39,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Flink resource that start local standalone clusters.
@@ -71,10 +73,8 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 
 	@Override
 	public ClusterController startCluster(int numTaskManagers) throws IOException {
-		distribution.startJobManager();
-		for (int x = 0; x < numTaskManagers; x++) {
-			distribution.startTaskManager();
-		}
+		distribution.setTaskExecutorHosts(IntStream.range(0, numTaskManagers).mapToObj(i -> "localhost").collect(Collectors.toList()));
+		distribution.startFlinkCluster();
 
 		try (final RestClient restClient = new RestClient(RestClientConfiguration.fromConfiguration(new Configuration()), Executors.directExecutor())) {
 			for (int retryAttempt = 0; retryAttempt < 30; retryAttempt++) {


### PR DESCRIPTION
Use the `start-cluster.sh` script to start the cluster, instead of manually starting each process. This is more in line with the documentation.