### PR TITLE
[FLINK-16371] [BulkWriter] Fix Hadoop Compression BulkWriter

### DIFF
--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
@@ -19,48 +19,40 @@
 package org.apache.flink.formats.compress.writers;
 
 import org.apache.flink.api.common.serialization.BulkWriter;
-import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.formats.compress.extractor.Extractor;
 
-import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 
 import java.io.IOException;
 
 /**
- * A {@link BulkWriter} implementation that compresses data using Hadoop codecs.
+ * A {@link BulkWriter} implementation that writes data that have been
+ * compressed using Hadoop {@link org.apache.hadoop.io.compress.CompressionCodec}.
  *
  * @param <T> The type of element to write.
  */
 public class HadoopCompressionBulkWriter<T> implements BulkWriter<T> {
 
 	private Extractor<T> extractor;
-	private FSDataOutputStream outputStream;
-	private CompressionOutputStream compressor;
+	private CompressionOutputStream out;
 
-	public HadoopCompressionBulkWriter(
-			FSDataOutputStream outputStream,
-			Extractor<T> extractor,
-			CompressionCodec compressionCodec) throws Exception {
-		this.outputStream = outputStream;
+	public HadoopCompressionBulkWriter(CompressionOutputStream out, Extractor<T> extractor) {
+		this.out = out;
 		this.extractor = extractor;
-		this.compressor = compressionCodec.createOutputStream(outputStream);
 	}
 
 	@Override
 	public void addElement(T element) throws IOException {
-		compressor.write(extractor.extract(element));
+		out.write(extractor.extract(element));
 	}
 
 	@Override
 	public void flush() throws IOException {
-		compressor.flush();
-		outputStream.flush();
+		out.flush();
 	}
 
 	@Override
 	public void finish() throws IOException {
-		compressor.finish();
-		outputStream.sync();
+		out.finish();
 	}
 }

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/HadoopCompressionBulkWriter.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.io.compress.CompressionOutputStream;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link BulkWriter} implementation that writes data that have been
  * compressed using Hadoop {@link org.apache.hadoop.io.compress.CompressionCodec}.
@@ -33,12 +35,12 @@ import java.io.IOException;
  */
 public class HadoopCompressionBulkWriter<T> implements BulkWriter<T> {
 
-	private Extractor<T> extractor;
-	private CompressionOutputStream out;
+	private final Extractor<T> extractor;
+	private final CompressionOutputStream out;
 
 	public HadoopCompressionBulkWriter(CompressionOutputStream out, Extractor<T> extractor) {
-		this.out = out;
-		this.extractor = extractor;
+		this.out = checkNotNull(out);
+		this.extractor = checkNotNull(extractor);
 	}
 
 	@Override

--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/writers/NoCompressionBulkWriter.java
@@ -24,6 +24,8 @@ import org.apache.flink.formats.compress.extractor.Extractor;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * A {@link BulkWriter} implementation that does not compress data. This is essentially a no-op
  * writer for use with {@link org.apache.flink.formats.compress.CompressWriterFactory} for the case
@@ -33,12 +35,12 @@ import java.io.IOException;
  */
 public class NoCompressionBulkWriter<T> implements BulkWriter<T> {
 
-	private Extractor<T> extractor;
-	private FSDataOutputStream outputStream;
+	private final Extractor<T> extractor;
+	private final FSDataOutputStream outputStream;
 
 	public NoCompressionBulkWriter(FSDataOutputStream outputStream, Extractor<T> extractor) {
-		this.outputStream = outputStream;
-		this.extractor = extractor;
+		this.outputStream = checkNotNull(outputStream);
+		this.extractor = checkNotNull(extractor);
 	}
 
 	@Override

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
@@ -40,6 +40,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.List;
@@ -104,7 +105,7 @@ public class CompressWriterFactoryTest extends TestLogger {
 		testCompressByName("org.apache.hadoop.io.compress.DefaultCodec");
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test(expected = IOException.class)
 	public void testCompressFailureWithUnknownCodec() throws Exception {
 		testCompressByName("com.bla.bla.UnknownCodec");
 	}
@@ -128,13 +129,12 @@ public class CompressWriterFactoryTest extends TestLogger {
 		testCompressByName(codec, new Configuration());
 	}
 
-	private void testCompressByName(String codec, Configuration configuration) throws Exception {
+	private void testCompressByName(String codec, Configuration conf) throws Exception {
 		CompressWriterFactory<String> writer = CompressWriters.forExtractor(new DefaultExtractor<String>())
-			.withHadoopCompression(codec, configuration);
+			.withHadoopCompression(codec, conf);
 		List<String> lines = Arrays.asList("line1", "line2", "line3");
 
 		File directory = prepareCompressedFile(writer, lines);
-		Configuration conf = (configuration != null) ? configuration : new Configuration();
 
 		validateResults(directory, lines, new CompressionCodecFactory(conf).getCodecByName(codec));
 	}

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CompressWriterFactoryTest.java
@@ -96,7 +96,7 @@ public class CompressWriterFactoryTest extends TestLogger {
 		testCompressByName("org.apache.hadoop.io.compress.DefaultCodec");
 	}
 
-	@Test(expected = RuntimeException.class)
+	@Test(expected = NullPointerException.class)
 	public void testCompressFailureWithUnknownCodec() throws Exception {
 		testCompressByName("com.bla.bla.UnknownCodec");
 	}

--- a/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CustomCompressionCodec.java
+++ b/flink-formats/flink-compress/src/test/java/org/apache/flink/formats/compress/CustomCompressionCodec.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.compress;
+
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+
+/**
+ * Just a dummy class which extends BZip2Codec to verify
+ * that custom Hadoop {@link CompressionCodec} can also
+ * be successfully loaded using the class name or alias,
+ * just like the default ones.
+ */
+public class CustomCompressionCodec extends BZip2Codec {
+	// Seriously nothing happens here
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixes the NotSerializableException which is thrown when CompressWriterFactory is created with Hadoop compression provided.


## Brief change log

 - FLINK-13634 introduces Hadoop Compression based `BulkWriter` implementation. However, it takes an instance of Hadoop `CompressionCodec` which causes java.io.NotSerializableException to be thrown since this object has to be sent over the wire when the overriden `create()` method gets called.
 - This PR changes the way the CompressionCodec instance is created i.e, it gets initialised lazily and inside the `create()` method.

## Verifying this change

This change added tests and can be verified as follows:
  - Updated the test cases to only use the String representation of a Compression Codec i.e. codec name or alias, instead of an object.
  - Added test that validates that an exception should be thrown when a non-existing codec name is provided
  - Manually verified the change on a cluster with a streaming pipeline.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
