### PR TITLE
[FLINK-16337][python][table-planner][table-planner-blink] Add support of vectorized Python UDF in blink planner and old planner

### DIFF
--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -220,6 +220,7 @@ class UserDefinedScalarFunctionWrapper(UserDefinedFunctionWrapper):
                                             bytearray(serialized_func),
                                             j_input_types,
                                             j_result_type,
+                                            j_function_kind,
                                             self._deterministic,
                                             _get_python_env())
 

--- a/flink-python/pyflink/table/udf.py
+++ b/flink-python/pyflink/table/udf.py
@@ -199,6 +199,8 @@ class UserDefinedScalarFunctionWrapper(UserDefinedFunctionWrapper):
         j_input_types = utils.to_jarray(gateway.jvm.TypeInformation,
                                         [_to_java_type(i) for i in self._input_types])
         j_result_type = _to_java_type(self._result_type)
+        j_function_kind = gateway.jvm.org.apache.flink.table.functions.python.\
+            PythonFunctionKind.GENERAL
         if is_blink_planner:
             PythonTableUtils = gateway.jvm\
                 .org.apache.flink.table.planner.utils.python.PythonTableUtils
@@ -208,6 +210,7 @@ class UserDefinedScalarFunctionWrapper(UserDefinedFunctionWrapper):
                                             bytearray(serialized_func),
                                             j_input_types,
                                             j_result_type,
+                                            j_function_kind,
                                             self._deterministic,
                                             _get_python_env())
         else:

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionKind.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonFunctionKind.java
@@ -20,29 +20,13 @@ package org.apache.flink.table.functions.python;
 
 import org.apache.flink.annotation.Internal;
 
-import java.io.Serializable;
-
 /**
- * The base interface of a wrapper of a Python function. It wraps the serialized Python function
- * and the execution environment.
+ * Categorizes the Python functions.
  */
 @Internal
