### PR TITLE
[FLINK-16406] Increase default value for JVM Metaspace to minimise its OutOfMemoryError

### DIFF
--- a/docs/_includes/generated/common_memory_section.html
+++ b/docs/_includes/generated/common_memory_section.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
-            <td style="word-wrap: break-word;">96 mb</td>
+            <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>
         </tr>

--- a/docs/_includes/generated/task_manager_memory_configuration.html
+++ b/docs/_includes/generated/task_manager_memory_configuration.html
@@ -28,7 +28,7 @@
         </tr>
         <tr>
             <td><h5>taskmanager.memory.jvm-metaspace.size</h5></td>
-            <td style="word-wrap: break-word;">96 mb</td>
+            <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
             <td>JVM Metaspace Size for the TaskExecutors.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -415,7 +415,7 @@ public class TaskManagerOptions {
 	public static final ConfigOption<MemorySize> JVM_METASPACE =
 		key("taskmanager.memory.jvm-metaspace.size")
 			.memoryType()
-			.defaultValue(MemorySize.parse("96m"))
+			.defaultValue(MemorySize.parse("256m"))
 			.withDescription("JVM Metaspace Size for the TaskExecutors.");
 
 	/**

--- a/flink-dist/src/main/resources/flink-conf.yaml
+++ b/flink-dist/src/main/resources/flink-conf.yaml
@@ -46,7 +46,7 @@ jobmanager.heap.size: 1024m
 #
 # Note this accounts for all memory usage within the TaskManager process, including JVM metaspace and other overhead.
 
-taskmanager.memory.process.size: 1568m
+taskmanager.memory.process.size: 1728m
 
 # To exclude JVM metaspace and overhead, please, use total Flink memory size instead of 'taskmanager.memory.process.size'.
 # It is not recommended to set both 'taskmanager.memory.process.size' and Flink memory.

--- a/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_rocksdb_state_memory_control.sh
@@ -41,7 +41,7 @@ CHECKPOINT_DIR_URI="file://$CHECKPOINT_DIR"
 EXPECTED_MAX_MEMORY_USAGE=200000000
 
 set_config_key "taskmanager.numberOfTaskSlots" "$PARALLELISM"
-set_config_key "taskmanager.memory.process.size" "1024m"
+set_config_key "taskmanager.memory.process.size" "1184m"
 set_config_key "taskmanager.memory.managed.size" "300m"
 set_config_key "state.backend.rocksdb.memory.managed" "true"
 set_config_key "state.backend.rocksdb.memory.write-buffer-ratio" "0.8"

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -42,7 +42,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 	protected static final String POD_NAME = "taskmanager-pod-1";
 	private static final String DYNAMIC_PROPERTIES = "";
 
-	protected static final int TOTAL_PROCESS_MEMORY = 1024;
+	protected static final int TOTAL_PROCESS_MEMORY = 1184;
 	protected static final double TASK_MANAGER_CPU = 2.0;
 
 	protected final Map<String, String> customizedEnvs = new HashMap<String, String>() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdTaskManagerDecoratorTest.java
@@ -52,7 +52,7 @@ public class JavaCmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBa
 	private static final String jvmOpts = "-Djvm";
 
 	private static final String tmJvmMem =
-			"-Xmx251658235 -Xms251658235 -XX:MaxDirectMemorySize=211392922 -XX:MaxMetaspaceSize=100663296";
+			"-Xmx251658235 -Xms251658235 -XX:MaxDirectMemorySize=211392922 -XX:MaxMetaspaceSize=268435456";
 
 	private static final String mainClass = KubernetesTaskExecutorRunner.class.getCanonicalName();
 	private String mainClassArgs;


### PR DESCRIPTION
With FLIP-49 (#9801), we introduced a limit for JVM Metaspace ('taskmanager.memory.jvm-metaspace.size') when TM JVM process is started. It caused `OutOfMemoryError: Metaspace` for some use cases after upgrading to the latest 1.10 version. In some cases, a real class loading leak has been discovered. Some users had to increase the default value to accommodate for their use cases (mostly from `96Mb` to `256Mb`).

While this limit was introduced to properly plan Flink resources, especially for container environment, and to detect class loading leaks, the user experience should be as smooth as possible. In general, the size depends on the use case (job user code, how many jobs are deployed in the cluster etc).

This issue tries to tackle this problem by firstly increasing it to `256Mb` and overall default process size to `1728Mb` in `flink-conf.yaml` to have no impact on default sizes of other memory components.