### PR TITLE
[FLINK-16376][yarn] Use consistent method to get Yarn application dir…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -252,7 +252,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * Adds the given files to the list of files to ship.
 	 *
 	 * <p>Note that any file matching "<tt>flink-dist*.jar</tt>" will be excluded from the upload by
-	 * {@link #uploadAndRegisterFiles(Collection, FileSystem, Path, ApplicationId, List, Map, String, StringBuilder, int)}
+	 * {@link #uploadAndRegisterFiles(Collection, FileSystem, ApplicationId, List, Map, String, StringBuilder, int)}
 	 * since we upload the Flink uber jar ourselves and do not need to deploy it multiple times.
 	 *
 	 * @param shipFiles files to ship
@@ -406,7 +406,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			yarnClient.killApplication(applicationId);
 			Utils.deleteApplicationFiles(Collections.singletonMap(
 					YarnConfigKeys.FLINK_YARN_FILES,
-					getYarnFilesDir(applicationId).toUri().toString()));
+					Utils.getYarnFilesDir(FileSystem.get(yarnConfiguration), applicationId).toUri().toString()));
 		} catch (YarnException | IOException e) {
 			throw new FlinkException("Could not kill the Yarn Flink cluster with id " + applicationId + '.', e);
 		}
@@ -705,7 +705,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				if (!path.getFileSystem().isDistributedFS()) {
 					Path localPath = new Path(path.getPath());
 					Tuple2<Path, Long> remoteFileInfo =
-						Utils.uploadLocalFileToRemote(fs, appId.toString(), localPath, homeDir, entry.getKey(), fileReplication);
+						Utils.uploadLocalFileToRemote(fs, appId, localPath, entry.getKey(), fileReplication);
 					jobGraph.setUserArtifactRemotePath(entry.getKey(), remoteFileInfo.f0.toString());
 				}
 			}
@@ -724,7 +724,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		List<String> systemClassPaths = uploadAndRegisterFiles(
 			systemShipFiles,
 			fs,
-			homeDir,
 			appId,
 			paths,
 			localResources,
@@ -736,7 +735,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		uploadAndRegisterFiles(
 			shipOnlyFiles,
 			fs,
-			homeDir,
 			appId,
 			paths,
 			localResources,
@@ -747,7 +745,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		final List<String> userClassPaths = uploadAndRegisterFiles(
 			userJarFiles,
 			fs,
-			homeDir,
 			appId,
 			paths,
 			localResources,
@@ -782,7 +779,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				appId,
 				flinkJarPath,
 				localResources,
-				homeDir,
 				"",
 				fileReplication);
 
@@ -803,7 +799,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 				appId,
 				new Path(tmpConfigurationFile.getAbsolutePath()),
 				localResources,
-				homeDir,
 				"",
 				fileReplication);
 			envShipFileList.append(flinkConfigKey).append("=").append(remotePathConf).append(",");
@@ -841,7 +836,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 						appId,
 						new Path(tmpJobGraphFile.toURI()),
 						localResources,
-						homeDir,
 						"",
 						fileReplication);
 				paths.add(pathFromYarnURL);
@@ -856,7 +850,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			}
 		}
 
-		final Path yarnFilesDir = getYarnFilesDir(appId);
+		final Path yarnFilesDir = Utils.getYarnFilesDir(fs, appId);
 		FsPermission permission = new FsPermission(FsAction.ALL, FsAction.NONE, FsAction.NONE);
 		fs.setPermission(yarnFilesDir, permission); // set permission for path.
 
@@ -877,7 +871,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					appId,
 					yarnSitePath,
 					localResources,
-					homeDir,
 					"",
 					fileReplication);
 
@@ -892,7 +885,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 						appId,
 						krb5ConfPath,
 						localResources,
-						homeDir,
 						"",
 						fileReplication);
 				hasKrb5 = true;
@@ -910,7 +902,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 					appId,
 					new Path(keytab),
 					localResources,
-					homeDir,
 					"",
 					fileReplication);
 		}
@@ -1051,17 +1042,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	}
 
 	/**
-	 * Returns the Path where the YARN application files should be uploaded to.
-	 *
-	 * @param appId YARN application id
-	 */
-	private Path getYarnFilesDir(final ApplicationId appId) throws IOException {
-		final FileSystem fileSystem = FileSystem.get(yarnConfiguration);
-		final Path homeDir = fileSystem.getHomeDirectory();
-		return new Path(homeDir, ".flink/" + appId + '/');
-	}
-
-	/**
 	 * Uploads and registers a single resource and adds it to <tt>localResources</tt>.
 	 *
 	 * @param key
@@ -1085,14 +1065,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			ApplicationId appId,
 			Path localSrcPath,
 			Map<String, LocalResource> localResources,
-			Path targetHomeDir,
 			String relativeTargetPath,
 			int replication) throws IOException {
 		Tuple2<Path, LocalResource> resource = Utils.setupLocalResource(
 				fs,
-				appId.toString(),
+				appId,
 				localSrcPath,
-				targetHomeDir,
 				relativeTargetPath,
 				replication);
 
@@ -1119,8 +1097,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * 		files to upload
 	 * @param fs
 	 * 		file system to upload to
-	 * @param targetHomeDir
-	 * 		remote home directory to upload to
 	 * @param appId
 	 * 		application ID
 	 * @param remotePaths
@@ -1139,7 +1115,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	static List<String> uploadAndRegisterFiles(
 			Collection<File> shipFiles,
 			FileSystem fs,
-			Path targetHomeDir,
 			ApplicationId appId,
 			List<Path> remotePaths,
 			Map<String, LocalResource> localResources,
@@ -1182,7 +1157,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 						appId,
 						localPath,
 						localResources,
-						targetHomeDir,
 						relativePath.getParent().toString(),
 						replication);
 				remotePaths.add(remotePath);

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTestS3ITCase.java
@@ -159,10 +159,8 @@ public class YarnFileStageTestS3ITCase extends TestLogger {
 		assumeFalse(fs.exists(basePath));
 
 		try {
-			final Path directory = new Path(basePath, pathSuffix);
-
 			YarnFileStageTest.testCopyFromLocalRecursive(fs.getHadoopFileSystem(),
-				new org.apache.hadoop.fs.Path(directory.toUri()), Path.CUR_DIR, tempFolder, false);
+				Path.CUR_DIR, tempFolder, false);
 		} finally {
 			// clean up
 			fs.delete(basePath, true);


### PR DESCRIPTION
…ectory.

## What is the purpose of the change

Currently, the Yarn application directory of Flink is "/user/{user.name}/.flink", but this logic is separated in different places. This PR aims to improve this.

## Brief change log

  - Move `getYarnFilesDir` method from `YarnClusterDescriptor` to `Utils`.
  - Use `getYarnFilesDir` to get target directory of shipped files.

## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.yarn.YarnFileStageTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (*yes, Yarn deployment*)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
