### PR TITLE
[FLINK-11427][formats] Add protobuf parquet support for StreamingFileSink

### DIFF
--- a/docs/dev/connectors/streamfile_sink.md
+++ b/docs/dev/connectors/streamfile_sink.md
@@ -205,6 +205,43 @@ input.addSink(sink)
 </div>
 </div>
 
+Similarly, a StreamingFileSink that writers Protobuf data to Parquet format can be created like this:
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.formats.parquet.protobuf.ParquetProtoWriters;
+
+// ProtoRecord is a generated protobuf Message class.
+DataStream<ProtoRecord> stream = ...;
+
+final StreamingFileSink<ProtoRecord> sink = StreamingFileSink
+	.forBulkFormat(outputBasePath, ParquetProtoWriters.forType(ProtoRecord.class))
+	.build();
+
+input.addSink(sink);
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink
+import org.apache.flink.formats.parquet.protobuf.ParquetProtoWriters
+
+// ProtoRecord is a generated protobuf Message class.
+val input: DataStream[ProtoRecord] = ...
+
+val sink: StreamingFileSink[ProtoRecord] = StreamingFileSink
+    .forBulkFormat(outputBasePath, ParquetProtoWriters.forType(classOf[ProtoRecord]))
+    .build()
+
+input.addSink(sink)
+
+{% endhighlight %}
+</div>
+</div>
+
 #### Avro format
 
 Flink also provides built-in support for writing data into Avro files. A list of convenience methods to create

--- a/docs/dev/connectors/streamfile_sink.zh.md
+++ b/docs/dev/connectors/streamfile_sink.zh.md
@@ -190,6 +190,43 @@ input.addSink(sink)
 </div>
 </div>
 
+类似的，将 Protobuf 数据写入到 Parquet 格式可以通过：
+
+<div class="codetabs" markdown="1">
+<div data-lang="java" markdown="1">
+{% highlight java %}
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.formats.parquet.protobuf.ParquetProtoWriters;
+
+// ProtoRecord is a generated protobuf Message class.
+DataStream<ProtoRecord> stream = ...;
+
+final StreamingFileSink<ProtoRecord> sink = StreamingFileSink
+	.forBulkFormat(outputBasePath, ParquetProtoWriters.forType(ProtoRecord.class))
+	.build();
+
+input.addSink(sink);
+
+{% endhighlight %}
+</div>
+<div data-lang="scala" markdown="1">
+{% highlight scala %}
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink
+import org.apache.flink.formats.parquet.protobuf.ParquetProtoWriters
+
+// ProtoRecord is a generated protobuf Message class.
+val input: DataStream[ProtoRecord] = ...
+
+val sink: StreamingFileSink[ProtoRecord] = StreamingFileSink
+    .forBulkFormat(outputBasePath, ParquetProtoWriters.forType(classOf[ProtoRecord]))
+    .build()
+
+input.addSink(sink)
+
+{% endhighlight %}
+</div>
+</div>
+
 #### Avro格式
 
 Flink 也提供了将数据写入 Avro 文件的内置支持。对于创建 AvroWriterFactory 的快捷方法，更多信息可以参考 

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -232,6 +232,12 @@ under the License.
 				<version>0.5.1</version>
 				<extensions>true</extensions>
 				<configuration>
+					<!-- Currently Flink azure test pipeline would first pre-compile and then upload the compiled
+					 directory, then it download the directory and run the corresponding tests. However, the protoc
+					 executable under the target directory would lost the execution permission bit after downloading.
+					 To solve this issue we would skip generating the target files if they already exist after
+					 downloading. -->
+					<checkStaleness>true</checkStaleness>
 					<protoTestSourceRoot>${project.basedir}/src/test/resources/protobuf</protoTestSourceRoot>
 					<!-- Generates classes into a separate directory since the generator always removes existing files. -->
 					<outputDirectory>${project.build.directory}/generated-test-sources/protobuf/java</outputDirectory>

--- a/flink-formats/flink-parquet/pom.xml
+++ b/flink-formats/flink-parquet/pom.xml
@@ -96,12 +96,24 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
 			<scope>provided</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- For now, fastutil is provided already by flink-runtime -->
@@ -127,6 +139,19 @@ under the License.
 				<exclusion>
 					<groupId>it.unimi.dsi</groupId>
 					<artifactId>fastutil</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.parquet</groupId>
+			<artifactId>parquet-protobuf</artifactId>
+			<version>${flink.format.parquet.version}</version>
+			<optional>true</optional>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.hadoop</groupId>
+					<artifactId>hadoop-client</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -172,6 +197,14 @@ under the License.
 	</dependencies>
 
 	<build>
