### PR TITLE
[FLINK-16380][AZP] Fix jdk11 switch

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -53,7 +53,7 @@ jobs:
     displayName: Cache Maven local repo
   - script: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_11_X64"
-      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin;$PATH"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin:$PATH"
     displayName: "Set to jdk11"
     condition: eq('${{parameters.jdk}}', 'jdk11')
   # Compile
@@ -116,7 +116,7 @@ jobs:
     displayName: Cache Maven local repo
   - script: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_11_X64"
-      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin;$PATH"
+      echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin:$PATH"
     displayName: "Set to jdk11"
     condition: eq('${{parameters.jdk}}', 'jdk11')  
   # Test
@@ -147,7 +147,7 @@ jobs:
       continueOnError: true
     - script: |
         echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_11_X64"
-        echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin;$PATH"
+        echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin:$PATH"
       displayName: "Set to jdk11"
       condition: eq('${{parameters.jdk}}', 'jdk11')
     - script: ./tools/travis/setup_maven.sh


### PR DESCRIPTION
## What is the purpose of the change

- Fix the failing python tests in the jdk11 profile


## Brief change log

- fix issue in setting the java version. (This issue was not discovered before because maven evaluates JAVA_HOME, which was set correctly)

## Verifying this change

JDK11 + python is passing here: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=57&view=logs&j=584fa981-f71a-5840-1c49-f800c954fe4b&t=0d0f8639-a7cb-550f-f4bb-13e97d089a48
