### PR TITLE
[FLINK-xxxx] Add the taskmanager direct memory test

### DIFF
--- a/flink-end-to-end-tests/flink-taskmanager-direct-memory-test/pom.xml
+++ b/flink-end-to-end-tests/flink-taskmanager-direct-memory-test/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<version>1.11-SNAPSHOT</version>
+		<relativePath>..</relativePath>
+	</parent>
+
+	<artifactId>flink-taskmanager-direct-memory-test</artifactId>
+	<name>flink-taskmanager-direct-memory-test</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+<!--			<scope>provided</scope>-->
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>TaskManagerDirectMemoryTestProgram</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>TaskManagerDirectMemoryTestProgram</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.streaming.tests.TaskManagerDirectMemoryTestProgram</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-end-to-end-tests/flink-taskmanager-direct-memory-test/src/main/java/org/apache/flink/streaming/tests/TaskManagerDirectMemoryTestProgram.java
+++ b/flink-end-to-end-tests/flink-taskmanager-direct-memory-test/src/main/java/org/apache/flink/streaming/tests/TaskManagerDirectMemoryTestProgram.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.tests;
+
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/**
+ * Test program for taskmanager direct memory consumption.
+ */
+public class TaskManagerDirectMemoryTestProgram {
+	private static ConfigOption<Integer> RUNNING_TIME_IN_SECONDS = ConfigOptions
+		.key("test.running_time_in_seconds")
+		.defaultValue(120)
+		.withDescription("The time to run.");
+
+	private static ConfigOption<Integer> RECORD_LENGTH = ConfigOptions
+		.key("test.record_length")
+		.defaultValue(2048)
+		.withDescription("The length of record.");
+
+	private static ConfigOption<Integer> MAP_PARALLELISM = ConfigOptions
+		.key("test.map_parallelism")
+		.defaultValue(1)
+		.withDescription("The number of map tasks.");
+
+	private static ConfigOption<Integer> REDUCE_PARALLELISM = ConfigOptions
+		.key("test.reduce_parallelism")
+		.defaultValue(1)
+		.withDescription("The number of reduce tasks.");
+
+	public static void main(String[] args) throws Exception {
+		// parse the parameters
+		final ParameterTool params = ParameterTool.fromArgs(args);
+
+		final int runningTimeInSeconds = params.getInt(RUNNING_TIME_IN_SECONDS.key(), RUNNING_TIME_IN_SECONDS.defaultValue());
+		final int recordLength = params.getInt(RECORD_LENGTH.key(), RECORD_LENGTH.defaultValue());
+		final int mapParallelism = params.getInt(MAP_PARALLELISM.key(), MAP_PARALLELISM.defaultValue());
+		final int reduceParallelism = params.getInt(REDUCE_PARALLELISM.key(), REDUCE_PARALLELISM.defaultValue());
+
+		checkArgument(runningTimeInSeconds > 0,
+			"The running time in seconds should be positive, but it is {}",
+			recordLength);
+		checkArgument(recordLength > 0,
+			"The record length should be positive, but it is {}",
+			recordLength);
+		checkArgument(mapParallelism > 0,
+			"The number of map tasks should be positive, but it is {}",
+			mapParallelism);
+		checkArgument(reduceParallelism > 0,
+			"The number of reduce tasks should be positve, but it is {}",
+			reduceParallelism);
+
+		byte[] bytes = new byte[recordLength];
+		for (int i = 0; i < recordLength; ++i) {
+			bytes[i] = 'a';
+		}
+		String str = new String(bytes);
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.addSource(new StringSourceFunction(str, runningTimeInSeconds))
+			.setParallelism(mapParallelism)
+			.slotSharingGroup("a")
+			.rebalance()
+			.addSink(new DummySink())
+			.setParallelism(reduceParallelism)
+			.slotSharingGroup("b");
+
+		// execute program
+		env.execute("TaskManager Direct Memory Test");
+	}
+
+	public static class StringSourceFunction extends RichParallelSourceFunction<String> {
+		private static final long serialVersionUID = 1L;
+
+		private volatile boolean isRunning;
+
+		private final String str;
+
+		private final long runningTimeInSeconds;
+
+		private transient long stopTime;
+
+		public StringSourceFunction(String str, long runningTimeInSeconds) {
+			this.str = str;
+			this.runningTimeInSeconds = runningTimeInSeconds;
+		}
+
+		@Override
+		public void open(Configuration parameters) {
+			isRunning = true;
+			stopTime = System.nanoTime() + runningTimeInSeconds * 1_000_000_000L;
+		}
+
+		@Override
+		public void run(SourceContext<String> ctx) {
+			while (isRunning && (System.nanoTime() < stopTime)) {
+				ctx.collect(str);
+			}
+		}
+
+		@Override
+		public void cancel() {
+			isRunning = false;
+		}
+	}
+
+	private static class DummySink extends RichSinkFunction<String> {
+
+		@Override
+		public void invoke(String value, Context context) throws Exception {
+			// Do nothing.
+		}
+	}
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -88,6 +88,7 @@ under the License.
 		<module>flink-elasticsearch7-test</module>
 		<module>flink-end-to-end-tests-common-kafka</module>
 		<module>flink-tpcds-test</module>
+		<module>flink-taskmanager-direct-memory-test</module>
 	</modules>
 
 	<profiles>

--- a/flink-end-to-end-tests/test-scripts/test_taskmanager_direct_memory.sh
+++ b/flink-end-to-end-tests/test-scripts/test_taskmanager_direct_memory.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/common.sh
+
+TEST=flink-taskmanager-direct-memory-test
+TEST_PROGRAM_NAME=TaskManagerDirectMemoryTestProgram
+TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
+
+set_config_key "akka.ask.timeout" "60 s"
+set_config_key "web.timeout" "60000"
+
+set_config_key "taskmanager.memory.process.size" "1536m"
+
+set_config_key "taskmanager.memory.managed.size" "8" # 8Mb
+set_config_key "taskmanager.memory.network.min" "256mb"
+set_config_key "taskmanager.memory.network.max" "256mb"
+set_config_key "taskmanager.memory.jvm-metaspace.size" "64m"
+
+set_config_key "taskmanager.numberOfTaskSlots" "20" # 20 slots per TM
+set_config_key "taskmanager.network.netty.num-arenas" "1" # Use only one arena for each TM
+set_config_key "taskmanager.memory.framework.off-heap.size" "20m" # One chunk (16M) and some additional consumption
+
+start_cluster # this also starts 1TM
+start_taskmanagers 4 # 1TM + 4TM = 5TM a 20 slots = 100 slots
+
+$FLINK_DIR/bin/flink run ${TEST_PROGRAM_JAR} \
+--test.map_parallelism 80 \
+--test.reduce_parallelism 20 \
+--test.record_length 4096 \
+--test.running_time_in_seconds 120

--- a/tools/travis/splits/split_misc.sh
+++ b/tools/travis/splits/split_misc.sh
@@ -57,6 +57,8 @@ run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/tes
 run_test "Streaming File Sink s3 end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh s3" "skip_check_exceptions"
 run_test "Stateful stream job upgrade end-to-end test" "$END_TO_END_DIR/test-scripts/test_stateful_stream_job_upgrade.sh 2 4"
 
+run_test "TaskManager Direct memory Consumption end-to-end test" "$END_TO_END_DIR/test-scripts/test_taskmanager_direct_memory.sh"
+
 run_test "Elasticsearch (v5.1.2) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 5 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.tar.gz"
 run_test "Elasticsearch (v6.3.1) sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_elasticsearch.sh 6 https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.1.tar.gz"
 


### PR DESCRIPTION
## What is the purpose of the change

Adds end-to-end test for testing the direct memory consumption of TaskManager. It fixes the number of Netty arena to 1.

This test is used to verify the effect of [FLINK-10742](https://issues.apache.org/jira/browse/FLINK-10742) and [FLINK-15962](https://issues.apache.org/jira/browse/FLINK-15962):

1. With the current implementation, Netty may use more than two chunks, and the direct memory has to be set to be more than one chunk.
2. With the zero-copy optimization in [FLINK-10742](https://issues.apache.org/jira/browse/FLINK-10742), the direct memory used by Netty should not exceed one chunk, thus the direct memory required could be less than one chunk.
3. With [FLINK-15962](https://issues.apache.org/jira/browse/FLINK-15962), we could further reduce the chunk size and total direct memory. The zero-copy optimization ensures one chunk of 1M is enough.

## Brief change log

- 6cbbf3d0ffc092ca0d273ffae0f34b6e100770d4 adds the end-to-end test.

## Verifying this change

The end-to-end test is running manually.

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  **no**
  - The serializers:  **no**
  - The runtime per-record code paths (performance sensitive):  **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  **no**
  - The S3 file system connector:  **no**

## Documentation

  - Does this pull request introduce a new feature?  **no**
  - If yes, how is the feature documented? **not applicable**
