### PR TITLE
[FLINK-16432] Fix dependencies in Hive Connector build

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -707,12 +707,20 @@ under the License.
 					<artifactId>jdk.tools</artifactId>
 				</exclusion>
 				<exclusion>
+					<artifactId>jms</artifactId>
+					<groupId>javax.jms</groupId>
+				</exclusion>
+				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.pentaho</groupId>
+					<artifactId>pentaho-aggdesigner-algorithm</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

* I was unable to build the software due to dependency problems with the hive connector*

## Brief change log

  - *Added a valid repository so the pentaho dependency could be loaded.*
  - *Excluded javax.jms:jms because that is nowhere in a maven repo*

## Verifying this change

This change is already covered by existing tests, such as *being able to actually build everything without errors*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *yes*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? not applicable
