### PR TITLE
 [FLINK-16189][e2e] Remove test logic from FlinkDistribution

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResource.java
@@ -28,13 +28,20 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
+import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.ConfigurationException;
 
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -51,16 +58,28 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneFlinkResource.class);
 
-	private final FlinkDistribution distribution = new FlinkDistribution();
+	private final TemporaryFolder temporaryFolder = new TemporaryFolder();
+	private final Path distributionDirectory;
+	@Nullable
+	private final Path logBackupDirectory;
 	private final FlinkResourceSetup setup;
 
-	LocalStandaloneFlinkResource(FlinkResourceSetup setup) {
+	private FlinkDistribution distribution;
+
+	LocalStandaloneFlinkResource(Path distributionDirectory, Optional<Path> logBackupDirectory, FlinkResourceSetup setup) {
+		this.distributionDirectory = distributionDirectory;
+		this.logBackupDirectory = logBackupDirectory.orElse(null);
 		this.setup = setup;
 	}
 
 	@Override
 	public void before() throws Exception {
-		distribution.before();
+		temporaryFolder.create();
+		Path tmp = temporaryFolder.newFolder().toPath();
+		LOG.info("Copying distribution to {}.", tmp);
+		TestUtils.copyDirectory(distributionDirectory, tmp);
+
+		distribution = new FlinkDistribution(tmp);
 		for (JarMove jarMove : setup.getJarMoveOperations()) {
 			distribution.moveJar(jarMove);
 		}
@@ -71,12 +90,33 @@ public class LocalStandaloneFlinkResource implements FlinkResource {
 
 	@Override
 	public void afterTestSuccess() {
-		distribution.afterTestSuccess();
+		shutdownCluster();
+		temporaryFolder.delete();
 	}
 
 	@Override
 	public void afterTestFailure() {
-		distribution.afterTestFailure();
+		if (distribution != null) {
+			shutdownCluster();
+			if (logBackupDirectory != null) {
+				final Path targetDirectory = logBackupDirectory.resolve(UUID.randomUUID().toString());
+				try {
+					distribution.copyLogsTo(targetDirectory);
+					LOG.info("Backed up logs to {}.", targetDirectory);
+				} catch (IOException e) {
+					LOG.warn("An error has occurred while backing up logs to {}.", targetDirectory, e);
+				}
+			}
+		}
+		temporaryFolder.delete();
+	}
+
+	private void shutdownCluster() {
+		try {
+			distribution.stopFlinkCluster();
+		} catch (IOException e) {
+			LOG.warn("Error while shutting down Flink cluster.", e);
+		}
 	}
 
 	@Override

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.tests.util.flink;
 
+import org.apache.flink.tests.util.parameters.ParameterProperty;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
@@ -29,9 +33,21 @@ import java.util.Optional;
 public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceFactory {
 	private static final Logger LOG = LoggerFactory.getLogger(LocalStandaloneFlinkResourceFactory.class);
 
+	private static final ParameterProperty<Path> DISTRIBUTION_DIRECTORY = new ParameterProperty<>("distDir", Paths::get);
+	private static final ParameterProperty<Path> DISTRIBUTION_LOG_BACKUP_DIRECTORY = new ParameterProperty<>("logBackupDir", Paths::get);
+
 	@Override
 	public Optional<FlinkResource> create(FlinkResourceSetup setup) {
+		Optional<Path> distributionDirectory = DISTRIBUTION_DIRECTORY.get();
+		if (!distributionDirectory.isPresent()) {
+			LOG.warn("The distDir property was not set. You can set it when running maven via -DdistDir=<path> .");
+			return Optional.empty();
+		}
+		Optional<Path> logBackupDirectory = DISTRIBUTION_LOG_BACKUP_DIRECTORY.get();
+		if (!logBackupDirectory.isPresent()) {
+			LOG.warn("Property {} not set, logs will not be backed up in case of test failures.", DISTRIBUTION_LOG_BACKUP_DIRECTORY.getPropertyName());
+		}
 		LOG.info("Created {}.", LocalStandaloneFlinkResource.class.getSimpleName());
-		return Optional.of(new LocalStandaloneFlinkResource(setup));
+		return Optional.of(new LocalStandaloneFlinkResource(distributionDirectory.get(), logBackupDirectory, setup));
 	}
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/flink/LocalStandaloneFlinkResourceFactory.java
@@ -48,6 +48,6 @@ public final class LocalStandaloneFlinkResourceFactory implements FlinkResourceF
 			LOG.warn("Property {} not set, logs will not be backed up in case of test failures.", DISTRIBUTION_LOG_BACKUP_DIRECTORY.getPropertyName());
 		}
 		LOG.info("Created {}.", LocalStandaloneFlinkResource.class.getSimpleName());
-		return Optional.of(new LocalStandaloneFlinkResource(distributionDirectory.get(), logBackupDirectory, setup));
+		return Optional.of(new LocalStandaloneFlinkResource(distributionDirectory.get(), logBackupDirectory.orElse(null), setup));
 	}
 }


### PR DESCRIPTION
Based on #11240.

Removes all test-specific logic from the `FlinkDistribution` and moves it one layer up into the `FlinkResource`.
The `FlinkDistribution` is now a simple wrapper for interacting with an actual distribution.

This removes a few limitations; for example so far it was not possible to work against 2 separate distributions.
Additionally it reduces the number of points where we access system properties, making things a bit easier to understand.