### PR TITLE
[FLINK-16438][yarn] Make YarnResourceManager starts workers using WorkerResourceSpec requested by SlotManager

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -179,7 +179,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 				new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
 
 			final KubernetesJobManagerSpecification kubernetesJobManagerSpec =
-				KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+				KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 			client.createJobManagerComponent(kubernetesJobManagerSpec);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -257,7 +257,6 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 		final KubernetesTaskManagerParameters kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(
 			flinkConfig,
 			podName,
-			defaultMemoryMB,
 			dynamicProperties,
 			taskManagerParameters);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesTaskManagerFactory;
@@ -319,11 +318,6 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			internalStopPod(pod.getName());
 			requestKubernetesPodIfRequired();
 		}
-	}
-
-	@Override
-	protected double getCpuCores(Configuration configuration) {
-		return TaskExecutorProcessUtils.getCpuCoresWithFallbackConfigOption(configuration, KubernetesConfigOptions.TASK_MANAGER_CPU);
 	}
 
 	private void internalStopPod(String podName) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.entrypoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
@@ -39,7 +40,8 @@ public class KubernetesWorkerResourceSpecFactory extends WorkerResourceSpecFacto
 		return workerResourceSpecFromConfigAndCpu(configuration, getDefaultCpus(configuration));
 	}
 
-	private static CPUResource getDefaultCpus(Configuration configuration) {
+	@VisibleForTesting
+	static CPUResource getDefaultCpus(Configuration configuration) {
 		double fallback = configuration.getDouble(KubernetesConfigOptions.TASK_MANAGER_CPU);
 		return TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback);
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -49,7 +49,7 @@ import java.util.Map;
  */
 public class KubernetesJobManagerFactory {
 
-	public static KubernetesJobManagerSpecification createJobManagerComponent(
+	public static KubernetesJobManagerSpecification buildKubernetesJobManagerSpecification(
 			KubernetesJobManagerParameters kubernetesJobManagerParameters) throws IOException {
 		FlinkPod flinkPod = new FlinkPod.Builder().build();
 		List<HasMetadata> accompanyingResources = new ArrayList<>();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -35,7 +35,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
  */
 public class KubernetesTaskManagerFactory {
 
-	public static KubernetesPod createTaskManagerComponent(KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
+	public static KubernetesPod buildTaskManagerKubernetesPod(KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
 		FlinkPod flinkPod = new FlinkPod.Builder().build();
 
 		final KubernetesStepDecorator[] stepDecorators = new KubernetesStepDecorator[] {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -42,8 +42,6 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
 	private final String podName;
 
-	private final int taskManagerMemoryMB;
-
 	private final String dynamicProperties;
 
 	private final ContaineredTaskManagerParameters containeredTaskManagerParameters;
@@ -51,12 +49,10 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 	public KubernetesTaskManagerParameters(
 			Configuration flinkConfig,
 			String podName,
-			int taskManagerMemoryMB,
 			String dynamicProperties,
 			ContaineredTaskManagerParameters containeredTaskManagerParameters) {
 		super(flinkConfig);
 		this.podName = checkNotNull(podName);
-		this.taskManagerMemoryMB = taskManagerMemoryMB;
 		this.dynamicProperties = checkNotNull(dynamicProperties);
 		this.containeredTaskManagerParameters = checkNotNull(containeredTaskManagerParameters);
 	}
@@ -99,7 +95,7 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 	}
 
 	public int getTaskManagerMemoryMB() {
-		return taskManagerMemoryMB;
+		return containeredTaskManagerParameters.getTaskExecutorProcessSpec().getTotalProcessMemorySize().getMebiBytes();
 	}
 
 	public double getTaskManagerCPU() {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -306,45 +306,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 	}
 
 	@Test
-	public void testGetCpuCoresCommonOption() throws Exception {
-		new Context() {{
-			runTest(() -> {
-				final Configuration configuration = new Configuration();
-				configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-				assertThat(resourceManager.getCpuCores(configuration), is(1.0));
-			});
-		}};
-	}
-
-	@Test
-	public void testGetCpuCoresKubernetesOption() throws Exception {
-		new Context() {{
-			runTest(() -> {
-				final Configuration configuration = new Configuration();
-				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-				assertThat(resourceManager.getCpuCores(configuration), is(2.0));
-			});
-		}};
-	}
-
-	@Test
-	public void testGetCpuCoresNumSlots() throws Exception {
-		new Context() {{
-			runTest(() -> {
-				final Configuration configuration = new Configuration();
-				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-				assertThat(resourceManager.getCpuCores(configuration), is(3.0));
-			});
-		}};
-	}
-
-	@Test
 	public void testCreateTaskManagerPodFailedAndRetry() throws Exception {
 		new Context() {{
 			final AtomicInteger retries = new AtomicInteger(0);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.function.RunnableWithException;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
@@ -106,9 +107,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	private TestingFatalErrorHandler testingFatalErrorHandler;
 
-	private TestingKubernetesResourceManager resourceManager;
-	private SlotManager slotManager;
-
 	@Before
 	public void setup() throws Exception {
 		super.setup();
@@ -117,13 +115,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 		flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
 
 		testingFatalErrorHandler = new TestingFatalErrorHandler();
-
-		WorkerResourceSpec workerResourceSpec = KubernetesWorkerResourceSpecFactory.INSTANCE.createDefaultWorkerResourceSpec(flinkConfig);
-		slotManager = SlotManagerBuilder.newBuilder()
-			.setDefaultWorkerResourceSpec(workerResourceSpec)
-			.build();
-
-		resourceManager = createAndStartResourceManager(flinkConfig, flinkKubeClient, slotManager);
 
 		final Deployment mockDeployment = new DeploymentBuilder()
 			.editOrNewMetadata()
@@ -135,7 +126,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	@After
 	public void teardown() throws Exception {
-		resourceManager.close();
 		if (testingFatalErrorHandler != null) {
 			testingFatalErrorHandler.rethrowError();
 		}
@@ -189,245 +179,295 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 	@Test
 	public void testStartAndStopWorker() throws Exception {
-		registerSlotRequest();
+		new Context() {{
+			runTest(() -> {
+				registerSlotRequest();
 
-		final PodList list = kubeClient.pods().list();
-		assertEquals(1, list.getItems().size());
-		final Pod pod = list.getItems().get(0);
+				final PodList list = kubeClient.pods().list();
+				assertEquals(1, list.getItems().size());
+				final Pod pod = list.getItems().get(0);
 
-		final Map<String, String> labels = getCommonLabels();
-		labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
-		assertEquals(labels, pod.getMetadata().getLabels());
+				final Map<String, String> labels = getCommonLabels();
+				labels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_TASK_MANAGER);
+				assertEquals(labels, pod.getMetadata().getLabels());
 
-		assertEquals(1, pod.getSpec().getContainers().size());
-		final Container tmContainer = pod.getSpec().getContainers().get(0);
-		assertEquals(CONTAINER_IMAGE, tmContainer.getImage());
+				assertEquals(1, pod.getSpec().getContainers().size());
+				final Container tmContainer = pod.getSpec().getContainers().get(0);
+				assertEquals(CONTAINER_IMAGE, tmContainer.getImage());
 
-		final String podName = CLUSTER_ID + "-taskmanager-1-1";
-		assertEquals(podName, pod.getMetadata().getName());
+				final String podName = CLUSTER_ID + "-taskmanager-1-1";
+				assertEquals(podName, pod.getMetadata().getName());
 
-		// Check environments
-		assertThat(tmContainer.getEnv(), Matchers.contains(
-			new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
+				// Check environments
+				assertThat(tmContainer.getEnv(), Matchers.contains(
+					new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
 
-		// Check task manager main class args.
-		assertEquals(3, tmContainer.getArgs().size());
-		final String confDirOption = "--configDir " + flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
-		assertTrue(tmContainer.getArgs().get(2).contains(confDirOption));
+				// Check task manager main class args.
+				assertEquals(3, tmContainer.getArgs().size());
+				final String confDirOption = "--configDir " + flinkConfig.getString(KubernetesConfigOptions.FLINK_CONF_DIR);
+				assertTrue(tmContainer.getArgs().get(2).contains(confDirOption));
 
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod)));
-		final ResourceID resourceID = new ResourceID(podName);
-		assertThat(resourceManager.getWorkerNodes().keySet(), Matchers.contains(resourceID));
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod)));
+				final ResourceID resourceID = new ResourceID(podName);
+				assertThat(resourceManager.getWorkerNodes().keySet(), Matchers.contains(resourceID));
 
-		registerTaskExecutor(resourceID);
+				registerTaskExecutor(resourceID);
 
-		// Unregister all task executors and release all task managers.
-		CompletableFuture<?> unregisterAndReleaseFuture = resourceManager.runInMainThread(() -> {
-			slotManager.unregisterTaskManagersAndReleaseResources();
-			return null;
-		});
-		unregisterAndReleaseFuture.get();
-		assertEquals(0, kubeClient.pods().list().getItems().size());
-		assertEquals(0, resourceManager.getWorkerNodes().size());
+				// Unregister all task executors and release all task managers.
+				CompletableFuture<?> unregisterAndReleaseFuture = resourceManager.runInMainThread(() -> {
+					slotManager.unregisterTaskManagersAndReleaseResources();
+					return null;
+				});
+				unregisterAndReleaseFuture.get();
+				assertEquals(0, kubeClient.pods().list().getItems().size());
+				assertEquals(0, resourceManager.getWorkerNodes().size());
+			});
+		}};
 	}
 
 	@Test
 	public void testTaskManagerPodTerminated() throws Exception {
-		registerSlotRequest();
+		new Context() {{
+			runTest(() -> {
+				registerSlotRequest();
 
-		final Pod pod1 = kubeClient.pods().list().getItems().get(0);
-		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-1-";
+				final Pod pod1 = kubeClient.pods().list().getItems().get(0);
+				final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-1-";
 
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod1)));
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod1)));
 
-		// General modification event
-		resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
-		assertEquals(1, kubeClient.pods().list().getItems().size());
-		assertEquals(taskManagerPrefix + 1, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+				// General modification event
+				resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
+				assertEquals(1, kubeClient.pods().list().getItems().size());
+				assertEquals(taskManagerPrefix + 1, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
 
-		// Terminate the pod.
-		terminatePod(pod1);
-		resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
+				// Terminate the pod.
+				terminatePod(pod1);
+				resourceManager.onModified(Collections.singletonList(new KubernetesPod(pod1)));
 
-		// Old pod should be deleted and a new task manager should be created
-		assertEquals(1, kubeClient.pods().list().getItems().size());
-		final Pod pod2 = kubeClient.pods().list().getItems().get(0);
-		assertEquals(taskManagerPrefix + 2, pod2.getMetadata().getName());
+				// Old pod should be deleted and a new task manager should be created
+				assertEquals(1, kubeClient.pods().list().getItems().size());
+				final Pod pod2 = kubeClient.pods().list().getItems().get(0);
+				assertEquals(taskManagerPrefix + 2, pod2.getMetadata().getName());
 
-		// Error happens in the pod.
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod2)));
-		terminatePod(pod2);
-		resourceManager.onError(Collections.singletonList(new KubernetesPod(pod2)));
-		final Pod pod3 = kubeClient.pods().list().getItems().get(0);
-		assertEquals(taskManagerPrefix + 3, pod3.getMetadata().getName());
+				// Error happens in the pod.
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod2)));
+				terminatePod(pod2);
+				resourceManager.onError(Collections.singletonList(new KubernetesPod(pod2)));
+				final Pod pod3 = kubeClient.pods().list().getItems().get(0);
+				assertEquals(taskManagerPrefix + 3, pod3.getMetadata().getName());
 
-		// Delete the pod.
-		resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod3)));
-		terminatePod(pod3);
-		resourceManager.onDeleted(Collections.singletonList(new KubernetesPod(pod3)));
-		assertEquals(taskManagerPrefix + 4, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+				// Delete the pod.
+				resourceManager.onAdded(Collections.singletonList(new KubernetesPod(pod3)));
+				terminatePod(pod3);
+				resourceManager.onDeleted(Collections.singletonList(new KubernetesPod(pod3)));
+				assertEquals(taskManagerPrefix + 4, kubeClient.pods().list().getItems().get(0).getMetadata().getName());
+			});
+		}};
 	}
 
 	@Test
 	public void testGetWorkerNodesFromPreviousAttempts() throws Exception {
-		// Prepare pod of previous attempt
-		final String previewPodName = CLUSTER_ID + "-taskmanager-1-1";
+		new Context() {{
+			runTest(() -> {
+				// Prepare pod of previous attempt
+				final String previewPodName = CLUSTER_ID + "-taskmanager-1-1";
 
-		final Pod mockTaskManagerPod = new PodBuilder()
-			.editOrNewMetadata()
-				.withName(previewPodName)
-				.withLabels(KubernetesUtils.getTaskManagerLabels(CLUSTER_ID))
-				.endMetadata()
-			.editOrNewSpec()
-				.endSpec()
-			.build();
+				final Pod mockTaskManagerPod = new PodBuilder()
+					.editOrNewMetadata()
+						.withName(previewPodName)
+						.withLabels(KubernetesUtils.getTaskManagerLabels(CLUSTER_ID))
+						.endMetadata()
+					.editOrNewSpec()
+						.endSpec()
+					.build();
 
-		flinkKubeClient.createTaskManagerPod(new KubernetesPod(mockTaskManagerPod)).get();
-		assertEquals(1, kubeClient.pods().list().getItems().size());
+				flinkKubeClient.createTaskManagerPod(new KubernetesPod(mockTaskManagerPod));
+				assertEquals(1, kubeClient.pods().list().getItems().size());
 
-		// Call initialize method to recover worker nodes from previous attempt.
-		resourceManager.initialize();
+				// Call initialize method to recover worker nodes from previous attempt.
+				resourceManager.initialize();
 
-		final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-";
-		// Register the previous taskmanager, no new pod should be created
-		registerTaskExecutor(new ResourceID(previewPodName));
-		registerSlotRequest();
-		assertEquals(1, kubeClient.pods().list().getItems().size());
+				final String taskManagerPrefix = CLUSTER_ID + "-taskmanager-";
+				// Register the previous taskmanager, no new pod should be created
+				registerTaskExecutor(new ResourceID(previewPodName));
+				registerSlotRequest();
+				assertEquals(1, kubeClient.pods().list().getItems().size());
 
-		// Register a new slot request, a new taskmanger pod will be created with attempt2
-		registerSlotRequest();
-		assertEquals(2, kubeClient.pods().list().getItems().size());
-		assertThat(kubeClient.pods().list().getItems().stream()
-				.map(e -> e.getMetadata().getName())
-				.collect(Collectors.toList()),
-			Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+				// Register a new slot request, a new taskmanger pod will be created with attempt2
+				registerSlotRequest();
+				assertEquals(2, kubeClient.pods().list().getItems().size());
+				assertThat(kubeClient.pods().list().getItems().stream()
+						.map(e -> e.getMetadata().getName())
+						.collect(Collectors.toList()),
+					Matchers.containsInAnyOrder(taskManagerPrefix + "1-1", taskManagerPrefix + "2-1"));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresCommonOption() {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresCommonOption() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(1.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(1.0));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresKubernetesOption() {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresKubernetesOption() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(2.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(2.0));
+			});
+		}};
 	}
 
 	@Test
-	public void testGetCpuCoresNumSlots() {
-		final Configuration configuration = new Configuration();
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+	public void testGetCpuCoresNumSlots() throws Exception {
+		new Context() {{
+			runTest(() -> {
+				final Configuration configuration = new Configuration();
+				configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
 
-		assertThat(resourceManager.getCpuCores(configuration), is(3.0));
+				assertThat(resourceManager.getCpuCores(configuration), is(3.0));
+			});
+		}};
 	}
 
 	@Test
 	public void testCreateTaskManagerPodFailedAndRetry() throws Exception {
-		final AtomicInteger retries = new AtomicInteger(0);
-		final int numOfFailedRetries = 3;
-		final OneShotLatch podCreated = new OneShotLatch();
-		final FlinkKubeClient flinkKubeClient = createTestingFlinkKubeClientAllocatingPodsAfter(numOfFailedRetries, retries, podCreated);
-		final TestingKubernetesResourceManager testRM = createAndStartResourceManager(flinkConfig, flinkKubeClient, slotManager);
-		registerSlotRequest(testRM);
+		new Context() {{
+			final AtomicInteger retries = new AtomicInteger(0);
+			final int numOfFailedRetries = 3;
+			final OneShotLatch podCreated = new OneShotLatch();
+			flinkKubeClient = createTestingFlinkKubeClientAllocatingPodsAfter(numOfFailedRetries, retries, podCreated);
 
-		podCreated.await();
-		// Creating taskmanager should retry 4 times (3 failed and then succeed)
-		assertThat(
-			"Creating taskmanager should fail " + numOfFailedRetries + " times and then succeed",
-			retries.get(),
-			is(numOfFailedRetries + 1));
+			runTest(() -> {
+				registerSlotRequest();
+				podCreated.await();
+				// Creating taskmanager should retry 4 times (3 failed and then succeed)
+				assertThat(
+					"Creating taskmanager should fail " + numOfFailedRetries + " times and then succeed",
+					retries.get(),
+					is(numOfFailedRetries + 1));
+			});
 
-		testRM.close();
-		flinkKubeClient.close();
+			flinkKubeClient.close();
+		}};
 	}
 
-	private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration, FlinkKubeClient flinkKubeClient, SlotManager slotManager) throws Exception {
+	class Context {
+		TestingKubernetesResourceManager resourceManager = null;
+		SlotManager slotManager = null;
+		FlinkKubeClient flinkKubeClient = null;
 
-		final TestingRpcService rpcService = new TestingRpcService(configuration);
-		final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT, slotManager);
+		void runTest(RunnableWithException testMethod) throws Exception {
+			if (slotManager == null) {
+				WorkerResourceSpec workerResourceSpec = KubernetesWorkerResourceSpecFactory.INSTANCE
+					.createDefaultWorkerResourceSpec(flinkConfig);
+				slotManager = SlotManagerBuilder.newBuilder()
+					.setDefaultWorkerResourceSpec(workerResourceSpec)
+					.build();
+			}
 
-		final TestingKubernetesResourceManager kubernetesResourceManager = new TestingKubernetesResourceManager(
-			rpcService,
-			ResourceID.generate(),
-			configuration,
-			rmServices.highAvailabilityServices,
-			rmServices.heartbeatServices,
-			rmServices.slotManager,
-			rmServices.jobLeaderIdService,
-			new ClusterInformation("localhost", 1234),
-			testingFatalErrorHandler,
-			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-			flinkKubeClient,
-			new KubernetesResourceManagerConfiguration(CLUSTER_ID, TESTING_POD_CREATION_RETRY_INTERVAL));
-		kubernetesResourceManager.start();
-		rmServices.grantLeadership();
-		return kubernetesResourceManager;
-	}
+			if (flinkKubeClient == null) {
+				flinkKubeClient = KubernetesResourceManagerTest.this.flinkKubeClient;
+			}
 
-	private void registerSlotRequest(TestingKubernetesResourceManager resourceManager) throws Exception {
-		CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
-			slotManager.registerSlotRequest(
-				new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, JOB_MANAGER_HOST));
-			return null;
-		});
-		registerSlotRequestFuture.get();
-	}
+			resourceManager = createAndStartResourceManager(flinkConfig, slotManager, flinkKubeClient);
 
-	private void registerSlotRequest() throws Exception {
-		registerSlotRequest(resourceManager);
-	}
+			try {
+				testMethod.run();
+			} finally {
+				resourceManager.close();
+			}
+		}
 
