### PR TITLE
[FLINK-16204][sql] Support JSON_ARRAY for blink planner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/LogicalTypeRoot.java
@@ -140,6 +140,10 @@ public enum LogicalTypeRoot {
 		LogicalTypeFamily.CONSTRUCTED,
 		LogicalTypeFamily.EXTENSION),
 
+	OBJECT(
+		LogicalTypeFamily.CONSTRUCTED,
+		LogicalTypeFamily.EXTENSION),
+
 	ROW(
 		LogicalTypeFamily.CONSTRUCTED),
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ObjectType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/ObjectType.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Logical type of an arbitrary serialized type. This type is a black box within the table ecosystem
+ * and is only deserialized at the edges. The raw type is an extension to the SQL standard.
+ *
+ * <p>The serialized string representation is {@code OBJECT('c', 's')} where {@code c} is the originating
+ * class and {@code s} is the serialized {@link TypeSerializerSnapshot} in Base64 encoding.
+ *
+ * @param <T> originating class for this type
+ */
+@PublicEvolving
+public final class ObjectType<T> extends LogicalType {
+
+	private static final String FORMAT = "OBJECT('%s', '%s')";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryGeneric");
+
+	private final Class<T> clazz;
+
+	private final TypeSerializer<T> serializer;
+
+	private transient String serializerString;
+
+	public ObjectType(boolean isNullable, Class<T> clazz, TypeSerializer<T> serializer) {
+		super(isNullable, LogicalTypeRoot.OBJECT);
+		this.clazz = Preconditions.checkNotNull(clazz, "Class must not be null.");
+		this.serializer = Preconditions.checkNotNull(serializer, "Serializer must not be null.");
+	}
+
+	public ObjectType(Class<T> clazz, TypeSerializer<T> serializer) {
+		this(true, clazz, serializer);
+	}
+
+	public Class<T> getOriginatingClass() {
+		return clazz;
+	}
+
+	public TypeSerializer<T> getTypeSerializer() {
+		return serializer;
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		return new ObjectType<>(isNullable, clazz, serializer.duplicate());
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(FORMAT, clazz.getName(), "...");
+	}
+
+	@Override
+	public String asSerializableString() {
+		return withNullability(FORMAT, clazz.getName(), getOrCreateSerializerString());
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return this.clazz.isAssignableFrom(clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return clazz.isAssignableFrom(this.clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultConversion() {
+		return clazz;
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		ObjectType<?> rawType = (ObjectType<?>) o;
+		return clazz.equals(rawType.clazz) && serializer.equals(rawType.serializer);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), clazz, serializer);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	private String getOrCreateSerializerString() {
+		if (serializerString == null) {
+			final DataOutputSerializer outputSerializer = new DataOutputSerializer(128);
+			try {
+				TypeSerializerSnapshot.writeVersionedSnapshot(outputSerializer, serializer.snapshotConfiguration());
+				serializerString = EncodingUtils.encodeBytesToBase64(outputSerializer.getCopyOfBuffer());
+				return serializerString;
+			} catch (Exception e) {
+				throw new TableException(String.format(
+					"Unable to generate a string representation of the serializer snapshot of '%s' " +
+						"describing the class '%s' for the OBJECT type.",
+					serializer.getClass().getName(),
+					clazz.toString()), e);
+			}
+		}
+		return serializerString;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationObjectType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/TypeInformationObjectType.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.types.logical;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Placeholder type of an arbitrary serialized type backed by {@link TypeInformation}. This type is
+ * a black box within the table ecosystem and is only deserialized at the edges. The raw type is an
+ * extension to the SQL standard.
+ *
+ * <p>Compared to an {@link RawType}, this type does not contain a {@link TypeSerializer} yet. The
+ * serializer will be generated from the enclosed {@link TypeInformation} but needs access to the
+ * {@link ExecutionConfig} of the current execution environment. Thus, this type is just a placeholder
+ * for the fully resolved {@link RawType} returned by {@link #resolve(ExecutionConfig)}.
+ *
+ * <p>This type has no serializable string representation.
+ *
+ * <p>If no type information is supplied, generic type serialization for {@link Object} is used.
+ */
+@PublicEvolving
+public final class TypeInformationObjectType<T> extends LogicalType {
+
+	private static final String FORMAT = "OBJECT('%s', ?)";
+
+	private static final Set<String> INPUT_OUTPUT_CONVERSION = conversionSet(
+		byte[].class.getName(),
+		"org.apache.flink.table.dataformat.BinaryGeneric");
+
+	private static final TypeInformation<?> DEFAULT_TYPE_INFO = Types.GENERIC(Object.class);
+
+	private final TypeInformation<T> typeInfo;
+
+	public TypeInformationObjectType(boolean isNullable, TypeInformation<T> typeInfo) {
+		super(isNullable, LogicalTypeRoot.OBJECT);
+		this.typeInfo = Preconditions.checkNotNull(typeInfo, "Type information must not be null.");
+	}
+
+	public TypeInformationObjectType(TypeInformation<T> typeInfo) {
+		this(false, typeInfo);
+	}
+
+	@SuppressWarnings("unchecked")
+	public TypeInformationObjectType() {
+		this(false, (TypeInformation<T>) DEFAULT_TYPE_INFO);
+	}
+
+	public TypeInformation<T> getTypeInformation() {
+		return typeInfo;
+	}
+
+	@Internal
+	public ObjectType<T> resolve(ExecutionConfig config) {
+		return new ObjectType<>(isNullable(), typeInfo.getTypeClass(), typeInfo.createSerializer(config));
+	}
+
+	@Override
+	public LogicalType copy(boolean isNullable) {
+		// we must assume immutability here
+		return new TypeInformationObjectType<>(false, typeInfo);
+	}
+
+	@Override
+	public String asSummaryString() {
+		return withNullability(FORMAT, typeInfo.getTypeClass().getName());
+	}
+
+	@Override
+	public String asSerializableString() {
+		throw new TableException(
+			"A raw type backed by type information has no serializable string representation. It " +
+				"needs to be resolved into a proper raw type.");
+	}
+
+	@Override
+	public boolean supportsInputConversion(Class<?> clazz) {
+		return typeInfo.getTypeClass().isAssignableFrom(clazz) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public boolean supportsOutputConversion(Class<?> clazz) {
+		return clazz.isAssignableFrom(typeInfo.getTypeClass()) ||
+			INPUT_OUTPUT_CONVERSION.contains(clazz.getName());
+	}
+
+	@Override
+	public Class<?> getDefaultConversion() {
+		return typeInfo.getTypeClass();
+	}
+
+	@Override
+	public List<LogicalType> getChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <R> R accept(LogicalTypeVisitor<R> visitor) {
+		return visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TypeInformationObjectType<?> that = (TypeInformationObjectType<?>) o;
+		return typeInfo.equals(that.typeInfo);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), typeInfo);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -1000,4 +1000,7 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 	public static final SqlAggFunction ROW_NUMBER = SqlStdOperatorTable.ROW_NUMBER;
 	public static final SqlAggFunction LEAD = SqlStdOperatorTable.LEAD;
 	public static final SqlAggFunction LAG = SqlStdOperatorTable.LAG;
+
+	// JSON FUNCTIONS
+	public static final SqlFunction JSON_ARRAY = SqlStdOperatorTable.JSON_ARRAY;
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -463,6 +463,10 @@ object FlinkTypeFactory {
         val genericRelDataType = relDataType.asInstanceOf[GenericRelDataType]
         genericRelDataType.genericType
 
+      case ANY if relDataType.isInstanceOf[BasicSqlType] =>
+        new TypeInformationObjectType[Any](
+          TypeExtractor.createTypeInfo(classOf[Any]))
+
       case ROW if relDataType.isInstanceOf[RelRecordType] =>
         toLogicalRowType(relDataType)
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -186,6 +186,7 @@ object CodeGenUtils {
     case TIMESTAMP_WITHOUT_TIME_ZONE | TIMESTAMP_WITH_LOCAL_TIME_ZONE => className[SqlTimestamp]
 
     case RAW => className[BinaryGeneric[_]]
+    case OBJECT => "Object"
   }
 
   /**
@@ -203,6 +204,7 @@ object CodeGenUtils {
     case INTERVAL_YEAR_MONTH => "-1"
     case INTERVAL_DAY_TIME => "-1L"
 
+    case OBJECT => "null"
     case _ => "null"
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -148,6 +148,15 @@ object GenerateUtils {
     }
   }
 
+  def generateStringResultCallWithStmtIfArgsNullable(
+      ctx: CodeGeneratorContext,
+      operands: Seq[GeneratedExpression])
+      (call: Seq[String] => String): GeneratedExpression = {
+    generateCallIfArgsNullable(ctx, new VarCharType(VarCharType.MAX_LENGTH), operands) {
+      args => s"$BINARY_STRING.fromString(${call(args)})"
+    }
+  }
+
   /**
     * Generates a call with the nullable args.
     */
@@ -274,7 +283,7 @@ object GenerateUtils {
       ctx: CodeGeneratorContext,
       literalType: LogicalType,
       literalValue: Any): GeneratedExpression = {
-    if (literalValue == null) {
+    if (literalValue == null && literalType.isNullable) {
       return generateNullLiteral(literalType, ctx.nullCheck)
     }
     // non-null values
@@ -417,6 +426,10 @@ object GenerateUtils {
           .getTypeInformation.getTypeClass.isAssignableFrom(classOf[Enum[_]]) =>
         generateSymbol(literalValue.asInstanceOf[Enum[_]])
 
+      case OBJECT if literalType.asInstanceOf[TypeInformationObjectType[_]]
+        .getTypeInformation.getTypeClass.isAssignableFrom(classOf[Object]) =>
+        generateObjectSymbol(literalType, literalValue)
+
       case t@_ =>
         throw new CodeGenException(s"Type not supported: $t")
     }
@@ -430,6 +443,26 @@ object GenerateUtils {
       new TypeInformationRawType[AnyRef](new GenericTypeInfo[AnyRef](
         enum.getDeclaringClass.asInstanceOf[Class[AnyRef]])),
       literalValue = Some(enum))
+  }
+
+  def generateObjectSymbol(resultType: LogicalType, literalValue:Any): GeneratedExpression = {
+    val defaultValue = primitiveDefaultValue(resultType)
+    val resultTypeTerm = primitiveTypeTermForType(resultType)
+    if (resultType.isNullable) {
+      GeneratedExpression(
+        s"(($resultTypeTerm) $defaultValue)",
+        ALWAYS_NULL,
+        NO_CODE,
+        resultType,
+        literalValue = Some(null))  // the literal is null
+    } else {
+      GeneratedExpression(
+        s"(($resultTypeTerm) $defaultValue)",
+        NEVER_NULL,
+        NO_CODE,
+        resultType,
+        literalValue = Some(literalValue.asInstanceOf[Object]))
+    }
   }
 
   /**

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -22,10 +22,12 @@ import org.apache.flink.table.dataformat.{Decimal, SqlTimestamp}
 import org.apache.flink.table.runtime.functions._
 import org.apache.calcite.avatica.util.TimeUnitRange
 import org.apache.calcite.linq4j.tree.Types
-import org.apache.calcite.runtime.SqlFunctions
+import org.apache.calcite.runtime.{JsonFunctions, SqlFunctions}
 import java.lang.reflect.Method
 import java.lang.{Byte => JByte, Integer => JInteger, Long => JLong, Short => JShort}
 import java.util.TimeZone
+
+import org.apache.calcite.sql.SqlJsonConstructorNullClause
 
 object BuiltInMethods {
 
@@ -463,4 +465,8 @@ object BuiltInMethods {
 
   val TRUNCATE_SQL_TIMESTAMP = Types.lookupMethod(classOf[SqlDateTimeUtils], "truncate",
     classOf[SqlTimestamp], classOf[Int])
+
+  // JSON FUNCTIONS
+  val JSON_ARRAY = Types.lookupMethod(classOf[JsonFunctions], "jsonArray",
+    classOf[SqlJsonConstructorNullClause], classOf[Array[AnyRef]])
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FunctionGenerator.scala
@@ -753,6 +753,15 @@ object FunctionGenerator {
     Seq(FLOAT, INTEGER),
     BuiltInMethods.TRUNCATE_FLOAT)
 
+  addSqlFunctionMethod(
+    JSON_ARRAY,
+    Seq(RAW),
+    BuiltInMethods.JSON_ARRAY)
+
+  addSqlFunctionMethod(
+    JSON_ARRAY,
+    Seq(RAW, OBJECT),
+    BuiltInMethods.JSON_ARRAY)
 
   // ----------------------------------------------------------------------------------------------
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -981,6 +981,15 @@ object ScalarOperatorGens {
           s""" "" + $converterTerm.toExternal(${terms.head})"""
       }
 
+    case (OBJECT, VARCHAR | CHAR | INTEGER | BOOLEAN) =>
+      generateStringResultCallIfArgsNotNull(ctx, Seq(operand)) {
+        terms =>
+          val converter = DataFormatConverters.getConverterForDataType(
+            fromLogicalTypeToDataType(operand.resultType))
+          val converterTerm = ctx.addReusableObject(converter, "converter")
+          s""" "" + $converterTerm.toExternal($converterTerm.toInternal(${terms.head}))"""
+      }
+
     // * (not Date/Time/Timestamp) -> String
     // TODO: GenericType with Date/Time/Timestamp -> String would call toString implicitly
     case (_, VARCHAR | CHAR) =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/StringCallGen.scala
@@ -21,18 +21,16 @@ package org.apache.flink.table.planner.codegen.calls
 import org.apache.flink.table.api.DataTypes
 import org.apache.flink.table.dataformat.DataFormatConverters
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
-import org.apache.flink.table.planner.codegen.GenerateUtils.{generateCallIfArgsNotNull, generateCallIfArgsNullable, generateStringResultCallIfArgsNotNull}
+import org.apache.flink.table.planner.codegen.GenerateUtils.{generateCallIfArgsNotNull, generateCallIfArgsNullable, generateStringResultCallIfArgsNotNull, generateStringResultCallWithStmtIfArgsNullable}
 import org.apache.flink.table.planner.codegen.calls.ScalarOperatorGens._
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, GeneratedExpression}
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable._
 import org.apache.flink.table.runtime.functions.SqlFunctionUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isTimestamp, isTimestampWithLocalZone}
 import org.apache.flink.table.types.logical.{BooleanType, IntType, LogicalType, MapType, VarBinaryType, VarCharType}
-
-import org.apache.calcite.runtime.SqlFunctions
+import org.apache.calcite.runtime.{JsonFunctions, SqlFunctions}
 import org.apache.calcite.sql.SqlOperator
 import org.apache.calcite.sql.fun.SqlTrimFunction.Flag.{BOTH, LEADING, TRAILING}
-
 import java.lang.reflect.Method
 
 /**
@@ -222,6 +220,9 @@ object StringCallGen {
           isCharacterString(operands(1).resultType) &&
           isCharacterString(operands(2).resultType) =>
         methodGen(BuiltInMethods.CONVERT_TZ)
+
+      case JSON_ARRAY if operands.nonEmpty =>
+        generateJsonArray(ctx, returnType, operands)
 
       case _ => null
     }
@@ -675,6 +676,17 @@ object StringCallGen {
     generateStringResultCallIfArgsNotNull(ctx, operands) {
       terms =>
         s"$className.jsonValue(${safeToStringTerms(terms, operands)})"
+    }
+  }
+
+  def generateJsonArray(
+    ctx: CodeGeneratorContext,
+    returnType: LogicalType,
+    operands: Seq[GeneratedExpression]): GeneratedExpression = {
+    val className = classOf[JsonFunctions].getCanonicalName
+    generateStringResultCallWithStmtIfArgsNullable(ctx, operands) {
+      terms =>
+        s"$className.jsonArray(${safeToStringTerms(terms, operands)})"
     }
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions
+
+import org.apache.flink.table.planner.expressions.utils.ScalarTypesTestBase
+import org.junit.Test
+
+class JsonFunctionsTest extends ScalarTypesTestBase {
+  //-------------------------------------------------------------------
+  // JSON functions
+  //-------------------------------------------------------------------
+  @Test
+  def testJsonQuery(): Unit = {
+    testSqlApi("json_array()", "[]")
+    testSqlApi("json_array('foo')", "[\"foo\"]")
+    testSqlApi("json_array('foo', 'bar')", "[\"foo\",\"bar\"]")
+    testSqlApi("json_array(null)", "[]")
+    testSqlApi("json_array(null null on null)", "[null]")
+    testSqlApi("json_array(null absent on null)", "[]")
+    testSqlApi("json_array(100)", "[100]")
+    testSqlApi("json_array(json_array('foo'))", "[\"[\\\"foo\\\"]\"]")
+
+    testSqlApi("json_array(f36, f28)", "[\"b\",0.45]")
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

Support `JSON_ARRAY` function for blink planner

## Brief change log

*(for example:)*

- Introduce `JSON_ARRAY` to `FlinkSqlOperatorTable`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `JsonFunctionsTest.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)