+		<extensions>
+			<extension>
+				<groupId>kr.motd.maven</groupId>
+				<artifactId>os-maven-plugin</artifactId>
+				<version>1.5.0.Final</version>
+			</extension>
+		</extensions>
+
 		<plugins>
 			<!-- Generate Test class from avro schema -->
 			<plugin>
@@ -187,6 +220,48 @@ under the License.
 						<configuration>
 							<testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
 							<testOutputDirectory>${project.basedir}/src/test/java/</testOutputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Geneate Test class from protobuf schema -->
+			<plugin>
+				<groupId>org.xolstice.maven.plugins</groupId>
+				<artifactId>protobuf-maven-plugin</artifactId>
+				<version>0.5.1</version>
+				<extensions>true</extensions>
+				<configuration>
+					<protoTestSourceRoot>${project.basedir}/src/test/resources/protobuf</protoTestSourceRoot>
+					<!-- Generates classes into a separate directory since the generator always removes existing files. -->
+					<outputDirectory>${project.build.directory}/generated-test-sources/protobuf/java</outputDirectory>
+					<protocArtifact>com.google.protobuf:protoc:3.5.1:exe:${os.detected.classifier}</protocArtifact>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<!-- Adding protobuf generated classes to test build path -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-test-source</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>add-test-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.build.directory}/generated-test-sources/protobuf/java</source>
+							</sources>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoWriters.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoWriters.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.protobuf;
+
+import org.apache.flink.formats.parquet.ParquetBuilder;
+import org.apache.flink.formats.parquet.ParquetWriterFactory;
+
+import com.google.protobuf.Message;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.api.WriteSupport;
+import org.apache.parquet.io.OutputFile;
+import org.apache.parquet.proto.ProtoWriteSupport;
+
+/**
+ * Convenience builder to create {@link ParquetWriterFactory} instances for the protobuf classes.
+ */
+public class ParquetProtoWriters {
+
+	/**
+	 * Creates a ParquetWriterFactory for the given type. The type should represent a protobuf message.
+	 *
+	 * @param type The class of the type to write.
+	 */
+	public static <T extends Message> ParquetWriterFactory<T> forType(Class<T> type) {
+		ParquetBuilder<T> builder = (out) -> new ParquetProtoWriterBuilder<>(out, type).build();
+		return new ParquetWriterFactory<>(builder);
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The builder for protobuf {@link ParquetWriter}.
+	 */
+	private static class ParquetProtoWriterBuilder<T extends Message>
+		extends ParquetWriter.Builder<T, ParquetProtoWriterBuilder<T>> {
+
+		private final Class<T> clazz;
+
+		protected ParquetProtoWriterBuilder(OutputFile outputFile, Class<T> clazz) {
+			super(outputFile);
+			this.clazz = clazz;
+		}
+
+		@Override
+		protected ParquetProtoWriterBuilder<T> self() {
+			return this;
+		}
+
+		@Override
+		protected WriteSupport<T> getWriteSupport(Configuration conf) {
+			return new ProtoWriteSupport<>(clazz);
+		}
+	}
+
+	/** Class is not meant to be instantiated. */
+	private ParquetProtoWriters() {}
+}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.formats.parquet.avro;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
 import org.apache.flink.formats.parquet.generated.Address;
@@ -167,7 +166,7 @@ public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
 		for (File partFile : partFiles) {
 			assertTrue(partFile.length() > 0);
 
-			final List<Tuple2<Long, String>> fileContent = readParquetFile(partFile, dataModel);
+			final List<T> fileContent = readParquetFile(partFile, dataModel);
 			assertEquals(expected, fileContent);
 		}
 	}

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/ParquetAvroStreamingFileSinkITCase.java
@@ -62,7 +62,7 @@ import static org.junit.Assert.assertTrue;
  * {@link StreamingFileSink} with Parquet.
  */
 @SuppressWarnings("serial")
