### PR TITLE
[FLINK-16350][e2e] Run half of streaming HA tests against ZK 3.5

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -113,15 +113,15 @@ run_test "Wordcount on Docker test (custom fs plugin)" "$END_TO_END_DIR/test-scr
 
 run_test "Running HA dataset end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_dataset.sh" "skip_check_exceptions"
 
-run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file true false" "skip_check_exceptions"
-run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file false false" "skip_check_exceptions"
-run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true false" "skip_check_exceptions"
-run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true true" "skip_check_exceptions"
+run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file true false 3.4" "skip_check_exceptions"
+run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file false false 3.5" "skip_check_exceptions"
+run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true false 3.4" "skip_check_exceptions"
+run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true true 3.5" "skip_check_exceptions"
 
-run_test "Running HA per-job cluster (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file true false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file false false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true true" "skip_check_exceptions"
+run_test "Running HA per-job cluster (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file true false 3.4" "skip_check_exceptions"
+run_test "Running HA per-job cluster (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file false false 3.5" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true false 3.4" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true true 3.5" "skip_check_exceptions"
 
 ################################################################################
 # Kubernetes

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -101,7 +101,6 @@ function revert_flink_dir() {
     CURL_SSL_ARGS=""
 }
 
-FLINK_DIR=.
 function setup_flink_shaded_zookeeper() {
   local version=$1
   # if it is already in lib we don't have to do anything

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -103,15 +103,19 @@ function revert_flink_dir() {
 
 function use_zookeeper_34() {
   if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* ]; then
-    mv "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/opt"
-    mv "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/lib"
+    # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
+    # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
+    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/opt"
+    cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/lib"
   fi
 }
 
 function use_zookeeper_35() {
   if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* ]; then
-    mv "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/opt"
-    mv "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/lib"
+    # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
+    # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
+    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/opt"
+    cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/lib"
   fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -105,7 +105,7 @@ function use_zookeeper_34() {
   if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* ]; then
     # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
     # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
-    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/opt"
+    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5*
     cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/lib"
   fi
 }
@@ -114,7 +114,7 @@ function use_zookeeper_35() {
   if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* ]; then
     # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
     # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
-    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/opt"
+    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4*
     cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/lib"
   fi
 }

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -101,6 +101,20 @@ function revert_flink_dir() {
     CURL_SSL_ARGS=""
 }
 
