### PR TITLE
[FLINK-16374][AZP] Disable java e2e tests in misc profile

### DIFF
--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -304,17 +304,17 @@ case $TEST in
                 echo "Previous build failure detected, skipping bash end-to-end tests.\n"
                 echo "==============================================================================\n"
             fi
-        fi
-        if [ $EXIT_CODE == 0 ]; then
-            echo "\n\n==============================================================================\n"
-            echo "Running java end-to-end tests\n"
-            echo "==============================================================================\n"
+	        if [ $EXIT_CODE == 0 ]; then
+	            echo "\n\n==============================================================================\n"
+	            echo "Running java end-to-end tests\n"
+	            echo "==============================================================================\n"
 
-            run_with_watchdog "$MVN_E2E -DdistDir=$(readlink -e build-target)"
-        else
-            echo "\n==============================================================================\n"
-            echo "Previous build failure detected, skipping java end-to-end tests.\n"
-        fi
+	            run_with_watchdog "$MVN_E2E -DdistDir=$(readlink -e build-target)"
+	        else
+	            echo "\n==============================================================================\n"
+	            echo "Previous build failure detected, skipping java end-to-end tests.\n"
+	        fi
+	    fi
     ;;
 esac
 


### PR DESCRIPTION
## What is the purpose of the change

Disable java e2e tests in misc profile because the java e2e tests are executed in the e2e profile.

As a side effect of this, we are fixing an unstable java e2e test (because it won't be executed anymore in the docker+custom machines, but in the AZP VM setup)

## Brief change log

- There is already a condition in the travis watchdog to check if we are on AZP or Travis. This change expands the AZP case to exclude anything e2e test execution related.


