### PR TITLE
[FLINK-16437][runtime] Make SlotManager allocate resource from ResourceManager at the worker granularity.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.util.MathUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -100,8 +101,10 @@ public final class PerJobMiniClusterFactory {
 			ConfigConstants.LOCAL_NUMBER_TASK_MANAGER,
 			ConfigConstants.DEFAULT_LOCAL_NUMBER_TASK_MANAGER);
 
-		// we have to use the maximum parallelism as a default here, otherwise streaming pipelines would not run
-		int numSlotsPerTaskManager = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS, maximumParallelism);
+		int numSlotsPerTaskManager = configuration.getOptional(TaskManagerOptions.NUM_TASK_SLOTS)
+			.orElseGet(() -> maximumParallelism > 0 ?
+				MathUtils.divideRoundUp(maximumParallelism, numTaskManagers) :
+				TaskManagerOptions.NUM_TASK_SLOTS.defaultValue());
 
 		return new MiniClusterConfiguration.Builder()
 			.setConfiguration(configuration)

--- a/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/MathUtils.java
@@ -207,6 +207,17 @@ public final class MathUtils {
 		return in ^ Long.MIN_VALUE;
 	}
 
+	/**
+	 * Divide and rounding up to integer.
+	 * E.g., divideRoundUp(3, 2) returns 2.
+	 * @param dividend value to be divided by the divisor
+	 * @param divisor value by which the dividend is to be divided
+	 * @return the quotient rounding up to integer
+	 */
+	public static int divideRoundUp(int dividend, int divisor) {
+		return (dividend - 1) / divisor + 1;
+	}
+
 	// ============================================================================================
 
 	/**

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -33,7 +33,6 @@ import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -42,10 +41,12 @@ import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManager;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +56,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -163,8 +165,11 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 	}
 
 	@Override
-	public boolean startNewWorker(ResourceProfile resourceProfile) {
-		LOG.info("Starting new worker with resource profile, {}", resourceProfile);
+	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
+		Preconditions.checkArgument(Objects.equals(
+			workerResourceSpec,
+			WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec)));
+		LOG.info("Starting new worker with worker resource spec, {}", workerResourceSpec);
 		requestKubernetesPod();
 		return true;
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -123,8 +123,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 
 		this.kubeClient = kubeClient;
 
-		this.taskManagerParameters =
-			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec, numSlotsPerTaskManager);
+		this.taskManagerParameters = ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 		this.configuration = configuration;
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -52,8 +52,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -166,13 +164,10 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 	}
 
 	@Override
-	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
+	public boolean startNewWorker(ResourceProfile resourceProfile) {
 		LOG.info("Starting new worker with resource profile, {}", resourceProfile);
-		if (!resourceProfilesPerWorker.iterator().next().isMatching(resourceProfile)) {
-			return Collections.emptyList();
-		}
 		requestKubernetesPod();
-		return resourceProfilesPerWorker;
+		return true;
 	}
 
 	@Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -286,10 +286,9 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 	 * Request new pod if pending pods cannot satisfy pending slot requests.
 	 */
 	private void requestKubernetesPodIfRequired() {
-		final int requiredTaskManagerSlots = getNumberRequiredTaskManagerSlots();
-		final int pendingTaskManagerSlots = numPendingPodRequests * numSlotsPerTaskManager;
+		final int requiredTaskManagers = getNumberRequiredTaskManagers();
 
-		if (requiredTaskManagerSlots > pendingTaskManagerSlots) {
+		while (requiredTaskManagers > numPendingPodRequests) {
 			requestKubernetesPod();
 		}
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -68,7 +68,8 @@ public class KubernetesResourceManagerFactory extends ActiveResourceManagerFacto
 			@Nullable String webInterfaceUrl,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
 		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration =
-			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(
+				configuration, KubernetesWorkerResourceSpecFactory.INSTANCE);
 		final ResourceManagerRuntimeServices rmRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			rmServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpecFactory;
+
+/**
+ * Implementation of {@link WorkerResourceSpecFactory} for Kubernetes deployments.
+ */
+public class KubernetesWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
+
+	public static final KubernetesWorkerResourceSpecFactory INSTANCE = new KubernetesWorkerResourceSpecFactory();
+
+	private KubernetesWorkerResourceSpecFactory() {}
+
+	@Override
+	public WorkerResourceSpec createDefaultWorkerResourceSpec(Configuration configuration) {
+		return workerResourceSpecFromConfigAndCpu(configuration, getDefaultCpus(configuration));
+	}
+
+	private static CPUResource getDefaultCpus(Configuration configuration) {
+		double fallback = configuration.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU);
+		return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback);
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -88,8 +88,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 		this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_NODE_SELECTOR, nodeSelector);
 
 		taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(flinkConfig);
-		containeredTaskManagerParameters = ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec,
-				flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS));
+		containeredTaskManagerParameters = ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 		kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(
 				flinkConfig,
 				POD_NAME,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -74,8 +74,7 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
 		final TaskExecutorProcessSpec taskExecutorProcessSpec =
 			TaskExecutorProcessUtils.processSpecFromConfig(flinkConfig);
 		final ContaineredTaskManagerParameters containeredTaskManagerParameters =
-			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec,
-				flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS));
+			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 
 		this.kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(flinkConfig,
 			POD_NAME,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
@@ -72,7 +72,8 @@ public class MesosResourceManagerFactory extends ActiveResourceManagerFactory<Re
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration =
+			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, MesosWorkerResourceSpecFactory.INSTANCE);
 		final ResourceManagerRuntimeServices rmRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			rmServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -21,7 +21,6 @@ package org.apache.flink.mesos.runtime.clusterframework;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
@@ -52,9 +51,6 @@ public class MesosTaskManagerParameters {
 
 	/** Pattern replaced in the {@link #MESOS_TM_HOSTNAME} by the actual task id of the Mesos task. */
 	public static final Pattern TASK_ID_PATTERN = Pattern.compile("_TASK_", Pattern.LITERAL);
-
-	public static final ConfigOption<Integer> MESOS_RM_TASKS_SLOTS =
-		TaskManagerOptions.NUM_TASK_SLOTS;
 
 	public static final ConfigOption<Integer> MESOS_RM_TASKS_DISK_MB =
 		key("mesos.resourcemanager.tasks.disk")
@@ -406,8 +402,7 @@ public class MesosTaskManagerParameters {
 
 		return ContaineredTaskManagerParameters.create(
 			flinkConfig,
-			taskExecutorProcessSpec,
-			flinkConfig.getInteger(MESOS_RM_TASKS_SLOTS));
+			taskExecutorProcessSpec);
 	}
 
 	private static double getCpuCores(final Configuration configuration) {

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosWorkerResourceSpecFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosWorkerResourceSpecFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.mesos.runtime.clusterframework;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpecFactory;
+
+/**
+ * Implementation of {@link WorkerResourceSpecFactory} for Mesos deployments.
+ */
+public class MesosWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
+
+	public static final MesosWorkerResourceSpecFactory INSTANCE = new MesosWorkerResourceSpecFactory();
+
+	private MesosWorkerResourceSpecFactory() {}
+
+	@Override
+	public WorkerResourceSpec createDefaultWorkerResourceSpec(Configuration configuration) {
+		return workerResourceSpecFromConfigAndCpu(configuration, getDefaultCpus(configuration));
+	}
+
+	private static CPUResource getDefaultCpus(Configuration configuration) {
+		double fallback = configuration.getDouble(MesosTaskManagerParameters.MESOS_RM_TASKS_CPUS);
+		return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback);
+	}
+}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/MesosWorkerStore.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/store/MesosWorkerStore.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.mesos.runtime.clusterframework.store;
 
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import org.apache.mesos.Protos;
 
