### PR TITLE
[FLINK-16370][build] Only bundle javax as Java11-exclusive dependency

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -635,7 +635,7 @@ under the License.
 									<overWrite>true</overWrite>
 								</artifactItem>
 							</artifactItems>
-							<outputDirectory>${project.build.directory}/temporary</outputDirectory>
+							<outputDirectory>${project.build.directory}/temporary/java11_exclusive</outputDirectory>
 						</configuration>
 					</execution>
 					<execution>
@@ -665,16 +665,16 @@ under the License.
 				<artifactId>maven-antrun-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>unpack-javax-libraries</id>
+						<id>bundle-java11-exclusive-dependencies</id>
 						<phase>process-resources</phase>
 						<goals>
 							<goal>run</goal>
 						</goals>
 						<configuration>
 							<target>
-								<echo message="unpacking javax jars"/>
+								<echo message="bundling java11-exclusive dependencies"/>
 								<unzip dest="${project.build.directory}/classes/META-INF/versions/11">
-									<fileset dir="${project.build.directory}/temporary">
+									<fileset dir="${project.build.directory}/temporary/java11_exclusive">
 										<include name="*"/>
 									</fileset>
 								</unzip>


### PR DESCRIPTION
Fixes an issue where ZK 3.5 was bundled in flink-dist as a java11-exclusive dependency.

The underlying issue was a lack of clarity in the build process of flink-dist; some dependencies are downloaded by the `dependency-plugin` to `flink-dist/target/temporary`. In a later step we bundled all dependencies in this directory as java11-exclusive dependencies.
In the introduction of ZK 3.5 this directory was re-used for ZK (which is bundled in /opt), which led to it's inclusion.

There is now a dedicated directory for dependencies that should be bundled as java11-exclusive dependencies, and various names were adjusted to increase clarity.