### PR TITLE
[FLINK-16377][table] Support inline user defined functions in expression dsl

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.types.utils.ValueDataTypeConverter;
@@ -509,10 +510,20 @@ public final class Expressions {
 	 * @see TableEnvironment#createTemporaryFunction
 	 * @see TableEnvironment#createTemporarySystemFunction
 	 */
-	public static ApiExpression call(String path, Object... params) {
+	public static ApiExpression call(String path, Object... arguments) {
 		return new ApiExpression(ApiExpressionUtils.lookupCall(
 			path,
-			Arrays.stream(params).map(ApiExpressionUtils::objectToExpression).toArray(Expression[]::new)));
+			Arrays.stream(arguments).map(ApiExpressionUtils::objectToExpression).toArray(Expression[]::new)));
+	}
+
+	/**
+	 * A call to an unregistered, inline function.
+	 *
+	 * <p>For functions that have been registered before and are identified by a name, use
+	 * {@link #call(String, Object...)}.
+	 */
+	public static ApiExpression call(UserDefinedFunction function, Object... arguments) {
+		return apiCall(function, arguments);
 	}
 
 	private static ApiExpression apiCall(FunctionDefinition functionDefinition, Object... args) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/QueryOperationVisitor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/QueryOperationVisitor.java
@@ -43,7 +43,7 @@ public interface QueryOperationVisitor<T> {
 
 	T visit(SortQueryOperation sort);
 
-	<U> T visit(CalculatedQueryOperation<U> calculatedTable);
+	T visit(CalculatedQueryOperation calculatedTable);
 
 	T visit(CatalogQueryOperation catalogTable);
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/OperationTreeBuilder.java
@@ -471,9 +471,14 @@ public final class OperationTreeBuilder {
 			throw new ValidationException("Only a table function can be used in the flatMap operator.");
 		}
 
-		TypeInformation<?> resultType = ((TableFunctionDefinition) ((UnresolvedCallExpression) resolvedTableFunction)
-			.getFunctionDefinition())
-			.getResultType();
+		FunctionDefinition functionDefinition = ((UnresolvedCallExpression) resolvedTableFunction)
+			.getFunctionDefinition();
+		if (!(functionDefinition instanceof TableFunctionDefinition)) {
+			throw new ValidationException(
+				"The new type inference for functions is not supported in the flatMap yet.");
+		}
+
+		TypeInformation<?> resultType = ((TableFunctionDefinition) functionDefinition).getResultType();
 		List<String> originFieldNames = Arrays.asList(FieldInfoUtils.getFieldNames(resultType));
 
 		List<String> childFields = Arrays.asList(child.getTableSchema().getFieldNames());

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/expressionDsl.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/expressionDsl.scala
@@ -504,6 +504,14 @@ trait ImplicitExpressionConversions {
    */
   def call(path: String, params: Expression*): Expression = Expressions.call(path, params: _*)
 
+  /**
+   * A call to an unregistered, inline function. For functions that have been registered before and
+   * are identified by a name, use [[call(String, Object...)]].
+   */
+  def call(function: UserDefinedFunction, params: Expression*): Expression = Expressions.call(
+    function,
+    params: _*)
+
   // ----------------------------------------------------------------------------------------------
   // Implicit expressions in prefix notation
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerTypeInferenceUtilImpl.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/PlannerTypeInferenceUtilImpl.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.planner.validate.ValidationResult;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.TypeInferenceUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -54,6 +55,10 @@ public final class PlannerTypeInferenceUtilImpl implements PlannerTypeInferenceU
 	public TypeInferenceUtil.Result runTypeInference(
 			UnresolvedCallExpression unresolvedCall,
 			List<ResolvedExpression> resolvedArgs) {
+		// We should not try to resolve the children again with the old type stack
+		// The arguments might have been resolved with the new stack already. In that case the
+		// resolution will fail.
+		unresolvedCall = unresolvedCall.replaceArgs(new ArrayList<>(resolvedArgs));
 		final PlannerExpression plannerCall = unresolvedCall.accept(CONVERTER);
 
 		if (plannerCall instanceof InputTypeSpec) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CallExpressionConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/CallExpressionConvertRule.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.expressions.converter;
 
+import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
@@ -52,5 +53,7 @@ public interface CallExpressionConvertRule {
 		RelBuilder getRelBuilder();
 
 		FlinkTypeFactory getTypeFactory();
+
+		DataTypeFactory getDataTypeFactory();
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/FunctionDefinitionConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/FunctionDefinitionConvertRule.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions.converter;
+
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction;
+import org.apache.flink.table.types.inference.TypeInference;
+import org.apache.flink.table.types.inference.TypeStrategies;
+
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * A call expression converter rule that converts calls to user defined functions.
+ */
+public class FunctionDefinitionConvertRule implements CallExpressionConvertRule {
+	@Override
+	public Optional<RexNode> convert(
+			CallExpression call,
+			ConvertContext context) {
+		TypeInference typeInference = call.getFunctionDefinition().getTypeInference(context.getDataTypeFactory());
+
+		if (typeInference.getOutputTypeStrategy() == TypeStrategies.MISSING) {
+			return Optional.empty();
+		}
+
+		switch (call.getFunctionDefinition().getKind()) {
+			case SCALAR:
+			case TABLE:
+				List<RexNode> args = call.getChildren().stream().map(context::toRexNode).collect(Collectors.toList());
+
+				final BridgingSqlFunction sqlFunction = BridgingSqlFunction.of(
+					context.getDataTypeFactory(),
+					context.getTypeFactory(),
+					SqlKind.OTHER_FUNCTION,
+					call.getFunctionIdentifier().orElse(null),
+					call.getFunctionDefinition(),
+					typeInference);
+
+				return Optional.of(context.getRelBuilder().call(sqlFunction, args));
+			default:
+				return Optional.empty();
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/LegacyScalarFunctionConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/LegacyScalarFunctionConvertRule.java
@@ -35,7 +35,7 @@ import static org.apache.flink.table.planner.expressions.converter.ExpressionCon
 /**
  * {@link CallExpressionConvertRule} to convert {@link ScalarFunctionDefinition}.
  */
-public class ScalarFunctionConvertRule implements CallExpressionConvertRule {
+public class LegacyScalarFunctionConvertRule implements CallExpressionConvertRule {
 
 	@Override
 	public Optional<RexNode> convert(CallExpression call, ConvertContext context) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlAggFunction.java
@@ -33,7 +33,10 @@ import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.Optionality;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
@@ -55,7 +58,7 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
 
 	private final FlinkTypeFactory typeFactory;
 
-	private final FunctionIdentifier identifier;
+	private final @Nullable FunctionIdentifier identifier;
 
 	private final FunctionDefinition definition;
 
@@ -67,11 +70,11 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
 			DataTypeFactory dataTypeFactory,
 			FlinkTypeFactory typeFactory,
 			SqlKind kind,
-			FunctionIdentifier identifier,
+			@Nullable FunctionIdentifier identifier,
 			FunctionDefinition definition,
 			TypeInference typeInference) {
 		super(
-			createName(identifier),
+			createName(identifier, definition),
 			createSqlIdentifier(identifier),
 			kind,
 			createSqlReturnTypeInference(dataTypeFactory, definition, typeInference),
@@ -130,8 +133,8 @@ public final class BridgingSqlAggFunction extends SqlAggFunction {
 		return typeFactory;
 	}
 
-	public FunctionIdentifier getIdentifier() {
-		return identifier;
+	public Optional<FunctionIdentifier> getIdentifier() {
+		return Optional.ofNullable(identifier);
 	}
 
 	public FunctionDefinition getDefinition() {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/bridging/BridgingSqlFunction.java
@@ -31,7 +31,10 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlKind;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
+import java.util.Optional;
 
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createName;
 import static org.apache.flink.table.planner.functions.bridging.BridgingUtils.createParamTypes;
@@ -53,7 +56,7 @@ public final class BridgingSqlFunction extends SqlFunction {
 
 	private final FlinkTypeFactory typeFactory;
 
-	private final FunctionIdentifier identifier;
+	private final @Nullable FunctionIdentifier identifier;
 
 	private final FunctionDefinition definition;
 
@@ -63,11 +66,11 @@ public final class BridgingSqlFunction extends SqlFunction {
 			DataTypeFactory dataTypeFactory,
 			FlinkTypeFactory typeFactory,
 			SqlKind kind,
-			FunctionIdentifier identifier,
+			@Nullable FunctionIdentifier identifier,
 			FunctionDefinition definition,
 			TypeInference typeInference) {
 		super(
-			createName(identifier),
+			createName(identifier, definition),
 			createSqlIdentifier(identifier),
 			kind,
 			createSqlReturnTypeInference(dataTypeFactory, definition, typeInference),
@@ -98,7 +101,7 @@ public final class BridgingSqlFunction extends SqlFunction {
 			DataTypeFactory dataTypeFactory,
 			FlinkTypeFactory typeFactory,
 			SqlKind kind,
-			FunctionIdentifier identifier,
+			@Nullable FunctionIdentifier identifier,
 			FunctionDefinition definition,
 			TypeInference typeInference) {
 
@@ -123,8 +126,8 @@ public final class BridgingSqlFunction extends SqlFunction {
 		return typeFactory;
 	}
 
-	public FunctionIdentifier getIdentifier() {
-		return identifier;
+	public Optional<FunctionIdentifier> getIdentifier() {
+		return Optional.ofNullable(identifier);
 	}
 
 	public FunctionDefinition getDefinition() {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -26,6 +26,7 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.apache.flink.table.api.{TableConfig, TableException, ValidationException}
 import org.apache.flink.table.dataformat.{BaseRow, GenericRow, JoinedRow}
+import org.apache.flink.table.functions.FunctionKind
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.functions.bridging.BridgingSqlFunction
@@ -36,6 +37,8 @@ import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
 import org.apache.flink.table.runtime.util.StreamRecordCollector
 import org.apache.flink.table.types.logical.RowType
+
+import org.apache.calcite.sql.SqlKind
 
 import scala.collection.JavaConversions._
 
@@ -65,9 +68,11 @@ object CorrelateCodeGenerator {
 
     // according to the SQL standard, every scalar function should also be a table function
     // but we don't allow that for now
-    if (!rexCall.getOperator.isInstanceOf[BridgingSqlFunction] &&
-        !rexCall.getOperator.isInstanceOf[TableSqlFunction]) {
-      throw new ValidationException("Currently, only table functions can emit rows.")
+    rexCall.getOperator match {
+      case func: BridgingSqlFunction if func.getDefinition.getKind == FunctionKind.TABLE => // ok
+      case _: TableSqlFunction => // ok
+      case _ =>
+        throw new ValidationException("Currently, only table functions can emit rows.")
     }
 
     val swallowInputOnly = if (projectProgram.isDefined) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/aggregations.scala
@@ -19,18 +19,37 @@ package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
 import org.apache.flink.api.java.typeutils.MultisetTypeInfo
+import org.apache.flink.table.expressions.CallExpression
 import org.apache.flink.table.functions.{AggregateFunction, TableAggregateFunction, UserDefinedAggregateFunction}
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.planner.typeutils.TypeInfoCheckUtils
 import org.apache.flink.table.planner.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.{fromLogicalTypeToTypeInfo, fromTypeInfoToLogicalType}
+import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 
 abstract sealed class Aggregation extends PlannerExpression {
 
   override def toString = s"Aggregate"
 
+}
+
+/**
+ * Wrapper for call expressions resolved already in the API with the new type inference stack.
+ * Separate from [[ApiResolvedCallExpression]] because others' expressions validation logic
+ * check for the [[Aggregation]] trait.
+ */
+case class ApiResolvedAggregateCallExpression(
+    resolvedCall: CallExpression)
+  extends Aggregation {
+
+  private[flink] val children = Nil
+
+  override private[flink] def resultType: TypeInformation[_] = TypeConversions
+    .fromDataTypeToLegacyInfo(
+      resolvedCall
+        .getOutputDataType)
 }
 
 case class DistinctAgg(child: PlannerExpression) extends Aggregation {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.expressions
 
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation, Types}
+import org.apache.flink.table.expressions.CallExpression
 import org.apache.flink.table.functions._
 import org.apache.flink.table.planner.functions.utils.UserDefinedFunctionUtils._
 import org.apache.flink.table.planner.validate.{ValidationFailure, ValidationResult, ValidationSuccess}
@@ -25,8 +26,22 @@ import org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromLog
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter.fromDataTypeToTypeInfo
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter.fromTypeInfoToLogicalType
 import org.apache.flink.table.types.logical.LogicalType
+import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo
+
+/**
+ * Wrapper for call expressions resolved already in the API with the new type inference stack.
+ */
+case class ApiResolvedCallExpression(
+    resolvedCall: CallExpression)
+  extends LeafExpression {
+
+  override private[flink] def resultType: TypeInformation[_] = TypeConversions
+    .fromDataTypeToLegacyInfo(
+      resolvedCall
+        .getOutputDataType)
+}
 
 /**
   * Over call with unresolved alias for over window.

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
@@ -56,7 +56,8 @@ class TableSqlFunction(
     functionImpl: FlinkTableFunction,
     operandTypeInfer: Option[SqlOperandTypeChecker] = None)
   extends SqlUserDefinedTableFunction(
-    new SqlIdentifier(identifier.toList, SqlParserPos.ZERO),
+    Option(identifier).map(id => new SqlIdentifier(id.toList, SqlParserPos.ZERO))
+      .getOrElse(new SqlIdentifier(udtf.functionIdentifier(), SqlParserPos.ZERO)),
     ReturnTypes.CURSOR,
     // type inference has the UNKNOWN operand types.
     createOperandTypeInference(displayName, udtf, typeFactory),

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/FunctionITCase.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.table;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for user defined functions in the Table API.
+ */
+public class FunctionITCase extends StreamingTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testScalarFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of(1, 1L, 1L),
+			Row.of(2, 2L, 1L),
+			Row.of(3, 3L, 1L)
+		);
+
+		final List<Row> sinkData = Arrays.asList(
+			Row.of(1, 2L, 1L),
+			Row.of(2, 4L, 1L),
+			Row.of(3, 6L, 1L)
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate("CREATE TABLE TestTable(a INT, b BIGINT, c BIGINT) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().from("TestTable")
+			.select(
+				$("a"),
+				call(new SimpleScalarFunction(), $("a"), $("b")),
+				call(new SimpleScalarFunction(), $("a"), $("b"))
+					.plus(1)
+					.minus(call(new SimpleScalarFunction(), $("a"), $("b")))
+			)
+			.insertInto("TestTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testJoinWithTableFunction() throws Exception {
+		final List<Row> sourceData = Arrays.asList(
+			Row.of("1,2,3"),
+			Row.of("2,3,4"),
+			Row.of("3,4,5"),
+			Row.of((String) null)
+		);
+
+		final List<Row> sinkData = Arrays.asList(
+			Row.of("1,2,3", new String[]{"1", "2", "3"}),
+			Row.of("2,3,4", new String[]{"2", "3", "4"}),
+			Row.of("3,4,5", new String[]{"3", "4", "5"})
+		);
+
+		TestCollectionTableFactory.reset();
+		TestCollectionTableFactory.initData(sourceData);
+
+		tEnv().sqlUpdate("CREATE TABLE SourceTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING>) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().from("SourceTable")
+			.joinLateral(call(new SimpleTableFunction(), $("s")).as("a", "b"))
+			.select($("a"), $("b"))
+			.insertInto("SinkTable");
+		tEnv().execute("Test Job");
+
+		assertThat(TestCollectionTableFactory.getResult(), equalTo(sinkData));
+	}
+
+	@Test
+	public void testLateralJoinWithScalarFunction() throws Exception {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("Currently, only table functions can emit rows.");
+
+		TestCollectionTableFactory.reset();
+		tEnv().sqlUpdate("CREATE TABLE SourceTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING>) WITH ('connector' = 'COLLECTION')");
+
+		tEnv().from("SourceTable")
+			.joinLateral(call(new RowScalarFunction(), $("s")).as("a", "b"))
+			.select($("a"), $("b"))
+			.insertInto("SinkTable");
+		tEnv().execute("Test Job");
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Test functions
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Simple scalar function.
+	 */
+	public static class SimpleScalarFunction extends ScalarFunction {
+		public Long eval(Integer i, Long j) {
+			return i + j;
+		}
+	}
+
+	/**
+	 * Scalar function that returns a row.
+	 */
+	@FunctionHint(output = @DataTypeHint("ROW<s STRING, sa ARRAY<STRING>>"))
+	public static class RowScalarFunction extends ScalarFunction {
+		public Row eval(String s) {
+			return Row.of(s, s.split(","));
+		}
+	}
+
+	/**
+	 * Table function that returns a row.
+	 */
+	@FunctionHint(output = @DataTypeHint("ROW<s STRING, sa ARRAY<STRING>>"))
+	public static class SimpleTableFunction extends TableFunction<Row> {
+		public void eval(String s) {
+			if (s == null) {
+				collect(null);
+			} else {
+				collect(Row.of(s, s.split(",")));
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -24,7 +24,7 @@ import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
 import org.apache.flink.streaming.api.scala.DataStream
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, TableFunc1, TableFunc2, TableTestBase}
+import org.apache.flink.table.planner.utils._
 import org.apache.flink.types.Row
 
 import org.junit.Test
@@ -52,17 +52,17 @@ class CorrelateStringExpressionTest extends TableTestBase {
     javaUtil.addFunction("func1", func1)
     scalaUtil.addFunction("func1", func1)
 
-    var scalaTable = sTab.joinLateral(func1('c) as 's).select('c, 's)
+    var scalaTable = sTab.joinLateral(call("func1", 'c) as 's).select('c, 's)
     var javaTable = jTab.joinLateral("func1(c).as(s)").select("c, s")
     verifyTableEquals(scalaTable, javaTable)
 
     // test left outer join
-    scalaTable = sTab.leftOuterJoinLateral(func1('c) as 's).select('c, 's)
+    scalaTable = sTab.leftOuterJoinLateral(call("func1", 'c) as 's).select('c, 's)
     javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select("c, s")
     verifyTableEquals(scalaTable, javaTable)
 
     // test overloading
-    scalaTable = sTab.joinLateral(func1('c, "$") as 's).select('c, 's)
+    scalaTable = sTab.joinLateral(call("func1", 'c, "$") as 's).select('c, 's)
     javaTable = jTab.joinLateral("func1(c, '$') as (s)").select("c, s")
     verifyTableEquals(scalaTable, javaTable)
 
@@ -70,7 +70,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val func2 = new TableFunc2
     javaUtil.addFunction("func2", func2)
     scalaUtil.addFunction("func2", func2)
-    scalaTable = sTab.joinLateral(func2('c) as ('name, 'len)).select('c, 'name, 'len)
+    scalaTable = sTab.joinLateral(call("func2", 'c) as ('name, 'len)).select('c, 'name, 'len)
     javaTable = jTab.joinLateral(
       "func2(c).as(name, len)").select("c, name, len")
     verifyTableEquals(scalaTable, javaTable)
@@ -80,7 +80,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     javaUtil.addFunction("hierarchy", hierarchy)
     scalaUtil.addFunction("hierarchy", hierarchy)
     scalaTable = sTab.joinLateral(
-      hierarchy('c) as ('name, 'adult, 'len)).select('c, 'name, 'len, 'adult)
+      call("hierarchy", 'c) as ('name, 'adult, 'len)).select('c, 'name, 'len, 'adult)
     javaTable = jTab.joinLateral("AS(hierarchy(c), name, adult, len)")
       .select("c, name, len, adult")
     verifyTableEquals(scalaTable, javaTable)
@@ -89,13 +89,13 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val pojo = new PojoTableFunc
     javaUtil.addFunction("pojo", pojo)
     scalaUtil.addFunction("pojo", pojo)
-    scalaTable = sTab.joinLateral(pojo('c)).select('c, 'name, 'age)
+    scalaTable = sTab.joinLateral(call("pojo", 'c)).select('c, 'name, 'age)
     javaTable = jTab.joinLateral("pojo(c)").select("c, name, age")
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
     scalaTable = sTab.joinLateral(
-      func2('c) as ('name, 'len)).select('c, 'name, 'len).filter('len > 2)
+      call("func2", 'c) as ('name, 'len)).select('c, 'name, 'len).filter('len > 2)
     javaTable = jTab.joinLateral("func2(c) as (name, len)")
       .select("c, name, len").filter("len > 2")
     verifyTableEquals(scalaTable, javaTable)
@@ -119,7 +119,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val func1 = new TableFunc1
     scalaUtil.addFunction("func1", func1)
     javaUtil.addFunction("func1", func1)
-    var scalaTable = sTab.flatMap(func1('c)).as('s).select('s)
+    var scalaTable = sTab.flatMap(call("func1", 'c)).as('s).select('s)
     var javaTable = jTab.flatMap("func1(c)").as("s").select("s")
     verifyTableEquals(scalaTable, javaTable)
 
@@ -127,7 +127,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val func2 = new TableFunc2
     scalaUtil.addFunction("func2", func2)
     javaUtil.addFunction("func2", func2)
-    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len)
+    scalaTable = sTab.flatMap(call("func2", 'c)).as('name, 'len).select('name, 'len)
     javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len")
     verifyTableEquals(scalaTable, javaTable)
 
@@ -135,7 +135,9 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val hierarchy = new HierarchyTableFunction
     scalaUtil.addFunction("hierarchy", hierarchy)
     javaUtil.addFunction("hierarchy", hierarchy)
-    scalaTable = sTab.flatMap(hierarchy('c)).as('name, 'adult, 'len).select('name, 'len, 'adult)
+    scalaTable = sTab.flatMap(call("hierarchy", 'c))
+      .as('name, 'adult, 'len)
+      .select('name, 'len, 'adult)
     javaTable = jTab.flatMap("hierarchy(c)").as("name, adult, len").select("name, len, adult")
     verifyTableEquals(scalaTable, javaTable)
 
@@ -143,17 +145,20 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val pojo = new PojoTableFunc
     scalaUtil.addFunction("pojo", pojo)
     javaUtil.addFunction("pojo", pojo)
-    scalaTable = sTab.flatMap(pojo('c)).select('name, 'age)
+    scalaTable = sTab.flatMap(call("pojo", 'c)).select('name, 'age)
     javaTable = jTab.flatMap("pojo(c)").select("name, age")
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
-    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len).filter('len > 2)
+    scalaTable = sTab.flatMap(call("func2", 'c))
+      .as('name, 'len)
+      .select('name, 'len)
+      .filter('len > 2)
     javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len").filter("len > 2")
     verifyTableEquals(scalaTable, javaTable)
 
     // test with scalar function
-    scalaTable = sTab.flatMap(func1('c.substring(2))).as('s).select('s)
+    scalaTable = sTab.flatMap(call("func1", 'c.substring(2))).as('s).select('s)
     javaTable = jTab.flatMap("func1(substring(c, 2))").as("s").select("s")
     verifyTableEquals(scalaTable, javaTable)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CalcValidationTest.scala
@@ -149,17 +149,4 @@ class CalcValidationTest extends TableTestBase {
       "MyTable", 'string)
       .map("func(string) as a") // do not support TableFunction as input
   }
-
-  @Test
-  def testInvalidParameterTypes(): Unit = {
-    expectedException.expect(classOf[ValidationException])
-    expectedException.expectMessage("log('long) fails on input type checking: " +
-      "[expecting Double on 0th input, get Long].\nOperand should be casted to proper type")
-
-    val util = streamTestUtil()
-
-    util.addFunction("func", new TableFunc0)
-    util.addTableSource[(Int, Long, String)]("MyTable", 'int, 'long, 'string)
-      .select('int, 'long.log as 'long, 'string)
-  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CorrelateValidationTest.scala
@@ -68,10 +68,6 @@ class CorrelateValidationTest extends TableTestBase {
     //========= throw exception when the called function is a scalar function ====
     util.addFunction("func0", Func0)
 
-    // Java Table API call
-    expectExceptionThrown(
-      t.joinLateral("func0(a)"),
-      "only accepts a string expression which defines a table function call")
     // SQL API call
     // NOTE: it doesn't throw an exception but an AssertionError, maybe a Calcite bug
     expectExceptionThrown(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/expressions/PlannerExpressionConverter.scala
@@ -110,6 +110,10 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
           tafd.getAccumulatorTypeInfo,
           args)
 
+      case _ : UserDefinedFunction =>
+        throw new ValidationException(
+          "The new type inference for functions is only supported in the Blink planner.")
+
       case fd: FunctionDefinition =>
         fd match {
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.stream.sql;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
@@ -30,7 +31,9 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +51,9 @@ import static org.junit.Assert.fail;
 public class FunctionITCase extends AbstractTestBase {
 
 	private static final String TEST_FUNCTION = TestUDF.class.getName();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testCreateCatalogFunctionInDefaultCatalog() {
@@ -442,6 +448,31 @@ public class FunctionITCase extends AbstractTestBase {
 
 		tableEnv.sqlUpdate("drop table t1");
 		tableEnv.sqlUpdate("drop table t2");
+	}
+
+	@Test
+	public void testDataTypeBasedTypeInferenceNotSupported() throws Exception {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("The new type inference for functions is only supported in the Blink planner.");
+
+		StreamExecutionEnvironment streamExecEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(streamExecEnvironment);
+
+		tableEnvironment.createTemporarySystemFunction("func", SimpleScalarFunction.class);
+		Table table = tableEnvironment
+			.sqlQuery("SELECT func(1)");
+		tableEnvironment.toAppendStream(table, Row.class).print();
+
+		streamExecEnvironment.execute();
+	}
+
+	/**
+	 * Simple scalar function.
+	 */
+	public static class SimpleScalarFunction extends ScalarFunction {
+		public long eval(Integer i) {
+			return i;
+		}
 	}
 
 	private TableEnvironment getTableEnvironment() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/table/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/table/FunctionITCase.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.stream.table;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.annotation.FunctionHint;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.flink.types.Row;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+
+/**
+ * Tests for user defined functions in the Table API.
+ */
+public class FunctionITCase extends AbstractTestBase {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testDataTypeBasedTypeInferenceNotSupported() throws Exception {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("The new type inference for functions is only supported in the Blink planner.");
+
+		StreamExecutionEnvironment streamExecEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(streamExecEnvironment);
+
+		Table table = tableEnvironment
+			.sqlQuery("SELECT * FROM (VALUES (1)) AS TableName(f0)")
+			.select(call(new SimpleScalarFunction(), $("f0")));
+		tableEnvironment.toAppendStream(table, Row.class).print();
+
+		streamExecEnvironment.execute();
+	}
+
+	@Test
+	public void testDataTypeBasedTypeInferenceNotSupportedInLateralJoin() throws Exception {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("The new type inference for functions is only supported in the Blink planner.");
+
+		StreamExecutionEnvironment streamExecEnvironment = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tableEnvironment = StreamTableEnvironment.create(streamExecEnvironment);
+
+		Table table = tableEnvironment
+			.sqlQuery("SELECT * FROM (VALUES ('A,B,C')) AS TableName(f0)")
+			.joinLateral(call(new SimpleTableFunction(), $("f0")).as("a", "b"))
+			.select($("a"), $("b"));
+		tableEnvironment.toAppendStream(table, Row.class).print();
+
+		streamExecEnvironment.execute();
+	}
+
+	/**
+	 * Simple scalar function.
+	 */
+	public static class SimpleScalarFunction extends ScalarFunction {
+		public long eval(Integer i) {
+			return i;
+		}
+	}
+
+	/**
+	 * Simple table function.
+	 */
+	@FunctionHint(output = @DataTypeHint("ROW<s STRING, sa ARRAY<STRING>>"))
+	public static class SimpleTableFunction extends TableFunction<Row> {
+		public void eval(String s) {
+			// no-op
+		}
+	}
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
@@ -70,10 +70,6 @@ class CorrelateValidationTest extends TableTestBase {
     //========= throw exception when the called function is a scalar function ====
     util.tableEnv.registerFunction("func0", Func0)
 
-    // Java Table API call
-    expectExceptionThrown(
-      t.joinLateral("func0(a)"),
-      "only accepts a string expression which defines a table function call")
     // SQL API call
     // NOTE: it doesn't throw an exception but an AssertionError, maybe a Calcite bug
     expectExceptionThrown(


### PR DESCRIPTION
## What is the purpose of the change

It adds a method `call(UserDefinedFunction function, Object... params)` that let users use user defined functions without registering them in a catalog before.

It also adds support for the new type inference stack when functions are used from the expression dsl.

It is extracted from #11081 . The comments there were applied.

## Verifying this change

This change added tests and can be verified as follows:
- Extended `ExpressionResolverTest`
- Extended `FunctionITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
