### PR TITLE
[FLINK-10917][metrics] Bump dropwizard to 3.2.6

### DIFF
--- a/flink-metrics/flink-metrics-dropwizard/pom.xml
+++ b/flink-metrics/flink-metrics-dropwizard/pom.xml
@@ -50,7 +50,7 @@ under the License.
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
-			<version>${metrics.version}</version>
+			<version>${dropwizard.version}</version>
 		</dependency>
 
 

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -56,13 +56,13 @@ under the License.
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
-			<version>${metrics.version}</version>
+			<version>${dropwizard.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-graphite</artifactId>
-			<version>${metrics.version}</version>
+			<version>${dropwizard.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
@@ -6,5 +6,5 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.dropwizard.metrics:metrics-core:3.1.5
-- io.dropwizard.metrics:metrics-graphite:3.1.5
+- io.dropwizard.metrics:metrics-core:3.2.6
+- io.dropwizard.metrics:metrics-graphite:3.2.6

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -33,6 +33,10 @@ under the License.
 	<name>flink-metrics</name>
 	<packaging>pom</packaging>
 
+	<properties>
+		<dropwizard.version>3.1.5</dropwizard.version>
+	</properties>
+
 	<modules>
 		<module>flink-metrics-core</module>
 		<module>flink-metrics-dropwizard</module>

--- a/flink-metrics/pom.xml
+++ b/flink-metrics/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<dropwizard.version>3.1.5</dropwizard.version>
+		<dropwizard.version>3.2.6</dropwizard.version>
 	</properties>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@ under the License.
 		<!-- Only the curator2 TestingServer works with ZK 3.4 -->
 		<curator.version>2.12.0</curator.version>
 		<jackson.version>2.10.1</jackson.version>
-		<metrics.version>3.1.5</metrics.version>
 		<prometheus.version>0.3.0</prometheus.version>
 		<avro.version>1.8.2</avro.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>


### PR DESCRIPTION
Bumps dropwizard to 3.2.6, which contains a few performance/stability improvements.

Compatibility was tested by a user (see the JIRA).