### PR TITLE
[FLINK-16427][api] Remove directly throw ProgramInvocationExceptions in RemoteStreamEnvironment

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/RemoteStreamEnvironment.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Public;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.RemoteEnvironmentConfigUtils;
-import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -215,16 +214,7 @@ public class RemoteStreamEnvironment extends StreamExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(StreamGraph streamGraph) throws Exception {
-		try {
-			return super.execute(streamGraph);
-		}
-		catch (ProgramInvocationException e) {
-			throw e;
-		}
-		catch (Exception e) {
-			String term = e.getMessage() == null ? "." : (": " + e.getMessage());
-			throw new ProgramInvocationException("The program execution failed" + term, e);
-		}
+		return super.execute(streamGraph);
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

This issue is a child issue of FLINK-15090.

With a previous discussion with @aljoscha  we tend to reverse the dependency from flink-streaming-java to flink-client so that we have a semantic correct module dependency. That says, flink-streaming-java, just like flink-java(batch api), is an api module which should not know about the runtime.

This issue closes #11261 .

## Brief change log

- Remove directly throw `ProgramInvocationExceptions` in `RemoteStreamEnvironment`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes, we possibly change the actual exception thrown from `RemoteStreamEnvironment#execute`, it is previously always `ProgramInvocationException` which is an unfortunately accident. We change the behavior for reverse the dependency from flink-streaming-java to flink-client in the future)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

cc @tillrohrmann 
