### PR TITLE
[FLINK-16387][runtime]Use LinkedHashMap for deterministic order in HeapMapState.java

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -30,6 +30,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -96,7 +97,7 @@ class HeapMapState<K, N, UK, UV>
 
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
 		if (userMap == null) {
-			userMap = new HashMap<>();
+			userMap = new LinkedHashMap<>();
 			stateTable.put(currentNamespace, userMap);
 		}
 


### PR DESCRIPTION
## What is the purpose of the change
This PR aims to solve the issue here: https://issues.apache.org/jira/browse/FLINK-16387

The fix is to use LinkedHashMap instead of HashMap. In this way, the test in `org.apache.flink.table.runtime.operators.join.ProcTimeBoundedStreamJoinTest#testProcTimeInnerJoinWithCommonBounds` and `org.apache.flink.table.runtime.operators.join.RowTimeBoundedStreamJoinTest#testRowTimeInnerJoinWithCommonBounds` will not suffer from failure any more and the code will be more stable, free of non-deterministic behaviours.


## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable