### PR TITLE
[FLINK-10885][e2e] Stabilize confluent schema registry test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/kafka-common.sh
+++ b/flink-end-to-end-tests/test-scripts/kafka-common.sh
@@ -69,8 +69,11 @@ function start_kafka_cluster {
   $KAFKA_DIR/bin/kafka-server-start.sh -daemon $KAFKA_DIR/config/server.properties
 
   start_time=$(date +%s)
-  # zookeeper outputs the "Node does not exist" bit to stderr
-  while [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /brokers/ids/0 2>&1) =~ .*Node\ does\ not\ exist.* ]]; do
+  #
+  # Wait for the broker info to appear in ZK. We assume propery registration once an entry
+  # similar to this is in ZK: {"listener_security_protocol_map":{"PLAINTEXT":"PLAINTEXT"},"endpoints":["PLAINTEXT://my-host:9092"],"jmx_port":-1,"host":"honorary-pig","timestamp":"1583157804932","port":9092,"version":4}
+  #
+  while ! [[ $($KAFKA_DIR/bin/zookeeper-shell.sh localhost:2181 get /brokers/ids/0 2>&1) =~ .*listener_security_protocol_map.* ]]; do
     current_time=$(date +%s)
     time_diff=$((current_time - start_time))
 


### PR DESCRIPTION
## What is the purpose of the change

**Potential problem**:
- the error message "No supported Kafka endpoints are configured. Either kafkastore.bootstrap.servers must have at least one endpoint matching kafkastore.security.protocol or broker endpoints loaded from ZooKeeper must have at least one endpoint matching" indicates that one of the mentioned config parameters has to be set, or the brokers need to be listed in Zookeeper.
- The source code of the "KafkaStore" in the schema registry supports this hypothesis: https://github.com/confluentinc/schema-registry/blob/3.2.0-post/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java#L121
- after starting the Kafka cluster, we wait until "Node does not exist" is not returned by the ZK Cli.
- However, if ZK is not (yet) running, we'll also have outputs such as "WARN Session 0x0 for server null, unexpected error, closing socket connection and attempting reconnect (org.apache.zookeeper.ClientCnxn)", stopping the wait loop.

**Solution**: Wait till we have a ZK Cli output indicating that the broker is registered.


## Verifying this change

I ran this change 3 times over night, without a failure. Still, there is no guarantee that the problem is really fixed


