### PR TITLE
[FLINK-16414]fix sql validation failed when using udaf/udtf which doesn't implement getResultType

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
@@ -45,7 +45,7 @@ public class FunctionDefinitionUtil {
 			return new TableFunctionDefinition(
 				name,
 				t,
-				t.getResultType()
+				UserDefinedFunctionHelper.getReturnTypeOfTableFunction(t)
 			);
 		} else if (udf instanceof AggregateFunction) {
 			AggregateFunction a = (AggregateFunction) udf;
@@ -53,8 +53,8 @@ public class FunctionDefinitionUtil {
 			return new AggregateFunctionDefinition(
 				name,
 				a,
-				a.getAccumulatorType(),
-				a.getResultType()
+				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a),
+				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a)
 			);
 		} else if (udf instanceof TableAggregateFunction) {
 			TableAggregateFunction a = (TableAggregateFunction) udf;
@@ -62,8 +62,8 @@ public class FunctionDefinitionUtil {
 			return new TableAggregateFunctionDefinition(
 				name,
 				a,
-				a.getAccumulatorType(),
-				a.getResultType()
+				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a),
+				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a)
 			);
 		} else {
 			throw new UnsupportedOperationException(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
@@ -40,32 +40,56 @@ public class FunctionDefinitionUtilTest {
 
 	@Test
 	public void testTableFunction() {
-		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
+		FunctionDefinition fd1 = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
 			TestTableFunction.class.getName()
 		);
 
-		assertTrue(((TableFunctionDefinition) fd).getTableFunction() instanceof TestTableFunction);
+		assertTrue(((TableFunctionDefinition) fd1).getTableFunction() instanceof TestTableFunction);
+
+		FunctionDefinition fd2 = FunctionDefinitionUtil.createFunctionDefinition(
+				"test",
+				TestTableFunctionWithoutResultType.class.getName()
+		);
+
+		assertTrue(((TableFunctionDefinition) fd2).getTableFunction() instanceof TestTableFunctionWithoutResultType);
 	}
 
 	@Test
 	public void testAggregateFunction() {
-		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
+		FunctionDefinition fd1 = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
 			TestAggFunction.class.getName()
 		);
 
-		assertTrue(((AggregateFunctionDefinition) fd).getAggregateFunction() instanceof TestAggFunction);
+		assertTrue(((AggregateFunctionDefinition) fd1).getAggregateFunction() instanceof TestAggFunction);
+
+		FunctionDefinition fd2 = FunctionDefinitionUtil.createFunctionDefinition(
+				"test",
+				TestAggFunctionWithoutResultType.class.getName()
+		);
+
+		assertTrue(((AggregateFunctionDefinition) fd2).getAggregateFunction()
+				instanceof TestAggFunctionWithoutResultType);
+
 	}
 
 	@Test
 	public void testTableAggregateFunction() {
-		FunctionDefinition fd = FunctionDefinitionUtil.createFunctionDefinition(
+		FunctionDefinition fd1 = FunctionDefinitionUtil.createFunctionDefinition(
 			"test",
 			TestTableAggFunction.class.getName()
 		);
 
-		assertTrue(((TableAggregateFunctionDefinition) fd).getTableAggregateFunction() instanceof TestTableAggFunction);
+		assertTrue(((TableAggregateFunctionDefinition) fd1).getTableAggregateFunction() instanceof TestTableAggFunction);
+
+		FunctionDefinition fd2 = FunctionDefinitionUtil.createFunctionDefinition(
+				"test",
+				TestTableAggFunctionWithoutResultType.class.getName()
+		);
+
+		assertTrue(((TableAggregateFunctionDefinition) fd2).getTableAggregateFunction()
+				instanceof TestTableAggFunctionWithoutResultType);
 	}
 
 	/**
@@ -83,6 +107,12 @@ public class FunctionDefinitionUtilTest {
 		public TypeInformation getResultType() {
 			return TypeInformation.of(Object.class);
 		}
+	}
+
+	/**
+	 * Test function.
+	 */
+	public static class TestTableFunctionWithoutResultType extends TableFunction<String> {
 	}
 
 	/**
@@ -113,6 +143,21 @@ public class FunctionDefinitionUtilTest {
 	/**
 	 * Test function.
 	 */
+	public static class TestAggFunctionWithoutResultType extends AggregateFunction<Long, Long> {
+		@Override
+		public Long createAccumulator() {
+			return null;
+		}
+
+		@Override
+		public Long getValue(Long accumulator) {
+			return null;
+		}
+	}
+
+	/**
+	 * Test function.
+	 */
 	public static class TestTableAggFunction extends TableAggregateFunction {
 		@Override
 		public Object createAccumulator() {
@@ -127,6 +172,16 @@ public class FunctionDefinitionUtilTest {
 		@Override
 		public TypeInformation getAccumulatorType() {
 			return TypeInformation.of(Object.class);
+		}
+	}
+
+	/**
+	 * Test function.
+	 */
+	public static class TestTableAggFunctionWithoutResultType extends TableAggregateFunction<Long, Long> {
+		@Override
+		public Long createAccumulator() {
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*fix sql validation failed when using udaf/udtf which doesn't implement getResultTyp)*


## Brief change log

  - * d549e32  fix sql validation bug and add test case *


## Verifying this change

This change added tests and can be verified as follows:
  - *add more test case in FunctionDefinitionUtilTest.java *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
