### PR TITLE
CodeGenUtils generates code that has two semicolons for GroupingWindowAggsHandler in blink

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -495,7 +495,7 @@ object CodeGenUtils {
       }
     } else if (rowClass == classOf[GenericRow] || rowClass == classOf[BoxedWrapperRow]) {
       val writeField = if (rowClass == classOf[GenericRow]) {
-        s"$rowTerm.setField($indexTerm, $fieldTerm);"
+        s"$rowTerm.setField($indexTerm, $fieldTerm)"
       } else {
         boxedWrapperRowFieldSetAccess(rowTerm, indexTerm, fieldTerm, fieldType)
       }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18002496/76136992-cff99500-6072-11ea-8c66-235133051249.png)
![image](https://user-images.githubusercontent.com/18002496/76136994-d6880c80-6072-11ea-8133-ab8504886bf2.png)
