### PR TITLE
[FLINK-16330][AZP] Enable tests requiring S3 credentials

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -216,8 +216,6 @@ fi
 ARTIFACTS_DIR="${HERE}/artifacts"
 mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
 
-env > $ARTIFACTS_DIR/environment
-
 LOG4J_PROPERTIES=${HERE}/../tools/log4j-travis.properties
 
 MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -17,7 +17,7 @@
 #
 # This file defines the Flink build for the "apache/flink" repository, including
 # the following:
-#  - PR builds
+#  - PR builds (triggered through ci-bot)
 #  - custom triggered e2e tests
 #  - nightly builds
 

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -162,6 +162,7 @@ jobs:
       displayName: Setup Docker
     - script: ./tools/azure-pipelines/free_disk_space.sh
       displayName: Free up disk space
+    - script: sudo apt-get install -y bc
     - script: M2_HOME=/home/vsts/maven_cache/apache-maven-3.2.5/ PATH=/home/vsts/maven_cache/apache-maven-3.2.5/bin:$PATH ${{parameters.environment}} STAGE=compile ./tools/azure_controller.sh compile
       displayName: Build Flink
     # TODO remove pre-commit tests script by adding the tests to the nightly script
@@ -169,6 +170,10 @@ jobs:
 #      displayName: Test - precommit 
     - script: ${{parameters.environment}} FLINK_DIR=`pwd`/build-target flink-end-to-end-tests/run-nightly-tests.sh
       displayName: Run e2e tests
+      env:
+        IT_CASE_S3_BUCKET: $(IT_CASE_S3_BUCKET)
+        IT_CASE_S3_ACCESS_KEY: $(IT_CASE_S3_ACCESS_KEY)
+        IT_CASE_S3_SECRET_KEY: $(IT_CASE_S3_SECRET_KEY)
       # upload debug artifacts
     - task: PublishPipelineArtifact@1
       condition: and(succeededOrFailed(), not(eq('$(ARTIFACT_DIR)', '')))


### PR DESCRIPTION
## What is the purpose of the change
Some end to end tests only execute if certain environment variables are set. They contain credentials for accessing S3.

This change is preparing our azure configuration file to pass the secret values as environment variables.

**Security**:
- Secure variables are defined in the web ui of azure pipelines
- the secret values are only set for the [pipeline](https://dev.azure.com/rmetzger/Flink/_build?definitionId=8&_a=summary) connected to this repository: https://github.com/flink-ci/flink-mirror. This repository does not receive pull requests through ci-bot. It receives master and release pushes.
- Pull requests are pushed into this repository: https://github.com/flink-ci/flink. It is connected to this [pipeline](https://dev.azure.com/rmetzger/Flink/_build?definitionId=4&_a=summary) (which doesn't have the secrets set)
- Secrets are not made available to pull request builds (if somebody opens a PR to `flink-ci/flink-mirror`, they won't be able to steal the secrets).

## Verifying this change

This change has been tested on this repo (which has the credentials set): https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=107&view=results