-public interface PythonFunction extends Serializable {
+public enum PythonFunctionKind {
 
-	/**
-	 * Returns the serialized representation of the user-defined python function.
-	 */
-	byte[] getSerializedPythonFunction();
+	GENERAL,
 
-	/**
-	 * Returns the Python execution environment.
-	 */
-	PythonEnv getPythonEnv();
-
-	/**
-	 * Returns the kind of the user-defined python function.
-	 */
-	default PythonFunctionKind getPythonFunctionKind() {
-		return PythonFunctionKind.GENERAL;
-	}
+	PANDAS
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/SimplePythonFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/SimplePythonFunction.java
@@ -39,9 +39,15 @@ public final class SimplePythonFunction implements PythonFunction {
 	 */
 	private final PythonEnv pythonEnv;
 
-	public SimplePythonFunction(byte[] serializedPythonFunction, PythonEnv pythonEnv) {
+	/**
+	 * The kind of the user-defined python function.
+	 */
+	private final PythonFunctionKind pythonFunctionKind;
+
+	public SimplePythonFunction(byte[] serializedPythonFunction, PythonEnv pythonEnv, PythonFunctionKind pythonFunctionKind) {
 		this.serializedPythonFunction = Preconditions.checkNotNull(serializedPythonFunction);
 		this.pythonEnv = Preconditions.checkNotNull(pythonEnv);
+		this.pythonFunctionKind = Preconditions.checkNotNull(pythonFunctionKind);
 	}
 
 	@Override
@@ -52,5 +58,10 @@ public final class SimplePythonFunction implements PythonFunction {
 	@Override
 	public PythonEnv getPythonEnv() {
 		return pythonEnv;
+	}
+
+	@Override
+	public PythonFunctionKind getPythonFunctionKind() {
+		return pythonFunctionKind;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -92,7 +92,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		}
 		RexNode rexNode = pythonTableFuncScan.getCall();
 		if (rexNode instanceof RexCall) {
-			return PythonUtil.isPythonCall(rexNode) && PythonUtil.containsNonPythonCall(rexNode);
+			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode);
 		}
 		return false;
 	}
@@ -196,7 +196,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		ScalarFunctionSplitter splitter = new ScalarFunctionSplitter(
 			primitiveLeftFieldCount,
 			extractedJavaRexCalls,
-			false
+			PythonUtil::isNonPythonCall
 		);
 
 		RelNode rightNewInput;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCorrelateRule.java
@@ -58,7 +58,7 @@ public class BatchExecPythonCorrelateRule extends ConverterRule {
 			// right node is a table function
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
 			// return true if the table function is python table function
-			return PythonUtil.isPythonCall(scan.getCall());
+			return PythonUtil.isPythonCall(scan.getCall(), null);
 		} else if (right instanceof FlinkLogicalCalc) {
 			// a filter is pushed above the table function
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
@@ -66,7 +66,7 @@ public class BatchExecPythonCorrelateRule extends ConverterRule {
 			if (input instanceof FlinkLogicalTableFunctionScan) {
 				FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) input;
 				// return true if the table function is python table function
-				return PythonUtil.isPythonCall(scan.getCall());
+				return PythonUtil.isPythonCall(scan.getCall(), null);
 			}
 		}
 		return false;

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCorrelateRule.java
@@ -54,7 +54,7 @@ public class StreamExecPythonCorrelateRule extends ConverterRule {
 		RelNode child = ((RelSubset) calc.getInput()).getOriginal();
 		if (child instanceof FlinkLogicalTableFunctionScan) {
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) child;
-			return PythonUtil.isPythonCall(scan.getCall());
+			return PythonUtil.isPythonCall(scan.getCall(), null);
 		} else if (child instanceof FlinkLogicalCalc) {
 			FlinkLogicalCalc childCalc = (FlinkLogicalCalc) child;
 			return findTableFunction(childCalc);
@@ -70,7 +70,7 @@ public class StreamExecPythonCorrelateRule extends ConverterRule {
 			// right node is a table function
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
 			// return true if the table function is python table function
-			return PythonUtil.isPythonCall(scan.getCall());
+			return PythonUtil.isPythonCall(scan.getCall(), null);
 		} else if (right instanceof FlinkLogicalCalc) {
 			// a filter is pushed above the table function
 			return findTableFunction((FlinkLogicalCalc) right);

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
@@ -74,7 +74,8 @@ trait CommonPythonBase {
     // the serialized Python function, the Python env, etc
     val pythonFunction = new SimplePythonFunction(
       func.asInstanceOf[PythonFunction].getSerializedPythonFunction,
-      func.asInstanceOf[PythonFunction].getPythonEnv)
+      func.asInstanceOf[PythonFunction].getPythonEnv,
+      func.asInstanceOf[PythonFunction].getPythonFunctionKind)
     new PythonFunctionInfo(pythonFunction, inputs.toArray)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecMatch.scala
@@ -76,8 +76,8 @@ class StreamExecMatch(
   with StreamPhysicalRel
   with StreamExecNode[BaseRow] {
 
-  if (logicalMatch.measures.values().exists(containsPythonCall) ||
-    logicalMatch.patternDefinitions.values().exists(containsPythonCall)) {
+  if (logicalMatch.measures.values().exists(containsPythonCall(_)) ||
+    logicalMatch.patternDefinitions.values().exists(containsPythonCall(_))) {
     throw new TableException("Python Function can not be used in MATCH_RECOGNIZE for now.")
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -367,6 +367,7 @@ object FlinkBatchRuleSets {
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -349,6 +349,7 @@ object FlinkStreamRuleSets {
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
@@ -18,13 +18,16 @@
 
 package org.apache.flink.table.planner.plan.rules.logical
 
+import java.util.function.Function
+
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.functions.python.PythonFunctionKind
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc
-import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsPythonCall, containsNonPythonCall, isPythonCall, isNonPythonCall}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsNonPythonCall, containsPythonCall, isNonPythonCall, isPythonCall}
 import org.apache.flink.table.planner.plan.utils.{InputRefVisitor, RexDefaultVisitor}
 
 import scala.collection.JavaConverters._
@@ -52,7 +55,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
     val splitter = new ScalarFunctionSplitter(
       extractedFunctionOffset,
       extractedRexCalls,
-      isConvertPythonFunction(program))
+      new Function[RexCall, Boolean] {
+        override def apply(rexCall: RexCall): Boolean = needConvertRexCall(program, rexCall)
+      })
 
     val (bottomCalcCondition, topCalcCondition, topCalcProjects) = split(program, splitter)
     val accessedFields = extractRefInputFields(
@@ -112,9 +117,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
   }
 
   /**
-    * Returns true if converting Python functions.
+    * Returns true if need to convert the specified call.
     */
-  def isConvertPythonFunction(program: RexProgram): Boolean
+  def needConvertRexCall(program: RexProgram, call: RexCall): Boolean
 
   /**
     * Splits the specified [[RexProgram]] using the specified [[ScalarFunctionSplitter]].
@@ -138,10 +143,10 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
 
     // matches if it contains Python functions in condition
     Option(calc.getProgram.getCondition)
-      .map(calc.getProgram.expandLocalRef).exists(containsPythonCall)
+      .map(calc.getProgram.expandLocalRef).exists(containsPythonCall(_))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = true
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -150,12 +155,22 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
   }
 }
 
+abstract class PythonCalcSplitProjectionRuleBase(description: String)
+    extends PythonCalcSplitRuleBase(description) {
+
+  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
+      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
+    (Option(program.getCondition).map(program.expandLocalRef), None,
+      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  }
+}
+
 /**
   * Rule that splits [[FlinkLogicalCalc]]s which contain both Java functions and Python functions
   * in the projection into multiple [[FlinkLogicalCalc]]s. After this rule is applied, it will
   * only contain Python functions or Java functions in the projection of each [[FlinkLogicalCalc]].
   */
-object PythonCalcSplitProjectionRule extends PythonCalcSplitRuleBase(
+object PythonCalcSplitProjectionRule extends PythonCalcSplitProjectionRuleBase(
   "PythonCalcSplitProjectionRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
@@ -163,17 +178,36 @@ object PythonCalcSplitProjectionRule extends PythonCalcSplitRuleBase(
     val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
 
     // matches if it contains both Python functions and Java functions in the projection
-    projects.exists(containsPythonCall) && projects.exists(containsNonPythonCall)
+    projects.exists(containsPythonCall(_)) && projects.exists(containsNonPythonCall)
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = {
-    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall)
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(call)
+  }
+}
+
+/**
+  * Rule that splits [[FlinkLogicalCalc]]s which contain both general Python functions and
+  * pandas Python functions in the projection into multiple [[FlinkLogicalCalc]]s. After
+  * this rule is applied, it will only contain general Python functions or pandas Python
+  * functions in the projection of each [[FlinkLogicalCalc]].
+  */
+object PythonCalcSplitPandasInProjectionRule extends PythonCalcSplitProjectionRuleBase(
+  "PythonCalcSplitPandasInProjectionRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
+
+    // matches if it contains both general Python functions and
+    // pandas Python functions in the projection
+    projects.exists(containsPythonCall(_, PythonFunctionKind.GENERAL)) &&
+      projects.exists(containsPythonCall(_, PythonFunctionKind.PANDAS))
   }
 
-  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
-      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
-    (Option(program.getCondition).map(program.expandLocalRef), None,
-      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+     program.getProjectList.map(program.expandLocalRef).exists(
+       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(call, PythonFunctionKind.PANDAS)
   }
 }
 
@@ -191,10 +225,11 @@ object PythonCalcPushConditionRule extends PythonCalcSplitRuleBase(
     // matches if all the following conditions hold true:
     // 1) the condition is not null
     // 2) it contains Python functions in the projection
-    calc.getProgram.getCondition != null && projects.exists(containsPythonCall)
+    calc.getProgram.getCondition != null && projects.exists(containsPythonCall(_))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = false
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean =
+    isNonPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -221,13 +256,13 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
     // 1) it contains Python functions in the projection
     // 2) it contains RexNodes besides RexInputRef and RexCall or
     //    not all the RexCalls lying at the end of the project list
-    projects.exists(containsPythonCall) &&
+    projects.exists(containsPythonCall(_)) &&
       (projects.exists(expr => !expr.isInstanceOf[RexCall] && !expr.isInstanceOf[RexInputRef]) ||
         projects.indexWhere(_.isInstanceOf[RexCall]) <
           projects.lastIndexWhere(_.isInstanceOf[RexInputRef]))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = true
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -238,11 +273,11 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
 private class ScalarFunctionSplitter(
     extractedFunctionOffset: Int,
     extractedRexCalls: mutable.ArrayBuffer[RexCall],
-    convertPythonFunction: Boolean)
+    needConvertRexCall: Function[RexCall, Boolean])
   extends RexDefaultVisitor[RexNode] {
 
   override def visitCall(call: RexCall): RexNode = {
-    visit(if (isPythonCall(call)) convertPythonFunction else !convertPythonFunction, call)
+    visit(needConvertRexCall(call), call)
   }
 
   override def visitNode(rexNode: RexNode): RexNode = rexNode
@@ -299,10 +334,11 @@ private class ExtractedFunctionInputRewriter(
 object PythonCalcSplitRule {
   /**
     * These rules should be applied sequentially in the order of
-    * SPLIT_CONDITION, SPLIT_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
+    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
     */
   val SPLIT_CONDITION: RelOptRule = PythonCalcSplitConditionRule
   val SPLIT_PROJECT: RelOptRule = PythonCalcSplitProjectionRule
+  val SPLIT_PANDAS_IN_PROJECT: RelOptRule = PythonCalcSplitPandasInProjectionRule
   val PUSH_CONDITION: RelOptRule = PythonCalcPushConditionRule
   val REWRITE_PROJECT: RelOptRule = PythonCalcRewriteProjectionRule
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
@@ -55,7 +55,7 @@ class SplitPythonConditionFromCorrelateRule
     joinType == JoinRelType.INNER &&
       Option(mergedCalc.getProgram.getCondition)
         .map(mergedCalc.getProgram.expandLocalRef)
-        .exists(containsPythonCall)
+        .exists(containsPythonCall(_))
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
@@ -97,7 +97,7 @@ class SplitPythonConditionFromCorrelateRule
       correlate.getRowType.getFieldCount - mergedCalc.getRowType.getFieldCount)
 
     val pythonFilters = correlateFilters
-      .filter(containsPythonCall)
+      .filter(containsPythonCall(_))
       .map(_.accept(inputRefRewriter))
 
     val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
@@ -43,7 +43,7 @@ class SplitPythonConditionFromJoinRule extends RelOptRule(
     val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
     val joinType: JoinRelType = join.getJoinType
     // matches if it is inner join and it contains Python functions in condition
-    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall)
+    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall(_))
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
@@ -51,7 +51,7 @@ class SplitPythonConditionFromJoinRule extends RelOptRule(
     val rexBuilder = join.getCluster.getRexBuilder
 
     val joinFilters = RelOptUtil.conjunctions(join.getCondition)
-    val pythonFilters = joinFilters.filter(containsPythonCall)
+    val pythonFilters = joinFilters.filter(containsPythonCall(_))
     val remainingFilters = joinFilters.filter(!containsPythonCall(_))
 
     val newJoinCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecCalcRule.scala
@@ -41,7 +41,7 @@ class BatchExecCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    !program.getExprList.asScala.exists(containsPythonCall)
+    !program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecPythonCalcRule.scala
@@ -41,7 +41,7 @@ class BatchExecPythonCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    program.getExprList.asScala.exists(containsPythonCall)
+    program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecCalcRule.scala
@@ -41,7 +41,7 @@ class StreamExecCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    !program.getExprList.asScala.exists(containsPythonCall)
+    !program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCalcRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamExecPythonCalcRule.scala
@@ -41,7 +41,7 @@ class StreamExecPythonCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    program.getExprList.asScala.exists(containsPythonCall)
+    program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/PythonUtil.scala
@@ -19,7 +19,8 @@
 package org.apache.flink.table.planner.plan.utils
 
 import org.apache.calcite.rex.{RexCall, RexNode}
-import org.apache.flink.table.functions.python.PythonFunction
+import org.apache.flink.table.functions.UserDefinedFunction
+import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionKind}
 import org.apache.flink.table.planner.functions.utils.{ScalarSqlFunction, TableSqlFunction}
 
 import scala.collection.JavaConversions._
@@ -27,12 +28,16 @@ import scala.collection.JavaConversions._
 object PythonUtil {
 
   /**
-    * Checks whether it contains Python function call in the specified node.
+    * Checks whether it contains the specified kind of Python function call in the specified node.
+    * If the parameter pythonFunctionKind is null, it will return true for any kind of Python
+    * function.
     *
     * @param node the RexNode to check
+    * @param pythonFunctionKind the kind of the python function
     * @return true if it contains the Python function call in the specified node.
     */
-  def containsPythonCall(node: RexNode): Boolean = node.accept(new FunctionFinder(true, true))
+  def containsPythonCall(node: RexNode, pythonFunctionKind: PythonFunctionKind = null): Boolean =
+    node.accept(new FunctionFinder(true, Option(pythonFunctionKind), true))
 
   /**
     * Checks whether it contains non-Python function call in the specified node.
@@ -40,15 +45,20 @@ object PythonUtil {
     * @param node the RexNode to check
     * @return true if it contains the non-Python function call in the specified node.
     */
-  def containsNonPythonCall(node: RexNode): Boolean = node.accept(new FunctionFinder(false, true))
+  def containsNonPythonCall(node: RexNode): Boolean =
+    node.accept(new FunctionFinder(false, None, true))
 
   /**
-    * Checks whether the specified node is a Python function call.
+    * Checks whether the specified node is the specified kind of Python function call.
+    * If the parameter pythonFunctionKind is null, it will return true for any kind of Python
+    * function.
     *
     * @param node the RexNode to check
+    * @param pythonFunctionKind the kind of the python function
     * @return true if the specified node is a Python function call.
     */
-  def isPythonCall(node: RexNode): Boolean = node.accept(new FunctionFinder(true, false))
+  def isPythonCall(node: RexNode, pythonFunctionKind: PythonFunctionKind = null): Boolean =
+    node.accept(new FunctionFinder(true, Option(pythonFunctionKind), false))
 
   /**
     * Checks whether the specified node is a non-Python function call.
@@ -56,27 +66,39 @@ object PythonUtil {
     * @param node the RexNode to check
     * @return true if the specified node is a non-Python function call.
     */
-  def isNonPythonCall(node: RexNode): Boolean = node.accept(new FunctionFinder(false, false))
+  def isNonPythonCall(node: RexNode): Boolean = node.accept(new FunctionFinder(false, None, false))
 
   /**
     * Checks whether it contains the specified kind of function in a RexNode.
     *
     * @param findPythonFunction true to find python function, false to find non-python function
+    * @param pythonFunctionKind the kind of the python function
     * @param recursive whether check the inputs
     */
-  private class FunctionFinder(findPythonFunction: Boolean, recursive: Boolean)
+  private class FunctionFinder(
+      findPythonFunction: Boolean,
+      pythonFunctionKind: Option[PythonFunctionKind],
+      recursive: Boolean)
     extends RexDefaultVisitor[Boolean] {
 
     /**
-      * Checks whether the specified rexCall is python function call.
+      * Checks whether the specified rexCall is a python function call of the specified kind.
       *
       * @param rexCall the RexCall to check.
-      * @return true if it is python function call.
+      * @return true if it is python function call of the specified kind.
       */
-    private def isPythonRexCall(rexCall: RexCall): Boolean = rexCall.getOperator match {
-      case sfc: ScalarSqlFunction => sfc.scalarFunction.isInstanceOf[PythonFunction]
-      case tfc: TableSqlFunction => tfc.udtf.isInstanceOf[PythonFunction]
-      case _ => false
+    private def isPythonRexCall(rexCall: RexCall): Boolean =
+      rexCall.getOperator match {
+        case sfc: ScalarSqlFunction => isPythonFunction(sfc.scalarFunction)
+        case tfc: TableSqlFunction => isPythonFunction(tfc.udtf)
+        case _ => false
+    }
+
+    private def isPythonFunction(userDefinedFunction: UserDefinedFunction): Boolean = {
+      userDefinedFunction.isInstanceOf[PythonFunction] &&
+        (pythonFunctionKind.isEmpty ||
+          userDefinedFunction.asInstanceOf[PythonFunction].getPythonFunctionKind ==
+            pythonFunctionKind.get)
     }
 
     override def visitCall(call: RexCall): Boolean = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/utils/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/utils/python/PythonTableUtils.scala
@@ -32,7 +32,7 @@ import org.apache.flink.api.java.typeutils.{MapTypeInfo, ObjectArrayTypeInfo, Ro
 import org.apache.flink.core.io.InputSplit
 import org.apache.flink.table.api.{TableConfig, TableSchema, Types}
 import org.apache.flink.table.functions.{ScalarFunction, TableFunction}
-import org.apache.flink.table.functions.python.PythonEnv
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunctionKind}
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, PythonFunctionCodeGenerator}
 import org.apache.flink.table.sources.InputFormatTableSource
 import org.apache.flink.types.Row
@@ -48,6 +48,7 @@ object PythonTableUtils {
     * @param serializedScalarFunction serialized Python scalar function
     * @param inputTypes input data types
     * @param resultType expected result type
+    * @param pythonFunctionKind the kind of the Python function
     * @param deterministic the determinism of the function's results
     * @param pythonEnv the Python execution environment
     * @return A generated Java ScalarFunction representation for the specified Python ScalarFunction
@@ -58,6 +59,7 @@ object PythonTableUtils {
       serializedScalarFunction: Array[Byte],
       inputTypes: Array[TypeInformation[_]],
       resultType: TypeInformation[_],
+      pythonFunctionKind: PythonFunctionKind,
       deterministic: Boolean,
       pythonEnv: PythonEnv): ScalarFunction =
     PythonFunctionCodeGenerator.generateScalarFunction(
@@ -66,6 +68,7 @@ object PythonTableUtils {
       serializedScalarFunction,
       inputTypes,
       resultType,
+      pythonFunctionKind,
       deterministic,
       pythonEnv)
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunction;
+import org.apache.flink.table.functions.python.PythonFunctionKind;
 
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -271,6 +272,34 @@ public class JavaUserDefinedScalarFunctions {
 		@Override
 		public PythonEnv getPythonEnv() {
 			return null;
+		}
+	}
+
+	/**
+	 * Test for Pandas Python Scalar Function.
+	 */
+	public static class PandasScalarFunction extends PythonScalarFunction {
+		public PandasScalarFunction(String name) {
+			super(name);
+		}
+
+		@Override
+		public PythonFunctionKind getPythonFunctionKind() {
+			return PythonFunctionKind.PANDAS;
+		}
+	}
+
+	/**
+	 * Test for Pandas Python Scalar Function.
+	 */
+	public static class BooleanPandasScalarFunction extends BooleanPythonScalarFunction {
+		public BooleanPandasScalarFunction(String name) {
+			super(name);
+		}
+
+		@Override
+		public PythonFunctionKind getPythonFunctionKind() {
+			return PythonFunctionKind.PANDAS;
 		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -16,17 +16,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testChainingPandasFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc3(pandasFunc2(a + pandasFunc1(a, c), b), c) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc3(pandasFunc2(+($0, pandasFunc1($0, $2)), $1), $2)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[pandasFunc3(pandasFunc2(f0, b), c) AS EXPR$0])
++- FlinkLogicalCalc(select=[b, c, +(a, f0) AS f0])
+   +- FlinkLogicalCalc(select=[b, c, a, pandasFunc1(a, c) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testChainingPythonFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc3(pyFunc2(a + pyFunc1(a, c), b), c) FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc3(pyFunc2(+($0, pyFunc1($0, $2)), $1), $2)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -35,20 +52,17 @@ FlinkLogicalCalc(select=[pyFunc3(pyFunc2(f0, b), c) AS EXPR$0])
    +- FlinkLogicalCalc(select=[b, c, a, pyFunc1(a, c) AS f0])
       +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testFieldNameUniquify">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(f1, f2), f0 + 1 FROM MyTable2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($1, $2)], EXPR$1=[+($0, 1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(f0, f1, f2)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -56,41 +70,17 @@ FlinkLogicalCalc(select=[f00 AS EXPR$0, +(f0, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[f0, pyFunc1(f1, f2) AS f00])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
 ]]>
-
-    </Resource>
-  </TestCase>
-  <TestCase name="testPythonFunctionAsInputOfJavaFunction">
-    <Resource name="sql">
-      <![CDATA[SELECT pyFunc1(a, b) + 1 FROM MyTable]]>
-
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[+(pyFunc1($0, $1), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
-+- FlinkLogicalCalc(select=[pyFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLiteral">
     <Resource name="sql">
       <![CDATA[SELECT a, b, pyFunc1(a, c), 1 FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], EXPR$2=[pyFunc1($0, $2)], EXPR$3=[1])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -98,33 +88,64 @@ FlinkLogicalCalc(select=[a, b, f0 AS EXPR$2, 1 AS EXPR$3])
 +- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOnePandasFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOnlyOnePandasFunctionInWhereClause">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b FROM MyTable WHERE pandasFunc4(a, c)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1])
++- LogicalFilter(condition=[pandasFunc4($0, $2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b], where=[f0])
++- FlinkLogicalCalc(select=[a, b, pandasFunc4(a, c) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOnePythonFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b) FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
 +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOnePythonFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT a, b FROM MyTable WHERE pyFunc4(a, c)]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -132,7 +153,6 @@ LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -140,13 +160,144 @@ FlinkLogicalCalc(select=[a, b], where=[f0])
 +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionAsInputOfJavaFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, b) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, $1), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
++- FlinkLogicalCalc(select=[pyFunc1(a, b) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionAsInputOfJavaFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pandasFunc1($0, $1), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
++- FlinkLogicalCalc(select=[pandasFunc1(a, b) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithGeneralPythonFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+(pyFunc1($0, $2), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(f1, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[f0, pyFunc1(a, c) AS f1])
+   +- FlinkLogicalCalc(select=[a, c, pandasFunc1(a, b) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithJavaFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithJavaFunctionInWhereClause">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable WHERE pandasFunc2(a, c) > 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
++- LogicalFilter(condition=[>(pandasFunc2($0, $2), 0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
+   +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
+      +- FlinkLogicalCalc(select=[a, b, c, pandasFunc2(a, c) AS f0])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionNotChainingWithGeneralPythonFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, pandasFunc1(a, b)) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, pandasFunc1($0, $1)), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
++- FlinkLogicalCalc(select=[pyFunc1(a, f0) AS f0])
+   +- FlinkLogicalCalc(select=[a, pandasFunc1(a, b) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionInWhereClause">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b) FROM MyTable WHERE pandasFunc4(a, c)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)])
++- LogicalFilter(condition=[pandasFunc4($0, $2)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
++- FlinkLogicalCalc(select=[a, b], where=[f0])
+   +- FlinkLogicalCalc(select=[a, b, pandasFunc4(a, c) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b) FROM MyTable WHERE pyFunc4(a, c)]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -154,7 +305,6 @@ LogicalProject(EXPR$0=[pyFunc1($0, $1)])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -163,20 +313,17 @@ FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
    +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
       +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionMixedWithJavaFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b), c + 1 FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -184,20 +331,17 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[c, pyFunc1(a, b) AS f0])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testReorderPythonCalc">
     <Resource name="sql">
       <![CDATA[SELECT a, pyFunc1(a, c), b FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -205,13 +349,11 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
 +- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionMixedWithJavaFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b), c + 1 FROM MyTable WHERE pyFunc2(a, c) > 0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -219,7 +361,6 @@ LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
 +- LogicalFilter(condition=[>(pyFunc2($0, $2), 0)])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -229,7 +370,6 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
       +- FlinkLogicalCalc(select=[a, b, c, pyFunc2(a, c) AS f0])
          +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -20,8 +20,8 @@ package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.flink.api.scala._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
 import org.apache.flink.table.planner.expressions.utils.{Func1, RichFunc1}
 import org.apache.flink.table.planner.utils.TableTestBase
 import org.junit.Test

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCorrelateRule.java
@@ -59,12 +59,12 @@ public class DataStreamPythonCorrelateRule extends ConverterRule {
 		if (right instanceof FlinkLogicalTableFunctionScan) {
 			// right node is a python table function
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
-			return PythonUtil.isPythonCall(scan.getCall());
+			return PythonUtil.isPythonCall(scan.getCall(), null);
 		} else if (right instanceof FlinkLogicalCalc) {
 			// a filter is pushed above the table function
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
 			Option<FlinkLogicalTableFunctionScan> scan = CorrelateUtil.getTableFunctionScan(calc);
-			return scan.isDefined() && PythonUtil.isPythonCall(scan.get().getCall());
+			return scan.isDefined() && PythonUtil.isPythonCall(scan.get().getCall(), null);
 		}
 		return false;
 	}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -99,7 +99,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		}
 		RexNode rexNode = pythonTableFuncScan.getCall();
 		if (rexNode instanceof RexCall) {
-			return PythonUtil.isPythonCall(rexNode) && PythonUtil.containsNonPythonCall(rexNode);
+			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode);
 		}
 		return false;
 	}
@@ -203,7 +203,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		ScalarFunctionSplitter splitter = new ScalarFunctionSplitter(
 			primitiveLeftFieldCount,
 			extractedJavaRexCalls,
-			false
+			PythonUtil::isNonPythonCall
 		);
 
 		RelNode rightNewInput;

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
@@ -72,7 +72,8 @@ trait CommonPythonBase {
     // the serialized Python function, the Python env, etc
     val pythonFunction = new SimplePythonFunction(
       func.asInstanceOf[PythonFunction].getSerializedPythonFunction,
-      func.asInstanceOf[PythonFunction].getPythonEnv)
+      func.asInstanceOf[PythonFunction].getPythonEnv,
+      func.asInstanceOf[PythonFunction].getPythonFunctionKind)
     new PythonFunctionInfo(pythonFunction, inputs.toArray)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -18,9 +18,16 @@
 package org.apache.flink.table.plan.nodes
 
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
-import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
+import org.apache.flink.table.plan.nodes.CommonPythonCalc.{ARROW_PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, PYTHON_SCALAR_FUNCTION_OPERATOR_NAME}
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.types.logical.RowType
 
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 trait CommonPythonCalc extends CommonPythonBase {
@@ -50,4 +57,44 @@ trait CommonPythonCalc extends CommonPythonBase {
       .collect { case inputRef: RexInputRef => inputRef.getIndex }
       .toArray
   }
+
+  private[flink] def getPythonScalarFunctionOperator(
+      config: Configuration,
+      inputRowType: RowType,
+      outputRowType: RowType,
+      calcProgram: RexProgram) = {
+    val clazz = if (calcProgram.getExprList.asScala.exists(
+      containsPythonCall(_, PythonFunctionKind.PANDAS))) {
+      loadClass(ARROW_PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
+    } else {
+      loadClass(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
+    }
+    val ctor = clazz.getConstructor(
+      classOf[Configuration],
+      classOf[Array[PythonFunctionInfo]],
+      classOf[RowType],
+      classOf[RowType],
+      classOf[Array[Int]],
+      classOf[Array[Int]])
+    val (udfInputOffsets, pythonFunctionInfos) =
+      extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
+    ctor.newInstance(
+      config,
+      pythonFunctionInfos,
+      inputRowType,
+      outputRowType,
+      udfInputOffsets,
+      getForwardedFields(calcProgram))
+      .asInstanceOf[OneInputStreamOperator[CRow, CRow]]
+  }
 }
+
+object CommonPythonCalc {
+  val PYTHON_SCALAR_FUNCTION_OPERATOR_NAME =
+    "org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperator"
+
+  val ARROW_PYTHON_SCALAR_FUNCTION_OPERATOR_NAME =
+    "org.apache.flink.table.runtime.operators.python.scalar.arrow." +
+      "ArrowPythonScalarFunctionOperator"
+}
+

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamMatch.scala
@@ -77,8 +77,8 @@ class DataStreamMatch(
   with CommonMatchRecognize
   with DataStreamRel {
 
-  if (logicalMatch.measures.values().exists(containsPythonCall) ||
-    logicalMatch.patternDefinitions.values().exists(containsPythonCall)) {
+  if (logicalMatch.measures.values().exists(containsPythonCall(_)) ||
+    logicalMatch.patternDefinitions.values().exists(containsPythonCall(_))) {
     throw new TableException("Python Function can not be used in MATCH_RECOGNIZE for now.")
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -23,14 +23,10 @@ import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.Calc
 import org.apache.calcite.rex.RexProgram
 import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.datastream.DataStream
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.api.StreamQueryConfig
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.plan.nodes.CommonPythonCalc
-import org.apache.flink.table.plan.nodes.datastream.DataStreamPythonCalc.PYTHON_SCALAR_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.plan.schema.RowSchema
 import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.table.runtime.types.{CRow, CRowTypeInfo}
@@ -101,34 +97,4 @@ class DataStreamPythonCalc(
       // keep parallelism to ensure order of accumulate and retract messages
       .setParallelism(inputParallelism)
   }
-
-  private[flink] def getPythonScalarFunctionOperator(
-      config: Configuration,
-      inputRowType: RowType,
-      outputRowType: RowType,
-      calcProgram: RexProgram) = {
-    val clazz = loadClass(PYTHON_SCALAR_FUNCTION_OPERATOR_NAME)
-    val ctor = clazz.getConstructor(
-      classOf[Configuration],
-      classOf[Array[PythonFunctionInfo]],
-      classOf[RowType],
-      classOf[RowType],
-      classOf[Array[Int]],
-      classOf[Array[Int]])
-    val (udfInputOffsets, pythonFunctionInfos) =
-      extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
-    ctor.newInstance(
-      config,
-      pythonFunctionInfos,
-      inputRowType,
-      outputRowType,
-      udfInputOffsets,
-      getForwardedFields(calcProgram))
-      .asInstanceOf[OneInputStreamOperator[CRow, CRow]]
-  }
-}
-
-object DataStreamPythonCalc {
-  val PYTHON_SCALAR_FUNCTION_OPERATOR_NAME =
-    "org.apache.flink.table.runtime.operators.python.scalar.PythonScalarFunctionOperator"
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -157,6 +157,7 @@ object FlinkRuleSets {
     CalcMergeRule.INSTANCE,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetCalcRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetCalcRule.scala
@@ -38,7 +38,7 @@ class DataSetCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    !program.getExprList.asScala.exists(containsPythonCall)
+    !program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetPythonCalcRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetPythonCalcRule.scala
@@ -38,7 +38,7 @@ class DataSetPythonCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    program.getExprList.asScala.exists(containsPythonCall)
+    program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCalcRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamCalcRule.scala
@@ -39,7 +39,7 @@ class DataStreamCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    !program.getExprList.asScala.exists(containsPythonCall)
+    !program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCalcRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamPythonCalcRule.scala
@@ -39,7 +39,7 @@ class DataStreamPythonCalcRule
   override def matches(call: RelOptRuleCall): Boolean = {
     val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
     val program = calc.getProgram
-    program.getExprList.asScala.exists(containsPythonCall)
+    program.getExprList.asScala.exists(containsPythonCall(_))
   }
 
   def convert(rel: RelNode): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
@@ -18,13 +18,16 @@
 
 package org.apache.flink.table.plan.rules.logical
 
+import java.util.function.Function
+
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.flink.table.functions.ScalarFunction
+import org.apache.flink.table.functions.python.PythonFunctionKind
 import org.apache.flink.table.plan.nodes.logical.FlinkLogicalCalc
-import org.apache.flink.table.plan.util.PythonUtil.{containsPythonCall, containsNonPythonCall, isPythonCall, isNonPythonCall}
+import org.apache.flink.table.plan.util.PythonUtil.{containsNonPythonCall, containsPythonCall, isNonPythonCall, isPythonCall}
 import org.apache.flink.table.plan.util.{InputRefVisitor, RexDefaultVisitor}
 
 import scala.collection.JavaConverters._
@@ -52,7 +55,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
     val splitter = new ScalarFunctionSplitter(
       extractedFunctionOffset,
       extractedRexCalls,
-      isConvertPythonFunction(program))
+      new Function[RexCall, Boolean] {
+        override def apply(rexCall: RexCall): Boolean = needConvertRexCall(program, rexCall)
+      })
 
     val (bottomCalcCondition, topCalcCondition, topCalcProjects) = split(program, splitter)
     val accessedFields = extractRefInputFields(
@@ -112,9 +117,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
   }
 
   /**
-    * Returns true if converting Python functions.
+    * Returns true if need to convert the specified call.
     */
-  def isConvertPythonFunction(program: RexProgram): Boolean
+  def needConvertRexCall(program: RexProgram, call: RexCall): Boolean
 
   /**
     * Splits the specified [[RexProgram]] using the specified [[ScalarFunctionSplitter]].
@@ -138,10 +143,10 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
 
     // matches if it contains Python functions in condition
     Option(calc.getProgram.getCondition)
-      .map(calc.getProgram.expandLocalRef).exists(containsPythonCall)
+      .map(calc.getProgram.expandLocalRef).exists(containsPythonCall(_))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = true
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -150,12 +155,22 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
   }
 }
 
+abstract class PythonCalcSplitProjectionRuleBase(description: String)
+    extends PythonCalcSplitRuleBase(description) {
+
+  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
+      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
+    (Option(program.getCondition).map(program.expandLocalRef), None,
+      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  }
+}
+
 /**
   * Rule that splits [[FlinkLogicalCalc]]s which contain both Java functions and Python functions
   * in the projection into multiple [[FlinkLogicalCalc]]s. After this rule is applied, it will
   * only contain Python functions or Java functions in the projection of each [[FlinkLogicalCalc]].
   */
-object PythonCalcSplitProjectionRule extends PythonCalcSplitRuleBase(
+object PythonCalcSplitProjectionRule extends PythonCalcSplitProjectionRuleBase(
   "PythonCalcSplitProjectionRule") {
 
   override def matches(call: RelOptRuleCall): Boolean = {
@@ -163,17 +178,36 @@ object PythonCalcSplitProjectionRule extends PythonCalcSplitRuleBase(
     val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
 
     // matches if it contains both Python functions and Java functions in the projection
-    projects.exists(containsPythonCall) && projects.exists(containsNonPythonCall)
+    projects.exists(containsPythonCall(_)) && projects.exists(containsNonPythonCall)
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = {
-    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall)
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(call)
+  }
+}
+
+/**
+  * Rule that splits [[FlinkLogicalCalc]]s which contain both general Python functions and
+  * pandas Python functions in the projection into multiple [[FlinkLogicalCalc]]s. After
+  * this rule is applied, it will only contain general Python functions or pandas Python
+  * functions in the projection of each [[FlinkLogicalCalc]].
+  */
+object PythonCalcSplitPandasInProjectionRule extends PythonCalcSplitProjectionRuleBase(
+  "PythonCalcSplitPandasInProjectionRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
+
+    // matches if it contains both general Python functions and
+    // pandas Python functions in the projection
+    projects.exists(containsPythonCall(_, PythonFunctionKind.GENERAL)) &&
+      projects.exists(containsPythonCall(_, PythonFunctionKind.PANDAS))
   }
 
-  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
-      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
-    (Option(program.getCondition).map(program.expandLocalRef), None,
-      program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+     program.getProjectList.map(program.expandLocalRef).exists(
+       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(call, PythonFunctionKind.PANDAS)
   }
 }
 
@@ -191,10 +225,11 @@ object PythonCalcPushConditionRule extends PythonCalcSplitRuleBase(
     // matches if all the following conditions hold true:
     // 1) the condition is not null
     // 2) it contains Python functions in the projection
-    calc.getProgram.getCondition != null && projects.exists(containsPythonCall)
+    calc.getProgram.getCondition != null && projects.exists(containsPythonCall(_))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = false
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean =
+    isNonPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -221,13 +256,13 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
     // 1) it contains Python functions in the projection
     // 2) it contains RexNodes besides RexInputRef and RexCall or
     //    not all the RexCalls lying at the end of the project list
-    projects.exists(containsPythonCall) &&
+    projects.exists(containsPythonCall(_)) &&
       (projects.exists(expr => !expr.isInstanceOf[RexCall] && !expr.isInstanceOf[RexInputRef]) ||
         projects.indexWhere(_.isInstanceOf[RexCall]) <
           projects.lastIndexWhere(_.isInstanceOf[RexInputRef]))
   }
 
-  override def isConvertPythonFunction(program: RexProgram): Boolean = true
+  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -238,11 +273,11 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
 private class ScalarFunctionSplitter(
     extractedFunctionOffset: Int,
     extractedRexCalls: mutable.ArrayBuffer[RexCall],
-    convertPythonFunction: Boolean)
+    needConvertRexCall: Function[RexCall, Boolean])
   extends RexDefaultVisitor[RexNode] {
 
   override def visitCall(call: RexCall): RexNode = {
-    visit(if (isPythonCall(call)) convertPythonFunction else !convertPythonFunction, call)
+    visit(needConvertRexCall(call), call)
   }
 
   override def visitNode(rexNode: RexNode): RexNode = rexNode
@@ -299,10 +334,11 @@ private class ExtractedFunctionInputRewriter(
 object PythonCalcSplitRule {
   /**
     * These rules should be applied sequentially in the order of
-    * SPLIT_CONDITION, SPLIT_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
+    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
     */
   val SPLIT_CONDITION: RelOptRule = PythonCalcSplitConditionRule
   val SPLIT_PROJECT: RelOptRule = PythonCalcSplitProjectionRule
+  val SPLIT_PANDAS_IN_PROJECT: RelOptRule = PythonCalcSplitPandasInProjectionRule
   val PUSH_CONDITION: RelOptRule = PythonCalcPushConditionRule
   val REWRITE_PROJECT: RelOptRule = PythonCalcRewriteProjectionRule
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromCorrelateRule.scala
@@ -54,7 +54,7 @@ class SplitPythonConditionFromCorrelateRule
     joinType == JoinRelType.INNER &&
       Option(mergedCalc.getProgram.getCondition)
         .map(mergedCalc.getProgram.expandLocalRef)
-        .exists(containsPythonCall)
+        .exists(containsPythonCall(_))
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
@@ -95,7 +95,7 @@ class SplitPythonConditionFromCorrelateRule
       correlate.getRowType.getFieldCount - mergedCalc.getRowType.getFieldCount)
 
     val pythonFilters = correlateFilters
-      .filter(containsPythonCall)
+      .filter(containsPythonCall(_))
       .map(_.accept(inputRefRewriter))
     val topCalcCondition = RexUtil.composeConjunction(rexBuilder, pythonFilters)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/SplitPythonConditionFromJoinRule.scala
@@ -43,7 +43,7 @@ class SplitPythonConditionFromJoinRule extends RelOptRule(
     val join: FlinkLogicalJoin = call.rel(0).asInstanceOf[FlinkLogicalJoin]
     val joinType: JoinRelType = join.getJoinType
     // matches if it is inner join and it contains Python functions in condition
-    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall)
+    joinType == JoinRelType.INNER && Option(join.getCondition).exists(containsPythonCall(_))
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
@@ -51,7 +51,7 @@ class SplitPythonConditionFromJoinRule extends RelOptRule(
     val rexBuilder = join.getCluster.getRexBuilder
 
     val joinFilters = RelOptUtil.conjunctions(join.getCondition)
-    val pythonFilters = joinFilters.filter(containsPythonCall)
+    val pythonFilters = joinFilters.filter(containsPythonCall(_))
     val remainingFilters = joinFilters.filter(!containsPythonCall(_))
 
     val newJoinCondition = RexUtil.composeConjunction(rexBuilder, remainingFilters)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/python/PythonTableUtils.scala
@@ -33,7 +33,7 @@ import org.apache.flink.core.io.InputSplit
 import org.apache.flink.table.api.{TableSchema, Types}
 import org.apache.flink.table.codegen.PythonFunctionCodeGenerator
 import org.apache.flink.table.functions.{ScalarFunction, TableFunction}
-import org.apache.flink.table.functions.python.PythonEnv
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunctionKind}
 import org.apache.flink.table.sources.InputFormatTableSource
 import org.apache.flink.types.Row
 
@@ -48,6 +48,7 @@ object PythonTableUtils {
     * @param serializedScalarFunction serialized Python scalar function
     * @param inputTypes input data types
     * @param resultType expected result type
+    * @param pythonFunctionKind the kind of the Python function
     * @param deterministic the determinism of the function's results
     * @param pythonEnv the Python execution environment
     * @return A generated Java ScalarFunction representation for the specified Python ScalarFunction
@@ -57,6 +58,7 @@ object PythonTableUtils {
       serializedScalarFunction: Array[Byte],
       inputTypes: Array[TypeInformation[_]],
       resultType: TypeInformation[_],
+      pythonFunctionKind: PythonFunctionKind,
       deterministic: Boolean,
       pythonEnv: PythonEnv): ScalarFunction =
     PythonFunctionCodeGenerator.generateScalarFunction(
@@ -64,6 +66,7 @@ object PythonTableUtils {
       serializedScalarFunction,
       inputTypes,
       resultType,
+      pythonFunctionKind,
       deterministic,
       pythonEnv)
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -118,11 +118,6 @@ public class JavaUserDefinedScalarFunctions {
 		public PythonEnv getPythonEnv() {
 			return null;
 		}
-
-		@Override
-		public PythonFunctionKind getPythonFunctionKind() {
-			return PythonFunctionKind.GENERAL;
-		}
 	}
 
 	/**
@@ -158,10 +153,33 @@ public class JavaUserDefinedScalarFunctions {
 		public PythonEnv getPythonEnv() {
 			return null;
 		}
+	}
+
+	/**
+	 * Test for Pandas Python Scalar Function.
+	 */
+	public static class PandasScalarFunction extends PythonScalarFunction {
+		public PandasScalarFunction(String name) {
+			super(name);
+		}
 
 		@Override
 		public PythonFunctionKind getPythonFunctionKind() {
-			return PythonFunctionKind.GENERAL;
+			return PythonFunctionKind.PANDAS;
+		}
+	}
+
+	/**
+	 * Test for Pandas Python Scalar Function.
+	 */
+	public static class BooleanPandasScalarFunction extends BooleanPythonScalarFunction {
+		public BooleanPandasScalarFunction(String name) {
+			super(name);
+		}
+
+		@Override
+		public PythonFunctionKind getPythonFunctionKind() {
+			return PythonFunctionKind.PANDAS;
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.python.PythonEnv;
 import org.apache.flink.table.functions.python.PythonFunction;
+import org.apache.flink.table.functions.python.PythonFunctionKind;
 
 import java.util.Arrays;
 
@@ -117,6 +118,11 @@ public class JavaUserDefinedScalarFunctions {
 		public PythonEnv getPythonEnv() {
 			return null;
 		}
+
+		@Override
+		public PythonFunctionKind getPythonFunctionKind() {
+			return PythonFunctionKind.GENERAL;
+		}
 	}
 
 	/**
@@ -151,6 +157,11 @@ public class JavaUserDefinedScalarFunctions {
 		@Override
 		public PythonEnv getPythonEnv() {
 			return null;
+		}
+
+		@Override
+		public PythonFunctionKind getPythonFunctionKind() {
+			return PythonFunctionKind.GENERAL;
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -581,6 +581,4 @@ object DeterministicPythonFunc extends ScalarFunction with PythonFunction {
   override def getSerializedPythonFunction: Array[Byte] = null
 
   override def getPythonEnv: PythonEnv = null
-
-  override def getPythonFunctionKind: PythonFunctionKind = PythonFunctionKind.GENERAL
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.{Func1, RichFunc1}
 import org.apache.flink.table.functions.ScalarFunction
-import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
+import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction, PythonFunctionKind}
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
 
@@ -581,4 +581,6 @@ object DeterministicPythonFunc extends ScalarFunction with PythonFunction {
   override def getSerializedPythonFunction: Array[Byte] = null
 
   override def getPythonEnv: PythonEnv = null
+
+  override def getPythonFunctionKind: PythonFunctionKind = PythonFunctionKind.GENERAL
 }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds the relNodes and rules to support vectorized Python UDF in blink planner and old planner.*

## Brief change log

  - *Introduce relNodes and rules to support vectorized Python UDF in blink planner such as StreamExecArrowPythonCalc, BatchExecArrowPythonCalc, etc *
  - *Introduce relNodes and rules to support vectorized Python UDF in old planner such as DataStreamArrowPythonCalc*
  - *Introduce PythonCalcSplitPandasInProjectionRule which is used to support use non-vectorized Python UDF and vectorized Python UDF in the same job*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests in PythonCalcSplitRuleTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
