### PR TITLE
[FLINK-15633][build] Bump javadoc-plugin to 3.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1137,7 +1137,6 @@ under the License.
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
 						<configuration>
 							<quiet>true</quiet>
 						</configuration>
@@ -1221,7 +1220,6 @@ under the License.
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -929,6 +929,15 @@ under the License.
 								<excludedGroups>org.apache.flink.testutils.junit.FailsOnJava11</excludedGroups>
 							</configuration>
 						</plugin>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-javadoc-plugin</artifactId>
+							<configuration>
+								<additionalJOptions>
+									<additionalJOption>--add-exports=java.base/sun.net.util=ALL-UNNAMED</additionalJOption>
+								</additionalJOptions>
+							</configuration>
+						</plugin>
 					</plugins>
 				</pluginManagement>
 
@@ -1724,11 +1733,13 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
+					<version>3.1.1</version><!--$NO-MVN-MAN-VER$-->
 					<configuration>
 						<quiet>true</quiet>
-						<additionalparam>-Xdoclint:none</additionalparam>
 						<detectOfflineLinks>false</detectOfflineLinks>
+						<additionalJOptions>
+							<additionalJOption>-Xdoclint:none</additionalJOption>
+						</additionalJOptions>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
Bumps the javadoc-plugin to 3.1.1, as earlier versions don't work on Java 11.

`additionalparam` was replaced in 3.0.0 (see MJAVADOC-475) with `additionalJOptions` with which you can better define arguments as lists, which is actually quite nice.

The extra configuration in the java11 profile is necessary as without it the javadoc-plugin failed on `org.apache.flink.util.NetUtils`.