### PR TITLE
[FLINK-16386][sql]Use LinkedHashMap for deterministic order SqlFunctionUtils.java

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -40,6 +40,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.MatchResult;
@@ -723,7 +724,7 @@ public class SqlFunctionUtils {
 		}
 
 		String[] keyValuePairs = text.split(listDelimiter);
-		Map<String, String> ret = new HashMap<>(keyValuePairs.length);
+		Map<String, String> ret = new LinkedHashMap<>(keyValuePairs.length);
 		for (String keyValuePair : keyValuePairs) {
 			String[] keyValue = keyValuePair.split(keyValueDelimiter, 2);
 			if (keyValue.length < 2) {


### PR DESCRIPTION
## What is the purpose of the change
This PR aims to solve the issue here: https://issues.apache.org/jira/browse/FLINK-16386
The fix is to use LinkedHashMap instead of HashMap. In this way, the test in `org.apache.flink.table.planner.expressions.ScalarFunctionsTest#testStringToMap` will not suffer from failure any more and the code will be more stable, free of this non-deterministic behaviour.

## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
