### PR TITLE
[FLINK-15727] Let BashJavaUtils return dynamic configs and JVM parame…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -633,10 +633,9 @@ runBashJavaUtilsCmd() {
 }
 
 extractExecutionParams() {
-    local output=$1
+    local execution_config=$1
     local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
 
-    local execution_config=`echo "$output" | tail -n 1`
     if ! [[ $execution_config =~ ^${EXECUTION_PREFIX}.* ]]; then
         echo "[ERROR] Unexpected result: $execution_config" 1>&2
         echo "[ERROR] The last line of the BashJavaUtils outputs is expected to be the execution result, following the prefix '${EXECUTION_PREFIX}'" 1>&2

--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -48,8 +48,9 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 
     # Startup parameters
 
-    jvm_params_output=`runBashJavaUtilsCmd GET_TM_RESOURCE_JVM_PARAMS ${FLINK_CONF_DIR}`
-    jvm_params=`extractExecutionParams "$jvm_params_output"`
+    params_output=$(runBashJavaUtilsCmd GET_TM_RESOURCE_PARAMS ${FLINK_CONF_DIR} | tail -n 2)
+
+    jvm_params=$(extractExecutionParams "$(echo "$params_output" | head -n 1)")
     if [[ $? -ne 0 ]]; then
         echo "[ERROR] Could not get JVM parameters properly."
         exit 1
@@ -58,8 +59,7 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
 
     IFS=$" "
 
-    dynamic_configs_output=`runBashJavaUtilsCmd GET_TM_RESOURCE_DYNAMIC_CONFIGS ${FLINK_CONF_DIR}`
-    dynamic_configs=`extractExecutionParams "$dynamic_configs_output"`
+    dynamic_configs=$(extractExecutionParams "$(echo "$params_output" | tail -n 1)")
     if [[ $? -ne 0 ]]; then
         echo "[ERROR] Could not get dynamic configurations properly."
         exit 1
@@ -69,11 +69,9 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     export FLINK_INHERITED_LOGS="
 $FLINK_INHERITED_LOGS
 
-TM_RESOURCES_JVM_PARAMS extraction logs:
-$jvm_params_output
-
-TM_RESOURCES_DYNAMIC_CONFIGS extraction logs:
-$dynamic_configs_output
+TM_RESOURCE_PARAMS extraction logs:
+jvm_params: $jvm_params
+dynamic_configs: $dynamic_configs
 "
 fi
 

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -36,5 +36,6 @@ FLINK_DIST_JAR=`find $FLINK_TARGET_DIR -name 'flink-dist*.jar'`
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
-output=`runBashJavaUtilsCmd ${COMMAND} ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:$FLINK_DIST_JAR}"`
-extractExecutionParams "$output"
+output=$(runBashJavaUtilsCmd GET_TM_RESOURCE_PARAMS ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:$FLINK_DIST_JAR}" | tail -n 2)
+extractExecutionParams "$(echo "$output" | head -n 1)"
+extractExecutionParams "$(echo "$output" | tail -n 1)"

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -23,9 +23,10 @@ import org.apache.flink.runtime.util.BashJavaUtils;
 
 import org.junit.Test;
 
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for BashJavaUtils.
@@ -36,32 +37,13 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
 
 	private static final String RUN_BASH_JAVA_UTILS_CMD_SCRIPT = "src/test/bin/runBashJavaUtilsCmd.sh";
 
-	/**
-	 * Executes the given shell script wrapper and returns the last line.
-	 */
-	private String executeScriptAndFetchLastLine(final String command) throws IOException {
-		String[] commands = {RUN_BASH_JAVA_UTILS_CMD_SCRIPT, command};
-		String[] lines = executeScript(commands).split(System.lineSeparator());
-		if (lines.length == 0) {
-			return "";
-		} else {
-			return lines[lines.length - 1];
-		}
-	}
-
 	@Test
-	public void testGetTmResourceDynamicConfigs() throws Exception {
-		String result = executeScriptAndFetchLastLine(BashJavaUtils.Command.GET_TM_RESOURCE_DYNAMIC_CONFIGS.toString());
+	public void testGetTmResourceParamsConfigs() throws Exception {
+		String[] commands = {RUN_BASH_JAVA_UTILS_CMD_SCRIPT, BashJavaUtils.Command.GET_TM_RESOURCE_PARAMS.toString()};
+		List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
-		assertNotNull(result);
-		ConfigurationUtils.parseTmResourceDynamicConfigs(result);
-	}
-
-	@Test
-	public void testGetTmResourceJvmParams() throws Exception {
-		String result = executeScriptAndFetchLastLine(BashJavaUtils.Command.GET_TM_RESOURCE_JVM_PARAMS.toString());
-
-		assertNotNull(result);
-		ConfigurationUtils.parseTmResourceJvmParams(result);
+		assertEquals(2, lines.size());
+		ConfigurationUtils.parseTmResourceJvmParams(lines.get(lines.size() - 2));
+		ConfigurationUtils.parseTmResourceDynamicConfigs(lines.get(lines.size() - 1));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
@@ -39,11 +39,8 @@ public class BashJavaUtils {
 		checkArgument(args.length > 0, "Command not specified.");
 
 		switch (Command.valueOf(args[0])) {
-			case GET_TM_RESOURCE_DYNAMIC_CONFIGS:
-				getTmResourceDynamicConfigs(args);
-				break;
-			case GET_TM_RESOURCE_JVM_PARAMS:
-				getTmResourceJvmParams(args);
+			case GET_TM_RESOURCE_PARAMS:
+				getTmResourceParams(args);
 				break;
 			default:
 				// unexpected, Command#valueOf should fail if a unknown command is passed in
@@ -51,16 +48,15 @@ public class BashJavaUtils {
 		}
 	}
 
-	private static void getTmResourceDynamicConfigs(String[] args) throws Exception {
-		Configuration configuration = getConfigurationForStandaloneTaskManagers(args);
-		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
-		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
-	}
-
-	private static void getTmResourceJvmParams(String[] args) throws Exception {
+	/**
+	 * Generate and print JVM parameters and dynamic configs of task executor resources. The last two lines of
+	 * the output should be JVM parameters and dynamic configs respectively.
+	 */
+	private static void getTmResourceParams(String[] args) throws Exception {
 		Configuration configuration = getConfigurationForStandaloneTaskManagers(args);
 		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
 		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateJvmParametersStr(taskExecutorProcessSpec));
+		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
 	}
 
 	private static Configuration getConfigurationForStandaloneTaskManagers(String[] args) throws Exception {
@@ -74,13 +70,8 @@ public class BashJavaUtils {
 	 */
 	public enum Command {
 		/**
-		 * Get dynamic configs of task executor resources.
+		 * Get JVM parameters and dynamic configs of task executor resources.
 		 */
-		GET_TM_RESOURCE_DYNAMIC_CONFIGS,
-
-		/**
-		 * Get JVM parameters of task executor resources.
-		 */
-		GET_TM_RESOURCE_JVM_PARAMS
+		GET_TM_RESOURCE_PARAMS
 	}
 }


### PR DESCRIPTION
…ters in one call


## What is the purpose of the change

Let BashJavaUtils return dynamic configs and JVM parameters in one call.

## Brief change log

Let BashJavaUtils return dynamic configs and JVM parameters in one call. The second last line of output is JVM parameters and the last line is dynamic configs.

## Verifying this change

This change is already covered by tests: BashJavaUtilsITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
