### PR TITLE
[FLINK-15447][yarn] Add config to define 'java.io.tmpdir' property of…

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1571,6 +1571,10 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			javaOpts += " -Djava.security.krb5.conf=krb5.conf";
 		}
 
+		final Path tmpDirPath = new Path(ApplicationConstants.Environment.PWD.$$(),
+			flinkConfiguration.getString(YarnConfigOptions.TMP_DIR));
+		javaOpts += " -Djava.io.tmpdir=" + tmpDirPath;
+
 		// Set up the container launch context for the application master
 		ContainerLaunchContext amContainer = Records.newRecord(ContainerLaunchContext.class);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptions.java
@@ -71,6 +71,14 @@ public class YarnConfigOptions {
 				.build());
 
 	/**
+	 * The tmp directory of Yarn containers.
+	 */
+	public static final ConfigOption<String> TMP_DIR =
+		key("yarn.container.tmpdir")
+			.defaultValue("/tmp")
+			.withDescription("Defines the 'java.io.tmpdir' property of Yarn containers.");
+
+	/**
 	 * Set the number of retries for failed YARN ApplicationMasters/JobManagers in high
 	 * availability mode. This value is usually limited by YARN.
 	 * By default, it's 1 in the standalone case and 2 in the high availability case.

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnClusterDescriptorTest.java
@@ -161,6 +161,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 		final String jvmOpts = "-Djvm"; // if set
 		final String jmJvmOpts = "-DjmJvm"; // if set
 		final String krb5 = "-Djava.security.krb5.conf=krb5.conf";
+		final String tmpdir = "-Djava.io.tmpdir=/tmp";
 		final String logfile =
 			"-Dlog.file=\"" + ApplicationConstants.LOG_DIR_EXPANSION_VAR +
 				"/jobmanager.log\""; // if set
@@ -179,7 +180,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// no logging, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + tmpdir + // jvmOpts
 					"" + // logging
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -193,7 +194,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + krb5 + " " + tmpdir + // jvmOpts
 					"" + // logging
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -208,7 +209,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback only, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -222,7 +223,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + krb5 + " " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -237,7 +238,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + tmpdir + // jvmOpts
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -251,7 +252,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + krb5 + " " + tmpdir + // jvmOpts
 					" " + logfile + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -266,7 +267,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			// logback + log4j, with/out krb5
 			assertEquals(
 				java + " " + jvmmem +
-					"" + // jvmOpts
+					" " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -280,7 +281,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + krb5 + // jvmOpts
+					" " + krb5 + " " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -298,7 +299,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JVM_OPTIONS, jvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts +
+					" " + jvmOpts + " " + tmpdir +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -312,7 +313,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + krb5 + // jvmOpts
+					" " + jvmOpts + " " + krb5 + " " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -329,7 +330,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			cfg.setString(CoreOptions.FLINK_JM_JVM_OPTIONS, jmJvmOpts);
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + jmJvmOpts +
+					" " + jvmOpts + " " + jmJvmOpts + " " + tmpdir +
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -343,7 +344,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 
 			assertEquals(
 				java + " " + jvmmem +
-					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + " " + tmpdir + // jvmOpts
 					" " + logfile + " " + logback + " " + log4j +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor
@@ -361,7 +362,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 				"%java% 1 %jvmmem% 2 %jvmopts% 3 %logging% 4 %class% 5 %args% 6 %redirects%");
 			assertEquals(
 				java + " 1 " + jvmmem +
-					" 2 " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" 2 " + jvmOpts + " " + jmJvmOpts + " " + krb5 + " " + tmpdir + // jvmOpts
 					" 3 " + logfile + " " + logback + " " + log4j +
 					" 4 " + mainClass + " 5 6 " + redirects,
 				clusterDescriptor
@@ -379,7 +380,7 @@ public class YarnClusterDescriptorTest extends TestLogger {
 			assertEquals(
 				java +
 					" " + logfile + " " + logback + " " + log4j +
-					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + // jvmOpts
+					" " + jvmOpts + " " + jmJvmOpts + " " + krb5 + " " + tmpdir + // jvmOpts
 					" " + jvmmem +
 					" " + mainClass + " " + redirects,
 				clusterDescriptor


### PR DESCRIPTION
… Yarn containers

## What is the purpose of the change

Currently, the `java.io.tmpdir` property of Flink Yarn containers is set to the default value, which is "/tmp". This directory is shared by all processes and not cleaned automatically by Yarn, as a result, the users may encounter exceptions caused by a full "/tmp" directory.

This PR aims to enable configuring the `java.io.tmpdir` property of  Yarn containers.

## Brief change log

*(for example:)*
  - Add a configuration named "yarn.container.tmpdir" to `YarnConfigOptions`, with a default value "/tmp", which is consistent with the previous behavior.
  - Add "-Djava.io.tmpdir=xxxx" options to Java start command, with the value configured in the above option.

## Verifying this change

This change is already covered by existing tests, such as `org.apache.flink.yarn.YarnClusterDescriptorTest`. This test is updated accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes, Yarn deployment**)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (**yes**)
  - If yes, how is the feature documented? (JavaDocs)
