### PR TITLE
[FLINK-14971][checkpointing] Make all the non-IO operations in CheckpointCoordinator single-threaded

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1370,6 +1370,7 @@ public class CheckpointCoordinator {
 		return this.pendingCheckpoints.size();
 	}
 
+	@VisibleForTesting
 	public int getNumberOfRetainedSuccessfulCheckpoints() {
 		synchronized (lock) {
 			return completedCheckpointStore.getNumberOfRetainedCheckpoints();
@@ -1382,6 +1383,7 @@ public class CheckpointCoordinator {
 		}
 	}
 
+	@VisibleForTesting
 	public List<CompletedCheckpoint> getSuccessfulCheckpoints() throws Exception {
 		synchronized (lock) {
 			return completedCheckpointStore.getAllCheckpoints();
@@ -1392,6 +1394,7 @@ public class CheckpointCoordinator {
 		return checkpointStorage;
 	}
 
+	@VisibleForTesting
 	public CompletedCheckpointStore getCheckpointStore() {
 		return completedCheckpointStore;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -656,7 +656,9 @@ public class CheckpointCoordinator {
 			props,
 			checkpointStorageLocation,
 			executor,
-			onCompletionPromise);
+			timer,
+			onCompletionPromise,
+			completedCheckpointStore);
 
 		if (statsTracker != null) {
 			PendingCheckpointStats callback = statsTracker.reportPendingCheckpoint(
@@ -1018,61 +1020,44 @@ public class CheckpointCoordinator {
 	 * <p>Important: This method should only be called in the checkpoint lock scope.
 	 *
 	 * @param pendingCheckpoint to complete
-	 * @throws CheckpointException if the completion failed
 	 */
-	private void completePendingCheckpoint(PendingCheckpoint pendingCheckpoint) throws CheckpointException {
-		final long checkpointId = pendingCheckpoint.getCheckpointId();
-		final CompletedCheckpoint completedCheckpoint;
-
+	private void completePendingCheckpoint(PendingCheckpoint pendingCheckpoint) {
 		// As a first step to complete the checkpoint, we register its state with the registry
 		Map<OperatorID, OperatorState> operatorStates = pendingCheckpoint.getOperatorStates();
 		sharedStateRegistry.registerAll(operatorStates.values());
 
-		try {
-			try {
-				completedCheckpoint = pendingCheckpoint.finalizeCheckpoint();
-				failureManager.handleCheckpointSuccess(pendingCheckpoint.getCheckpointId());
-			}
-			catch (Exception e1) {
-				// abort the current pending checkpoint if we fails to finalize the pending checkpoint.
-				if (!pendingCheckpoint.isDiscarded()) {
-					abortPendingCheckpoint(
-						pendingCheckpoint,
-						new CheckpointException(
-							CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE, e1));
-				}
-
-				throw new CheckpointException("Could not finalize the pending checkpoint " + checkpointId + '.',
-					CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE, e1);
-			}
-
-			// the pending checkpoint must be discarded after the finalization
-			Preconditions.checkState(pendingCheckpoint.isDiscarded() && completedCheckpoint != null);
-
-			try {
-				completedCheckpointStore.addCheckpoint(completedCheckpoint);
-			} catch (Exception exception) {
-				// we failed to store the completed checkpoint. Let's clean up
-				executor.execute(new Runnable() {
-					@Override
-					public void run() {
-						try {
-							completedCheckpoint.discardOnFailedStoring();
-						} catch (Throwable t) {
-							LOG.warn("Could not properly discard completed checkpoint {}.", completedCheckpoint.getCheckpointID(), t);
-						}
+		pendingCheckpoint.finalizeCheckpoint()
+			.whenCompleteAsync((completedCheckpoint, throwable) -> {
+				synchronized (lock) {
+					if (shutdown) {
+						return;
 					}
-				});
+					if (throwable != null) {
+						if (!pendingCheckpoint.isDiscarded()) {
+							abortPendingCheckpoint(
+								pendingCheckpoint,
+								new CheckpointException(
+									CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE, throwable));
+						}
+					} else {
+						onCheckpointSuccess(completedCheckpoint);
+					}
+				}
+			}, timer);
+	}
 
-				throw new CheckpointException("Could not complete the pending checkpoint " + checkpointId + '.',
-					CheckpointFailureReason.FINALIZE_CHECKPOINT_FAILURE, exception);
-			}
-		} finally {
-			pendingCheckpoints.remove(checkpointId);
+	/**
+	 * It's the last step of a checkpoint.
+	 *
+	 * @param completedCheckpoint the completed checkpoint
+	 */
+	private void onCheckpointSuccess(CompletedCheckpoint completedCheckpoint) {
+		final long checkpointId = completedCheckpoint.getCheckpointID();
 
-			resumePeriodicTriggering();
-		}
+		pendingCheckpoints.remove(checkpointId);
 
+		resumePeriodicTriggering();
+		failureManager.handleCheckpointSuccess(checkpointId);
 		rememberRecentCheckpointId(checkpointId);
 
 		// drop those pending checkpoints that are at prior to the completed one

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -23,12 +23,16 @@ import org.apache.flink.api.common.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.util.List;
 import java.util.ListIterator;
 
 /**
  * A bounded LIFO-queue of {@link CompletedCheckpoint} instances.
+ * Note that it might be visited by multiple threads. So implementation should keep it thread-safe.
  */
+@ThreadSafe
 public interface CompletedCheckpointStore {
 
 	Logger LOG = LoggerFactory.getLogger(CompletedCheckpointStore.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStore.java
@@ -29,6 +29,8 @@ import org.apache.flink.util.function.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.concurrent.ThreadSafe;
+
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -40,6 +42,7 @@ import java.util.concurrent.Executor;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * {@link CompletedCheckpointStore} for JobManagers running in {@link HighAvailabilityMode#ZOOKEEPER}.
@@ -64,6 +67,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * checkpoints is consistent. Currently, after recovery we start out with only a single
  * checkpoint to circumvent those situations.
  */
+@ThreadSafe
 public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointStore {
 
 	private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperCompletedCheckpointStore.class);
@@ -84,6 +88,10 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	private final ArrayDeque<CompletedCheckpoint> completedCheckpoints;
 
 	private final Executor executor;
+
+	private final Object lock = new Object();
+
+	private boolean shutdown = false;
 
 	/**
 	 * Creates a {@link ZooKeeperCompletedCheckpointStore} instance.
@@ -127,77 +135,79 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	public void recover() throws Exception {
 		LOG.info("Recovering checkpoints from ZooKeeper.");
 
-		// Get all there is first
-		List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> initialCheckpoints;
-		while (true) {
-			try {
-				initialCheckpoints = checkpointsInZooKeeper.getAllAndLock();
-				break;
-			}
-			catch (ConcurrentModificationException e) {
-				LOG.warn("Concurrent modification while reading from ZooKeeper. Retrying.");
-			}
-		}
-
-		Collections.sort(initialCheckpoints, STRING_COMPARATOR);
-
-		int numberOfInitialCheckpoints = initialCheckpoints.size();
-
-		LOG.info("Found {} checkpoints in ZooKeeper.", numberOfInitialCheckpoints);
-
-		// Try and read the state handles from storage. We try until we either successfully read
-		// all of them or when we reach a stable state, i.e. when we successfully read the same set
-		// of checkpoints in two tries. We do it like this to protect against transient outages
-		// of the checkpoint store (for example a DFS): if the DFS comes online midway through
-		// reading a set of checkpoints we would run the risk of reading only a partial set
-		// of checkpoints while we could in fact read the other checkpoints as well if we retried.
-		// Waiting until a stable state protects against this while also being resilient against
-		// checkpoints being actually unreadable.
-		//
-		// These considerations are also important in the scope of incremental checkpoints, where
-		// we use ref-counting for shared state handles and might accidentally delete shared state
-		// of checkpoints that we don't read due to transient storage outages.
-		List<CompletedCheckpoint> lastTryRetrievedCheckpoints = new ArrayList<>(numberOfInitialCheckpoints);
-		List<CompletedCheckpoint> retrievedCheckpoints = new ArrayList<>(numberOfInitialCheckpoints);
-		do {
-			LOG.info("Trying to fetch {} checkpoints from storage.", numberOfInitialCheckpoints);
-
-			lastTryRetrievedCheckpoints.clear();
-			lastTryRetrievedCheckpoints.addAll(retrievedCheckpoints);
-
-			retrievedCheckpoints.clear();
-
-			for (Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> checkpointStateHandle : initialCheckpoints) {
-
-				CompletedCheckpoint completedCheckpoint;
-
+		synchronized (lock) {
+			checkState(!shutdown, "ZooKeeperCompletedCheckpointStore has been shut down");
+			// Get all there is first
+			List<Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String>> initialCheckpoints;
+			while (true) {
 				try {
-					completedCheckpoint = retrieveCompletedCheckpoint(checkpointStateHandle);
-					if (completedCheckpoint != null) {
-						retrievedCheckpoints.add(completedCheckpoint);
-					}
-				} catch (Exception e) {
-					LOG.warn("Could not retrieve checkpoint, not adding to list of recovered checkpoints.", e);
+					initialCheckpoints = checkpointsInZooKeeper.getAllAndLock();
+					break;
+				} catch (ConcurrentModificationException e) {
+					LOG.warn("Concurrent modification while reading from ZooKeeper. Retrying.");
 				}
 			}
 
-		} while (retrievedCheckpoints.size() != numberOfInitialCheckpoints &&
-			!CompletedCheckpoint.checkpointsMatch(lastTryRetrievedCheckpoints, retrievedCheckpoints));
+			Collections.sort(initialCheckpoints, STRING_COMPARATOR);
 
-		// Clear local handles in order to prevent duplicates on
-		// recovery. The local handles should reflect the state
-		// of ZooKeeper.
-		completedCheckpoints.clear();
-		completedCheckpoints.addAll(retrievedCheckpoints);
+			int numberOfInitialCheckpoints = initialCheckpoints.size();
 
-		if (completedCheckpoints.isEmpty() && numberOfInitialCheckpoints > 0) {
-			throw new FlinkException(
-				"Could not read any of the " + numberOfInitialCheckpoints + " checkpoints from storage.");
-		} else if (completedCheckpoints.size() != numberOfInitialCheckpoints) {
-			LOG.warn(
-				"Could only fetch {} of {} checkpoints from storage.",
-				completedCheckpoints.size(),
-				numberOfInitialCheckpoints);
+			LOG.info("Found {} checkpoints in ZooKeeper.", numberOfInitialCheckpoints);
+
+			// Try and read the state handles from storage. We try until we either successfully read
+			// all of them or when we reach a stable state, i.e. when we successfully read the same set
+			// of checkpoints in two tries. We do it like this to protect against transient outages
+			// of the checkpoint store (for example a DFS): if the DFS comes online midway through
+			// reading a set of checkpoints we would run the risk of reading only a partial set
+			// of checkpoints while we could in fact read the other checkpoints as well if we retried.
+			// Waiting until a stable state protects against this while also being resilient against
+			// checkpoints being actually unreadable.
+			//
+			// These considerations are also important in the scope of incremental checkpoints, where
+			// we use ref-counting for shared state handles and might accidentally delete shared state
+			// of checkpoints that we don't read due to transient storage outages.
+			List<CompletedCheckpoint> lastTryRetrievedCheckpoints = new ArrayList<>(numberOfInitialCheckpoints);
+			List<CompletedCheckpoint> retrievedCheckpoints = new ArrayList<>(numberOfInitialCheckpoints);
+			do {
+				LOG.info("Trying to fetch {} checkpoints from storage.", numberOfInitialCheckpoints);
+
+				lastTryRetrievedCheckpoints.clear();
+				lastTryRetrievedCheckpoints.addAll(retrievedCheckpoints);
+
+				retrievedCheckpoints.clear();
+
+				for (Tuple2<RetrievableStateHandle<CompletedCheckpoint>, String> checkpointStateHandle : initialCheckpoints) {
+
+					CompletedCheckpoint completedCheckpoint;
+
+					try {
+						completedCheckpoint = retrieveCompletedCheckpoint(checkpointStateHandle);
+						if (completedCheckpoint != null) {
+							retrievedCheckpoints.add(completedCheckpoint);
+						}
+					} catch (Exception e) {
+						LOG.warn("Could not retrieve checkpoint, not adding to list of recovered checkpoints.", e);
+					}
+				}
+
+			} while (retrievedCheckpoints.size() != numberOfInitialCheckpoints &&
+				!CompletedCheckpoint.checkpointsMatch(lastTryRetrievedCheckpoints, retrievedCheckpoints));
+
+			// Clear local handles in order to prevent duplicates on
+			// recovery. The local handles should reflect the state
+			// of ZooKeeper.
+			completedCheckpoints.clear();
+			completedCheckpoints.addAll(retrievedCheckpoints);
+
+			if (completedCheckpoints.isEmpty() && numberOfInitialCheckpoints > 0) {
+				throw new FlinkException(
+					"Could not read any of the " + numberOfInitialCheckpoints + " checkpoints from storage.");
+			} else if (completedCheckpoints.size() != numberOfInitialCheckpoints) {
+				LOG.warn(
+					"Could only fetch {} of {} checkpoints from storage.",
+					completedCheckpoints.size(),
+					numberOfInitialCheckpoints);
+			}
 		}
 	}
 
@@ -210,20 +220,24 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 	public void addCheckpoint(final CompletedCheckpoint checkpoint) throws Exception {
 		checkNotNull(checkpoint, "Checkpoint");
 
-		final String path = checkpointIdToPath(checkpoint.getCheckpointID());
+		synchronized (lock) {
+			checkState(!shutdown, "ZooKeeperCompletedCheckpointStore has been shut down");
 
-		// Now add the new one. If it fails, we don't want to loose existing data.
-		checkpointsInZooKeeper.addAndLock(path, checkpoint);
+			final String path = checkpointIdToPath(checkpoint.getCheckpointID());
 
-		completedCheckpoints.addLast(checkpoint);
+			// Now add the new one. If it fails, we don't want to loose existing data.
+			checkpointsInZooKeeper.addAndLock(path, checkpoint);
 
-		// Everything worked, let's remove a previous checkpoint if necessary.
-		while (completedCheckpoints.size() > maxNumberOfCheckpointsToRetain) {
-			final CompletedCheckpoint completedCheckpoint = completedCheckpoints.removeFirst();
-			tryRemoveCompletedCheckpoint(completedCheckpoint, CompletedCheckpoint::discardOnSubsume);
+			completedCheckpoints.addLast(checkpoint);
+
+			// Everything worked, let's remove a previous checkpoint if necessary.
+			while (completedCheckpoints.size() > maxNumberOfCheckpointsToRetain) {
+				final CompletedCheckpoint completedCheckpoint = completedCheckpoints.removeFirst();
+				tryRemoveCompletedCheckpoint(completedCheckpoint, CompletedCheckpoint::discardOnSubsume);
+			}
+
+			LOG.debug("Added {} to {}.", checkpoint, path);
 		}
-
-		LOG.debug("Added {} to {}.", checkpoint, path);
 	}
 
 	private void tryRemoveCompletedCheckpoint(CompletedCheckpoint completedCheckpoint, ThrowingConsumer<CompletedCheckpoint, Exception> discardCallback) {
@@ -245,12 +259,16 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 	@Override
 	public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
-		return new ArrayList<>(completedCheckpoints);
+		synchronized (lock) {
+			return new ArrayList<>(completedCheckpoints);
+		}
 	}
 
 	@Override
 	public int getNumberOfRetainedCheckpoints() {
-		return completedCheckpoints.size();
+		synchronized (lock) {
+			return completedCheckpoints.size();
+		}
 	}
 
 	@Override
@@ -260,25 +278,30 @@ public class ZooKeeperCompletedCheckpointStore implements CompletedCheckpointSto
 
 	@Override
 	public void shutdown(JobStatus jobStatus) throws Exception {
-		if (jobStatus.isGloballyTerminalState()) {
-			LOG.info("Shutting down");
+		synchronized (lock) {
+			if (!shutdown) {
+				shutdown = true;
+				if (jobStatus.isGloballyTerminalState()) {
+					LOG.info("Shutting down");
 
-			for (CompletedCheckpoint checkpoint : completedCheckpoints) {
-				tryRemoveCompletedCheckpoint(
-					checkpoint,
-					completedCheckpoint -> completedCheckpoint.discardOnShutdown(jobStatus));
+					for (CompletedCheckpoint checkpoint : completedCheckpoints) {
+						tryRemoveCompletedCheckpoint(
+							checkpoint,
+							completedCheckpoint -> completedCheckpoint.discardOnShutdown(jobStatus));
+					}
+
+					completedCheckpoints.clear();
+					checkpointsInZooKeeper.deleteChildren();
+				} else {
+					LOG.info("Suspending");
+
+					// Clear the local handles, but don't remove any state
+					completedCheckpoints.clear();
+
+					// Release the state handle locks in ZooKeeper such that they can be deleted
+					checkpointsInZooKeeper.releaseAll();
+				}
 			}
-
-			completedCheckpoints.clear();
-			checkpointsInZooKeeper.deleteChildren();
-		} else {
-			LOG.info("Suspending");
-
-			// Clear the local handles, but don't remove any state
-			completedCheckpoints.clear();
-
-			// Release the state handle locks in ZooKeeper such that they can be deleted
-			checkpointsInZooKeeper.releaseAll();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -397,6 +397,9 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	public void start(@Nonnull ComponentMainThreadExecutor jobMasterMainThreadExecutor) {
 		this.jobMasterMainThreadExecutor = jobMasterMainThreadExecutor;
+		if (checkpointCoordinator != null) {
+			checkpointCoordinator.start(this.jobMasterMainThreadExecutor);
+		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -798,13 +798,11 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final String taskManagerLocationInfo = retrieveTaskManagerLocation(executionAttemptID);
 
 		if (checkpointCoordinator != null) {
-			ioExecutor.execute(() -> {
-				try {
-					checkpointCoordinator.receiveAcknowledgeMessage(ackMessage, taskManagerLocationInfo);
-				} catch (Throwable t) {
-					log.warn("Error while processing checkpoint acknowledgement message", t);
-				}
-			});
+			try {
+				checkpointCoordinator.receiveAcknowledgeMessage(ackMessage, taskManagerLocationInfo);
+			} catch (Throwable t) {
+				log.warn("Error while processing checkpoint acknowledgement message", t);
+			}
 		} else {
 			String errorMessage = "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
 			if (executionGraph.getState() == JobStatus.RUNNING) {
@@ -823,13 +821,11 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final String taskManagerLocationInfo = retrieveTaskManagerLocation(decline.getTaskExecutionId());
 
 		if (checkpointCoordinator != null) {
-			ioExecutor.execute(() -> {
-				try {
-					checkpointCoordinator.receiveDeclineMessage(decline, taskManagerLocationInfo);
-				} catch (Exception e) {
-					log.error("Error in CheckpointCoordinator while processing {}", decline, e);
-				}
-			});
+			try {
+				checkpointCoordinator.receiveDeclineMessage(decline, taskManagerLocationInfo);
+			} catch (Exception e) {
+				log.error("Error in CheckpointCoordinator while processing {}", decline, e);
+			}
 		} else {
 			String errorMessage = "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
 			if (executionGraph.getState() == JobStatus.RUNNING) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -109,13 +108,9 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		AcknowledgeCheckpoint acknowledgeMessage = new AcknowledgeCheckpoint(jid, executionAttemptId, checkpointId, new CheckpointMetrics(), subtaskState);
 
-		try {
-			coord.receiveAcknowledgeMessage(acknowledgeMessage, "Unknown location");
-			fail("Expected a checkpoint exception because the completed checkpoint store could not " +
-				"store the completed checkpoint.");
-		} catch (CheckpointException e) {
-			// ignore because we expected this exception
-		}
+		coord.receiveAcknowledgeMessage(acknowledgeMessage, "Unknown location");
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// make sure that the pending checkpoint has been discarded after we could not complete it
 		assertTrue(pendingCheckpoint.isDiscarded());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -61,7 +61,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 	public void testFailingCompletedCheckpointStoreAdd() throws Exception {
 		JobID jid = new JobID();
 
-		final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
+		final ManuallyTriggeredScheduledExecutor mainThreadExecutor =
 			new ManuallyTriggeredScheduledExecutor();
 
 		final ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
@@ -75,12 +75,12 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(new ExecutionVertex[] { vertex })
 				.setCompletedCheckpointStore(new FailingCompletedCheckpointStore())
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		coord.triggerCheckpoint(triggerTimestamp, false);
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
@@ -110,7 +110,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		coord.receiveAcknowledgeMessage(acknowledgeMessage, "Unknown location");
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		// make sure that the pending checkpoint has been discarded after we could not complete it
 		assertTrue(pendingCheckpoint.isDiscarded());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -444,7 +445,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 	private CheckpointCoordinator instantiateCheckpointCoordinator(
 		JobID jid,
-		ScheduledExecutor testingScheduledExecutor,
+		ScheduledExecutor mainThreadExecutor,
 		ExecutionVertex... ackVertices) {
 
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
@@ -456,7 +457,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 			true,
 			false,
 			0);
-		return new CheckpointCoordinator(
+		final CheckpointCoordinator checkpointCoordinator = new CheckpointCoordinator(
 				jid,
 				chkConfig,
 				new ExecutionVertex[0],
@@ -467,11 +468,16 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new StandaloneCompletedCheckpointStore(10),
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
-				testingScheduledExecutor,
+				new ManuallyTriggeredScheduledExecutor(),
 				SharedStateRegistry.DEFAULT_FACTORY,
 				new CheckpointFailureManager(
 					0,
 					NoOpFailJobCall.INSTANCE));
+		checkpointCoordinator.start(
+			new ComponentMainThreadExecutorServiceAdapter(
+				mainThreadExecutor,
+				Thread.currentThread()));
+		return checkpointCoordinator;
 	}
 
 	private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -210,6 +210,8 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		final long checkpointId = cc.getPendingCheckpoints().values().iterator().next().getCheckpointId();
 		cc.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, execId, checkpointId), "Unknown location");
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertEquals(0, cc.getNumberOfPendingCheckpoints());
 
 		assertEquals(1, cc.getNumberOfRetainedSuccessfulCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -184,6 +184,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				subtaskState);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -299,6 +301,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForCheckpoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			CompletedCheckpoint success = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, success.getJobId());
@@ -326,6 +330,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			checkpointId = checkpointIDCounter.getLast();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForSavepoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertNotNull(savepointFuture.get());
 
@@ -467,6 +473,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				taskOperatorSubtaskStates);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -614,6 +622,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				taskOperatorSubtaskStates);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -94,14 +94,14 @@ import static org.mockito.Mockito.when;
 public class CheckpointCoordinatorRestoringTest extends TestLogger {
 	private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
-	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
+	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
-		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
+		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	/**
@@ -147,12 +147,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
 				.setCompletedCheckpointStore(store)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -185,7 +185,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -274,13 +274,13 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					.setCheckpointIDCounter(checkpointIDCounter)
 					.setCompletedCheckpointStore(store)
 					.setTasks(new ExecutionVertex[] { stateful1, stateless1 })
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			//trigger a checkpoint and wait to become a completed checkpoint
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			long checkpointId = checkpointIDCounter.getLast();
@@ -302,7 +302,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForCheckpoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			CompletedCheckpoint success = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, success.getJobId());
@@ -326,12 +326,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					StateObjectCollection.singleton(serializedKeyGroupStatesForSavepoint),
 					StateObjectCollection.empty()));
 
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			checkpointId = checkpointIDCounter.getLast();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForSavepoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			assertNotNull(savepointFuture.get());
 
@@ -416,12 +416,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -474,7 +474,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -581,12 +581,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -623,7 +623,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -823,7 +823,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setTasks(newJobVertex1.getTaskVertices())
 				.setCompletedCheckpointStore(standaloneCompletedCheckpointStore)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		coord.restoreLatestCheckpointedState(tasks, false, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -554,6 +554,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// acknowledge the other task.
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
+
 			// the checkpoint is internally converted to a successful checkpoint and the
 			// pending checkpoint object is disposed
 			assertTrue(checkpoint.isDiscarded());
@@ -593,6 +596,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -710,6 +715,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the first checkpoint should be confirmed
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -721,6 +728,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// send the last remaining ack for the second checkpoint
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId2), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -872,6 +881,9 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1, new CheckpointMetrics(), taskOperatorSubtaskStates11), TASK_MANAGER_LOCATION_INFO);
 
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2, new CheckpointMetrics(), taskOperatorSubtaskStates22), TASK_MANAGER_LOCATION_INFO);
+
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed, and the first discarded
 			// actually both pending checkpoints are discarded, and the second has been transformed
@@ -1244,6 +1256,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// acknowledge the other task.
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// the checkpoint is internally converted to a successful checkpoint and the
 		// pending checkpoint object is disposed
@@ -1283,6 +1297,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1364,6 +1380,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// 2nd checkpoint should subsume the 1st checkpoint, but not the savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1386,6 +1404,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// 2nd savepoint should subsume the last checkpoint, but not the 1st savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId2), TASK_MANAGER_LOCATION_INFO);
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(2, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1397,6 +1417,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Ack first savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId1), TASK_MANAGER_LOCATION_INFO);
+		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(3, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1462,11 +1484,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// now, once we acknowledge one checkpoint, it should trigger the next one
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID, 1L), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			final Collection<ScheduledFuture<?>> periodicScheduledTasks =
 				manuallyTriggeredScheduledExecutor.getPeriodicScheduledTask();
 			assertEquals(1, periodicScheduledTasks.size());
-			final ScheduledFuture scheduledFuture = periodicScheduledTasks.iterator().next();
 
 			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
 			manuallyTriggeredScheduledExecutor.triggerAll();
@@ -1663,6 +1686,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jobId, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
 		}
 
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		// After ACKs, all should be completed
 		for (CompletableFuture<CompletedCheckpoint> savepointFuture : savepointFutures) {
 			assertNotNull(savepointFuture.get());
@@ -2375,6 +2399,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				taskStateSnapshot);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -109,14 +109,17 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
-	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
+	private ManuallyTriggeredScheduledExecutor timer;
+
+	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
-		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
+		timer = new ManuallyTriggeredScheduledExecutor();
+		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	@Test
@@ -134,7 +137,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -163,7 +166,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -192,7 +195,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -241,7 +244,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkPointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkPointFuture.isCompletedExceptionally());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
@@ -297,7 +300,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
@@ -305,7 +308,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
 
 			// we have one task scheduled that will cancel after timeout
-			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			PendingCheckpoint checkpoint = coord.getPendingCheckpoints().get(checkpointId);
@@ -342,7 +345,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertTrue(checkpoint.isDiscarded());
 
 			// the canceler is also removed
-			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
 
 			// validate that we have no new pending checkpoint
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -383,24 +386,24 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
 
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			// trigger second checkpoint, should also succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp + 2, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(2, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(2, mainThreadExecutor.getScheduledTasks().size());
 
 			Iterator<Map.Entry<Long, PendingCheckpoint>> it = coord.getPendingCheckpoints().entrySet().iterator();
 			long checkpoint1Id = it.next().getKey();
@@ -447,7 +450,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// validate that we have only one pending checkpoint left
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
 
 			// validate that it is the same second checkpoint from earlier
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
@@ -495,18 +498,18 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
 
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			PendingCheckpoint checkpoint = coord.getPendingCheckpoints().get(checkpointId);
@@ -555,7 +558,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			// the checkpoint is internally converted to a successful checkpoint and the
 			// pending checkpoint object is disposed
@@ -566,7 +569,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
 			// the canceler should be removed now
-			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
 
 			// validate that the subtasks states have registered their shared states.
 			{
@@ -591,17 +594,17 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// ---------------
 			final long timestampNew = timestamp + 7;
 			coord.triggerCheckpoint(timestampNew, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
+			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
 
 			CompletedCheckpoint successNew = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, successNew.getJobId());
@@ -661,7 +664,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -670,7 +673,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp1, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -690,7 +693,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp2, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
@@ -716,7 +719,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			// now, the first checkpoint should be confirmed
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -729,7 +732,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// send the last remaining ack for the second checkpoint
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -796,7 +799,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -805,7 +808,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp1, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -840,7 +843,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp2, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
@@ -883,7 +886,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2, new CheckpointMetrics(), taskOperatorSubtaskStates22), TASK_MANAGER_LOCATION_INFO);
 
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed, and the first discarded
 			// actually both pending checkpoints are discarded, and the second has been transformed
@@ -962,13 +965,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			// trigger a checkpoint, partially acknowledged
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
@@ -984,7 +987,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpoint.getCheckpointId(), new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
 			// triggers cancelling
-			manuallyTriggeredScheduledExecutor.triggerScheduledTasks();
+			mainThreadExecutor.triggerScheduledTasks();
 			assertTrue("Checkpoint was not canceled by the timeout", checkpoint.isDiscarded());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1028,12 +1031,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			long checkpointId = coord.getPendingCheckpoints().keySet().iterator().next();
@@ -1093,12 +1096,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
 				.setTasksToWaitFor(new ExecutionVertex[] {triggerVertex, ackVertex1, ackVertex2})
 				.setTasksToCommitTo(new ExecutionVertex[0])
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 			coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(checkpointFuture.isCompletedExceptionally());
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -1210,7 +1213,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// trigger the first checkpoint. this should succeed
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 		CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(savepointFuture.isDone());
 
 		// validate that we have a pending savepoint
@@ -1257,7 +1260,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// acknowledge the other task.
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		// the checkpoint is internally converted to a successful checkpoint and the
 		// pending checkpoint object is disposed
@@ -1291,14 +1294,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// ---------------
 		final long timestampNew = timestamp + 7;
 		savepointFuture = coord.triggerSavepoint(timestampNew, savepointDir);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(savepointFuture.isDone());
 
 		long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1352,7 +1355,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
 				.setCheckpointIDCounter(counter)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
@@ -1360,19 +1363,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Trigger savepoint and checkpoint
 		CompletableFuture<CompletedCheckpoint> savepointFuture1 = coord.triggerSavepoint(timestamp, savepointDir);
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		long savepointId1 = counter.getLast();
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 			coord.triggerCheckpoint(timestamp + 1, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertEquals(2, coord.getNumberOfPendingCheckpoints());
 		assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 			coord.triggerCheckpoint(timestamp + 2, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(checkpointFuture2.isCompletedExceptionally());
 		long checkpointId2 = counter.getLast();
 		assertEquals(3, coord.getNumberOfPendingCheckpoints());
@@ -1381,7 +1384,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1391,12 +1394,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture3 =
 			coord.triggerCheckpoint(timestamp + 3, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(checkpointFuture3.isCompletedExceptionally());
 		assertEquals(2, coord.getNumberOfPendingCheckpoints());
 
 		CompletableFuture<CompletedCheckpoint> savepointFuture2 = coord.triggerSavepoint(timestamp + 4, savepointDir);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		long savepointId2 = counter.getLast();
 		assertFalse(savepointFuture2.isCompletedExceptionally());
 		assertEquals(3, coord.getNumberOfPendingCheckpoints());
@@ -1405,7 +1408,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(2, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1418,7 +1421,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(3, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1467,14 +1470,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setTimer(timer)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
 			for (int i = 0; i < maxConcurrentAttempts; i++) {
-				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-				manuallyTriggeredScheduledExecutor.triggerAll();
+				timer.triggerPeriodicScheduledTasks();
+				mainThreadExecutor.triggerAll();
 			}
 
 			assertEquals(maxConcurrentAttempts, numCalls.get());
@@ -1485,20 +1489,20 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// now, once we acknowledge one checkpoint, it should trigger the next one
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID, 1L), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			final Collection<ScheduledFuture<?>> periodicScheduledTasks =
-				manuallyTriggeredScheduledExecutor.getPeriodicScheduledTask();
+				timer.getPeriodicScheduledTask();
 			assertEquals(1, periodicScheduledTasks.size());
 
-			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			timer.triggerPeriodicScheduledTasks();
+			mainThreadExecutor.triggerAll();
 
 			assertEquals(maxConcurrentAttempts + 1, numCalls.get());
 
 			// no further checkpoints should happen
-			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			timer.triggerPeriodicScheduledTasks();
+			mainThreadExecutor.triggerAll();
 			assertEquals(maxConcurrentAttempts + 1, numCalls.get());
 
 			coord.shutdown(JobStatus.FINISHED);
@@ -1539,14 +1543,15 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setTimer(timer)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
 			do {
-				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-				manuallyTriggeredScheduledExecutor.triggerAll();
+				timer.triggerPeriodicScheduledTasks();
+				mainThreadExecutor.triggerAll();
 			}
 			while (coord.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
@@ -1562,8 +1567,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// after a while, there should be the new checkpoints
 			do {
-				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-				manuallyTriggeredScheduledExecutor.triggerAll();
+				timer.triggerPeriodicScheduledTasks();
+				mainThreadExecutor.triggerAll();
 			}
 			while (coord.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
@@ -1612,13 +1617,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setTimer(timer)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
-			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			timer.triggerPeriodicScheduledTasks();
+			mainThreadExecutor.triggerAll();
 			// no checkpoint should have started so far
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
@@ -1626,8 +1632,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			currentState.set(ExecutionState.RUNNING);
 
 			// the coordinator should start checkpointing now
-			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			timer.triggerPeriodicScheduledTasks();
+			mainThreadExecutor.triggerAll();
 
 			assertTrue(coord.getNumberOfPendingCheckpoints() > 0);
 		}
@@ -1661,7 +1667,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasks(new ExecutionVertex[] { vertex1 })
 				.setCheckpointIDCounter(checkpointIDCounter)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		List<CompletableFuture<CompletedCheckpoint>> savepointFutures = new ArrayList<>();
@@ -1678,7 +1684,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertFalse(savepointFuture.isDone());
 		}
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		// ACK all savepoints
 		long checkpointId = checkpointIDCounter.getLast();
@@ -1686,7 +1692,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jobId, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
 		}
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		// After ACKs, all should be completed
 		for (CompletableFuture<CompletedCheckpoint> savepointFuture : savepointFutures) {
 			assertNotNull(savepointFuture.get());
@@ -1707,7 +1713,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setCheckpointCoordinatorConfiguration(chkConfig)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
@@ -1735,12 +1741,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			CheckpointCoordinator coord =
 				new CheckpointCoordinatorBuilder()
 					.setCheckpointCoordinatorConfiguration(chkConfig)
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			for (PendingCheckpoint checkpoint : coord.getPendingCheckpoints().values()) {
@@ -1956,7 +1962,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
@@ -1968,7 +1974,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Trigger a checkpoint and verify callback
 		CompletableFuture<CompletedCheckpoint> checkpointFuture =
 			coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		assertFalse(checkpointFuture.isCompletedExceptionally());
 
 		verify(tracker, times(1))
@@ -1986,7 +1992,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
 				.setCompletedCheckpointStore(store)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 
 		store.addCheckpoint(new CompletedCheckpoint(
@@ -2041,7 +2047,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
 				.setCompletedCheckpointStore(store)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.setSharedStateRegistryFactory(
 					deleteExecutor -> {
 						SharedStateRegistry instance = new SharedStateRegistry(deleteExecutor);
@@ -2203,7 +2209,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		final CompletableFuture<CompletedCheckpoint> savepointFuture = coordinator
 				.triggerSynchronousSavepoint(10L, false, "test-dir");
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 		final PendingCheckpoint syncSavepoint = declineSynchronousSavepoint(jobId, coordinator, attemptID1, expectedRootCause);
 
 		assertTrue(syncSavepoint.isDiscarded());
@@ -2235,7 +2241,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
 				.setCheckpointIDCounter(idCounter)
-				.setTimer(manuallyTriggeredScheduledExecutor)
+				.setMainThreadExecutor(mainThreadExecutor)
 				.build();
 		idCounter.setOwner(coord);
 
@@ -2250,7 +2256,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					null,
 					true,
 					false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 			try {
 				onCompletionPromise.get();
 				fail("should not trigger periodic checkpoint after stop the coordinator.");
@@ -2274,7 +2280,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		return new CheckpointCoordinatorBuilder()
 			.setJobId(jobId)
 			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
-			.setTimer(manuallyTriggeredScheduledExecutor)
+			.setMainThreadExecutor(mainThreadExecutor)
 			.build();
 	}
 
@@ -2287,7 +2293,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		return new CheckpointCoordinatorBuilder()
 			.setJobId(jobId)
 			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
-			.setTimer(manuallyTriggeredScheduledExecutor)
+			.setMainThreadExecutor(mainThreadExecutor)
 			.setFailureManager(failureManager)
 			.build();
 	}
@@ -2316,7 +2322,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			.setTasksToTrigger(new ExecutionVertex[] { triggerVertex1, triggerVertex2 })
 			.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 			.setTasksToCommitTo(new ExecutionVertex[] {})
-			.setTimer(manuallyTriggeredScheduledExecutor)
+			.setMainThreadExecutor(mainThreadExecutor)
 			.build();
 	}
 
@@ -2342,7 +2348,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		manuallyTriggeredScheduledExecutor.triggerAll();
+		mainThreadExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -2400,7 +2406,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -98,7 +98,7 @@ public class CheckpointStateRestoreTest {
 			tasks.add(stateful);
 			tasks.add(stateless);
 
-			ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
+			ManuallyTriggeredScheduledExecutor mainThreadExecutor =
 				new ManuallyTriggeredScheduledExecutor();
 
 			CheckpointCoordinator coord =
@@ -107,13 +107,13 @@ public class CheckpointStateRestoreTest {
 					.setTasksToTrigger(new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 })
 					.setTasksToWaitFor(new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 })
 					.setTasksToCommitTo(new ExecutionVertex[0])
-					.setTimer(manuallyTriggeredScheduledExecutor)
+					.setMainThreadExecutor(mainThreadExecutor)
 					.build();
 
 			// create ourselves a checkpoint with state
 			final long timestamp = 34623786L;
 			coord.triggerCheckpoint(timestamp, false);
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			PendingCheckpoint pending = coord.getPendingCheckpoints().values().iterator().next();
 			final long checkpointId = pending.getCheckpointId();
@@ -134,7 +134,7 @@ public class CheckpointStateRestoreTest {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
+			mainThreadExecutor.triggerAll();
 
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -133,6 +133,8 @@ public class CheckpointStateRestoreTest {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec3.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStates), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
+			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -146,8 +146,6 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 			.setAllocationTimeout(timeout)
 			.build();
 
-		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
 			100,
 			100,
@@ -168,6 +166,8 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 				store,
 				new MemoryStateBackend(),
 				CheckpointStatsTrackerTest.createTestTracker());
+
+		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		return executionGraph;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -158,6 +158,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		assertNull(client.checkExists().forPath(CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
 
 		sharedStateRegistry.close();
+		store = createCompletedCheckpoints(1);
 		store.recover();
 
 		assertEquals(0, store.getNumberOfRetainedCheckpoints());
@@ -192,6 +193,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 		// Recover again
 		sharedStateRegistry.close();
+		store = createCompletedCheckpoints(1);
 		store.recover();
 
 		CompletedCheckpoint recovered = store.getLatestCheckpoint(false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -103,8 +103,6 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			.setJobGraph(jobGraph)
 			.build();
 
-		runtimeGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
-
 		List<ExecutionJobVertex> jobVertices = new ArrayList<>();
 		jobVertices.add(runtimeGraph.getJobVertex(v1ID));
 		jobVertices.add(runtimeGraph.getJobVertex(v2ID));
@@ -137,6 +135,8 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			statsTracker);
 
 		runtimeGraph.setJsonPlan("{}");
+
+		runtimeGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		runtimeGraph.getJobVertex(v2ID).getTaskVertices()[0].getCurrentExecutionAttempt().fail(new RuntimeException("This exception was thrown on purpose."));
 	}


### PR DESCRIPTION
## What is the purpose of the change

* This is the last part of refactoring threading model of `CheckpointCoordinator`
* The threading model of `CheckpointCoordinator` would be simplified a lot
  * All the non-IO operations are executed in a single-threaded way
  * A lot of competitions inside or outside `CheckpointCoordinator` could be avoided. So it's easier for `CheckpointCoordinator` to cooperate with other components

## Brief change log

* Split the ACK and declined message handling into two ways
  * Handle non-IO operations in timer thread
  * Handle IO operations in IO thread
  * This is a preparation of introducing main thread executor in `CheckpointCoordinator`. After this, there would be non-IO operations executed in IO thread
* Introduce main thread executor in `CheckpointCoordinator`
  * It's used to execute all non-IO operations instead of the timer thread now
  * The timer thread would be kept for now. It's only used to schedule the periodic triggering, because currently main thread executor does not support periodic scheduling yet.
* The coordinator-wide lock of `CheckpointCoordinator` and lock of `PendingCheckpoint` could be avoided because there is no thread competition after introducing main thread executor

## Verifying this change

* This change is already covered by existing tests, and some test cases are added at the same time

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
