### PR TITLE
[FLINK-16439][k8s] Make KubernetesResourceManager starts workers using WorkerResourceSpec requested by SlotManager

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -179,7 +179,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 				new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
 
 			final KubernetesJobManagerSpecification kubernetesJobManagerSpec =
-				KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+				KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 			client.createJobManagerComponent(kubernetesJobManagerSpec);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -257,7 +257,6 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 		final KubernetesTaskManagerParameters kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(
 			flinkConfig,
 			podName,
-			defaultMemoryMB,
 			dynamicProperties,
 			taskManagerParameters);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -49,7 +49,7 @@ import java.util.Map;
  */
 public class KubernetesJobManagerFactory {
 
-	public static KubernetesJobManagerSpecification createJobManagerComponent(
+	public static KubernetesJobManagerSpecification buildKubernetesJobManagerSpecification(
 			KubernetesJobManagerParameters kubernetesJobManagerParameters) throws IOException {
 		FlinkPod flinkPod = new FlinkPod.Builder().build();
 		List<HasMetadata> accompanyingResources = new ArrayList<>();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -35,7 +35,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
  */
 public class KubernetesTaskManagerFactory {
 
-	public static KubernetesPod createTaskManagerComponent(KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
+	public static KubernetesPod buildTaskManagerKubernetesPod(KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
 		FlinkPod flinkPod = new FlinkPod.Builder().build();
 
 		final KubernetesStepDecorator[] stepDecorators = new KubernetesStepDecorator[] {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -42,8 +42,6 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
 	private final String podName;
 
-	private final int taskManagerMemoryMB;
-
 	private final String dynamicProperties;
 
 	private final ContaineredTaskManagerParameters containeredTaskManagerParameters;
@@ -51,12 +49,10 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 	public KubernetesTaskManagerParameters(
 			Configuration flinkConfig,
 			String podName,
-			int taskManagerMemoryMB,
 			String dynamicProperties,
 			ContaineredTaskManagerParameters containeredTaskManagerParameters) {
 		super(flinkConfig);
 		this.podName = checkNotNull(podName);
-		this.taskManagerMemoryMB = taskManagerMemoryMB;
 		this.dynamicProperties = checkNotNull(dynamicProperties);
 		this.containeredTaskManagerParameters = checkNotNull(containeredTaskManagerParameters);
 	}
@@ -99,7 +95,7 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 	}
 
 	public int getTaskManagerMemoryMB() {
-		return taskManagerMemoryMB;
+		return containeredTaskManagerParameters.getTaskExecutorProcessSpec().getTotalProcessMemorySize().getMebiBytes();
 	}
 
 	public double getTaskManagerCPU() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.function.RunnableWithException;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
@@ -106,9 +107,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	private TestingFatalErrorHandler testingFatalErrorHandler;
 
-	private TestingKubernetesResourceManager resourceManager;
-	private SlotManager slotManager;
-
 	@Before
 	public void setup() throws Exception {
 		super.setup();
@@ -117,13 +115,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 		flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
 		testingFatalErrorHandler = new TestingFatalErrorHandler();
-
-		WorkerResourceSpec workerResourceSpec = KubernetesWorkerResourceSpecFactory.INSTANCE.createDefaultWorkerResourceSpec(flinkConfig);
-		slotManager = SlotManagerBuilder.newBuilder()
-			.setDefaultWorkerResourceSpec(workerResourceSpec)
-			.build();
-
-		resourceManager = createAndStartResourceManager(flinkConfig, flinkKubeClient, slotManager);
 
 		final Deployment mockDeployment = new DeploymentBuilder()
 			.editOrNewMetadata()
@@ -135,7 +126,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	@After
 	public void teardown() throws Exception {
-		resourceManager.close();
 		if (testingFatalErrorHandler != null) {
 			testingFatalErrorHandler.rethrowError();
 		}
@@ -189,245 +179,295 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	@Test
 	public void testStartAndStopWorker() throws Exception {
-		registerSlotRequest();
+		new Context() {{
+			runTest(() -> {
+				registerSlotRequest();
 
-		final PodList list = kubeClient.pods().list();
-		assertEquals(1, list.getItems().size());
-		final Pod pod = list.getItems().get(0);
+				final PodList list = kubeClient.pods().list();
+				assertEquals(1, list.getItems().size());
+				final Pod pod = list.getItems().get(0);
 
-		final Map<String, String> labels = getCommonLabels();
-		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
-		assertEquals(labels, pod.getMetadata().getLabels());
+				final Map<String, String> labels = getCommonLabels();
+				labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
+				assertEquals(labels, pod.getMetadata().getLabels());
 
-		assertEquals(1, pod.getSpec().getContainers().size());
-		final Container tmContainer = pod.getSpec().getContainers().get(0);
-		assertEquals(CONTAINER_IMAGE, tmContainer.getImage());
+				assertEquals(1, pod.getSpec().getContainers().size());
+				final Container tmContainer = pod.getSpec().getContainers().get(0);
+				assertEquals(CONTAINER_IMAGE, tmContainer.getImage());
 
-		final String podName = CLUSTER_ID + "-taskmanager-1-1";
-		assertEquals(podName, pod.getMetadata().getName());
+				final String podName = CLUSTER_ID + "-taskmanager-1-1";
+				assertEquals(podName, pod.getMetadata().getName());
 
-		// Check environments
-		assertThat(tmContainer.getEnv(), Matchers.contains(
-			new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
+				// Check environments
+				assertThat(tmContainer.getEnv(), Matchers.contains(
+					new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
 
-		// Check task manager main class args.
-		assertEquals(3, tmContainer.getArgs().size());
-		final String confDirOption = "--configDir " + flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
-		assertTrue(tmContainer.getArgs().get(2).contains(confDirOption));
+				// Check task manager main class args.
+				assertEquals(3, tmContainer.getArgs().size());
+				final String confDirOption = "--configDir " + flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
+				assertTrue(tmContainer.getArgs().get(2).contains(confDirOption));
 
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod)));
-		final ResourceID resourceID = new ResourceID(podName);
-		assertThat(resourceManager.getWorkerNodes().keySet(), Matchers.contains(resourceID));
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod)));
+				final ResourceID resourceID = new ResourceID(podName);
+				assertThat(resourceManager.getWorkerNodes().keySet(), Matchers.contains(resourceID));
 
-		registerTaskExecutor(resourceID);
+				registerTaskExecutor(resourceID);
 
-		// Unregister all task executors and release all task managers.
-		CompletableFuture<?> unregisterAndReleaseFuture = resourceManager.runInMainThread(() -> {
-			slotManager.unregisterTaskManagersAndReleaseResources();
-			return null;
-		});
-		unregisterAndReleaseFuture.get();
-		assertEquals(0, kubeClient.pods().list().getItems().size());
-		assertEquals(0, resourceManager.getWorkerNodes().size());
+				// Unregister all task executors and release all task managers.
+				CompletableFuture<?> unregisterAndReleaseFuture = resourceManager.runInMainThread(() -> {
+					slotManager.unregisterTaskManagersAndReleaseResources();
+					return null;
+				});
+				unregisterAndReleaseFuture.get();
+				assertEquals(0, kubeClient.pods().list().getItems().size());
+				assertEquals(0, resourceManager.getWorkerNodes().size());
+			});
+		}};
 	}
 
 	@Test
 	public void testTaskManagerPodTerminated() throws Exception {
-		registerSlotRequest();
+		new Context() {{
+			runTest(() -> {
+				registerSlotRequest();
 
-		final Pod pod1 = kubeClient.pods().list().getItems().get(0);
-		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-1-";
+				final Pod pod1 = kubeClient.pods().list().getItems().get(0);
+				final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-1-";
 
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod1)));
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod1)));
 
-		// General modification event
-		resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
-		assertEquals(1, kubeClient.pods().list().getItems().size());
-		assertEquals(taskManagerPrefix + 1, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+				// General modification event
+				resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
+				assertEquals(1, kubeClient.pods().list().getItems().size());
+				assertEquals(taskManagerPrefix + 1, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
 
-		// Terminate the pod.
-		terminatePod(pod1);
-		resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
+				// Terminate the pod.
+				terminatePod(pod1);
+				resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
 
-		// Old pod should be deleted and a new task manager should be created
-		assertEquals(1, kubeClient.pods().list().getItems().size());
-		final Pod pod2 = kubeClient.pods().list().getItems().get(0);
-		assertEquals(taskManagerPrefix + 2, pod2.getMetadata().getName());
+				// Old pod should be deleted and a new task manager should be created
+				assertEquals(1, kubeClient.pods().list().getItems().size());
+				final Pod pod2 = kubeClient.pods().list().getItems().get(0);
+				assertEquals(taskManagerPrefix + 2, pod2.getMetadata().getName());
 
-		// Error happens in the pod.
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod2)));
-		terminatePod(pod2);
-		resourceManager.onError(Collections.singletonList(new KubernetesPod(pod2)));
-		final Pod pod3 = kubeClient.pods().list().getItems().get(0);
-		assertEquals(taskManagerPrefix + 3, pod3.getMetadata().getName());
+				// Error happens in the pod.
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod2)));
+				terminatePod(pod2);
+				resourceManager.onError(Collections.singletonList(new KubernetesPod(pod2)));
+				final Pod pod3 = kubeClient.pods().list().getItems().get(0);
+				assertEquals(taskManagerPrefix + 3, pod3.getMetadata().getName());
 
-		// Delete the pod.
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod3)));
-		terminatePod(pod3);
-		resourceManager.onDeleted(Collections.singletonList(new KubernetesPod(pod3)));
-		assertEquals(taskManagerPrefix + 4, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+				// Delete the pod.
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod3)));
+				terminatePod(pod3);
+				resourceManager.onDeleted(Collections.singletonList(new KubernetesPod(pod3)));
+				assertEquals(taskManagerPrefix + 4, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+			});
+		}};
 	}
 
 	@Test
 	public void testGetWorkerNodesFromPreviousAttempts() throws Exception {
-		// Prepare pod of previous attempt
-		final String previewPodName = CLUSTER_ID + "-taskmanager-1-1";
+		new Context() {{
+			runTest(() -> {
+				// Prepare pod of previous attempt
+				final String previewPodName = CLUSTER_ID + "-taskmanager-1-1";
 
-		final Pod mockTaskManagerPod = new PodBuilder()
-			.editOrNewMetadata()
-				.withName(previewPodName)
-				.withLabels(KubernetesUtils.getTaskManagerLabels(CLUSTER_ID))
-				.endMetadata()
-			.editOrNewSpec()
-				.endSpec()
-			.build();
+				final Pod mockTaskManagerPod = new PodBuilder()
+					.editOrNewMetadata()
+						.withName(previewPodName)
+						.withLabels(KubernetesUtils.getTaskManagerLabels(CLUSTER_ID))
+						.endMetadata()
+					.editOrNewSpec()
+						.endSpec()
+					.build();
 
-		flinkKubeClient.createTaskManagerPod(new KubernetesPod(mockTaskManagerPod)).get();
-		assertEquals(1, kubeClient.pods().list().getItems().size());
+				flinkKubeClient.createTaskManagerPod(new KubernetesPod(mockTaskManagerPod));
+				assertEquals(1, kubeClient.pods().list().getItems().size());
 
-		// Call initialize method to recover worker nodes from previous attempt.
-		resourceManager.initialize();
+				// Call initialize method to recover worker nodes from previous attempt.
+				resourceManager.initialize();
 
-		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-";
-		// Register the previous taskmanager, no new pod should be created
-		registerTaskExecutor(new ResourceID(previewPodName));
-		registerSlotRequest();
-		assertEquals(1, kubeClient.pods().list().getItems().size());
+				final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-";
+				// Register the previous taskmanager, no new pod should be created
+				registerTaskExecutor(new ResourceID(previewPodName));
+				registerSlotRequest();
+				assertEquals(1, kubeClient.pods().list().getItems().size());
 
-		// Register a new slot request, a new taskmanger pod will be created with attempt2
-		registerSlotRequest();
-		assertEquals(2, kubeClient.pods().list().getItems().size());
-		assertThat(kubeClient.pods().list().getItems().stream()
-				.map(e -> e.getMetadata().getName())
-				.collect(Collectors.toList()),
-			Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+				// Register a new slot request, a new taskmanger pod will be created with attempt2
+				registerSlotRequest();
+				assertEquals(2, kubeClient.pods().list().getItems().size());
+				assertThat(kubeClient.pods().list().getItems().stream()
+						.map(e -> e.getMetadata().getName())
+						.collect(Collectors.toList()),
+					Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresCommonOption() {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresCommonOption() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(1.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(1.0));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresKubernetesOption() {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresKubernetesOption() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(2.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(2.0));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresNumSlots() {
-		final Configuration configuration = new Configuration();
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresNumSlots() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(3.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(3.0));
+			});
+		}};
 	}
 
 	@Test
 	public void testCreateTaskManagerPodFailedAndRetry() throws Exception {
-		final AtomicInteger retries = new AtomicInteger(0);
-		final int numOfFailedRetries = 3;
-		final OneShotLatch podCreated = new OneShotLatch();
-		final FlinkKubeClient flinkKubeClient = createTestingFlinkKubeClientAllocatingPodsAfter(numOfFailedRetries, retries, podCreated);
-		final TestingKubernetesResourceManager testRM = createAndStartResourceManager(flinkConfig, flinkKubeClient, slotManager);
-		registerSlotRequest(testRM);
+		new Context() {{
+			final AtomicInteger retries = new AtomicInteger(0);
+			final int numOfFailedRetries = 3;
+			final OneShotLatch podCreated = new OneShotLatch();
+			flinkKubeClient = createTestingFlinkKubeClientAllocatingPodsAfter(numOfFailedRetries, retries, podCreated);
 
-		podCreated.await();
-		// Creating taskmanager should retry 4 times (3 failed and then succeed)
-		assertThat(
-			"Creating taskmanager should fail " + numOfFailedRetries + " times and then succeed",
-			retries.get(),
-			is(numOfFailedRetries + 1));
+			runTest(() -> {
+				registerSlotRequest();
+				podCreated.await();
+				// Creating taskmanager should retry 4 times (3 failed and then succeed)
+				assertThat(
+					"Creating taskmanager should fail " + numOfFailedRetries + " times and then succeed",
+					retries.get(),
+					is(numOfFailedRetries + 1));
+			});
 
-		testRM.close();
-		flinkKubeClient.close();
+			flinkKubeClient.close();
+		}};
 	}
 
-	private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration, FlinkKubeClient flinkKubeClient, SlotManager slotManager) throws Exception {
+	class Context {
+		TestingKubernetesResourceManager resourceManager = null;
+		SlotManager slotManager = null;
+		FlinkKubeClient flinkKubeClient = null;
 
-		final TestingRpcService rpcService = new TestingRpcService(configuration);
-		final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT, slotManager);
+		void runTest(RunnableWithException testMethod) throws Exception {
+			if (slotManager == null) {
+				WorkerResourceSpec workerResourceSpec = KubernetesWorkerResourceSpecFactory.INSTANCE
+					.createDefaultWorkerResourceSpec(flinkConfig);
+				slotManager = SlotManagerBuilder.newBuilder()
+					.setDefaultWorkerResourceSpec(workerResourceSpec)
+					.build();
+			}
 
-		final TestingKubernetesResourceManager kubernetesResourceManager = new TestingKubernetesResourceManager(
-			rpcService,
-			ResourceID.generate(),
-			configuration,
-			rmServices.highAvailabilityServices,
-			rmServices.heartbeatServices,
-			rmServices.slotManager,
-			rmServices.jobLeaderIdService,
-			new ClusterInformation("localhost", 1234),
-			testingFatalErrorHandler,
-			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-			flinkKubeClient,
-			new KubernetesResourceManagerConfiguration(CLUSTER_ID, TESTING_POD_CREATION_RETRY_INTERVAL));
-		kubernetesResourceManager.start();
-		rmServices.grantLeadership();
-		return kubernetesResourceManager;
-	}
+			if (flinkKubeClient == null) {
+				flinkKubeClient = KubernetesResourceManagerTest.this.flinkKubeClient;
+			}
 
-	private void registerSlotRequest(TestingKubernetesResourceManager resourceManager) throws Exception {
-		CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
-			slotManager.registerSlotRequest(
-				new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, JOB_MANAGER_HOST));
-			return null;
-		});
-		registerSlotRequestFuture.get();
-	}
+			resourceManager = createAndStartResourceManager(flinkConfig, slotManager, flinkKubeClient);
 
-	private void registerSlotRequest() throws Exception {
-		registerSlotRequest(resourceManager);
-	}
+			try {
+				testMethod.run();
+			} finally {
+				resourceManager.close();
+			}
+		}
 
-	private void registerTaskExecutor(ResourceID resourceID) throws Exception {
-		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.createTestingTaskExecutorGateway();
-		((TestingRpcService) resourceManager.getRpcService()).registerGateway(resourceID.toString(), taskExecutorGateway);
+		private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration, SlotManager slotManager, FlinkKubeClient flinkKubeClient) throws Exception {
 
-		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
+			final TestingRpcService rpcService = new TestingRpcService(configuration);
+			final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT, slotManager);
 
-		final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
+			final TestingKubernetesResourceManager kubernetesResourceManager = new TestingKubernetesResourceManager(
+				rpcService,
+				ResourceID.generate(),
+				configuration,
+				rmServices.highAvailabilityServices,
+				rmServices.heartbeatServices,
+				rmServices.slotManager,
+				rmServices.jobLeaderIdService,
+				new ClusterInformation("localhost", 1234),
+				testingFatalErrorHandler,
+				UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
+				flinkKubeClient,
+				new KubernetesResourceManagerConfiguration(CLUSTER_ID, TESTING_POD_CREATION_RETRY_INTERVAL));
+			kubernetesResourceManager.start();
+			rmServices.grantLeadership();
+			return kubernetesResourceManager;
+		}
 
