### PR TITLE
[FLINK-16273][python] Set io.netty.tryReflectionSetAccessible to true by default

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
@@ -51,6 +51,10 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 		// be set to true for JDK >= 9. Please refer to ARROW-5412 for more details.
 		if (System.getProperty("io.netty.tryReflectionSetAccessible") == null) {
 			System.setProperty("io.netty.tryReflectionSetAccessible", "true");
+		} else if (!io.netty.util.internal.PlatformDependent.hasDirectBufferNoCleanerConstructor()) {
+			throw new RuntimeException("Vectorized Python UDF depends on " +
+				"DirectByteBuffer.<init>(long, int) which is not available. Please set the " +
+				"system property 'io.netty.tryReflectionSetAccessible' to 'true'.");
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
@@ -49,7 +49,9 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 	static {
 		// Arrow requires the property io.netty.tryReflectionSetAccessible to
 		// be set to true for JDK >= 9. Please refer to ARROW-5412 for more details.
-		System.setProperty("io.netty.tryReflectionSetAccessible", "true");
+		if (System.getProperty("io.netty.tryReflectionSetAccessible") == null) {
+			System.setProperty("io.netty.tryReflectionSetAccessible", "true");
+		}
 	}
 
 	/**

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
@@ -46,6 +46,12 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 
 	private static final String SCHEMA_ARROW_CODER_URN = "flink:coder:schema:scalar_function:arrow:v1";
 
+	static {
+		// Arrow requires the property io.netty.tryReflectionSetAccessible to
+		// be set to true for JDK >= 9. Please refer to ARROW-5412 for more details.
+		System.setProperty("io.netty.tryReflectionSetAccessible", "true");
+	}
+
 	/**
 	 * Max number of elements to include in an arrow batch.
 	 */


### PR DESCRIPTION

## What is the purpose of the change

* This pull request set the property io.netty.tryReflectionSetAccessible to true by default for ArrowScalarFunctionOperator to work around the issue of ARROW-5412.*

## Brief change log

  - *Set the property io.netty.tryReflectionSetAccessible to true by default for ArrowScalarFunctionOperator.*

## Verifying this change

This change has been tested manually.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
