### PR TITLE
[FLINK-16447][Formats] fix non deserializable field on CompressWriterFactory

### DIFF
--- a/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
+++ b/flink-formats/flink-compress/src/main/java/org/apache/flink/formats/compress/CompressWriterFactory.java
@@ -50,11 +50,11 @@ public class CompressWriterFactory<IN> implements BulkWriter.Factory<IN> {
 	}
 
 	public CompressWriterFactory<IN> withHadoopCompression(String hadoopCodecName) {
-		return withHadoopCompression(hadoopCodecName, new Configuration());
+		return withHadoopCompression(createCodec(hadoopCodecName));
 	}
 
 	public CompressWriterFactory<IN> withHadoopCompression(String hadoopCodecName, Configuration hadoopConfiguration) {
-		return withHadoopCompression(new CompressionCodecFactory(hadoopConfiguration).getCodecByName(hadoopCodecName));
+		return withHadoopCompression(createCodec(hadoopCodecName, hadoopConfiguration));
 	}
 
 	public CompressWriterFactory<IN> withHadoopCompression(CompressionCodec hadoopCodec) {
@@ -67,7 +67,7 @@ public class CompressWriterFactory<IN> implements BulkWriter.Factory<IN> {
 	public BulkWriter<IN> create(FSDataOutputStream out) throws IOException {
 		try {
 			return (hadoopCodecName != null)
-				? new HadoopCompressionBulkWriter<>(out, extractor, new CompressionCodecFactory(new Configuration()).getCodecByName(hadoopCodecName))
+				? new HadoopCompressionBulkWriter<>(out, extractor, createCodec(hadoopCodecName))
 				: new NoCompressionBulkWriter<>(out, extractor);
 		} catch (Exception e) {
 			throw new IOException(e.getLocalizedMessage(), e);
@@ -78,4 +78,11 @@ public class CompressWriterFactory<IN> implements BulkWriter.Factory<IN> {
 		return ObjectUtils.defaultIfNull(hadoopCodecExtension, "");
 	}
 
+	private CompressionCodec createCodec(String hadoopCodecName) {
+		return createCodec(hadoopCodecName, new Configuration());
+	}
+
+	private CompressionCodec createCodec(String hadoopCodecName, Configuration hadoopConfiguration) {
+		return new CompressionCodecFactory(hadoopConfiguration).getCodecByName(hadoopCodecName);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change

*Fix a non serializable field on CompressWriterFactory *

## Brief change log
  - *change field with seriablizable fields*

## Verifying this change
This change is already covered by existing tests, such as *CompressWriterFactoryTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