@@ -95,7 +95,7 @@ public interface MesosWorkerStore {
 
 		private final Protos.TaskID taskID;
 
-		private final ResourceProfile profile;
+		private final WorkerResourceSpec workerResourceSpec;
 
 		private final Option<Protos.SlaveID> slaveID;
 
@@ -103,10 +103,10 @@ public interface MesosWorkerStore {
 
 		private final WorkerState state;
 
-		private Worker(Protos.TaskID taskID, ResourceProfile profile,
+		private Worker(Protos.TaskID taskID, WorkerResourceSpec workerResourceSpec,
 				Option<Protos.SlaveID> slaveID, Option<String> hostname, WorkerState state) {
 			this.taskID = requireNonNull(taskID, "taskID");
-			this.profile = requireNonNull(profile, "profile");
+			this.workerResourceSpec = requireNonNull(workerResourceSpec, "workerResourceSpec");
 			this.slaveID = requireNonNull(slaveID, "slaveID");
 			this.hostname = requireNonNull(hostname, "hostname");
 			this.state = requireNonNull(state, "state");
@@ -120,11 +120,11 @@ public interface MesosWorkerStore {
 		}
 
 		/**
-		 * Get the resource profile associated with the worker.
+		 * Get the worker request associated with the worker.
 		 * @return
 		 */
-		public ResourceProfile profile() {
-			return profile;
+		public WorkerResourceSpec workerResourceSpec() {
+			return workerResourceSpec;
 		}
 
 		/**
@@ -154,22 +154,10 @@ public interface MesosWorkerStore {
 		 * Create a new worker with the given taskID.
 		 * @return a new worker instance.
 		 */
-		public static Worker newWorker(Protos.TaskID taskID) {
+		public static Worker newWorker(Protos.TaskID taskID, WorkerResourceSpec workerResourceSpec) {
 			return new Worker(
 				taskID,
-				ResourceProfile.UNKNOWN,
-				Option.<Protos.SlaveID>empty(), Option.<String>empty(),
-				WorkerState.New);
-		}
-
-		/**
-		 * Create a new worker with the given taskID.
-		 * @return a new worker instance.
-		 */
-		public static Worker newWorker(Protos.TaskID taskID, ResourceProfile profile) {
-			return new Worker(
-				taskID,
-				profile,
+				workerResourceSpec,
 				Option.<Protos.SlaveID>empty(), Option.<String>empty(),
 				WorkerState.New);
 		}
@@ -179,7 +167,7 @@ public interface MesosWorkerStore {
 		 * @return a new worker instance (does not mutate the current instance).
 		 */
 		public Worker launchWorker(Protos.SlaveID slaveID, String hostname) {
-			return new Worker(taskID, profile, Option.apply(slaveID), Option.apply(hostname), WorkerState.Launched);
+			return new Worker(taskID, workerResourceSpec, Option.apply(slaveID), Option.apply(hostname), WorkerState.Launched);
 		}
 
 		/**
@@ -187,7 +175,7 @@ public interface MesosWorkerStore {
 		 * @return a new worker instance (does not mutate the current instance).
 		 */
 		public Worker releaseWorker() {
-			return new Worker(taskID, profile, slaveID, hostname, WorkerState.Released);
+			return new Worker(taskID, workerResourceSpec, slaveID, hostname, WorkerState.Released);
 		}
 
 		@Override
@@ -202,13 +190,13 @@ public interface MesosWorkerStore {
 			return Objects.equals(taskID, worker.taskID) &&
 				Objects.equals(slaveID, worker.slaveID) &&
 				Objects.equals(hostname, worker.hostname) &&
-				Objects.equals(profile, worker.profile) &&
+				Objects.equals(workerResourceSpec, worker.workerResourceSpec) &&
 				state == worker.state;
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(taskID, slaveID, hostname, state, profile);
+			return Objects.hash(taskID, slaveID, hostname, state, workerResourceSpec);
 		}
 
 		@Override
@@ -218,7 +206,7 @@ public interface MesosWorkerStore {
 				", slaveID=" + slaveID +
 				", hostname=" + hostname +
 				", state=" + state +
-				", profile=" + profile +
+				", workerRequest=" + workerResourceSpec +
 				'}';
 		}
 	}

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/util/MesosUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.mesos.util;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.mesos.configuration.MesosOptions;
 import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.mesos.runtime.clusterframework.MesosTaskManagerParameters;
@@ -110,7 +111,7 @@ public class MesosUtils {
 		final TaskExecutorProcessSpec taskExecutorProcessSpec = taskManagerParameters.containeredParameters().getTaskExecutorProcessSpec();
 
 		log.info("TaskManagers will be created with {} task slots",
-			taskManagerParameters.containeredParameters().numSlots());
+			configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS));
 		log.info("TaskManagers will be started with container size {} MB, JVM heap size {} MB, " +
 				"JVM direct memory limit {} MB, {} cpus, {} gpus, disk space {} MB",
 			taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes(),

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceActions;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -131,7 +132,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 	private static final Logger LOG = LoggerFactory.getLogger(MesosResourceManagerTest.class);
 
-	private static Configuration flinkConfig = new Configuration();
+	private static final Configuration flinkConfig = new Configuration();
 
 	private static ActorSystem system;
 
@@ -244,9 +245,7 @@ public class MesosResourceManagerTest extends TestLogger {
 		ResourceID rmResourceID;
 		static final String RM_ADDRESS = "resourceManager";
 		TestingMesosResourceManager resourceManager;
-
-		// domain objects for test purposes
-		final ResourceProfile resourceProfile1 = ResourceProfile.UNKNOWN;
+		WorkerResourceSpec workerResourceSpec;
 
 		Protos.FrameworkID framework1 = Protos.FrameworkID.newBuilder().setValue("framework1").build();
 		public Protos.SlaveID slave1 = Protos.SlaveID.newBuilder().setValue("slave1").build();
@@ -310,6 +309,7 @@ public class MesosResourceManagerTest extends TestLogger {
 					tmParams,
 					containerSpecification,
 					UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup());
+			workerResourceSpec = WorkerResourceSpec.fromTaskExecutorProcessSpec(spec);
 
 			// TaskExecutors
 			task1Executor = mockTaskExecutor(task1);
@@ -476,17 +476,17 @@ public class MesosResourceManagerTest extends TestLogger {
 		/**
 		 * Allocate a worker using the RM.
 		 */
-		public MesosWorkerStore.Worker allocateWorker(Protos.TaskID taskID, ResourceProfile resourceProfile) throws Exception {
+		public MesosWorkerStore.Worker allocateWorker(Protos.TaskID taskID, WorkerResourceSpec workerResourceSpec) throws Exception {
 			when(rmServices.workerStore.newTaskID()).thenReturn(taskID);
 			rmServices.slotManagerStarted.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 
 			CompletableFuture<Void> allocateResourceFuture = resourceManager.callAsync(
 				() -> {
-					rmServices.rmActions.allocateResource(resourceProfile);
+					rmServices.rmActions.allocateResource(workerResourceSpec);
 					return null;
 				},
 				timeout);
-			MesosWorkerStore.Worker expected = MesosWorkerStore.Worker.newWorker(taskID, resourceProfile);
+			MesosWorkerStore.Worker expected = MesosWorkerStore.Worker.newWorker(taskID, workerResourceSpec);
 
 			// check for exceptions
 			allocateResourceFuture.get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
@@ -531,9 +531,9 @@ public class MesosResourceManagerTest extends TestLogger {
 	public void testRecoverWorkers() throws Exception {
 		new Context() {{
 			// set the initial persistent state then initialize the RM
-			MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1);
-			MesosWorkerStore.Worker worker2 = MesosWorkerStore.Worker.newWorker(task2).launchWorker(slave1, slave1host);
-			MesosWorkerStore.Worker worker3 = MesosWorkerStore.Worker.newWorker(task3).launchWorker(slave1, slave1host).releaseWorker();
+			MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec);
+			MesosWorkerStore.Worker worker2 = MesosWorkerStore.Worker.newWorker(task2, workerResourceSpec).launchWorker(slave1, slave1host);
+			MesosWorkerStore.Worker worker3 = MesosWorkerStore.Worker.newWorker(task3, workerResourceSpec).launchWorker(slave1, slave1host).releaseWorker();
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(Arrays.asList(worker1, worker2, worker3));
 			startResourceManager();
@@ -568,7 +568,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 			CompletableFuture<Void> allocateResourceFuture = resourceManager.callAsync(
 				() -> {
-					rmServices.rmActions.allocateResource(resourceProfile1);
+					rmServices.rmActions.allocateResource(workerResourceSpec);
 					return null;
 				},
 				timeout);
@@ -578,7 +578,7 @@ public class MesosResourceManagerTest extends TestLogger {
 
 			// verify that a new worker was persisted, the internal state was updated, the task router was notified,
 			// and the launch coordinator was asked to launch a task
-			MesosWorkerStore.Worker expected = MesosWorkerStore.Worker.newWorker(task1, resourceProfile1);
+			MesosWorkerStore.Worker expected = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec);
 			verify(rmServices.workerStore, Mockito.timeout(timeout.toMilliseconds())).putWorker(expected);
 			assertThat(resourceManager.workersInNew, hasEntry(extractResourceID(task1), expected));
 			resourceManager.taskRouter.expectMsgClass(TaskMonitor.TaskGoalStateUpdated.class);
@@ -611,7 +611,7 @@ public class MesosResourceManagerTest extends TestLogger {
 			startResourceManager();
 
 			// allocate a new worker
-			MesosWorkerStore.Worker worker1 = allocateWorker(task1, resourceProfile1);
+			MesosWorkerStore.Worker worker1 = allocateWorker(task1, workerResourceSpec);
 
 			// send an AcceptOffers message as the LaunchCoordinator would
 			// to launch task1 onto slave1 with offer1
@@ -656,7 +656,7 @@ public class MesosResourceManagerTest extends TestLogger {
 	public void testWorkerStarted() throws Exception {
 		new Context() {{
 			// set the initial state with a (recovered) launched worker
-			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
+			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec).launchWorker(slave1, slave1host);
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(singletonList(worker1launched));
 			startResourceManager();
@@ -695,7 +695,7 @@ public class MesosResourceManagerTest extends TestLogger {
 	public void testWorkerFailed() throws Exception {
 		new Context() {{
 			// set the initial persistent state with a launched worker
-			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
+			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec).launchWorker(slave1, slave1host);
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(singletonList(worker1launched));
 			when(rmServices.workerStore.newTaskID()).thenReturn(task2);
@@ -724,7 +724,7 @@ public class MesosResourceManagerTest extends TestLogger {
 	public void testStopWorker() throws Exception {
 		new Context() {{
 			// set the initial persistent state with a launched worker
-			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1).launchWorker(slave1, slave1host);
+			MesosWorkerStore.Worker worker1launched = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec).launchWorker(slave1, slave1host);
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(singletonList(worker1launched));
 			startResourceManager();
@@ -826,9 +826,9 @@ public class MesosResourceManagerTest extends TestLogger {
 	@Test
 	public void testClearStateAfterRevokeLeadership() throws Exception {
 		new Context() {{
-			final MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1);
-			final MesosWorkerStore.Worker worker2 = MesosWorkerStore.Worker.newWorker(task2).launchWorker(slave1, slave1host);
-			final MesosWorkerStore.Worker worker3 = MesosWorkerStore.Worker.newWorker(task3).launchWorker(slave1, slave1host).releaseWorker();
+			final MesosWorkerStore.Worker worker1 = MesosWorkerStore.Worker.newWorker(task1, workerResourceSpec);
+			final MesosWorkerStore.Worker worker2 = MesosWorkerStore.Worker.newWorker(task2, workerResourceSpec).launchWorker(slave1, slave1host);
+			final MesosWorkerStore.Worker worker3 = MesosWorkerStore.Worker.newWorker(task3, workerResourceSpec).launchWorker(slave1, slave1host).releaseWorker();
 			when(rmServices.workerStore.getFrameworkID()).thenReturn(Option.apply(framework1));
 			when(rmServices.workerStore.recoverWorkers()).thenReturn(Arrays.asList(worker1, worker2, worker3)).thenReturn(Collections.emptyList());
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -284,7 +284,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				.withTotalProcessMemory(totalProcessMemory)
 				.build();
 			ContaineredTaskManagerParameters containeredParams =
-				new ContaineredTaskManagerParameters(spec, 4, new HashMap<String, String>());
+				new ContaineredTaskManagerParameters(spec, new HashMap<String, String>());
 			MesosTaskManagerParameters tmParams = new MesosTaskManagerParameters(
 				1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/ContaineredTaskManagerParameters.java
@@ -31,9 +31,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 	private static final long serialVersionUID = -3096987654278064670L;
 
-	/** The number of slots per TaskManager. */
-	private final int numSlots;
-
 	/** Environment variables to add to the Java process. */
 	private final HashMap<String, String> taskManagerEnv;
 
@@ -41,11 +38,9 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 	public ContaineredTaskManagerParameters(
 			TaskExecutorProcessSpec taskExecutorProcessSpec,
-			int numSlots,
 			HashMap<String, String> taskManagerEnv) {
 
 		this.taskExecutorProcessSpec = taskExecutorProcessSpec;
-		this.numSlots = numSlots;
 		this.taskManagerEnv = taskManagerEnv;
 	}
 
@@ -53,10 +48,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 
 	public TaskExecutorProcessSpec getTaskExecutorProcessSpec() {
 		return taskExecutorProcessSpec;
-	}
-
-	public int numSlots() {
-		return numSlots;
 	}
 
 	public Map<String, String> taskManagerEnv() {
@@ -70,7 +61,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	public String toString() {
 		return "TaskManagerParameters {" +
 			"taskExecutorProcessSpec=" + taskExecutorProcessSpec +
-			", numSlots=" + numSlots +
 			", taskManagerEnv=" + taskManagerEnv +
 			'}';
 	}
@@ -84,13 +74,11 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 	 *
 	 * @param config The Flink configuration.
 	 * @param taskExecutorProcessSpec The resource specifics of the task executor.
-	 * @param numSlots Number of slots of the task executor.
 	 * @return The parameters to start the TaskManager processes with.
 	 */
 	public static ContaineredTaskManagerParameters create(
 			Configuration config,
-			TaskExecutorProcessSpec taskExecutorProcessSpec,
-			int numSlots) {
+			TaskExecutorProcessSpec taskExecutorProcessSpec) {
 
 		// obtain the additional environment variables from the configuration
 		final HashMap<String, String> envVars = new HashMap<>();
@@ -105,7 +93,6 @@ public class ContaineredTaskManagerParameters implements java.io.Serializable {
 		}
 
 		// done
-		return new ContaineredTaskManagerParameters(
-			taskExecutorProcessSpec, numSlots, envVars);
+		return new ContaineredTaskManagerParameters(taskExecutorProcessSpec, envVars);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessSpec.java
@@ -125,15 +125,15 @@ public class TaskExecutorProcessSpec extends CommonProcessMemorySpec<TaskExecuto
 		return getFlinkMemory().getFrameworkOffHeap();
 	}
 
-	MemorySize getTaskHeapSize() {
+	public MemorySize getTaskHeapSize() {
 		return getFlinkMemory().getTaskHeap();
 	}
 
-	MemorySize getTaskOffHeapSize() {
+	public MemorySize getTaskOffHeapSize() {
 		return getFlinkMemory().getTaskOffHeap();
 	}
 
-	MemorySize getNetworkMemSize() {
+	public MemorySize getNetworkMemSize() {
 		return getFlinkMemory().getNetwork();
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.util.config.memory.CommonProcessMemorySpec;
 import org.apache.flink.runtime.util.config.memory.JvmMetaspaceAndOverhead;
@@ -37,9 +36,7 @@ import org.apache.flink.runtime.util.config.memory.taskmanager.TaskExecutorFlink
 import org.apache.flink.runtime.util.config.memory.taskmanager.TaskExecutorFlinkMemoryUtils;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -98,30 +95,6 @@ public class TaskExecutorProcessUtils {
 			sb.append("-D ").append(entry.getKey()).append("=").append(entry.getValue()).append(" ");
 		}
 		return sb.toString();
-	}
-
-	// ------------------------------------------------------------------------
-	//  Generating Slot Resource Profiles
-	// ------------------------------------------------------------------------
-
-	public static List<ResourceProfile> createDefaultWorkerSlotProfiles(
-			TaskExecutorProcessSpec taskExecutorProcessSpec,
-			int numberOfSlots) {
-		final ResourceProfile resourceProfile =
-			generateDefaultSlotResourceProfile(taskExecutorProcessSpec, numberOfSlots);
-		return Collections.nCopies(numberOfSlots, resourceProfile);
-	}
-
-	public static ResourceProfile generateDefaultSlotResourceProfile(
-			TaskExecutorProcessSpec taskExecutorProcessSpec,
-			int numberOfSlots) {
-		return ResourceProfile.newBuilder()
-			.setCpuCores(taskExecutorProcessSpec.getCpuCores().divide(numberOfSlots))
-			.setTaskHeapMemory(taskExecutorProcessSpec.getTaskHeapSize().divide(numberOfSlots))
-			.setTaskOffHeapMemory(taskExecutorProcessSpec.getTaskOffHeapSize().divide(numberOfSlots))
-			.setManagedMemory(taskExecutorProcessSpec.getManagedMemorySize().divide(numberOfSlots))
-			.setNetworkMemory(taskExecutorProcessSpec.getNetworkMemSize().divide(numberOfSlots))
-			.build();
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -39,7 +38,6 @@ import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nullable;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,8 +55,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	protected final TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	protected final int defaultMemoryMB;
-
-	protected final Collection<ResourceProfile> resourceProfilesPerWorker;
 
 	/**
 	 * The updated Flink configuration. The client uploaded configuration may be updated before passed on to
@@ -107,9 +103,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 			.withCpuCores(defaultCpus)
 			.build();
 		this.defaultMemoryMB = taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
-
-		this.resourceProfilesPerWorker = TaskExecutorProcessUtils
-			.createDefaultWorkerSlotProfiles(taskExecutorProcessSpec, numSlotsPerTaskManager);
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -50,8 +50,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	/** The process environment variables. */
 	protected final Map<String, String> env;
 
-	protected final int numSlotsPerTaskManager;
-
 	protected final TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	protected final int defaultMemoryMB;
@@ -96,7 +94,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 		this.flinkConfig = flinkConfig;
 		this.env = env;
 
-		this.numSlotsPerTaskManager = flinkConfig.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 		double defaultCpus = getCpuCores(flinkConfig);
 		this.taskExecutorProcessSpec = TaskExecutorProcessUtils
 			.newProcessSpecBuilder(flinkConfig)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -66,7 +66,7 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 			resourceManagerMetricGroup);
 	}
 
-	public static Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
+	private static Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
 		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			originalConfiguration, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ArbitraryWorkerResourceSpecFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ArbitraryWorkerResourceSpecFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Implementation of {@link WorkerResourceSpecFactory} that creates arbitrary {@link WorkerResourceSpec}.
+ * Used for scenarios where the values in the default {@link WorkerResourceSpec} does not matter.
+ */
+public class ArbitraryWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
+
+	public static final ArbitraryWorkerResourceSpecFactory INSTANCE = new ArbitraryWorkerResourceSpecFactory();
+
+	private ArbitraryWorkerResourceSpecFactory() {}
+
+	@Override
+	public WorkerResourceSpec createDefaultWorkerResourceSpec(Configuration configuration) {
+		return WorkerResourceSpec.ZERO;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1236,8 +1236,12 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	//  Resource Management
 	// ------------------------------------------------------------------------
 
-	protected int getNumberRequiredTaskManagerSlots() {
-		return slotManager.getNumberPendingTaskManagerSlots();
+	protected int getNumberRequiredTaskManagers() {
+		return getRequiredResources().values().stream().reduce(0, Integer::sum);
+	}
+
+	protected Map<WorkerResourceSpec, Integer> getRequiredResources() {
+		return slotManager.getRequiredResources();
 	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -1080,13 +1079,13 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		@Nullable String optionalDiagnostics) throws ResourceManagerException;
 
 	/**
-	 * Allocates a resource using the resource profile.
+	 * Allocates a resource using the worker resource specification.
 	 *
-	 * @param resourceProfile The resource description
+	 * @param workerResourceSpec workerResourceSpec specifies the size of the to be allocated resource
 	 * @return whether the resource can be allocated
 	 */
 	@VisibleForTesting
-	public abstract boolean startNewWorker(ResourceProfile resourceProfile);
+	public abstract boolean startNewWorker(WorkerResourceSpec workerResourceSpec);
 
 	/**
 	 * Callback when a worker was started.
@@ -1124,9 +1123,9 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public boolean allocateResource(ResourceProfile resourceProfile) {
+		public boolean allocateResource(WorkerResourceSpec workerResourceSpec) {
 			validateRunsInMainThread();
-			return startNewWorker(resourceProfile);
+			return startNewWorker(workerResourceSpec);
 		}
 
 		@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1083,10 +1083,10 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	 * Allocates a resource using the resource profile.
 	 *
 	 * @param resourceProfile The resource description
-	 * @return Collection of {@link ResourceProfile} describing the launched slots
+	 * @return whether the resource can be allocated
 	 */
 	@VisibleForTesting
-	public abstract Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile);
+	public abstract boolean startNewWorker(ResourceProfile resourceProfile);
 
 	/**
 	 * Callback when a worker was started.
@@ -1124,7 +1124,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 
 		@Override
-		public Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile) {
+		public boolean allocateResource(ResourceProfile resourceProfile) {
 			validateRunsInMainThread();
 			return startNewWorker(resourceProfile);
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -20,12 +20,8 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.resourcemanager.slotmanager.AnyMatchingSlotMatchingStrategy;
-import org.apache.flink.runtime.resourcemanager.slotmanager.LeastUtilizationSlotMatchingStrategy;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
-import org.apache.flink.runtime.resourcemanager.slotmanager.SlotMatchingStrategy;
 import org.apache.flink.util.Preconditions;
 
 /**
@@ -67,22 +63,6 @@ public class ResourceManagerRuntimeServices {
 	}
 
 	private static SlotManager createSlotManager(ResourceManagerRuntimeServicesConfiguration configuration, ScheduledExecutor scheduledExecutor) {
-		final SlotManagerConfiguration slotManagerConfiguration = configuration.getSlotManagerConfiguration();
-
-		final SlotMatchingStrategy slotMatchingStrategy;
-
-		if (slotManagerConfiguration.evenlySpreadOutSlots()) {
-			slotMatchingStrategy = LeastUtilizationSlotMatchingStrategy.INSTANCE;
-		} else {
-			slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
-		}
-
-		return new SlotManagerImpl(
-			slotMatchingStrategy,
-			scheduledExecutor,
-			slotManagerConfiguration.getTaskManagerRequestTimeout(),
-			slotManagerConfiguration.getSlotRequestTimeout(),
-			slotManagerConfiguration.getTaskManagerTimeout(),
-			slotManagerConfiguration.isWaitResultConsumedBeforeRelease());
+		return new SlotManagerImpl(scheduledExecutor, configuration.getSlotManagerConfiguration());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServicesConfiguration.java
@@ -50,7 +50,9 @@ public class ResourceManagerRuntimeServicesConfiguration {
 
 	// ---------------------------- Static methods ----------------------------------
 
-	public static ResourceManagerRuntimeServicesConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
+	public static ResourceManagerRuntimeServicesConfiguration fromConfiguration(
+			Configuration configuration,
+			WorkerResourceSpecFactory defaultWorkerResourceSpecFactory) throws ConfigurationException {
 
 		final String strJobTimeout = configuration.getString(ResourceManagerOptions.JOB_TIMEOUT);
 		final Time jobTimeout;
@@ -62,7 +64,9 @@ public class ResourceManagerRuntimeServicesConfiguration {
 				"value " + ResourceManagerOptions.JOB_TIMEOUT + '.', e);
 		}
 
-		final SlotManagerConfiguration slotManagerConfiguration = SlotManagerConfiguration.fromConfiguration(configuration);
+		final WorkerResourceSpec defaultWorkerResourceSpec = defaultWorkerResourceSpecFactory.createDefaultWorkerResourceSpec(configuration);
+		final SlotManagerConfiguration slotManagerConfiguration =
+			SlotManagerConfiguration.fromConfiguration(configuration, defaultWorkerResourceSpec);
 
 		return new ResourceManagerRuntimeServicesConfiguration(jobTimeout, slotManagerConfiguration);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -88,7 +87,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 	}
 
 	@Override
-	public boolean startNewWorker(ResourceProfile resourceProfile) {
+	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
 		return false;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -35,8 +35,6 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -90,8 +88,8 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 	}
 
 	@Override
-	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
-		return Collections.emptyList();
+	public boolean startNewWorker(ResourceProfile resourceProfile) {
+		return false;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -50,7 +50,8 @@ public enum StandaloneResourceManagerFactory implements ResourceManagerFactory<R
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration =
+			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, ArbitraryWorkerResourceSpecFactory.INSTANCE);
 		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpec.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Objects;
+
+/**
+ * Resource specification of a worker, mainly used by SlotManager requesting from ResourceManager.
+ */
+public class WorkerResourceSpec {
+
+	public static final WorkerResourceSpec ZERO = new Builder().build();
+
+	private final CPUResource cpuCores;
+
+	private final MemorySize taskHeapSize;
+
+	private final MemorySize taskOffHeapSize;
+
+	private final MemorySize networkMemSize;
+
+	private final MemorySize managedMemSize;
+
+	private WorkerResourceSpec(
+		CPUResource cpuCores,
+		MemorySize taskHeapSize,
+		MemorySize taskOffHeapSize,
+		MemorySize networkMemSize,
+		MemorySize managedMemSize) {
+
+		this.cpuCores = Preconditions.checkNotNull(cpuCores);
+		this.taskHeapSize = Preconditions.checkNotNull(taskHeapSize);
+		this.taskOffHeapSize = Preconditions.checkNotNull(taskOffHeapSize);
+		this.networkMemSize = Preconditions.checkNotNull(networkMemSize);
+		this.managedMemSize = Preconditions.checkNotNull(managedMemSize);
+	}
+
+	public static WorkerResourceSpec fromTaskExecutorProcessSpec(final TaskExecutorProcessSpec taskExecutorProcessSpec) {
+		Preconditions.checkNotNull(taskExecutorProcessSpec);
+		return new WorkerResourceSpec(
+			taskExecutorProcessSpec.getCpuCores(),
+			taskExecutorProcessSpec.getTaskHeapSize(),
+			taskExecutorProcessSpec.getTaskOffHeapSize(),
+			taskExecutorProcessSpec.getNetworkMemSize(),
+			taskExecutorProcessSpec.getManagedMemorySize());
+	}
+
+	public CPUResource getCpuCores() {
+		return cpuCores;
+	}
+
+	public MemorySize getTaskHeapSize() {
+		return taskHeapSize;
+	}
+
+	public MemorySize getTaskOffHeapSize() {
+		return taskOffHeapSize;
+	}
+
+	public MemorySize getNetworkMemSize() {
+		return networkMemSize;
+	}
+
+	public MemorySize getManagedMemSize() {
+		return managedMemSize;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(cpuCores, taskHeapSize, taskOffHeapSize, networkMemSize, managedMemSize);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		} else if (obj != null && obj.getClass() == WorkerResourceSpec.class) {
+			WorkerResourceSpec that = (WorkerResourceSpec) obj;
+			return Objects.equals(this.cpuCores, that.cpuCores) &&
+				Objects.equals(this.taskHeapSize, that.taskHeapSize) &&
+				Objects.equals(this.taskOffHeapSize, that.taskOffHeapSize) &&
+				Objects.equals(this.networkMemSize, that.networkMemSize) &&
+				Objects.equals(this.managedMemSize, that.managedMemSize);
+		}
+		return false;
+	}
+
+	@Override
+	public String toString() {
+		return "WorkerResourceSpec {"
+			+ "cpuCores=" + cpuCores.getValue().doubleValue()
+			+ ", taskHeapSize=" + taskHeapSize.toHumanReadableString()
+			+ ", taskOffHeapSize=" + taskOffHeapSize.toHumanReadableString()
+			+ ", networkMemSize=" + networkMemSize.toHumanReadableString()
+			+ ", managedMemSize=" + managedMemSize.toHumanReadableString()
+			+ "}";
+	}
+
+	/**
+	 * Builder for {@link WorkerResourceSpec}.
+	 */
+	public static class Builder {
+		private CPUResource cpuCores = new CPUResource(0.0);
+		private MemorySize taskHeapSize = MemorySize.ZERO;
+		private MemorySize taskOffHeapSize = MemorySize.ZERO;
+		private MemorySize networkMemSize = MemorySize.ZERO;
+		private MemorySize managedMemSize = MemorySize.ZERO;
+
+		public Builder() {}
+
+		public Builder setCpuCores(double cpuCores) {
+			this.cpuCores = new CPUResource(cpuCores);
+			return this;
+		}
+
+		public Builder setTaskHeapMemoryMB(int taskHeapMemoryMB) {
+			this.taskHeapSize = MemorySize.ofMebiBytes(taskHeapMemoryMB);
+			return this;
+		}
+
+		public Builder setTaskOffHeapMemoryMB(int taskOffHeapMemoryMB) {
+			this.taskOffHeapSize = MemorySize.ofMebiBytes(taskOffHeapMemoryMB);
+			return this;
+		}
+
+		public Builder setNetworkMemoryMB(int networkMemoryMB) {
+			this.networkMemSize = MemorySize.ofMebiBytes(networkMemoryMB);
+			return this;
+		}
+
+		public Builder setManagedMemoryMB(int managedMemoryMB) {
+			this.managedMemSize = MemorySize.ofMebiBytes(managedMemoryMB);
+			return this;
+		}
+
+		public WorkerResourceSpec build() {
+			return new WorkerResourceSpec(
+				cpuCores,
+				taskHeapSize,
+				taskOffHeapSize,
+				networkMemSize,
+				managedMemSize);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+
+/**
+ * Factory for creating deployment specific default {@link WorkerResourceSpec}.
+ */
+public abstract class WorkerResourceSpecFactory {
+
+	public abstract WorkerResourceSpec createDefaultWorkerResourceSpec(Configuration configuration);
+
+	protected WorkerResourceSpec workerResourceSpecFromConfigAndCpu(Configuration configuration, CPUResource cpuResource) {
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils
+			.newProcessSpecBuilder(configuration)
+			.withCpuCores(cpuResource)
+			.build();
+		return WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 
 import java.util.Collection;
 
@@ -44,9 +43,8 @@ public interface ResourceActions {
 	 *
 	 * @param resourceProfile for the to be allocated resource
 	 * @return Collection of {@link ResourceProfile} describing the allocated slots
-	 * @throws ResourceManagerException if the resource cannot be allocated
 	 */
-	Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile) throws ResourceManagerException;
+	Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile);
 
 	/**
 	 * Notifies that an allocation failure has occurred.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -23,8 +23,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 
-import java.util.Collection;
-
 /**
  * Resource related actions which the {@link SlotManager} can perform.
  */
@@ -42,9 +40,9 @@ public interface ResourceActions {
 	 * Requests to allocate a resource with the given {@link ResourceProfile}.
 	 *
 	 * @param resourceProfile for the to be allocated resource
-	 * @return Collection of {@link ResourceProfile} describing the allocated slots
+	 * @return whether the resource can be allocated
 	 */
-	Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile);
+	boolean allocateResource(ResourceProfile resourceProfile);
 
 	/**
 	 * Notifies that an allocation failure has occurred.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -20,8 +20,8 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 /**
  * Resource related actions which the {@link SlotManager} can perform.
@@ -37,12 +37,12 @@ public interface ResourceActions {
 	void releaseResource(InstanceID instanceId, Exception cause);
 
 	/**
-	 * Requests to allocate a resource with the given {@link ResourceProfile}.
+	 * Requests to allocate a resource with the given {@link WorkerResourceSpec}.
 	 *
-	 * @param resourceProfile for the to be allocated resource
+	 * @param workerResourceSpec for the to be allocated worker
 	 * @return whether the resource can be allocated
 	 */
-	boolean allocateResource(ResourceProfile resourceProfile);
+	boolean allocateResource(WorkerResourceSpec workerResourceSpec);
 
 	/**
 	 * Notifies that an allocation failure has occurred.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -25,10 +25,12 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
+import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
@@ -51,7 +53,12 @@ public interface SlotManager extends AutoCloseable {
 
 	int getNumberFreeSlotsOf(InstanceID instanceId);
 
-	int getNumberPendingTaskManagerSlots();
+	/**
+	 * Get number of workers SlotManager requested from {@link ResourceActions} that are not yet fulfilled.
+	 * @return a map whose key set is all the unique resource specs of the pending workers,
+	 * and the corresponding value is number of pending workers of that resource spec.
+	 */
+	Map<WorkerResourceSpec, Integer> getRequiredResources();
 
 	int getNumberPendingSlotRequests();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -38,7 +37,7 @@ import java.util.concurrent.Executor;
  * their allocation and all pending slot requests. Whenever a new slot is registered or an
  * allocated slot is freed, then it tries to fulfill another pending slot request. Whenever there
  * are not enough slots available the slot manager will notify the resource manager about it via
- * {@link ResourceActions#allocateResource(ResourceProfile)}.
+ * {@link ResourceActions#allocateResource(WorkerResourceSpec)}.
  *
  * <p>In order to free resources and avoid resource leaks, idling task managers (task managers whose
  * slots are currently not used) and pending slot requests time out triggering their release and

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.ConfigurationException;
@@ -45,6 +46,7 @@ public class SlotManagerConfiguration {
 	private final boolean waitResultConsumedBeforeRelease;
 	private final SlotMatchingStrategy slotMatchingStrategy;
 	private final WorkerResourceSpec defaultWorkerResourceSpec;
+	private final int numSlotsPerWorker;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
@@ -52,7 +54,8 @@ public class SlotManagerConfiguration {
 			Time taskManagerTimeout,
 			boolean waitResultConsumedBeforeRelease,
 			SlotMatchingStrategy slotMatchingStrategy,
-			WorkerResourceSpec defaultWorkerResourceSpec) {
+			WorkerResourceSpec defaultWorkerResourceSpec,
+			int numSlotsPerWorker) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
@@ -60,6 +63,7 @@ public class SlotManagerConfiguration {
 		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
 		this.slotMatchingStrategy = slotMatchingStrategy;
 		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		this.numSlotsPerWorker = numSlotsPerWorker;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -86,6 +90,10 @@ public class SlotManagerConfiguration {
 		return defaultWorkerResourceSpec;
 	}
 
+	public int getNumSlotsPerWorker() {
+		return numSlotsPerWorker;
+	}
+
 	public static SlotManagerConfiguration fromConfiguration(
 			Configuration configuration,
 			WorkerResourceSpec defaultWorkerResourceSpec) throws ConfigurationException {
@@ -109,13 +117,16 @@ public class SlotManagerConfiguration {
 		final SlotMatchingStrategy slotMatchingStrategy = evenlySpreadOutSlots ?
 			LeastUtilizationSlotMatchingStrategy.INSTANCE : AnyMatchingSlotMatchingStrategy.INSTANCE;
 
+		int numSlotsPerWorker = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
+
 		return new SlotManagerConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
 			taskManagerTimeout,
 			waitResultConsumedBeforeRelease,
 			slotMatchingStrategy,
-			defaultWorkerResourceSpec);
+			defaultWorkerResourceSpec,
+			numSlotsPerWorker);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.Preconditions;
 
@@ -43,19 +44,22 @@ public class SlotManagerConfiguration {
 	private final Time taskManagerTimeout;
 	private final boolean waitResultConsumedBeforeRelease;
 	private final SlotMatchingStrategy slotMatchingStrategy;
+	private final WorkerResourceSpec defaultWorkerResourceSpec;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
 			Time slotRequestTimeout,
 			Time taskManagerTimeout,
 			boolean waitResultConsumedBeforeRelease,
-			SlotMatchingStrategy slotMatchingStrategy) {
+			SlotMatchingStrategy slotMatchingStrategy,
+			WorkerResourceSpec defaultWorkerResourceSpec) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
 		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
 		this.slotMatchingStrategy = slotMatchingStrategy;
+		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -78,7 +82,14 @@ public class SlotManagerConfiguration {
 		return slotMatchingStrategy;
 	}
 
-	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
+	public WorkerResourceSpec getDefaultWorkerResourceSpec() {
+		return defaultWorkerResourceSpec;
+	}
+
+	public static SlotManagerConfiguration fromConfiguration(
+			Configuration configuration,
+			WorkerResourceSpec defaultWorkerResourceSpec) throws ConfigurationException {
+
 		final Time rpcTimeout;
 		try {
 			rpcTimeout = AkkaUtils.getTimeoutAsTime(configuration);
@@ -103,7 +114,8 @@ public class SlotManagerConfiguration {
 			slotRequestTimeout,
 			taskManagerTimeout,
 			waitResultConsumedBeforeRelease,
-			slotMatchingStrategy);
+			slotMatchingStrategy,
+			defaultWorkerResourceSpec);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -42,20 +42,20 @@ public class SlotManagerConfiguration {
 	private final Time slotRequestTimeout;
 	private final Time taskManagerTimeout;
 	private final boolean waitResultConsumedBeforeRelease;
-	private final boolean evenlySpreadOutSlots;
+	private final SlotMatchingStrategy slotMatchingStrategy;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
 			Time slotRequestTimeout,
 			Time taskManagerTimeout,
 			boolean waitResultConsumedBeforeRelease,
-			boolean evenlySpreadOutSlots) {
+			SlotMatchingStrategy slotMatchingStrategy) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
 		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
-		this.evenlySpreadOutSlots = evenlySpreadOutSlots;
+		this.slotMatchingStrategy = slotMatchingStrategy;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -74,8 +74,8 @@ public class SlotManagerConfiguration {
 		return waitResultConsumedBeforeRelease;
 	}
 
-	public boolean evenlySpreadOutSlots() {
-		return evenlySpreadOutSlots;
+	public SlotMatchingStrategy getSlotMatchingStrategy() {
+		return slotMatchingStrategy;
 	}
 
 	public static SlotManagerConfiguration fromConfiguration(Configuration configuration) throws ConfigurationException {
@@ -95,13 +95,15 @@ public class SlotManagerConfiguration {
 			configuration.getBoolean(ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
 
 		boolean evenlySpreadOutSlots = configuration.getBoolean(ClusterOptions.EVENLY_SPREAD_OUT_SLOTS_STRATEGY);
+		final SlotMatchingStrategy slotMatchingStrategy = evenlySpreadOutSlots ?
+			LeastUtilizationSlotMatchingStrategy.INSTANCE : AnyMatchingSlotMatchingStrategy.INSTANCE;
 
 		return new SlotManagerConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
 			taskManagerTimeout,
 			waitResultConsumedBeforeRelease,
-			evenlySpreadOutSlots);
+			slotMatchingStrategy);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnfulfillableSlotRequestException;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
@@ -125,6 +126,11 @@ public class SlotManagerImpl implements SlotManager {
 	 * */
 	private boolean failUnfulfillableRequest = true;
 
+	/**
+	 * The default resource spec of workers to request.
+	 */
+	private final WorkerResourceSpec defaultWorkerResourceSpec;
+
 	public SlotManagerImpl(
 			ScheduledExecutor scheduledExecutor,
 			SlotManagerConfiguration slotManagerConfiguration) {
@@ -137,6 +143,7 @@ public class SlotManagerImpl implements SlotManager {
 		this.slotRequestTimeout = slotManagerConfiguration.getSlotRequestTimeout();
 		this.taskManagerTimeout = slotManagerConfiguration.getTaskManagerTimeout();
 		this.waitResultConsumedBeforeRelease = slotManagerConfiguration.isWaitResultConsumedBeforeRelease();
+		this.defaultWorkerResourceSpec = slotManagerConfiguration.getDefaultWorkerResourceSpec();
 
 		slots = new HashMap<>(16);
 		freeSlots = new LinkedHashMap<>(16);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -126,19 +126,17 @@ public class SlotManagerImpl implements SlotManager {
 	private boolean failUnfulfillableRequest = true;
 
 	public SlotManagerImpl(
-			SlotMatchingStrategy slotMatchingStrategy,
 			ScheduledExecutor scheduledExecutor,
-			Time taskManagerRequestTimeout,
-			Time slotRequestTimeout,
-			Time taskManagerTimeout,
-			boolean waitResultConsumedBeforeRelease) {
+			SlotManagerConfiguration slotManagerConfiguration) {
 
-		this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
 		this.scheduledExecutor = Preconditions.checkNotNull(scheduledExecutor);
-		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
-		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
-		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
-		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
+
+		Preconditions.checkNotNull(slotManagerConfiguration);
+		this.slotMatchingStrategy = slotManagerConfiguration.getSlotMatchingStrategy();
+		this.taskManagerRequestTimeout = slotManagerConfiguration.getTaskManagerRequestTimeout();
+		this.slotRequestTimeout = slotManagerConfiguration.getSlotRequestTimeout();
+		this.taskManagerTimeout = slotManagerConfiguration.getTaskManagerTimeout();
+		this.waitResultConsumedBeforeRelease = slotManagerConfiguration.isWaitResultConsumedBeforeRelease();
 
 		slots = new HashMap<>(16);
 		freeSlots = new LinkedHashMap<>(16);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -131,6 +131,8 @@ public class SlotManagerImpl implements SlotManager {
 	 */
 	private final WorkerResourceSpec defaultWorkerResourceSpec;
 
+	private final int numSlotsPerWorker;
+
 	public SlotManagerImpl(
 			ScheduledExecutor scheduledExecutor,
 			SlotManagerConfiguration slotManagerConfiguration) {
@@ -144,6 +146,7 @@ public class SlotManagerImpl implements SlotManager {
 		this.taskManagerTimeout = slotManagerConfiguration.getTaskManagerTimeout();
 		this.waitResultConsumedBeforeRelease = slotManagerConfiguration.isWaitResultConsumedBeforeRelease();
 		this.defaultWorkerResourceSpec = slotManagerConfiguration.getDefaultWorkerResourceSpec();
+		this.numSlotsPerWorker = slotManagerConfiguration.getNumSlotsPerWorker();
 
 		slots = new HashMap<>(16);
 		freeSlots = new LinkedHashMap<>(16);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -793,7 +793,7 @@ public class SlotManagerImpl implements SlotManager {
 		return false;
 	}
 
-	private Optional<PendingTaskManagerSlot> allocateResource(ResourceProfile resourceProfile) throws ResourceManagerException {
+	private Optional<PendingTaskManagerSlot> allocateResource(ResourceProfile resourceProfile) {
 		final Collection<ResourceProfile> requestedSlots = resourceActions.allocateResource(resourceProfile);
 
 		if (requestedSlots.isEmpty()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -819,7 +819,7 @@ public class SlotManagerImpl implements SlotManager {
 			return Optional.empty();
 		}
 
-		if (!resourceActions.allocateResource(requestedSlotResourceProfile)) {
+		if (!resourceActions.allocateResource(defaultWorkerResourceSpec)) {
 			// resource cannot be allocated
 			return Optional.empty();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.OptionalConsumer;
 import org.apache.flink.util.Preconditions;
 
@@ -49,6 +50,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -199,6 +201,14 @@ public class SlotManagerImpl implements SlotManager {
 	}
 
 	@Override
+	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
+		final int pendingWorkerNum = MathUtils.divideRoundUp(pendingSlots.size(), numSlotsPerWorker);
+		return pendingWorkerNum > 0 ?
+			Collections.singletonMap(defaultWorkerResourceSpec, pendingWorkerNum) :
+			Collections.emptyMap();
+	}
+
+	@VisibleForTesting
 	public int getNumberPendingTaskManagerSlots() {
 		return pendingSlots.size();
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/ProcessMemoryUtils.java
@@ -136,7 +136,7 @@ public class ProcessMemoryUtils<FM extends FlinkMemory> {
 		return jvmMetaspaceAndOverhead;
 	}
 
-	private JvmMetaspaceAndOverhead deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(
+	public JvmMetaspaceAndOverhead deriveJvmMetaspaceAndOverheadFromTotalFlinkMemory(
 			Configuration config,
 			MemorySize totalFlinkMemorySize) {
 		MemorySize jvmMetaspaceSize = getMemorySizeFromConfig(config, options.getJvmOptions().getJvmMetaspaceOption());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/config/memory/taskmanager/TaskExecutorFlinkMemoryUtils.java
@@ -160,11 +160,11 @@ public class TaskExecutorFlinkMemoryUtils implements FlinkMemoryUtils<TaskExecut
 		return ProcessMemoryUtils.deriveWithInverseFraction("network memory", base, getNetworkMemoryRangeFraction(config));
 	}
 
-	private static MemorySize getFrameworkHeapMemorySize(final Configuration config) {
+	public static MemorySize getFrameworkHeapMemorySize(final Configuration config) {
 		return ProcessMemoryUtils.getMemorySizeFromConfig(config, TaskManagerOptions.FRAMEWORK_HEAP_MEMORY);
 	}
 
-	private static MemorySize getFrameworkOffHeapMemorySize(final Configuration config) {
+	public static MemorySize getFrameworkOffHeapMemorySize(final Configuration config) {
 		return ProcessMemoryUtils.getMemorySizeFromConfig(config, TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/BootstrapToolsTest.java
@@ -175,7 +175,7 @@ public class BootstrapToolsTest extends TestLogger {
 			new MemorySize(333), // jvmMetaspaceSize
 			new MemorySize(0)); // jvmOverheadSize
 		final ContaineredTaskManagerParameters containeredParams =
-			new ContaineredTaskManagerParameters(taskExecutorProcessSpec, 4, new HashMap<String, String>());
+			new ContaineredTaskManagerParameters(taskExecutorProcessSpec, new HashMap<String, String>());
 
 		// no logging, with/out krb5
 		final String java = "$JAVA_HOME/bin/java";

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -26,13 +26,11 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtilsTestBase;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -66,16 +64,6 @@ public class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<Tas
 		MemorySize.parse("6m"),
 		MemorySize.parse("7m"),
 		MemorySize.parse("8m"));
-
-	private static final int NUMBER_OF_SLOTS = 2;
-
-	private static final ResourceProfile DEFAULT_RESOURCE_PROFILE = ResourceProfile.newBuilder()
-		.setCpuCores(new CPUResource(0.5))
-		.setTaskHeapMemory(MemorySize.parse("3m").divide(NUMBER_OF_SLOTS))
-		.setTaskOffHeapMemory(MemorySize.parse("2m"))
-		.setNetworkMemory(MemorySize.parse("5m").divide(NUMBER_OF_SLOTS))
-		.setManagedMemory(MemorySize.parse("3m"))
-		.build();
 
 	public TaskExecutorProcessUtilsTest() {
 		super(TM_PROCESS_MEMORY_OPTIONS, TM_LEGACY_HEAP_OPTIONS, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
@@ -448,20 +436,6 @@ public class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<Tas
 
 		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(conf);
 		assertThat(taskExecutorProcessSpec.getTotalProcessMemorySize(), is(totalProcessMemorySize));
-	}
-
-	@Test
-	public void testCreateDefaultWorkerSlotProfiles() {
-		assertThat(
-			TaskExecutorProcessUtils.createDefaultWorkerSlotProfiles(TM_RESOURCE_SPEC, NUMBER_OF_SLOTS),
-			is(Arrays.asList(DEFAULT_RESOURCE_PROFILE, DEFAULT_RESOURCE_PROFILE)));
-	}
-
-	@Test
-	public void testGenerateDefaultSlotProfile() {
-		assertThat(
-			TaskExecutorProcessUtils.generateDefaultSlotResourceProfile(TM_RESOURCE_SPEC, NUMBER_OF_SLOTS),
-			is(DEFAULT_RESOURCE_PROFILE));
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/TaskExecutorProcessUtilsTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtilsTestBase;
 
 import org.junit.Test;
@@ -41,6 +42,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -92,6 +94,23 @@ public class TaskExecutorProcessUtilsTest extends ProcessMemoryUtilsTestBase<Tas
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.NETWORK_MEMORY_MAX.key())), is(TM_RESOURCE_SPEC.getNetworkMemSize()));
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.NETWORK_MEMORY_MIN.key())), is(TM_RESOURCE_SPEC.getNetworkMemSize()));
 		assertThat(MemorySize.parse(configs.get(TaskManagerOptions.MANAGED_MEMORY_SIZE.key())), is(TM_RESOURCE_SPEC.getManagedMemorySize()));
+	}
+
+	@Test
+	public void testProcessSpecFromWorkerResourceSpec() {
+		final WorkerResourceSpec workerResourceSpec = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(200)
+			.setNetworkMemoryMB(300)
+			.setManagedMemoryMB(400)
+			.build();
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(new Configuration(), workerResourceSpec);
+		assertEquals(workerResourceSpec.getCpuCores(), taskExecutorProcessSpec.getCpuCores());
+		assertEquals(workerResourceSpec.getTaskHeapSize(), taskExecutorProcessSpec.getTaskHeapSize());
+		assertEquals(workerResourceSpec.getTaskOffHeapSize(), taskExecutorProcessSpec.getTaskOffHeapSize());
+		assertEquals(workerResourceSpec.getNetworkMemSize(), taskExecutorProcessSpec.getNetworkMemSize());
+		assertEquals(workerResourceSpec.getManagedMemSize(), taskExecutorProcessSpec.getManagedMemorySize());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/StandaloneResourceManagerWithUUIDFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/StandaloneResourceManagerWithUUIDFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.ArbitraryWorkerResourceSpecFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
@@ -56,7 +57,8 @@ public enum StandaloneResourceManagerWithUUIDFactory implements ResourceManagerF
 		ClusterInformation clusterInformation,
 		@Nullable String webInterfaceUrl,
 		ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration =
+			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, ArbitraryWorkerResourceSpecFactory.INSTANCE);
 		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -73,7 +73,8 @@ public class ResourceManagerHATest extends TestLogger {
 				TestingUtils.infiniteTime(),
 				true,
 				AnyMatchingSlotMatchingStrategy.INSTANCE,
-				WorkerResourceSpec.ZERO));
+				WorkerResourceSpec.ZERO,
+				1));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices
 import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.slotmanager.AnyMatchingSlotMatchingStrategy;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
@@ -71,7 +72,7 @@ public class ResourceManagerHATest extends TestLogger {
 				TestingUtils.infiniteTime(),
 				TestingUtils.infiniteTime(),
 				true,
-				false));
+				AnyMatchingSlotMatchingStrategy.INSTANCE));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -72,7 +72,8 @@ public class ResourceManagerHATest extends TestLogger {
 				TestingUtils.infiniteTime(),
 				TestingUtils.infiniteTime(),
 				true,
-				AnyMatchingSlotMatchingStrategy.INSTANCE));
+				AnyMatchingSlotMatchingStrategy.INSTANCE,
+				WorkerResourceSpec.ZERO));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -34,9 +34,6 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 
 import javax.annotation.Nullable;
 
-import java.util.Collection;
-import java.util.Collections;
-
 /**
  * Simple {@link ResourceManager} implementation for testing purposes.
  */
@@ -79,8 +76,8 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
 	}
 
 	@Override
-	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
-		return Collections.emptyList();
+	public boolean startNewWorker(ResourceProfile resourceProfile) {
+		return false;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -76,7 +75,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
 	}
 
 	@Override
-	public boolean startNewWorker(ResourceProfile resourceProfile) {
+	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
 		return false;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/WorkerResourceSpecTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Tests for {@link WorkerResourceSpec}.
+ */
+public class WorkerResourceSpecTest extends TestLogger {
+
+	@Test
+	public void testEquals() {
+		final WorkerResourceSpec spec1 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec2 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec3 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.1)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec4 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(110)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec5 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(110)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec6 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(110)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec7 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(110)
+			.build();
+
+		assertEquals(spec1, spec1);
+		assertEquals(spec1, spec2);
+		assertNotEquals(spec1, spec3);
+		assertNotEquals(spec1, spec4);
+		assertNotEquals(spec1, spec5);
+		assertNotEquals(spec1, spec6);
+		assertNotEquals(spec1, spec7);
+	}
+
+	@Test
+	public void testHashCodeEquals() {
+		final WorkerResourceSpec spec1 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec2 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec3 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.1)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec4 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(110)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec5 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(110)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec6 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(110)
+			.setManagedMemoryMB(100)
+			.build();
+		final WorkerResourceSpec spec7 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(110)
+			.build();
+
+		assertEquals(spec1.hashCode(), spec1.hashCode());
+		assertEquals(spec1.hashCode(), spec2.hashCode());
+		assertNotEquals(spec1.hashCode(), spec3.hashCode());
+		assertNotEquals(spec1.hashCode(), spec4.hashCode());
+		assertNotEquals(spec1.hashCode(), spec5.hashCode());
+		assertNotEquals(spec1.hashCode(), spec6.hashCode());
+		assertNotEquals(spec1.hashCode(), spec7.hashCode());
+	}
+
+	@Test
+	public void testCreateFromTaskExecutorProcessSpec() {
+		final TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils
+			.newProcessSpecBuilder(new Configuration())
+			.withTotalProcessMemory(MemorySize.ofMebiBytes(1024))
+			.build();
+		final WorkerResourceSpec workerResourceSpec =
+			WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec);
+		assertEquals(workerResourceSpec.getCpuCores(), taskExecutorProcessSpec.getCpuCores());
+		assertEquals(workerResourceSpec.getTaskHeapSize(), taskExecutorProcessSpec.getTaskHeapSize());
+		assertEquals(workerResourceSpec.getTaskOffHeapSize(), taskExecutorProcessSpec.getTaskOffHeapSize());
+		assertEquals(workerResourceSpec.getNetworkMemSize(), taskExecutorProcessSpec.getNetworkMemSize());
+		assertEquals(workerResourceSpec.getManagedMemSize(), taskExecutorProcessSpec.getManagedMemorySize());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -32,6 +32,7 @@ public class SlotManagerBuilder {
 	private Time taskManagerTimeout;
 	private boolean waitResultConsumedBeforeRelease;
 	private WorkerResourceSpec defaultWorkerResourceSpec;
+	private int numSlotsPerWorker;
 
 	private SlotManagerBuilder() {
 		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -41,6 +42,7 @@ public class SlotManagerBuilder {
 		this.taskManagerTimeout = TestingUtils.infiniteTime();
 		this.waitResultConsumedBeforeRelease = true;
 		this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
+		this.numSlotsPerWorker = 1;
 	}
 
 	public static SlotManagerBuilder newBuilder() {
@@ -82,6 +84,11 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setNumSlotsPerWorker(int numSlotsPerWorker) {
+		this.numSlotsPerWorker = numSlotsPerWorker;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
@@ -89,7 +96,8 @@ public class SlotManagerBuilder {
 			taskManagerTimeout,
 			waitResultConsumedBeforeRelease,
 			slotMatchingStrategy,
-			defaultWorkerResourceSpec);
+			defaultWorkerResourceSpec,
+			numSlotsPerWorker);
 
 		return new SlotManagerImpl(
 			scheduledExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -75,12 +75,15 @@ public class SlotManagerBuilder {
 	}
 
 	public SlotManagerImpl build() {
-		return new SlotManagerImpl(
-			slotMatchingStrategy,
-			scheduledExecutor,
+		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
 			slotRequestTimeout,
 			taskManagerTimeout,
-			waitResultConsumedBeforeRelease);
+			waitResultConsumedBeforeRelease,
+			slotMatchingStrategy);
+
+		return new SlotManagerImpl(
+			scheduledExecutor,
+			slotManagerConfiguration);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
 /** Builder for {@link SlotManagerImpl}. */
@@ -30,6 +31,7 @@ public class SlotManagerBuilder {
 	private Time slotRequestTimeout;
 	private Time taskManagerTimeout;
 	private boolean waitResultConsumedBeforeRelease;
+	private WorkerResourceSpec defaultWorkerResourceSpec;
 
 	private SlotManagerBuilder() {
 		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -38,6 +40,7 @@ public class SlotManagerBuilder {
 		this.slotRequestTimeout = TestingUtils.infiniteTime();
 		this.taskManagerTimeout = TestingUtils.infiniteTime();
 		this.waitResultConsumedBeforeRelease = true;
+		this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
 	}
 
 	public static SlotManagerBuilder newBuilder() {
@@ -74,13 +77,19 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setDefaultWorkerResourceSpec(WorkerResourceSpec defaultWorkerResourceSpec) {
+		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
 			slotRequestTimeout,
 			taskManagerTimeout,
 			waitResultConsumedBeforeRelease,
-			slotMatchingStrategy);
+			slotMatchingStrategy,
+			defaultWorkerResourceSpec);
 
 		return new SlotManagerImpl(
 			scheduledExecutor,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -44,7 +45,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
 
 		final Configuration configuration = new Configuration();
 		configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, slotIdleTimeout);
-		final SlotManagerConfiguration slotManagerConfiguration = SlotManagerConfiguration.fromConfiguration(configuration);
+		final SlotManagerConfiguration slotManagerConfiguration = SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
 		assertThat(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(), is(equalTo(slotIdleTimeout)));
 	}
@@ -60,7 +61,7 @@ public class SlotManagerConfigurationTest extends TestLogger {
 		final Configuration configuration = new Configuration();
 		configuration.setLong(ResourceManagerOptions.SLOT_REQUEST_TIMEOUT, legacySlotIdleTimeout);
 		configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 300000L);
-		final SlotManagerConfiguration slotManagerConfiguration = SlotManagerConfiguration.fromConfiguration(configuration);
+		final SlotManagerConfiguration slotManagerConfiguration = SlotManagerConfiguration.fromConfiguration(configuration, WorkerResourceSpec.ZERO);
 
 		assertThat(slotManagerConfiguration.getSlotRequestTimeout().toMilliseconds(), is(equalTo(legacySlotIdleTimeout)));
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -48,7 +48,6 @@ import org.apache.flink.util.CoreMatchers;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.FunctionUtils;
-import org.apache.flink.util.function.FunctionWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.junit.Test;
@@ -59,6 +58,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -75,6 +75,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -227,9 +228,7 @@ public class SlotManagerImplTest extends TestLogger {
 			"localhost");
 
 		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setAllocateResourceFunction(value -> {
-				throw new ResourceManagerException("Test exception");
-			})
+			.setAllocateResourceFunction(value -> Collections.emptyList())
 			.build();
 
 		try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceManagerActions)) {
@@ -1462,7 +1461,7 @@ public class SlotManagerImplTest extends TestLogger {
 		}
 	}
 
-	private static FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> convert(FunctionWithException<ResourceProfile, Integer, ResourceManagerException> function) {
+	private static Function<ResourceProfile, Collection<ResourceProfile>> convert(Function<ResourceProfile, Integer> function) {
 		return (ResourceProfile resourceProfile) -> {
 			final int slots = function.apply(resourceProfile);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImplTest.java
@@ -207,7 +207,7 @@ public class SlotManagerImplTest extends TestLogger {
 			resourceProfile,
 			"localhost");
 
-		CompletableFuture<ResourceProfile> allocateResourceFuture = new CompletableFuture<>();
+		CompletableFuture<WorkerResourceSpec> allocateResourceFuture = new CompletableFuture<>();
 		ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
 			.setAllocateResourceConsumer(allocateResourceFuture::complete)
 			.build();
@@ -216,7 +216,7 @@ public class SlotManagerImplTest extends TestLogger {
 
 			slotManager.registerSlotRequest(slotRequest);
 
-			assertThat(allocateResourceFuture.get(), is(equalTo(resourceProfile)));
+			allocateResourceFuture.get();
 		}
 	}
 
@@ -447,7 +447,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final AtomicInteger numberAllocateResourceFunctionCalls = new AtomicInteger(0);
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setAllocateResourceConsumer(resourceProfile -> numberAllocateResourceFunctionCalls.incrementAndGet())
+			.setAllocateResourceConsumer(ignored -> numberAllocateResourceFunctionCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
@@ -502,7 +502,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final AtomicInteger allocateResourceCalls = new AtomicInteger(0);
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setAllocateResourceConsumer(resourceProfile -> allocateResourceCalls.incrementAndGet())
+			.setAllocateResourceConsumer(ignored -> allocateResourceCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);
@@ -545,7 +545,7 @@ public class SlotManagerImplTest extends TestLogger {
 		final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 		final AtomicInteger allocateResourceCalls = new AtomicInteger(0);
 		final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder()
-			.setAllocateResourceConsumer(resourceProfile -> allocateResourceCalls.incrementAndGet())
+			.setAllocateResourceConsumer(ignored -> allocateResourceCalls.incrementAndGet())
 			.build();
 		final AllocationID allocationId = new AllocationID();
 		final ResourceProfile resourceProfile1 = ResourceProfile.fromResources(1.0, 2);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -23,14 +23,13 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
-import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Testing implementation of the {@link ResourceActions}.
@@ -41,14 +40,14 @@ public class TestingResourceActions implements ResourceActions {
 	private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
 
 	@Nonnull
-	private final FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction;
+	private final Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction;
 
 	@Nonnull
 	private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
 
 	public TestingResourceActions(
 			@Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-			@Nonnull FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction,
+			@Nonnull Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction,
 			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
 		this.allocateResourceFunction = allocateResourceFunction;
@@ -61,7 +60,7 @@ public class TestingResourceActions implements ResourceActions {
 	}
 
 	@Override
-	public Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile) throws ResourceManagerException {
+	public Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile){
 		return allocateResourceFunction.apply(resourceProfile);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import javax.annotation.Nonnull;
 
@@ -39,14 +39,14 @@ public class TestingResourceActions implements ResourceActions {
 	private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
 
 	@Nonnull
-	private final Function<ResourceProfile, Boolean> allocateResourceFunction;
+	private final Function<WorkerResourceSpec, Boolean> allocateResourceFunction;
 
 	@Nonnull
 	private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
 
 	public TestingResourceActions(
 			@Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-			@Nonnull Function<ResourceProfile, Boolean> allocateResourceFunction,
+			@Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction,
 			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
 		this.allocateResourceFunction = allocateResourceFunction;
@@ -59,8 +59,8 @@ public class TestingResourceActions implements ResourceActions {
 	}
 
 	@Override
-	public boolean allocateResource(ResourceProfile resourceProfile){
-		return allocateResourceFunction.apply(resourceProfile);
+	public boolean allocateResource(WorkerResourceSpec workerResourceSpec){
+		return allocateResourceFunction.apply(workerResourceSpec);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.instance.InstanceID;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -40,14 +39,14 @@ public class TestingResourceActions implements ResourceActions {
 	private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
 
 	@Nonnull
-	private final Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction;
+	private final Function<ResourceProfile, Boolean> allocateResourceFunction;
 
 	@Nonnull
 	private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
 
 	public TestingResourceActions(
 			@Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-			@Nonnull Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction,
+			@Nonnull Function<ResourceProfile, Boolean> allocateResourceFunction,
 			@Nonnull Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
 		this.releaseResourceConsumer = releaseResourceConsumer;
 		this.allocateResourceFunction = allocateResourceFunction;
@@ -60,7 +59,7 @@ public class TestingResourceActions implements ResourceActions {
 	}
 
 	@Override
-	public Collection<ResourceProfile> allocateResource(ResourceProfile resourceProfile){
+	public boolean allocateResource(ResourceProfile resourceProfile){
 		return allocateResourceFunction.apply(resourceProfile);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -24,8 +24,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -35,7 +33,7 @@ import java.util.function.Function;
  */
 public class TestingResourceActionsBuilder {
 	private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
-	private Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction = (ignored) -> Collections.singleton(ResourceProfile.ANY);
+	private Function<ResourceProfile, Boolean> allocateResourceFunction = (ignored) -> true;
 	private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer = (ignored) -> {};
 
 	public TestingResourceActionsBuilder setReleaseResourceConsumer(BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
@@ -43,7 +41,7 @@ public class TestingResourceActionsBuilder {
 		return this;
 	}
 
-	public TestingResourceActionsBuilder setAllocateResourceFunction(Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction) {
+	public TestingResourceActionsBuilder setAllocateResourceFunction(Function<ResourceProfile, Boolean> allocateResourceFunction) {
 		this.allocateResourceFunction = allocateResourceFunction;
 		return this;
 	}
@@ -51,7 +49,7 @@ public class TestingResourceActionsBuilder {
 	public TestingResourceActionsBuilder setAllocateResourceConsumer(Consumer<ResourceProfile> allocateResourceConsumer) {
 		this.allocateResourceFunction = (ResourceProfile resourceProfile) -> {
 			allocateResourceConsumer.accept(resourceProfile);
-			return Collections.singleton(ResourceProfile.ANY);
+			return true;
 		};
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -21,8 +21,8 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -33,7 +33,7 @@ import java.util.function.Function;
  */
 public class TestingResourceActionsBuilder {
 	private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
-	private Function<ResourceProfile, Boolean> allocateResourceFunction = (ignored) -> true;
+	private Function<WorkerResourceSpec, Boolean> allocateResourceFunction = (ignored) -> true;
 	private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer = (ignored) -> {};
 
 	public TestingResourceActionsBuilder setReleaseResourceConsumer(BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
@@ -41,14 +41,14 @@ public class TestingResourceActionsBuilder {
 		return this;
 	}
 
-	public TestingResourceActionsBuilder setAllocateResourceFunction(Function<ResourceProfile, Boolean> allocateResourceFunction) {
+	public TestingResourceActionsBuilder setAllocateResourceFunction(Function<WorkerResourceSpec, Boolean> allocateResourceFunction) {
 		this.allocateResourceFunction = allocateResourceFunction;
 		return this;
 	}
 
-	public TestingResourceActionsBuilder setAllocateResourceConsumer(Consumer<ResourceProfile> allocateResourceConsumer) {
-		this.allocateResourceFunction = (ResourceProfile resourceProfile) -> {
-			allocateResourceConsumer.accept(resourceProfile);
+	public TestingResourceActionsBuilder setAllocateResourceConsumer(Consumer<WorkerResourceSpec> allocateResourceConsumer) {
+		this.allocateResourceFunction = workerRequest -> {
+			allocateResourceConsumer.accept(workerRequest);
 			return true;
 		};
 		return this;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -23,20 +23,19 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
-import org.apache.flink.util.function.FunctionWithException;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Builder for the {@link TestingResourceActions}.
  */
 public class TestingResourceActionsBuilder {
 	private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
-	private FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction = (ignored) -> Collections.singleton(ResourceProfile.ANY);
+	private Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction = (ignored) -> Collections.singleton(ResourceProfile.ANY);
 	private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer = (ignored) -> {};
 
 	public TestingResourceActionsBuilder setReleaseResourceConsumer(BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
@@ -44,7 +43,7 @@ public class TestingResourceActionsBuilder {
 		return this;
 	}
 
-	public TestingResourceActionsBuilder setAllocateResourceFunction(FunctionWithException<ResourceProfile, Collection<ResourceProfile>, ResourceManagerException> allocateResourceFunction) {
+	public TestingResourceActionsBuilder setAllocateResourceFunction(Function<ResourceProfile, Collection<ResourceProfile>> allocateResourceFunction) {
 		this.allocateResourceFunction = allocateResourceFunction;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -23,9 +23,12 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.SlotRequest;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
@@ -61,8 +64,8 @@ public class TestingSlotManager implements SlotManager {
 	}
 
 	@Override
-	public int getNumberPendingTaskManagerSlots() {
-		return 0;
+	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
+		return Collections.emptyMap();
 	}
 
 	@Override

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/UtilsTest.java
@@ -109,7 +109,7 @@ public class UtilsTest extends TestLogger {
 			.newProcessSpecBuilder(flinkConf)
 			.withTotalProcessMemory(MemorySize.parse("1g"))
 			.build();
-		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(spec, 1, new HashMap<>(1));
+		ContaineredTaskManagerParameters tmParams = new ContaineredTaskManagerParameters(spec, new HashMap<>(1));
 		Configuration taskManagerConf = new Configuration();
 
 		String workingDirectory = root.getAbsolutePath();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -36,6 +35,7 @@ import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTra
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManager;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -72,6 +72,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -291,7 +292,10 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	}
 
 	@Override
-	public boolean startNewWorker(ResourceProfile resourceProfile) {
+	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
+		Preconditions.checkArgument(Objects.equals(
+			workerResourceSpec,
+			WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec)));
 		requestYarnContainer();
 		return true;
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -564,7 +564,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec, numSlotsPerTaskManager);
+				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 
 		log.info("TaskExecutor {} will be started on {} with {}.",
 			containerId,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -291,12 +291,9 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	}
 
 	@Override
-	public Collection<ResourceProfile> startNewWorker(ResourceProfile resourceProfile) {
-		if (!resourceProfilesPerWorker.iterator().next().isMatching(resourceProfile)) {
-			return Collections.emptyList();
-		}
+	public boolean startNewWorker(ResourceProfile resourceProfile) {
 		requestYarnContainer();
-		return resourceProfilesPerWorker;
+		return true;
 	}
 
 	@VisibleForTesting

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -527,10 +527,9 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	 * Request new container if pending containers cannot satisfy pending slot requests.
 	 */
 	private void requestYarnContainerIfRequired() {
-		int requiredTaskManagerSlots = getNumberRequiredTaskManagerSlots();
-		int pendingTaskManagerSlots = numPendingContainerRequests * numSlotsPerTaskManager;
+		final int requiredTaskManagers = getNumberRequiredTaskManagers();
 
-		if (requiredTaskManagerSlots > pendingTaskManagerSlots) {
+		while (requiredTaskManagers > numPendingContainerRequests) {
 			requestYarnContainer();
 		}
 	}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
@@ -61,7 +61,8 @@ public class YarnResourceManagerFactory extends ActiveResourceManagerFactory<Yar
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration = ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration);
+		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration =
+			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, YarnWorkerResourceSpecFactory.INSTANCE);
 		final ResourceManagerRuntimeServices rmRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			rmServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.entrypoint;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpecFactory;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implementation of {@link WorkerResourceSpecFactory} for Yarn deployments.
+ */
+public class YarnWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
+
+	public static final YarnWorkerResourceSpecFactory INSTANCE = new YarnWorkerResourceSpecFactory();
+
+	private static final Logger LOG = LoggerFactory.getLogger(YarnWorkerResourceSpecFactory.class);
+
+	private YarnWorkerResourceSpecFactory() {}
+
+	@Override
+	public WorkerResourceSpec createDefaultWorkerResourceSpec(Configuration configuration) {
+		return workerResourceSpecFromConfigAndCpu(configuration, getDefaultCpus(configuration));
+	}
+
+	private static CPUResource getDefaultCpus(final Configuration configuration) {
+		int fallback = configuration.getInteger(YarnConfigOptions.VCORES);
+		double cpuCoresDouble = TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
+		@SuppressWarnings("NumericCastThatLosesPrecision")
+		long cpuCoresLong = Math.max((long) Math.ceil(cpuCoresDouble), 1L);
+		//noinspection FloatingPointEquality
+		if (cpuCoresLong != cpuCoresDouble) {
+			LOG.info(
+				"The amount of cpu cores must be a positive integer on Yarn. Rounding {} up to the closest positive integer {}.",
+				cpuCoresDouble,
+				cpuCoresLong);
+		}
+		if (cpuCoresLong > Integer.MAX_VALUE) {
+			throw new IllegalConfigurationException(String.format(
+				"The amount of cpu cores %d cannot exceed Integer.MAX_VALUE: %d",
+				cpuCoresLong,
+				Integer.MAX_VALUE));
+		}
+		//noinspection NumericCastThatLosesPrecision
+		return new CPUResource(cpuCoresLong);
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.runtime.resourcemanager.SlotRequest;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -59,6 +60,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
+import org.apache.flink.yarn.entrypoint.YarnWorkerResourceSpecFactory;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 
@@ -270,8 +272,11 @@ public class YarnResourceManagerTest extends TestLogger {
 		}
 
 		Context(Configuration configuration) throws  Exception {
+			final SlotManager slotManager = SlotManagerBuilder.newBuilder()
+				.setDefaultWorkerResourceSpec(YarnWorkerResourceSpecFactory.INSTANCE.createDefaultWorkerResourceSpec(configuration))
+				.build();
 			rpcService = new TestingRpcService();
-			rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT);
+			rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT, slotManager);
 
 			// resource manager
 			rmResourceID = ResourceID.generate();


### PR DESCRIPTION
## What is the purpose of the change

This is the first step of FLINK-14106, including all the major changes inside SlotManager and changes to the RM/SM interfaces, except changes for metrics and status.

At the end of this step, SlotManager should allocate resource from ResourceManager with a WorkerResourceSpec, instead of slot ResourceProfile. At this step, the WorkerResourceSpec will not be used, and the active RMs will always use `ActiveResourceManager#taskExecutorProcessSpec` for requesting TMs. We will change that in subsequent steps.

## Brief change log

- 5ee2a8ece3eefb4726618ed31a05a2e11737b57a..7d6bc425928a3b4f814ebd9a1a7dd19adc5a497c: Minor code clean-ups.
- 8f43c28607d29a23e86873ee7744cb54d9c356e5: Introduce `WorkerResourceSpec`.
- be5aa79fe00d32c91a953cfa6bc7e93b99807599: Create `SlotManagerImpl` with default `WorkerResourceSpec` in active resource manager setups.
- 0f77b1e538f096e75ddc9cea253ae77abd8e08d3: Create SlotManagerImpl with default numSlotsPerWorker.
- a88d719456bd225ffe7b5f95acb951fdfffe74dc: Compute pending slot profiles inside SlotManager when allocating resource.
  - This means also check unfulfillable slot profiles inside SlotManager.
- a4d73c5fcb893ed671f1f058b55f1d1a2cc46583: ResourceManager retrieve a collection of pending workers from SlotManager, instead of number of pending slots.
- 168639b5d6f1035dea8a8a7330de4416c089dbb5: Remove numSlotsPerTaskManager from ActiveResourceManager and ContaineredTaskManagerParameters.
  - Since now we compute pending slot profiles inside SlotManager, ResourceManagers no longer need to be aware of number of slots per worker.
- df11b25dc9094509f24cec5484a6c5b01622d3f8: SlotManager allocate resource from ResourceManager with WorkerRequest instead of ResourceProfile.
  - This marks ResourceManager is no longer aware of slot ResourceProfiles.

## Verifying this change

This is a refactoring work. Most of the behaviors are already covered by exist test cases. Only added a few new test cases for the added data structures and logics.
- Add `WorkerResourceSpecTest`.
- Add test case in `TaskExecutorProcessUtilsTest`.
- Add test case in `SlotManagerImplTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
