### PR TITLE
[FLINK-16245] Decoupling user classloader from context classloader.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -53,7 +54,7 @@ public enum ClientUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ClientUtils.class);
 
-	public static ClassLoader buildUserCodeClassLoader(
+	public static URLClassLoader buildUserCodeClassLoader(
 			List<URL> jars,
 			List<URL> classpaths,
 			ClassLoader parent,

--- a/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/ChildFirstClassLoader.java
@@ -20,7 +20,6 @@ package org.apache.flink.util;
 
 import java.io.IOException;
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -32,7 +31,7 @@ import java.util.List;
  * <p>{@link #getResourceAsStream(String)} uses {@link #getResource(String)} internally so we
  * don't override that.
  */
-public final class ChildFirstClassLoader extends URLClassLoader {
+public final class ChildFirstClassLoader extends FlinkUserCodeClassLoader {
 
 	/**
 	 * The classes that should always go through the parent ClassLoader. This is relevant
@@ -47,7 +46,7 @@ public final class ChildFirstClassLoader extends URLClassLoader {
 	}
 
 	@Override
-	protected synchronized Class<?> loadClass(
+	public synchronized Class<?> loadClass(
 		String name, boolean resolve) throws ClassNotFoundException {
 
 		// First, check if the class has already been loaded

--- a/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FlinkUserCodeClassLoader.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util;
+
+import org.apache.flink.annotation.Internal;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/**
+ * Base class for user code class loaders (child-first, parent-first).
+ */
+@Internal
+public class FlinkUserCodeClassLoader extends URLClassLoader {
+	public FlinkUserCodeClassLoader(URL[] urls, ClassLoader parent) {
+		super(urls, parent);
+	}
+
+	@Override
+	public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		return super.loadClass(name, resolve);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -16,9 +16,8 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.classloading;
+package org.apache.flink.runtime.execution.librarycache;
 
-import org.apache.flink.runtime.execution.librarycache.FlinkUserCodeClassLoaders;
 import org.apache.flink.runtime.rpc.messages.RemoteRpcInvocation;
 import org.apache.flink.testutils.ClassLoaderUtils;
 import org.apache.flink.util.SerializedValue;
@@ -44,7 +43,7 @@ import static org.junit.Assert.assertNotEquals;
 /**
  * Tests for classloading and class loader utilities.
  */
-public class ClassLoaderTest extends TestLogger {
+public class FlinkUserCodeClassLoadersTest extends TestLogger {
 
 	@ClassRule
 	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -104,7 +103,7 @@ public class ClassLoaderTest extends TestLogger {
 		final URLClassLoader childClassLoader2 = FlinkUserCodeClassLoaders.parentFirst(
 				new URL[] { childCodePath }, parentClassLoader);
 
-		final String className = ClassLoaderTest.class.getName();
+		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
 		final Class<?> clazz1 = Class.forName(className, false, parentClassLoader);
 		final Class<?> clazz2 = Class.forName(className, false, childClassLoader1);
@@ -130,7 +129,7 @@ public class ClassLoaderTest extends TestLogger {
 		final URLClassLoader childClassLoader2 = FlinkUserCodeClassLoaders.childFirst(
 				new URL[] { childCodePath }, parentClassLoader, new String[0]);
 
-		final String className = ClassLoaderTest.class.getName();
+		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
 		final Class<?> clazz1 = Class.forName(className, false, parentClassLoader);
 		final Class<?> clazz2 = Class.forName(className, false, childClassLoader1);
@@ -154,7 +153,7 @@ public class ClassLoaderTest extends TestLogger {
 		final URLClassLoader childClassLoader = FlinkUserCodeClassLoaders.childFirst(
 				new URL[] { childCodePath }, parentClassLoader, new String[0]);
 
-		final String className = ClassLoaderTest.class.getName();
+		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 
 		final Class<?> clazz1 = Class.forName(className, false, parentClassLoader);
 		final Class<?> clazz2 = Class.forName(className, false, childClassLoader);
@@ -171,7 +170,7 @@ public class ClassLoaderTest extends TestLogger {
 
 	@Test
 	public void testRepeatedParentFirstPatternClass() throws Exception {
-		final String className = ClassLoaderTest.class.getName();
+		final String className = FlinkUserCodeClassLoadersTest.class.getName();
 		final String parentFirstPattern = className.substring(0, className.lastIndexOf('.'));
 
 		final ClassLoader parentClassLoader = getClass().getClassLoader();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/FlinkUserCodeClassLoadersTest.java
@@ -39,6 +39,7 @@ import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
 
 /**
  * Tests for classloading and class loader utilities.
@@ -191,5 +192,33 @@ public class FlinkUserCodeClassLoadersTest extends TestLogger {
 		assertEquals(clazz1, clazz4);
 
 		childClassLoader.close();
+	}
+
+	@Test
+	public void testClosingOfClassloader() throws Exception {
+		final String className = ClassToLoad.class.getName();
+
+		final ClassLoader parentClassLoader = ClassLoader.getSystemClassLoader().getParent();
+
+		final URL childCodePath = getClass().getProtectionDomain().getCodeSource().getLocation();
+
+		final URLClassLoader childClassLoader = FlinkUserCodeClassLoaders.create(
+			FlinkUserCodeClassLoaders.ResolveOrder.CHILD_FIRST,
+			new URL[] { childCodePath },
+			parentClassLoader,
+			new String[0]);
+
+		final Class<?> loadedClass = childClassLoader.loadClass(className);
+
+		assertNotSame(ClassToLoad.class, loadedClass);
+
+		childClassLoader.close();
+
+		// after closing, no loaded class should be reachable anymore
+		expectedException.expect(isA(ClassNotFoundException.class));
+		childClassLoader.loadClass(className);
+	}
+
+	private static class ClassToLoad {
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -96,8 +96,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -118,13 +121,13 @@ import static org.apache.flink.util.Preconditions.checkState;
  *
  * @param <ClusterID> cluster id
  */
-public class ExecutionContext<ClusterID> {
+public class ExecutionContext<ClusterID> implements Closeable {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ExecutionContext.class);
 
 	private final Environment environment;
 	private final SessionContext originalSessionContext;
-	private final ClassLoader classLoader;
+	private final URLClassLoader classLoader;
 
 	private final Configuration flinkConfig;
 	private final ClusterClientFactory<ClusterID> clusterClientFactory;
@@ -701,6 +704,11 @@ public class ExecutionContext<ClusterID> {
 				"Invalid temporal table '" + temporalTableEntry.getName() + "' over table '" +
 					temporalTableEntry.getHistoryTable() + ".\nCause: " + e.getMessage());
 		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.classLoader.close();
 	}
 
 	//~ Inner Class -------------------------------------------------------------------------------

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -239,7 +239,12 @@ public class LocalExecutor implements Executor {
 			}
 		});
 		// Remove the session's ExecutionContext from contextMap.
-		this.contextMap.remove(sessionId);
+		try {
+			this.contextMap.remove(sessionId).close();
+		} catch (IOException e) {
+			LOG.debug("Error while closing execution context.", e);
+			// ignore any throwable to keep the clean up running
+		}
 	}
 
 	/**

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/BatchFineGrainedRecoveryITCase.java
@@ -60,6 +60,7 @@ import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.TemporaryClassLoaderContext;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -396,14 +397,16 @@ public class BatchFineGrainedRecoveryITCase extends TestLogger {
 		@Override
 		void fail(int trackingIndex) throws Exception {
 			//noinspection OverlyBroadCatchBlock
-			try {
-				restartTaskManager();
-			} catch (InterruptedException e) {
-				// ignore the exception, task should have been failed while stopping TM
-				Thread.currentThread().interrupt();
-			} catch (Throwable t) {
-				failureTracker.unrelatedFailure(t);
-				throw t;
+			try (TemporaryClassLoaderContext unused = TemporaryClassLoaderContext.of(ClassLoader.getSystemClassLoader())) {
+				try {
+					restartTaskManager();
+				} catch (InterruptedException e) {
+					// ignore the exception, task should have been failed while stopping TM
+					Thread.currentThread().interrupt();
+				} catch (Throwable t) {
+					failureTracker.unrelatedFailure(t);
+					throw t;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Decoupling user class loader from context classloader.

Thus, user classloader can be unloaded even though a reference on the context classloader outlives the user code.

## Brief change log

- Adding SafetyNetWrapperClassLoader
- Use it for FlinkUserCodeClassLoaders
- Make sure LocalExecutor closes user classloader


## Verifying this change

Added unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
