### PR TITLE
[FLINK-16360][orc] Flink STRING data type should map to ORC STRING type

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
@@ -140,7 +140,12 @@ public class OrcSplitReaderUtil {
 			case CHAR:
 				return TypeDescription.createChar().withMaxLength(((CharType) type).getLength());
 			case VARCHAR:
-				return TypeDescription.createVarchar().withMaxLength(((VarCharType) type).getLength());
+				int len = ((VarCharType) type).getLength();
+				if (len == VarCharType.MAX_LENGTH) {
+					return TypeDescription.createString();
+				} else {
+					return TypeDescription.createVarchar().withMaxLength(len);
+				}
 			case BOOLEAN:
 				return TypeDescription.createBoolean();
 			case VARBINARY:

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
@@ -36,6 +36,7 @@ public class OrcSplitReaderUtilTest {
 		test("boolean", DataTypes.BOOLEAN());
 		test("char(123)", DataTypes.CHAR(123));
 		test("varchar(123)", DataTypes.VARCHAR(123));
+		test("string", DataTypes.STRING());
 		test("binary", DataTypes.BYTES());
 		test("tinyint", DataTypes.TINYINT());
 		test("smallint", DataTypes.SMALLINT());
@@ -47,7 +48,7 @@ public class OrcSplitReaderUtilTest {
 		test("timestamp", DataTypes.TIMESTAMP());
 		test("array<float>", DataTypes.ARRAY(DataTypes.FLOAT()));
 		test("map<float,bigint>", DataTypes.MAP(DataTypes.FLOAT(), DataTypes.BIGINT()));
-		test("struct<int0:int,str1:varchar(2147483647),double2:double,row3:struct<int0:int,int1:int>>",
+		test("struct<int0:int,str1:string,double2:double,row3:struct<int0:int,int1:int>>",
 				DataTypes.ROW(
 						DataTypes.FIELD("int0", DataTypes.INT()),
 						DataTypes.FIELD("str1", DataTypes.STRING()),


### PR DESCRIPTION

## What is the purpose of the change

Hive 2.0 ORC not support schema evolution from STRING to VARCHAR.
We need produce STRING in ORC for VarcharType(MAX_LENGHT) in Flink.

## Brief change log

Flink STRING data type should map to ORC STRING type in `OrcSplitReaderUtil`

## Verifying this change

`OrcSplitReaderUtilTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)