### PR TITLE
[FLINK-16362] [table] Remove deprecated method in StreamTableSink

### DIFF
--- a/docs/dev/table/sourceSinks.md
+++ b/docs/dev/table/sourceSinks.md
@@ -452,7 +452,7 @@ The interface looks as follows:
 {% highlight java %}
 AppendStreamTableSink<T> implements TableSink<T> {
 
-  public void emitDataStream(DataStream<T> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<T> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -461,7 +461,7 @@ AppendStreamTableSink<T> implements TableSink<T> {
 {% highlight scala %}
 AppendStreamTableSink[T] extends TableSink[T] {
 
-  def emitDataStream(dataStream: DataStream[T]): Unit
+  def consumeDataStream(dataStream: DataStream[T]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>
@@ -484,7 +484,7 @@ RetractStreamTableSink<T> implements TableSink<Tuple2<Boolean, T>> {
 
   public TypeInformation<T> getRecordType();
 
-  public void emitDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -495,7 +495,7 @@ RetractStreamTableSink[T] extends TableSink[Tuple2[Boolean, T]] {
 
   def getRecordType: TypeInformation[T]
 
-  def emitDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): Unit
+  def consumeDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>
@@ -522,7 +522,7 @@ UpsertStreamTableSink<T> implements TableSink<Tuple2<Boolean, T>> {
 
   public TypeInformation<T> getRecordType();
 
-  public void emitDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -537,7 +537,7 @@ UpsertStreamTableSink[T] extends TableSink[Tuple2[Boolean, T]] {
 
   def getRecordType: TypeInformation[T]
 
-  def emitDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): Unit
+  def consumeDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>

--- a/docs/dev/table/sourceSinks.zh.md
+++ b/docs/dev/table/sourceSinks.zh.md
@@ -452,7 +452,7 @@ The interface looks as follows:
 {% highlight java %}
 AppendStreamTableSink<T> implements TableSink<T> {
 
-  public void emitDataStream(DataStream<T> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<T> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -461,7 +461,7 @@ AppendStreamTableSink<T> implements TableSink<T> {
 {% highlight scala %}
 AppendStreamTableSink[T] extends TableSink[T] {
 
-  def emitDataStream(dataStream: DataStream[T]): Unit
+  def consumeDataStream(dataStream: DataStream[T]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>
@@ -484,7 +484,7 @@ RetractStreamTableSink<T> implements TableSink<Tuple2<Boolean, T>> {
 
   public TypeInformation<T> getRecordType();
 
-  public void emitDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -495,7 +495,7 @@ RetractStreamTableSink[T] extends TableSink[Tuple2[Boolean, T]] {
 
   def getRecordType: TypeInformation[T]
 
-  def emitDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): Unit
+  def consumeDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>
@@ -522,7 +522,7 @@ UpsertStreamTableSink<T> implements TableSink<Tuple2<Boolean, T>> {
 
   public TypeInformation<T> getRecordType();
 
-  public void emitDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
+  public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, T>> dataStream);
 }
 {% endhighlight %}
 </div>
@@ -537,7 +537,7 @@ UpsertStreamTableSink[T] extends TableSink[Tuple2[Boolean, T]] {
 
   def getRecordType: TypeInformation[T]
 
-  def emitDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): Unit
+  def consumeDataStream(dataStream: DataStream[Tuple2[Boolean, T]]): DataStreamSink[_]
 }
 {% endhighlight %}
 </div>

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraAppendTableSink.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/streaming/connectors/cassandra/CassandraAppendTableSink.java
@@ -97,8 +97,4 @@ public class CassandraAppendTableSink implements AppendStreamTableSink<Row> {
 
 	}
 
-	@Override
-	public void emitDataStream(DataStream<Row> dataStream) {
-		consumeDataStream(dataStream);
-	}
 }

--- a/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/main/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchUpsertTableSinkBase.java
@@ -192,11 +192,6 @@ public abstract class ElasticsearchUpsertTableSinkBase implements UpsertStreamTa
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public TypeInformation<Tuple2<Boolean, Row>> getOutputType() {
 		return Types.TUPLE(Types.BOOLEAN, getRecordType());
 	}

--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch6/Elasticsearch6UpsertTableSinkFactoryTest.java
@@ -79,7 +79,7 @@ public class Elasticsearch6UpsertTableSinkFactoryTest extends ElasticsearchUpser
 				new StreamExecutionEnvironmentMock(),
 				Types.TUPLE(Types.BOOLEAN, schema.toRowType()));
 
-		testSink.emitDataStream(dataStreamMock);
+		testSink.consumeDataStream(dataStreamMock);
 
 		final ElasticsearchSink.Builder<Tuple2<Boolean, Row>> expectedBuilder = new ElasticsearchSink.Builder<>(
 			Collections.singletonList(new HttpHost(HOSTNAME, PORT, SCHEMA)),

--- a/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7UpsertTableSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-elasticsearch7/src/test/java/org/apache/flink/streaming/connectors/elasticsearch7/Elasticsearch7UpsertTableSinkFactoryTest.java
@@ -78,7 +78,7 @@ public class Elasticsearch7UpsertTableSinkFactoryTest extends ElasticsearchUpser
 				new StreamExecutionEnvironmentMock(),
 				Types.TUPLE(Types.BOOLEAN, schema.toRowType()));
 
-		testSink.emitDataStream(dataStreamMock);
+		testSink.consumeDataStream(dataStreamMock);
 
 		final ElasticsearchSink.Builder<Tuple2<Boolean, Row>> expectedBuilder = new ElasticsearchSink.Builder<>(
 			Collections.singletonList(new HttpHost(ElasticsearchUpsertTableSinkFactoryTestBase.HOSTNAME, ElasticsearchUpsertTableSinkFactoryTestBase.PORT, ElasticsearchUpsertTableSinkFactoryTestBase.SCHEMA)),

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSinkBase.java
@@ -104,11 +104,6 @@ public abstract class KafkaTableSinkBase implements AppendStreamTableSink<Row> {
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Row> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public TypeInformation<Row> getOutputType() {
 		return schema.toRowType();
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTableSourceSinkFactoryTestBase.java
@@ -304,7 +304,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		// test Kafka producer
 		final KafkaTableSinkBase actualKafkaSink = (KafkaTableSinkBase) actualSink;
 		final DataStreamMock streamMock = new DataStreamMock(new StreamExecutionEnvironmentMock(), schema.toRowType());
-		actualKafkaSink.emitDataStream(streamMock);
+		actualKafkaSink.consumeDataStream(streamMock);
 		assertTrue(getExpectedFlinkKafkaProducer().isAssignableFrom(streamMock.sinkFunction.getClass()));
 	}
 
@@ -357,7 +357,7 @@ public abstract class KafkaTableSourceSinkFactoryTestBase extends TestLogger {
 		// test Kafka producer
 		final KafkaTableSinkBase actualKafkaSink = (KafkaTableSinkBase) actualSink;
 		final DataStreamMock streamMock = new DataStreamMock(new StreamExecutionEnvironmentMock(), schema.toRowType());
-		actualKafkaSink.emitDataStream(streamMock);
+		actualKafkaSink.consumeDataStream(streamMock);
 		assertTrue(getExpectedFlinkKafkaProducer().isAssignableFrom(streamMock.sinkFunction.getClass()));
 	}
 

--- a/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/HBaseUpsertTableSink.java
+++ b/flink-connectors/flink-hbase/src/main/java/org/apache/flink/addons/hbase/HBaseUpsertTableSink.java
@@ -101,11 +101,6 @@ public class HBaseUpsertTableSink implements UpsertStreamTableSink<Row> {
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		if (!Arrays.equals(getFieldNames(), fieldNames) || !Arrays.equals(getFieldTypes(), fieldTypes)) {
 			throw new ValidationException("Reconfiguration with different fields is not allowed. " +

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSink.java
@@ -69,11 +69,6 @@ public class JDBCAppendTableSink implements AppendStreamTableSink<Row>, BatchTab
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Row> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public void emitDataSet(DataSet<Row> dataSet) {
 		dataSet.output(outputFormat);
 	}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSink.java
@@ -98,11 +98,6 @@ public class JDBCUpsertTableSink implements UpsertStreamTableSink<Row> {
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public void setKeyFields(String[] keys) {
 		this.keyFields = keys;
 	}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCAppendTableSinkTest.java
@@ -59,7 +59,7 @@ public class JDBCAppendTableSinkTest {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStream<Row> ds = env.fromCollection(Collections.singleton(Row.of("foo")), ROW_TYPE);
-		sink.emitDataStream(ds);
+		sink.consumeDataStream(ds);
 
 		Collection<Integer> sinkIds = env
 				.getStreamGraph(StreamExecutionEnvironment.DEFAULT_JOB_NAME, false)

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/CollectStreamTableSink.java
@@ -77,11 +77,6 @@ public class CollectStreamTableSink implements RetractStreamTableSink<Row> {
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Tuple2<Boolean, Row>> stream) {
-		consumeDataStream(stream);
-	}
-
-	@Override
 	public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, Row>> stream) {
 		// add sink
 		return stream

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/utils/TestTableSinkFactoryBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.client.gateway.utils;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.Types;
 import org.apache.flink.table.factories.StreamTableSinkFactory;
@@ -138,8 +139,8 @@ public abstract class TestTableSinkFactoryBase implements StreamTableSinkFactory
 		}
 
 		@Override
-		public void emitDataStream(DataStream<Row> dataStream) {
-			// do nothing
+		public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
+			return null;
 		}
 	}
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -158,11 +158,6 @@ public class CsvTableSink implements BatchTableSink<Row>, AppendStreamTableSink<
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Row> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public TableSink<Row> configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
 		if (this.fieldNames != null || this.fieldTypes != null) {
 			throw new IllegalStateException(

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
@@ -38,11 +38,6 @@ public abstract class OutputFormatTableSink<T> implements StreamTableSink<T> {
 	public abstract OutputFormat<T> getOutputFormat();
 
 	@Override
-	public final void emitDataStream(DataStream<T> dataStream) {
-		consumeDataStream(dataStream);
-	}
-
-	@Override
 	public final DataStreamSink<T> consumeDataStream(DataStream<T> dataStream) {
 		return dataStream
 			.writeUsingOutputFormat(getOutputFormat())

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/StreamTableSink.java
@@ -29,23 +29,8 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 public interface StreamTableSink<T> extends TableSink<T> {
 
 	/**
-	 * Emits the DataStream.
-	 *
-	 * @deprecated This method will be removed in future versions as it returns nothing.
-	 *  It is recommended to use {@link #consumeDataStream(DataStream)} instead which
-	 *  returns the {@link DataStreamSink}. The returned {@link DataStreamSink} will be
-	 *  used to set resources for the sink operator. If the {@link #consumeDataStream(DataStream)}
-	 *  is implemented, this method can be empty implementation.
-	 */
-	@Deprecated
-	void emitDataStream(DataStream<T> dataStream);
-
-	/**
 	 * Consumes the DataStream and return the sink transformation {@link DataStreamSink}.
 	 * The returned {@link DataStreamSink} will be used to set resources for the sink operator.
 	 */
-	default DataStreamSink<?> consumeDataStream(DataStream<T> dataStream) {
-		emitDataStream(dataStream);
-		return null;
-	}
+	DataStreamSink<?> consumeDataStream(DataStream<T> dataStream);
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/TableUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/TableUtils.java
@@ -154,11 +154,6 @@ public class TableUtils {
 		}
 
 		@Override
-		public void emitDataStream(DataStream<Row> dataStream) {
-			throw new UnsupportedOperationException("Deprecated method, use consumeDataStream instead");
-		}
-
-		@Override
 		public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
 			return dataStream.writeUsingOutputFormat(outputFormat).setParallelism(1).name("tableResult");
 		}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/CollectTableSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/sinks/CollectTableSink.scala
@@ -42,10 +42,6 @@ class CollectTableSink[T](produceOutputType: (Array[TypeInformation[_]] => TypeI
       .name("collect")
   }
 
-  override def emitDataStream(dataStream: DataStream[T]): Unit = {
-    consumeDataStream(dataStream)
-  }
-
   override protected def copy: TableSinkBase[T] = {
     new CollectTableSink(produceOutputType)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
@@ -173,10 +173,6 @@ object TestCollectionTableFactory {
 
     override def getTableSchema: TableSchema = schema
 
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
-      dataStream.addSink(new UnsafeMemorySinkFunction(schema.toRowType)).setParallelism(1)
-    }
-
     override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
       dataStream.addSink(new UnsafeMemorySinkFunction(schema.toRowType)).setParallelism(1)
     }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -306,11 +306,6 @@ private class TestSink(
 
   override def getOutputType: RowTypeInfo = rowType
 
-  override def emitDataStream(dataStream: DataStream[Row]): Unit = {
-    dataStream.addSink(new UnsafeMemorySinkFunction(rowType))
-        .setParallelism(dataStream.getParallelism)
-  }
-
   override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
     dataStream.addSink(new UnsafeMemorySinkFunction(rowType))
         .setParallelism(dataStream.getParallelism)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -310,10 +310,6 @@ final class TestingUpsertTableSink(val keys: Array[Int], val tz: TimeZone)
       .setParallelism(dataStream.getParallelism)
   }
 
-  override def emitDataStream(dataStream: DataStream[JTuple2[JBoolean, BaseRow]]): Unit = {
-    consumeDataStream(dataStream)
-  }
-
   override def configure(
       fieldNames: Array[String],
       fieldTypes: Array[TypeInformation[_]]): TestingUpsertTableSink = {
@@ -343,10 +339,6 @@ final class TestingAppendTableSink(tz: TimeZone) extends AppendStreamTableSink[R
   override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
     dataStream.addSink(sink).name("TestingAppendTableSink")
       .setParallelism(dataStream.getParallelism)
-  }
-
-  override def emitDataStream(dataStream: DataStream[Row]): Unit = {
-    consumeDataStream(dataStream)
   }
 
   override def getOutputType: TypeInformation[Row] = new RowTypeInfo(fTypes, fNames)
@@ -509,10 +501,6 @@ final class TestingRetractTableSink(tz: TimeZone) extends RetractStreamTableSink
       .addSink(sink)
       .name("TestingRetractTableSink")
       .setParallelism(dataStream.getParallelism)
-  }
-
-  override def emitDataStream(dataStream: DataStream[JTuple2[JBoolean, Row]]): Unit = {
-    consumeDataStream(dataStream)
   }
 
   override def getRecordType: TypeInformation[Row] =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/MemoryTableSourceSinkUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/MemoryTableSourceSinkUtil.scala
@@ -110,10 +110,6 @@ object MemoryTableSourceSinkUtil {
         .setParallelism(dataStream.getParallelism)
         .name(TableConnectorUtil.generateRuntimeName(this.getClass, getFieldNames))
     }
-
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
-      consumeDataStream(dataStream)
-    }
   }
 
   final class UnsafeMemoryOutputFormatTableSink extends OutputFormatTableSink[Row] {
@@ -192,6 +188,5 @@ object MemoryTableSourceSinkUtil {
       dataStream.writeUsingOutputFormat(new MemoryCollectionOutputFormat)
     }
 
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = ???
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
@@ -25,7 +25,7 @@ import org.apache.flink.api.java.io.{CollectionInputFormat, LocalCollectionOutpu
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSource}
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink, DataStreamSource}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.TableSchema
@@ -188,7 +188,7 @@ object TestCollectionTableFactory {
       outputType.getFieldTypes
     }
 
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
+    override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
       dataStream.addSink(new UnsafeMemorySinkFunction(outputType)).setParallelism(1)
     }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSinkITCase.scala
@@ -18,9 +18,6 @@
 
 package org.apache.flink.table.runtime.stream.table
 
-import java.io.File
-import java.lang.{Boolean => JBool}
-
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
@@ -39,8 +36,12 @@ import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
 import org.apache.flink.test.util.{AbstractTestBase, TestBaseUtils}
 import org.apache.flink.types.Row
 import org.apache.flink.util.Collector
+
 import org.junit.Assert._
 import org.junit.Test
+
+import java.io.File
+import java.lang.{Boolean => JBool}
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -623,10 +624,6 @@ private[flink] class TestAppendSink extends AppendStreamTableSink[Row] {
   var fNames: Array[String] = _
   var fTypes: Array[TypeInformation[_]] = _
 
-  override def emitDataStream(s: DataStream[Row]): Unit = {
-    consumeDataStream(s)
-  }
-
   override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
     dataStream.map(
       new MapFunction[Row, JTuple2[JBool, Row]] {
@@ -656,7 +653,7 @@ private[flink] class TestRetractSink extends RetractStreamTableSink[Row] {
   var fNames: Array[String] = _
   var fTypes: Array[TypeInformation[_]] = _
 
-  override def emitDataStream(s: DataStream[JTuple2[JBool, Row]]): Unit = {
+  override def consumeDataStream(s: DataStream[JTuple2[JBool, Row]]): DataStreamSink[_] = {
     s.addSink(new RowSink)
   }
 
@@ -703,7 +700,7 @@ private[flink] class TestUpsertSink(
 
   override def getRecordType: TypeInformation[Row] = new RowTypeInfo(fTypes, fNames)
 
-  override def emitDataStream(s: DataStream[JTuple2[JBool, Row]]): Unit = {
+  override def consumeDataStream(s: DataStream[JTuple2[JBool, Row]]): DataStreamSink[_] = {
     s.addSink(new RowSink)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MemoryTableSourceSinkUtil.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MemoryTableSourceSinkUtil.scala
@@ -24,7 +24,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.{DataSet, ExecutionEnvironment}
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
@@ -116,7 +116,7 @@ object MemoryTableSourceSinkUtil {
         .name(TableConnectorUtils.generateRuntimeName(this.getClass, getTableSchema.getFieldNames))
     }
 
-    override def emitDataStream(dataStream: DataStream[Row]): Unit = {
+    override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
       val inputParallelism = dataStream.getParallelism
       dataStream
         .addSink(new MemoryAppendSink)

--- a/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/table/SpendReportTableSink.java
+++ b/flink-walkthroughs/flink-walkthrough-common/src/main/java/org/apache/flink/walkthrough/common/table/SpendReportTableSink.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.BatchTableSink;
@@ -57,8 +58,8 @@ public class SpendReportTableSink implements AppendStreamTableSink<Row>, BatchTa
 	}
 
 	@Override
-	public void emitDataStream(DataStream<Row> dataStream) {
-		dataStream
+	public DataStreamSink<?> consumeDataStream(DataStream<Row> dataStream) {
+		return dataStream
 			.map(SpendReportTableSink::format)
 			.writeUsingOutputFormat(new LoggerOutputFormat())
 			.setParallelism(dataStream.getParallelism());
@@ -93,4 +94,5 @@ public class SpendReportTableSink implements AppendStreamTableSink<Row>, BatchTa
 		//noinspection MalformedFormatString
 		return String.format("%s, %s, $%.2f", row.getField(0), row.getField(1), row.getField(2));
 	}
+
 }


### PR DESCRIPTION


## What is the purpose of the change

*[FLIP-84](https://cwiki.apache.org/confluence/display/FLINK/FLIP-84%3A+Improve+%26+Refactor+API+of+TableEnvironment) proposes to unify the behavior of TableEnvironment and StreamTableEnvironment, and requires the StreamTableSink always returns DataStream. However
StreamTableSink.emitDataStream returns nothing and is deprecated since Flink 1.9, This PR *
removes this method*

## Brief change log

  - *Remove emitDataStream method in StreamTableSink*


## Verifying this change


This change is a code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