+function use_zookeeper_34() {
+  if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* ]; then
+    mv "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/opt"
+    mv "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/lib"
+  fi
+}
+
+function use_zookeeper_35() {
+  if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* ]; then
+    mv "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/opt"
+    mv "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/lib"
+  fi
+}
+
 function add_optional_lib() {
     local lib_name=$1
     cp "$FLINK_DIR/opt/flink-${lib_name}"*".jar" "$FLINK_DIR/lib"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -101,21 +101,20 @@ function revert_flink_dir() {
     CURL_SSL_ARGS=""
 }
 
-function use_zookeeper_34() {
-  if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5* ]; then
-    # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
-    # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
-    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.5*
-    cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.4* "${FLINK_DIR}/lib"
-  fi
-}
-
-function use_zookeeper_35() {
-  if [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4* ]; then
-    # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
-    # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
-    rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-3.4*
-    cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-3.5* "${FLINK_DIR}/lib"
+FLINK_DIR=.
+function setup_flink_shaded_zookeeper() {
+  local version=$1
+  # if it is already in lib we don't have to do anything
+  if ! [ -e "${FLINK_DIR}"/lib/flink-shaded-zookeeper-${version}* ]; then
+    if ! [ -e "${FLINK_DIR}"/opt/flink-shaded-zookeeper-${version}* ]; then
+      echo "Could not find ZK ${version} in opt or lib."
+      exit 1
+    else
+      # contents of 'opt' must not be changed since it is not backed up in common.sh#backup_flink_dir
+      # it is fine to delete jars from 'lib' since it is backed up and will be restored after the test
+      rm "${FLINK_DIR}"/lib/flink-shaded-zookeeper-*
+      cp "${FLINK_DIR}"/opt/flink-shaded-zookeeper-${version}* "${FLINK_DIR}/lib"
+    fi
   fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -34,6 +34,7 @@ function run_ha_test() {
     local BACKEND=$2
     local ASYNC=$3
     local INCREM=$4
+    local ZOOKEEPER_VERSION=$5
 
     local JM_KILLS=3
     local CHECKPOINT_DIR="${TEST_DATA_DIR}/checkpoints/"
@@ -46,6 +47,18 @@ function run_ha_test() {
     # jm killing loop
     set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
     set_config_key "env.java.opts" "-ea"
+    case ${ZOOKEEPER_VERSION} in
+      (3.4)
+        use_zookeeper_34
+      ;;
+      (3.5)
+        use_zookeeper_35
+      ;;
+      (*)
+          echo "Unknown Zookeeper version ${ZOOKEEPER_VERSION}"
+          exit 1
+      ;;
+    esac
     start_local_zk
     start_cluster
 
@@ -96,5 +109,6 @@ function run_ha_test() {
 STATE_BACKEND_TYPE=${1:-file}
 STATE_BACKEND_FILE_ASYNC=${2:-true}
 STATE_BACKEND_ROCKS_INCREMENTAL=${3:-false}
+ZOOKEEPER_VERSION=${4:-3.4}
 
-run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL}
+run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL} ${ZOOKEEPER_VERSION}

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -47,18 +47,7 @@ function run_ha_test() {
     # jm killing loop
     set_config_key "env.pid.dir" "${TEST_DATA_DIR}"
     set_config_key "env.java.opts" "-ea"
-    case ${ZOOKEEPER_VERSION} in
-      (3.4)
-        use_zookeeper_34
-      ;;
-      (3.5)
-        use_zookeeper_35
-      ;;
-      (*)
-          echo "Unknown Zookeeper version ${ZOOKEEPER_VERSION}"
-          exit 1
-      ;;
-    esac
+    setup_flink_shaded_zookeeper ${ZOOKEEPER_VERSION}
     start_local_zk
     start_cluster
 

--- a/tools/travis/splits/split_ha.sh
+++ b/tools/travis/splits/split_ha.sh
@@ -45,15 +45,15 @@ echo "Flink distribution directory: $FLINK_DIR"
 
 run_test "Running HA dataset end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_dataset.sh" "skip_check_exceptions"
 
-run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file true false" "skip_check_exceptions"
-run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file false false" "skip_check_exceptions"
-run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true false" "skip_check_exceptions"
-run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true true" "skip_check_exceptions"
+run_test "Running HA (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file true false 3.4" "skip_check_exceptions"
+run_test "Running HA (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh file false false 3.5" "skip_check_exceptions"
+run_test "Running HA (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true false 3.4" "skip_check_exceptions"
+run_test "Running HA (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_datastream.sh rocks true true 3.5" "skip_check_exceptions"
 
-run_test "Running HA per-job cluster (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file true false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file false false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true false" "skip_check_exceptions"
-run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true true" "skip_check_exceptions"
+run_test "Running HA per-job cluster (file, async) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file true false 3.4" "skip_check_exceptions"
+run_test "Running HA per-job cluster (file, sync) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh file false false 3.5" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, non-incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true false 3.4" "skip_check_exceptions"
+run_test "Running HA per-job cluster (rocks, incremental) end-to-end test" "$END_TO_END_DIR/test-scripts/test_ha_per_job_cluster_datastream.sh rocks true true 3.5" "skip_check_exceptions"
 
 printf "\n[PASS] All tests passed\n"
 exit 0


### PR DESCRIPTION
The test uses the `bin/zookeeper.sh` script from the Flink distribution to start zookeeper. This makes use of the zookeeper version bundled in `lib`. By switching the jars we thus not only change the version of the client, but also the version of the zk server.