-public class ParquetStreamingFileSinkITCase extends AbstractTestBase {
+public class ParquetAvroStreamingFileSinkITCase extends AbstractTestBase {
 
 	@Rule
 	public final Timeout timeoutPerTest = Timeout.seconds(20);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/protobuf/ParquetProtoStreamingFileSinkITCase.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet.protobuf;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import com.google.protobuf.Message;
+import com.google.protobuf.MessageOrBuilder;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.proto.ProtoParquetReader;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.protobuf.Message.Builder;
+import static org.apache.flink.formats.parquet.protobuf.SimpleRecord.SimpleProtoRecord;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Simple integration test case for writing bulk encoded files with the
+ * {@link StreamingFileSink} with Parquet.
+ */
+@SuppressWarnings("serial")
+public class ParquetProtoStreamingFileSinkITCase extends AbstractTestBase {
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(20);
+
+	@Test
+	public void testParquetProtoWriters() throws Exception {
+		File folder = TEMPORARY_FOLDER.newFolder();
+
+		List<SimpleProtoRecord> data = Arrays.asList(
+			SimpleProtoRecord.newBuilder().setFoo("a").setBar("x").setNum(1).build(),
+			SimpleProtoRecord.newBuilder().setFoo("b").setBar("y").setNum(2).build(),
+			SimpleProtoRecord.newBuilder().setFoo("c").setBar("z").setNum(3).build());
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.enableCheckpointing(100);
+
+		DataStream<SimpleProtoRecord> stream = env.addSource(
+			new FiniteTestSource<>(data), TypeInformation.of(SimpleProtoRecord.class));
+
+		stream.addSink(
+			StreamingFileSink.forBulkFormat(
+				Path.fromLocalFile(folder),
+				ParquetProtoWriters.forType(SimpleProtoRecord.class))
+			.build());
+
+		env.execute();
+
+		validateResults(folder, data);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static <T extends MessageOrBuilder> void validateResults(File folder, List<T> expected) throws Exception {
+		File[] buckets = folder.listFiles();
+		assertNotNull(buckets);
+		assertEquals(1, buckets.length);
+
+		File[] partFiles = buckets[0].listFiles();
+		assertNotNull(partFiles);
+		assertEquals(2, partFiles.length);
+
+		for (File partFile : partFiles) {
+			assertTrue(partFile.length() > 0);
+
+			final List<Message> fileContent = readParquetFile(partFile);
+			assertEquals(expected, fileContent);
+		}
+	}
+
+	private static List<Message> readParquetFile(File file) throws IOException {
+		org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(file.getAbsolutePath());
+
+		ArrayList<Message> results = new ArrayList<>();
+		try (ParquetReader<MessageOrBuilder> reader = ProtoParquetReader.<MessageOrBuilder>builder(path).build()) {
+			MessageOrBuilder next;
+			while ((next = reader.read()) != null) {
+				if (next instanceof Builder) {
+					// Builder is mutable and we need to ensure the saved reference does not change
+					// after reading more records.
+					results.add(((Builder) next).build());
+				} else {
+					results.add((Message) next);
+				}
+			}
+		}
+
+		return results;
+	}
+}

--- a/flink-formats/flink-parquet/src/test/resources/protobuf/simple_record.proto
+++ b/flink-formats/flink-parquet/src/test/resources/protobuf/simple_record.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package org.apache.flink.formats.parquet.protobuf;
+message SimpleProtoRecord {
+  string foo = 1;
+  string bar = 2;
+  int32 num = 3;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1474,6 +1474,7 @@ under the License.
 						<exclude>flink-formats/flink-json/src/test/resources/*.txt</exclude>
 						<exclude>flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/generated/*.java</exclude>
 						<exclude>flink-formats/flink-parquet/src/test/resources/avro/**</exclude>
+						<exclude>flink-formats/flink-parquet/src/test/resources/protobuf/**</exclude>
 						<!-- netty test file, still Apache License 2.0 but with a different header -->
 						<exclude>flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/AbstractByteBufTest.java</exclude>
 						<!-- Configuration Files. -->


### PR DESCRIPTION
## What is the purpose of the change

This PR adds support for writing protobuf records to parquet files. 

Since the tests need to generate protobuf classes from the proto files, two maven plugins are used:
1. [os-maven-plugin](https://github.com/trustin/os-maven-plugin) is used to detect the os version so that we could download the suitable `protoc` compiler.
2. [protobuf-maven-plugin](https://github.com/xolstice/protobuf-maven-plugin) is used to class `protoc` to generate the classes. 

Both of the two plugins are using Apache Licence.

## Brief change log

*(for example:)*
  - f5bd9b3f4d4b4aec514c974428765425356a7a43 hotfix that renames existing Avro Parquet test to keep consistency with the new tests.
  - f95e145f5eb004304fc918802147797fb52a6799 hotfix that fixes the generic parameter usage in Avro Parquet test.
  - 102d6df995f418e9d131380bfff3b747f7d7814a adds the protobuf parquet support.


## Verifying this change

This change added tests and can be verified as follows:
 - Added unit test that validates the read records are consistent with the written ones.  

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**