### PR TITLE
[FLINK-16435][python] Replace since decorator with versionadd to mark the version an API was introduced

### DIFF
--- a/flink-python/pyflink/__init__.py
+++ b/flink-python/pyflink/__init__.py
@@ -24,22 +24,6 @@ if sys.version_info < (3, 5):
         str(sys.version_info) + '].')
 
 
-def since(version):
-    """
-    A decorator that annotates a function to append the version the function was added.
-    """
-    import re
-    indent_p = re.compile(r'\n( +)')
-
-    def deco(f):
-        original_doc = f.__doc__ or ""
-        indents = indent_p.findall(original_doc)
-        indent = ' ' * (min(len(indent) for indent in indents) if indents else 0)
-        f.__doc__ = original_doc.rstrip() + "\n\n%s.. versionadded:: %s" % (indent, version)
-        return f
-    return deco
-
-
 def keyword(func):
     """
     A decorator that forces keyword arguments usage and store actual

--- a/flink-python/pyflink/table/catalog.py
+++ b/flink-python/pyflink/table/catalog.py
@@ -18,7 +18,6 @@
 
 from py4j.java_gateway import java_import
 
-from pyflink import since
 from pyflink.java_gateway import get_gateway
 from pyflink.table.table_schema import TableSchema
 
@@ -790,21 +789,23 @@ class CatalogFunction(object):
         else:
             return None
 
-    @since("1.10.0")
     def is_generic(self):
         """
         Whether or not is the function a flink UDF.
 
         :return: Whether is the function a flink UDF.
+
+        .. versionadded:: 1.10.0
         """
         return self._j_catalog_function.isGeneric()
 
-    @since("1.10.0")
     def get_function_language(self):
         """
         Get the language used for the function definition.
 
         :return: the language type of the function definition
+
+        .. versionadded:: 1.10.0
         """
         return self._j_catalog_function.getFunctionLanguage()
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -18,7 +18,6 @@
 
 from py4j.compat import long
 
-from pyflink import since
 from pyflink.common import Configuration
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.java_gateway import get_gateway
@@ -277,7 +276,6 @@ class TableConfig(object):
         """
         self._j_table_config.setSqlDialect(SqlDialect._to_j_sql_dialect(sql_dialect))
 
-    @since("1.10.0")
     def set_python_executable(self, python_exec):
         """
         Sets the path of the python interpreter which is used to execute the python udf workers.
@@ -312,10 +310,11 @@ class TableConfig(object):
 
         :param python_exec: The path of python interpreter.
         :type python_exec: str
+
+        .. versionadded:: 1.10.0
         """
         self.get_configuration().set_string(DependencyManager.PYTHON_EXEC, python_exec)
 
-    @since("1.10.0")
     def get_python_executable(self):
         """
         Gets the path of the python interpreter which is used to execute the python udf workers.
@@ -323,6 +322,8 @@ class TableConfig(object):
 
         :return: The path of the python interpreter which is used to execute the python udf workers.
         :rtype: str
+
+        .. versionadded:: 1.10.0
         """
         return self.get_configuration().get_string(DependencyManager.PYTHON_EXEC, None)
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -22,7 +22,6 @@ from abc import ABCMeta, abstractmethod
 
 from py4j.java_gateway import get_java_class, get_method
 
-from pyflink import since
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table.catalog import Catalog
@@ -246,7 +245,6 @@ class TableEnvironment(object):
         j_table = self._j_tenv.scan(j_table_paths)
         return Table(j_table)
 
-    @since("1.10.0")
     def from_path(self, path):
         """
         Reads a registered table and returns the resulting :class:`~pyflink.table.Table`.
@@ -281,6 +279,7 @@ class TableEnvironment(object):
 
         .. seealso:: :func:`use_catalog`
         .. seealso:: :func:`use_database`
+        .. versionadded:: 1.10.0
         """
         return Table(get_method(self._j_tenv, "from")(path))
 
@@ -319,13 +318,14 @@ class TableEnvironment(object):
         j_catalog_name_array = self._j_tenv.listCatalogs()
         return [item for item in j_catalog_name_array]
 
-    @since("1.10.0")
     def list_modules(self):
         """
         Gets the names of all modules registered in this environment.
 
         :return: List of module names.
         :rtype: list[str]
+
+        .. versionadded:: 1.10.0
         """
         j_module_name_array = self._j_tenv.listModules()
         return [item for item in j_module_name_array]
@@ -360,18 +360,18 @@ class TableEnvironment(object):
         j_udf_name_array = self._j_tenv.listUserDefinedFunctions()
         return [item for item in j_udf_name_array]
 
