### PR TITLE
[FLINK-16313][state-processor-api] Properly dispose of native resources when closing input split

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/KeyedStateInputFormat.java
@@ -180,7 +180,12 @@ public class KeyedStateInputFormat<K, N, OUT> extends RichInputFormat<OUT, KeyGr
 
 	@Override
 	public void close() throws IOException {
-		registry.close();
+		try {
+			operator.close();
+			registry.close();
+		} catch (Exception e) {
+			throw new IOException("Failed to close state backend", e);
+		}
 	}
 
 	@Override

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/StateReaderOperator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/operator/StateReaderOperator.java
@@ -104,7 +104,21 @@ public abstract class StateReaderOperator<F extends Function, KEY, N, OUT> imple
 	}
 
 	public void close() throws Exception {
-		FunctionUtils.closeFunction(function);
+		Exception exception = null;
+
+		try {
+			FunctionUtils.closeFunction(function);
+		} catch (Exception e) {
+			// The state backend must always be closed
+			// to release native resources.
+			exception = e;
+		}
+
+		keyedStateBackend.dispose();
+
+		if (exception != null) {
+			throw exception;
+		}
 	}
 
 	@Override

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendReaderKeyedStateITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/RocksDBStateBackendReaderKeyedStateITCase.java
@@ -22,12 +22,9 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 
-import org.junit.Ignore;
-
 /**
  * IT Case for reading state from a RocksDB keyed state backend.
  */
-@Ignore
 public class RocksDBStateBackendReaderKeyedStateITCase extends SavepointReaderKeyedStateITCase<RocksDBStateBackend> {
 	@Override
 	protected RocksDBStateBackend getStateBackend() {


### PR DESCRIPTION
## What is the purpose of the change

FLINK-15014 refactored the `KeyedStateInputFormat` to be more composable. The change did not properly account for the new ownership of the `StateBackend` object and did not dispose of native resources. 

This fix needs to be backported to 1.10

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