-	private void registerTaskExecutor(ResourceID resourceID) throws Exception {
-		final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
-			.createTestingTaskExecutorGateway();
-		((TestingRpcService) resourceManager.getRpcService()).registerGateway(resourceID.toString(), taskExecutorGateway);
+		private TestingKubernetesResourceManager createAndStartResourceManager(Configuration configuration, SlotManager slotManager, FlinkKubeClient flinkKubeClient) throws Exception {
 
-		final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
+			final TestingRpcService rpcService = new TestingRpcService(configuration);
+			final MockResourceManagerRuntimeServices rmServices = new MockResourceManagerRuntimeServices(rpcService, TIMEOUT, slotManager);
 
-		final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
+			final TestingKubernetesResourceManager kubernetesResourceManager = new TestingKubernetesResourceManager(
+				rpcService,
+				ResourceID.generate(),
+				configuration,
+				rmServices.highAvailabilityServices,
+				rmServices.heartbeatServices,
+				rmServices.slotManager,
+				rmServices.jobLeaderIdService,
+				new ClusterInformation("localhost", 1234),
+				testingFatalErrorHandler,
+				UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
+				flinkKubeClient,
+				new KubernetesResourceManagerConfiguration(CLUSTER_ID, TESTING_POD_CREATION_RETRY_INTERVAL));
+			kubernetesResourceManager.start();
+			rmServices.grantLeadership();
+			return kubernetesResourceManager;
+		}
 
-		TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
-			resourceID.toString(),
-			resourceID,
-			1234,
-			new HardwareDescription(1, 2L, 3L, 4L),
-			ResourceProfile.ZERO,
-			ResourceProfile.ZERO);
-		CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
-			.registerTaskExecutor(
-				taskExecutorRegistration,
-				TIMEOUT)
-			.thenCompose(
-				(RegistrationResponse response) -> {
-					assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));
-					final TaskExecutorRegistrationSuccess success = (TaskExecutorRegistrationSuccess) response;
-					return rmGateway.sendSlotReport(
-						resourceID,
-						success.getRegistrationId(),
-						slotReport,
-						TIMEOUT);
-				})
-			.handleAsync(
-				(Acknowledge ignored, Throwable throwable) -> slotManager.getNumberRegisteredSlots(),
-				resourceManager.getMainThreadExecutorForTesting());
-		Assert.assertEquals(1, numberRegisteredSlotsFuture.get().intValue());
-	}
+		void registerSlotRequest() throws Exception {
+			CompletableFuture<?> registerSlotRequestFuture = resourceManager.runInMainThread(() -> {
+				slotManager.registerSlotRequest(
+					new SlotRequest(new JobID(), new AllocationID(), ResourceProfile.UNKNOWN, JOB_MANAGER_HOST));
+				return null;
+			});
+			registerSlotRequestFuture.get();
+		}
 
