### PR TITLE
[FLINK-16359][table-runtime] Introduce WritableVectors for abstract writing

### DIFF
--- a/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
+++ b/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
@@ -55,11 +55,6 @@ public abstract class AbstractOrcNoHiveVector implements
 		return !orcVector.noNulls && orcVector.isNull[orcVector.isRepeating ? 0 : i];
 	}
 
-	@Override
-	public void reset() {
-		throw new UnsupportedOperationException();
-	}
-
 	public static org.apache.flink.table.dataformat.vector.ColumnVector createFlinkVector(
 			ColumnVector vector) {
 		if (vector instanceof LongColumnVector) {

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -55,11 +55,6 @@ public abstract class AbstractOrcColumnVector implements
 		return !vector.noNulls && vector.isNull[vector.isRepeating ? 0 : i];
 	}
 
-	@Override
-	public void reset() {
-		throw new UnsupportedOperationException();
-	}
-
 	public static org.apache.flink.table.dataformat.vector.ColumnVector createFlinkVector(
 			ColumnVector vector) {
 		if (vector instanceof LongColumnVector) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowBigIntColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowBigIntColumnVector.java
@@ -48,9 +48,4 @@ public final class ArrowBigIntColumnVector implements LongColumnVector {
 	public boolean isNullAt(int i) {
 		return bigIntVector.isNull(i);
 	}
-
-	@Override
-	public void reset() {
-		bigIntVector.reset();
-	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowIntColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowIntColumnVector.java
@@ -45,9 +45,4 @@ public final class ArrowIntColumnVector implements IntColumnVector {
 	public boolean isNullAt(int i) {
 		return intVector.isNull(i);
 	}
-
-	@Override
-	public void reset() {
-		intVector.reset();
-	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowSmallIntColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowSmallIntColumnVector.java
@@ -45,9 +45,4 @@ public final class ArrowSmallIntColumnVector implements ShortColumnVector {
 	public boolean isNullAt(int i) {
 		return smallIntVector.isNull(i);
 	}
-
-	@Override
-	public void reset() {
-		smallIntVector.reset();
-	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTinyIntColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTinyIntColumnVector.java
@@ -45,9 +45,4 @@ public final class ArrowTinyIntColumnVector implements ByteColumnVector {
 	public boolean isNullAt(int i) {
 		return tinyIntVector.isNull(i);
 	}
-
-	@Override
-	public void reset() {
-		tinyIntVector.reset();
-	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/ColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/ColumnVector.java
@@ -22,11 +22,5 @@ package org.apache.flink.table.dataformat.vector;
  * Nullable column vector. Access data through specific subclasses.
  */
 public interface ColumnVector {
-
 	boolean isNullAt(int i);
-
-	/**
-	 * Resets the column to default state.
-	 */
-	void reset();
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/Dictionary.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/Dictionary.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.dataformat.vector;
 
+import org.apache.flink.table.dataformat.SqlTimestamp;
+
 /**
  * The interface for dictionary in AbstractColumnVector to decode dictionary encoded values.
  */
@@ -31,4 +33,6 @@ public interface Dictionary {
 	double decodeToDouble(int id);
 
 	byte[] decodeToBinary(int id);
+
+	SqlTimestamp decodeToTimestamp(int id);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -47,16 +47,6 @@ public class VectorizedColumnBatch implements Serializable {
 		this.columns = vectors;
 	}
 
-	/**
-	 * Resets the batch for writing.
-	 */
-	public void reset() {
-		for (ColumnVector column : columns) {
-			column.reset();
-		}
-		this.numRows = 0;
-	}
-
 	public void setNumRows(int numRows) {
 		this.numRows = numRows;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapBooleanVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapBooleanVector.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.BooleanColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableBooleanVector;
+
+import java.util.Arrays;
 
 /**
  * This class represents a nullable heap boolean column vector.
  */
-public class HeapBooleanVector extends AbstractHeapVector implements BooleanColumnVector {
+public class HeapBooleanVector extends AbstractHeapVector implements WritableBooleanVector {
 
 	private static final long serialVersionUID = 4131239076731313596L;
 
@@ -47,5 +49,15 @@ public class HeapBooleanVector extends AbstractHeapVector implements BooleanColu
 	@Override
 	public boolean getBoolean(int i) {
 		return vector[i];
+	}
+
+	@Override
+	public void setBoolean(int i, boolean value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void fill(boolean value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapByteVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapByteVector.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.ByteColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableByteVector;
+
+import java.util.Arrays;
 
 /**
  * This class represents a nullable byte column vector.
  */
-public class HeapByteVector extends AbstractHeapVector implements ByteColumnVector {
+public class HeapByteVector extends AbstractHeapVector implements WritableByteVector {
 
 	private static final long serialVersionUID = 7216045902943789034L;
 
@@ -46,5 +48,15 @@ public class HeapByteVector extends AbstractHeapVector implements ByteColumnVect
 		} else {
 			return (byte) dictionary.decodeToInt(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setByte(int i, byte value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void fill(byte value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapBytesVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapBytesVector.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.BytesColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableBytesVector;
+
+import java.util.Arrays;
 
 /**
  * This class supports string and binary data by value reference -- i.e. each field is
@@ -35,7 +37,7 @@ import org.apache.flink.table.dataformat.vector.BytesColumnVector;
  * You can mix "by value" and "by reference" in the same column vector,
  * though that use is probably not typical.
  */
-public class HeapBytesVector extends AbstractHeapVector implements BytesColumnVector {
+public class HeapBytesVector extends AbstractHeapVector implements WritableBytesVector {
 
 	private static final long serialVersionUID = -8529155738773478597L;
 
@@ -79,18 +81,8 @@ public class HeapBytesVector extends AbstractHeapVector implements BytesColumnVe
 		elementsAppended = 0;
 	}
 
-	/**
-	 * Set a field by actually copying in to a local buffer.
-	 * If you must actually copy data in to the array, use this method.
-	 * DO NOT USE this method unless it's not practical to set data by reference with setRef().
-	 * Setting data by reference tends to run a lot faster than copying data in.
-	 *
-	 * @param elementNum index within column vector to set
-	 * @param sourceBuf  container of source data
-	 * @param start      start byte position within source
-	 * @param length     length of source byte sequence
-	 */
-	public void setVal(int elementNum, byte[] sourceBuf, int start, int length) {
+	@Override
+	public void appendBytes(int elementNum, byte[] sourceBuf, int start, int length) {
 		reserve(elementsAppended + length);
 		System.arraycopy(sourceBuf, start, buffer, elementsAppended, length);
 		this.start[elementNum] = elementsAppended;
@@ -98,17 +90,16 @@ public class HeapBytesVector extends AbstractHeapVector implements BytesColumnVe
 		elementsAppended += length;
 	}
 
-	/**
-	 * Set a field by actually copying in to a local buffer.
-	 * If you must actually copy data in to the array, use this method.
-	 * DO NOT USE this method unless it's not practical to set data by reference with setRef().
-	 * Setting data by reference tends to run a lot faster than copying data in.
-	 *
-	 * @param elementNum index within column vector to set
-	 * @param sourceBuf  container of source data
-	 */
-	public void setVal(int elementNum, byte[] sourceBuf) {
-		setVal(elementNum, sourceBuf, 0, sourceBuf.length);
+	@Override
+	public void fill(byte[] value) {
+		reserve(start.length * value.length);
+		for (int i = 0; i < start.length; i++) {
+			System.arraycopy(value, 0, buffer, i * value.length, value.length);
+		}
+		for (int i = 0; i < start.length; i++) {
+			this.start[i] = i * value.length;
+		}
+		Arrays.fill(this.length, value.length);
 	}
 
 	private void reserve(int requiredCapacity) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapDoubleVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapDoubleVector.java
@@ -18,14 +18,18 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.DoubleColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableDoubleVector;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
  * This class represents a nullable double precision floating point column vector.
  * This class will be used for operations on all floating point double types
  * and as such will use a 64-bit double value to hold the biggest possible value.
  */
-public class HeapDoubleVector extends AbstractHeapVector implements DoubleColumnVector {
+public class HeapDoubleVector extends AbstractHeapVector implements WritableDoubleVector {
 
 	private static final long serialVersionUID = 6193940154117411328L;
 
@@ -48,5 +52,28 @@ public class HeapDoubleVector extends AbstractHeapVector implements DoubleColumn
 		} else {
 			return dictionary.decodeToDouble(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setDouble(int i, double value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void setDoublesFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (LITTLE_ENDIAN) {
+			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
+					DOUBLE_ARRAY_OFFSET + rowId * 8L, count * 8L);
+		} else {
+			ByteBuffer bb = ByteBuffer.wrap(src).order(ByteOrder.BIG_ENDIAN);
+			for (int i = 0; i < count; ++i) {
+				vector[i + rowId] = bb.getDouble(srcIndex + (8 * i));
+			}
+		}
+	}
+
+	@Override
+	public void fill(double value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapDoubleVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapDoubleVector.java
@@ -61,6 +61,12 @@ public class HeapDoubleVector extends AbstractHeapVector implements WritableDoub
 
 	@Override
 	public void setDoublesFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (rowId + count > vector.length || srcIndex + count * 8L > src.length) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Index out of bounds, row id is %s, count is %s, binary src index is %s, binary" +
+							" length is %s, double array src index is %s, double array length is %s.",
+					rowId, count, srcIndex, src.length, rowId, vector.length));
+		}
 		if (LITTLE_ENDIAN) {
 			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
 					DOUBLE_ARRAY_OFFSET + rowId * 8L, count * 8L);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapFloatVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapFloatVector.java
@@ -18,13 +18,17 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.FloatColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableFloatVector;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
 
 /**
  * This class represents a nullable double precision floating point column vector.
  * This class will be used for operations on all floating point float types.
  */
-public class HeapFloatVector extends AbstractHeapVector implements FloatColumnVector {
+public class HeapFloatVector extends AbstractHeapVector implements WritableFloatVector {
 
 	private static final long serialVersionUID = 8928878923550041110L;
 
@@ -47,5 +51,28 @@ public class HeapFloatVector extends AbstractHeapVector implements FloatColumnVe
 		} else {
 			return dictionary.decodeToFloat(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setFloat(int i, float value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void setFloatsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (LITTLE_ENDIAN) {
+			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
+					FLOAT_ARRAY_OFFSET + rowId * 4L, count * 4L);
+		} else {
+			ByteBuffer bb = ByteBuffer.wrap(src).order(ByteOrder.BIG_ENDIAN);
+			for (int i = 0; i < count; ++i) {
+				vector[i + rowId] = bb.getFloat(srcIndex + (4 * i));
+			}
+		}
+	}
+
+	@Override
+	public void fill(float value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapFloatVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapFloatVector.java
@@ -60,6 +60,12 @@ public class HeapFloatVector extends AbstractHeapVector implements WritableFloat
 
 	@Override
 	public void setFloatsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (rowId + count > vector.length || srcIndex + count * 4L > src.length) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Index out of bounds, row id is %s, count is %s, binary src index is %s, binary" +
+							" length is %s, float array src index is %s, float array length is %s.",
+					rowId, count, srcIndex, src.length, rowId, vector.length));
+		}
 		if (LITTLE_ENDIAN) {
 			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
 					FLOAT_ARRAY_OFFSET + rowId * 4L, count * 4L);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapIntVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapIntVector.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.IntColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableIntVector;
+
+import java.util.Arrays;
 
 /**
  * This class represents a nullable int column vector.
  */
-public class HeapIntVector extends AbstractHeapVector implements IntColumnVector {
+public class HeapIntVector extends AbstractHeapVector implements WritableIntVector {
 
 	private static final long serialVersionUID = -2749499358889718254L;
 
@@ -46,5 +48,46 @@ public class HeapIntVector extends AbstractHeapVector implements IntColumnVector
 		} else {
 			return dictionary.decodeToInt(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setInt(int i, int value) {
+		if (i >= vector.length) {
+			throw new RuntimeException();
+		}
+		vector[i] = value;
+	}
+
+	@Override
+	public void setIntsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (LITTLE_ENDIAN) {
+			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
+					INT_ARRAY_OFFSET + rowId * 4L, count * 4L);
+		} else {
+			long srcOffset = srcIndex + BYTE_ARRAY_OFFSET;
+			for (int i = 0; i < count; ++i, srcOffset += 4) {
+				vector[i + rowId] = Integer.reverseBytes(UNSAFE.getInt(src, srcOffset));
+			}
+		}
+	}
+
+	@Override
+	public void setInts(int rowId, int count, int value) {
+		if (rowId + count - 1 >= vector.length) {
+			throw new RuntimeException();
+		}
+		for (int i = 0; i < count; ++i) {
+			vector[i + rowId] = value;
+		}
+	}
+
+	@Override
+	public void setInts(int rowId, int count, int[] src, int srcIndex) {
+		System.arraycopy(src, srcIndex, vector, rowId, count);
+	}
+
+	@Override
+	public void fill(int value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapIntVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapIntVector.java
@@ -52,14 +52,17 @@ public class HeapIntVector extends AbstractHeapVector implements WritableIntVect
 
 	@Override
 	public void setInt(int i, int value) {
-		if (i >= vector.length) {
-			throw new RuntimeException();
-		}
 		vector[i] = value;
 	}
 
 	@Override
 	public void setIntsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (rowId + count > vector.length || srcIndex + count * 4L > src.length) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Index out of bounds, row id is %s, count is %s, binary src index is %s, binary" +
+							" length is %s, int array src index is %s, int array length is %s.",
+					rowId, count, srcIndex, src.length, rowId, vector.length));
+		}
 		if (LITTLE_ENDIAN) {
 			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
 					INT_ARRAY_OFFSET + rowId * 4L, count * 4L);
@@ -73,9 +76,6 @@ public class HeapIntVector extends AbstractHeapVector implements WritableIntVect
 
 	@Override
 	public void setInts(int rowId, int count, int value) {
-		if (rowId + count - 1 >= vector.length) {
-			throw new RuntimeException();
-		}
 		for (int i = 0; i < count; ++i) {
 			vector[i + rowId] = value;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapLongVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapLongVector.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.LongColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableLongVector;
+
+import java.util.Arrays;
 
 /**
  * This class represents a nullable long column vector.
  */
-public class HeapLongVector extends AbstractHeapVector implements LongColumnVector {
+public class HeapLongVector extends AbstractHeapVector implements WritableLongVector {
 
 	private static final long serialVersionUID = 8534925169458006397L;
 
@@ -46,5 +48,28 @@ public class HeapLongVector extends AbstractHeapVector implements LongColumnVect
 		} else {
 			return dictionary.decodeToLong(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setLong(int i, long value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void setLongsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (LITTLE_ENDIAN) {
+			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
+					LONG_ARRAY_OFFSET + rowId * 8L, count * 8L);
+		} else {
+			long srcOffset = srcIndex + BYTE_ARRAY_OFFSET;
+			for (int i = 0; i < count; ++i, srcOffset += 8) {
+				vector[i + rowId] = Long.reverseBytes(UNSAFE.getLong(src, srcOffset));
+			}
+		}
+	}
+
+	@Override
+	public void fill(long value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapLongVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapLongVector.java
@@ -57,6 +57,12 @@ public class HeapLongVector extends AbstractHeapVector implements WritableLongVe
 
 	@Override
 	public void setLongsFromBinary(int rowId, int count, byte[] src, int srcIndex) {
+		if (rowId + count > vector.length || srcIndex + count * 8L > src.length) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Index out of bounds, row id is %s, count is %s, binary src index is %s, binary" +
+							" length is %s, long array src index is %s, long array length is %s.",
+					rowId, count, srcIndex, src.length, rowId, vector.length));
+		}
 		if (LITTLE_ENDIAN) {
 			UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + srcIndex, vector,
 					LONG_ARRAY_OFFSET + rowId * 8L, count * 8L);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapShortVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapShortVector.java
@@ -18,12 +18,14 @@
 
 package org.apache.flink.table.dataformat.vector.heap;
 
-import org.apache.flink.table.dataformat.vector.ShortColumnVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableShortVector;
+
+import java.util.Arrays;
 
 /**
  * This class represents a nullable short column vector.
  */
-public class HeapShortVector extends AbstractHeapVector implements ShortColumnVector {
+public class HeapShortVector extends AbstractHeapVector implements WritableShortVector {
 
 	private static final long serialVersionUID = -8278486456144676292L;
 
@@ -46,5 +48,15 @@ public class HeapShortVector extends AbstractHeapVector implements ShortColumnVe
 		} else {
 			return (short) dictionary.decodeToInt(dictionaryIds.vector[i]);
 		}
+	}
+
+	@Override
+	public void setShort(int i, short value) {
+		vector[i] = value;
+	}
+
+	@Override
+	public void fill(short value) {
+		Arrays.fill(vector, value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapTimestampVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/heap/HeapTimestampVector.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector.heap;
+
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.dataformat.vector.writable.WritableTimestampVector;
+
+import java.util.Arrays;
+
+import static org.apache.flink.table.dataformat.SqlTimestamp.fromEpochMillis;
+
+/**
+ * This class represents a nullable byte column vector.
+ */
+public class HeapTimestampVector extends AbstractHeapVector implements WritableTimestampVector {
+
+	private static final long serialVersionUID = 1L;
+
+	private final long[] milliseconds;
+	private final int[] nanoOfMilliseconds;
+
+	public HeapTimestampVector(int len) {
+		super(len);
+		this.milliseconds = new long[len];
+		this.nanoOfMilliseconds = new int[len];
+	}
+
+	@Override
+	public SqlTimestamp getTimestamp(int i, int precision) {
+		if (dictionary == null) {
+			return fromEpochMillis(milliseconds[i], nanoOfMilliseconds[i]);
+		} else {
+			return dictionary.decodeToTimestamp(dictionaryIds.vector[i]);
+		}
+	}
+
+	@Override
+	public void setTimestamp(int i, SqlTimestamp timestamp) {
+		milliseconds[i] = timestamp.getMillisecond();
+		nanoOfMilliseconds[i] = timestamp.getNanoOfMillisecond();
+	}
+
+	@Override
+	public void fill(SqlTimestamp value) {
+		Arrays.fill(milliseconds, value.getMillisecond());
+		Arrays.fill(nanoOfMilliseconds, value.getNanoOfMillisecond());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/AbstractWritableVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/AbstractWritableVector.java
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.table.dataformat.vector.Dictionary;
 
 import java.io.Serializable;
 
@@ -24,9 +27,9 @@ import java.io.Serializable;
  * Contains the shared structure for {@link ColumnVector}s, including NULL information and dictionary.
  * NOTE: if there are some nulls, must set {@link #noNulls} to false.
  */
-public abstract class AbstractColumnVector implements ColumnVector, Serializable {
+public abstract class AbstractWritableVector implements WritableColumnVector, Serializable {
 
-	private static final long serialVersionUID = 5340018531388047747L;
+	private static final long serialVersionUID = 1L;
 
 	// If the whole column vector has no nulls, this is true, otherwise false.
 	protected boolean noNulls = true;
@@ -40,22 +43,15 @@ public abstract class AbstractColumnVector implements ColumnVector, Serializable
 	/**
 	 * Update the dictionary.
 	 */
+	@Override
 	public void setDictionary(Dictionary dictionary) {
 		this.dictionary = dictionary;
 	}
 
 	/**
-	 * Reserve a integer column for ids of dictionary.
-	 * DictionaryIds maybe inconsistent with {@link #setDictionary}. Suppose a ColumnVector's data
-	 * comes from two pages. Perhaps one page uses a dictionary and the other page does not use a
-	 * dictionary. The first page that uses a field will have dictionaryIds, which requires
-	 * decoding the first page (Out batch does not support a mix of dictionary).
-	 */
-	public abstract IntColumnVector reserveDictionaryIds(int capacity);
-
-	/**
 	 * Returns true if this column has a dictionary.
 	 */
+	@Override
 	public boolean hasDictionary() {
 		return this.dictionary != null;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBooleanVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBooleanVector.java
@@ -16,36 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.BooleanColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link BooleanColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableBooleanVector extends WritableColumnVector, BooleanColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set boolean at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setBoolean(int rowId, boolean value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
-
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(boolean value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableByteVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableByteVector.java
@@ -16,36 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.ByteColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link ByteColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableByteVector extends WritableColumnVector, ByteColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set byte at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setByte(int rowId, byte value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
-
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(byte value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBytesVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBytesVector.java
@@ -26,7 +26,8 @@ import org.apache.flink.table.dataformat.vector.BytesColumnVector;
 public interface WritableBytesVector extends WritableColumnVector, BytesColumnVector {
 
 	/**
-	 * Set byte[] at rowId with the provided value.
+	 * Append byte[] at rowId with the provided value.
+	 * Note: Must append values according to the order of rowId, can not random append.
 	 */
 	void appendBytes(int rowId, byte[] value, int offset, int length);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBytesVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableBytesVector.java
@@ -16,36 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.BytesColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link BytesColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableBytesVector extends WritableColumnVector, BytesColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set byte[] at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void appendBytes(int rowId, byte[] value, int offset, int length);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
-
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(byte[] value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableColumnVector.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.table.dataformat.vector.Dictionary;
+
+/**
+ * Writable {@link ColumnVector}.
+ */
+public interface WritableColumnVector extends ColumnVector {
+
+	/**
+	 * Resets the column to default state.
+	 */
+	void reset();
+
+	/**
+	 * Set null at rowId.
+	 */
+	void setNullAt(int rowId);
+
+	/**
+	 * Set nulls from rowId to rowId + count (exclude).
+	 */
+	void setNulls(int rowId, int count);
+
+	/**
+	 * Fill the column vector with nulls.
+	 */
+	void fillWithNulls();
+
+	/**
+	 * Set the dictionary, it should work with dictionary ids.
+	 */
+	void setDictionary(Dictionary dictionary);
+
+	/**
+	 * Check if there's a dictionary.
+	 */
+	boolean hasDictionary();
+
+	/**
+	 * Reserve a integer column for ids of dictionary. The size of return {@link WritableIntVector}
+	 * should be equal to or bigger than capacity.
+	 * DictionaryIds must inconsistent with {@link #setDictionary}. We don't support a mix of
+	 * dictionary.
+	 */
+	WritableIntVector reserveDictionaryIds(int capacity);
+
+	/**
+	 * Get reserved dictionary ids.
+	 */
+	WritableIntVector getDictionaryIds();
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableDoubleVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableDoubleVector.java
@@ -16,36 +16,32 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.DoubleColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link DoubleColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableDoubleVector extends WritableColumnVector, DoubleColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set double at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setDouble(int rowId, double value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
+	/**
+	 * Set doubles from binary, need use UNSAFE to copy.
+	 *
+	 * @param rowId set start rowId.
+	 * @param count count for double, so the bytes size is count * 8.
+	 * @param src source binary.
+	 * @param srcIndex source binary index, it is the index for byte index.
+	 */
+	void setDoublesFromBinary(int rowId, int count, byte[] src, int srcIndex);
 
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(double value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableFloatVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableFloatVector.java
@@ -16,36 +16,32 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.FloatColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link FloatColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableFloatVector extends WritableColumnVector, FloatColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set float at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setFloat(int rowId, float value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
+	/**
+	 * Set floats from binary, need use UNSAFE to copy.
+	 *
+	 * @param rowId set start rowId.
+	 * @param count count for float, so the bytes size is count * 4.
+	 * @param src source binary.
+	 * @param srcIndex source binary index, it is the index for byte index.
+	 */
+	void setFloatsFromBinary(int rowId, int count, byte[] src, int srcIndex);
 
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(float value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableIntVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableIntVector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.IntColumnVector;
+
+/**
+ * Writable {@link IntColumnVector}.
+ */
+public interface WritableIntVector extends WritableColumnVector, IntColumnVector {
+
+	/**
+	 * Set int at rowId with the provided value.
+	 */
+	void setInt(int rowId, int value);
+
+	/**
+	 * Set ints from binary, need use UNSAFE to copy.
+	 *
+	 * @param rowId set start rowId.
+	 * @param count count for int, so the bytes size is count * 4.
+	 * @param src source binary.
+	 * @param srcIndex source binary index, it is the index for byte index.
+	 */
+	void setIntsFromBinary(int rowId, int count, byte[] src, int srcIndex);
+
+	/**
+	 * Sets value to [rowId, rowId + count) by the value, this is data that repeats continuously.
+	 */
+	void setInts(int rowId, int count, int value);
+
+	/**
+	 * Sets values from [src[srcIndex], src[srcIndex + count]) to [rowId, rowId + count).
+	 */
+	void setInts(int rowId, int count, int[] src, int srcIndex);
+
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(int value);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableLongVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableLongVector.java
@@ -16,36 +16,32 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.LongColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link LongColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableLongVector extends WritableColumnVector, LongColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set long at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setLong(int rowId, long value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
+	/**
+	 * Set longs from binary, need use UNSAFE to copy.
+	 *
+	 * @param rowId set start rowId.
+	 * @param count count for long, so the bytes size is count * 8.
+	 * @param src source binary.
+	 * @param srcIndex source binary index, it is the index for byte index.
+	 */
+	void setLongsFromBinary(int rowId, int count, byte[] src, int srcIndex);
 
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(long value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableShortVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableShortVector.java
@@ -16,36 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.vector.ShortColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link ShortColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableShortVector extends WritableColumnVector, ShortColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set short at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setShort(int rowId, short value);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
-
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(short value);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableTimestampVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/writable/WritableTimestampVector.java
@@ -16,36 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.dataformat.vector;
+package org.apache.flink.table.dataformat.vector.writable;
+
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.dataformat.vector.TimestampColumnVector;
 
 /**
- * Bytes column vector to get {@link Bytes}, it include original data and offset and length.
- * The data in {@link Bytes} maybe reuse.
+ * Writable {@link TimestampColumnVector}.
  */
-public interface BytesColumnVector extends ColumnVector {
-	Bytes getBytes(int i);
+public interface WritableTimestampVector extends WritableColumnVector, TimestampColumnVector {
 
 	/**
-	 * Bytes data.
+	 * Set {@link SqlTimestamp} at rowId with the provided value.
 	 */
-	class Bytes {
-		public final byte[] data;
-		public final int offset;
-		public final int len;
+	void setTimestamp(int rowId, SqlTimestamp timestamp);
 
-		public Bytes(byte[] data, int offset, int len) {
-			this.data = data;
-			this.offset = offset;
-			this.len = len;
-		}
-
-		public byte[] getBytes() {
-			if (offset == 0 && len == data.length) {
-				return data;
-			}
-			byte[] res = new byte[len];
-			System.arraycopy(data, offset, res, 0, len);
-			return res;
-		}
-	}
+	/**
+	 * Fill the column vector with the provided value.
+	 */
+	void fill(SqlTimestamp value);
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/ColumnVectorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/ColumnVectorTest.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector;
+
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.dataformat.vector.heap.HeapBooleanVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapByteVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapBytesVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapDoubleVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapFloatVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapIntVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapLongVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapShortVector;
+import org.apache.flink.table.dataformat.vector.heap.HeapTimestampVector;
+import org.apache.flink.table.dataformat.vector.writable.WritableColumnVector;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.BYTE_ARRAY_OFFSET;
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.DOUBLE_ARRAY_OFFSET;
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.FLOAT_ARRAY_OFFSET;
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.INT_ARRAY_OFFSET;
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.LONG_ARRAY_OFFSET;
+import static org.apache.flink.table.dataformat.vector.heap.AbstractHeapVector.UNSAFE;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test {@link ColumnVector}.
+ */
+public class ColumnVectorTest {
+
+	private static final int SIZE = 10;
+
+	@Test
+	public void testNulls() {
+		HeapBooleanVector vector = new HeapBooleanVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			if (i % 2 == 0) {
+				vector.setNullAt(i);
+			}
+		}
+		for (int i = 0; i < SIZE; i++) {
+			if (i % 2 == 0) {
+				assertTrue(vector.isNullAt(i));
+			} else {
+				assertFalse(vector.isNullAt(i));
+			}
+		}
+
+		vector.fillWithNulls();
+		for (int i = 0; i < SIZE; i++) {
+			assertTrue(vector.isNullAt(i));
+		}
+
+		vector.reset();
+		for (int i = 0; i < SIZE; i++) {
+			assertFalse(vector.isNullAt(i));
+		}
+
+		vector.setNulls(0, SIZE / 2);
+		for (int i = 0; i < SIZE / 2; i++) {
+			assertTrue(vector.isNullAt(i));
+		}
+	}
+
+	@Test
+	public void testBoolean() {
+		HeapBooleanVector vector = new HeapBooleanVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setBoolean(i, i % 2 == 0);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i % 2 == 0, vector.getBoolean(i));
+		}
+
+		vector.fill(true);
+		for (int i = 0; i < SIZE; i++) {
+			assertTrue(vector.getBoolean(i));
+		}
+	}
+
+	@Test
+	public void testByte() {
+		HeapByteVector vector = new HeapByteVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setByte(i, (byte) i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getByte(i));
+		}
+
+		vector.fill((byte) 22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getByte(i));
+		}
+
+		vector.setDictionary(new TestDictionary(IntStream.range(0, SIZE).boxed().toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getByte(i));
+		}
+	}
+
+	@Test
+	public void testShort() {
+		HeapShortVector vector = new HeapShortVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setShort(i, (short) i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getShort(i));
+		}
+
+		vector.fill((short) 22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getShort(i));
+		}
+
+		vector.setDictionary(new TestDictionary(IntStream.range(0, SIZE).boxed().toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getShort(i));
+		}
+	}
+
+	@Test
+	public void testInt() {
+		HeapIntVector vector = new HeapIntVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setInt(i, i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getInt(i));
+		}
+
+		vector.fill(22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getInt(i));
+		}
+
+		vector = new HeapIntVector(SIZE);
+		vector.setInts(0, SIZE, 22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getInt(i));
+		}
+
+		vector.setDictionary(new TestDictionary(IntStream.range(0, SIZE).boxed().toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getInt(i));
+		}
+
+		int[] ints = IntStream.range(0, SIZE).toArray();
+		byte[] binary = new byte[SIZE * 8];
+		UNSAFE.copyMemory(ints, INT_ARRAY_OFFSET, binary, BYTE_ARRAY_OFFSET, binary.length);
+		vector = new HeapIntVector(SIZE);
+		vector.setIntsFromBinary(0, SIZE, binary, 0);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getInt(i));
+		}
+	}
+
+	@Test
+	public void testLong() {
+		HeapLongVector vector = new HeapLongVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setLong(i, i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getLong(i));
+		}
+
+		vector.fill(22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getLong(i));
+		}
+
+		vector.setDictionary(new TestDictionary(LongStream.range(0, SIZE).boxed().toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getLong(i));
+		}
+
+		long[] longs = LongStream.range(0, SIZE).toArray();
+		byte[] binary = new byte[SIZE * 8];
+		UNSAFE.copyMemory(longs, LONG_ARRAY_OFFSET, binary, BYTE_ARRAY_OFFSET, binary.length);
+		vector = new HeapLongVector(SIZE);
+		vector.setLongsFromBinary(0, SIZE, binary, 0);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getLong(i));
+		}
+	}
+
+	@Test
+	public void testFloat() {
+		HeapFloatVector vector = new HeapFloatVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setFloat(i, i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getFloat(i), 0);
+		}
+
+		vector.fill(22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getFloat(i), 0);
+		}
+
+		vector.setDictionary(new TestDictionary(LongStream.range(0, SIZE).boxed()
+				.map(Number::floatValue).toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getFloat(i), 0);
+		}
+
+		float[] floats = new float[SIZE];
+		for (int i = 0; i < SIZE; i++) {
+			floats[i] = i;
+		}
+		byte[] binary = new byte[SIZE * 4];
+		UNSAFE.copyMemory(floats, FLOAT_ARRAY_OFFSET, binary, BYTE_ARRAY_OFFSET, binary.length);
+		vector = new HeapFloatVector(SIZE);
+		vector.setFloatsFromBinary(0, SIZE, binary, 0);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getFloat(i), 0);
+		}
+	}
+
+	@Test
+	public void testDouble() {
+		HeapDoubleVector vector = new HeapDoubleVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setDouble(i, i);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getDouble(i), 0);
+		}
+
+		vector.fill(22);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(22, vector.getDouble(i), 0);
+		}
+
+		vector.setDictionary(new TestDictionary(LongStream.range(0, SIZE).boxed()
+				.map(Number::doubleValue).toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getDouble(i), 0);
+		}
+
+		double[] doubles = LongStream.range(0, SIZE).boxed().mapToDouble(Number::doubleValue).toArray();
+		byte[] binary = new byte[SIZE * 8];
+		UNSAFE.copyMemory(doubles, DOUBLE_ARRAY_OFFSET, binary, BYTE_ARRAY_OFFSET, binary.length);
+		vector = new HeapDoubleVector(SIZE);
+		vector.setDoublesFromBinary(0, SIZE, binary, 0);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(i, vector.getDouble(i), 0);
+		}
+	}
+
+	private byte[] produceBytes(int i) {
+		return (i + "").getBytes(StandardCharsets.UTF_8);
+	}
+
+	@Test
+	public void testBytes() {
+		HeapBytesVector vector = new HeapBytesVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			byte[] bytes = produceBytes(i);
+			vector.appendBytes(i, bytes, 0, bytes.length);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertArrayEquals(produceBytes(i), vector.getBytes(i).getBytes());
+		}
+		vector.reset();
+		for (int i = 0; i < SIZE; i++) {
+			byte[] bytes = produceBytes(i);
+			vector.appendBytes(i, bytes, 0, bytes.length);
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertArrayEquals(produceBytes(i), vector.getBytes(i).getBytes());
+		}
+
+		vector.fill(produceBytes(22));
+		for (int i = 0; i < SIZE; i++) {
+			assertArrayEquals(produceBytes(22), vector.getBytes(i).getBytes());
+		}
+
+		vector.setDictionary(new TestDictionary(IntStream.range(0, SIZE)
+				.mapToObj(this::produceBytes).toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertArrayEquals(produceBytes(i), vector.getBytes(i).getBytes());
+		}
+	}
+
+	@Test
+	public void testTimestamp() {
+		HeapTimestampVector vector = new HeapTimestampVector(SIZE);
+
+		for (int i = 0; i < SIZE; i++) {
+			vector.setTimestamp(i, SqlTimestamp.fromEpochMillis(i, i));
+		}
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(SqlTimestamp.fromEpochMillis(i, i), vector.getTimestamp(i, 9));
+		}
+
+		vector.fill(SqlTimestamp.fromEpochMillis(22, 22));
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(SqlTimestamp.fromEpochMillis(22, 22), vector.getTimestamp(i, 9));
+		}
+
+		vector.setDictionary(new TestDictionary(IntStream.range(0, SIZE)
+				.mapToObj(i -> SqlTimestamp.fromEpochMillis(i, i)).toArray()));
+		setRangeDictIds(vector);
+		for (int i = 0; i < SIZE; i++) {
+			assertEquals(SqlTimestamp.fromEpochMillis(i, i), vector.getTimestamp(i, 9));
+		}
+	}
+
+	@Test
+	public void testReserveDictIds() {
+		HeapIntVector vector = new HeapIntVector(SIZE);
+		assertTrue(vector.reserveDictionaryIds(2).vector.length >= 2);
+		assertTrue(vector.reserveDictionaryIds(5).vector.length >= 5);
+		assertTrue(vector.reserveDictionaryIds(2).vector.length >= 2);
+	}
+
+	private void setRangeDictIds(WritableColumnVector vector) {
+		vector.reserveDictionaryIds(SIZE)
+				.setInts(0, SIZE, IntStream.range(0, SIZE).toArray(), 0);
+	}
+
+	/**
+	 * Test Dictionary. Just return Object value.
+	 */
+	static final class TestDictionary implements Dictionary {
+		private Object[] intDictionary;
+
+		TestDictionary(Object[] dictionary) {
+			this.intDictionary = dictionary;
+		}
+
+		@Override
+		public int decodeToInt(int id) {
+			return (int) intDictionary[id];
+		}
+
+		@Override
+		public long decodeToLong(int id) {
+			return (long) intDictionary[id];
+		}
+
+		@Override
+		public float decodeToFloat(int id) {
+			return (float) intDictionary[id];
+		}
+
+		@Override
+		public double decodeToDouble(int id) {
+			return (double) intDictionary[id];
+		}
+
+		@Override
+		public byte[] decodeToBinary(int id) {
+			return (byte[]) intDictionary[id];
+		}
+
+		@Override
+		public SqlTimestamp decodeToTimestamp(int id) {
+			return (SqlTimestamp) intDictionary[id];
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatchTest.java
@@ -57,7 +57,7 @@ public class VectorizedColumnBatchTest {
 		HeapBytesVector col1 = new HeapBytesVector(VECTOR_SIZE);
 		for (int i = 0; i < VECTOR_SIZE; i++) {
 			byte[] bytes = String.valueOf(i).getBytes(StandardCharsets.UTF_8);
-			col1.setVal(i, bytes, 0, bytes.length);
+			col1.appendBytes(i, bytes, 0, bytes.length);
 		}
 
 		HeapByteVector col2 = new HeapByteVector(VECTOR_SIZE);
@@ -107,11 +107,6 @@ public class VectorizedColumnBatchTest {
 			}
 
 			@Override
-			public void reset() {
-
-			}
-
-			@Override
 			public SqlTimestamp getTimestamp(int i, int precision) {
 				return SqlTimestamp.fromEpochMillis(vector8[i]);
 			}
@@ -132,11 +127,6 @@ public class VectorizedColumnBatchTest {
 			@Override
 			public boolean isNullAt(int i) {
 				return false;
-			}
-
-			@Override
-			public void reset() {
-
 			}
 		};
 
@@ -191,11 +181,6 @@ public class VectorizedColumnBatchTest {
 			public boolean isNullAt(int i) {
 				return false;
 			}
-
-			@Override
-			public void reset() {
-
-			}
 		};
 
 		long[] vector11 = new long[VECTOR_SIZE];
@@ -204,10 +189,6 @@ public class VectorizedColumnBatchTest {
 			@Override
 			public boolean isNullAt(int i) {
 				return false;
-			}
-
-			@Override
-			public void reset() {
 			}
 
 			@Override
@@ -252,8 +233,6 @@ public class VectorizedColumnBatchTest {
 		}
 
 		assertEquals(VECTOR_SIZE, batch.getNumRows());
-		batch.reset();
-		assertEquals(0, batch.getNumRows());
 	}
 
 	@Test
@@ -291,10 +270,10 @@ public class VectorizedColumnBatchTest {
 	public void testDictionary() {
 		// all null
 		HeapIntVector col = new HeapIntVector(VECTOR_SIZE);
-		int[] dict = new int[2];
+		Integer[] dict = new Integer[2];
 		dict[0] = 1998;
 		dict[1] = 9998;
-		col.setDictionary(new TestDictionary(dict));
+		col.setDictionary(new ColumnVectorTest.TestDictionary(dict));
 		HeapIntVector heapIntVector = col.reserveDictionaryIds(VECTOR_SIZE);
 		for (int i = 0; i < VECTOR_SIZE; i++) {
 			heapIntVector.vector[i] = i % 2 == 0 ? 0 : 1;
@@ -309,39 +288,6 @@ public class VectorizedColumnBatchTest {
 			} else {
 				assertEquals(row.getInt(0), 9998);
 			}
-		}
-	}
-
-	private final class TestDictionary implements Dictionary {
-		private int[] intDictionary;
-
-		public TestDictionary(int[] dictionary) {
-			this.intDictionary = dictionary;
-		}
-
-		@Override
-		public int decodeToInt(int id) {
-			return intDictionary[id];
-		}
-
-		@Override
-		public long decodeToLong(int id) {
-			throw new UnsupportedOperationException("Dictionary encoding does not support float");
-		}
-
-		@Override
-		public float decodeToFloat(int id) {
-			throw new UnsupportedOperationException("Dictionary encoding does not support float");
-		}
-
-		@Override
-		public double decodeToDouble(int id) {
-			throw new UnsupportedOperationException("Dictionary encoding does not support double");
-		}
-
-		@Override
-		public byte[] decodeToBinary(int id) {
-			throw new UnsupportedOperationException("Dictionary encoding does not support String");
 		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

In FLINK-11899 , we need write vectors from parquet input streams.

We need abstract vector writing, in future, we can provide OffHeapVectors.

## Brief change log

- Introduce WritableVector interfaces.
- Implement WritableVectors in Heap vectors.

## Verifying this change

`ColumnVectorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)