### PR TITLE
[FLINK-16409][flink-runtime] Use LinkedHashMap for deterministic iterations

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializer.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 /**
  * A serializer for {@link Map}. The serializer relies on a key serializer and a value serializer
@@ -143,7 +144,7 @@ public final class MapSerializer<K, V> extends TypeSerializer<Map<K, V>> {
 	public Map<K, V> deserialize(DataInputView source) throws IOException {
 		final int size = source.readInt();
 
-		final Map<K, V> map = new HashMap<>(size);
+		final Map<K, V> map = new LinkedHashMap<>(size);
 		for (int i = 0; i < size; ++i) {
 			K key = keySerializer.deserialize(source);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -96,7 +97,7 @@ class HeapMapState<K, N, UK, UV>
 
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
 		if (userMap == null) {
-			userMap = new HashMap<>();
+			userMap = new LinkedHashMap<>();
 			stateTable.put(currentNamespace, userMap);
 		}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->
Test `testKeyedMapStateUpgrade` depends on `put` in `HeapMapState.java` and `deserialize` in `MapSerializer.java`. It has this following test assertion 
`assertEquals((Integer) 1, actual.getKey());`
 that asserts the `getKey()` value of `actual`. However the `HashMap` in `put` and `deserialize` does not guarantee any specific order of entries. Therefore, the assertion will fail if the order is different.
## What is the purpose of the change
In this PR, we propose to fix [FLINK-16409] by making the test assertions more stable by considering any order of the result.

## Brief change log
For the method `put` in `HeapMapState.java` and the method `deserialize` in `MapSerializer.java`, we use `LinkedHashMap` instead of `HashMap`.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)