### PR TITLE
[FLINK-16344][table-planner-blink] Preserve nullability for nested types

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -293,6 +293,11 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
       case it: TimeIndicatorRelDataType =>
         new TimeIndicatorRelDataType(it.typeSystem, it.originalType, isNullable, it.isEventTime)
 
+      // for nested rows we keep the nullability property,
+      // top-level rows fall back to Calcite's default handling
+      case rt: RelRecordType if rt.getStructKind == StructKind.PEEK_FIELDS_NO_EXPAND =>
+        new RelRecordType(rt.getStructKind, rt.getFieldList, isNullable);
+
       case _ =>
         super.createTypeWithNullability(relDataType, isNullable)
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -603,7 +603,7 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.initData(sourceData);
 
 		tEnv().sqlUpdate("CREATE TABLE SourceTable(s STRING) WITH ('connector' = 'COLLECTION')");
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING>) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING> NOT NULL) WITH ('connector' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("RowTableFunction", RowTableFunction.class);
 		tEnv().sqlUpdate("INSERT INTO SinkTable SELECT t.s, t.sa FROM SourceTable, LATERAL TABLE(RowTableFunction(s)) t");
@@ -761,7 +761,7 @@ public class FunctionITCase extends StreamingTestBase {
 	/**
 	 * Function that returns a row.
 	 */
-	@FunctionHint(output = @DataTypeHint("ROW<s STRING, sa ARRAY<STRING>>"))
+	@FunctionHint(output = @DataTypeHint("ROW<s STRING, sa ARRAY<STRING> NOT NULL>"))
 	public static class RowTableFunction extends TableFunction<Row> {
 		public void eval(String s) {
 			if (s == null) {


### PR DESCRIPTION
## What is the purpose of the change

Avoids errors due to incompatible types during planning by preserving the nullability attributes of nested types.

This PR is based on FLINK-16336.

## Brief change log

FlinkTypeFactory adapted.

## Verifying this change

This change added tests and can be verified as follows: `FunctionITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