-    @since("1.10.0")
     def list_functions(self):
         """
         Gets the names of all functions in this environment.
 
         :return: List of the names of all functions in this environment.
         :rtype: list[str]
+
+        .. versionadded:: 1.10.0
         """
         j_function_name_array = self._j_tenv.listFunctions()
         return [item for item in j_function_name_array]
 
-    @since("1.10.0")
     def list_temporary_tables(self):
         """
         Gets the names of all temporary tables and views available in the current namespace
@@ -382,11 +382,11 @@ class TableEnvironment(object):
         :rtype: list[str]
 
         .. seealso:: :func:`list_tables`
+        .. versionadded:: 1.10.0
         """
         j_table_name_array = self._j_tenv.listTemporaryTables()
         return [item for item in j_table_name_array]
 
-    @since("1.10.0")
     def list_temporary_views(self):
         """
         Gets the names of all temporary views available in the current namespace (the current
@@ -397,11 +397,11 @@ class TableEnvironment(object):
         :rtype: list[str]
 
         .. seealso:: :func:`list_tables`
+        .. versionadded:: 1.10.0
         """
         j_view_name_array = self._j_tenv.listTemporaryViews()
         return [item for item in j_view_name_array]
 
-    @since("1.10.0")
     def drop_temporary_table(self, table_path):
         """
         Drops a temporary table registered in the given path.
@@ -413,10 +413,11 @@ class TableEnvironment(object):
         :type table_path: str
         :return: True if a table existed in the given path and was removed.
         :rtype: bool
+
+        .. versionadded:: 1.10.0
         """
         return self._j_tenv.dropTemporaryTable(table_path)
 
-    @since("1.10.0")
     def drop_temporary_view(self, view_path):
         """
         Drops a temporary view registered in the given path.
@@ -426,6 +427,8 @@ class TableEnvironment(object):
 
         :return: True if a view existed in the given path and was removed.
         :rtype: bool
+
+        .. versionadded:: 1.10.0
         """
         return self._j_tenv.dropTemporaryView(view_path)
 
@@ -737,7 +740,6 @@ class TableEnvironment(object):
             .loadClass(function_class_name).newInstance()
         self._j_tenv.registerFunction(name, java_function)
 
-    @since("1.10.0")
     def register_function(self, name, function):
         """
         Registers a python user-defined function under a unique name. Replaces already existing
@@ -765,11 +767,12 @@ class TableEnvironment(object):
         :type name: str
         :param function: The python user-defined function to register.
         :type function: pyflink.table.udf.UserDefinedFunctionWrapper
+
+        .. versionadded:: 1.10.0
         """
         self._j_tenv.registerFunction(name, function.java_user_defined_function(
             self._is_blink_planner, self.get_config()._j_table_config))
 
-    @since("1.10.0")
     def create_temporary_view(self, view_path, table):
         """
         Registers a :class:`~pyflink.table.Table` API object as a temporary view similar to SQL
@@ -785,10 +788,11 @@ class TableEnvironment(object):
         :type view_path: str
         :param table: The view to register.
         :type table: pyflink.table.Table
+
+        .. versionadded:: 1.10.0
         """
         self._j_tenv.createTemporaryView(view_path, table._j_table)
 
-    @since("1.10.0")
     def add_python_file(self, file_path):
         """
         Adds a python dependency which could be python files, python packages or
@@ -797,10 +801,11 @@ class TableEnvironment(object):
 
         :param file_path: The path of the python dependency.
         :type file_path: str
+
+        .. versionadded:: 1.10.0
         """
         self._dependency_manager.add_python_file(file_path)
 
-    @since("1.10.0")
     def set_python_requirements(self, requirements_file_path, requirements_cache_dir=None):
         """
         Specifies a requirements.txt file which defines the third-party dependencies.
@@ -834,11 +839,12 @@ class TableEnvironment(object):
         :param requirements_cache_dir: The path of the local directory which contains the
                                        installation packages.
         :type requirements_cache_dir: str
+
+        .. versionadded:: 1.10.0
         """
         self._dependency_manager.set_python_requirements(requirements_file_path,
                                                          requirements_cache_dir)
 
-    @since("1.10.0")
     def add_python_archive(self, archive_path, target_dir=None):
         """
         Adds a python archive file. The file will be extracted to the working directory of
@@ -889,6 +895,8 @@ class TableEnvironment(object):
         :type archive_path: str
         :param target_dir: Optional, the target dir name that the archive file extracted to.
         :type target_dir: str
+
+        .. versionadded:: 1.10.0
         """
         self._dependency_manager.add_python_archive(archive_path, target_dir)
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the ide static check in PyFlink*


## Brief change log

  - *Replace since decorator with versionadd*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
