### PR TITLE
[FLINK-16450][hive] Integrate parquet columnar row reader to hive

### DIFF
--- a/docs/dev/table/hive/read_write_hive.md
+++ b/docs/dev/table/hive/read_write_hive.md
@@ -171,13 +171,14 @@ It is especially beneficial when a table contains many columns.
 For queries with LIMIT clause, Flink will limit the number of output records wherever possible to minimize the
 amount of data transferred across network.
 
-### ORC Vectorized Optimization upon Read
+### Vectorized Optimization upon Read
 
 Optimization is used automatically when the following conditions are met:
 
+- Format: ORC or Parquet.
 - Columns without complex data type, like hive types: List, Map, Struct, Union.
 
-This feature is turned on by default. If there is a problem, you can use this config option to close ORC Vectorized Optimization:
+This feature is turned on by default. If there is a problem, you can use this config option to close Vectorized Optimization:
 
 {% highlight bash %}
 table.exec.hive.fallback-mapred-reader=true

--- a/docs/dev/table/hive/read_write_hive.zh.md
+++ b/docs/dev/table/hive/read_write_hive.zh.md
@@ -171,13 +171,14 @@ It is especially beneficial when a table contains many columns.
 For queries with LIMIT clause, Flink will limit the number of output records wherever possible to minimize the
 amount of data transferred across network.
 
-### ORC Vectorized Optimization upon Read
+### Vectorized Optimization upon Read
 
 Optimization is used automatically when the following conditions are met:
 
+- Format: ORC or Parquet.
 - Columns without complex data type, like hive types: List, Map, Struct, Union.
 
-This feature is turned on by default. If there is a problem, you can use this config option to close ORC Vectorized Optimization:
+This feature is turned on by default. If there is a problem, you can use this config option to close Vectorized Optimization:
 
 {% highlight bash %}
 table.exec.hive.fallback-mapred-reader=true

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -106,6 +106,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-parquet_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -761,6 +767,10 @@ under the License.
 				<executions>
 					<execution>
 						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
 						<configuration>
 							<shadeTestJar>false</shadeTestJar>
 							<artifactSet>
@@ -769,12 +779,26 @@ under the License.
 									<include>org.apache.flink:flink-orc_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-orc-nohive_${scala.binary.version}</include>
 									<include>org.apache.flink:flink-hadoop-compatibility_${scala.binary.version}</include>
+									<include>org.apache.flink:flink-parquet_${scala.binary.version}</include>
+									<include>org.apache.parquet:parquet-hadoop</include>
+									<include>org.apache.parquet:parquet-format</include>
+									<include>org.apache.parquet:parquet-column</include>
+									<include>org.apache.parquet:parquet-common</include>
+									<include>org.apache.parquet:parquet-encoding</include>
 								</includes>
 							</artifactSet>
 							<relocations>
 								<relocation>
 									<pattern>org.apache.flink.runtime.fs.hdfs</pattern>
 									<shadedPattern>org.apache.flink.connectors.hive.fs.hdfs</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.parquet</pattern>
