### PR TITLE
[FLINK-16417][e2e] Slightly increase offheap memory for ConnectedComp…

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -32,6 +32,7 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 set_config_key "taskmanager.numberOfTaskSlots" "$SLOTS_PER_TM"
 set_config_key "taskmanager.memory.network.min" "160m"
 set_config_key "taskmanager.memory.network.max" "160m"
+set_config_key "taskmanager.memory.framework.off-heap.size" "160m"
 
 print_mem_use
 start_cluster


### PR DESCRIPTION
## What is the purpose of the change

The connected components tests was failing due to an off heap out of memory on JDK11. This PR increases the memory setting

See JIRA ticket for details: https://issues.apache.org/jira/browse/FLINK-16417
