### PR TITLE
[FLINK-14121] Update commons-compress because of CVE-2019-12402

### DIFF
--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -19,7 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-cli:commons-cli:1.3.1
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.4
-- org.apache.commons:commons-compress:1.18
+- org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5
 - org.javassist:javassist:3.24.0-GA

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -30,7 +30,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - net.minidev:accessors-smart:1.2
 - net.minidev:json-smart:2.3
 - org.apache.avro:avro:1.8.2
-- org.apache.commons:commons-compress:1.18
+- org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-math3:3.5

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.htrace:htrace-core4:4.0.1-incubating
 - org.apache.httpcomponents:httpclient:4.5.3
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.apache.commons:commons-compress:1.18
+- org.apache.commons:commons-compress:1.20
 - org.apache.commons:commons-math3:3.5
 - commons-beanutils:commons-beanutils:1.8.3
 - commons-cli:commons-cli:1.3.1

--- a/pom.xml
+++ b/pom.xml
@@ -538,7 +538,7 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-compress</artifactId>
-				<version>1.18</version>
+				<version>1.20</version>
 			</dependency>
 
 			<!-- Managed dependency required for HBase in flink-hbase -->


### PR DESCRIPTION
## What is the purpose of the change

- Fix [CVE-2019-12402](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12402) 

## Brief change log

  - Update commons-compress to the latest release

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