+									<shadedPattern>org.apache.flink.shaded.org.apache.parquet</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>shaded.parquet</pattern>
+									<shadedPattern>org.apache.flink.reshaded.parquet</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.mapred.InputFormat;
@@ -113,14 +114,72 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 
 	@Override
 	public void open(HiveTableInputSplit split) throws IOException {
-		if (!useMapRedReader && useOrcVectorizedRead(split.getHiveTablePartition())) {
+		HiveTablePartition partition = split.getHiveTablePartition();
+		if (!useMapRedReader && useOrcVectorizedRead(partition)) {
 			this.reader = new HiveVectorizedOrcSplitReader(
+					hiveVersion, jobConf, fieldNames, fieldTypes, selectedFields, split);
+		} else if (!useMapRedReader && useParquetVectorizedRead(partition)) {
+			this.reader = new HiveVectorizedParquetSplitReader(
 					hiveVersion, jobConf, fieldNames, fieldTypes, selectedFields, split);
 		} else {
 			this.reader = new HiveMapredSplitReader(jobConf, partitionKeys, fieldTypes, selectedFields, split,
 					HiveShimLoader.loadHiveShim(hiveVersion));
 		}
 		currentReadCount = 0L;
+	}
+
+	private boolean isVectorizationSupport(LogicalType t) {
+		switch (t.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+			case BOOLEAN:
+			case BINARY:
+			case VARBINARY:
+			case DECIMAL:
+			case TINYINT:
+			case SMALLINT:
+			case INTEGER:
+			case BIGINT:
+			case FLOAT:
+			case DOUBLE:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				return false;
+			case TIMESTAMP_WITH_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+			case INTERVAL_DAY_TIME:
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case DISTINCT_TYPE:
+			case STRUCTURED_TYPE:
+			case NULL:
+			case RAW:
+			case SYMBOL:
+			default:
+				return true;
+		}
+	}
+
+	private boolean useParquetVectorizedRead(HiveTablePartition partition) {
+		boolean isParquet = partition.getStorageDescriptor().getSerdeInfo().getSerializationLib()
+				.toLowerCase().contains("parquet");
+		if (!isParquet) {
+			return false;
+		}
+
+		for (int i : selectedFields) {
+			if (isVectorizationSupport(fieldTypes[i].getLogicalType())) {
+				LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
+				return false;
+			}
+		}
+
+		LOG.info("Use flink parquet ColumnarRow reader.");
+		return true;
 	}
 
 	private boolean useOrcVectorizedRead(HiveTablePartition partition) {
@@ -131,39 +190,9 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		}
 
 		for (int i : selectedFields) {
-			switch (fieldTypes[i].getLogicalType().getTypeRoot()) {
-				case CHAR:
-				case VARCHAR:
-				case BOOLEAN:
-				case BINARY:
-				case VARBINARY:
-				case DECIMAL:
-				case TINYINT:
-				case SMALLINT:
-				case INTEGER:
-				case BIGINT:
-				case FLOAT:
-				case DOUBLE:
-				case DATE:
-				case TIME_WITHOUT_TIME_ZONE:
-				case TIMESTAMP_WITHOUT_TIME_ZONE:
-				case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-					break;
-				case TIMESTAMP_WITH_TIME_ZONE:
-				case INTERVAL_YEAR_MONTH:
-				case INTERVAL_DAY_TIME:
-				case ARRAY:
-				case MULTISET:
-				case MAP:
-				case ROW:
-				case DISTINCT_TYPE:
-				case STRUCTURED_TYPE:
-				case NULL:
-				case RAW:
-				case SYMBOL:
-				default:
-					LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
-					return false;
+			if (isVectorizationSupport(fieldTypes[i].getLogicalType())) {
+				LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
+				return false;
 			}
 		}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -128,7 +128,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		currentReadCount = 0L;
 	}
 
-	private boolean isVectorizationSupport(LogicalType t) {
+	private boolean isVectorizationUnsupported(LogicalType t) {
 		switch (t.getTypeRoot()) {
 			case CHAR:
 			case VARCHAR:
@@ -172,7 +172,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		}
 
 		for (int i : selectedFields) {
-			if (isVectorizationSupport(fieldTypes[i].getLogicalType())) {
+			if (isVectorizationUnsupported(fieldTypes[i].getLogicalType())) {
 				LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
 				return false;
 			}
@@ -190,7 +190,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<BaseRow, H
 		}
 
 		for (int i : selectedFields) {
-			if (isVectorizationSupport(fieldTypes[i].getLogicalType())) {
+			if (isVectorizationUnsupported(fieldTypes[i].getLogicalType())) {
 				LOG.info("Fallback to hadoop mapred reader, unsupported field type: " + fieldTypes[i]);
 				return false;
 			}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.parquet.vector.ParquetColumnarRowSplitReader;
+import org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.types.DataType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.IOException;
+
+import static org.apache.flink.table.dataformat.vector.VectorizedColumnBatch.DEFAULT_SIZE;
+
+/**
+ * Orc {@link SplitReader} to read files using {@link ParquetColumnarRowSplitReader}.
+ */
+public class HiveVectorizedParquetSplitReader implements SplitReader {
+
+	private ParquetColumnarRowSplitReader reader;
+
+	public HiveVectorizedParquetSplitReader(
+			String hiveVersion,
+			JobConf jobConf,
+			String[] fieldNames,
+			DataType[] fieldTypes,
+			int[] selectedFields,
+			HiveTableInputSplit split) throws IOException {
+		StorageDescriptor sd = split.getHiveTablePartition().getStorageDescriptor();
+
+		Configuration conf = new Configuration(jobConf);
+		sd.getSerdeInfo().getParameters().forEach(conf::set);
+
+		InputSplit hadoopSplit = split.getHadoopInputSplit();
+		FileSplit fileSplit;
+		if (hadoopSplit instanceof FileSplit) {
+			fileSplit = (FileSplit) hadoopSplit;
+		} else {
+			throw new IllegalArgumentException("Unknown split type: " + hadoopSplit);
+		}
+
+		this.reader = ParquetSplitReaderUtil.genPartColumnarRowReader(
+				hiveVersion.startsWith("3"),
+				conf,
+				fieldNames,
+				fieldTypes,
+				split.getHiveTablePartition().getPartitionSpec(),
+				selectedFields,
+				DEFAULT_SIZE,
+				new Path(fileSplit.getPath().toString()),
+				fileSplit.getStart(),
+				fileSplit.getLength());
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return this.reader.reachedEnd();
+	}
+
+	@Override
+	public BaseRow nextRecord(BaseRow reuse) {
+		return this.reader.nextRecord();
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.reader.close();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-hive/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,13 @@
+flink-connector-hive
+Copyright 2014-2019 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.apache.parquet:parquet-hadoop:1.10.0
+- org.apache.parquet:parquet-format:1.10.0
+- org.apache.parquet:parquet-column:1.10.0
+- org.apache.parquet:parquet-common:1.10.0
+- org.apache.parquet:parquet-encoding:1.10.0

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/TableEnvHiveConnectorTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.ArrayUtils;
 
 import com.klarna.hiverunner.HiveShell;
 import com.klarna.hiverunner.annotations.HiveSQL;
@@ -56,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -147,6 +149,7 @@ public class TableEnvHiveConnectorTest {
 			suffix = "stored as " + format;
 		}
 		String tableSchema;
+		// use 2018-08-20 00:00:00.1 to avoid multi-version print difference.
 		List<Object> row1 = new ArrayList<>(Arrays.asList(1, "a", "2018-08-20 00:00:00.1"));
 		List<Object> row2 = new ArrayList<>(Arrays.asList(2, "b", "2019-08-26 00:00:00.1"));
 		// some data types are not supported for parquet tables in early versions -- https://issues.apache.org/jira/browse/HIVE-6384
@@ -157,23 +160,37 @@ public class TableEnvHiveConnectorTest {
 		} else {
 			tableSchema = "(i int,s string,ts timestamp)";
 		}
-		hiveShell.execute(String.format("create table db1.src %s %s", tableSchema, suffix));
-		hiveShell.execute(String.format("create table db1.dest %s %s", tableSchema, suffix));
+
+		hiveShell.execute(String.format(
+				"create table db1.src %s partitioned by (p1 string, p2 timestamp) %s", tableSchema, suffix));
+		hiveShell.execute(String.format(
+				"create table db1.dest %s partitioned by (p1 string, p2 timestamp) %s", tableSchema, suffix));
 
 		// prepare source data with Hive
 		// TABLE keyword in INSERT INTO is mandatory prior to 1.1.0
-		hiveShell.execute(String.format("insert into table db1.src values (%s),(%s)",
-				toRowValue(row1), toRowValue(row2)));
+		hiveShell.execute(String.format(
+				"insert into table db1.src partition(p1='first',p2='2018-08-20 00:00:00.1') values (%s)",
+				toRowValue(row1)));
+		hiveShell.execute(String.format(
+				"insert into table db1.src partition(p1='second',p2='2018-08-26 00:00:00.1') values (%s)",
+				toRowValue(row2)));
+
+		List<String> expected = Arrays.asList(
+				String.join("\t", ArrayUtils.concat(
+						row1.stream().map(Object::toString).toArray(String[]::new),
+						new String[]{"first", "2018-08-20 00:00:00.1"})),
+				String.join("\t", ArrayUtils.concat(
+						row2.stream().map(Object::toString).toArray(String[]::new),
+						new String[]{"second", "2018-08-26 00:00:00.1"})));
+
+		verifyFlinkQueryResult(tableEnv.sqlQuery("select * from db1.src"), expected);
 
 		// populate dest table with source table
 		tableEnv.sqlUpdate("insert into db1.dest select * from db1.src");
 		tableEnv.execute("test_" + format);
 
 		// verify data on hive side
-		verifyHiveQueryResult("select * from db1.dest",
-				Arrays.asList(
-						row1.stream().map(Object::toString).collect(Collectors.joining("\t")),
-						row2.stream().map(Object::toString).collect(Collectors.joining("\t"))));
+		verifyHiveQueryResult("select * from db1.dest", expected);
 
 		hiveShell.execute("drop database db1 cascade");
 	}
@@ -520,6 +537,19 @@ public class TableEnvHiveConnectorTest {
 
 	private void verifyHiveQueryResult(String query, List<String> expected) {
 		List<String> results = hiveShell.executeQuery(query);
+		assertEquals(expected.size(), results.size());
+		assertEquals(new HashSet<>(expected), new HashSet<>(results));
+	}
+
+	private void verifyFlinkQueryResult(org.apache.flink.table.api.Table table, List<String> expected) throws Exception {
+		List<Row> rows = TableUtils.collectToList(table);
+		List<String> results = rows.stream().map(row ->
+				IntStream.range(0, row.getArity())
+						.mapToObj(row::getField)
+						.map(o -> o instanceof LocalDateTime ?
+								Timestamp.valueOf((LocalDateTime) o) : o)
+						.map(Object::toString)
+						.collect(Collectors.joining("\t"))).collect(Collectors.toList());
 		assertEquals(expected.size(), results.size());
 		assertEquals(new HashSet<>(expected), new HashSet<>(results));
 	}


### PR DESCRIPTION

## What is the purpose of the change

#10922 has introduce `ParquetColumnarRowSplitReader`, we should enable it in hive.

## Brief change log

- Modify hive pom to shade parquet
- Introduce `HiveVectorizedParquetSplitReader`

## Verifying this change

`TableEnvHiveConnectorTest` modify cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
