### PR TITLE
[FLINK-16203][sql] Support JSON_OBJECT for blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1000,4 +1000,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlAggFunction ROW_NUMBER = SqlStdOperatorTable.ROW_NUMBER;
 	public static final SqlAggFunction LEAD = SqlStdOperatorTable.LEAD;
 	public static final SqlAggFunction LAG = SqlStdOperatorTable.LAG;
+
+	// JSON FUNCTIONS
+	public static final SqlFunction JSON_OBJECT = SqlStdOperatorTable.JSON_OBJECT;
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -148,6 +148,15 @@ object GenerateUtils {
     }
   }
 
+  def generateStringResultCallWithStmtIfArgsNullable(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression])
+      (call: Seq[String] => String): GeneratedExpression = {
+    generateCallIfArgsNullable(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+      args => s"$BINARY_STRING.fromString(${call(args)})"
+    }
+  }
+
   /**
     * Generates a call with the nullable args.
     */
@@ -274,7 +283,7 @@ object GenerateUtils {
       ctx: CodeGeneratorContext,
       literalType: LogicalType,
       literalValue: Any): GeneratedExpression = {
-    if (literalValue == null) {
+    if (literalValue == null && literalType.isNullable) {
       return generateNullLiteral(literalType, ctx.nullCheck)
     }
     // non-null values

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -22,10 +22,12 @@ import org.apache.flink.table.dataformat.{Decimal, SqlTimestamp}
 import org.apache.flink.table.runtime.functions._
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.linq4j.tree.Types
-import org.apache.calcite.runtime.SqlFunctions
+import org.apache.calcite.runtime.{JsonFunctions, SqlFunctions}
 import java.lang.reflect.Method
 import java.lang.{Byte => JByte, Integer => JInteger, Long => JLong, Short => JShort}
 import java.util.TimeZone
+
+import org.apache.calcite.sql.SqlJsonConstructorNullClause
 
 object BuiltInMethods {
 
@@ -463,4 +465,8 @@ object BuiltInMethods {
 
   val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncate",
     classOf[SqlTimestamp], classOf[Int])
+
+  // JSON FUNCTIONS
+  val JSON_OBJECT = Types.lookupMethod(classOf[JsonFunctions], "jsonObject",
+    classOf[SqlJsonConstructorNullClause], classOf[Array[AnyRef]])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -753,6 +753,15 @@ object FunctionGenerator {
     Seq(FLOAT, INTEGER),
     BuiltInMethods.TRUNCATE_FLOAT)
 
+  addSqlFunctionMethod(
+    JSON_OBJECT,
+    Seq(RAW),
+    BuiltInMethods.JSON_OBJECT)
+
+  addSqlFunctionMethod(
+    JSON_OBJECT,
+    Seq(RAW, RAW),
+    BuiltInMethods.JSON_OBJECT)
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions
+
+import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
+import org.junit.Test
+
+class JsonFunctionsTest extends ScalarTypesTestBase {
+  //-------------------------------------------------------------------
+  // JSON functions
+  //-------------------------------------------------------------------
+  @Test
+  def testJsonObject(): Unit = {
+    testSqlApi("json_object()", "{}");
+    testSqlApi("json_object('foo': 'bar')", "{\"foo\":\"bar\"}");
+    testSqlApi("json_object('foo': 'bar', 'foo2': 'bar2')",
+      "{\"foo\":\"bar\",\"foo2\":\"bar2\"}");
+    testSqlApi("json_object('foo': null)", "{\"foo\":null}");
+    testSqlApi("json_object('foo': null null on null)", "{\"foo\":null}");
+    testSqlApi("json_object('foo': null absent on null)", "{}");
+    testSqlApi("json_object('foo': 100)", "{\"foo\":100}");
+    testSqlApi("json_object('foo': json_object('foo': 'bar'))",
+      "{\"foo\":\"{\\\"foo\\\":\\\"bar\\\"}\"}");
+
+    testSqlApi("json_object('foo': f36, 'bar': f28)", "{\"bar\":0.45,\"foo\":\"b\"}");
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support `JSON_OBJECT` function for blink planner

## Brief change log

*(for example:)*

- Introduce `JSON_OBJECT` to `FlinkSqlOperatorTable`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `JsonFunctionsTest.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)