### PR TITLE
[FLINK-16351][flink-table-runtime-blink]Use LinkedHashMap for deterministic iterations

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/AbstractMapBundleOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/AbstractMapBundleOperator.java
@@ -31,7 +31,7 @@ import org.apache.flink.table.runtime.operators.bundle.trigger.BundleTriggerCall
 import org.apache.flink.table.runtime.util.StreamRecordCollector;
 import org.apache.flink.util.Collector;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -85,7 +85,7 @@ public abstract class AbstractMapBundleOperator<K, V, IN, OUT>
 
 		this.numOfElements = 0;
 		this.collector = new StreamRecordCollector<>(output);
-		this.bundle = new HashMap<>();
+		this.bundle = new LinkedHashMap<>();
 
 		bundleTrigger.registerCallback(this);
 		// reset trigger


### PR DESCRIPTION


## What is the purpose of the change
In this PR, we propose to fix [FLINK-16351] by making the test assertions more stable by considering any order of the result.

## Brief change log
In `flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/bundle/AbstractMapBundleOperator.java`, we use `LinkedHashMap` instead of `HashMap` in `open`.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)