### PR TITLE
[FLINK-16410][e2e][build] Add explicit flink-runtime dependency

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/pom.xml
@@ -56,6 +56,12 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
 			<!-- To ensure that flink-dist is built beforehand -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-dist_${scala.binary.version}</artifactId>


### PR DESCRIPTION
The `provided` `flink-dist` dependency allows `flink-end-to-end-tests-common` to access `flink-runtime`, but the shade-plugin throws this dependency out when it creates the dependency-reduced pom.
As a result downstream users no longer see flink-runtime, resulting in missing classes.