-	private void terminatePod(Pod pod) {
-		pod.setStatus(new PodStatusBuilder()
-			.withContainerStatuses(new ContainerStatusBuilder().withState(
-				new ContainerStateBuilder().withNewTerminated().endTerminated().build())
-				.build())
-			.build());
+		void registerTaskExecutor(ResourceID resourceID) throws Exception {
+			final TaskExecutorGateway taskExecutorGateway = new TestingTaskExecutorGatewayBuilder()
+				.createTestingTaskExecutorGateway();
+			((TestingRpcService) resourceManager.getRpcService()).registerGateway(resourceID.toString(), taskExecutorGateway);
+
+			final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
+
+			final SlotReport slotReport = new SlotReport(new SlotStatus(new SlotID(resourceID, 1), ResourceProfile.ZERO));
+
+			TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+				resourceID.toString(),
+				resourceID,
+				1234,
+				new HardwareDescription(1, 2L, 3L, 4L),
+				ResourceProfile.ZERO,
+				ResourceProfile.ZERO);
+			CompletableFuture<Integer> numberRegisteredSlotsFuture = rmGateway
+				.registerTaskExecutor(
+					taskExecutorRegistration,
+					TIMEOUT)
+				.thenCompose(
+					(RegistrationResponse response) -> {
+						assertThat(response, instanceOf(TaskExecutorRegistrationSuccess.class));
+						final TaskExecutorRegistrationSuccess success = (TaskExecutorRegistrationSuccess) response;
+						return rmGateway.sendSlotReport(
+							resourceID,
+							success.getRegistrationId(),
+							slotReport,
+							TIMEOUT);
+					})
+				.handleAsync(
+					(Acknowledge ignored, Throwable throwable) -> slotManager.getNumberRegisteredSlots(),
+					resourceManager.getMainThreadExecutorForTesting());
+			Assert.assertEquals(1, numberRegisteredSlotsFuture.get().intValue());
+		}
+
+		void terminatePod(Pod pod) {
+			pod.setStatus(new PodStatusBuilder()
+				.withContainerStatuses(new ContainerStatusBuilder().withState(
+					new ContainerStateBuilder().withNewTerminated().endTerminated().build())
+					.build())
+				.build());
+		}
 	}
 
 	private FlinkKubeClient createTestingFlinkKubeClientAllocatingPodsAfter(

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/entrypoint/KubernetesWorkerResourceSpecFactoryTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link KubernetesWorkerResourceSpecFactory}.
+ */
+public class KubernetesWorkerResourceSpecFactoryTest extends TestLogger {
+
+	@Test
+	public void testGetCpuCoresCommonOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration),
+			is(new CPUResource(1.0)));
+	}
+
+	@Test
+	public void testGetCpuCoresKubernetesOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(KubernetesConfigOptions.TASK_MANAGER_CPU, 2.0);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration),
+			is(new CPUResource(2.0)));
+	}
+
+	@Test
+	public void testGetCpuCoresNumSlots() {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(KubernetesWorkerResourceSpecFactory.getDefaultCpus(configuration),
+			is(new CPUResource(3.0)));
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -94,7 +94,7 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
 		final KubernetesJobManagerParameters kubernetesJobManagerParameters =
 			new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
 		this.kubernetesJobManagerSpecification =
-			KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -92,7 +92,6 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 		kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(
 				flinkConfig,
 				POD_NAME,
-				TOTAL_PROCESS_MEMORY,
 				DYNAMIC_PROPERTIES,
 				containeredTaskManagerParameters);
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -77,7 +77,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_SERVICE_ACCOUNT, SERVICE_ACCOUNT_NAME);
 
 		this.kubernetesJobManagerSpecification =
-			KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+			KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 	}
 
 	@Test
@@ -215,7 +215,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	@Test
 	public void testExistingHadoopConfigMap() throws IOException {
 		flinkConfig.set(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP, EXISTING_HADOOP_CONF_CONFIG_MAP);
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
 			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));
