### PR TITLE
[FLINK-16445][build] Set property japicmp.referenceVersion to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@ under the License.
 			For Hadoop 2.7, the minor Hadoop version supported for flink-shaded-hadoop-2-uber is 2.7.5
 		-->
 		<hivemetastore.hadoop.version>2.7.5</hivemetastore.hadoop.version>
-		<japicmp.referenceVersion>1.9.1</japicmp.referenceVersion>
+		<japicmp.referenceVersion>1.10.0</japicmp.referenceVersion>
 		<japicmp.outputDir>tools/japicmp-output</japicmp.outputDir>
 		<test.scheduler.type></test.scheduler.type>
 		<test.groups></test.groups>


### PR DESCRIPTION
## What is the purpose of the change

*Set property japicmp.referenceVersion to 1.10.0*


## Brief change log
  - *Set property japicmp.referenceVersion to 1.10.0*


## Verifying this change

This change is already covered by existing tests, such as *building the project*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
