### PR TITLE
[FLINK-16177][checkpointing] Integrate OperatorCoordinator checkpoint triggering and committing

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -55,6 +55,8 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -109,6 +111,9 @@ public class CheckpointCoordinator {
 
 	/** Tasks who need to be sent a message when a checkpoint is confirmed. */
 	private final ExecutionVertex[] tasksToCommitTo;
+
+	/** The operator coordinators that need to be checkpointed. */
+	private final Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint;
 
 	/** Map from checkpoint ID to the pending checkpoint. */
 	private final Map<Long, PendingCheckpoint> pendingCheckpoints;
@@ -203,6 +208,7 @@ public class CheckpointCoordinator {
 		ExecutionVertex[] tasksToTrigger,
 		ExecutionVertex[] tasksToWaitFor,
 		ExecutionVertex[] tasksToCommitTo,
+		Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
 		CheckpointIDCounter checkpointIDCounter,
 		CompletedCheckpointStore completedCheckpointStore,
 		StateBackend checkpointStateBackend,
@@ -217,6 +223,7 @@ public class CheckpointCoordinator {
 			tasksToTrigger,
 			tasksToWaitFor,
 			tasksToCommitTo,
+			coordinatorsToCheckpoint,
 			checkpointIDCounter,
 			completedCheckpointStore,
 			checkpointStateBackend,
@@ -234,6 +241,7 @@ public class CheckpointCoordinator {
 			ExecutionVertex[] tasksToTrigger,
 			ExecutionVertex[] tasksToWaitFor,
 			ExecutionVertex[] tasksToCommitTo,
+			Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint,
 			CheckpointIDCounter checkpointIDCounter,
 			CompletedCheckpointStore completedCheckpointStore,
 			StateBackend checkpointStateBackend,
@@ -267,6 +275,7 @@ public class CheckpointCoordinator {
 		this.tasksToTrigger = checkNotNull(tasksToTrigger);
 		this.tasksToWaitFor = checkNotNull(tasksToWaitFor);
 		this.tasksToCommitTo = checkNotNull(tasksToCommitTo);
+		this.coordinatorsToCheckpoint = Collections.unmodifiableCollection(coordinatorsToCheckpoint);
 		this.pendingCheckpoints = new LinkedHashMap<>();
 		this.checkpointIdCounter = checkNotNull(checkpointIDCounter);
 		this.completedCheckpointStore = checkNotNull(completedCheckpointStore);
@@ -634,6 +643,7 @@ public class CheckpointCoordinator {
 			checkpointID,
 			timestamp,
 			ackTasks,
+			OperatorCoordinatorCheckpointContext.getIds(coordinatorsToCheckpoint),
 			masterHooks.keySet(),
 			props,
 			checkpointStorageLocation,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.checkpoint.metadata.MetadataSerializer;
 import org.apache.flink.runtime.checkpoint.metadata.MetadataSerializers;
-import org.apache.flink.runtime.checkpoint.metadata.MetadataV2Serializer;
+import org.apache.flink.runtime.checkpoint.metadata.MetadataV3Serializer;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -85,8 +85,8 @@ public class Checkpoints {
 		// write generic header
 		out.writeInt(HEADER_MAGIC_NUMBER);
 
-		out.writeInt(MetadataV2Serializer.VERSION);
-		MetadataV2Serializer.serialize(checkpointMetadata, out);
+		out.writeInt(MetadataV3Serializer.VERSION);
+		MetadataV3Serializer.serialize(checkpointMetadata, out);
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpointContext.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An {@link OperatorCoordinator} and its contextual information needed to trigger and
+ * acknowledge a checkpoint.
+ */
+public final class OperatorCoordinatorCheckpointContext {
+
+	private final OperatorCoordinator coordinator;
+
+	private final OperatorID operatorId;
+
+	private final int maxParallelism;
+
+	private final int currentParallelism;
+
+	public OperatorCoordinatorCheckpointContext(
+			OperatorCoordinator coordinator,
+			OperatorID operatorId,
+			int maxParallelism,
+			int currentParallelism) {
+
+		this.coordinator = checkNotNull(coordinator);
+		this.operatorId = checkNotNull(operatorId);
+		this.maxParallelism = maxParallelism;
+		this.currentParallelism = currentParallelism;
+	}
+
+	public OperatorCoordinator coordinator() {
+		return coordinator;
+	}
+
+	public OperatorID operatorId() {
+		return operatorId;
+	}
+
+	public int maxParallelism() {
+		return maxParallelism;
+	}
+
+	public int currentParallelism() {
+		return currentParallelism;
+	}
+
+	public static Collection<OperatorID> getIds(Collection<OperatorCoordinatorCheckpointContext> infos) {
+		return infos.stream()
+			.map(OperatorCoordinatorCheckpointContext::operatorId)
+			.collect(Collectors.toList());
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorCoordinatorCheckpoints.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+
+/**
+ * All the logic related to taking checkpoints of the {@link OperatorCoordinator}s.
+ *
+ * <p>NOTE: This class has a simplified error handling logic. If one of the several coordinator checkpoints
+ * fail, no cleanup is triggered for the other concurrent ones. That is okay, since they all produce just byte[]
+ * as the result. We have to change that once we allow then to create external resources that actually need
+ * to be cleaned up.
+ */
+final class OperatorCoordinatorCheckpoints {
+
+	public static CompletableFuture<CoordinatorSnapshot> triggerCoordinatorCheckpoint(
+			final OperatorCoordinatorCheckpointContext coordinatorInfo,
+			final long checkpointId) throws Exception {
+
+		final CompletableFuture<byte[]> checkpointFuture =
+				coordinatorInfo.coordinator().checkpointCoordinator(checkpointId);
+
+		return checkpointFuture.thenApply(
+				(state) -> new CoordinatorSnapshot(
+						coordinatorInfo, new ByteStreamStateHandle(coordinatorInfo.operatorId().toString(), state))
+		);
+	}
+
+	public static CompletableFuture<AllCoordinatorSnapshots> triggerAllCoordinatorCheckpoints(
+			final Collection<OperatorCoordinatorCheckpointContext> coordinators,
+			final long checkpointId) throws Exception {
+
+		final Collection<CompletableFuture<CoordinatorSnapshot>> individualSnapshots = new ArrayList<>(coordinators.size());
+
+		for (final OperatorCoordinatorCheckpointContext coordinator : coordinators) {
+			individualSnapshots.add(triggerCoordinatorCheckpoint(coordinator, checkpointId));
+		}
+
+		return FutureUtils.combineAll(individualSnapshots).thenApply(AllCoordinatorSnapshots::new);
+	}
+
+	public static CompletableFuture<Void> triggerAndAcknowledgeAllCoordinatorCheckpoints(
+			final Collection<OperatorCoordinatorCheckpointContext> coordinators,
+			final PendingCheckpoint checkpoint,
+			final Executor acknowledgeExecutor) throws Exception {
+
+		final CompletableFuture<AllCoordinatorSnapshots> snapshots =
+				triggerAllCoordinatorCheckpoints(coordinators, checkpoint.getCheckpointId());
+
+		return snapshots
+				.thenAcceptAsync(
+						(allSnapshots) -> {
+							try {
+								acknowledgeAllCoordinators(checkpoint, allSnapshots.snapshots);
+							}
+							catch (Exception e) {
+								throw new CompletionException(e);
+							}
+						},
+						acknowledgeExecutor);
+	}
+
+	public static CompletableFuture<Void> triggerAndAcknowledgeAllCoordinatorCheckpointsWithCompletion(
+			final Collection<OperatorCoordinatorCheckpointContext> coordinators,
+			final PendingCheckpoint checkpoint,
+			final Executor acknowledgeExecutor) throws CompletionException {
+
+		try {
+			return triggerAndAcknowledgeAllCoordinatorCheckpoints(coordinators, checkpoint, acknowledgeExecutor);
+		} catch (Exception e) {
+			throw new CompletionException(e);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static void acknowledgeAllCoordinators(PendingCheckpoint checkpoint, Collection<CoordinatorSnapshot> snapshots) throws CheckpointException {
+		for (final CoordinatorSnapshot snapshot : snapshots) {
+			final PendingCheckpoint.TaskAcknowledgeResult result =
+				checkpoint.acknowledgeCoordinatorState(snapshot.coordinator, snapshot.state);
+
+			if (result != PendingCheckpoint.TaskAcknowledgeResult.SUCCESS) {
+				throw new CheckpointException("Coordinator state not acknowledged successfully: " + result,
+					CheckpointFailureReason.TRIGGER_CHECKPOINT_FAILURE);
+			}
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	static final class AllCoordinatorSnapshots {
+
+		private final Collection<CoordinatorSnapshot> snapshots;
+
+		AllCoordinatorSnapshots(Collection<CoordinatorSnapshot> snapshots) {
+			this.snapshots = snapshots;
+		}
+
+		public Iterable<CoordinatorSnapshot> snapshots() {
+			return snapshots;
+		}
+	}
+
+	static final class CoordinatorSnapshot {
+
+		final OperatorCoordinatorCheckpointContext coordinator;
+		final StreamStateHandle state;
+
+		CoordinatorSnapshot(OperatorCoordinatorCheckpointContext coordinator, StreamStateHandle state) {
+			// if this is not true any more, we need more elaborate dispose/cleanup handling
+			// see comment above the class.
+			assert state instanceof ByteStreamStateHandle;
+
+			this.coordinator = coordinator;
+			this.state = state;
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -131,6 +131,10 @@ public class OperatorState implements CompositeStateHandle {
 		for (OperatorSubtaskState operatorSubtaskState : operatorSubtaskStates.values()) {
 			operatorSubtaskState.discardState();
 		}
+
+		if (coordinatorState != null) {
+			coordinatorState.discardState();
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -21,13 +21,18 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.CompositeStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * Simple container class which contains the raw/managed operator state and key-group state handles from all sub
@@ -42,6 +47,10 @@ public class OperatorState implements CompositeStateHandle {
 
 	/** The handles to states created by the parallel tasks: subtaskIndex -> subtaskstate. */
 	private final Map<Integer, OperatorSubtaskState> operatorSubtaskStates;
+
+	/** The state of the operator coordinator. Null, if no such state exists. */
+	@Nullable
+	private StreamStateHandle coordinatorState;
 
 	/** The parallelism of the operator when it was checkpointed. */
 	private final int parallelism;
@@ -87,6 +96,16 @@ public class OperatorState implements CompositeStateHandle {
 		}
 	}
 
+	public void setCoordinatorState(@Nullable StreamStateHandle coordinatorState) {
+		checkState(this.coordinatorState == null, "coordinator state already set");
+		this.coordinatorState = coordinatorState;
+	}
+
+	@Nullable
+	public StreamStateHandle getCoordinatorState() {
+		return coordinatorState;
+	}
+
 	public Map<Integer, OperatorSubtaskState> getSubtaskStates() {
 		return Collections.unmodifiableMap(operatorSubtaskStates);
 	}
@@ -123,7 +142,7 @@ public class OperatorState implements CompositeStateHandle {
 
 	@Override
 	public long getStateSize() {
-		long result = 0L;
+		long result = coordinatorState == null ? 0L : coordinatorState.getStateSize();
 
 		for (int i = 0; i < parallelism; i++) {
 			OperatorSubtaskState operatorSubtaskState = operatorSubtaskStates.get(i);
@@ -142,6 +161,7 @@ public class OperatorState implements CompositeStateHandle {
 
 			return operatorID.equals(other.operatorID)
 				&& parallelism == other.parallelism
+				&& Objects.equals(coordinatorState, other.coordinatorState)
 				&& operatorSubtaskStates.equals(other.operatorSubtaskStates);
 		} else {
 			return false;
@@ -161,6 +181,7 @@ public class OperatorState implements CompositeStateHandle {
 			"operatorID: " + operatorID +
 			", parallelism: " + parallelism +
 			", maxParallelism: " + maxParallelism +
+			", coordinatorState: " + (coordinatorState == null ? "(none)" : coordinatorState.getStateSize() + " bytes") +
 			", sub task states: " + operatorSubtaskStates.size() +
 			", total size (bytes): " + getStateSize() +
 			')';

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -117,30 +117,9 @@ public class PendingCheckpoint {
 
 	private volatile ScheduledFuture<?> cancellerHandle;
 
-	private CheckpointException failureCause = null;
+	private CheckpointException failureCause;
 
 	// --------------------------------------------------------------------------------------------
-	public PendingCheckpoint(
-		JobID jobId,
-		long checkpointId,
-		long checkpointTimestamp,
-		Map<ExecutionAttemptID, ExecutionVertex> verticesToConfirm,
-		Collection<String> masterStateIdentifiers,
-		CheckpointProperties props,
-		CheckpointStorageLocation targetLocation,
-		Executor executor) {
-
-		this(
-			jobId,
-			checkpointId,
-			checkpointTimestamp,
-			verticesToConfirm,
-			masterStateIdentifiers,
-			props,
-			targetLocation,
-			executor,
-			new CompletableFuture<>());
-	}
 
 	public PendingCheckpoint(
 			JobID jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
 import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateUtil;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -88,6 +90,8 @@ public class PendingCheckpoint {
 
 	private final Map<ExecutionAttemptID, ExecutionVertex> notYetAcknowledgedTasks;
 
+	private final Set<OperatorID> notYetAcknowledgedOperatorCoordinators;
+
 	private final List<MasterState> masterStates;
 
 	private final Set<String> notYetAcknowledgedMasterStates;
@@ -126,6 +130,7 @@ public class PendingCheckpoint {
 			long checkpointId,
 			long checkpointTimestamp,
 			Map<ExecutionAttemptID, ExecutionVertex> verticesToConfirm,
+			Collection<OperatorID> operatorCoordinatorsToConfirm,
 			Collection<String> masterStateIdentifiers,
 			CheckpointProperties props,
 			CheckpointStorageLocation targetLocation,
@@ -145,7 +150,10 @@ public class PendingCheckpoint {
 
 		this.operatorStates = new HashMap<>();
 		this.masterStates = new ArrayList<>(masterStateIdentifiers.size());
-		this.notYetAcknowledgedMasterStates = new HashSet<>(masterStateIdentifiers);
+		this.notYetAcknowledgedMasterStates = masterStateIdentifiers.isEmpty()
+				? Collections.emptySet() : new HashSet<>(masterStateIdentifiers);
+		this.notYetAcknowledgedOperatorCoordinators = operatorCoordinatorsToConfirm.isEmpty()
+				? Collections.emptySet() : new HashSet<>(operatorCoordinatorsToConfirm);
 		this.acknowledgedTasks = new HashSet<>(verticesToConfirm.size());
 		this.onCompletionPromise = checkNotNull(onCompletionPromise);
 	}
@@ -176,6 +184,10 @@ public class PendingCheckpoint {
 		return notYetAcknowledgedTasks.size();
 	}
 
+	public int getNumberOfNonAcknowledgedOperatorCoordinators() {
+		return notYetAcknowledgedOperatorCoordinators.size();
+	}
+
 	public int getNumberOfAcknowledgedTasks() {
 		return numAcknowledgedTasks;
 	}
@@ -188,11 +200,21 @@ public class PendingCheckpoint {
 		return masterStates;
 	}
 
-	public boolean areMasterStatesFullyAcknowledged() {
+	public boolean isFullyAcknowledged() {
+		return areTasksFullyAcknowledged() &&
+			areCoordinatorsFullyAcknowledged() &&
+			areMasterStatesFullyAcknowledged();
+	}
+
+	boolean areMasterStatesFullyAcknowledged() {
 		return notYetAcknowledgedMasterStates.isEmpty() && !discarded;
 	}
 
-	public boolean areTasksFullyAcknowledged() {
+	boolean areCoordinatorsFullyAcknowledged() {
+		return notYetAcknowledgedOperatorCoordinators.isEmpty() && !discarded;
+	}
+
+	boolean areTasksFullyAcknowledged() {
 		return notYetAcknowledgedTasks.isEmpty() && !discarded;
 	}
 
@@ -270,10 +292,8 @@ public class PendingCheckpoint {
 	public CompletedCheckpoint finalizeCheckpoint() throws IOException {
 
 		synchronized (lock) {
-			checkState(areMasterStatesFullyAcknowledged(),
-				"Pending checkpoint has not been fully acknowledged by master states yet.");
-			checkState(areTasksFullyAcknowledged(),
-				"Pending checkpoint has not been fully acknowledged by tasks yet.");
+			checkState(!isDiscarded(), "checkpoint is discarded");
+			checkState(isFullyAcknowledged(), "Pending checkpoint has not been fully acknowledged yet");
 
 			// make sure we fulfill the promise with an exception if something fails
 			try {
@@ -404,6 +424,38 @@ public class PendingCheckpoint {
 					checkpointStartDelayMillis);
 
 				statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
+			}
+
+			return TaskAcknowledgeResult.SUCCESS;
+		}
+	}
+
+	public TaskAcknowledgeResult acknowledgeCoordinatorState(
+			OperatorCoordinatorCheckpointContext coordinatorInfo,
+			@Nullable StreamStateHandle stateHandle) {
+
+		synchronized (lock) {
+			if (discarded) {
+				return TaskAcknowledgeResult.DISCARDED;
+			}
+
+			final OperatorID operatorId = coordinatorInfo.operatorId();
+			OperatorState operatorState = operatorStates.get(operatorId);
+
+			// sanity check for better error reporting
+			if (!notYetAcknowledgedOperatorCoordinators.remove(operatorId)) {
+				return operatorState != null && operatorState.getCoordinatorState() != null
+						? TaskAcknowledgeResult.DUPLICATE
+						: TaskAcknowledgeResult.UNKNOWN;
+			}
+
+			if (stateHandle != null) {
+				if (operatorState == null) {
+					operatorState = new OperatorState(
+						operatorId, coordinatorInfo.currentParallelism(), coordinatorInfo.maxParallelism());
+					operatorStates.put(operatorId, operatorState);
+				}
+				operatorState.setCoordinatorState(stateHandle);
 			}
 
 			return TaskAcknowledgeResult.SUCCESS;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializers.java
@@ -28,18 +28,17 @@ import java.util.Map;
  */
 public class MetadataSerializers {
 
-	private static final Map<Integer, MetadataSerializer> SERIALIZERS = new HashMap<>(2);
+	private static final Map<Integer, MetadataSerializer> SERIALIZERS = new HashMap<>(3);
 
 	static {
-		SERIALIZERS.put(MetadataV1Serializer.VERSION, MetadataV1Serializer.INSTANCE);
-		SERIALIZERS.put(MetadataV2Serializer.VERSION, MetadataV2Serializer.INSTANCE);
+		registerSerializer(MetadataV1Serializer.INSTANCE);
+		registerSerializer(MetadataV2Serializer.INSTANCE);
+		registerSerializer(MetadataV3Serializer.INSTANCE);
 	}
 
-	private MetadataSerializers() {
-		throw new AssertionError();
+	private static void registerSerializer(MetadataSerializer serializer) {
+		SERIALIZERS.put(serializer.getVersion(), serializer);
 	}
-
-	// ------------------------------------------------------------------------
 
 	/**
 	 * Returns the {@link MetadataSerializer} for the given savepoint version.
@@ -56,4 +55,9 @@ public class MetadataSerializers {
 			throw new IllegalArgumentException("Unrecognized checkpoint version number: " + version);
 		}
 	}
+
+	// ------------------------------------------------------------------------
+
+	/** Utility method class, not meant to be instantiated. */
+	private MetadataSerializers() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
@@ -19,9 +19,14 @@
 package org.apache.flink.runtime.checkpoint.metadata;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * (De)serializer for checkpoint metadata format version 2.
@@ -53,5 +58,86 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 	@Override
 	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader) throws IOException {
 		return deserializeMetadata(dis);
+	}
+
+	// ------------------------------------------------------------------------
+	//  version-specific serialization
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void serializeOperatorState(OperatorState operatorState, DataOutputStream dos) throws IOException {
+		// Operator ID
+		dos.writeLong(operatorState.getOperatorID().getLowerPart());
+		dos.writeLong(operatorState.getOperatorID().getUpperPart());
+
+		// Parallelism
+		int parallelism = operatorState.getParallelism();
+		dos.writeInt(parallelism);
+		dos.writeInt(operatorState.getMaxParallelism());
+
+		// this field was "chain length" before Flink 1.3, and it is still part
+		// of the format, despite being unused
+		dos.writeInt(1);
+
+		// Sub task states
+		Map<Integer, OperatorSubtaskState> subtaskStateMap = operatorState.getSubtaskStates();
+		dos.writeInt(subtaskStateMap.size());
+		for (Map.Entry<Integer, OperatorSubtaskState> entry : subtaskStateMap.entrySet()) {
+			dos.writeInt(entry.getKey());
+			serializeSubtaskState(entry.getValue(), dos);
+		}
+	}
+
+	@Override
+	protected OperatorState deserializeOperatorState(DataInputStream dis) throws IOException {
+		final OperatorID jobVertexId = new OperatorID(dis.readLong(), dis.readLong());
+		final int parallelism = dis.readInt();
+		final int maxParallelism = dis.readInt();
+
+		// this field was "chain length" before Flink 1.3, and it is still part
+		// of the format, despite being unused
+		dis.readInt();
+
+		// Add task state
+		final OperatorState taskState = new OperatorState(jobVertexId, parallelism, maxParallelism);
+
+		// Sub task states
+		final int numSubTaskStates = dis.readInt();
+
+		for (int j = 0; j < numSubTaskStates; j++) {
+			final int subtaskIndex = dis.readInt();
+			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis);
+			taskState.putState(subtaskIndex, subtaskState);
+		}
+
+		return taskState;
+	}
+
+	@Override
+	protected void serializeSubtaskState(OperatorSubtaskState subtaskState, DataOutputStream dos) throws IOException {
+		// write two unused fields for compatibility:
+		//   - "duration"
+		//   - number of legacy states
+		dos.writeLong(-1);
+		dos.writeInt(0);
+
+		super.serializeSubtaskState(subtaskState, dos);
+	}
+
+	@Override
+	protected OperatorSubtaskState deserializeSubtaskState(DataInputStream dis) throws IOException {
+		// read two unused fields for compatibility:
+		//   - "duration"
+		//   - number of legacy states
+		dis.readLong();
+		final int numLegacyTaskStates = dis.readInt();
+
+		if (numLegacyTaskStates > 0) {
+			throw new IOException(
+				"Legacy state (from Flink <= 1.1, created through the 'Checkpointed' interface) is " +
+					"no longer supported.");
+		}
+
+		return super.deserializeSubtaskState(dis);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -1,0 +1,555 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.metadata;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.checkpoint.MasterState;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
+import org.apache.flink.runtime.state.KeyGroupsStateHandle;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.StateHandleID;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.FileStateHandle;
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Base (De)serializer for checkpoint metadata format version 2 and 3.
+ *
+ * <p>The difference between versions 2 and 3 is minor. Version 3 includes
+ * operator coordinator state for each operator, and drops some minor unused fields.
+ *
+ * <p>Basic checkpoint metadata layout:
+ * <pre>
+ *  +--------------+---------------+-----------------+
+ *  | checkpointID | master states | operator states |
+ *  +--------------+---------------+-----------------+
+ *
+ *  Master state:
+ *  +--------------+---------------------+---------+------+---------------+
+ *  | magic number | num remaining bytes | version | name | payload bytes |
+ *  +--------------+---------------------+---------+------+---------------+
+ * </pre>
+ */
+@Internal
+public abstract class MetadataV2V3SerializerBase {
+
+	/** Random magic number for consistency checks. */
+	private static final int MASTER_STATE_MAGIC_NUMBER = 0xc96b1696;
+
+	private static final byte NULL_HANDLE = 0;
+	private static final byte BYTE_STREAM_STATE_HANDLE = 1;
+	private static final byte FILE_STREAM_STATE_HANDLE = 2;
+	private static final byte KEY_GROUPS_HANDLE = 3;
+	private static final byte PARTITIONABLE_OPERATOR_STATE_HANDLE = 4;
+	private static final byte INCREMENTAL_KEY_GROUPS_HANDLE = 5;
+
+	// ------------------------------------------------------------------------
+	//  (De)serialization entry points
+	// ------------------------------------------------------------------------
+
+	protected void serializeMetadata(CheckpointMetadata checkpointMetadata, DataOutputStream dos) throws IOException {
+		// first: checkpoint ID
+		dos.writeLong(checkpointMetadata.getCheckpointId());
+
+		// second: master state
+		final Collection<MasterState> masterStates = checkpointMetadata.getMasterStates();
+		dos.writeInt(masterStates.size());
+		for (MasterState ms : masterStates) {
+			serializeMasterState(ms, dos);
+		}
+
+		// third: operator states
+		Collection<OperatorState> operatorStates = checkpointMetadata.getOperatorStates();
+		dos.writeInt(operatorStates.size());
+
+		for (OperatorState operatorState : operatorStates) {
+			serializeOperatorState(operatorState, dos);
+		}
+	}
+
+	protected CheckpointMetadata deserializeMetadata(DataInputStream dis) throws IOException {
+		// first: checkpoint ID
+		final long checkpointId = dis.readLong();
+		if (checkpointId < 0) {
+			throw new IOException("invalid checkpoint ID: " + checkpointId);
+		}
+
+		// second: master state
+		final List<MasterState> masterStates;
+		final int numMasterStates = dis.readInt();
+
+		if (numMasterStates == 0) {
+			masterStates = Collections.emptyList();
+		}
+		else if (numMasterStates > 0) {
+			masterStates = new ArrayList<>(numMasterStates);
+			for (int i = 0; i < numMasterStates; i++) {
+				masterStates.add(deserializeMasterState(dis));
+			}
+		}
+		else {
+			throw new IOException("invalid number of master states: " + numMasterStates);
+		}
+
+		// third: operator states
+		final int numTaskStates = dis.readInt();
+		final List<OperatorState> operatorStates = new ArrayList<>(numTaskStates);
+
+		for (int i = 0; i < numTaskStates; i++) {
+			operatorStates.add(deserializeOperatorState(dis));
+		}
+
+		return new CheckpointMetadata(checkpointId, operatorStates, masterStates);
+	}
+
+	// ------------------------------------------------------------------------
+	//  master state (de)serialization methods
+	// ------------------------------------------------------------------------
+
+	protected void serializeMasterState(MasterState state, DataOutputStream dos) throws IOException {
+		// magic number for error detection
+		dos.writeInt(MASTER_STATE_MAGIC_NUMBER);
+
+		// for safety, we serialize first into an array and then write the array and its
+		// length into the checkpoint
+		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final DataOutputStream out = new DataOutputStream(baos);
+
+		out.writeInt(state.version());
+		out.writeUTF(state.name());
+
+		final byte[] bytes = state.bytes();
+		out.writeInt(bytes.length);
+		out.write(bytes, 0, bytes.length);
+
+		out.close();
+		byte[] data = baos.toByteArray();
+
+		dos.writeInt(data.length);
+		dos.write(data, 0, data.length);
+	}
+
+	protected MasterState deserializeMasterState(DataInputStream dis) throws IOException {
+		final int magicNumber = dis.readInt();
+		if (magicNumber != MASTER_STATE_MAGIC_NUMBER) {
+			throw new IOException("incorrect magic number in master styte byte sequence");
+		}
+
+		final int numBytes = dis.readInt();
+		if (numBytes <= 0) {
+			throw new IOException("found zero or negative length for master state bytes");
+		}
+
+		final byte[] data = new byte[numBytes];
+		dis.readFully(data);
+
+		final DataInputStream in = new DataInputStream(new ByteArrayInputStream(data));
+
+		final int version = in.readInt();
+		final String name = in.readUTF();
+
+		final byte[] bytes = new byte[in.readInt()];
+		in.readFully(bytes);
+
+		// check that the data is not corrupt
+		if (in.read() != -1) {
+			throw new IOException("found trailing bytes in master state");
+		}
+
+		return new MasterState(name, bytes, version);
+	}
+
+	// ------------------------------------------------------------------------
+	//  operator state (de)serialization methods
+	// ------------------------------------------------------------------------
+
+	protected void serializeOperatorState(OperatorState operatorState, DataOutputStream dos) throws IOException {
+		// Operator ID
+		dos.writeLong(operatorState.getOperatorID().getLowerPart());
+		dos.writeLong(operatorState.getOperatorID().getUpperPart());
+
+		// Parallelism
+		int parallelism = operatorState.getParallelism();
+		dos.writeInt(parallelism);
+		dos.writeInt(operatorState.getMaxParallelism());
+
+		// this field was "chain length" before Flink 1.3, and it is still part
+		// of the format, despite being unused
+		dos.writeInt(1);
+
+		// Sub task states
+		Map<Integer, OperatorSubtaskState> subtaskStateMap = operatorState.getSubtaskStates();
+		dos.writeInt(subtaskStateMap.size());
+		for (Map.Entry<Integer, OperatorSubtaskState> entry : subtaskStateMap.entrySet()) {
+			dos.writeInt(entry.getKey());
+			serializeSubtaskState(entry.getValue(), dos);
+		}
+	}
+
+	protected OperatorState deserializeOperatorState(DataInputStream dis) throws IOException {
+		final OperatorID jobVertexId = new OperatorID(dis.readLong(), dis.readLong());
+		final int parallelism = dis.readInt();
+		final int maxParallelism = dis.readInt();
+
+		// this field was "chain length" before Flink 1.3, and it is still part
+		// of the format, despite being unused
+		dis.readInt();
+
+		// Add task state
+		final OperatorState taskState = new OperatorState(jobVertexId, parallelism, maxParallelism);
+
+		// Sub task states
+		final int numSubTaskStates = dis.readInt();
+
+		for (int j = 0; j < numSubTaskStates; j++) {
+			final int subtaskIndex = dis.readInt();
+			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis);
+			taskState.putState(subtaskIndex, subtaskState);
+		}
+
+		return taskState;
+	}
+
+	// ------------------------------------------------------------------------
+	//  operator subtask state (de)serialization methods
+	// ------------------------------------------------------------------------
+
+	protected void serializeSubtaskState(OperatorSubtaskState subtaskState, DataOutputStream dos) throws IOException {
+
+		dos.writeLong(-1);
+
+		int len = 0;
+		dos.writeInt(len);
+
+		OperatorStateHandle operatorStateBackend = extractSingleton(subtaskState.getManagedOperatorState());
+
+		len = operatorStateBackend != null ? 1 : 0;
+		dos.writeInt(len);
+		if (len == 1) {
+			serializeOperatorStateHandle(operatorStateBackend, dos);
+		}
+
+		OperatorStateHandle operatorStateFromStream = extractSingleton(subtaskState.getRawOperatorState());
+
+		len = operatorStateFromStream != null ? 1 : 0;
+		dos.writeInt(len);
+		if (len == 1) {
+			serializeOperatorStateHandle(operatorStateFromStream, dos);
+		}
+
+		KeyedStateHandle keyedStateBackend = extractSingleton(subtaskState.getManagedKeyedState());
+		serializeKeyedStateHandle(keyedStateBackend, dos);
+
+		KeyedStateHandle keyedStateStream = extractSingleton(subtaskState.getRawKeyedState());
+		serializeKeyedStateHandle(keyedStateStream, dos);
+	}
+
+	protected OperatorSubtaskState deserializeSubtaskState(DataInputStream dis) throws IOException {
+		// Duration field has been removed from SubtaskState, do not remove
+		long ignoredDuration = dis.readLong();
+
+		final int numLegacyTaskStates = dis.readInt();
+		if (numLegacyTaskStates > 0) {
+			throw new IOException(
+				"Legacy state (from Flink <= 1.1, created through the 'Checkpointed' interface) is " +
+				"no longer supported.");
+		}
+
+		int len = dis.readInt();
+		OperatorStateHandle operatorStateBackend = len == 0 ? null : deserializeOperatorStateHandle(dis);
+
+		len = dis.readInt();
+		OperatorStateHandle operatorStateStream = len == 0 ? null : deserializeOperatorStateHandle(dis);
+
+		KeyedStateHandle keyedStateBackend = deserializeKeyedStateHandle(dis);
+
+		KeyedStateHandle keyedStateStream = deserializeKeyedStateHandle(dis);
+
+		return new OperatorSubtaskState(
+				operatorStateBackend,
+				operatorStateStream,
+				keyedStateBackend,
+				keyedStateStream);
+	}
+
+	@VisibleForTesting
+	public static void serializeKeyedStateHandle(
+			KeyedStateHandle stateHandle, DataOutputStream dos) throws IOException {
+
+		if (stateHandle == null) {
+			dos.writeByte(NULL_HANDLE);
+		} else if (stateHandle instanceof KeyGroupsStateHandle) {
+			KeyGroupsStateHandle keyGroupsStateHandle = (KeyGroupsStateHandle) stateHandle;
+
+			dos.writeByte(KEY_GROUPS_HANDLE);
+			dos.writeInt(keyGroupsStateHandle.getKeyGroupRange().getStartKeyGroup());
+			dos.writeInt(keyGroupsStateHandle.getKeyGroupRange().getNumberOfKeyGroups());
+			for (int keyGroup : keyGroupsStateHandle.getKeyGroupRange()) {
+				dos.writeLong(keyGroupsStateHandle.getOffsetForKeyGroup(keyGroup));
+			}
+			serializeStreamStateHandle(keyGroupsStateHandle.getDelegateStateHandle(), dos);
+		} else if (stateHandle instanceof IncrementalRemoteKeyedStateHandle) {
+			IncrementalRemoteKeyedStateHandle incrementalKeyedStateHandle =
+				(IncrementalRemoteKeyedStateHandle) stateHandle;
+
+			dos.writeByte(INCREMENTAL_KEY_GROUPS_HANDLE);
+
+			dos.writeLong(incrementalKeyedStateHandle.getCheckpointId());
+			dos.writeUTF(String.valueOf(incrementalKeyedStateHandle.getBackendIdentifier()));
+			dos.writeInt(incrementalKeyedStateHandle.getKeyGroupRange().getStartKeyGroup());
+			dos.writeInt(incrementalKeyedStateHandle.getKeyGroupRange().getNumberOfKeyGroups());
+
+			serializeStreamStateHandle(incrementalKeyedStateHandle.getMetaStateHandle(), dos);
+
+			serializeStreamStateHandleMap(incrementalKeyedStateHandle.getSharedState(), dos);
+			serializeStreamStateHandleMap(incrementalKeyedStateHandle.getPrivateState(), dos);
+		} else {
+			throw new IllegalStateException("Unknown KeyedStateHandle type: " + stateHandle.getClass());
+		}
+	}
+
+	private static void serializeStreamStateHandleMap(
+			Map<StateHandleID, StreamStateHandle> map,
+			DataOutputStream dos) throws IOException {
+
+		dos.writeInt(map.size());
+		for (Map.Entry<StateHandleID, StreamStateHandle> entry : map.entrySet()) {
+			dos.writeUTF(entry.getKey().toString());
+			serializeStreamStateHandle(entry.getValue(), dos);
+		}
+	}
+
+	private static Map<StateHandleID, StreamStateHandle> deserializeStreamStateHandleMap(
+			DataInputStream dis) throws IOException {
+
+		final int size = dis.readInt();
+		Map<StateHandleID, StreamStateHandle> result = new HashMap<>(size);
+
+		for (int i = 0; i < size; ++i) {
+			StateHandleID stateHandleID = new StateHandleID(dis.readUTF());
+			StreamStateHandle stateHandle = deserializeStreamStateHandle(dis);
+			result.put(stateHandleID, stateHandle);
+		}
+
+		return result;
+	}
+
+	@VisibleForTesting
+	public static KeyedStateHandle deserializeKeyedStateHandle(DataInputStream dis) throws IOException {
+		final int type = dis.readByte();
+		if (NULL_HANDLE == type) {
+
+			return null;
+		} else if (KEY_GROUPS_HANDLE == type) {
+
+			int startKeyGroup = dis.readInt();
+			int numKeyGroups = dis.readInt();
+			KeyGroupRange keyGroupRange =
+				KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
+			long[] offsets = new long[numKeyGroups];
+			for (int i = 0; i < numKeyGroups; ++i) {
+				offsets[i] = dis.readLong();
+			}
+			KeyGroupRangeOffsets keyGroupRangeOffsets = new KeyGroupRangeOffsets(
+				keyGroupRange, offsets);
+			StreamStateHandle stateHandle = deserializeStreamStateHandle(dis);
+			return new KeyGroupsStateHandle(keyGroupRangeOffsets, stateHandle);
+		} else if (INCREMENTAL_KEY_GROUPS_HANDLE == type) {
+
+			long checkpointId = dis.readLong();
+			String backendId = dis.readUTF();
+			int startKeyGroup = dis.readInt();
+			int numKeyGroups = dis.readInt();
+			KeyGroupRange keyGroupRange =
+				KeyGroupRange.of(startKeyGroup, startKeyGroup + numKeyGroups - 1);
+
+			StreamStateHandle metaDataStateHandle = deserializeStreamStateHandle(dis);
+			Map<StateHandleID, StreamStateHandle> sharedStates = deserializeStreamStateHandleMap(dis);
+			Map<StateHandleID, StreamStateHandle> privateStates = deserializeStreamStateHandleMap(dis);
+
+			UUID uuid;
+
+			try {
+				uuid = UUID.fromString(backendId);
+			} catch (Exception ex) {
+				// compatibility with old format pre FLINK-6964:
+				uuid = UUID.nameUUIDFromBytes(backendId.getBytes(StandardCharsets.UTF_8));
+			}
+
+			return new IncrementalRemoteKeyedStateHandle(
+				uuid,
+				keyGroupRange,
+				checkpointId,
+				sharedStates,
+				privateStates,
+				metaDataStateHandle);
+		} else {
+			throw new IllegalStateException("Reading invalid KeyedStateHandle, type: " + type);
+		}
+	}
+
+	@VisibleForTesting
+	public static void serializeOperatorStateHandle(
+		OperatorStateHandle stateHandle, DataOutputStream dos) throws IOException {
+
+		if (stateHandle != null) {
+			dos.writeByte(PARTITIONABLE_OPERATOR_STATE_HANDLE);
+			Map<String, OperatorStateHandle.StateMetaInfo> partitionOffsetsMap =
+					stateHandle.getStateNameToPartitionOffsets();
+			dos.writeInt(partitionOffsetsMap.size());
+			for (Map.Entry<String, OperatorStateHandle.StateMetaInfo> entry : partitionOffsetsMap.entrySet()) {
+				dos.writeUTF(entry.getKey());
+
+				OperatorStateHandle.StateMetaInfo stateMetaInfo = entry.getValue();
+
+				int mode = stateMetaInfo.getDistributionMode().ordinal();
+				dos.writeByte(mode);
+
+				long[] offsets = stateMetaInfo.getOffsets();
+				dos.writeInt(offsets.length);
+				for (long offset : offsets) {
+					dos.writeLong(offset);
+				}
+			}
+			serializeStreamStateHandle(stateHandle.getDelegateStateHandle(), dos);
+		} else {
+			dos.writeByte(NULL_HANDLE);
+		}
+	}
+
+	@VisibleForTesting
+	public static OperatorStateHandle deserializeOperatorStateHandle(
+			DataInputStream dis) throws IOException {
+
+		final int type = dis.readByte();
+		if (NULL_HANDLE == type) {
+			return null;
+		} else if (PARTITIONABLE_OPERATOR_STATE_HANDLE == type) {
+			int mapSize = dis.readInt();
+			Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>(mapSize);
+			for (int i = 0; i < mapSize; ++i) {
+				String key = dis.readUTF();
+
+				int modeOrdinal = dis.readByte();
+				OperatorStateHandle.Mode mode = OperatorStateHandle.Mode.values()[modeOrdinal];
+
+				long[] offsets = new long[dis.readInt()];
+				for (int j = 0; j < offsets.length; ++j) {
+					offsets[j] = dis.readLong();
+				}
+
+				OperatorStateHandle.StateMetaInfo metaInfo =
+						new OperatorStateHandle.StateMetaInfo(offsets, mode);
+				offsetsMap.put(key, metaInfo);
+			}
+			StreamStateHandle stateHandle = deserializeStreamStateHandle(dis);
+			return new OperatorStreamStateHandle(offsetsMap, stateHandle);
+		} else {
+			throw new IllegalStateException("Reading invalid OperatorStateHandle, type: " + type);
+		}
+	}
+
+	@VisibleForTesting
+	public static void serializeStreamStateHandle(
+			StreamStateHandle stateHandle, DataOutputStream dos) throws IOException {
+
+		if (stateHandle == null) {
+			dos.writeByte(NULL_HANDLE);
+
+		} else if (stateHandle instanceof FileStateHandle) {
+			dos.writeByte(FILE_STREAM_STATE_HANDLE);
+			FileStateHandle fileStateHandle = (FileStateHandle) stateHandle;
+			dos.writeLong(stateHandle.getStateSize());
+			dos.writeUTF(fileStateHandle.getFilePath().toString());
+
+		} else if (stateHandle instanceof ByteStreamStateHandle) {
+			dos.writeByte(BYTE_STREAM_STATE_HANDLE);
+			ByteStreamStateHandle byteStreamStateHandle = (ByteStreamStateHandle) stateHandle;
+			dos.writeUTF(byteStreamStateHandle.getHandleName());
+			byte[] internalData = byteStreamStateHandle.getData();
+			dos.writeInt(internalData.length);
+			dos.write(byteStreamStateHandle.getData());
+		} else {
+			throw new IOException("Unknown implementation of StreamStateHandle: " + stateHandle.getClass());
+		}
+
+		dos.flush();
+	}
+
+	public static StreamStateHandle deserializeStreamStateHandle(DataInputStream dis) throws IOException {
+		final int type = dis.read();
+		if (NULL_HANDLE == type) {
+			return null;
+		} else if (FILE_STREAM_STATE_HANDLE == type) {
+			long size = dis.readLong();
+			String pathString = dis.readUTF();
+			return new FileStateHandle(new Path(pathString), size);
+		} else if (BYTE_STREAM_STATE_HANDLE == type) {
+			String handleName = dis.readUTF();
+			int numBytes = dis.readInt();
+			byte[] data = new byte[numBytes];
+			dis.readFully(data);
+			return new ByteStreamStateHandle(handleName, data);
+		} else {
+			throw new IOException("Unknown implementation of StreamStateHandle, code: " + type);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	//  utilities
+	// ------------------------------------------------------------------------
+
+	@Nullable
+	private static <T> T extractSingleton(Collection<T> collection) {
+		if (collection == null || collection.isEmpty()) {
+			return null;
+		}
+
+		if (collection.size() == 1) {
+			return collection.iterator().next();
+		} else {
+			throw new IllegalStateException("Expected singleton collection, but found size: " + collection.size());
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
@@ -21,25 +21,29 @@ package org.apache.flink.runtime.checkpoint.metadata;
 import org.apache.flink.annotation.Internal;
 
 import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
- * (De)serializer for checkpoint metadata format version 2.
- * This format was introduced with Apache Flink 1.3.0.
+ * (De)serializer for checkpoint metadata format version 3.
+ * This format was introduced with Apache Flink 1.11.0.
+ *
+ * <p>Compared to format version 2, this drops some unused fields and introduces
+ * operator coordinator state.
  *
  * <p>See {@link MetadataV2V3SerializerBase} for a description of the format layout.
  */
 @Internal
-public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements MetadataSerializer{
+public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements MetadataSerializer {
 
 	/** The metadata format version. */
-	public static final int VERSION = 2;
+	public static final int VERSION = 3;
 
 	/** The singleton instance of the serializer. */
-	public static final MetadataV2Serializer INSTANCE = new MetadataV2Serializer();
+	public static final MetadataV3Serializer INSTANCE = new MetadataV3Serializer();
 
 	/** Singleton, not meant to be instantiated. */
-	private MetadataV2Serializer() {}
+	private MetadataV3Serializer() {}
 
 	@Override
 	public int getVersion() {
@@ -47,8 +51,12 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 	}
 
 	// ------------------------------------------------------------------------
-	//  Deserialization entry point
+	//  (De)serialization entry points
 	// ------------------------------------------------------------------------
+
+	public static void serialize(CheckpointMetadata checkpointMetadata, DataOutputStream dos) throws IOException {
+		INSTANCE.serializeMetadata(checkpointMetadata, dos);
+	}
 
 	@Override
 	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
@@ -81,6 +81,9 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 		dos.writeInt(operatorState.getParallelism());
 		dos.writeInt(operatorState.getMaxParallelism());
 
+		// Coordinator state
+		serializeStreamStateHandle(operatorState.getCoordinatorState(), dos);
+
 		// Sub task states
 		final Map<Integer, OperatorSubtaskState> subtaskStateMap = operatorState.getSubtaskStates();
 		dos.writeInt(subtaskStateMap.size());
@@ -96,8 +99,10 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 		final int parallelism = dis.readInt();
 		final int maxParallelism = dis.readInt();
 
-		// Add task state
 		final OperatorState operatorState = new OperatorState(jobVertexId, parallelism, maxParallelism);
+
+		// Coordinator state
+		operatorState.setCoordinatorState(deserializeStreamStateHandle(dis));
 
 		// Sub task states
 		final int numSubTaskStates = dis.readInt();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointStatsSnapshot;
 import org.apache.flink.runtime.checkpoint.CheckpointStatsTracker;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpointStore;
 import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
+import org.apache.flink.runtime.checkpoint.OperatorCoordinatorCheckpointContext;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils.ConjunctFuture;
@@ -60,10 +61,12 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.ScheduleMode;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotProvider;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.adapter.DefaultExecutionTopology;
@@ -457,6 +460,8 @@ public class ExecutionGraph implements AccessExecutionGraph {
 		ExecutionVertex[] tasksToWaitFor = collectExecutionVertices(verticesToWaitFor);
 		ExecutionVertex[] tasksToCommitTo = collectExecutionVertices(verticesToCommitTo);
 
+		final Collection<OperatorCoordinatorCheckpointContext> operatorCoordinators = buildOpCoordinatorCheckpointContexts();
+
 		checkpointStatsTracker = checkNotNull(statsTracker, "CheckpointStatsTracker");
 
 		CheckpointFailureManager failureManager = new CheckpointFailureManager(
@@ -487,6 +492,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			tasksToTrigger,
 			tasksToWaitFor,
 			tasksToCommitTo,
+			operatorCoordinators,
 			checkpointIDCounter,
 			checkpointStore,
 			checkpointStateBackend,
@@ -564,6 +570,21 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			}
 			return all.toArray(new ExecutionVertex[all.size()]);
 		}
+	}
+
+	private Collection<OperatorCoordinatorCheckpointContext> buildOpCoordinatorCheckpointContexts() {
+		final ArrayList<OperatorCoordinatorCheckpointContext> contexts = new ArrayList<>();
+		for (final ExecutionJobVertex vertex : verticesInCreationOrder) {
+			for (final Map.Entry<OperatorID, OperatorCoordinator> coordinator : vertex.getOperatorCoordinatorMap().entrySet()) {
+				contexts.add(new OperatorCoordinatorCheckpointContext(
+						coordinator.getValue(),
+						coordinator.getKey(),
+						vertex.getMaxParallelism(),
+						vertex.getParallelism()));
+			}
+		}
+		contexts.trimToSize();
+		return contexts;
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -249,10 +249,12 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		}
 
 		try {
-			this.operatorCoordinators = OperatorCoordinatorUtil.instantiateCoordinators(
+			final Map<OperatorID, OperatorCoordinator> coordinators = OperatorCoordinatorUtil.instantiateCoordinators(
 					jobVertex.getOperatorCoordinators(),
 					graph.getUserClassLoader(),
 					(opId) -> new ExecutionJobVertexCoordinatorContext(opId, this));
+
+			this.operatorCoordinators = Collections.unmodifiableMap(coordinators);
 		}
 		catch (IOException | ClassNotFoundException e) {
 			throw new JobException("Cannot instantiate the coordinator for operator " + getName(), e);
@@ -402,8 +404,12 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		return operatorCoordinators.get(operatorId);
 	}
 
+	public Map<OperatorID, OperatorCoordinator> getOperatorCoordinatorMap() {
+		return operatorCoordinators;
+	}
+
 	public Collection<OperatorCoordinator> getOperatorCoordinators() {
-		return Collections.unmodifiableCollection(operatorCoordinators.values());
+		return operatorCoordinators.values();
 	}
 
 	public Either<SerializedValue<TaskInformation>, PermanentBlobKey> getTaskInformationOrBlobKey() throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -67,7 +67,18 @@ public interface OperatorCoordinator extends AutoCloseable {
 
 	CompletableFuture<byte[]> checkpointCoordinator(long checkpointId) throws Exception;
 
-	void checkpointComplete(long checkpointId) throws Exception;
+	/**
+	 * Notifies the coordinator that the checkpoint with the given checkpointId completes and
+	 * was committed.
+	 *
+	 * <p><b>Important:</b> This method is not supposed to throw an exception, because by the
+	 * time we notify that the checkpoint is complete, the checkpoint is committed and cannot be
+	 * aborted any more. If the coordinator gets into an inconsistent state internally, it should
+	 * fail the job ({@link Context#failJob(Throwable)}) instead. Any exception propagating from
+	 * this method may be treated as a fatal error for the JobManager, crashing the JobManager,
+	 * and leading to an expensive "master failover" procedure.
+	 */
+	void checkpointComplete(long checkpointId);
 
 	void resetToCheckpoint(byte[] checkpointData) throws Exception;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -460,6 +460,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new ExecutionVertex[0],
 				ackVertices,
 				new ExecutionVertex[0],
+				Collections.emptyList(),
 				new StandaloneCheckpointIDCounter(),
 				new StandaloneCompletedCheckpointStore(10),
 				new MemoryStateBackend(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -735,7 +735,7 @@ public class CheckpointCoordinatorTestingUtils {
 			return this;
 		}
 
-		public CheckpointCoordinatorBuilder setIoExecutor(Executor exioExecutorecutor) {
+		public CheckpointCoordinatorBuilder setIoExecutor(Executor ioExecutor) {
 			this.ioExecutor = ioExecutor;
 			return this;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -659,6 +659,8 @@ public class CheckpointCoordinatorTestingUtils {
 
 		private ExecutionVertex[] tasksToCommitTo;
 
+		private Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint = Collections.emptyList();
+
 		private CheckpointIDCounter checkpointIDCounter =
 			new StandaloneCheckpointIDCounter();
 
@@ -718,6 +720,10 @@ public class CheckpointCoordinatorTestingUtils {
 			return this;
 		}
 
+		public void setCoordinatorsToCheckpoint(Collection<OperatorCoordinatorCheckpointContext> coordinatorsToCheckpoint) {
+			this.coordinatorsToCheckpoint = coordinatorsToCheckpoint;
+		}
+
 		public CheckpointCoordinatorBuilder setCheckpointIDCounter(
 			CheckpointIDCounter checkpointIDCounter) {
 			this.checkpointIDCounter = checkpointIDCounter;
@@ -764,6 +770,7 @@ public class CheckpointCoordinatorTestingUtils {
 				tasksToTrigger,
 				tasksToWaitFor,
 				tasksToCommitTo,
+				coordinatorsToCheckpoint,
 				checkpointIDCounter,
 				completedCheckpointStore,
 				checkpointStateBackend,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.junit.Assert.assertEquals;
@@ -79,6 +80,7 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 			new ExecutionVertex[] { executionVertex },
 			new ExecutionVertex[] { executionVertex },
 			new ExecutionVertex[] { executionVertex },
+			Collections.emptyList(),
 			new StandaloneCheckpointIDCounter(),
 			new StandaloneCompletedCheckpointStore(1),
 			new MemoryStateBackend(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -462,7 +462,8 @@ public class PendingCheckpointTest {
 			masterStateIdentifiers,
 			props,
 			location,
-			executor);
+			executor,
+			new CompletableFuture<>());
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.StringSerializer;
+import org.apache.flink.runtime.checkpoint.PendingCheckpoint.TaskAcknowledgeResult;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
@@ -30,10 +31,14 @@ import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinator;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +51,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,11 +65,12 @@ import java.util.concurrent.ScheduledFuture;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.nullable;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -189,7 +196,6 @@ public class PendingCheckpointTest {
 	 * Tests that abort discards state.
 	 */
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testAbortDiscardsState() throws Exception {
 		CheckpointProperties props = new CheckpointProperties(false, CheckpointType.SAVEPOINT, false, false, false, false, false);
 		QueueExecutor executor = new QueueExecutor();
@@ -428,21 +434,109 @@ public class PendingCheckpointTest {
 		assertEquals("state", deserializedState);
 	}
 
+	@Test
+	public void testInitiallyUnacknowledgedCoordinatorStates() throws Exception {
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithCoordinators(
+				createOperatorCoordinator(), createOperatorCoordinator());
+
+		assertEquals(2, checkpoint.getNumberOfNonAcknowledgedOperatorCoordinators());
+		assertFalse(checkpoint.isFullyAcknowledged());
+	}
+
+	@Test
+	public void testAcknowledgedCoordinatorStates() throws Exception {
+		final OperatorCoordinatorCheckpointContext coord1 = createOperatorCoordinator();
+		final OperatorCoordinatorCheckpointContext coord2 = createOperatorCoordinator();
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithCoordinators(coord1, coord2);
+
+		final TaskAcknowledgeResult ack1 = checkpoint.acknowledgeCoordinatorState(coord1, new TestingStreamStateHandle());
+		final TaskAcknowledgeResult ack2 = checkpoint.acknowledgeCoordinatorState(coord2, null);
+
+		assertEquals(TaskAcknowledgeResult.SUCCESS, ack1);
+		assertEquals(TaskAcknowledgeResult.SUCCESS, ack2);
+		assertEquals(0, checkpoint.getNumberOfNonAcknowledgedOperatorCoordinators());
+		assertTrue(checkpoint.isFullyAcknowledged());
+		assertThat(checkpoint.getOperatorStates().keySet(), Matchers.contains(coord1.operatorId()));
+	}
+
+	@Test
+	public void testDuplicateAcknowledgeCoordinator() throws Exception {
+		final OperatorCoordinatorCheckpointContext coordinator = createOperatorCoordinator();
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithCoordinators(coordinator);
+
+		checkpoint.acknowledgeCoordinatorState(coordinator, new TestingStreamStateHandle());
+		final TaskAcknowledgeResult secondAck = checkpoint.acknowledgeCoordinatorState(coordinator, null);
+
+		assertEquals(TaskAcknowledgeResult.DUPLICATE, secondAck);
+	}
+
+	@Test
+	public void testAcknowledgeUnknownCoordinator() throws Exception {
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithCoordinators(createOperatorCoordinator());
+
+		final TaskAcknowledgeResult ack = checkpoint.acknowledgeCoordinatorState(createOperatorCoordinator(), null);
+
+		assertEquals(TaskAcknowledgeResult.UNKNOWN, ack);
+	}
+
+	@Test
+	public void testDisposeDisposesCoordinatorStates() throws Exception {
+		final TestingStreamStateHandle handle1 = new TestingStreamStateHandle();
+		final TestingStreamStateHandle handle2 = new TestingStreamStateHandle();
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithAcknowledgedCoordinators(handle1, handle2);
+
+		checkpoint.abort(CheckpointFailureReason.CHECKPOINT_EXPIRED);
+
+		assertTrue(handle1.isDisposed());
+		assertTrue(handle2.isDisposed());
+	}
+
 	// ------------------------------------------------------------------------
 
 	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props) throws IOException {
-		return createPendingCheckpoint(props, Collections.emptyList(), Executors.directExecutor());
+		return createPendingCheckpoint(props, Collections.emptyList(), Collections.emptyList(), Executors.directExecutor());
 	}
 
 	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props, Executor executor) throws IOException {
-		return createPendingCheckpoint(props, Collections.emptyList(), executor);
+		return createPendingCheckpoint(props, Collections.emptyList(), Collections.emptyList(), executor);
 	}
 
 	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props, Collection<String> masterStateIdentifiers) throws IOException {
-		return createPendingCheckpoint(props, masterStateIdentifiers, Executors.directExecutor());
+		return createPendingCheckpoint(props, Collections.emptyList(), masterStateIdentifiers, Executors.directExecutor());
 	}
 
-	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props, Collection<String> masterStateIdentifiers, Executor executor) throws IOException {
+	private PendingCheckpoint createPendingCheckpointWithCoordinators(
+			OperatorCoordinatorCheckpointContext... coordinators) throws IOException {
+
+		final PendingCheckpoint checkpoint = createPendingCheckpoint(
+				CheckpointProperties.forCheckpoint(CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION),
+				OperatorCoordinatorCheckpointContext.getIds(Arrays.asList(coordinators)),
+				Collections.emptyList(),
+				Executors.directExecutor());
+
+		checkpoint.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
+		return checkpoint;
+	}
+
+	private PendingCheckpoint createPendingCheckpointWithAcknowledgedCoordinators(StreamStateHandle... handles) throws IOException {
+		OperatorCoordinatorCheckpointContext[] coords = new OperatorCoordinatorCheckpointContext[handles.length];
+		for (int i = 0; i < handles.length; i++) {
+			coords[i] = createOperatorCoordinator();
+		}
+
+		final PendingCheckpoint checkpoint = createPendingCheckpointWithCoordinators(coords);
+		for (int i = 0; i < handles.length; i++) {
+			checkpoint.acknowledgeCoordinatorState(coords[i], handles[i]);
+		}
+
+		return checkpoint;
+	}
+
+	private PendingCheckpoint createPendingCheckpoint(
+			CheckpointProperties props,
+			Collection<OperatorID> operatorCoordinators,
+			Collection<String> masterStateIdentifiers,
+			Executor executor) throws IOException {
 
 		final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());
 		final FsCheckpointStorageLocation location = new FsCheckpointStorageLocation(
@@ -459,11 +553,20 @@ public class PendingCheckpointTest {
 			0,
 			1,
 			ackTasks,
+			operatorCoordinators,
 			masterStateIdentifiers,
 			props,
 			location,
 			executor,
 			new CompletableFuture<>());
+	}
+
+	private static OperatorCoordinatorCheckpointContext createOperatorCoordinator() {
+		return new OperatorCoordinatorCheckpointContext(
+				new MockOperatorCoordinator(),
+				new OperatorID(),
+				256,
+				50);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
@@ -30,13 +30,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class MetadataV2Test {
+/**
+ * Simple tests for the {@link CheckpointMetadata} data holder class.
+ */
+public class CheckpointMetadataTest {
 
-	/**
-	 * Simple test of savepoint methods.
-	 */
 	@Test
-	public void testSavepointV2() throws Exception {
+	public void testConstructAndDispose() throws Exception {
 		final Random rnd = new Random();
 
 		final long checkpointId = rnd.nextInt(Integer.MAX_VALUE) + 1;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -22,11 +22,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.checkpoint.SubtaskState;
-import org.apache.flink.runtime.checkpoint.TaskState;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.state.ChainedStateHandle;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
@@ -59,13 +55,6 @@ public class CheckpointTestUtils {
 	/**
 	 * Creates a random collection of OperatorState objects containing various types of state handles.
 	 */
-	public static Collection<OperatorState> createOperatorStates(int numTaskStates, int numSubtasksPerTask) {
-		return createOperatorStates(new Random(), numTaskStates, numSubtasksPerTask);
-	}
-
-	/**
-	 * Creates a random collection of OperatorState objects containing various types of state handles.
-	 */
 	public static Collection<OperatorState> createOperatorStates(
 			Random random,
 			int numTaskStates,
@@ -93,7 +82,7 @@ public class CheckpointTestUtils {
 
 				OperatorStateHandle operatorStateHandleBackend = null;
 				OperatorStateHandle operatorStateHandleStream = null;
-				
+
 				Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>();
 				offsetsMap.put("A", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
 				offsetsMap.put("B", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
@@ -136,89 +125,6 @@ public class CheckpointTestUtils {
 	}
 
 	/**
-	 * Creates a random collection of TaskState objects containing various types of state handles.
-	 */
-	public static Collection<TaskState> createTaskStates(int numTaskStates, int numSubtasksPerTask) {
-		return createTaskStates(new Random(), numTaskStates, numSubtasksPerTask);
-	}
-
-	/**
-	 * Creates a random collection of TaskState objects containing various types of state handles.
-	 */
-	public static Collection<TaskState> createTaskStates(
-			Random random,
-			int numTaskStates,
-			int numSubtasksPerTask) {
-
-		List<TaskState> taskStates = new ArrayList<>(numTaskStates);
-
-		for (int stateIdx = 0; stateIdx < numTaskStates; ++stateIdx) {
-
-			int chainLength = 1 + random.nextInt(8);
-
-			TaskState taskState = new TaskState(new JobVertexID(), numSubtasksPerTask, 128, chainLength);
-
-			int noNonPartitionableStateAtIndex = random.nextInt(chainLength);
-			int noOperatorStateBackendAtIndex = random.nextInt(chainLength);
-			int noOperatorStateStreamAtIndex = random.nextInt(chainLength);
-
-			boolean hasKeyedBackend = random.nextInt(4) != 0;
-			boolean hasKeyedStream = random.nextInt(4) != 0;
-
-			for (int subtaskIdx = 0; subtaskIdx < numSubtasksPerTask; subtaskIdx++) {
-
-				List<OperatorStateHandle> operatorStatesBackend = new ArrayList<>(chainLength);
-				List<OperatorStateHandle> operatorStatesStream = new ArrayList<>(chainLength);
-
-				for (int chainIdx = 0; chainIdx < chainLength; ++chainIdx) {
-
-					StreamStateHandle operatorStateBackend =
-							new ByteStreamStateHandle("b-" + chainIdx, ("Beautiful-" + chainIdx).getBytes(ConfigConstants.DEFAULT_CHARSET));
-					StreamStateHandle operatorStateStream =
-							new ByteStreamStateHandle("b-" + chainIdx, ("Beautiful-" + chainIdx).getBytes(ConfigConstants.DEFAULT_CHARSET));
-					Map<String, OperatorStateHandle.StateMetaInfo> offsetsMap = new HashMap<>();
-					offsetsMap.put("A", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-					offsetsMap.put("B", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
-					offsetsMap.put("C", new OperatorStateHandle.StateMetaInfo(new long[]{60, 70, 80}, OperatorStateHandle.Mode.UNION));
-
-					if (chainIdx != noOperatorStateBackendAtIndex) {
-						OperatorStateHandle operatorStateHandleBackend =
-								new OperatorStreamStateHandle(offsetsMap, operatorStateBackend);
-						operatorStatesBackend.add(operatorStateHandleBackend);
-					}
-
-					if (chainIdx != noOperatorStateStreamAtIndex) {
-						OperatorStateHandle operatorStateHandleStream =
-								new OperatorStreamStateHandle(offsetsMap, operatorStateStream);
-						operatorStatesStream.add(operatorStateHandleStream);
-					}
-				}
-
-				KeyGroupsStateHandle keyedStateBackend = null;
-				KeyGroupsStateHandle keyedStateStream = null;
-
-				if (hasKeyedBackend) {
-					keyedStateBackend = createDummyKeyGroupStateHandle(random);
-				}
-
-				if (hasKeyedStream) {
-					keyedStateStream = createDummyKeyGroupStateHandle(random);
-				}
-
-				taskState.putState(subtaskIdx, new SubtaskState(
-						new ChainedStateHandle<>(operatorStatesBackend),
-						new ChainedStateHandle<>(operatorStatesStream),
-						keyedStateStream,
-						keyedStateBackend));
-			}
-
-			taskStates.add(taskState);
-		}
-
-		return taskStates;
-	}
-
-	/**
 	 * Creates a bunch of random master states.
 	 */
 	public static Collection<MasterState> createRandomMasterStates(Random random, int num) {
@@ -238,7 +144,7 @@ public class CheckpointTestUtils {
 
 	/**
 	 * Asserts that two MasterStates are equal.
-	 * 
+	 *
 	 * <p>The MasterState avoids overriding {@code equals()} on purpose, because equality is not well
 	 * defined in the raw contents.
 	 */
@@ -251,9 +157,8 @@ public class CheckpointTestUtils {
 
 	// ------------------------------------------------------------------------
 
-	/** utility class, not meant to be instantiated */
+	/** utility class, not meant to be instantiated. */
 	private CheckpointTestUtils() {}
-
 
 	public static IncrementalRemoteKeyedStateHandle createDummyIncrementalKeyedStateHandle(Random rnd) {
 		return new IncrementalRemoteKeyedStateHandle(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -66,6 +66,12 @@ public class CheckpointTestUtils {
 
 			OperatorState taskState = new OperatorState(new OperatorID(), numSubtasksPerTask, 128);
 
+			final boolean hasCoordinatorState = random.nextBoolean();
+			if (hasCoordinatorState) {
+				final StreamStateHandle stateHandle = createDummyStreamStateHandle(random);
+				taskState.setCoordinatorState(stateHandle);
+			}
+
 			boolean hasOperatorStateBackend = random.nextBoolean();
 			boolean hasOperatorStateStream = random.nextBoolean();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * Various tests for the version 2 format serializer of a checkpoint.
  */
-public class MetadataV2SerializerTest {
+public class MetadataV3SerializerTest {
 
 	@Test
 	public void testCheckpointWithNoState() throws Exception {
@@ -122,7 +122,7 @@ public class MetadataV2SerializerTest {
 			Collection<OperatorState> operatorStates,
 			Collection<MasterState> masterStates) throws IOException {
 
-		MetadataV2Serializer serializer = MetadataV2Serializer.INSTANCE;
+		MetadataV3Serializer serializer = MetadataV3Serializer.INSTANCE;
 
 		ByteArrayOutputStreamWithPos baos = new ByteArrayOutputStreamWithPos();
 		DataOutputStream out = new DataOutputViewStreamWrapper(baos);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -38,7 +38,7 @@ import java.util.Random;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Various tests for the version 2 format serializer of a checkpoint.
+ * Various tests for the version 3 format serializer of a checkpoint.
  */
 public class MetadataV3SerializerTest {
 
@@ -127,7 +127,7 @@ public class MetadataV3SerializerTest {
 		ByteArrayOutputStreamWithPos baos = new ByteArrayOutputStreamWithPos();
 		DataOutputStream out = new DataOutputViewStreamWrapper(baos);
 
-		serializer.serialize(new CheckpointMetadata(checkpointId, operatorStates, masterStates), out);
+		MetadataV3Serializer.serialize(new CheckpointMetadata(checkpointId, operatorStates, masterStates), out);
 		out.close();
 
 		byte[] bytes = baos.toByteArray();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An empty interface implementation of the {@link OperatorCoordinator}.
+ * If you need a testing stub, use the {@link TestingOperatorCoordinator} instead.
+ */
+public final class MockOperatorCoordinator implements OperatorCoordinator {
+
+	@Override
+	public void start() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void close() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void handleEventFromOperator(int subtask, OperatorEvent event) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void subtaskFailed(int subtask) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletableFuture<byte[]> checkpointCoordinator(long checkpointId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void checkpointComplete(long checkpointId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void resetToCheckpoint(byte[] checkpointData) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingStreamStateHandle.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestingStreamStateHandle.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+
+import javax.annotation.Nullable;
+
+/**
+ * A simple test mock for a {@link StreamStateHandle}.
+ */
+public class TestingStreamStateHandle implements StreamStateHandle {
+	private static final long serialVersionUID = 1L;
+
+	@Nullable
+	private final FSDataInputStream inputStream;
+
+	private final long size;
+
+	private boolean disposed;
+
+	public TestingStreamStateHandle() {
+		this(null, 0L);
+	}
+
+	public TestingStreamStateHandle(@Nullable FSDataInputStream inputStream, long size) {
+		this.inputStream = inputStream;
+		this.size = size;
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public FSDataInputStream openInputStream() {
+		if (inputStream == null) {
+			throw new UnsupportedOperationException("no input stream provided");
+		}
+		return inputStream;
+	}
+
+	@Override
+	public void discardState() {
+		disposed = true;
+	}
+
+	@Override
+	public long getStateSize() {
+		return size;
+	}
+
+	// ------------------------------------------------------------------------
+
+	public boolean isDisposed() {
+		return disposed;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.util;
 
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
-import org.apache.flink.runtime.checkpoint.metadata.MetadataV2Serializer;
+import org.apache.flink.runtime.checkpoint.metadata.MetadataV3Serializer;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 
@@ -55,13 +55,13 @@ public class OperatorSnapshotUtil {
 			dos.writeInt(0);
 
 			// still required for compatibility
-			MetadataV2Serializer.serializeStreamStateHandle(null, dos);
+			MetadataV3Serializer.serializeStreamStateHandle(null, dos);
 
 			Collection<OperatorStateHandle> rawOperatorState = state.getRawOperatorState();
 			if (rawOperatorState != null) {
 				dos.writeInt(rawOperatorState.size());
 				for (OperatorStateHandle operatorStateHandle : rawOperatorState) {
-					MetadataV2Serializer.serializeOperatorStateHandle(operatorStateHandle, dos);
+					MetadataV3Serializer.serializeOperatorStateHandle(operatorStateHandle, dos);
 				}
 			} else {
 				// this means no states, not even an empty list
@@ -72,7 +72,7 @@ public class OperatorSnapshotUtil {
 			if (managedOperatorState != null) {
 				dos.writeInt(managedOperatorState.size());
 				for (OperatorStateHandle operatorStateHandle : managedOperatorState) {
-					MetadataV2Serializer.serializeOperatorStateHandle(operatorStateHandle, dos);
+					MetadataV3Serializer.serializeOperatorStateHandle(operatorStateHandle, dos);
 				}
 			} else {
 				// this means no states, not even an empty list
@@ -83,7 +83,7 @@ public class OperatorSnapshotUtil {
 			if (rawKeyedState != null) {
 				dos.writeInt(rawKeyedState.size());
 				for (KeyedStateHandle keyedStateHandle : rawKeyedState) {
-					MetadataV2Serializer.serializeKeyedStateHandle(keyedStateHandle, dos);
+					MetadataV3Serializer.serializeKeyedStateHandle(keyedStateHandle, dos);
 				}
 			} else {
 				// this means no operator states, not even an empty list
@@ -94,7 +94,7 @@ public class OperatorSnapshotUtil {
 			if (managedKeyedState != null) {
 				dos.writeInt(managedKeyedState.size());
 				for (KeyedStateHandle keyedStateHandle : managedKeyedState) {
-					MetadataV2Serializer.serializeKeyedStateHandle(keyedStateHandle, dos);
+					MetadataV3Serializer.serializeKeyedStateHandle(keyedStateHandle, dos);
 				}
 			} else {
 				// this means no operator states, not even an empty list
@@ -113,14 +113,14 @@ public class OperatorSnapshotUtil {
 			dis.readInt();
 
 			// still required for compatibility to consume the bytes.
-			MetadataV2Serializer.deserializeStreamStateHandle(dis);
+			MetadataV3Serializer.deserializeStreamStateHandle(dis);
 
 			List<OperatorStateHandle> rawOperatorState = null;
 			int numRawOperatorStates = dis.readInt();
 			if (numRawOperatorStates >= 0) {
 				rawOperatorState = new ArrayList<>();
 				for (int i = 0; i < numRawOperatorStates; i++) {
-					OperatorStateHandle operatorState = MetadataV2Serializer.deserializeOperatorStateHandle(
+					OperatorStateHandle operatorState = MetadataV3Serializer.deserializeOperatorStateHandle(
 						dis);
 					rawOperatorState.add(operatorState);
 				}
@@ -131,7 +131,7 @@ public class OperatorSnapshotUtil {
 			if (numManagedOperatorStates >= 0) {
 				managedOperatorState = new ArrayList<>();
 				for (int i = 0; i < numManagedOperatorStates; i++) {
-					OperatorStateHandle operatorState = MetadataV2Serializer.deserializeOperatorStateHandle(
+					OperatorStateHandle operatorState = MetadataV3Serializer.deserializeOperatorStateHandle(
 						dis);
 					managedOperatorState.add(operatorState);
 				}
@@ -142,7 +142,7 @@ public class OperatorSnapshotUtil {
 			if (numRawKeyedStates >= 0) {
 				rawKeyedState = new ArrayList<>();
 				for (int i = 0; i < numRawKeyedStates; i++) {
-					KeyedStateHandle keyedState = MetadataV2Serializer.deserializeKeyedStateHandle(
+					KeyedStateHandle keyedState = MetadataV3Serializer.deserializeKeyedStateHandle(
 						dis);
 					rawKeyedState.add(keyedState);
 				}
@@ -153,7 +153,7 @@ public class OperatorSnapshotUtil {
 			if (numManagedKeyedStates >= 0) {
 				managedKeyedState = new ArrayList<>();
 				for (int i = 0; i < numManagedKeyedStates; i++) {
-					KeyedStateHandle keyedState = MetadataV2Serializer.deserializeKeyedStateHandle(
+					KeyedStateHandle keyedState = MetadataV3Serializer.deserializeKeyedStateHandle(
 						dis);
 					managedKeyedState.add(keyedState);
 				}


### PR DESCRIPTION
## What is the purpose of the change

**This is part of [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface?src=contextnavpagetreemode)**

This integrates the previously added `OperatorCoordinators` with checkpointing, in particular with checkpoint triggering and committing.

This PR implements initially a simplified version of checkpoint triggering that does not offer the facilities to align coordinator checkpoints and source checkpoint barrier triggering. 

## Brief change log

  - Add "Operator Coordinator State" to the "OperatorState"
  - Introduce a new version of the Checkpoint Metadata format
  - Add Coordinator State to `PendingCheckpoint`
  - Add a new stage to the checkpoint triggering procedure

## Not Addressed issues

Separate follow-ups are needed for the following two issues:

  - **Checkpoint restoring** The operator coordinators only need to restore on "global restore", meaning when the master fails over, or when a "global job failure" is triggered. Otherwise, the coordinators are notified of local task failures (for example to invalidate specific split assignments).

    To support that, the calls from the scheduler to the checkpoint coordinator need to differentiate between "common failover" (pipelined region) and full job failover (safety net, when encountering inconsistencies / unexpected exceptions in the execution graph or in the coordinators). See [FLINK-16357](https://issues.apache.org/jira/browse/FLINK-16357)

  - **Exactly Once** alignment between coordinator checkpoints and source barrier injection is not included. In this version here, the source barriers are injected once all coordinators are done with their checkpoints. There exist different ideas for how to deal with in flight `OperatorEvents`, which we plan to validate when implementing the `SourceEnumeratorCoordinator`. Hence, this is not yet included, but the code is written to support adding these changes isolated (in the `OperatorCoordinatorCheckpointContext`).

## Verifying this change

This change is already covered by existing tests, and partially extends the class `PendingCheckpointTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **yes**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
