### PR TITLE
[FLINK-16122][AZP] Upload build debug logs as artifacts

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -48,10 +48,13 @@ function run_test {
       echo "[FAIL] Test script contains errors."
       post_test_validation 1 "$description" "$skip_check_exceptions"
     }
+    # set a trap to catch a test execution error
     trap 'test_error' ERR
 
     ${command}
     exit_code="$?"
+    # remove trap for test execution
+    trap - ERR
     post_test_validation ${exit_code} "$description" "$skip_check_exceptions"
 }
 

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -44,13 +44,13 @@ variables:
 
 stages:
   # CI / PR triggered stage:
-  - stage: ci_build
+  - stage: ci
     displayName: "CI build (custom builders)"
     condition: not(eq(variables['Build.Reason'], in('Schedule', 'Manual')))
     jobs:
       - template: jobs-template.yml
         parameters:
-          stage_name: ci_build
+          stage_name: ci
           test_pool_definition:
             name: Default
           e2e_pool_definition:
@@ -67,7 +67,7 @@ stages:
     jobs:
       - template: jobs-template.yml
         parameters:
-          stage_name: cron_build_hadoop241
+          stage_name: cron_hadoop241
           test_pool_definition:
             name: Default
           e2e_pool_definition:
@@ -78,7 +78,7 @@ stages:
           jdk: jdk8
       - template: jobs-template.yml
         parameters:
-          stage_name: cron_build_scala212
+          stage_name: cron_scala212
           test_pool_definition:
             name: Default
           e2e_pool_definition:
@@ -89,7 +89,7 @@ stages:
           jdk: jdk8
       - template: jobs-template.yml
         parameters:
-          stage_name: cron_build_jdk11
+          stage_name: cron_jdk11
           test_pool_definition:
             name: Default
           e2e_pool_definition:
@@ -100,7 +100,7 @@ stages:
           jdk: jdk11
       - template: jobs-template.yml
         parameters:
-          stage_name: cron_build_hadoopfree
+          stage_name: cron_hadoopfree
           test_pool_definition:
             name: Default
           e2e_pool_definition:

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -126,7 +126,13 @@ jobs:
   - task: PublishTestResults@2
     inputs:
       testResultsFormat: 'JUnit'
-
+  # upload debug artifacts
+  - task: PublishPipelineArtifact@1
+    condition: and(succeededOrFailed(), not(eq('$(ARTIFACT_DIR)', '')))
+    displayName: Upload Logs
+    inputs:
+      path: $(ARTIFACT_DIR)
+      artifact: logs-${{parameters.stage_name}}-$(ARTIFACT_NAME)
 
 - job: e2e_${{parameters.stage_name}}
   # uncomment below condition to run the e2e tests only on request.
@@ -163,4 +169,12 @@ jobs:
 #      displayName: Test - precommit 
     - script: FLINK_DIR=`pwd`/build-target flink-end-to-end-tests/run-nightly-tests.sh
       displayName: Run e2e tests
+      # upload debug artifacts
+    - task: PublishPipelineArtifact@1
+      condition: and(succeededOrFailed(), not(eq('$(ARTIFACT_DIR)', '')))
+      displayName: Upload Logs
+      inputs:
+        path: $(ARTIFACT_DIR)
+        artifact: logs-${{parameters.stage_name}}-e2e
+        
 

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -146,9 +146,6 @@ upload_artifacts_s3() {
 
 	# On Azure, publish ARTIFACTS_FILE as a build artifact
 	if [ ! -z "$TF_BUILD" ] ; then
-		echo "DEBBUGGING"
-		env
-		set -x
 		ARTIFACT_DIR="$(pwd)/artifact-dir"
 		mkdir $ARTIFACT_DIR
 		cp $ARTIFACTS_FILE $ARTIFACT_DIR/


### PR DESCRIPTION
## What is the purpose of the change

We used to rely on transfer.sh for sharing making the full logs available in our builds. However, transfer.sh has become very unstable recently.


## Brief change log

- if we are in a AZP build, prepare the logs to be published as a build artifact
- add a task to upload the logs, also when the build fails
- reduce timeout / retries of transfer.sh upload to reduce impact on build time
- shorten the names of the cron tasks (so that they are better readable in the AZP UI)



## Verifying this change

Easily verifiable through the AZP test

## Does this pull request potentially affect one of the following parts:

only affects the build infra
