### PR TITLE
[FLINK-16025][k8s] Parse BlobServer port from Configuration instead f using constant

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ServiceDecorator.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesService;
-import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -34,6 +34,8 @@ import io.fabric8.kubernetes.api.model.ServiceSpec;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Setup services port.
@@ -81,12 +83,15 @@ public class ServiceDecorator extends Decorator<Service, KubernetesService> {
 			flinkConfig.getInteger(RestOptions.PORT)));
 
 		if (!onlyRestPort) {
+			final int blobServerPort = KubernetesUtils.parsePort(flinkConfig, BlobServerOptions.PORT);
+			checkArgument(blobServerPort > 0, "%s should not be 0.", BlobServerOptions.PORT.key());
+
 			servicePorts.add(getServicePort(
 				getPortName(JobManagerOptions.PORT.key()),
 				flinkConfig.getInteger(JobManagerOptions.PORT)));
 			servicePorts.add(getServicePort(
 				getPortName(BlobServerOptions.PORT.key()),
-				Constants.BLOB_SERVER_PORT));
+				blobServerPort));
 		}
 
 		spec.setPorts(servicePorts);


### PR DESCRIPTION
## What is the purpose of the change

Fix bug reported by [FLINK-16025](https://issues.apache.org/jira/browse/FLINK-16025?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
