### PR TITLE
[FLINK-15911][runtime] Make Flink work with NAT.

### DIFF
--- a/docs/_includes/generated/all_taskmanager_section.html
+++ b/docs/_includes/generated/all_taskmanager_section.html
@@ -54,7 +54,7 @@
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
+            <td>The external address of the network interface where the TaskManager is exposed. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>
@@ -109,7 +109,7 @@
             <td><h5>taskmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>
-            <td>The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
+            <td>The external RPC port where the TaskManager is exposed. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/all_taskmanager_section.html
+++ b/docs/_includes/generated/all_taskmanager_section.html
@@ -30,7 +30,7 @@
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
-            <td>The task manager’s port used for data exchange operations.</td>
+            <td>The task manager’s external port used for data exchange operations.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.ssl.enabled</h5></td>

--- a/docs/_includes/generated/common_host_port_section.html
+++ b/docs/_includes/generated/common_host_port_section.html
@@ -54,7 +54,7 @@
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
-            <td>The task manager’s port used for data exchange operations.</td>
+            <td>The task manager’s external port used for data exchange operations.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.host</h5></td>

--- a/docs/_includes/generated/common_host_port_section.html
+++ b/docs/_includes/generated/common_host_port_section.html
@@ -60,13 +60,13 @@
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
+            <td>The external address of the network interface where the TaskManager is exposed. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>
-            <td>The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
+            <td>The external RPC port where the TaskManager is exposed. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/job_manager_configuration.html
+++ b/docs/_includes/generated/job_manager_configuration.html
@@ -15,6 +15,12 @@
             <td>Dictionary for JobManager to store the archives of completed jobs.</td>
         </tr>
         <tr>
+            <td><h5>jobmanager.bind-host</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The local address of the network interface that the job manager binds to. If not configured, '0.0.0.0' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>jobmanager.execution.attempts-history-size</h5></td>
             <td style="word-wrap: break-word;">16</td>
             <td>Integer</td>
@@ -37,6 +43,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
             <td>The config parameter defining the network address to connect to for communication with the job manager. This value is only interpreted in setups where a single JobManager with static name or address exists (simple standalone setups, or container setups with dynamic service name resolution). It is not used in many high-availability setups, when a leader-election service (like ZooKeeper) is used to elect and discover the JobManager leader from potentially multiple standby JobManagers.</td>
+        </tr>
+        <tr>
+            <td><h5>jobmanager.rpc.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The local RPC port that the JobManager binds to. If not configured, the external port (configured by 'jobmanager.rpc.port') will be used.</td>
         </tr>
         <tr>
             <td><h5>jobmanager.rpc.port</h5></td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -9,10 +9,16 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>taskmanager.data.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The task manager's bind port used for data exchange operations. If not configured, 'taskmanager.data.port' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.data.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>
-            <td>The task manager’s port used for data exchange operations.</td>
+            <td>The task manager’s external port used for data exchange operations.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.data.ssl.enabled</h5></td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -27,6 +27,12 @@
             <td>Time we wait for the timers in milliseconds to finish all pending timer threads when the stream task is cancelled.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.bind-host</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The local address of the network interface that the task manager binds to. If not configured, '0.0.0.0' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.debug.memory.log</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -42,7 +48,7 @@
             <td><h5>taskmanager.host</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The address of the network interface that the TaskManager binds to. This option can be used to define explicitly a binding address. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
