### PR TITLE
[FLINK-16336][table] Add new type inference for temporal table functions

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/TemporalTableFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/TemporalTableFunctionImpl.java
@@ -20,8 +20,13 @@ package org.apache.flink.table.functions;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.operations.QueryOperation;
+import org.apache.flink.table.types.inference.InputTypeStrategies;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
 
 import java.sql.Timestamp;
 
@@ -52,7 +57,7 @@ public final class TemporalTableFunctionImpl extends TemporalTableFunction {
 		this.resultType = resultType;
 	}
 
-	public void eval(Timestamp row) {
+	public void eval(Timestamp t) {
 		throw new IllegalStateException("This should never be called");
 	}
 
@@ -62,6 +67,14 @@ public final class TemporalTableFunctionImpl extends TemporalTableFunction {
 
 	public Expression getPrimaryKey() {
 		return primaryKey;
+	}
+
+	@Override
+	public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+		return TypeInference.newBuilder()
+			.inputTypeStrategy(InputTypeStrategies.explicitSequence(DataTypes.TIMESTAMP(3)))
+			.outputTypeStrategy(TypeStrategies.explicit(underlyingHistoryTable.getTableSchema().toRowDataType()))
+			.build();
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -53,7 +53,7 @@ LogicalProject(rate=[$0], secondary_key=[$1], t3_comment=[$2], t3_secondary_key=
       :  +- LogicalFilter(condition=[OR(=($7, $3), =($9, $4))])
       :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
       :        :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      :        +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType(TIME ATTRIBUTE(ROWTIME) rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)], elementType=[class [Ljava.lang.Object;])
+      :        +- LogicalTableFunctionScan(invocation=[Rates($cor0.o_rowtime)], rowType=[RecordType:peek_no_expand(TIME ATTRIBUTE(ROWTIME) rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
       +- LogicalTableScan(table=[[default_catalog, default_database, Table3]])
 ]]>
     </Resource>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -104,7 +104,7 @@ class TemporalJoinTest extends TableTestBase {
     val rates = util.tableEnv
       .sqlQuery("SELECT * FROM RatesHistory WHERE rate > 110")
       .createTemporalTableFunction("rowtime", "currency")
-    util.addFunction("Rates", rates)
+    util.addTemporarySystemFunction("Rates", rates)
 
     val sqlQuery =
       "SELECT * FROM " +

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -142,7 +142,7 @@ class TemporalJoinITCase(state: StateBackendMode)
     tEnv.registerTable("RatesHistory", ratesHistory)
     tEnv.registerTable("FilteredRatesHistory",
       tEnv.sqlQuery("SELECT * FROM RatesHistory WHERE rate > 110"))
-    tEnv.registerFunction(
+    tEnv.createTemporarySystemFunction(
       "Rates",
       tEnv
         .scan("FilteredRatesHistory")
@@ -213,7 +213,7 @@ class TemporalJoinITCase(state: StateBackendMode)
 
     tEnv.createTemporaryView("Orders", orders)
     tEnv.createTemporaryView("RatesHistory", ratesHistory)
-    tEnv.registerFunction(
+    tEnv.createTemporarySystemFunction(
       "Rates",
       ratesHistory.createTemporalTableFunction("rowtime", "currency"))
     tEnv.registerFunction(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -563,6 +563,13 @@ abstract class TableTestUtil(
   }
 
   /**
+   * Registers a [[UserDefinedFunction]] according to FLIP-65.
+   */
+  def addTemporarySystemFunction(name: String, function: UserDefinedFunction): Unit = {
+    testingTableEnv.createTemporarySystemFunction(name, function)
+  }
+
+  /**
     * Registers a [[TableFunction]] under given name into the TableEnvironment's catalog.
     */
   def addFunction[T: TypeInformation](


### PR DESCRIPTION
## What is the purpose of the change

Uses the new type system with new type inference in temporal table functions.

Depends on FLINK-16261.

## Brief change log

Function now implements both `getResultType()` and `getTypeInference()`.

## Verifying this change

This change is already covered by existing tests, such as `TemporalJoinITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
