### PR TITLE
[FLINK-16352][flink-table/flink-table-common]Use LinkedHashMap for deterministic iterations

### DIFF
--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java
@@ -32,7 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.Period;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
@@ -112,7 +112,7 @@ public class ExpressionTest {
 					DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING())))
 				.toString());
 
-		final Map<String, Integer> map = new HashMap<>();
+		final Map<String, Integer> map = new LinkedHashMap<>();
 		map.put("key1", 1);
 		map.put("key2", 2);
 		map.put("key3", 3);


### PR DESCRIPTION
The test `testValueLiteralString` in `ExpressionTest` may fail due if `HashMap` iterates in a different order. The final variable `map` is a `HashMap`. However, `HashMap` does not guarantee any specific order of entries. Thus, the test can fail due to a different iteration order.

## What is the purpose of the change

In this PR, we propose to fix [FLINK-16352] by making the test assertions more stable by considering any order of result.

## Brief change log

In `flink-table/flink-table-common/src/test/java/org/apache/flink/table/expressions/ExpressionTest.java`, we use `LinkedHashMap` instead of `HashMap` in `testValueLiteralString`.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)