### PR TITLE
[FLINK-16341][metrics][datadog] Unify DatadogHttpRequest and DSeries

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DSeries.java
@@ -29,14 +29,22 @@ public class DSeries {
 	 * Names of series field and its getters must not be changed
 	 * since they are mapped to json objects in a Datadog-defined format.
 	 */
-	private List<DMetric> series;
+	private final List<DMetric> series;
 
 	public DSeries() {
 		series = new ArrayList<>();
 	}
 
-	public void addMetric(DMetric metric) {
-		series.add(metric);
+	public void addGauge(DGauge gauge) {
+		series.add(gauge);
+	}
+
+	public void addCounter(DCounter counter) {
+		series.add(counter);
+	}
+
+	public void addMeter(DMeter meter) {
+		series.add(meter);
 	}
 
 	public List<DMetric> getSeries() {

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -99,8 +99,8 @@ public class DatadogHttpClient {
 		}
 	}
 
-	public void send(DatadogHttpReporter.DatadogHttpRequest request) throws Exception {
-		String postBody = serialize(request.getSeries());
+	public void send(DSeries request) throws Exception {
+		String postBody = serialize(request);
 
 		Request r = new Request.Builder()
 			.url(seriesUrl)

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -122,8 +122,23 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 
 	@Override
 	public void report() {
-		DatadogHttpRequest request = new DatadogHttpRequest();
+		DSeries request = new DSeries();
 
+		addGaugesAndUnregisterOnException(request);
+		counters.values().forEach(request::addCounter);
+		meters.values().forEach(request::addMeter);
+
+		try {
+			client.send(request);
+			LOGGER.debug("Reported series with size {}.", request.getSeries().size());
+		} catch (SocketTimeoutException e) {
+			LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}", e.getMessage());
+		} catch (Exception e) {
+			LOGGER.warn("Failed reporting metrics to Datadog.", e);
+		}
+	}
+
+	private void addGaugesAndUnregisterOnException(DSeries request) {
 		List<Gauge> gaugesToRemove = new ArrayList<>();
 		for (Map.Entry<Gauge, DGauge> entry : gauges.entrySet()) {
 			DGauge g = entry.getValue();
@@ -145,23 +160,6 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 			}
 		}
 		gaugesToRemove.forEach(gauges::remove);
-
-		for (DCounter c : counters.values()) {
-			request.addCounter(c);
-		}
-
-		for (DMeter m : meters.values()) {
-			request.addMeter(m);
-		}
-
-		try {
-			client.send(request);
-			LOGGER.debug("Reported series with size {}.", request.getSeries().getSeries().size());
-		} catch (SocketTimeoutException e) {
-			LOGGER.warn("Failed reporting metrics to Datadog because of socket timeout: {}.", e.getMessage());
-		} catch (Exception e) {
-			LOGGER.warn("Failed reporting metrics to Datadog.", e);
-		}
 	}
 
 	/**
@@ -195,32 +193,5 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	 */
 	private String getVariableName(String str) {
 		return str.substring(1, str.length() - 1);
-	}
-
-	/**
-	 * Compact metrics in batch, serialize them, and send to Datadog via HTTP.
-	 */
-	static class DatadogHttpRequest {
-		private final DSeries series;
-
-		public DatadogHttpRequest() {
-			series = new DSeries();
-		}
-
-		public void addGauge(DGauge gauge) {
-			series.addMetric(gauge);
-		}
-
-		public void addCounter(DCounter counter) {
-			series.addMetric(counter);
-		}
-
-		public void addMeter(DMeter meter) {
-			series.addMetric(meter);
-		}
-
-		public DSeries getSeries() {
-			return series;
-		}
 	}
 }


### PR DESCRIPTION
Removes the `DatadogHttpRequest` class which was a simple wrapper around the `DSeries`. It just adds another layer of indirection of which the datadog code already as more than enough.