+            <td>The external address of the network interface where the TaskManager is exposed. Because different TaskManagers need different values for this option, usually it is specified in an additional non-shared TaskManager-specific config file.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.jvm-exit-on-oom</h5></td>
@@ -88,10 +94,16 @@
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.rpc.bind-port</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>The local RPC port that the TaskManager binds to. If not configured, the external port (configured by 'taskmanager.rpc.port') will be used.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>
-            <td>The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
+            <td>The external RPC port where the TaskManager is exposed. Accepts a list of ports (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid collisions when multiple TaskManagers are running on the same machine.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/JobManagerOptions.java
@@ -55,6 +55,16 @@ public class JobManagerOptions {
 			" leader from potentially multiple standby JobManagers.");
 
 	/**
+	 * The local address of the network interface that the job manager binds to.
+	 */
+	public static final ConfigOption<String> BIND_HOST =
+		key("jobmanager.bind-host")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("The local address of the network interface that the job manager binds to. If not" +
+				" configured, '0.0.0.0' will be used.");
+
+	/**
 	 * The config parameter defining the network port to connect to
 	 * for communication with the job manager.
 	 *
@@ -77,6 +87,16 @@ public class JobManagerOptions {
 			" This config option is not used in many high-availability setups, when a" +
 			" leader-election service (like ZooKeeper) is used to elect and discover the JobManager" +
 			" leader from potentially multiple standby JobManagers.");
+
+	/**
+	 * The local port that the job manager binds to.
+	 */
+	public static final ConfigOption<Integer> RPC_BIND_PORT =
+		key("jobmanager.rpc.bind-port")
+			.intType()
+			.noDefaultValue()
+			.withDescription("The local RPC port that the JobManager binds to. If not configured, the external port" +
+				" (configured by '" + PORT.key() + "') will be used.");
 
 	/**
 	 * JVM heap size for the JobManager with memory size.

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -41,7 +41,17 @@ public class NettyShuffleEnvironmentOptions {
 	public static final ConfigOption<Integer> DATA_PORT =
 		key("taskmanager.data.port")
 			.defaultValue(0)
-			.withDescription("The task manager’s port used for data exchange operations.");
+			.withDescription("The task manager’s external port used for data exchange operations.");
+
+	/**
+	 * The local network port that the task manager listen at for data exchange.
+	 */
+	public static final ConfigOption<Integer> DATA_BIND_PORT =
+		key("taskmanager.data.bind-port")
+			.intType()
+			.noDefaultValue()
+			.withDescription("The task manager's bind port used for data exchange operations. If not configured, '" +
+				DATA_PORT.key() + "' will be used.");
 
 	/**
 	 * Config parameter to override SSL support for taskmanager's data transport.

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -94,7 +94,7 @@ public class TaskManagerOptions {
 				" or if it has been quarantined by another actor system.");
 
 	/**
-	 * The config parameter defining the task manager's hostname.
+	 * The external address of the network interface where the TaskManager is exposed.
 	 * Overrides {@link #HOST_BIND_POLICY} automatic address binding.
 	 */
 	@Documentation.Section({Documentation.Sections.COMMON_HOST_PORT, Documentation.Sections.ALL_TASK_MANAGER})
@@ -102,10 +102,19 @@ public class TaskManagerOptions {
 		key("taskmanager.host")
 			.stringType()
 			.noDefaultValue()
-			.withDescription("The address of the network interface that the TaskManager binds to." +
-				" This option can be used to define explicitly a binding address. Because" +
-				" different TaskManagers need different values for this option, usually it is specified in an" +
+			.withDescription("The external address of the network interface where the TaskManager is exposed." +
+				" Because different TaskManagers need different values for this option, usually it is specified in an" +
 				" additional non-shared TaskManager-specific config file.");
+
+	/**
+	 * The local address of the network interface that the task manager binds to.
+	 */
+	public static final ConfigOption<String> BIND_HOST =
+		key("taskmanager.bind-host")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("The local address of the network interface that the task manager binds to. If not" +
+				" configured, '0.0.0.0' will be used.");
 
 	/**
 	 * The default network port range the task manager expects incoming IPC connections. The {@code "0"} means that
@@ -116,9 +125,20 @@ public class TaskManagerOptions {
 		key("taskmanager.rpc.port")
 			.stringType()
 			.defaultValue("0")
-			.withDescription("The task manager’s IPC port. Accepts a list of ports (“50100,50101”), ranges" +
-				" (“50100-50200”) or a combination of both. It is recommended to set a range of ports to avoid" +
-				" collisions when multiple TaskManagers are running on the same machine.");
+			.withDescription("The external RPC port where the TaskManager is exposed. Accepts a list of ports" +
+				" (“50100,50101”), ranges (“50100-50200”) or a combination of both. It is recommended to set a" +
+				" range of ports to avoid collisions when multiple TaskManagers are running on the same machine.");
+
+
+	/**
+	 * The local port that the task manager binds to.
+	 */
+	public static final ConfigOption<Integer> RPC_BIND_PORT =
+		key("taskmanager.rpc.bind-port")
+			.intType()
+			.noDefaultValue()
+			.withDescription("The local RPC port that the TaskManager binds to. If not configured, the external port" +
+				" (configured by '" + RPC_PORT.key() + "') will be used.");
 
 	/**
 	 * The initial registration backoff between two consecutive registration attempts. The backoff

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -113,6 +113,8 @@ if [[ ${PROFILE} != *"jdk11"* ]]; then
 	run_test "Run Kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
 	run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubernetes_session.sh"
 
+	run_test "Running Flink over NAT end-to-end test" "$END_TO_END_DIR/test-scripts/test_nat.sh" "skip_check_exceptions"
+
 	if [[ $PROFILE == *"include-hadoop"* ]]; then
 		run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
 		run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"

--- a/flink-end-to-end-tests/run-pre-commit-tests.sh
+++ b/flink-end-to-end-tests/run-pre-commit-tests.sh
@@ -47,7 +47,7 @@ echo "Flink distribution directory: $FLINK_DIR"
 # carefully though. A valid reasons for doing so could be e.g killing TMs randomly as we cannot predict what exception could be thrown. Whenever
 # those checks are disabled, one should take care that a proper checks are performed in the tests itself that ensure that the test finished
 # in an expected state.
-
+run_test "Running Flink over NAT end-to-end test" "$END_TO_END_DIR/test-scripts/test_nat.sh" "skip_check_exceptions"
 run_test "State Migration end-to-end test from 1.6" "$END_TO_END_DIR/test-scripts/test_state_migration.sh"
 run_test "State Evolution end-to-end test" "$END_TO_END_DIR/test-scripts/test_state_evolution.sh"
 run_test "Wordcount end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh file"

--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -32,3 +32,9 @@ function containers_health_check() {
     fi
   done
 }
+
+function build_image_with_jar() {
+    local job_artifacts=$1
+    local image_name=${2:-flink-job}
+    ./build.sh --from-local-dist --job-artifacts ${job_artifacts} --image-name ${image_name}
+}

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -18,6 +18,7 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_docker.sh
 
 DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
 KUBERNETES_MODULE_DIR=${END_TO_END_DIR}/../flink-container/kubernetes

--- a/flink-end-to-end-tests/test-scripts/container-scripts/docker-compose.nat.yml
+++ b/flink-end-to-end-tests/test-scripts/container-scripts/docker-compose.nat.yml
@@ -1,0 +1,90 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Docker compose file for a Flink job cluster deployment with NAT network.
+#
+# All the network traffics are intended to go through the Docker host. NAT port mapping is simulated by publishing
+# internal container ports to different external Docker host ports. A container's external hostname is simulated
+# resolvable to all other containers except itself, by adding extra hosts to other containers that maps the hostname to
+# the IP address of the Docker host. 
+#
+# Parameters:
+# * FLINK_DOCKER_IMAGE_NAME - Image name to use for the deployment (default: flink-job:latest)
+# * FLINK_JOB - Name of the Flink job to execute (default: none)
+# * FLINK_JOB_ARGUMENTS - Additional arguments which will be passed to the job cluster (default: none)
+#
+# * INPUT_VOLUME - Volume to be mounted for input.
+# * OUTPUT_VOLUME - Volume to be mounted for output.
+# * INPUT_PATH - Path inside container for the input.
+# * OUTPUT_PATH - Path outside container for the input.
+#
+# * HOST_IP - IP address of the Docker host. This will be used for resolving JM/TM external addresses.
+# * JM_EX_HOSTNAME - External hostname for JM.
+# * TM_1_EX_HOSTNAME - External hostname for TM 1.
+# * TM_2_EX_HOSTNAME - External hostname for TM 2.
+#
+# * JM_RPC_EX_PORT - External RPC port for JM.
+# * JM_RPC_IN_PORT - Internal RPC port for JM.
+# * TM_1_RPC_EX_PORT - External RPC port for TM 1.
+# * TM_2_RPC_EX_PORT - External RPC port for TM 2.
+# * TM_RPC_IN_PORT - Internal RPC port for both TMs.
+#
+# * TM_1_DATA_EX_PORT - External data port for TM 1.
+# * TM_2_DATA_EX_PORT - External data port for TM 2.
+# * TM_DATA_IN_PORT - Internal data port for both TMs.
+
+version: "2.2"
+services:
+  job-cluster:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
+    ports:
+      - "8081:8081"
+      - ${JM_RPC_EX_PORT}:${JM_RPC_IN_PORT}
+    volumes:
+      - ${INPUT_VOLUME}:${INPUT_PATH}
+      - ${OUTPUT_VOLUME}:${OUTPUT_PATH}
+    command: job-cluster --job-classname ${FLINK_JOB} -Dparallelism.default=2 -Djobmanager.rpc.address=${JM_EX_HOSTNAME} -Djobmanager.bind-host=0.0.0.0 -Djobmanager.rpc.port=${JM_RPC_EX_PORT} -Djobmanager.rpc.bind-port=${JM_RPC_IN_PORT} ${FLINK_JOB_ARGUMENTS}
+    extra_hosts:
+      - ${TM_1_EX_HOSTNAME}:${HOST_IP}
+      - ${TM_2_EX_HOSTNAME}:${HOST_IP}
+
+  taskmanager1:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
+    ports:
+      - ${TM_1_RPC_EX_PORT}:${TM_RPC_IN_PORT}
+      - ${TM_1_DATA_EX_PORT}:${TM_DATA_IN_PORT}
+    volumes:
+      - ${INPUT_VOLUME}:${INPUT_PATH}
+      - ${OUTPUT_VOLUME}:${OUTPUT_PATH}
+    command: task-manager -Djobmanager.rpc.address=${JM_EX_HOSTNAME} -Djobmanager.rpc.port=${JM_RPC_EX_PORT} -Dtaskmanager.host=${TM_1_EX_HOSTNAME} -Dtaskmanager.bind-host=0.0.0.0 -Dtaskmanager.rpc.port=${TM_1_RPC_EX_PORT} -Dtaskmanager.rpc.bind-port=${TM_RPC_IN_PORT} -Dtaskmanager.data.port=${TM_1_DATA_EX_PORT} -Dtaskmanager.data.bind-port=${TM_DATA_IN_PORT}
+    extra_hosts:
+      - ${JM_EX_HOSTNAME}:${HOST_IP}
+      - ${TM_2_EX_HOSTNAME}:${HOST_IP}
+
+  taskmanager2:
+    image: ${FLINK_DOCKER_IMAGE_NAME:-flink-job}
+    ports:
+      - ${TM_2_RPC_EX_PORT}:${TM_RPC_IN_PORT}
+      - ${TM_2_DATA_EX_PORT}:${TM_DATA_IN_PORT}
+    volumes:
+      - ${INPUT_VOLUME}:${INPUT_PATH}
+      - ${OUTPUT_VOLUME}:${OUTPUT_PATH}
+    command: task-manager -Djobmanager.rpc.address=${JM_EX_HOSTNAME} -Djobmanager.rpc.port=${JM_RPC_EX_PORT} -Dtaskmanager.host=${TM_2_EX_HOSTNAME} -Dtaskmanager.bind-host=0.0.0.0 -Dtaskmanager.rpc.port=${TM_2_RPC_EX_PORT} -Dtaskmanager.rpc.bind-port=${TM_RPC_IN_PORT} -Dtaskmanager.data.port=${TM_2_DATA_EX_PORT} -Dtaskmanager.data.bind-port=${TM_DATA_IN_PORT}
+    extra_hosts:
+      - ${JM_EX_HOSTNAME}:${HOST_IP}
+      - ${TM_1_EX_HOSTNAME}:${HOST_IP}

--- a/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_docker_embedded_job.sh
@@ -18,6 +18,7 @@
 ################################################################################
 
 source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_docker.sh
 
 DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
 DOCKER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
@@ -52,7 +53,7 @@ esac
 export FLINK_JOB_ARGUMENTS="${INPUT_ARGS} --output ${OUTPUT_PATH}/docker_wc_out"
 
 build_image() {
-    ./build.sh --from-local-dist --job-artifacts ${FLINK_DIR}/examples/batch/WordCount.jar --image-name ${FLINK_DOCKER_IMAGE_NAME}
+    build_image_with_jar ${FLINK_DIR}/examples/batch/WordCount.jar ${FLINK_DOCKER_IMAGE_NAME}
 }
 
 # user inside the container must be able to create files, this is a workaround in-container permissions

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -38,7 +38,7 @@ start_kubernetes
 mkdir -p $OUTPUT_VOLUME
 
 cd "$DOCKER_MODULE_DIR"
-./build.sh --from-local-dist --job-artifacts ${FLINK_DIR}/examples/batch/WordCount.jar --image-name ${FLINK_IMAGE_NAME}
+build_image_with_jar ${FLINK_DIR}/examples/batch/WordCount.jar ${FLINK_IMAGE_NAME}
 cd "$END_TO_END_DIR"
 
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_session.sh
@@ -36,7 +36,7 @@ start_kubernetes
 
 cd "$DOCKER_MODULE_DIR"
 # Build a Flink image without any user jars
-./build.sh --from-local-dist --job-artifacts ${TEST_INFRA_DIR}/test-data/words --image-name ${FLINK_IMAGE_NAME}
+build_image_with_jar ${TEST_INFRA_DIR}/test-data/words ${FLINK_IMAGE_NAME}
 
 kubectl create clusterrolebinding ${CLUSTER_ROLE_BINDING} --clusterrole=edit --serviceaccount=default:default --namespace=default
 

--- a/flink-end-to-end-tests/test-scripts/test_nat.sh
+++ b/flink-end-to-end-tests/test-scripts/test_nat.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+source "$(dirname "$0")"/common_docker.sh
+
+DOCKER_MODULE_DIR=${END_TO_END_DIR}/../flink-container/docker
+DOCKER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
+DOCKER_IMAGE_BUILD_RETRIES=3
+BUILD_BACKOFF_TIME=5
+
+export FLINK_JOB=org.apache.flink.examples.java.wordcount.WordCount
+export FLINK_DOCKER_IMAGE_NAME=test_nat
+export INPUT_VOLUME=${END_TO_END_DIR}/test-scripts/test-data
+export OUTPUT_VOLUME=${TEST_DATA_DIR}/out
+export INPUT_PATH=/data/test/input
+export OUTPUT_PATH=/data/test/output
+
+export HOST_IP=$(get_node_ip | awk '{print $1}')
+export JM_EX_HOSTNAME=jm.flink.test
+export TM_1_EX_HOSTNAME=tm1.flink.test
+export TM_2_EX_HOSTNAME=tm2.flink.test
+
+export JM_RPC_EX_PORT=10000
+export JM_RPC_IN_PORT=10000
+
+export TM_1_RPC_EX_PORT=10001
+export TM_2_RPC_EX_PORT=10002
+export TM_RPC_IN_PORT=10000
+
+export TM_1_DATA_EX_PORT=11001
+export TM_2_DATA_EX_PORT=11002
+export TM_DATA_IN_PORT=11000
+
+RESULT_HASH="72a690412be8928ba239c2da967328a5"
+INPUT_ARGS="--input ${INPUT_PATH}/words"
+OUTPUT_PREFIX="docker_wc_out"
+
+export FLINK_JOB_ARGUMENTS="${INPUT_ARGS} --output ${OUTPUT_PATH}/${OUTPUT_PREFIX}"
+
+build_image() {
+    build_image_with_jar ${FLINK_DIR}/examples/batch/WordCount.jar ${FLINK_DOCKER_IMAGE_NAME}
+}
+
+# user inside the container must be able to create files, this is a workaround in-container permissions
+mkdir -p $OUTPUT_VOLUME
+chmod 777 $OUTPUT_VOLUME
+
+pushd "$DOCKER_MODULE_DIR"
+if ! retry_times $DOCKER_IMAGE_BUILD_RETRIES ${BUILD_BACKOFF_TIME} build_image; then
+    echo "Failed to build docker image. Aborting..."
+    exit 1
+fi
+popd
+
+docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml up --abort-on-container-exit --exit-code-from job-cluster &> /dev/null
+docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs job-cluster > ${FLINK_DIR}/log/jobmanager.log
+docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager1 > ${FLINK_DIR}/log/taskmanager1.log
+docker-compose -f ${DOCKER_SCRIPTS}/docker-compose.nat.yml logs taskmanager2 > ${FLINK_DIR}/log/taskmanager2.log
+
+check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_PREFIX}/ "${RESULT_HASH}"

--- a/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerBase.java
+++ b/flink-queryable-state/flink-queryable-state-client-java/src/main/java/org/apache/flink/queryablestate/network/AbstractServerBase.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.BindException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -74,8 +73,8 @@ public abstract class AbstractServerBase<REQ extends MessageBody, RESP extends M
 	/** The name of the server, useful for debugging. */
 	private final String serverName;
 
-	/** The {@link InetAddress address} to listen to. */
-	private final InetAddress bindAddress;
+	/** The address to listen to. */
+	private final String bindAddress;
 
 	/** A port range on which to try to connect. */
 	private final Set<Integer> bindPortRange;
@@ -113,7 +112,7 @@ public abstract class AbstractServerBase<REQ extends MessageBody, RESP extends M
 	 */
 	protected AbstractServerBase(
 			final String serverName,
-			final InetAddress bindAddress,
+			final String bindAddress,
 			final Iterator<Integer> bindPortIterator,
 			final Integer numEventLoopThreads,
 			final Integer numQueryThreads) {

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImpl.java
@@ -33,7 +33,6 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
@@ -57,7 +56,7 @@ public class KvStateClientProxyImpl extends AbstractServerBase<KvStateRequest, K
 	 * Creates the Queryable State Client Proxy.
 	 *
 	 * <p>The server is instantiated using reflection by the
-	 * {@link org.apache.flink.runtime.query.QueryableStateUtils#createKvStateClientProxy(InetAddress, Iterator, int, int, KvStateRequestStats)
+	 * {@link org.apache.flink.runtime.query.QueryableStateUtils#createKvStateClientProxy(String, Iterator, int, int, KvStateRequestStats)
 	 * QueryableStateUtils.createKvStateClientProxy(InetAddress, Iterator, int, int, KvStateRequestStats)}.
 	 *
 	 * <p>The server needs to be started via {@link #start()} in order to bind
@@ -70,7 +69,7 @@ public class KvStateClientProxyImpl extends AbstractServerBase<KvStateRequest, K
 	 * @param stats the statistics collector.
 	 */
 	public KvStateClientProxyImpl(
-			final InetAddress bindAddress,
+			final String bindAddress,
 			final Iterator<Integer> bindPortIterator,
 			final Integer numEventLoopThreads,
 			final Integer numQueryThreads,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerImpl.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/main/java/org/apache/flink/queryablestate/server/KvStateServerImpl.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.KvStateServer;
 import org.apache.flink.util.Preconditions;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
@@ -51,7 +50,7 @@ public class KvStateServerImpl extends AbstractServerBase<KvStateInternalRequest
 	 * Creates the state server.
 	 *
 	 * <p>The server is instantiated using reflection by the
-	 * {@link org.apache.flink.runtime.query.QueryableStateUtils#createKvStateServer(InetAddress, Iterator, int, int, KvStateRegistry, KvStateRequestStats)
+	 * {@link org.apache.flink.runtime.query.QueryableStateUtils#createKvStateServer(String, Iterator, int, int, KvStateRegistry, KvStateRequestStats)
 	 * QueryableStateUtils.createKvStateServer(InetAddress, Iterator, int, int, KvStateRegistry, KvStateRequestStats)}.
 	 *
 	 * <p>The server needs to be started via {@link #start()} in order to bind
@@ -65,7 +64,7 @@ public class KvStateServerImpl extends AbstractServerBase<KvStateInternalRequest
 	 * @param stats the statistics collector.
 	 */
 	public KvStateServerImpl(
-			final InetAddress bindAddress,
+			final String bindAddress,
 			final Iterator<Integer> bindPortIterator,
 			final Integer numEventLoopThreads,
 			final Integer numQueryThreads,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImplTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/client/proxy/KvStateClientProxyImplTest.java
@@ -47,7 +47,7 @@ public class KvStateClientProxyImplTest extends TestLogger {
 	@Before
 	public void setup() {
 		kvStateClientProxy = new KvStateClientProxyImpl(
-			InetAddress.getLoopbackAddress(),
+			InetAddress.getLoopbackAddress().getHostName(),
 			Collections.singleton(0).iterator(),
 			1,
 			1,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/AbstractServerTest.java
@@ -160,7 +160,7 @@ public class AbstractServerTest extends TestLogger {
 		private final KvStateRequestStats requestStats;
 
 		TestServer(String name, KvStateRequestStats stats, Iterator<Integer> bindPort) throws UnknownHostException {
-			super(name, InetAddress.getLocalHost(), bindPort, 1, 1);
+			super(name, InetAddress.getLocalHost().getHostName(), bindPort, 1, 1);
 			this.requestStats = stats;
 		}
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/ClientTest.java
@@ -673,7 +673,7 @@ public class ClientTest {
 				registry[i] = new KvStateRegistry();
 				serverStats[i] = new AtomicKvStateRequestStats();
 				server[i] = new KvStateServerImpl(
-						InetAddress.getLocalHost(),
+						InetAddress.getLocalHost().getHostName(),
 						Collections.singletonList(0).iterator(),
 						numServerEventLoopThreads,
 						numServerQueryThreads,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -89,7 +89,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 	public static void setup() {
 		try {
 			testServer = new KvStateServerImpl(
-					InetAddress.getLocalHost(),
+					InetAddress.getLocalHost().getHostName(),
 					Collections.singletonList(0).iterator(),
 					1,
 					1,
@@ -408,7 +408,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		AtomicKvStateRequestStats stats = new AtomicKvStateRequestStats();
 
 		KvStateServerImpl localTestServer = new KvStateServerImpl(
-				InetAddress.getLocalHost(),
+				InetAddress.getLocalHost().getHostName(),
 				Collections.singletonList(0).iterator(),
 				1,
 				1,

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerTest.java
@@ -99,7 +99,7 @@ public class KvStateServerTest {
 			KvStateRequestStats stats = new AtomicKvStateRequestStats();
 
 			server = new KvStateServerImpl(
-					InetAddress.getLocalHost(),
+					InetAddress.getLocalHost().getHostName(),
 					Collections.singletonList(0).iterator(),
 					1,
 					1,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -282,7 +282,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 	@Nonnull
 	private RpcService createRpcService(Configuration configuration, String bindAddress, String portRange) throws Exception {
-		return AkkaRpcServiceUtils.createRpcService(bindAddress, portRange, configuration);
+		return AkkaRpcServiceUtils.remoteServiceBuilder(configuration, bindAddress, portRange).createAndStart();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -43,7 +43,7 @@ import org.apache.flink.runtime.rpc.RpcTimeout;
 import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 
 import javax.annotation.Nullable;
 
@@ -167,13 +167,13 @@ public interface JobMasterGateway extends
 	 * Registers the task manager at the job manager.
 	 *
 	 * @param taskManagerRpcAddress the rpc address of the task manager
-	 * @param taskManagerLocation   location of the task manager
+	 * @param unresolvedTaskManagerLocation   unresolved location of the task manager
 	 * @param timeout               for the rpc call
 	 * @return Future registration response indicating whether the registration was successful or not
 	 */
 	CompletableFuture<RegistrationResponse> registerTaskManager(
 			final String taskManagerRpcAddress,
-			final TaskManagerLocation taskManagerLocation,
+			final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
 			@RpcTimeout final Time timeout);
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -136,12 +136,10 @@ public class MetricUtils {
 		final String portRange = configuration.getString(MetricOptions.QUERY_SERVICE_PORT);
 		final int threadPriority = configuration.getInteger(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
 
-		return AkkaRpcServiceUtils.createRpcService(
-			hostname,
-			portRange,
-			configuration,
-			METRICS_ACTOR_SYSTEM_NAME,
-			new BootstrapTools.FixedThreadPoolExecutorConfiguration(1, 1, threadPriority));
+		return AkkaRpcServiceUtils.remoteServiceBuilder(configuration, hostname, portRange)
+			.withActorSystemName(METRICS_ACTOR_SYSTEM_NAME)
+			.withActorSystemExecutorConfiguration(new BootstrapTools.FixedThreadPoolExecutorConfiguration(1, 1, threadPriority))
+			.createAndStart();
 	}
 
 	private static void instantiateClassLoaderMetrics(MetricGroup metrics) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -904,16 +904,16 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 	protected class DedicatedRpcServiceFactory implements RpcServiceFactory {
 
 		private final AkkaRpcServiceConfiguration akkaRpcServiceConfig;
-		private final String jobManagerBindAddress;
+		private final String bindAddress;
 
-		DedicatedRpcServiceFactory(AkkaRpcServiceConfiguration akkaRpcServiceConfig, String jobManagerBindAddress) {
+		DedicatedRpcServiceFactory(AkkaRpcServiceConfiguration akkaRpcServiceConfig, String bindAddress) {
 			this.akkaRpcServiceConfig = akkaRpcServiceConfig;
-			this.jobManagerBindAddress = jobManagerBindAddress;
+			this.bindAddress = bindAddress;
 		}
 
 		@Override
 		public RpcService createRpcService() {
-			final RpcService rpcService = MiniCluster.this.createRpcService(akkaRpcServiceConfig, true, jobManagerBindAddress);
+			final RpcService rpcService = MiniCluster.this.createRpcService(akkaRpcServiceConfig, true, bindAddress);
 
 			synchronized (lock) {
 				rpcServices.add(rpcService);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -106,6 +106,14 @@ public class MiniClusterConfiguration {
 				configuration.getString(TaskManagerOptions.HOST, "localhost");
 	}
 
+	public String getJobManagerBindPortRange() {
+		return String.valueOf(configuration.getInteger(JobManagerOptions.PORT, 0));
+	}
+
+	public String getTaskManagerBindPortRange() {
+		return configuration.getString(TaskManagerOptions.RPC_PORT);
+	}
+
 	public Time getRpcTimeout() {
 		return AkkaUtils.getTimeoutAsTime(configuration);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -94,24 +94,36 @@ public class MiniClusterConfiguration {
 		return numTaskManagers;
 	}
 
+	public String getJobManagerExternalAddress() {
+		return commonBindAddress != null ?
+			commonBindAddress :
+			configuration.getString(JobManagerOptions.ADDRESS, "localhost");
+	}
+
+	public String getTaskManagerExternalAddress() {
+		return commonBindAddress != null ?
+			commonBindAddress :
+			configuration.getString(TaskManagerOptions.HOST, "localhost");
+	}
+
+	public String getJobManagerExternalPortRange() {
+		return String.valueOf(configuration.getInteger(JobManagerOptions.PORT, 0));
+	}
+
+	public String getTaskManagerExternalPortRange() {
+		return configuration.getString(TaskManagerOptions.RPC_PORT);
+	}
+
 	public String getJobManagerBindAddress() {
 		return commonBindAddress != null ?
 				commonBindAddress :
-				configuration.getString(JobManagerOptions.ADDRESS, "localhost");
+				configuration.getString(JobManagerOptions.BIND_HOST, "localhost");
 	}
 
 	public String getTaskManagerBindAddress() {
 		return commonBindAddress != null ?
 				commonBindAddress :
-				configuration.getString(TaskManagerOptions.HOST, "localhost");
-	}
-
-	public String getJobManagerBindPortRange() {
-		return String.valueOf(configuration.getInteger(JobManagerOptions.PORT, 0));
-	}
-
-	public String getTaskManagerBindPortRange() {
-		return configuration.getString(TaskManagerOptions.RPC_PORT);
+				configuration.getString(TaskManagerOptions.BIND_HOST, "localhost");
 	}
 
 	public Time getRpcTimeout() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniClusterConfiguration.java
@@ -29,9 +29,6 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorResourceUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
@@ -40,8 +37,6 @@ import static org.apache.flink.runtime.minicluster.RpcServiceSharing.SHARED;
  * Configuration object for the {@link MiniCluster}.
  */
 public class MiniClusterConfiguration {
-
-	private static final Logger LOG = LoggerFactory.getLogger(MiniClusterConfiguration.class);
 
 	static final String SCHEDULER_TYPE_KEY = JobManagerOptions.SCHEDULER.key();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/query/QueryableStateUtils.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.net.InetAddress;
 import java.util.Iterator;
 
 /**
@@ -54,7 +53,7 @@ public final class QueryableStateUtils {
 	 * @return the {@link KvStateClientProxy client proxy}.
 	 */
 	public static KvStateClientProxy createKvStateClientProxy(
-			final InetAddress address,
+			final String address,
 			final Iterator<Integer> ports,
 			final int eventLoopThreads,
 			final int queryThreads,
@@ -70,7 +69,7 @@ public final class QueryableStateUtils {
 			String classname = "org.apache.flink.queryablestate.client.proxy.KvStateClientProxyImpl";
 			Class<? extends KvStateClientProxy> clazz = Class.forName(classname).asSubclass(KvStateClientProxy.class);
 			Constructor<? extends KvStateClientProxy> constructor = clazz.getConstructor(
-					InetAddress.class,
+					String.class,
 					Iterator.class,
 					Integer.class,
 					Integer.class,
@@ -108,7 +107,7 @@ public final class QueryableStateUtils {
 	 * @return the {@link KvStateServer state server}.
 	 */
 	public static KvStateServer createKvStateServer(
-			final InetAddress address,
+			final String address,
 			final Iterator<Integer> ports,
 			final int eventLoopThreads,
 			final int queryThreads,
@@ -126,7 +125,7 @@ public final class QueryableStateUtils {
 			String classname = "org.apache.flink.queryablestate.server.KvStateServerImpl";
 			Class<? extends KvStateServer> clazz = Class.forName(classname).asSubclass(KvStateServer.class);
 			Constructor<? extends KvStateServer> constructor = clazz.getConstructor(
-					InetAddress.class,
+					String.class,
 					Iterator.class,
 					Integer.class,
 					Integer.class,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -106,6 +107,7 @@ public class AkkaRpcService implements RpcService {
 
 	private volatile boolean stopped;
 
+	@VisibleForTesting
 	public AkkaRpcService(final ActorSystem actorSystem, final AkkaRpcServiceConfiguration configuration) {
 		this.actorSystem = checkNotNull(actorSystem, "actor system");
 		this.configuration = checkNotNull(configuration, "akka rpc service configuration");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -69,6 +69,24 @@ public class AkkaRpcServiceUtils {
 	//  RPC instantiation
 	// ------------------------------------------------------------------------
 
+	public static AkkaRpcService createRemoteRpcService(
+		Configuration configuration,
+		@Nullable String externalAddress,
+		String externalPortRange,
+		@Nullable String bindAddress,
+		@SuppressWarnings("OptionalUsedAsFieldOrParameterType") Optional<Integer> bindPort) throws Exception {
+		final AkkaRpcServiceBuilder akkaRpcServiceBuilder =
+			AkkaRpcServiceUtils.remoteServiceBuilder(configuration, externalAddress, externalPortRange);
+
+		if (bindAddress != null) {
+			akkaRpcServiceBuilder.withBindAddress(bindAddress);
+		}
+
+		bindPort.ifPresent(akkaRpcServiceBuilder::withBindPort);
+
+		return akkaRpcServiceBuilder.createAndStart();
+	}
+
 	public static AkkaRpcServiceBuilder remoteServiceBuilder(Configuration configuration, @Nullable String externalAddress, String externalPortRange) {
 		return new AkkaRpcServiceBuilder(configuration, LOG, externalAddress, externalPortRange);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.runtime.rpc.akka;
 
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
@@ -31,6 +29,8 @@ import org.apache.flink.util.NetUtils;
 import org.apache.flink.util.Preconditions;
 
 import akka.actor.ActorSystem;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/JobLeaderService.java
@@ -33,7 +33,7 @@ import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.registration.RetryingRegistration;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.rpc.RpcService;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -64,7 +64,7 @@ public class JobLeaderService {
 	private static final Logger LOG = LoggerFactory.getLogger(JobLeaderService.class);
 
 	/** Self's location, used for the job manager connection. */
-	private final TaskManagerLocation ownLocation;
+	private final UnresolvedTaskManagerLocation ownLocation;
 
 	/** The leader retrieval service and listener for each registered job. */
 	private final Map<JobID, Tuple2<LeaderRetrievalService, JobLeaderService.JobManagerLeaderListener>> jobLeaderServices;
@@ -87,7 +87,7 @@ public class JobLeaderService {
 	private JobLeaderListener jobLeaderListener;
 
 	public JobLeaderService(
-			TaskManagerLocation location,
+			UnresolvedTaskManagerLocation location,
 			RetryingRegistrationConfiguration retryingRegistrationConfiguration) {
 		this.ownLocation = Preconditions.checkNotNull(location);
 		this.retryingRegistrationConfiguration = Preconditions.checkNotNull(retryingRegistrationConfiguration);
@@ -418,7 +418,7 @@ public class JobLeaderService {
 
 		private final String taskManagerRpcAddress;
 
-		private final TaskManagerLocation taskManagerLocation;
+		private final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 
 		JobManagerRetryingRegistration(
 				Logger log,
@@ -429,7 +429,7 @@ public class JobLeaderService {
 				JobMasterId jobMasterId,
 				RetryingRegistrationConfiguration retryingRegistrationConfiguration,
 				String taskManagerRpcAddress,
-				TaskManagerLocation taskManagerLocation) {
+				UnresolvedTaskManagerLocation unresolvedTaskManagerLocation) {
 			super(
 				log,
 				rpcService,
@@ -440,7 +440,7 @@ public class JobLeaderService {
 				retryingRegistrationConfiguration);
 
 			this.taskManagerRpcAddress = taskManagerRpcAddress;
-			this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
+			this.unresolvedTaskManagerLocation = Preconditions.checkNotNull(unresolvedTaskManagerLocation);
 		}
 
 		@Override
@@ -448,7 +448,7 @@ public class JobLeaderService {
 				JobMasterGateway gateway,
 				JobMasterId fencingToken,
 				long timeoutMillis) {
-			return gateway.registerTaskManager(taskManagerRpcAddress, taskManagerLocation, Time.milliseconds(timeoutMillis));
+			return gateway.registerTaskManager(taskManagerRpcAddress, unresolvedTaskManagerLocation, Time.milliseconds(timeoutMillis));
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/KvStateService.java
@@ -170,7 +170,7 @@ public class KvStateService {
 			int numProxyServerQueryThreads = qsConfig.numProxyQueryThreads() == 0 ?
 				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numProxyQueryThreads();
 			kvClientProxy = QueryableStateUtils.createKvStateClientProxy(
-				taskManagerServicesConfiguration.getTaskManagerAddress(),
+				taskManagerServicesConfiguration.getExternalAddress(),
 				qsConfig.getProxyPortRange(),
 				numProxyServerNetworkThreads,
 				numProxyServerQueryThreads,
@@ -181,7 +181,7 @@ public class KvStateService {
 			int numStateServerQueryThreads = qsConfig.numStateQueryThreads() == 0 ?
 				taskManagerServicesConfiguration.getNumberOfSlots() : qsConfig.numStateQueryThreads();
 			kvStateServer = QueryableStateUtils.createKvStateServer(
-				taskManagerServicesConfiguration.getTaskManagerAddress(),
+				taskManagerServicesConfiguration.getExternalAddress(),
 				qsConfig.getStateServerPortRange(),
 				numStateServerNetworkThreads,
 				numStateServerQueryThreads,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -117,7 +117,7 @@ import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerActions;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.types.SerializableOptional;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
@@ -180,7 +180,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	// --------- TaskManager services --------
 
 	/** The connection information of this task manager. */
-	private final TaskManagerLocation taskManagerLocation;
+	private final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 
 	private final TaskManagerMetricGroup taskManagerMetricGroup;
 
@@ -269,7 +269,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.taskSlotTable = taskExecutorServices.getTaskSlotTable();
 		this.jobManagerTable = taskExecutorServices.getJobManagerTable();
 		this.jobLeaderService = taskExecutorServices.getJobLeaderService();
-		this.taskManagerLocation = taskExecutorServices.getTaskManagerLocation();
+		this.unresolvedTaskManagerLocation = taskExecutorServices.getUnresolvedTaskManagerLocation();
 		this.localStateStoresManager = taskExecutorServices.getTaskManagerStateStore();
 		this.shuffleEnvironment = taskExecutorServices.getShuffleEnvironment();
 		this.kvStateService = taskExecutorServices.getKvStateService();
@@ -283,7 +283,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		this.resourceManagerConnection = null;
 		this.currentRegistrationTimeoutId = null;
 
-		final ResourceID resourceId = taskExecutorServices.getTaskManagerLocation().getResourceID();
+		final ResourceID resourceId = taskExecutorServices.getUnresolvedTaskManagerLocation().getResourceID();
 		this.jobManagerHeartbeatManager = createJobManagerHeartbeatManager(heartbeatServices, resourceId);
 		this.resourceManagerHeartbeatManager = createResourceManagerHeartbeatManager(heartbeatServices, resourceId);
 	}
@@ -1035,7 +1035,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 		final TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
 			getAddress(),
 			getResourceID(),
-			taskManagerLocation.dataPort(),
+			unresolvedTaskManagerLocation.getDataPort(),
 			hardwareDescription,
 			taskManagerConfiguration.getDefaultSlotResourceProfile(),
 			taskManagerConfiguration.getTotalResourceProfile()
@@ -1652,7 +1652,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	// ------------------------------------------------------------------------
 
 	public ResourceID getResourceID() {
-		return taskManagerLocation.getResourceID();
+		return unresolvedTaskManagerLocation.getResourceID();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -351,7 +351,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		LOG.info("Starting TaskManager with ResourceID: {}", resourceID);
 
-		InetAddress remoteAddress = InetAddress.getByName(rpcService.getAddress());
+		InetAddress externalAddress = InetAddress.getByName(rpcService.getAddress());
 
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
 
@@ -359,13 +359,13 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			TaskManagerServicesConfiguration.fromConfiguration(
 				configuration,
 				resourceID,
-				remoteAddress,
+				externalAddress,
 				localCommunicationOnly,
 				taskExecutorResourceSpec);
 
 		Tuple2<TaskManagerMetricGroup, MetricGroup> taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
 			metricRegistry,
-			TaskManagerLocation.getHostName(remoteAddress),
+			TaskManagerLocation.getHostName(externalAddress),
 			resourceID,
 			taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -415,10 +415,12 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		checkNotNull(configuration);
 		checkNotNull(haServices);
 
-		final String taskManagerAddress = determineTaskManagerBindAddress(configuration, haServices);
-		final String portRangeDefinition = configuration.getString(TaskManagerOptions.RPC_PORT);
-
-		return AkkaRpcServiceUtils.remoteServiceBuilder(configuration, taskManagerAddress, portRangeDefinition).createAndStart();
+		return AkkaRpcServiceUtils.createRemoteRpcService(
+			configuration,
+			determineTaskManagerBindAddress(configuration, haServices),
+			configuration.getString(TaskManagerOptions.RPC_PORT),
+			configuration.getString(TaskManagerOptions.BIND_HOST),
+			configuration.getOptional(TaskManagerOptions.RPC_BIND_PORT));
 	}
 
 	private static String determineTaskManagerBindAddress(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -418,7 +418,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		final String taskManagerAddress = determineTaskManagerBindAddress(configuration, haServices);
 		final String portRangeDefinition = configuration.getString(TaskManagerOptions.RPC_PORT);
 
-		return AkkaRpcServiceUtils.createRpcService(taskManagerAddress, portRangeDefinition, configuration);
+		return AkkaRpcServiceUtils.remoteServiceBuilder(configuration, taskManagerAddress, portRangeDefinition).createAndStart();
 	}
 
 	private static String determineTaskManagerBindAddress(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -54,7 +54,6 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcServiceUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.Hardware;
@@ -132,7 +131,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 		highAvailabilityServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
 			configuration,
 			executor,
-			HighAvailabilityServicesUtils.AddressResolution.TRY_ADDRESS_RESOLUTION);
+			HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
 
 		rpcService = createRpcService(configuration, highAvailabilityServices);
 
@@ -351,7 +350,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		LOG.info("Starting TaskManager with ResourceID: {}", resourceID);
 
-		InetAddress externalAddress = InetAddress.getByName(rpcService.getAddress());
+		String externalAddress = rpcService.getAddress();
 
 		final TaskExecutorResourceSpec taskExecutorResourceSpec = TaskExecutorResourceUtils.resourceSpecFromConfig(configuration);
 
@@ -365,7 +364,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 		Tuple2<TaskManagerMetricGroup, MetricGroup> taskManagerMetricGroup = MetricUtils.instantiateTaskManagerMetricGroup(
 			metricRegistry,
-			TaskManagerLocation.getHostName(externalAddress),
+			externalAddress,
 			resourceID,
 			taskManagerServicesConfiguration.getSystemResourceMetricsProbingInterval());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -229,15 +229,19 @@ public class TaskManagerServices {
 			taskManagerServicesConfiguration,
 			taskEventDispatcher,
 			taskManagerMetricGroup);
-		final int dataPort = shuffleEnvironment.start();
+		final int listeningDataPort = shuffleEnvironment.start();
 
 		final KvStateService kvStateService = KvStateService.fromConfiguration(taskManagerServicesConfiguration);
 		kvStateService.start();
 
 		final TaskManagerLocation taskManagerLocation = new TaskManagerLocation(
 			taskManagerServicesConfiguration.getResourceID(),
-			taskManagerServicesConfiguration.getTaskManagerAddress(),
-			dataPort);
+			taskManagerServicesConfiguration.getExternalAddress(),
+			// we expose the task manager location with the listening port
+			// iff the external data port is not explicitly defined
+			taskManagerServicesConfiguration.getExternalDataPort() > 0 ?
+				taskManagerServicesConfiguration.getExternalDataPort() :
+				listeningDataPort);
 
 		final BroadcastVariableManager broadcastVariableManager = new BroadcastVariableManager();
 
@@ -304,7 +308,7 @@ public class TaskManagerServices {
 			taskManagerServicesConfiguration.getResourceID(),
 			taskManagerServicesConfiguration.getNetworkMemorySize(),
 			taskManagerServicesConfiguration.isLocalCommunicationOnly(),
-			taskManagerServicesConfiguration.getTaskManagerAddress(),
+			taskManagerServicesConfiguration.getBindAddress(),
 			taskEventDispatcher,
 			taskManagerMetricGroup);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl;
 import org.apache.flink.runtime.taskexecutor.slot.TimerService;
 import org.apache.flink.runtime.taskmanager.Task;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
@@ -59,7 +59,7 @@ public class TaskManagerServices {
 	public static final String LOCAL_STATE_SUB_DIRECTORY_ROOT = "localState";
 
 	/** TaskManager services. */
-	private final TaskManagerLocation taskManagerLocation;
+	private final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 	private final long managedMemorySize;
 	private final IOManager ioManager;
 	private final ShuffleEnvironment<?, ?> shuffleEnvironment;
@@ -72,7 +72,7 @@ public class TaskManagerServices {
 	private final TaskEventDispatcher taskEventDispatcher;
 
 	TaskManagerServices(
-		TaskManagerLocation taskManagerLocation,
+		UnresolvedTaskManagerLocation unresolvedTaskManagerLocation,
 		long managedMemorySize,
 		IOManager ioManager,
 		ShuffleEnvironment<?, ?> shuffleEnvironment,
@@ -84,7 +84,7 @@ public class TaskManagerServices {
 		TaskExecutorLocalStateStoresManager taskManagerStateStore,
 		TaskEventDispatcher taskEventDispatcher) {
 
-		this.taskManagerLocation = Preconditions.checkNotNull(taskManagerLocation);
+		this.unresolvedTaskManagerLocation = Preconditions.checkNotNull(unresolvedTaskManagerLocation);
 		this.managedMemorySize = managedMemorySize;
 		this.ioManager = Preconditions.checkNotNull(ioManager);
 		this.shuffleEnvironment = Preconditions.checkNotNull(shuffleEnvironment);
@@ -117,8 +117,8 @@ public class TaskManagerServices {
 		return kvStateService;
 	}
 
-	public TaskManagerLocation getTaskManagerLocation() {
-		return taskManagerLocation;
+	public UnresolvedTaskManagerLocation getUnresolvedTaskManagerLocation() {
+		return unresolvedTaskManagerLocation;
 	}
 
 	public BroadcastVariableManager getBroadcastVariableManager() {
@@ -234,7 +234,7 @@ public class TaskManagerServices {
 		final KvStateService kvStateService = KvStateService.fromConfiguration(taskManagerServicesConfiguration);
 		kvStateService.start();
 
-		final TaskManagerLocation taskManagerLocation = new TaskManagerLocation(
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new UnresolvedTaskManagerLocation(
 			taskManagerServicesConfiguration.getResourceID(),
 			taskManagerServicesConfiguration.getExternalAddress(),
 			// we expose the task manager location with the listening port
@@ -253,7 +253,7 @@ public class TaskManagerServices {
 
 		final JobManagerTable jobManagerTable = new JobManagerTable();
 
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, taskManagerServicesConfiguration.getRetryingRegistrationConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, taskManagerServicesConfiguration.getRetryingRegistrationConfiguration());
 
 		final String[] stateRootDirectoryStrings = taskManagerServicesConfiguration.getLocalRecoveryStateRootDirectories();
 
@@ -269,7 +269,7 @@ public class TaskManagerServices {
 			taskIOExecutor);
 
 		return new TaskManagerServices(
-			taskManagerLocation,
+			unresolvedTaskManagerLocation,
 			taskManagerServicesConfiguration.getManagedMemorySize().getBytes(),
 			ioManager,
 			shuffleEnvironment,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -23,10 +23,13 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
+import org.apache.flink.util.NetUtils;
 
 import javax.annotation.Nullable;
 
@@ -46,7 +49,11 @@ public class TaskManagerServicesConfiguration {
 
 	private final ResourceID resourceID;
 
-	private final InetAddress taskManagerAddress;
+	private final InetAddress externalAddress;
+
+	private final InetAddress bindAddress;
+
+	private final int externalDataPort;
 
 	private final boolean localCommunicationOnly;
 
@@ -74,7 +81,9 @@ public class TaskManagerServicesConfiguration {
 	public TaskManagerServicesConfiguration(
 			Configuration configuration,
 			ResourceID resourceID,
-			InetAddress taskManagerAddress,
+			InetAddress externalAddress,
+			InetAddress bindAddress,
+			int externalDataPort,
 			boolean localCommunicationOnly,
 			String[] tmpDirPaths,
 			String[] localRecoveryStateRootDirectories,
@@ -89,7 +98,9 @@ public class TaskManagerServicesConfiguration {
 		this.configuration = checkNotNull(configuration);
 		this.resourceID = checkNotNull(resourceID);
 
-		this.taskManagerAddress = checkNotNull(taskManagerAddress);
+		this.externalAddress = checkNotNull(externalAddress);
+		this.bindAddress = checkNotNull(bindAddress);
+		this.externalDataPort = externalDataPort;
 		this.localCommunicationOnly = localCommunicationOnly;
 		this.tmpDirPaths = checkNotNull(tmpDirPaths);
 		this.localRecoveryStateRootDirectories = checkNotNull(localRecoveryStateRootDirectories);
@@ -121,8 +132,16 @@ public class TaskManagerServicesConfiguration {
 		return resourceID;
 	}
 
-	InetAddress getTaskManagerAddress() {
-		return taskManagerAddress;
+	InetAddress getExternalAddress() {
+		return externalAddress;
+	}
+
+	InetAddress getBindAddress() {
+		return bindAddress;
+	}
+
+	int getExternalDataPort() {
+		return externalDataPort;
 	}
 
 	boolean isLocalCommunicationOnly() {
@@ -188,7 +207,7 @@ public class TaskManagerServicesConfiguration {
 	 *
 	 * @param configuration The configuration.
 	 * @param resourceID resource ID of the task manager
-	 * @param remoteAddress identifying the IP address under which the TaskManager will be accessible
+	 * @param externalAddress identifying the IP address under which the TaskManager will be accessible
 	 * @param localCommunicationOnly True if only local communication is possible.
 	 *                               Use only in cases where only one task manager runs.
 	 *
@@ -197,9 +216,9 @@ public class TaskManagerServicesConfiguration {
 	public static TaskManagerServicesConfiguration fromConfiguration(
 			Configuration configuration,
 			ResourceID resourceID,
-			InetAddress remoteAddress,
+			InetAddress externalAddress,
 			boolean localCommunicationOnly,
-			TaskExecutorResourceSpec taskExecutorResourceSpec) {
+			TaskExecutorResourceSpec taskExecutorResourceSpec) throws Exception {
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);
 		String[] localStateRootDir = ConfigurationUtils.parseLocalStateDirectories(configuration);
 		if (localStateRootDir.length == 0) {
@@ -215,10 +234,17 @@ public class TaskManagerServicesConfiguration {
 
 		final RetryingRegistrationConfiguration retryingRegistrationConfiguration = RetryingRegistrationConfiguration.fromConfiguration(configuration);
 
+		final int externalDataPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
+
+		String bindAddr = configuration.getString(TaskManagerOptions.BIND_HOST, NetUtils.getWildcardIPAddress());
+		InetAddress bindAddress = InetAddress.getByName(bindAddr);
+
 		return new TaskManagerServicesConfiguration(
 			configuration,
 			resourceID,
-			remoteAddress,
+			externalAddress,
+			bindAddress,
+			externalDataPort,
 			localCommunicationOnly,
 			tmpDirs,
 			localStateRootDir,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesConfiguration.java
@@ -49,7 +49,7 @@ public class TaskManagerServicesConfiguration {
 
 	private final ResourceID resourceID;
 
-	private final InetAddress externalAddress;
+	private final String externalAddress;
 
 	private final InetAddress bindAddress;
 
@@ -81,7 +81,7 @@ public class TaskManagerServicesConfiguration {
 	public TaskManagerServicesConfiguration(
 			Configuration configuration,
 			ResourceID resourceID,
-			InetAddress externalAddress,
+			String externalAddress,
 			InetAddress bindAddress,
 			int externalDataPort,
 			boolean localCommunicationOnly,
@@ -132,7 +132,7 @@ public class TaskManagerServicesConfiguration {
 		return resourceID;
 	}
 
-	InetAddress getExternalAddress() {
+	String getExternalAddress() {
 		return externalAddress;
 	}
 
@@ -216,7 +216,7 @@ public class TaskManagerServicesConfiguration {
 	public static TaskManagerServicesConfiguration fromConfiguration(
 			Configuration configuration,
 			ResourceID resourceID,
-			InetAddress externalAddress,
+			String externalAddress,
 			boolean localCommunicationOnly,
 			TaskExecutorResourceSpec taskExecutorResourceSpec) throws Exception {
 		final String[] tmpDirs = ConfigurationUtils.parseTempDirectories(configuration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -182,11 +182,11 @@ public class NettyShuffleEnvironmentConfiguration {
 		boolean localTaskManagerCommunication,
 		InetAddress taskManagerAddress) {
 
-		final int dataport = getDataport(configuration);
+		final int dataBindPort = getDataBindPort(configuration);
 
 		final int pageSize = ConfigurationParserUtils.getPageSize(configuration);
 
-		final NettyConfig nettyConfig = createNettyConfig(configuration, localTaskManagerCommunication, taskManagerAddress, dataport);
+		final NettyConfig nettyConfig = createNettyConfig(configuration, localTaskManagerCommunication, taskManagerAddress, dataBindPort);
 
 		final int numberOfNetworkBuffers = calculateNumberOfNetworkBuffers(
 			configuration,
@@ -238,12 +238,21 @@ public class NettyShuffleEnvironmentConfiguration {
 	 * @param configuration configuration object
 	 * @return the data port
 	 */
-	private static int getDataport(Configuration configuration) {
-		final int dataport = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
-		ConfigurationParserUtils.checkConfigParameter(dataport >= 0, dataport, NettyShuffleEnvironmentOptions.DATA_PORT.key(),
-			"Leave config parameter empty or use 0 to let the system choose a port automatically.");
-
-		return dataport;
+	private static int getDataBindPort(Configuration configuration) {
+		final int dataBindPort;
+		if (configuration.contains(NettyShuffleEnvironmentOptions.DATA_BIND_PORT)) {
+			dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_BIND_PORT);
+			ConfigurationParserUtils.checkConfigParameter(
+				dataBindPort >= 0, dataBindPort, NettyShuffleEnvironmentOptions.DATA_BIND_PORT.key(),
+				"Leave config parameter empty to fallback to '" +
+					NettyShuffleEnvironmentOptions.DATA_PORT.key() + "' automatically.");
+		} else {
+			dataBindPort = configuration.getInteger(NettyShuffleEnvironmentOptions.DATA_PORT);
+			ConfigurationParserUtils.checkConfigParameter(
+				dataBindPort >= 0, dataBindPort, NettyShuffleEnvironmentOptions.DATA_PORT.key(),
+				"Leave config parameter empty or use 0 to let the system choose a port automatically.");
+		}
+		return dataBindPort;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskmanager;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.util.NetUtils;
 
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -73,6 +75,7 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 	 * @param dataPort
 	 *        the port instance's task manager expects to receive transfer envelopes on
 	 */
+	@VisibleForTesting
 	public TaskManagerLocation(ResourceID resourceID, InetAddress inetAddress, int dataPort) {
 		// -1 indicates a local instance connection info
 		checkArgument(dataPort > 0 || dataPort == -1, "dataPort must be > 0, or -1 (local)");
@@ -88,6 +91,14 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
 
 		this.stringRepresentation = String.format(
 				"%s @ %s (dataPort=%d)", resourceID, fqdnHostName, dataPort);
+	}
+
+	public static TaskManagerLocation fromUnresolvedLocation(final UnresolvedTaskManagerLocation unresolvedLocation)
+		throws UnknownHostException {
+		return new TaskManagerLocation(
+			unresolvedLocation.getResourceID(),
+			InetAddress.getByName(unresolvedLocation.getExternalAddress()),
+			unresolvedLocation.getDataPort());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/UnresolvedTaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/UnresolvedTaskManagerLocation.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class encapsulates the connection information of a TaskManager, without resolving the hostname.
+ * See also {@link TaskManagerLocation}.
+ */
+public class UnresolvedTaskManagerLocation implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final ResourceID resourceID;
+	private final String externalAddress;
+	private final int dataPort;
+
+	public UnresolvedTaskManagerLocation(final ResourceID resourceID, final String externalAddress, final int dataPort) {
+		// -1 indicates a local instance connection info
+		checkArgument(dataPort > 0 || dataPort == -1, "dataPort must be > 0, or -1 (local)");
+
+		this.resourceID = checkNotNull(resourceID);
+		this.externalAddress = checkNotNull(externalAddress);
+		this.dataPort = dataPort;
+	}
+
+	public ResourceID getResourceID() {
+		return resourceID;
+	}
+
+	public String getExternalAddress() {
+		return externalAddress;
+	}
+
+	public int getDataPort() {
+		return dataPort;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -392,7 +392,7 @@ public class BootstrapToolsTest extends TestLogger {
 							CheckedSupplier.unchecked(() -> {
 								cyclicBarrier.await();
 
-								return BootstrapTools.startActorSystem(
+								return BootstrapTools.startRemoteActorSystem(
 									new Configuration(),
 									"localhost",
 									"0",
@@ -420,7 +420,7 @@ public class BootstrapToolsTest extends TestLogger {
 
 		try {
 			final int port = portOccupier.getLocalPort();
-			BootstrapTools.startActorSystem(new Configuration(), "0.0.0.0", port, LOG);
+			BootstrapTools.startRemoteActorSystem(new Configuration(), "0.0.0.0", String.valueOf(port), LOG);
 			fail("Expected to fail with a BindException");
 		} catch (Exception e) {
 			assertThat(ExceptionUtils.findThrowable(e, BindException.class).isPresent(), is(true));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterPartitionReleaseTest.java
@@ -43,7 +43,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -186,7 +186,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
 		private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-		private final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		private final LocalUnresolvedTaskManagerLocation localTaskManagerUnresolvedLocation = new LocalUnresolvedTaskManagerLocation();
 
 		private final CompletableFuture<ResourceID> taskExecutorIdForStopTracking = new CompletableFuture<>();
 		private final CompletableFuture<ResourceID> taskExecutorIdForPartitionRelease = new CompletableFuture<>();
@@ -248,12 +248,12 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 
 			rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-			jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
+			jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), localTaskManagerUnresolvedLocation, testingTimeout).get();
 
 			final AllocationID allocationId = resourceManagerGateway.takeAllocationId();
 			Collection<SlotOffer> slotOffers = Collections.singleton(new SlotOffer(allocationId, 0, ResourceProfile.UNKNOWN));
 
-			jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), slotOffers, testingTimeout).get();
+			jobMasterGateway.offerSlots(localTaskManagerUnresolvedLocation.getResourceID(), slotOffers, testingTimeout).get();
 		}
 
 		public JobMasterGateway getJobMasterGateway() {
@@ -261,7 +261,7 @@ public class JobMasterPartitionReleaseTest extends TestLogger {
 		}
 
 		public ResourceID getTaskExecutorResourceID() {
-			return taskManagerLocation.getResourceID();
+			return localTaskManagerUnresolvedLocation.getResourceID();
 		}
 
 		public CompletableFuture<ResourceID> getStopTrackingPartitionsTargetResourceId() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -122,9 +122,10 @@ import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.taskexecutor.rpc.RpcCheckpointResponder;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
@@ -357,7 +358,7 @@ public class JobMasterTest extends TestLogger {
 	public void testHeartbeatTimeoutWithTaskManager() throws Exception {
 		final CompletableFuture<ResourceID> heartbeatResourceIdFuture = new CompletableFuture<>();
 		final CompletableFuture<JobID> disconnectedJobManagerFuture = new CompletableFuture<>();
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
 			.setHeartbeatJobManagerConsumer((taskManagerId, ignored) -> heartbeatResourceIdFuture.complete(taskManagerId))
 			.setDisconnectJobManagerConsumer((jobId, throwable) -> disconnectedJobManagerFuture.complete(jobId))
@@ -384,7 +385,7 @@ public class JobMasterTest extends TestLogger {
 			// register task manager will trigger monitor heartbeat target, schedule heartbeat request at interval time
 			CompletableFuture<RegistrationResponse> registrationResponse = jobMasterGateway.registerTaskManager(
 				taskExecutorGateway.getAddress(),
-				taskManagerLocation,
+				unresolvedTaskManagerLocation,
 				testingTimeout);
 
 			// wait for the completion of the registration
@@ -413,7 +414,7 @@ public class JobMasterTest extends TestLogger {
 	@Test
 	public void testAllocatedSlotReportDoesNotContainStaleInformation() throws Exception {
 		final CompletableFuture<Void> assertionFuture = new CompletableFuture<>();
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		final AtomicBoolean terminateHeartbeatVerification = new AtomicBoolean(false);
 		final OneShotLatch hasReceivedSlotOffers = new OneShotLatch();
 		final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
@@ -454,7 +455,7 @@ public class JobMasterTest extends TestLogger {
 			// register task manager will trigger monitor heartbeat target, schedule heartbeat request at interval time
 			CompletableFuture<RegistrationResponse> registrationResponse = jobMasterGateway.registerTaskManager(
 				taskExecutorGateway.getAddress(),
-				taskManagerLocation,
+				unresolvedTaskManagerLocation,
 				testingTimeout);
 
 			// wait for the completion of the registration
@@ -462,7 +463,7 @@ public class JobMasterTest extends TestLogger {
 
 			final SlotOffer slotOffer = new SlotOffer(new AllocationID(), 0, ResourceProfile.ANY);
 
-			final CompletableFuture<Collection<SlotOffer>> slotOfferFuture = jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout);
+			final CompletableFuture<Collection<SlotOffer>> slotOfferFuture = jobMasterGateway.offerSlots(unresolvedTaskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout);
 
 			assertThat(slotOfferFuture.get(), containsInAnyOrder(slotOffer));
 
@@ -868,7 +869,7 @@ public class JobMasterTest extends TestLogger {
 			blockingQueue.take();
 
 			final CompletableFuture<TaskDeploymentDescriptor> submittedTaskFuture = new CompletableFuture<>();
-			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			final LocalUnresolvedTaskManagerLocation taskManagerUnresolvedLocation = new LocalUnresolvedTaskManagerLocation();
 			final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
 				.setSubmitTaskConsumer((tdd, ignored) -> {
 					submittedTaskFuture.complete(tdd);
@@ -878,7 +879,7 @@ public class JobMasterTest extends TestLogger {
 
 			rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-			jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
+			jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerUnresolvedLocation, testingTimeout).get();
 
 			// wait for the slot request timeout
 			final SlotRequest slotRequest = blockingQueue.take();
@@ -891,7 +892,7 @@ public class JobMasterTest extends TestLogger {
 
 			final SlotOffer slotOffer = new SlotOffer(slotRequest.getAllocationId(), 0, ResourceProfile.ANY);
 
-			final CompletableFuture<Collection<SlotOffer>> acceptedSlotsFuture = jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout);
+			final CompletableFuture<Collection<SlotOffer>> acceptedSlotsFuture = jobMasterGateway.offerSlots(taskManagerUnresolvedLocation.getResourceID(), Collections.singleton(slotOffer), testingTimeout);
 
 			final Collection<SlotOffer> acceptedSlots = acceptedSlotsFuture.get();
 
@@ -1731,7 +1732,7 @@ public class JobMasterTest extends TestLogger {
 
 		final JobGraph jobGraph = JobGraphTestUtils.createSingleVertexJobGraph();
 
-		final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final LocalUnresolvedTaskManagerLocation taskManagerUnresolvedLocation = new LocalUnresolvedTaskManagerLocation();
 
 		final AtomicBoolean isTrackingPartitions = new AtomicBoolean(true);
 		final TestingJobMasterPartitionTracker partitionTracker = new TestingJobMasterPartitionTracker();
@@ -1761,7 +1762,7 @@ public class JobMasterTest extends TestLogger {
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway, taskManagerLocation);
+			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, testingTaskExecutorGateway, taskManagerUnresolvedLocation);
 
 			// check that we accepted the offered slot
 			assertThat(slotOffers, hasSize(1));
@@ -1893,7 +1894,7 @@ public class JobMasterTest extends TestLogger {
 
 	private void runJobFailureWhenTaskExecutorTerminatesTest(
 			HeartbeatServices heartbeatServices,
-			BiConsumer<LocalTaskManagerLocation, JobMasterGateway> jobReachedRunningState,
+			BiConsumer<LocalUnresolvedTaskManagerLocation, JobMasterGateway> jobReachedRunningState,
 			BiFunction<JobMasterGateway, ResourceID, BiConsumer<ResourceID, AllocatedSlotReport>> heartbeatConsumerFunction) throws Exception {
 		final JobGraph jobGraph = JobGraphTestUtils.createSingleVertexJobGraph();
 		final JobMasterBuilder.TestingOnCompletionActions onCompletionActions = new JobMasterBuilder.TestingOnCompletionActions();
@@ -1910,24 +1911,24 @@ public class JobMasterTest extends TestLogger {
 
 			final JobMasterGateway jobMasterGateway = jobMaster.getSelfGateway(JobMasterGateway.class);
 
-			final LocalTaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+			final LocalUnresolvedTaskManagerLocation taskManagerUnresolvedLocation = new LocalUnresolvedTaskManagerLocation();
 			final CompletableFuture<ExecutionAttemptID> taskDeploymentFuture = new CompletableFuture<>();
 			final TestingTaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
 				.setSubmitTaskConsumer((taskDeploymentDescriptor, jobMasterId) -> {
 					taskDeploymentFuture.complete(taskDeploymentDescriptor.getExecutionAttemptId());
 					return CompletableFuture.completedFuture(Acknowledge.get());
 				})
-				.setHeartbeatJobManagerConsumer(heartbeatConsumerFunction.apply(jobMasterGateway, taskManagerLocation.getResourceID()))
+				.setHeartbeatJobManagerConsumer(heartbeatConsumerFunction.apply(jobMasterGateway, taskManagerUnresolvedLocation.getResourceID()))
 				.createTestingTaskExecutorGateway();
 
-			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, taskExecutorGateway, taskManagerLocation);
+			final Collection<SlotOffer> slotOffers = registerSlotsAtJobMaster(1, jobMasterGateway, taskExecutorGateway, taskManagerUnresolvedLocation);
 			assertThat(slotOffers, hasSize(1));
 
 			final ExecutionAttemptID executionAttemptId = taskDeploymentFuture.get();
 
 			jobMasterGateway.updateTaskExecutionState(new TaskExecutionState(jobGraph.getJobID(), executionAttemptId, ExecutionState.RUNNING)).get();
 
-			jobReachedRunningState.accept(taskManagerLocation, jobMasterGateway);
+			jobReachedRunningState.accept(taskManagerUnresolvedLocation, jobMasterGateway);
 
 			final ArchivedExecutionGraph archivedExecutionGraph = onCompletionActions.getJobReachedGloballyTerminalStateFuture().get();
 
@@ -1945,21 +1946,21 @@ public class JobMasterTest extends TestLogger {
 			numberSlots,
 			jobMasterGateway,
 			taskExecutorGateway,
-			new LocalTaskManagerLocation());
+			new LocalUnresolvedTaskManagerLocation());
 	}
 
 	private Collection<SlotOffer> registerSlotsAtJobMaster(
 			int numberSlots,
 			JobMasterGateway jobMasterGateway,
 			TaskExecutorGateway taskExecutorGateway,
-			TaskManagerLocation taskManagerLocation) throws ExecutionException, InterruptedException {
+			UnresolvedTaskManagerLocation unresolvedTaskManagerLocation) throws ExecutionException, InterruptedException {
 		final AllocationIdsResourceManagerGateway allocationIdsResourceManagerGateway = new AllocationIdsResourceManagerGateway();
 		rpcService.registerGateway(allocationIdsResourceManagerGateway.getAddress(), allocationIdsResourceManagerGateway);
 		notifyResourceManagerLeaderListeners(allocationIdsResourceManagerGateway);
 
 		rpcService.registerGateway(taskExecutorGateway.getAddress(), taskExecutorGateway);
 
-		jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), taskManagerLocation, testingTimeout).get();
+		jobMasterGateway.registerTaskManager(taskExecutorGateway.getAddress(), unresolvedTaskManagerLocation, testingTimeout).get();
 
 		Collection<SlotOffer> slotOffers = IntStream
 			.range(0, numberSlots)
@@ -1970,7 +1971,7 @@ public class JobMasterTest extends TestLogger {
 				})
 			.collect(Collectors.toList());
 
-		return jobMasterGateway.offerSlots(taskManagerLocation.getResourceID(), slotOffers, testingTimeout).get();
+		return jobMasterGateway.offerSlots(unresolvedTaskManagerLocation.getResourceID(), slotOffers, testingTimeout).get();
 	}
 
 	private static final class AllocationIdsResourceManagerGateway extends TestingResourceManagerGateway {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -51,7 +51,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.TriConsumer;
 import org.apache.flink.util.function.TriFunction;
@@ -107,7 +107,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	private final TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer;
 
 	@Nonnull
-	private final BiFunction<String, TaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction;
+	private final BiFunction<String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction;
 
 	@Nonnull
 	private final BiConsumer<ResourceID, AccumulatorReport> taskManagerHeartbeatConsumer;
@@ -169,7 +169,7 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 			@Nonnull Consumer<ResourceManagerId> disconnectResourceManagerConsumer,
 			@Nonnull BiFunction<ResourceID, Collection<SlotOffer>, CompletableFuture<Collection<SlotOffer>>> offerSlotsFunction,
 			@Nonnull TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer,
-			@Nonnull BiFunction<String, TaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction,
+			@Nonnull BiFunction<String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction,
 			@Nonnull BiConsumer<ResourceID, AccumulatorReport> taskManagerHeartbeatConsumer,
 			@Nonnull Consumer<ResourceID> resourceManagerHeartbeatConsumer,
 			@Nonnull Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier,
@@ -262,8 +262,8 @@ public class TestingJobMasterGateway implements JobMasterGateway {
 	}
 
 	@Override
-	public CompletableFuture<RegistrationResponse> registerTaskManager(String taskManagerRpcAddress, TaskManagerLocation taskManagerLocation, Time timeout) {
-		return registerTaskManagerFunction.apply(taskManagerRpcAddress, taskManagerLocation);
+	public CompletableFuture<RegistrationResponse> registerTaskManager(String taskManagerRpcAddress, UnresolvedTaskManagerLocation unresolvedTaskManagerLocation, Time timeout) {
+		return registerTaskManagerFunction.apply(taskManagerRpcAddress, unresolvedTaskManagerLocation);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -51,7 +51,7 @@ import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.TriConsumer;
 import org.apache.flink.util.function.TriFunction;
@@ -85,7 +85,7 @@ public class TestingJobMasterGatewayBuilder {
 	private Consumer<ResourceManagerId> disconnectResourceManagerConsumer = ignored -> {};
 	private BiFunction<ResourceID, Collection<SlotOffer>, CompletableFuture<Collection<SlotOffer>>> offerSlotsFunction = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(Collections.emptyList());
 	private TriConsumer<ResourceID, AllocationID, Throwable> failSlotConsumer = (ignoredA, ignoredB, ignoredC) -> {};
-	private BiFunction<String, TaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(new JMTMRegistrationSuccess(RESOURCE_MANAGER_ID));
+	private BiFunction<String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction = (ignoredA, ignoredB) -> CompletableFuture.completedFuture(new JMTMRegistrationSuccess(RESOURCE_MANAGER_ID));
 	private BiConsumer<ResourceID, AccumulatorReport> taskManagerHeartbeatConsumer = (ignoredA, ignoredB) -> {};
 	private Consumer<ResourceID> resourceManagerHeartbeatConsumer = ignored -> {};
 	private Supplier<CompletableFuture<JobDetails>> requestJobDetailsSupplier = () -> FutureUtils.completedExceptionally(new UnsupportedOperationException());
@@ -158,7 +158,7 @@ public class TestingJobMasterGatewayBuilder {
 		return this;
 	}
 
-	public TestingJobMasterGatewayBuilder setRegisterTaskManagerFunction(BiFunction<String, TaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction) {
+	public TestingJobMasterGatewayBuilder setRegisterTaskManagerFunction(BiFunction<String, UnresolvedTaskManagerLocation, CompletableFuture<RegistrationResponse>> registerTaskManagerFunction) {
 		this.registerTaskManagerFunction = registerTaskManagerFunction;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorOversizedResponseMessageTest.java
@@ -67,8 +67,8 @@ public class AkkaRpcActorOversizedResponseMessageTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		configuration.setString(AkkaOptions.FRAMESIZE, FRAMESIZE + " b");
 
-		rpcService1 = AkkaRpcServiceUtils.createRpcService("localhost", 0, configuration);
-		rpcService2 = AkkaRpcServiceUtils.createRpcService("localhost", 0, configuration);
+		rpcService1 = AkkaRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0).createAndStart();
+		rpcService2 = AkkaRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0).createAndStart();
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/MessageSerializationTest.java
@@ -59,8 +59,8 @@ public class MessageSerializationTest extends TestLogger {
 		Configuration configuration = new Configuration();
 		configuration.setString(AkkaOptions.FRAMESIZE, maxFrameSize + "b");
 
-		akkaRpcService1 = AkkaRpcServiceUtils.createRpcService("localhost", 0, configuration);
-		akkaRpcService2 = AkkaRpcServiceUtils.createRpcService("localhost", 0, configuration);
+		akkaRpcService1 = AkkaRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0).createAndStart();
+		akkaRpcService2 = AkkaRpcServiceUtils.remoteServiceBuilder(configuration, "localhost", 0).createAndStart();
 	}
 
 	@AfterClass

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -207,7 +207,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,
 			ResourceID.generate(),
-			InetAddress.getLocalHost(),
+			InetAddress.getLocalHost().getHostName(),
 			true,
 			TaskExecutorResourceUtils.resourceSpecFromConfigForLocalExecution(config));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.InetAddress;
 
 public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
@@ -204,7 +203,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 	}
 
 	private TaskManagerServicesConfiguration createTaskManagerServiceConfiguration(
-			Configuration config) throws IOException {
+			Configuration config) throws Exception {
 		return TaskManagerServicesConfiguration.fromConfiguration(
 			config,
 			ResourceID.generate(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/JobLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/JobLeaderServiceTest.java
@@ -28,7 +28,7 @@ import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.leaderretrieval.SettableLeaderRetrievalService;
 import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
@@ -53,7 +53,7 @@ public class JobLeaderServiceTest extends TestLogger {
 	@Test
 	public void handlesConcurrentJobAdditionsAndLeaderChanges() throws Exception {
 		final JobLeaderService jobLeaderService = new JobLeaderService(
-			new LocalTaskManagerLocation(),
+			new LocalUnresolvedTaskManagerLocation(),
 			RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final TestingJobLeaderListener jobLeaderListener = new TestingJobLeaderListener();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -95,9 +95,9 @@ import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTableImpl;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.Task;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -201,7 +201,7 @@ public class TaskExecutorTest extends TestLogger {
 
 	private Configuration configuration;
 
-	private TaskManagerLocation taskManagerLocation;
+	private UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 
 	private JobID jobId;
 
@@ -228,7 +228,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		configuration = new Configuration();
 
-		taskManagerLocation = new LocalTaskManagerLocation();
+		unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		jobId = new JobID();
 
 		testingFatalErrorHandler = new TestingFatalErrorHandler();
@@ -272,7 +272,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testShouldShutDownTaskManagerServicesInPostStop() throws Exception {
 		final TaskSlotTableImpl<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final IOManager ioManager = new IOManagerAsync(tmp.newFolder().getAbsolutePath());
 
@@ -287,7 +287,7 @@ public class TaskExecutorTest extends TestLogger {
 		kvStateService.start();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setIoManager(ioManager)
 			.setShuffleEnvironment(nettyShuffleEnvironment)
 			.setKvStateService(kvStateService)
@@ -313,7 +313,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testHeartbeatTimeoutWithJobManager() throws Exception {
 		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final long heartbeatInterval = 1L;
 		final long heartbeatTimeout = 3L;
@@ -325,12 +325,12 @@ public class TaskExecutorTest extends TestLogger {
 
 		final ResourceID jmResourceId = ResourceID.generate();
 		final CountDownLatch registrationAttempts = new CountDownLatch(2);
-		final CompletableFuture<TaskManagerLocation> taskManagerLocationFuture = new CompletableFuture<>();
+		final CompletableFuture<UnresolvedTaskManagerLocation> taskManagerUnresolvedLocationFuture = new CompletableFuture<>();
 		final CompletableFuture<ResourceID> disconnectTaskManagerFuture = new CompletableFuture<>();
 		final TestingJobMasterGateway jobMasterGateway = new TestingJobMasterGatewayBuilder()
-			.setRegisterTaskManagerFunction((s, taskManagerLocation) -> {
+			.setRegisterTaskManagerFunction((s, taskManagerUnresolvedLocation) -> {
 				registrationAttempts.countDown();
-				taskManagerLocationFuture.complete(taskManagerLocation);
+				taskManagerUnresolvedLocationFuture.complete(taskManagerUnresolvedLocation);
 				return CompletableFuture.completedFuture(new JMTMRegistrationSuccess(jmResourceId));
 			})
 			.setDisconnectTaskManagerFunction(
@@ -344,7 +344,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobLeaderService(jobLeaderService)
 			.setTaskStateManager(localStateStoresManager)
@@ -366,12 +366,12 @@ public class TaskExecutorTest extends TestLogger {
 			jobManagerLeaderRetriever.notifyListener(jobMasterAddress, jmLeaderId);
 
 			// register task manager success will trigger monitoring heartbeat target between tm and jm
-			final TaskManagerLocation taskManagerLocation1 = taskManagerLocationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
-			assertThat(taskManagerLocation1, equalTo(taskManagerLocation));
+			final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation1 = taskManagerUnresolvedLocationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
+			assertThat(unresolvedTaskManagerLocation1, equalTo(unresolvedTaskManagerLocation));
 
 			// the timeout should trigger disconnecting from the JobManager
 			final ResourceID resourceID = disconnectTaskManagerFuture.get(heartbeatTimeout * 50L, TimeUnit.MILLISECONDS);
-			assertThat(resourceID, equalTo(taskManagerLocation.getResourceID()));
+			assertThat(resourceID, equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 			assertTrue(
 				"The TaskExecutor should try to reconnect to the JM",
@@ -428,7 +428,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -442,10 +442,10 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(rmAddress, rmLeaderId.toUUID());
 
 			// register resource manager success will trigger monitoring heartbeat target between tm and rm
-			assertThat(taskExecutorRegistrationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS), equalTo(taskManagerLocation.getResourceID()));
+			assertThat(taskExecutorRegistrationFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS), equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 			// heartbeat timeout should trigger disconnect TaskManager from ResourceManager
-			assertThat(taskExecutorDisconnectFuture.get(heartbeatTimeout * 50L, TimeUnit.MILLISECONDS), equalTo(taskManagerLocation.getResourceID()));
+			assertThat(taskExecutorDisconnectFuture.get(heartbeatTimeout * 50L, TimeUnit.MILLISECONDS), equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 			assertTrue(
 				"The TaskExecutor should try to reconnect to the RM",
@@ -489,7 +489,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		rpc.registerGateway(rmAddress, rmGateway);
 
-		final SlotID slotId = new SlotID(taskManagerLocation.getResourceID(), 0);
+		final SlotID slotId = new SlotID(unresolvedTaskManagerLocation.getResourceID(), 0);
 		final ResourceProfile resourceProfile = ResourceProfile.fromResources(1.0, 1);
 		final SlotReport slotReport1 = new SlotReport(
 			new SlotStatus(
@@ -512,7 +512,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -528,7 +528,7 @@ public class TaskExecutorTest extends TestLogger {
 			resourceManagerLeaderRetriever.notifyListener(rmAddress, rmLeaderId);
 
 			// register resource manager success will trigger monitoring heartbeat target between tm and rm
-			assertThat(taskExecutorRegistrationFuture.get(), equalTo(taskManagerLocation.getResourceID()));
+			assertThat(taskExecutorRegistrationFuture.get(), equalTo(unresolvedTaskManagerLocation.getResourceID()));
 			assertThat(initialSlotReportFuture.get(), equalTo(slotReport1));
 
 			TaskExecutorGateway taskExecutorGateway = taskManager.getSelfGateway(TaskExecutorGateway.class);
@@ -585,7 +585,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskSlotTable taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -636,7 +636,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -655,7 +655,7 @@ public class TaskExecutorTest extends TestLogger {
 			verify(rmGateway1, Mockito.timeout(timeout.toMilliseconds())).registerTaskExecutor(
 				argThat(taskExecutorRegistration ->
 					taskExecutorRegistration.getTaskExecutorAddress().equals(taskManagerAddress) &&
-					taskExecutorRegistration.getResourceId().equals(taskManagerLocation.getResourceID())),
+					taskExecutorRegistration.getResourceId().equals(unresolvedTaskManagerLocation.getResourceID())),
 				any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 
@@ -668,7 +668,7 @@ public class TaskExecutorTest extends TestLogger {
 			verify(rmGateway2, Mockito.timeout(timeout.toMilliseconds())).registerTaskExecutor(
 				argThat(taskExecutorRegistration ->
 					taskExecutorRegistration.getTaskExecutorAddress().equals(taskManagerAddress) &&
-					taskExecutorRegistration.getResourceId().equals(taskManagerLocation.getResourceID())),
+					taskExecutorRegistration.getResourceId().equals(unresolvedTaskManagerLocation.getResourceID())),
 				any(Time.class));
 			assertNotNull(taskManager.getResourceManagerConnection());
 		}
@@ -722,7 +722,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testJobLeaderDetection() throws Exception {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 		CompletableFuture<Void> initialSlotReportFuture = new CompletableFuture<>();
@@ -744,12 +744,12 @@ public class TaskExecutorTest extends TestLogger {
 		rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
 		final AllocationID allocationId = new AllocationID();
-		final SlotID slotId = new SlotID(taskManagerLocation.getResourceID(), 0);
+		final SlotID slotId = new SlotID(unresolvedTaskManagerLocation.getResourceID(), 0);
 
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobManagerTable(jobManagerTable)
 			.setJobLeaderService(jobLeaderService)
@@ -800,7 +800,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testSlotAcceptance() throws Exception {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final String resourceManagerAddress = "rm";
 		final UUID resourceManagerLeaderId = UUID.randomUUID();
@@ -836,7 +836,7 @@ public class TaskExecutorTest extends TestLogger {
 
 		when(jobMasterGateway.registerTaskManager(
 				any(String.class),
-				eq(taskManagerLocation),
+				eq(unresolvedTaskManagerLocation),
 				any(Time.class)
 		)).thenReturn(CompletableFuture.completedFuture(new JMTMRegistrationSuccess(jmResourceId)));
 		when(jobMasterGateway.getHostname()).thenReturn(jobManagerAddress);
@@ -851,7 +851,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobManagerTable(jobManagerTable)
 			.setJobLeaderService(jobLeaderService)
@@ -863,7 +863,7 @@ public class TaskExecutorTest extends TestLogger {
 		try {
 			taskManager.start();
 
-			assertThat(registrationFuture.get(), equalTo(taskManagerLocation.getResourceID()));
+			assertThat(registrationFuture.get(), equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 			taskSlotTable.allocateSlot(0, jobId, allocationId1, Time.milliseconds(10000L));
 			taskSlotTable.allocateSlot(1, jobId, allocationId2, Time.milliseconds(10000L));
@@ -874,7 +874,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			final Tuple3<InstanceID, SlotID, AllocationID> instanceIDSlotIDAllocationIDTuple3 = availableSlotFuture.get();
 
-			final Tuple3<InstanceID, SlotID, AllocationID> expectedResult = Tuple3.of(registrationId, new SlotID(taskManagerLocation.getResourceID(), 1), allocationId2);
+			final Tuple3<InstanceID, SlotID, AllocationID> expectedResult = Tuple3.of(registrationId, new SlotID(unresolvedTaskManagerLocation.getResourceID(), 1), allocationId2);
 
 			assertThat(instanceIDSlotIDAllocationIDTuple3, equalTo(expectedResult));
 
@@ -893,7 +893,7 @@ public class TaskExecutorTest extends TestLogger {
 	public void testSubmitTaskBeforeAcceptSlot() throws Exception {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(2);
 		final JobManagerTable jobManagerTable = new JobManagerTable();
-		final JobLeaderService jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		final JobLeaderService jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 
 		final TestingResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
 		resourceManagerLeaderRetriever.notifyListener(resourceManagerGateway.getAddress(), resourceManagerGateway.getFencingToken().toUUID());
@@ -934,7 +934,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setShuffleEnvironment(nettyShuffleEnvironment)
 			.setTaskSlotTable(taskSlotTable)
 			.setJobLeaderService(jobLeaderService)
@@ -991,7 +991,7 @@ public class TaskExecutorTest extends TestLogger {
 	private void requestSlots(TaskExecutorGateway tmGateway, Iterable<? extends AllocationID> allocationIds, ResourceManagerId resourceManagerId, String jobMasterGatewayAddress) {
 		int slotIndex = 0;
 		for (AllocationID allocationId : allocationIds) {
-			final SlotID slotId1 = new SlotID(taskManagerLocation.getResourceID(), slotIndex);
+			final SlotID slotId1 = new SlotID(unresolvedTaskManagerLocation.getResourceID(), slotIndex);
 			tmGateway.requestSlot(
 				slotId1,
 				jobId,
@@ -1022,7 +1022,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setJobManagerTable(jobManagerTableMock)
 			.setJobLeaderService(jobLeaderService)
 			.setTaskStateManager(localStateStoresManager)
@@ -1084,7 +1084,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -1127,7 +1127,7 @@ public class TaskExecutorTest extends TestLogger {
 		final TaskExecutorLocalStateStoresManager localStateStoresManager = createTaskExecutorLocalStateStoresManager();
 
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.setTaskSlotTable(taskSlotTable)
 			.setTaskStateManager(localStateStoresManager)
 			.build();
@@ -1159,7 +1159,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			final TaskExecutorGateway taskExecutorGateway = taskExecutor.getSelfGateway(TaskExecutorGateway.class);
 
-			final SlotID slotId = new SlotID(taskManagerLocation.getResourceID(), 0);
+			final SlotID slotId = new SlotID(unresolvedTaskManagerLocation.getResourceID(), 0);
 			final AllocationID allocationId = new AllocationID();
 
 			assertThat(startFuture.isDone(), is(false));
@@ -1245,7 +1245,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			final ResourceID registrationResourceId = registrationFuture.get();
 
-			assertThat(registrationResourceId, equalTo(taskManagerServices.getTaskManagerLocation().getResourceID()));
+			assertThat(registrationResourceId, equalTo(taskManagerServices.getUnresolvedTaskManagerLocation().getResourceID()));
 
 			secondRegistration.await();
 
@@ -1308,10 +1308,10 @@ public class TaskExecutorTest extends TestLogger {
 	@Test
 	public void testReconnectionAttemptIfExplicitlyDisconnected() throws Exception {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		final TaskExecutor taskExecutor = createTaskExecutor(new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.build());
 
 		taskExecutor.start();
@@ -1332,7 +1332,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			final ResourceID firstRegistrationAttempt = registrationQueue.take();
 
-			assertThat(firstRegistrationAttempt, equalTo(taskManagerLocation.getResourceID()));
+			assertThat(firstRegistrationAttempt, equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 			final TaskExecutorGateway taskExecutorGateway = taskExecutor.getSelfGateway(TaskExecutorGateway.class);
 
@@ -1342,7 +1342,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			final ResourceID secondRegistrationAttempt = registrationQueue.take();
 
-			assertThat(secondRegistrationAttempt, equalTo(taskManagerLocation.getResourceID()));
+			assertThat(secondRegistrationAttempt, equalTo(unresolvedTaskManagerLocation.getResourceID()));
 
 		} finally {
 			RpcUtils.terminateRpcEndpoint(taskExecutor, timeout);
@@ -1416,10 +1416,10 @@ public class TaskExecutorTest extends TestLogger {
 	@Test
 	public void testInitialSlotReportFailure() throws Exception {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(1);
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.build();
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
 
@@ -1579,7 +1579,7 @@ public class TaskExecutorTest extends TestLogger {
 
 			initialSlotReportFuture.get();
 
-			ResourceID resourceID = taskManagerServices.getTaskManagerLocation().getResourceID();
+			ResourceID resourceID = taskManagerServices.getUnresolvedTaskManagerLocation().getResourceID();
 			taskExecutorGateway.requestSlot(
 				new SlotID(resourceID, 0),
 				jobId,
@@ -1769,7 +1769,7 @@ public class TaskExecutorTest extends TestLogger {
 			.setTaskSlotTable(new AllocateSlotNotifyingTaskSlotTable(receivedSlotRequest))
 			.build();
 		final TaskExecutor taskExecutor = createTaskExecutor(taskManagerServices);
-		final ResourceID taskExecutorResourceId = taskManagerServices.getTaskManagerLocation().getResourceID();
+		final ResourceID taskExecutorResourceId = taskManagerServices.getUnresolvedTaskManagerLocation().getResourceID();
 
 		taskExecutor.start();
 
@@ -1857,10 +1857,10 @@ public class TaskExecutorTest extends TestLogger {
 
 	private TaskExecutor createTaskExecutor(int numberOFSlots) {
 		final TaskSlotTable<Task> taskSlotTable = TaskSlotUtils.createTaskSlotTable(numberOFSlots);
-		final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
+		final UnresolvedTaskManagerLocation unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		final TaskManagerServices taskManagerServices = new TaskManagerServicesBuilder()
 			.setTaskSlotTable(taskSlotTable)
-			.setTaskManagerLocation(taskManagerLocation)
+			.setUnresolvedTaskManagerLocation(unresolvedTaskManagerLocation)
 			.build();
 		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, numberOFSlots);
 		return createTaskExecutor(taskManagerServices);
@@ -1923,7 +1923,7 @@ public class TaskExecutorTest extends TestLogger {
 		rpc.registerGateway(jobMasterGateway.getAddress(), jobMasterGateway);
 
 		final JobLeaderService jobLeaderService = new JobLeaderService(
-			taskManagerLocation,
+			unresolvedTaskManagerLocation,
 			RetryingRegistrationConfiguration.defaultConfiguration());
 
 		TaskExecutorLocalStateStoresManager stateStoresManager = createTaskExecutorLocalStateStoresManager();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerServicesBuilder.java
@@ -28,9 +28,9 @@ import org.apache.flink.runtime.registration.RetryingRegistrationConfiguration;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TestingTaskSlotTable;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
-import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.Task;
-import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
 public class TaskManagerServicesBuilder {
 
 	/** TaskManager services. */
-	private TaskManagerLocation taskManagerLocation;
+	private UnresolvedTaskManagerLocation unresolvedTaskManagerLocation;
 	private IOManager ioManager;
 	private ShuffleEnvironment<?, ?> shuffleEnvironment;
 	private KvStateService kvStateService;
@@ -54,7 +54,7 @@ public class TaskManagerServicesBuilder {
 	private TaskEventDispatcher taskEventDispatcher;
 
 	public TaskManagerServicesBuilder() {
-		taskManagerLocation = new LocalTaskManagerLocation();
+		unresolvedTaskManagerLocation = new LocalUnresolvedTaskManagerLocation();
 		ioManager = mock(IOManager.class);
 		shuffleEnvironment = mock(ShuffleEnvironment.class);
 		kvStateService = new KvStateService(new KvStateRegistry(), null, null);
@@ -62,12 +62,12 @@ public class TaskManagerServicesBuilder {
 		taskEventDispatcher = new TaskEventDispatcher();
 		taskSlotTable = TestingTaskSlotTable.<Task>newBuilder().closeAsyncReturns(CompletableFuture.completedFuture(null)).build();
 		jobManagerTable = new JobManagerTable();
-		jobLeaderService = new JobLeaderService(taskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
+		jobLeaderService = new JobLeaderService(unresolvedTaskManagerLocation, RetryingRegistrationConfiguration.defaultConfiguration());
 		taskStateManager = mock(TaskExecutorLocalStateStoresManager.class);
 	}
 
-	public TaskManagerServicesBuilder setTaskManagerLocation(TaskManagerLocation taskManagerLocation) {
-		this.taskManagerLocation = taskManagerLocation;
+	public TaskManagerServicesBuilder setUnresolvedTaskManagerLocation(UnresolvedTaskManagerLocation unresolvedTaskManagerLocation) {
+		this.unresolvedTaskManagerLocation = unresolvedTaskManagerLocation;
 		return this;
 	}
 
@@ -113,7 +113,7 @@ public class TaskManagerServicesBuilder {
 
 	public TaskManagerServices build() {
 		return new TaskManagerServices(
-			taskManagerLocation,
+			unresolvedTaskManagerLocation,
 			MemoryManager.MIN_PAGE_SIZE,
 			ioManager,
 			shuffleEnvironment,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LocalUnresolvedTaskManagerLocation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/LocalUnresolvedTaskManagerLocation.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.taskmanager;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+
+/**
+ * Dummy local task manager unresolved location for testing purposes.
+ */
+public class LocalUnresolvedTaskManagerLocation extends UnresolvedTaskManagerLocation {
+	private static final long serialVersionUID = 1L;
+
+	public LocalUnresolvedTaskManagerLocation() {
+		super(ResourceID.generate(), "localhost", 42);
+	}
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -253,7 +253,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 		config.set(TaskManagerOptions.TASK_HEAP_MEMORY, MemorySize.parse("128m"));
 		config.set(TaskManagerOptions.CPU_CORES, 1.0);
 
-		final RpcService rpcService = AkkaRpcServiceUtils.createRpcService("localhost", 0, config);
+		final RpcService rpcService = AkkaRpcServiceUtils.remoteServiceBuilder(config, "localhost", 0).createAndStart();
 
 		try {
 			final Deadline deadline = Deadline.fromNow(TEST_TIMEOUT);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -123,7 +123,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		config.set(TaskManagerOptions.CPU_CORES, 1.0);
 		config.setInteger(RestOptions.PORT, 0);
 
-		final RpcService rpcService = AkkaRpcServiceUtils.createRpcService("localhost", 0, config);
+		final RpcService rpcService = AkkaRpcServiceUtils.remoteServiceBuilder(config, "localhost", 0).createAndStart();
 		final int jobManagerPort = rpcService.getPort();
 		config.setInteger(JobManagerOptions.PORT, jobManagerPort);
 

--- a/tools/travis/splits/split_container.sh
+++ b/tools/travis/splits/split_container.sh
@@ -53,6 +53,7 @@ if [[ "${HADOOP_INTEGRATION}" = "with-hadoop" ]]; then
     run_test "Run Mesos WordCount test" "$END_TO_END_DIR/test-scripts/test_mesos_wordcount.sh"
     run_test "Run Mesos multiple submission test" "$END_TO_END_DIR/test-scripts/test_mesos_multiple_submissions.sh"
 fi
+run_test "Running Flink over NAT end-to-end test" "$END_TO_END_DIR/test-scripts/test_nat.sh" "skip_check_exceptions"
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
## What is the purpose of the change

This PR makes Flink work with NAT by introducing separated configuration options for address/port and bind-address/bind-port of JM/TM RPC services and Netty Shuffle Service.

## Brief change log

- 5cb9b8065bbf6bf6f9445cb20b4d7e984688e468: Minor code clean-ups.
- 1fcee59ad6fb19a8e6f73b648fb635c939612e5f: Deduplicate codes in docker e2e tests.
- b3e88d6c08f91698136d6f150750592955a15f2e: Refactor to create `AkkaRpsService` with builder class. Currently there are too many nested methods for creating a `AkkaRpsService`, making it hard to understand which changes affect which code paths.
- 3d5e3f6cf4b800a9e43c88552a531122bbae3ad5: Separate config options for JM/TM hostname/bind-hostname and RPC port/bind-port.
- d2e5f15a8823a2de0aec24764a9cc93b75f0deaa: Separate config options for Netty Shuffle Service data port/bind-port.
- a8d628c0a325485aa33c7beed94b1eea9d880faa: Introduce e2e test for Flink over NAT.
- 6e0a577481f9300c87299b0629fab6dc1b3bd71a: **DO_NOT_MERGE_THIS** Add the NAT e2e test to pre-commit tests, for the convenience of review.

## Verifying this change

Added a docker-based e2e test for verifying Flink works over NAT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