@@ -228,7 +228,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	public void testHadoopConfConfigMap() throws IOException {
 		setHadoopConfDirEnv();
 		generateHadoopConfFileItems();
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		final ConfigMap resultConfigMap = (ConfigMap) kubernetesJobManagerSpecification.getAccompanyingResources()
 			.stream()
@@ -248,7 +248,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	@Test
 	public void testEmptyHadoopConfDirectory() throws IOException {
 		setHadoopConfDirEnv();
-		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(kubernetesJobManagerParameters);
 
 		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
 			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -50,7 +50,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		generateHadoopConfFileItems();
 
 		this.resultPod =
-			KubernetesTaskManagerFactory.createTaskManagerComponent(kubernetesTaskManagerParameters).getInternalResource();
+			KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(kubernetesTaskManagerParameters).getInternalResource();
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -78,7 +78,6 @@ public class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
 
 		this.kubernetesTaskManagerParameters = new KubernetesTaskManagerParameters(flinkConfig,
 			POD_NAME,
-			TASK_MANAGER_MEMORY,
 			DYNAMIC_PROPERTIES,
 			containeredTaskManagerParameters);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -53,7 +53,7 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	/** The process environment variables. */
 	protected final Map<String, String> env;
 
-	protected final TaskExecutorProcessSpec taskExecutorProcessSpec;
+	protected final TaskExecutorProcessSpec defaultTaskExecutorProcessSpec;
 
 	protected final int defaultMemoryMB;
 
@@ -98,11 +98,11 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 		this.env = env;
 
 		double defaultCpus = getCpuCores(flinkConfig);
-		this.taskExecutorProcessSpec = TaskExecutorProcessUtils
+		this.defaultTaskExecutorProcessSpec = TaskExecutorProcessUtils
 			.newProcessSpecBuilder(flinkConfig)
 			.withCpuCores(defaultCpus)
 			.build();
-		this.defaultMemoryMB = taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
+		this.defaultMemoryMB = defaultTaskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
@@ -35,9 +36,11 @@ import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -62,6 +65,8 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 	/** Flink configuration uploaded by client. */
 	protected final Configuration flinkClientConfig;
+
+	private final PendingWorkerCounter pendingWorkerCounter;
 
 	public ActiveResourceManager(
 			Configuration flinkConfig,
@@ -101,6 +106,8 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();
+
+		pendingWorkerCounter = new PendingWorkerCounter();
 	}
 
 	protected CompletableFuture<Void> getStopTerminationFutureOrCompletedExceptionally(@Nullable Throwable exception) {
@@ -117,4 +124,76 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	protected abstract Configuration loadClientConfiguration();
 
 	protected abstract double getCpuCores(final Configuration configuration);
+
+	protected int getNumPendingWorkers() {
+		return pendingWorkerCounter.getTotalNum();
+	}
+
+	protected int getNumPendingWorkersFor(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.getNum(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that a worker with the given resource spec has been requested.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerRequested(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.increaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that a worker with the given resource spec has been allocated.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerAllocated(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.decreaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Notify that allocation of a worker with the given resource spec has failed.
+	 * @param workerResourceSpec resource spec of the requested worker
+	 * @return updated number of pending workers for the given resource spec
+	 */
+	protected int notifyNewWorkerAllocationFailed(WorkerResourceSpec workerResourceSpec) {
+		return pendingWorkerCounter.decreaseAndGet(workerResourceSpec);
+	}
+
+	/**
+	 * Utility class for counting pending workers per {@link WorkerResourceSpec}.
+	 */
+	@VisibleForTesting
+	static class PendingWorkerCounter {
+		private final Map<WorkerResourceSpec, Integer> pendingWorkerNums;
+
+		PendingWorkerCounter() {
+			pendingWorkerNums = new HashMap<>();
+		}
+
+		int getTotalNum() {
+			return pendingWorkerNums.values().stream().reduce(0, Integer::sum);
+		}
+
+		int getNum(final WorkerResourceSpec workerResourceSpec) {
+			return pendingWorkerNums.getOrDefault(Preconditions.checkNotNull(workerResourceSpec), 0);
+		}
+
+		int increaseAndGet(final WorkerResourceSpec workerResourceSpec) {
+			return pendingWorkerNums.compute(
+				Preconditions.checkNotNull(workerResourceSpec),
+				(ignored, num) -> num != null ? num + 1 : 1);
+		}
+
+		int decreaseAndGet(final WorkerResourceSpec workerResourceSpec) {
+			final Integer newValue = pendingWorkerNums.compute(
+				Preconditions.checkNotNull(workerResourceSpec),
+				(ignored, num) -> {
+					Preconditions.checkState(num != null && num > 0,
+						"Cannot decrease, no pending worker of spec %s.", workerResourceSpec);
+					return num == 1 ? null : num - 1;
+				});
+			return newValue != null ? newValue : 0;
+		}
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -22,8 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
-import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -52,10 +50,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 
 	/** The process environment variables. */
 	protected final Map<String, String> env;
-
-	protected final TaskExecutorProcessSpec defaultTaskExecutorProcessSpec;
-
-	protected final int defaultMemoryMB;
 
 	/**
 	 * The updated Flink configuration. The client uploaded configuration may be updated before passed on to
@@ -97,13 +91,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 		this.flinkConfig = flinkConfig;
 		this.env = env;
 
-		double defaultCpus = getCpuCores(flinkConfig);
-		this.defaultTaskExecutorProcessSpec = TaskExecutorProcessUtils
-			.newProcessSpecBuilder(flinkConfig)
-			.withCpuCores(defaultCpus)
-			.build();
-		this.defaultMemoryMB = defaultTaskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes();
-
 		// Load the flink config uploaded by flink client
 		this.flinkClientConfig = loadClientConfiguration();
 
@@ -122,8 +109,6 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 	}
 
 	protected abstract Configuration loadClientConfiguration();
-
-	protected abstract double getCpuCores(final Configuration configuration);
 
 	protected int getNumPendingWorkers() {
 		return pendingWorkerCounter.getTotalNum();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Tests for {@link ActiveResourceManager}.
+ */
+public class ActiveResourceManagerTest extends TestLogger {
+
+	@Test
+	public void testPendingWorkerCounterIncreaseAndDecrease() {
+		final WorkerResourceSpec spec1 = new WorkerResourceSpec.Builder().setCpuCores(1.0).build();
+		final WorkerResourceSpec spec2 = new WorkerResourceSpec.Builder().setCpuCores(2.0).build();
+
+		final ActiveResourceManager.PendingWorkerCounter counter = new ActiveResourceManager.PendingWorkerCounter();
+		assertThat(counter.getTotalNum(), is(0));
+		assertThat(counter.getNum(spec1), is(0));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec1), is(1));
+		assertThat(counter.getTotalNum(), is(1));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec1), is(2));
+		assertThat(counter.getTotalNum(), is(2));
+		assertThat(counter.getNum(spec1), is(2));
+		assertThat(counter.getNum(spec2), is(0));
+
+		assertThat(counter.increaseAndGet(spec2), is(1));
+		assertThat(counter.getTotalNum(), is(3));
+		assertThat(counter.getNum(spec1), is(2));
+		assertThat(counter.getNum(spec2), is(1));
+
+		assertThat(counter.decreaseAndGet(spec1), is(1));
+		assertThat(counter.getTotalNum(), is(2));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(1));
+
+		assertThat(counter.decreaseAndGet(spec2), is(0));
+		assertThat(counter.getTotalNum(), is(1));
+		assertThat(counter.getNum(spec1), is(1));
+		assertThat(counter.getNum(spec2), is(0));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testPendingWorkerCounterDecreaseOnZero() {
+		final WorkerResourceSpec spec = new WorkerResourceSpec.Builder().build();
+		final ActiveResourceManager.PendingWorkerCounter counter = new ActiveResourceManager.PendingWorkerCounter();
+		counter.decreaseAndGet(spec);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -27,10 +27,10 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Implementation of {@link SlotManager} for testing purpose.
@@ -38,9 +38,13 @@ import java.util.function.Consumer;
 public class TestingSlotManager implements SlotManager {
 
 	private final Consumer<Boolean> setFailUnfulfillableRequestConsumer;
+	private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
 
-	TestingSlotManager(Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
+	TestingSlotManager(
+			Consumer<Boolean> setFailUnfulfillableRequestConsumer,
+			Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
 		this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
+		this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
 	}
 
 	@Override
@@ -65,7 +69,7 @@ public class TestingSlotManager implements SlotManager {
 
 	@Override
 	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
-		return Collections.emptyMap();
+		return getRequiredResourcesSupplier.get();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -18,7 +18,12 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Factory for {@link TestingSlotManager}.
@@ -26,13 +31,19 @@ import java.util.function.Consumer;
 public class TestingSlotManagerBuilder {
 
 	private Consumer<Boolean> setFailUnfulfillableRequestConsumer = ignored -> {};
+	private Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier = () -> Collections.emptyMap();
 
 	public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
 		this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
 		return this;
 	}
 
+	public TestingSlotManagerBuilder setGetRequiredResourcesSupplier(Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
+		this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
+		return this;
+	}
+
 	public TestingSlotManager createSlotManager() {
-		return new TestingSlotManager(setFailUnfulfillableRequestConsumer);
+		return new TestingSlotManager(setFailUnfulfillableRequestConsumer, getRequiredResourcesSupplier);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -51,7 +51,6 @@ public class WorkerSpecContainerResourceAdapter {
 	private final int maxMemMB;
 	private final int minVcore;
 	private final int maxVcore;
-	private final WorkerSpecContainerResourceAdapter.MatchingStrategy matchingStrategy;
 	private final Map<WorkerResourceSpec, Resource> workerSpecToContainerResource;
 	private final Map<Resource, Set<WorkerResourceSpec>> containerResourceToWorkerSpecs;
 	private final Map<Integer, Set<Resource>> containerMemoryToContainerResource;
@@ -61,14 +60,12 @@ public class WorkerSpecContainerResourceAdapter {
 		final int minMemMB,
 		final int minVcore,
 		final int maxMemMB,
-		final int maxVcore,
-		final WorkerSpecContainerResourceAdapter.MatchingStrategy matchingStrategy) {
+		final int maxVcore) {
 		this.flinkConfig = Preconditions.checkNotNull(flinkConfig);
 		this.minMemMB = minMemMB;
 		this.minVcore = minVcore;
 		this.maxMemMB = maxMemMB;
 		this.maxVcore = maxVcore;
-		this.matchingStrategy = matchingStrategy;
 		workerSpecToContainerResource = new HashMap<>();
 		containerResourceToWorkerSpecs = new HashMap<>();
 		containerMemoryToContainerResource = new HashMap<>();
@@ -82,14 +79,14 @@ public class WorkerSpecContainerResourceAdapter {
 	}
 
 	@VisibleForTesting
-	Set<WorkerResourceSpec> getWorkerSpecs(final Resource containerResource) {
-		return getEquivalentContainerResource(containerResource).stream()
+	Set<WorkerResourceSpec> getWorkerSpecs(final Resource containerResource, final MatchingStrategy matchingStrategy) {
+		return getEquivalentContainerResource(containerResource, matchingStrategy).stream()
 			.flatMap(resource -> containerResourceToWorkerSpecs.getOrDefault(resource, Collections.emptySet()).stream())
 			.collect(Collectors.toSet());
 	}
 
 	@VisibleForTesting
-	Set<Resource> getEquivalentContainerResource(final Resource containerResource) {
+	Set<Resource> getEquivalentContainerResource(final Resource containerResource, final MatchingStrategy matchingStrategy) {
 		// Yarn might ignore the requested vcores, depending on its configurations.
 		// In such cases, we should also not matching vcores.
 		final Set<Resource> equivalentContainerResources;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Utility class for converting between Flink {@link WorkerResourceSpec} and Yarn {@link Resource}.
+ */
+public class WorkerSpecContainerResourceAdapter {
+	private static final Logger LOG = LoggerFactory.getLogger(WorkerSpecContainerResourceAdapter.class);
+
+	private final Configuration flinkConfig;
+	private final int minMemMB;
+	private final int maxMemMB;
+	private final int minVcore;
+	private final int maxVcore;
+	private final WorkerSpecContainerResourceAdapter.MatchingStrategy matchingStrategy;
+	private final Map<WorkerResourceSpec, Resource> workerSpecToContainerResource;
+	private final Map<Resource, Set<WorkerResourceSpec>> containerResourceToWorkerSpecs;
+	private final Map<Integer, Set<Resource>> containerMemoryToContainerResource;
+
+	WorkerSpecContainerResourceAdapter(
+		final Configuration flinkConfig,
+		final int minMemMB,
+		final int minVcore,
+		final int maxMemMB,
+		final int maxVcore,
+		final WorkerSpecContainerResourceAdapter.MatchingStrategy matchingStrategy) {
+		this.flinkConfig = Preconditions.checkNotNull(flinkConfig);
+		this.minMemMB = minMemMB;
+		this.minVcore = minVcore;
+		this.maxMemMB = maxMemMB;
+		this.maxVcore = maxVcore;
+		this.matchingStrategy = matchingStrategy;
+		workerSpecToContainerResource = new HashMap<>();
+		containerResourceToWorkerSpecs = new HashMap<>();
+		containerMemoryToContainerResource = new HashMap<>();
+	}
+
+	@VisibleForTesting
+	Optional<Resource> tryComputeContainerResource(final WorkerResourceSpec workerResourceSpec) {
+		return Optional.ofNullable(workerSpecToContainerResource.computeIfAbsent(
+			Preconditions.checkNotNull(workerResourceSpec),
+			this::createAndMapContainerResource));
+	}
+
+	@VisibleForTesting
+	Set<WorkerResourceSpec> getWorkerSpecs(final Resource containerResource) {
+		return getEquivalentContainerResource(containerResource).stream()
+			.flatMap(resource -> containerResourceToWorkerSpecs.getOrDefault(resource, Collections.emptySet()).stream())
+			.collect(Collectors.toSet());
+	}
+
+	@VisibleForTesting
+	Set<Resource> getEquivalentContainerResource(final Resource containerResource) {
+		// Yarn might ignore the requested vcores, depending on its configurations.
+		// In such cases, we should also not matching vcores.
+		final Set<Resource> equivalentContainerResources;
+		switch (matchingStrategy) {
+			case MATCH_VCORE:
+				equivalentContainerResources = Collections.singleton(containerResource);
+				break;
+			case IGNORE_VCORE:
+			default:
+				equivalentContainerResources = containerMemoryToContainerResource
+					.getOrDefault(containerResource.getMemory(), Collections.emptySet());
+				break;
+		}
+		return equivalentContainerResources;
+	}
+
+	@Nullable
+	private Resource createAndMapContainerResource(final WorkerResourceSpec workerResourceSpec) {
+		final TaskExecutorProcessSpec taskExecutorProcessSpec =
+			TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(flinkConfig, workerResourceSpec);
+		final Resource containerResource = Resource.newInstance(
+			normalize(taskExecutorProcessSpec.getTotalProcessMemorySize().getMebiBytes(), minMemMB),
+			normalize(taskExecutorProcessSpec.getCpuCores().getValue().intValue(), minVcore));
+
+		if (resourceWithinMaxAllocation(containerResource)) {
+			containerResourceToWorkerSpecs.computeIfAbsent(containerResource, ignored -> new HashSet<>())
+				.add(workerResourceSpec);
+			containerMemoryToContainerResource.computeIfAbsent(containerResource.getMemory(), ignored -> new HashSet<>())
+				.add(containerResource);
+			return containerResource;
+		} else {
+			LOG.warn("Requested container resource {} exceeds yarn max allocation {}. Will not allocate resource.",
+				containerResource,
+				Resource.newInstance(maxMemMB, maxVcore));
+			return null;
+		}
+	}
+
+	/**
+	 * Normalize to the minimum integer that is greater or equal to 'value' and is integer multiple of 'unitValue'.
+	 */
+	private int normalize(final int value, final int unitValue) {
+		return MathUtils.divideRoundUp(value, unitValue) * unitValue;
+	}
+
+	boolean resourceWithinMaxAllocation(final Resource resource) {
+		return resource.getMemory() <= maxMemMB && resource.getVirtualCores() <= maxVcore;
+	}
+
+	enum MatchingStrategy {
+		MATCH_VCORE,
+		IGNORE_VCORE
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -657,28 +656,5 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		taskExecutorLaunchContext.getEnvironment()
 				.put(ENV_FLINK_NODE_ID, host);
 		return taskExecutorLaunchContext;
-	}
-
-	@Override
-	protected double getCpuCores(final Configuration configuration) {
-		int fallback = configuration.getInteger(YarnConfigOptions.VCORES);
-		double cpuCoresDouble = TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
-		@SuppressWarnings("NumericCastThatLosesPrecision")
-		long cpuCoresLong = Math.max((long) Math.ceil(cpuCoresDouble), 1L);
-		//noinspection FloatingPointEquality
-		if (cpuCoresLong != cpuCoresDouble) {
-			log.info(
-				"The amount of cpu cores must be a positive integer on Yarn. Rounding {} up to the closest positive integer {}.",
-				cpuCoresDouble,
-				cpuCoresLong);
-		}
-		if (cpuCoresLong > Integer.MAX_VALUE) {
-			throw new IllegalConfigurationException(String.format(
-				"The amount of cpu cores %d cannot exceed Integer.MAX_VALUE: %d",
-				cpuCoresLong,
-				Integer.MAX_VALUE));
-		}
-		//noinspection NumericCastThatLosesPrecision
-		return cpuCoresLong;
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -167,7 +167,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		numPendingContainerRequests = 0;
 
 		this.webInterfaceUrl = webInterfaceUrl;
-		this.resource = Resource.newInstance(defaultMemoryMB, taskExecutorProcessSpec.getCpuCores().getValue().intValue());
+		this.resource = Resource.newInstance(defaultMemoryMB, defaultTaskExecutorProcessSpec.getCpuCores().getValue().intValue());
 	}
 
 	protected AMRMClientAsync<AMRMClient.ContainerRequest> createAndStartResourceManagerClient(
@@ -293,7 +293,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
 		Preconditions.checkArgument(Objects.equals(
 			workerResourceSpec,
-			WorkerResourceSpec.fromTaskExecutorProcessSpec(taskExecutorProcessSpec)));
+			WorkerResourceSpec.fromTaskExecutorProcessSpec(defaultTaskExecutorProcessSpec)));
 		requestYarnContainer();
 		return true;
 	}
@@ -566,12 +566,12 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
+				ContaineredTaskManagerParameters.create(flinkConfig, defaultTaskExecutorProcessSpec);
 
 		log.info("TaskExecutor {} will be started on {} with {}.",
 			containerId,
 			host,
-			taskExecutorProcessSpec);
+			defaultTaskExecutorProcessSpec);
 
 		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -73,11 +74,11 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
 
 /**
  * The yarn implementation of the resource manager. Used when the system is started
@@ -116,11 +117,6 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 	/** Client to communicate with the Node manager and launch TaskExecutor processes. */
 	private NMClientAsync nodeManagerClient;
-
-	/** The number of containers requested, but not yet granted. */
-	private int numPendingContainerRequests;
-
-	private final Resource resource;
 
 	private final WorkerSpecContainerResourceAdapter workerSpecContainerResourceAdapter;
 
@@ -167,10 +163,8 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		}
 		yarnHeartbeatIntervalMillis = yarnHeartbeatIntervalMS;
 		containerRequestHeartbeatIntervalMillis = flinkConfig.getInteger(YarnConfigOptions.CONTAINER_REQUEST_HEARTBEAT_INTERVAL_MILLISECONDS);
-		numPendingContainerRequests = 0;
 
 		this.webInterfaceUrl = webInterfaceUrl;
-		this.resource = Resource.newInstance(defaultMemoryMB, defaultTaskExecutorProcessSpec.getCpuCores().getValue().intValue());
 
 		this.workerSpecContainerResourceAdapter = new WorkerSpecContainerResourceAdapter(
 			flinkConfig,
@@ -312,16 +306,12 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 	@Override
 	public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
-		Preconditions.checkArgument(Objects.equals(
-			workerResourceSpec,
-			WorkerResourceSpec.fromTaskExecutorProcessSpec(defaultTaskExecutorProcessSpec)));
-		requestYarnContainer();
-		return true;
+		return requestYarnContainer(workerResourceSpec);
 	}
 
 	@VisibleForTesting
-	Resource getContainerResource() {
-		return resource;
+	Optional<Resource> getContainerResource(WorkerResourceSpec workerResourceSpec) {
+		return workerSpecContainerResourceAdapter.tryComputeContainerResource(workerResourceSpec);
 	}
 
 	@Override
@@ -372,31 +362,66 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	@Override
 	public void onContainersAllocated(List<Container> containers) {
 		runAsync(() -> {
-			log.info("Received {} containers with {} pending container requests.", containers.size(), numPendingContainerRequests);
-			final Collection<AMRMClient.ContainerRequest> pendingRequests = getPendingRequests();
-			final Iterator<AMRMClient.ContainerRequest> pendingRequestsIterator = pendingRequests.iterator();
+			log.info("Received {} containers.", containers.size());
 
-			// number of allocated containers can be larger than the number of pending container requests
-			final int numAcceptedContainers = Math.min(containers.size(), numPendingContainerRequests);
-			final List<Container> requiredContainers = containers.subList(0, numAcceptedContainers);
-			final List<Container> excessContainers = containers.subList(numAcceptedContainers, containers.size());
-
-			for (int i = 0; i < requiredContainers.size(); i++) {
-				removeContainerRequest(pendingRequestsIterator.next());
+			for (Map.Entry<Resource, List<Container>> entry : groupContainerByResource(containers).entrySet()) {
+				onContainersOfResourceAllocated(entry.getKey(), entry.getValue());
 			}
-
-			excessContainers.forEach(this::returnExcessContainer);
-			requiredContainers.forEach(this::startTaskExecutorInContainer);
 
 			// if we are waiting for no further containers, we can go to the
 			// regular heartbeat interval
-			if (numPendingContainerRequests <= 0) {
+			if (getNumPendingWorkers() <= 0) {
 				resourceManagerClient.setHeartbeatInterval(yarnHeartbeatIntervalMillis);
 			}
 		});
 	}
 
-	private void startTaskExecutorInContainer(Container container) {
+	private Map<Resource, List<Container>> groupContainerByResource(List<Container> containers) {
+		return containers.stream().collect(Collectors.groupingBy(Container::getResource));
+	}
+
+	private void onContainersOfResourceAllocated(Resource resource, List<Container> containers) {
+		final List<WorkerResourceSpec> pendingWorkerResourceSpecs =
+			workerSpecContainerResourceAdapter.getWorkerSpecs(resource).stream()
+				.flatMap(spec -> Collections.nCopies(getNumPendingWorkersFor(spec), spec).stream())
+				.collect(Collectors.toList());
+
+		int numPending = pendingWorkerResourceSpecs.size();
+		log.info("Received {} containers with resource {}, {} pending container requests.",
+			containers.size(),
+			resource,
+			numPending);
+
+		final Iterator<Container> containerIterator = containers.iterator();
+		final Iterator<WorkerResourceSpec> pendingWorkerSpecIterator = pendingWorkerResourceSpecs.iterator();
+		final Iterator<AMRMClient.ContainerRequest> pendingRequestsIterator =
+			getPendingRequestsAndCheckConsistency(resource, pendingWorkerResourceSpecs.size()).iterator();
+
+		int numAccepted = 0;
+		while (containerIterator.hasNext() && pendingWorkerSpecIterator.hasNext()) {
+			final WorkerResourceSpec workerResourceSpec = pendingWorkerSpecIterator.next();
+			final Container container = containerIterator.next();
+			final AMRMClient.ContainerRequest pendingRequest = pendingRequestsIterator.next();
+
+			notifyNewWorkerAllocated(workerResourceSpec);
+			startTaskExecutorInContainer(container, workerResourceSpec);
+			removeContainerRequest(pendingRequest, workerResourceSpec);
+
+			numAccepted++;
+		}
+		numPending -= numAccepted;
+
+		int numExcess = 0;
+		while (containerIterator.hasNext()) {
+			returnExcessContainer(containerIterator.next());
+			numExcess++;
+		}
+
+		log.info("Accepted {} requested containers, returned {} excess containers, {} pending container requests of resource {}.",
+			numAccepted, numExcess, numPending, resource);
+	}
+
+	private void startTaskExecutorInContainer(Container container, WorkerResourceSpec workerResourceSpec) {
 		final String containerIdStr = container.getId().toString();
 		final ResourceID resourceId = new ResourceID(containerIdStr);
 
@@ -406,7 +431,8 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			// Context information used to start a TaskExecutor Java process
 			ContainerLaunchContext taskExecutorLaunchContext = createTaskExecutorLaunchContext(
 				containerIdStr,
-				container.getNodeId().getHost());
+				container.getNodeId().getHost(),
+				TaskExecutorProcessUtils.processSpecFromWorkerResourceSpec(flinkConfig, workerResourceSpec));
 
 			nodeManagerClient.startContainerAsync(container, taskExecutorLaunchContext);
 		} catch (Throwable t) {
@@ -421,7 +447,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 		final ResourceID resourceId = new ResourceID(containerId.toString());
 		// release the failed container
-		workerNodeMap.remove(resourceId);
+		YarnWorkerNode yarnWorkerNode = workerNodeMap.remove(resourceId);
 		resourceManagerClient.releaseAssignedContainer(containerId);
 		// and ask for a new one
 		requestYarnContainerIfRequired();
@@ -432,19 +458,20 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		resourceManagerClient.releaseAssignedContainer(excessContainer.getId());
 	}
 
-	private void removeContainerRequest(AMRMClient.ContainerRequest pendingContainerRequest) {
-		numPendingContainerRequests--;
-
-		log.info("Removing container request {}. Pending container requests {}.", pendingContainerRequest, numPendingContainerRequests);
-
+	private void removeContainerRequest(AMRMClient.ContainerRequest pendingContainerRequest, WorkerResourceSpec workerResourceSpec) {
+		log.info("Removing container request {}.", pendingContainerRequest);
 		resourceManagerClient.removeContainerRequest(pendingContainerRequest);
 	}
 
-	private Collection<AMRMClient.ContainerRequest> getPendingRequests() {
-		final List<? extends Collection<AMRMClient.ContainerRequest>> matchingRequests = resourceManagerClient.getMatchingRequests(
-			RM_REQUEST_PRIORITY,
-			ResourceRequest.ANY,
-			getContainerResource());
+	private Collection<AMRMClient.ContainerRequest> getPendingRequestsAndCheckConsistency(Resource resource, int expectedNum) {
+		final Collection<Resource> equivalentResources = workerSpecContainerResourceAdapter.getEquivalentContainerResource(resource);
+		final List<? extends Collection<AMRMClient.ContainerRequest>> matchingRequests =
+			equivalentResources.stream()
+				.flatMap(equivalentResource -> resourceManagerClient.getMatchingRequests(
+					RM_REQUEST_PRIORITY,
+					ResourceRequest.ANY,
+					equivalentResource).stream())
+				.collect(Collectors.toList());
 
 		final Collection<AMRMClient.ContainerRequest> matchingContainerRequests;
 
@@ -456,8 +483,10 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 		}
 
 		Preconditions.checkState(
-			matchingContainerRequests.size() == numPendingContainerRequests,
-			"The RMClient's and YarnResourceManagers internal state about the number of pending container requests has diverged. Number client's pending container requests %s != Number RM's pending container requests %s.", matchingContainerRequests.size(), numPendingContainerRequests);
+			matchingContainerRequests.size() == expectedNum,
+			"The RMClient's and YarnResourceManagers internal state about the number of pending container requests for resource %s has diverged. " +
+				"Number client's pending container requests %s != Number RM's pending container requests %s.",
+			resource, matchingContainerRequests.size(), expectedNum);
 
 		return matchingContainerRequests;
 	}
@@ -550,30 +579,40 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 	 * Request new container if pending containers cannot satisfy pending slot requests.
 	 */
 	private void requestYarnContainerIfRequired() {
-		final int requiredTaskManagers = getNumberRequiredTaskManagers();
-
-		while (requiredTaskManagers > numPendingContainerRequests) {
-			requestYarnContainer();
+		for (Map.Entry<WorkerResourceSpec, Integer> requiredWorkersPerResourceSpec : getRequiredResources().entrySet()) {
+			final WorkerResourceSpec workerResourceSpec = requiredWorkersPerResourceSpec.getKey();
+			while (requiredWorkersPerResourceSpec.getValue() > getNumPendingWorkersFor(workerResourceSpec)) {
+				final boolean requestContainerSuccess = requestYarnContainer(workerResourceSpec);
+				Preconditions.checkState(requestContainerSuccess,
+					"Cannot request container for worker resource spec {}.", workerResourceSpec);
+			}
 		}
 	}
 
-	private void requestYarnContainer() {
-		resourceManagerClient.addContainerRequest(getContainerRequest());
+	private boolean requestYarnContainer(WorkerResourceSpec workerResourceSpec) {
+		Optional<Resource> containerResourceOptional = getContainerResource(workerResourceSpec);
 
-		// make sure we transmit the request fast and receive fast news of granted allocations
-		resourceManagerClient.setHeartbeatInterval(containerRequestHeartbeatIntervalMillis);
-		numPendingContainerRequests++;
+		if (containerResourceOptional.isPresent()) {
+			resourceManagerClient.addContainerRequest(getContainerRequest(containerResourceOptional.get()));
 
-		log.info("Requesting new TaskExecutor container with resources {}. Number pending requests {}.",
-			resource,
-			numPendingContainerRequests);
+			// make sure we transmit the request fast and receive fast news of granted allocations
+			resourceManagerClient.setHeartbeatInterval(containerRequestHeartbeatIntervalMillis);
+			int numPendingWorkers = notifyNewWorkerRequested(workerResourceSpec);
+
+			log.info("Requesting new TaskExecutor container with resource {}. Number pending workers of this resource is {}.",
+				workerResourceSpec,
+				numPendingWorkers);
+			return true;
+		} else {
+			return false;
+		}
 	}
 
 	@Nonnull
 	@VisibleForTesting
-	AMRMClient.ContainerRequest getContainerRequest() {
+	AMRMClient.ContainerRequest getContainerRequest(Resource containerResource) {
 		return new AMRMClient.ContainerRequest(
-			getContainerResource(),
+			containerResource,
 			null,
 			null,
 			RM_REQUEST_PRIORITY);
@@ -581,18 +620,19 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 	private ContainerLaunchContext createTaskExecutorLaunchContext(
 		String containerId,
-		String host) throws Exception {
+		String host,
+		TaskExecutorProcessSpec taskExecutorProcessSpec) throws Exception {
 
 		// init the ContainerLaunchContext
 		final String currDir = env.get(ApplicationConstants.Environment.PWD.key());
 
 		final ContaineredTaskManagerParameters taskManagerParameters =
-				ContaineredTaskManagerParameters.create(flinkConfig, defaultTaskExecutorProcessSpec);
+				ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 
 		log.info("TaskExecutor {} will be started on {} with {}.",
 			containerId,
 			host,
-			defaultTaskExecutorProcessSpec);
+			taskExecutorProcessSpec);
 
 		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/configuration/YarnConfigOptionsInternal.java
@@ -20,6 +20,9 @@ package org.apache.flink.yarn.configuration;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
+import org.apache.flink.yarn.YarnResourceManager;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -34,4 +37,27 @@ public class YarnConfigOptionsInternal {
 					.stringType()
 					.noDefaultValue()
 					.withDescription("**DO NOT USE** The location of the log config file, e.g. the path to your log4j.properties for log4j.");
+
+	/**
+	 * **DO NOT USE** Whether {@link YarnResourceManager} should match the vcores of allocated containers with those requested.
+	 *
+	 * <p>By default, Yarn ignores vcores in the container requests, and always allocate 1 vcore for each container.
+	 * Iff 'yarn.scheduler.capacity.resource-calculator' is set to 'DominantResourceCalculator' for Yarn, will it
+	 * allocate container vcores as requested.
+	 *
+	 * <P>For Hadoop 2.6+, we can learn whether Yarn matches vcores from
+	 * {@link org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse}. However, this is not
+	 * available to earlier Hadoop versions (pre 2.6). Therefore, for earlier Hadoop versions, the user needs to make
+	 * sure this configuration option is consistent with the Yarn setup.
+	 *
+	 * <p>ATM, it should be fine to keep this option 'false', because with the current {@link SlotManagerImpl} all the
+	 * TM containers should have the same resources. If later we add another {@link SlotManager} implementation that may
+	 * have TMs with different resources, and if we need it to work with pre 2.6 Hadoop versions, we can expose this
+	 * configuration option to users.
+	 */
+	public static final ConfigOption<Boolean> MATCH_CONTAINER_VCORES =
+			key("$internal.yarn.resourcemanager.enable-vcore-matching")
+					.booleanType()
+					.defaultValue(false)
+					.withDescription("**DO NOT USE** Whether YarnResourceManager should match the container vcores.");
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.yarn.entrypoint;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
@@ -46,7 +47,8 @@ public class YarnWorkerResourceSpecFactory extends WorkerResourceSpecFactory {
 		return workerResourceSpecFromConfigAndCpu(configuration, getDefaultCpus(configuration));
 	}
 
-	private static CPUResource getDefaultCpus(final Configuration configuration) {
+	@VisibleForTesting
+	static CPUResource getDefaultCpus(final Configuration configuration) {
 		int fallback = configuration.getInteger(YarnConfigOptions.VCORES);
 		double cpuCoresDouble = TaskExecutorProcessUtils.getCpuCoresWithFallback(configuration, fallback).getValue().doubleValue();
 		@SuppressWarnings("NumericCastThatLosesPrecision")

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
@@ -62,8 +62,7 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
 
 		final List<Container> containersFromPreviousAttemptsUnsafe =
-			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new
-				HasMethod());
+			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new HasMethod());
 
 		assertThat(containersFromPreviousAttemptsUnsafe, hasSize(1));
 	}
@@ -74,8 +73,7 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
 
 		final List<Container> containersFromPreviousAttemptsUnsafe =
-			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new
-				Object());
+			registerApplicationMasterResponseReflector.getContainersFromPreviousAttemptsUnsafe(new Object());
 
 		assertThat(containersFromPreviousAttemptsUnsafe, empty());
 	}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/RegisterApplicationMasterResponseReflectorTest.java
@@ -30,15 +30,19 @@ import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.apache.flink.yarn.YarnTestUtils.isHadoopVersionGreaterThanOrEquals;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -57,7 +61,7 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 	}
 
 	@Test
-	public void testCallsMethodIfPresent() {
+	public void testCallsGetContainersFromPreviousAttemptsMethodIfPresent() {
 		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
 			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
 
@@ -68,7 +72,7 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 	}
 
 	@Test
-	public void testDoesntCallMethodIfAbsent() {
+	public void testDoesntCallGetContainersFromPreviousAttemptsMethodIfAbsent() {
 		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
 			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
 
@@ -79,7 +83,7 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 	}
 
 	@Test
-	public void testGetMethodReflectiveHadoop22() {
+	public void testGetContainersFromPreviousAttemptsMethodReflectiveHadoop22() {
 		assumeTrue(
 			"Method getContainersFromPreviousAttempts is not supported by Hadoop: " +
 				VersionInfo.getVersion(),
@@ -88,8 +92,43 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
 			new RegisterApplicationMasterResponseReflector(LOG);
 
-		final Method method = registerApplicationMasterResponseReflector.getMethod();
-		assertThat(method, notNullValue());
+		assertTrue(registerApplicationMasterResponseReflector.getGetContainersFromPreviousAttemptsMethod().isPresent());
+	}
+
+	@Test
+	public void testCallsGetSchedulerResourceTypesMethodIfPresent() {
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
+
+		final Optional<Set<String>> schedulerResourceTypeNames =
+			registerApplicationMasterResponseReflector.getSchedulerResourceTypeNamesUnsafe(new HasMethod());
+
+		assertTrue(schedulerResourceTypeNames.isPresent());
+		assertThat(schedulerResourceTypeNames.get(), containsInAnyOrder("MEMORY", "CPU"));
+	}
+
+	@Test
+	public void testDoesntCallGetSchedulerResourceTypesMethodIfAbsent() {
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG, HasMethod.class);
+
+		final Optional<Set<String>> schedulerResourceTypeNames =
+			registerApplicationMasterResponseReflector.getSchedulerResourceTypeNamesUnsafe(new Object());
+
+		assertFalse(schedulerResourceTypeNames.isPresent());
+	}
+
+	@Test
+	public void testGetSchedulerResourceTypesMethodReflectiveHadoop26() {
+		assumeTrue(
+			"Method getSchedulerResourceTypes is not supported by Hadoop: " +
+				VersionInfo.getVersion(),
+			isHadoopVersionGreaterThanOrEquals(2, 6));
+
+		final RegisterApplicationMasterResponseReflector registerApplicationMasterResponseReflector =
+			new RegisterApplicationMasterResponseReflector(LOG);
+
+		assertTrue(registerApplicationMasterResponseReflector.getGetSchedulerResourceTypesMethod().isPresent());
 	}
 
 	/**
@@ -99,11 +138,25 @@ public class RegisterApplicationMasterResponseReflectorTest extends TestLogger {
 	private class HasMethod {
 
 		/**
-		 * Called from {@link #testCallsMethodIfPresent()}.
+		 * Called from {@link #testCallsGetContainersFromPreviousAttemptsMethodIfPresent()}.
 		 */
 		@SuppressWarnings("unused")
 		public List<Container> getContainersFromPreviousAttempts() {
 			return Collections.singletonList(mockContainer);
 		}
+
+		/**
+		 * Called from {@link #testCallsGetSchedulerResourceTypesMethodIfPresent()}.
+		 */
+		@SuppressWarnings("unused")
+		public EnumSet<MockSchedulerResourceTypes> getSchedulerResourceTypes() {
+			return EnumSet.allOf(MockSchedulerResourceTypes.class);
+		}
+	}
+
+	@SuppressWarnings("unused")
+	private enum MockSchedulerResourceTypes {
+		MEMORY,
+		CPU
 	}
 }

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingContainer.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingContainer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.impl.pb.ContainerPBImpl;
+
+/**
+ * A {@link Container} implementation for testing.
+ */
+class TestingContainer extends ContainerPBImpl {
+	private final ContainerId containerId;
+	private final NodeId nodeId;
+	private final Resource resource;
+	private final Priority priority;
+
+	TestingContainer(
+		final ContainerId containerId,
+		final NodeId nodeId,
+		final Resource resource,
+		final Priority priority) {
+
+		this.containerId = containerId;
+		this.nodeId = nodeId;
+		this.resource = resource;
+		this.priority = priority;
+	}
+
+	@Override
+	public ContainerId getId() {
+		return containerId;
+	}
+
+	@Override
+	public NodeId getNodeId() {
+		return nodeId;
+	}
+
+	@Override
+	public Resource getResource() {
+		return resource;
+	}
+
+	@Override
+	public Priority getPriority() {
+		return priority;
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingContainerStatus.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingContainerStatus.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerState;
+import org.apache.hadoop.yarn.api.records.ContainerStatus;
+import org.apache.hadoop.yarn.api.records.impl.pb.ContainerStatusPBImpl;
+
+/**
+ * A {@link ContainerStatus} implementation for testing.
+ */
+class TestingContainerStatus extends ContainerStatusPBImpl {
+
+	private final ContainerId containerId;
+	private final ContainerState containerState;
+	private final String diagnostics;
+	private final int exitStatus;
+
+	TestingContainerStatus(
+		final ContainerId containerId,
+		final ContainerState containerState,
+		final String diagnostics,
+		final int exitStatus) {
+
+		this.containerId = containerId;
+		this.containerState = containerState;
+		this.diagnostics = diagnostics;
+		this.exitStatus = exitStatus;
+	}
+
+	@Override
+	public ContainerId getContainerId() {
+		return containerId;
+	}
+
+	@Override
+	public ContainerState getState() {
+		return containerState;
+	}
+
+	@Override
+	public int getExitStatus() {
+		return exitStatus;
+	}
+
+	@Override
+	public String getDiagnostics() {
+		return diagnostics;
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnAMRMClientAsync.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnAMRMClientAsync.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.TriConsumer;
+import org.apache.flink.util.function.TriFunction;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
+import org.apache.hadoop.yarn.api.records.Priority;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
+import org.apache.hadoop.yarn.client.api.async.impl.AMRMClientAsyncImpl;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * A Yarn {@link AMRMClientAsync} implementation for testing.
+ */
+public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.ContainerRequest> {
+
+	private volatile Function<Tuple4<Priority, String, Resource, CallbackHandler>, List<? extends Collection<AMRMClient.ContainerRequest>>>
+		getMatchingRequestsFunction = ignored -> Collections.emptyList();
+	private volatile BiConsumer<AMRMClient.ContainerRequest, CallbackHandler> addContainerRequestConsumer = (ignored1, ignored2) -> {};
+	private volatile BiConsumer<AMRMClient.ContainerRequest, CallbackHandler> removeContainerRequestConsumer = (ignored1, ignored2) -> {};
+	private volatile BiConsumer<ContainerId, CallbackHandler> releaseAssignedContainerConsumer = (ignored1, ignored2) -> {};
+	private volatile Consumer<Integer> setHeartbeatIntervalConsumer = (ignored) -> {};
+	private volatile TriFunction<String, Integer, String, RegisterApplicationMasterResponse> registerApplicationMasterFunction =
+		(ignored1, ignored2, ignored3) -> RegisterApplicationMasterResponse.newInstance(
+			Resource.newInstance(0, 0),
+			Resource.newInstance(Integer.MAX_VALUE, Integer.MAX_VALUE),
+			Collections.emptyMap(),
+			null,
+			Collections.emptyList(),
+			null,
+			Collections.emptyList());
+	private volatile TriConsumer<FinalApplicationStatus, String, String> unregisterApplicationMasterConsumer = (ignored1, ignored2, ignored3) -> {};
+
+	TestingYarnAMRMClientAsync(CallbackHandler callbackHandler) {
+		super(0, callbackHandler);
+	}
+
+	@Override
+	public List<? extends Collection<AMRMClient.ContainerRequest>> getMatchingRequests(Priority priority, String resourceName, Resource capability) {
+		return getMatchingRequestsFunction.apply(Tuple4.of(priority, resourceName, capability, handler));
+	}
+
+	@Override
+	public void addContainerRequest(AMRMClient.ContainerRequest req) {
+		addContainerRequestConsumer.accept(req, handler);
+	}
+
+	@Override
+	public void removeContainerRequest(AMRMClient.ContainerRequest req) {
+		removeContainerRequestConsumer.accept(req, handler);
+	}
+
+	@Override
+	public void releaseAssignedContainer(ContainerId containerId) {
+		releaseAssignedContainerConsumer.accept(containerId, handler);
+	}
+
+	@Override
+	public void setHeartbeatInterval(int interval) {
+		setHeartbeatIntervalConsumer.accept(interval);
+	}
+
+	@Override
+	public RegisterApplicationMasterResponse registerApplicationMaster(String appHostName, int appHostPort, String appTrackingUrl) {
+		return registerApplicationMasterFunction.apply(appHostName, appHostPort, appTrackingUrl);
+	}
+
+	@Override
+	public void unregisterApplicationMaster(FinalApplicationStatus appStatus, String appMessage, String appTrackingUrl) {
+		unregisterApplicationMasterConsumer.accept(appStatus, appMessage, appTrackingUrl);
+	}
+
+	void setGetMatchingRequestsFunction(
+		Function<Tuple4<Priority, String, Resource, CallbackHandler>, List<? extends Collection<AMRMClient.ContainerRequest>>>
+			getMatchingRequestsFunction) {
+		this.getMatchingRequestsFunction = Preconditions.checkNotNull(getMatchingRequestsFunction);
+	}
+
+	void setAddContainerRequestConsumer(
+		BiConsumer<AMRMClient.ContainerRequest, CallbackHandler> addContainerRequestConsumer) {
+		this.addContainerRequestConsumer = Preconditions.checkNotNull(addContainerRequestConsumer);
+	}
+
+	void setRemoveContainerRequestConsumer(
+		BiConsumer<AMRMClient.ContainerRequest, CallbackHandler> removeContainerRequestConsumer) {
+		this.removeContainerRequestConsumer = Preconditions.checkNotNull(removeContainerRequestConsumer);
+	}
+
+	void setReleaseAssignedContainerConsumer(
+		BiConsumer<ContainerId, CallbackHandler> releaseAssignedContainerConsumer) {
+		this.releaseAssignedContainerConsumer = Preconditions.checkNotNull(releaseAssignedContainerConsumer);
+	}
+
+	void setSetHeartbeatIntervalConsumer(
+		Consumer<Integer> setHeartbeatIntervalConsumer) {
+		this.setHeartbeatIntervalConsumer = setHeartbeatIntervalConsumer;
+	}
+
+	void setRegisterApplicationMasterFunction(
+		TriFunction<String, Integer, String, RegisterApplicationMasterResponse> registerApplicationMasterFunction) {
+		this.registerApplicationMasterFunction = registerApplicationMasterFunction;
+	}
+
+	void setUnregisterApplicationMasterConsumer(
+		TriConsumer<FinalApplicationStatus, String, String> unregisterApplicationMasterConsumer) {
+		this.unregisterApplicationMasterConsumer = unregisterApplicationMasterConsumer;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Override lifecycle methods to avoid actually starting the service
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void serviceInit(Configuration conf) throws Exception {
+		// noop
+	}
+
+	@Override
+	protected void serviceStart() throws Exception {
+		// noop
+	}
+
+	@Override
+	protected void serviceStop() throws Exception {
+		// noop
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnNMClientAsync.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnNMClientAsync.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.TriConsumer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.api.records.Container;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.hadoop.yarn.client.api.async.NMClientAsync;
+import org.apache.hadoop.yarn.client.api.async.impl.NMClientAsyncImpl;
+
+/**
+ * A Yarn {@link NMClientAsync} implementation for testing.
+ */
+class TestingYarnNMClientAsync extends NMClientAsyncImpl {
+
+	private volatile TriConsumer<Container, ContainerLaunchContext, CallbackHandler> startContainerAsyncConsumer = (ignored1, ignored2, ignored3) -> {};
+	private volatile TriConsumer<ContainerId, NodeId, CallbackHandler> stopContainerAsyncConsumer = (ignored1, ignored2, ignored3) -> {};
+
+	TestingYarnNMClientAsync(final CallbackHandler callbackHandler) {
+		super(callbackHandler);
+	}
+
+	@Override
+	public void startContainerAsync(Container container, ContainerLaunchContext containerLaunchContext) {
+		this.startContainerAsyncConsumer.accept(container, containerLaunchContext, callbackHandler);
+	}
+
+	@Override
+	public void stopContainerAsync(ContainerId containerId, NodeId nodeId) {
+		this.stopContainerAsyncConsumer.accept(containerId, nodeId, callbackHandler);
+	}
+
+	void setStartContainerAsyncConsumer(TriConsumer<Container, ContainerLaunchContext, CallbackHandler> startContainerAsyncConsumer) {
+		this.startContainerAsyncConsumer = Preconditions.checkNotNull(startContainerAsyncConsumer);
+	}
+
+	void setStopContainerAsyncConsumer(TriConsumer<ContainerId, NodeId, CallbackHandler> stopContainerAsyncConsumer) {
+		this.stopContainerAsyncConsumer = Preconditions.checkNotNull(stopContainerAsyncConsumer);
+	}
+
+	// ------------------------------------------------------------------------
+	//  Override lifecycle methods to avoid actually starting the service
+	// ------------------------------------------------------------------------
+
+	@Override
+	protected void serviceInit(Configuration conf) throws Exception {
+		// noop
+	}
+
+	@Override
+	protected void serviceStart() throws Exception {
+		// noop
+	}
+
+	@Override
+	protected void serviceStop() throws Exception {
+		// noop
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link WorkerSpecContainerResourceAdapter}.
+ */
+public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
+
+	@Test
+	public void testMatchVcores() {
+		final int minMemMB = 100;
+		final int minVcore = 10;
+		final WorkerSpecContainerResourceAdapter adapter =
+			new WorkerSpecContainerResourceAdapter(
+				getConfigProcessSpecEqualsWorkerSpec(),
+				minMemMB,
+				minVcore,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				WorkerSpecContainerResourceAdapter.MatchingStrategy.MATCH_VCORE);
+
+		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(10)
+			.setTaskOffHeapMemoryMB(10)
+			.setNetworkMemoryMB(10)
+			.setManagedMemoryMB(10)
+			.build();
+		final WorkerResourceSpec workerSpec2 = new WorkerResourceSpec.Builder()
+			.setCpuCores(10.0)
+			.setTaskHeapMemoryMB(25)
+			.setTaskOffHeapMemoryMB(25)
+			.setNetworkMemoryMB(25)
+			.setManagedMemoryMB(25)
+			.build();
+		final WorkerResourceSpec workerSpec3 = new WorkerResourceSpec.Builder()
+			.setCpuCores(5.0)
+			.setTaskHeapMemoryMB(30)
+			.setTaskOffHeapMemoryMB(30)
+			.setNetworkMemoryMB(30)
+			.setManagedMemoryMB(30)
+			.build();
+		final WorkerResourceSpec workerSpec4 = new WorkerResourceSpec.Builder()
+			.setCpuCores(15.0)
+			.setTaskHeapMemoryMB(10)
+			.setTaskOffHeapMemoryMB(10)
+			.setNetworkMemoryMB(10)
+			.setManagedMemoryMB(10)
+			.build();
+
+		final Resource containerResource1 = Resource.newInstance(100, 10);
+		final Resource containerResource2 = Resource.newInstance(200, 10);
+		final Resource containerResource3 = Resource.newInstance(100, 20);
+
+		assertThat(adapter.getWorkerSpecs(containerResource1), empty());
+		assertThat(adapter.getWorkerSpecs(containerResource2), empty());
+
+		assertThat(adapter.tryComputeContainerResource(workerSpec1).get(), is(containerResource1));
+		assertThat(adapter.tryComputeContainerResource(workerSpec2).get(), is(containerResource1));
+		assertThat(adapter.tryComputeContainerResource(workerSpec3).get(), is(containerResource2));
+		assertThat(adapter.tryComputeContainerResource(workerSpec4).get(), is(containerResource3));
+
+		assertThat(adapter.getWorkerSpecs(containerResource1), containsInAnyOrder(workerSpec1, workerSpec2));
+		assertThat(adapter.getWorkerSpecs(containerResource2), contains(workerSpec3));
+		assertThat(adapter.getWorkerSpecs(containerResource3), contains(workerSpec4));
+	}
+
+	@Test
+	public void testIgnoreVcores() {
+		final int minMemMB = 100;
+		final int minVcore = 1;
+		final WorkerSpecContainerResourceAdapter adapter =
+			new WorkerSpecContainerResourceAdapter(
+				getConfigProcessSpecEqualsWorkerSpec(),
+				minMemMB,
+				minVcore,
+				Integer.MAX_VALUE,
+				Integer.MAX_VALUE,
+				WorkerSpecContainerResourceAdapter.MatchingStrategy.IGNORE_VCORE);
+
+		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
+			.setCpuCores(5.0)
+			.setTaskHeapMemoryMB(10)
+			.setTaskOffHeapMemoryMB(10)
+			.setNetworkMemoryMB(10)
+			.setManagedMemoryMB(10)
+			.build();
+		final WorkerResourceSpec workerSpec2 = new WorkerResourceSpec.Builder()
+			.setCpuCores(10.0)
+			.setTaskHeapMemoryMB(10)
+			.setTaskOffHeapMemoryMB(10)
+			.setNetworkMemoryMB(10)
+			.setManagedMemoryMB(10)
+			.build();
+		final WorkerResourceSpec workerSpec3 = new WorkerResourceSpec.Builder()
+			.setCpuCores(5.0)
+			.setTaskHeapMemoryMB(25)
+			.setTaskOffHeapMemoryMB(25)
+			.setNetworkMemoryMB(25)
+			.setManagedMemoryMB(25)
+			.build();
+		final WorkerResourceSpec workerSpec4 = new WorkerResourceSpec.Builder()
+			.setCpuCores(5.0)
+			.setTaskHeapMemoryMB(30)
+			.setTaskOffHeapMemoryMB(30)
+			.setNetworkMemoryMB(30)
+			.setManagedMemoryMB(30)
+			.build();
+
+		final Resource containerResource1 = Resource.newInstance(100, 5);
+		final Resource containerResource2 = Resource.newInstance(100, 10);
+		final Resource containerResource3 = Resource.newInstance(200, 5);
+
+		final Resource containerResource4 = Resource.newInstance(100, 1);
+		final Resource containerResource5 = Resource.newInstance(200, 1);
+
+		assertThat(adapter.tryComputeContainerResource(workerSpec1).get(), is(containerResource1));
+		assertThat(adapter.tryComputeContainerResource(workerSpec2).get(), is(containerResource2));
+		assertThat(adapter.tryComputeContainerResource(workerSpec3).get(), is(containerResource1));
+		assertThat(adapter.tryComputeContainerResource(workerSpec4).get(), is(containerResource3));
+
+		assertThat(adapter.getEquivalentContainerResource(containerResource4), containsInAnyOrder(containerResource1, containerResource2));
+		assertThat(adapter.getEquivalentContainerResource(containerResource5), contains(containerResource3));
+
+		assertThat(adapter.getWorkerSpecs(containerResource4), containsInAnyOrder(workerSpec1, workerSpec2, workerSpec3));
+		assertThat(adapter.getWorkerSpecs(containerResource5), contains(workerSpec4));
+	}
+
+	@Test
+	public void testMaxLimit() {
+		final int minMemMB = 100;
+		final int minVcore = 1;
+		final int maxMemMB = 1000;
+		final int maxVcore = 10;
+		final WorkerSpecContainerResourceAdapter adapter =
+			new WorkerSpecContainerResourceAdapter(
+				getConfigProcessSpecEqualsWorkerSpec(),
+				minMemMB,
+				minVcore,
+				maxMemMB,
+				maxVcore,
+				WorkerSpecContainerResourceAdapter.MatchingStrategy.MATCH_VCORE);
+
+		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
+			.setCpuCores(5.0)
+			.setTaskHeapMemoryMB(300)
+			.setTaskOffHeapMemoryMB(300)
+			.setNetworkMemoryMB(300)
+			.setManagedMemoryMB(300)
+			.build();
+		final WorkerResourceSpec workerSpec2 = new WorkerResourceSpec.Builder()
+			.setCpuCores(15.0)
+			.setTaskHeapMemoryMB(10)
+			.setTaskOffHeapMemoryMB(10)
+			.setNetworkMemoryMB(10)
+			.setManagedMemoryMB(10)
+			.build();
+
+		assertFalse(adapter.tryComputeContainerResource(workerSpec1).isPresent());
+		assertFalse(adapter.tryComputeContainerResource(workerSpec2).isPresent());
+	}
+
+	private Configuration getConfigProcessSpecEqualsWorkerSpec() {
+		final Configuration config = new Configuration();
+		config.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ZERO);
+		config.set(TaskManagerOptions.FRAMEWORK_OFF_HEAP_MEMORY, MemorySize.ZERO);
+		config.set(TaskManagerOptions.JVM_METASPACE, MemorySize.ZERO);
+		config.set(TaskManagerOptions.JVM_OVERHEAD_MIN, MemorySize.ZERO);
+		config.set(TaskManagerOptions.JVM_OVERHEAD_MAX, MemorySize.ZERO);
+		return config;
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapterTest.java
@@ -41,6 +41,8 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 
 	@Test
 	public void testMatchVcores() {
+		final WorkerSpecContainerResourceAdapter.MatchingStrategy strategy =
+			WorkerSpecContainerResourceAdapter.MatchingStrategy.MATCH_VCORE;
 		final int minMemMB = 100;
 		final int minVcore = 10;
 		final WorkerSpecContainerResourceAdapter adapter =
@@ -49,8 +51,7 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 				minMemMB,
 				minVcore,
 				Integer.MAX_VALUE,
-				Integer.MAX_VALUE,
-				WorkerSpecContainerResourceAdapter.MatchingStrategy.MATCH_VCORE);
+				Integer.MAX_VALUE);
 
 		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
 			.setCpuCores(1.0)
@@ -85,21 +86,23 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 		final Resource containerResource2 = Resource.newInstance(200, 10);
 		final Resource containerResource3 = Resource.newInstance(100, 20);
 
-		assertThat(adapter.getWorkerSpecs(containerResource1), empty());
-		assertThat(adapter.getWorkerSpecs(containerResource2), empty());
+		assertThat(adapter.getWorkerSpecs(containerResource1, strategy), empty());
+		assertThat(adapter.getWorkerSpecs(containerResource2, strategy), empty());
 
 		assertThat(adapter.tryComputeContainerResource(workerSpec1).get(), is(containerResource1));
 		assertThat(adapter.tryComputeContainerResource(workerSpec2).get(), is(containerResource1));
 		assertThat(adapter.tryComputeContainerResource(workerSpec3).get(), is(containerResource2));
 		assertThat(adapter.tryComputeContainerResource(workerSpec4).get(), is(containerResource3));
 
-		assertThat(adapter.getWorkerSpecs(containerResource1), containsInAnyOrder(workerSpec1, workerSpec2));
-		assertThat(adapter.getWorkerSpecs(containerResource2), contains(workerSpec3));
-		assertThat(adapter.getWorkerSpecs(containerResource3), contains(workerSpec4));
+		assertThat(adapter.getWorkerSpecs(containerResource1, strategy), containsInAnyOrder(workerSpec1, workerSpec2));
+		assertThat(adapter.getWorkerSpecs(containerResource2, strategy), contains(workerSpec3));
+		assertThat(adapter.getWorkerSpecs(containerResource3, strategy), contains(workerSpec4));
 	}
 
 	@Test
 	public void testIgnoreVcores() {
+		final WorkerSpecContainerResourceAdapter.MatchingStrategy strategy =
+			WorkerSpecContainerResourceAdapter.MatchingStrategy.IGNORE_VCORE;
 		final int minMemMB = 100;
 		final int minVcore = 1;
 		final WorkerSpecContainerResourceAdapter adapter =
@@ -108,8 +111,7 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 				minMemMB,
 				minVcore,
 				Integer.MAX_VALUE,
-				Integer.MAX_VALUE,
-				WorkerSpecContainerResourceAdapter.MatchingStrategy.IGNORE_VCORE);
+				Integer.MAX_VALUE);
 
 		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
 			.setCpuCores(5.0)
@@ -152,11 +154,11 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 		assertThat(adapter.tryComputeContainerResource(workerSpec3).get(), is(containerResource1));
 		assertThat(adapter.tryComputeContainerResource(workerSpec4).get(), is(containerResource3));
 
-		assertThat(adapter.getEquivalentContainerResource(containerResource4), containsInAnyOrder(containerResource1, containerResource2));
-		assertThat(adapter.getEquivalentContainerResource(containerResource5), contains(containerResource3));
+		assertThat(adapter.getEquivalentContainerResource(containerResource4, strategy), containsInAnyOrder(containerResource1, containerResource2));
+		assertThat(adapter.getEquivalentContainerResource(containerResource5, strategy), contains(containerResource3));
 
-		assertThat(adapter.getWorkerSpecs(containerResource4), containsInAnyOrder(workerSpec1, workerSpec2, workerSpec3));
-		assertThat(adapter.getWorkerSpecs(containerResource5), contains(workerSpec4));
+		assertThat(adapter.getWorkerSpecs(containerResource4, strategy), containsInAnyOrder(workerSpec1, workerSpec2, workerSpec3));
+		assertThat(adapter.getWorkerSpecs(containerResource5, strategy), contains(workerSpec4));
 	}
 
 	@Test
@@ -171,8 +173,7 @@ public class WorkerSpecContainerResourceAdapterTest extends TestLogger {
 				minMemMB,
 				minVcore,
 				maxMemMB,
-				maxVcore,
-				WorkerSpecContainerResourceAdapter.MatchingStrategy.MATCH_VCORE);
+				maxVcore);
 
 		final WorkerResourceSpec workerSpec1 = new WorkerResourceSpec.Builder()
 			.setCpuCores(5.0)

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -123,7 +123,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * General tests for the YARN resource manager component.
@@ -342,17 +341,10 @@ public class YarnResourceManagerTest extends TestLogger {
 			final NodeId nodeId = NodeId.newInstance("container", 1234);
 			return new TestingContainer(containerId, nodeId, resourceManager.getContainerResource(), Priority.UNDEFINED);
 		}
-	}
 
-	private static ContainerStatus mockContainerStatus(ContainerId containerId) {
-		ContainerStatus mockContainerStatus = mock(ContainerStatus.class);
-
-		when(mockContainerStatus.getContainerId()).thenReturn(containerId);
-		when(mockContainerStatus.getState()).thenReturn(ContainerState.COMPLETE);
-		when(mockContainerStatus.getDiagnostics()).thenReturn("Test exit");
-		when(mockContainerStatus.getExitStatus()).thenReturn(-1);
-
-		return mockContainerStatus;
+		ContainerStatus createTestingContainerStatus(final ContainerId containerId) {
+			return new TestingContainerStatus(containerId, ContainerState.COMPLETE, "Test exit", -1);
+		}
 	}
 
 	@Test
@@ -487,7 +479,7 @@ public class YarnResourceManagerTest extends TestLogger {
 
 				// Callback from YARN when container is Completed, pending request can not be fulfilled by pending
 				// containers, need to request new container.
-				ContainerStatus testingContainerStatus = mockContainerStatus(testingContainer.getId());
+				ContainerStatus testingContainerStatus = createTestingContainerStatus(testingContainer.getId());
 
 				resourceManager.onContainersCompleted(ImmutableList.of(testingContainerStatus));
 				verify(mockResourceManagerClient, VERIFICATION_TIMEOUT.times(2)).addContainerRequest(any(AMRMClient.ContainerRequest.class));

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.yarn;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -61,7 +60,6 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
-import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.entrypoint.YarnWorkerResourceSpecFactory;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
@@ -551,59 +549,6 @@ public class YarnResourceManagerTest extends TestLogger {
 				verifyFutureCompleted(releaseAssignedContainerFuture);
 				verifyFutureCompleted(addContainerRequestFutures.get(1));
 			});
-		}};
-	}
-
-	@Test
-	public void testGetCpuCoresCommonOption() throws Exception {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
-		configuration.setInteger(YarnConfigOptions.VCORES, 2);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-		new Context() {{
-			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(1.0)));
-		}};
-	}
-
-	@Test
-	public void testGetCpuCoresYarnOption() throws Exception {
-		final Configuration configuration = new Configuration();
-		configuration.setInteger(YarnConfigOptions.VCORES, 2);
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-		new Context() {{
-			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(2.0)));
-		}};
-	}
-
-	@Test
-	public void testGetCpuCoresNumSlots() throws Exception {
-		final Configuration configuration = new Configuration();
-		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
-
-		new Context() {{
-			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(3.0)));
-		}};
-	}
-
-	@Test
-	public void testGetCpuRoundUp() throws Exception {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(TaskManagerOptions.CPU_CORES, 0.5);
-
-		new Context() {{
-			runTest(() -> assertThat(resourceManager.getCpuCores(configuration), is(1.0)));
-		}};
-	}
-
-	@Test(expected = IllegalConfigurationException.class)
-	public void testGetCpuExceedMaxInt() throws Exception {
-		final Configuration configuration = new Configuration();
-		configuration.setDouble(TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
-
-		new Context() {{
-			resourceManager.getCpuCores(configuration);
 		}};
 	}
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -53,8 +53,8 @@ import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
-import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorRegistrationSuccess;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
@@ -115,7 +115,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * General tests for the YARN resource manager component.
@@ -376,8 +375,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				verifyFutureCompleted(startContainerAsyncFuture);
 
 				// Remote task executor registers with YarnResourceManager.
-				TaskExecutorGateway mockTaskExecutorGateway = mock(TaskExecutorGateway.class);
-				rpcService.registerGateway(taskHost, mockTaskExecutorGateway);
+				rpcService.registerGateway(taskHost, new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway());
 
 				final ResourceManagerGateway rmGateway = resourceManager.getSelfGateway(ResourceManagerGateway.class);
 

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -332,26 +332,16 @@ public class YarnResourceManagerTest extends TestLogger {
 		void verifyContainerHasBeenRequested() {
 			verify(mockResourceManagerClient, VERIFICATION_TIMEOUT).addContainerRequest(any(AMRMClient.ContainerRequest.class));
 		}
-	}
 
-	private static Container mockContainer(String host, int port, int containerId, Resource resource) {
-		Container mockContainer = mock(Container.class);
-
-		NodeId mockNodeId = NodeId.newInstance(host, port);
-		ContainerId mockContainerId = ContainerId.newInstance(
-			ApplicationAttemptId.newInstance(
-				ApplicationId.newInstance(System.currentTimeMillis(), 1),
-				1
-			),
-			containerId
-		);
-
-		when(mockContainer.getId()).thenReturn(mockContainerId);
-		when(mockContainer.getNodeId()).thenReturn(mockNodeId);
-		when(mockContainer.getResource()).thenReturn(resource);
-		when(mockContainer.getPriority()).thenReturn(Priority.UNDEFINED);
-
-		return mockContainer;
+		Container createTestingContainer() {
+			final ContainerId containerId = ContainerId.newInstance(
+				ApplicationAttemptId.newInstance(
+					ApplicationId.newInstance(System.currentTimeMillis(), 1),
+					1),
+				1);
+			final NodeId nodeId = NodeId.newInstance("container", 1234);
+			return new TestingContainer(containerId, nodeId, resourceManager.getContainerResource(), Priority.UNDEFINED);
+		}
 	}
 
 	private static ContainerStatus mockContainerStatus(ContainerId containerId) {
@@ -388,7 +378,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
 
 				// Callback from YARN when container is allocated.
-				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
+				Container testingContainer = createTestingContainer();
 
 				doReturn(Collections.singletonList(Collections.singletonList(resourceManager.getContainerRequest())))
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
@@ -486,7 +476,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
 
 				// Callback from YARN when container is allocated.
-				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
+				Container testingContainer = createTestingContainer();
 
 				doReturn(Collections.singletonList(Collections.singletonList(resourceManager.getContainerRequest())))
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));
@@ -515,7 +505,7 @@ public class YarnResourceManagerTest extends TestLogger {
 		new Context() {{
 			runTest(() -> {
 				registerSlotRequest(resourceManager, rmServices, resourceProfile1, taskHost);
-				Container testingContainer = mockContainer("container", 1234, 1, resourceManager.getContainerResource());
+				Container testingContainer = createTestingContainer();
 
 				doReturn(Collections.singletonList(Collections.singletonList(resourceManager.getContainerRequest())))
 					.when(mockResourceManagerClient).getMatchingRequests(any(Priority.class), anyString(), any(Resource.class));

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactoryTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/entrypoint/YarnWorkerResourceSpecFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn.entrypoint;
+
+import org.apache.flink.api.common.resources.CPUResource;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.yarn.configuration.YarnConfigOptions;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link YarnWorkerResourceSpecFactory}.
+ */
+public class YarnWorkerResourceSpecFactoryTest extends TestLogger {
+
+	@Test
+	public void testGetCpuCoresCommonOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 1.0);
+		configuration.setInteger(YarnConfigOptions.VCORES, 2);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration), is(new CPUResource(1.0)));
+	}
+
+	@Test
+	public void testGetCpuCoresYarnOption() {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(YarnConfigOptions.VCORES, 2);
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration), is(new CPUResource(2.0)));
+	}
+
+	@Test
+	public void testGetCpuCoresNumSlots() {
+		final Configuration configuration = new Configuration();
+		configuration.setInteger(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+
+		assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration), is(new CPUResource(3.0)));
+	}
+
+	@Test
+	public void testGetCpuRoundUp() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, 0.5);
+
+		assertThat(YarnWorkerResourceSpecFactory.getDefaultCpus(configuration), is(new CPUResource(1.0)));
+	}
+
+	@Test(expected = IllegalConfigurationException.class)
+	public void testGetCpuExceedMaxInt() {
+		final Configuration configuration = new Configuration();
+		configuration.setDouble(TaskManagerOptions.CPU_CORES, Double.MAX_VALUE);
+
+		YarnWorkerResourceSpecFactory.getDefaultCpus(configuration);
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR is one step of FLINK-14106, making `YarnResourceManager` starts workers using `WorkerResourceSpec` requested by `SlotManager`.

This also means `YarnResourceManager` no longer:
- be aware of the default task executor resources
- assumes all workers are identical

This PR is based on #11323.

## Brief change log
- 5ee2a8ece3eefb4726618ed31a05a2e11737b57a..d7a0626255f2445cfe20dcb7bab1aede3af4b0d7: Commits from previous PR.
- 2f2053259d86240c56ad4498eadae237ab30e979..4e214f940b187704d0599b15380b78094b7ad7a8: Refactoring `YarnResourceManagerTest`, getting rid of using of `Mockito`.
- ef959ec03f964ceb0664388b4b72c8eac5773fbd: Introduce `WorkerSpecContainerResourceAdapter` for converting between Flink `WorkerResourceSpec` and Yarn container `Resource` in `YarnResourceManager`.
  - This is to address the problem that resource of containers allocated from Yarn can differs from what were requested.
- 785558f7c2944cb50e57e191a242c5e981ab42b7: `YarnResourceManager` starts workers with resources requested by `SlotManager`.
- 0c5eb8c3d46d2142f9dd64acfaba9d27102ad3f2: Remove unused `TaskExecutorProcessSpec` from `ActiveResourceManager`.

## Verifying this change

Added test cases in `YarnResourceManagerTest`, for:
- Validating behaviors of `WorkerSpecContainerResourceAdapter`.
- Validating `YarnResourceManager` dealing with workers with different resources.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