-		TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
-			resourceID.toString(),
-			resourceID,
-			1234,
-			new HardwareDescription(1, 2L, 3L, 4L),
-			ResourceProfile.ZERO,
-			ResourceProfile.ZERO);
-		CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
-			.registerTaskExecutor(
-				taskExecutorRegistration,
-				TIMEOUT)
-			.thenCompose(
-				(RegistrationResponse response) -> {
-					assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));
-					final TaskExecutorRegistrationSuccess success = (TaskExecutorRegistrationSuccess) response;
-					return rmGateway.sendSlotReport(
-						resourceID,
-						success.getRegistrationId(),
-						slotReport,
-						TIMEOUT);
-				})
-			.handleAsync(
-				(Acknowledge ignored, Throwable throwable) -> slotManager.getNumberRegisteredSlots(),
-				resourceManager.getMainThreadExecutorForTesting());
-		Assert.assertEquals(1, numberRegisteredSlotsFuture.get().intValue());
-	}
+		void registerSlotRequest() throws Exception {
+			CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
+				slotManager.registerSlotRequest(
+					new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, JOB_MANAGER_HOST));
+				return null;
+			});
+			registerSlotRequestFuture.get();
+		}
 
-	private void terminatePod(Pod pod) {
-		pod.setStatus(new PodStatusBuilder()
-			.withContainerStatuses(new ContainerStatusBuilder().withState(
-				new ContainerStateBuilder().withNewTerminated().endTerminated().build())
-				.build())
-			.build());
+		void registerTaskExecutor(ResourceID resourceID) throws Exception {
+			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.createTestingTaskExecutorGateway();
+			((TestingRpcService) resourceManager.getRpcService()).registerGateway(resourceID.toString(), taskExecutorGateway);
+
+			final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
+
+			final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
+
+			TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+				resourceID.toString(),
+				resourceID,
+				1234,
+				new HardwareDescription(1, 2L, 3L, 4L),
+				ResourceProfile.ZERO,
+				ResourceProfile.ZERO);
+			CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
+				.registerTaskExecutor(
+					taskExecutorRegistration,
+					TIMEOUT)
+				.thenCompose(
+					(RegistrationResponse response) -> {
+						assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));
+						final TaskExecutorRegistrationSuccess success = (TaskExecutorRegistrationSuccess) response;
+						return rmGateway.sendSlotReport(
+							resourceID,
+							success.getRegistrationId(),
+							slotReport,
+							TIMEOUT);
+					})
+				.handleAsync(
+					(Acknowledge ignored, Throwable throwable) -> slotManager.getNumberRegisteredSlots(),
+					resourceManager.getMainThreadExecutorForTesting());
+			Assert.assertEquals(1, numberRegisteredSlotsFuture.get().intValue());
+		}
+
+		void terminatePod(Pod pod) {
+			pod.setStatus(new PodStatusBuilder()
+				.withContainerStatuses(new ContainerStatusBuilder().withState(
+					new ContainerStateBuilder().withNewTerminated().endTerminated().build())
+					.build())
+				.build());
+		}
 	}
 
 	private FlinkKubeClient createTestingFlinkKubeClientAllocatingPodsAfter(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -94,7 +94,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
 		final KubernetesJobManagerParameters kubernetesJobManagerParameters =
 			new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
 		this.kubernetesJobManagerSpecification =
-			KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -92,7 +92,6 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 		kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(
 				flinkConfig,
 				POD_NAME,
-				TOTAL_PROCESS_MEMORY,
 				DYNAMIC_PROPERTIES,
 				containeredTaskManagerParameters);
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -77,7 +77,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
 
 		this.kubernetesJobManagerSpecification =
-			KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 	}
 
 	@Test
