### PR TITLE
[FLINK-16467][core] Fix MemorySizeTest#testToHumanReadableString locale problem.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MemorySize.java
@@ -191,6 +191,7 @@ public class MemorySize implements java.io.Serializable, Comparable<MemorySize> 
 		} else {
 			double approximate = 1.0 * bytes / highestUnit.getMultiplier();
 			return String.format(
+				Locale.ROOT,
 				"%.3f%s (%d bytes)",
 				approximate,
 				highestUnit.getUnits()[1],


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the problem that `MemorySize#toHumanReadableString` generate string in different formats depending on the Locale, which causes test failures.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