@@ -215,7 +215,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	@Test
 	public void testExistingHadoopConfigMap() throws IOException {
 		flinkConfig.set(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP, EXISTING_HADOOP_CONF_CONFIG_MAP);
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
 			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));
@@ -228,7 +228,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	public void testHadoopConfConfigMap() throws IOException {
 		setHadoopConfDirEnv();
 		generateHadoopConfFileItems();
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		final ConfigMap resultConfigMap = (ConfigMap) kubernetesJobManagerSpecification.getAccompanyingResources()
 			.stream()
@@ -248,7 +248,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	@Test
 	public void testEmptyHadoopConfDirectory() throws IOException {
 		setHadoopConfDirEnv();
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
 			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -50,7 +50,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		generateHadoopConfFileItems();
 
 		this.resultPod =
-			KubernetesTaskManagerFactory.createTaskManagerComponent(kubernetesTaskManagerParameters).getInternalResource();
+			KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(kubernetesTaskManagerParameters).getInternalResource();
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -78,7 +78,6 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
 
 		this.kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(flinkConfig,
 			POD_NAME,
-			TASK_MANAGER_MEMORY,
 			DYNAMIC_PROPERTIES,
 			containeredTaskManagerParameters);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -53,7 +53,7 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	/** The process environment variables. */
 	protected final Map<String, String> env;
 
-	protected final TaskExecutorProcessSpec taskExecutorProcessSpec;
+	protected final TaskExecutorProcessSpec defaultTaskExecutorProcessSpec;
 
 	protected final int defaultMemoryMB;
 
@@ -98,11 +98,11 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 		this.env = env;
 
 		double defaultCpus = getCpuCores(flinkConfig);
-		this.taskExecutorProcessSpec = TaskExecutorProcessUtils
+		this.defaultTaskExecutorProcessSpec = TaskExecutorProcessUtils
 			.newProcessSpecBuilder(flinkConfig)
 			.withCpuCores(defaultCpus)
 			.build();
-		this.defaultMemoryMB = taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
+		this.defaultMemoryMB = defaultTaskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -35,9 +36,11 @@ import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -62,6 +65,8 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 	/** Flink configuration uploaded by client. */
 	protected final Configuration flinkClientConfig;
+
+	private final PendingWorkerCounter pendingWorkerCounter;
 
 	public ActiveResourceManager(
 			Configuration flinkConfig,
@@ -101,6 +106,8 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();
+
+		pendingWorkerCounter = new PendingWorkerCounter();
 	}
 
 	protected CompletableFuture<Void> getStopTerminationFutureOrCompletedExceptionally(@Nullable Throwable exception) {
@@ -117,4 +124,76 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	protected abstract Configuration loadClientConfiguration();
 
 	protected abstract double getCpuCores(final Configuration configuration);
+
+	protected int getNumPendingWorkers() {
+		return pendingWorkerCounter.getTotalNum();
+	}
+
+	protected int getNumPendingWorkersFor(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.getNum(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that a worker with the given resource spec has been requested.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerRequested(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.increaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that a worker with the given resource spec has been allocated.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerAllocated(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.decreaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that allocation of a worker with the given resource spec has failed.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerAllocationFailed(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.decreaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Utility class for counting pending workers per {@link WorkerResourceSpec}.
+	 */
+	@VisibleForTesting
+	static class PendingWorkerCounter {
+		private final Map<WorkerResourceSpec, Integer> pendingWorkerNums;
+
+		PendingWorkerCounter() {
+			pendingWorkerNums = new HashMap<>();
+		}
+
+		int getTotalNum() {
+			return pendingWorkerNums.values().stream().reduce(0, Integer::sum);
+		}
+
+		int getNum(final WorkerResourceSpec workerResourceSpec) {
+			return pendingWorkerNums.getOrDefault(Preconditions.checkNotNull(workerResourceSpec), 0);
+		}
+
+		int increaseAndGet(final WorkerResourceSpec workerResourceSpec) {
+			return pendingWorkerNums.compute(
+				Preconditions.checkNotNull(workerResourceSpec),
+				(ignored, num) -> num != null ? num + 1 : 1);
+		}
+
+		int decreaseAndGet(final WorkerResourceSpec workerResourceSpec) {
+			final Integer newValue = pendingWorkerNums.compute(
+				Preconditions.checkNotNull(workerResourceSpec),
+				(ignored, num) -> {
+					Preconditions.checkState(num != null && num > 0,
+						"Cannot decrease, no pending worker of spec %s.", workerResourceSpec);
+					return num == 1 ? null : num - 1;
+				});
+			return newValue != null ? newValue : 0;
+		}
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Tests for {@link ActiveResourceManager}.
+ */
+public class ActiveResourceManagerTest extends TestLogger {
+
+	@Test
+	public void testPendingWorkerCounterIncreaseAndDecrease() {
+		final WorkerResourceSpec spec1 = new WorkerResourceSpec.Builder().setCpuCores(1.0).build();
+		final WorkerResourceSpec spec2 = new WorkerResourceSpec.Builder().setCpuCores(2.0).build();
+
+		final ActiveResourceManager.PendingWorkerCounter counter = new ActiveResourceManager.PendingWorkerCounter();
+		assertThat(counter.getTotalNum(), is(0));
+		assertThat(counter.getNum(spec1), is(0));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec1), is(1));
+		assertThat(counter.getTotalNum(), is(1));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec1), is(2));
+		assertThat(counter.getTotalNum(), is(2));
+		assertThat(counter.getNum(spec1), is(2));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec2), is(1));
+		assertThat(counter.getTotalNum(), is(3));
+		assertThat(counter.getNum(spec1), is(2));
+		assertThat(counter.getNum(spec2), is(1));
+
+		assertThat(counter.decreaseAndGet(spec1), is(1));
+		assertThat(counter.getTotalNum(), is(2));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(1));
+
+		assertThat(counter.decreaseAndGet(spec2), is(0));
+		assertThat(counter.getTotalNum(), is(1));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(0));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testPendingWorkerCounterDecreaseOnZero() {
+		final WorkerResourceSpec spec = new WorkerResourceSpec.Builder().build();
+		final ActiveResourceManager.PendingWorkerCounter counter = new ActiveResourceManager.PendingWorkerCounter();
+		counter.decreaseAndGet(spec);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -27,10 +27,10 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Implementation of {@link SlotManager} for testing purpose.
@@ -38,9 +38,13 @@ import java.util.function.Consumer;
 public class TestingSlotManager implements SlotManager {
 
 	private final Consumer<Boolean> setFailUnfulfillableRequestConsumer;
+	private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
 
-	TestingSlotManager(Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
+	TestingSlotManager(
+			Consumer<Boolean> setFailUnfulfillableRequestConsumer,
+			Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
 		this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
+		this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
 	}
 
 	@Override
@@ -65,7 +69,7 @@ public class TestingSlotManager implements SlotManager {
 
 	@Override
 	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
-		return Collections.emptyMap();
+		return getRequiredResourcesSupplier.get();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Factory for {@link TestingSlotManager}.
@@ -26,13 +31,19 @@ import java.util.function.Consumer;
 public class TestingSlotManagerBuilder {
 
 	private Consumer<Boolean> setFailUnfulfillableRequestConsumer = ignored -> {};
+	private Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier = () -> Collections.emptyMap();
 
 	public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
 		this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
 		return this;
 	}
 
+	public TestingSlotManagerBuilder setGetRequiredResourcesSupplier(Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
+		this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
+		return this;
+	}
+
 	public TestingSlotManager createSlotManager() {
-		return new TestingSlotManager(setFailUnfulfillableRequestConsumer);
+		return new TestingSlotManager(setFailUnfulfillableRequestConsumer, getRequiredResourcesSupplier);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -167,7 +167,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		numPendingContainerRequests = 0;
 
 		this.webInterfaceUrl = webInterfaceUrl;
-		this.resource = Resource.newInstance(defaultMemoryMB, taskExecutorProcessSpec.getCpuCores().getValue().intValue());
+		this.resource = Resource.newInstance(defaultMemoryMB, defaultTaskExecutorProcessSpec.getCpuCores().getValue().intValue());
 	}
 
 	protected AMRMClientAsync<AMRMClient.ContainerRequest> createAndStartResourceManagerClient(
@@ -293,7 +293,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
 		Preconditions.checkArgument(Objects.equals(
 			workerResourceSpec,
-			WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec)));
+			WorkerResourceSpec.fromTaskExecutorProcessSpec(defaultTaskExecutorProcessSpec)));
 		requestYarnContainer();
 		return true;
 	}
@@ -566,12 +566,12 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
+				ContaineredTaskManagerParameters.create(flinkConfig, defaultTaskExecutorProcessSpec);
 
 		log.info("TaskExecutor {} will be started on {} with {}.",
 			containerId,
 			host,
-			taskExecutorProcessSpec);
+			defaultTaskExecutorProcessSpec);
 
 		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 


### PR DESCRIPTION
## What is the purpose of the change
This PR is one step of FLINK-14106, making `KubernetesResourceManager` starts workers using `WorkerResourceSpec` requested by `SlotManager`.

This also means `KubernetesResourceManager` no longer:
- be aware of the default task executor resources
- assumes all workers are identical

This PR is based on #11320.

## Brief change log

- 8fcadbff7c80832626b317dc8cf75bc49b2a47d7..df11b25dc9094509f24cec5484a6c5b01622d3f8: Commits of previous PR.
- 76786fd6aa7e806f669eb3375ca8a3bd0534a0ab: Minor code clean-ups.
- d3fc9010a987cd299f355ddc1fbeb4225b5fb418: Introduce `PendingWorkerCounter` for counting pending workers per `WorkerResourceSpec` in `ActiveResourceManager`.
- d7a0626255f2445cfe20dcb7bab1aede3af4b0d7: KubernetesResourceManager starts workers with resources requested by SlotManager.

## Verifying this change

- Add `KubernetesResourceManagerTest#testStartAndRecoverVariousResourceSpec`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
