### PR TITLE
[FLINK-16440][runtime] Extend SlotManager metrics and status for dynamic slot allocation.

### DIFF
--- a/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
+++ b/flink-container/src/main/java/org/apache/flink/container/entrypoint/StandaloneJobClusterEntryPoint.java
@@ -80,7 +80,7 @@ public final class StandaloneJobClusterEntryPoint extends ClusterEntrypoint {
 				new DefaultDispatcherRunnerFactory(
 						ApplicationDispatcherLeaderProcessFactoryFactory
 								.create(configuration, SessionDispatcherFactory.INSTANCE, program)),
-				StandaloneResourceManagerFactory.INSTANCE,
+				StandaloneResourceManagerFactory.getInstance(),
 				JobRestEndpointFactory.INSTANCE);
 	}
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/resources/Resource.java
@@ -68,6 +68,14 @@ public abstract class Resource implements Serializable {
 		return create(value.subtract(other.value));
 	}
 
+	public Resource multiply(BigDecimal multiplier) {
+		return create(value.multiply(multiplier));
+	}
+
+	public Resource multiply(int multiplier) {
+		return multiply(BigDecimal.valueOf(multiplier));
+	}
+
 	public Resource divide(BigDecimal by) {
 		return create(value.divide(by, 16, RoundingMode.DOWN));
 	}

--- a/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/resources/ResourceTest.java
@@ -126,6 +126,34 @@ public class ResourceTest extends TestLogger {
 		resource.divide(by);
 	}
 
+	@Test
+	public void testMultiply() {
+		final Resource resource = new TestResource(0.3);
+		final BigDecimal by = BigDecimal.valueOf(0.2);
+		assertTestResourceValueEquals(0.06, resource.multiply(by));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMutiplyNegative() {
+		final Resource resource = new TestResource(0.3);
+		final BigDecimal by = BigDecimal.valueOf(-0.2);
+		resource.multiply(by);
+	}
+
+	@Test
+	public void testMultiplyInteger() {
+		final Resource resource = new TestResource(0.3);
+		final int by = 2;
+		assertTestResourceValueEquals(0.6, resource.multiply(by));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMutiplyNegativeInteger() {
+		final Resource resource = new TestResource(0.3);
+		final int by = -2;
+		resource.multiply(by);
+	}
+
 	private static void assertTestResourceValueEquals(final double value, final Resource resource) {
 		assertEquals(new TestResource(value), resource);
 	}

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2642,6 +2642,37 @@
               "freeSlots" : {
                 "type" : "integer"
               },
+              "totalResource" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo",
+                "properties" : {
+                  "cpuCores" : {
+                    "type" : "number"
+                  },
+                  "taskHeapMemory" : {
+                    "type" : "integer"
+                  },
+                  "taskOffHeapMemory" : {
+                    "type" : "integer"
+                  },
+                  "managedMemory" : {
+                    "type" : "integer"
+                  },
+                  "networkMemory" : {
+                    "type" : "integer"
+                  },
+                  "extendedResources" : {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "number"
+                    }
+                  }
+                }
+              },
+              "freeResource" : {
+                "type" : "object",
+                "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
+              },
               "hardware" : {
                 "type" : "object",
                 "id" : "urn:jsonschema:org:apache:flink:runtime:instance:HardwareDescription",
@@ -2728,6 +2759,37 @@
         },
         "freeSlots" : {
           "type" : "integer"
+        },
+        "totalResource" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo",
+          "properties" : {
+            "cpuCores" : {
+              "type" : "number"
+            },
+            "taskHeapMemory" : {
+              "type" : "integer"
+            },
+            "taskOffHeapMemory" : {
+              "type" : "integer"
+            },
+            "managedMemory" : {
+              "type" : "integer"
+            },
+            "networkMemory" : {
+              "type" : "integer"
+            },
+            "extendedResources" : {
+              "type" : "object",
+              "additionalProperties" : {
+                "type" : "number"
+              }
+            }
+          }
+        },
+        "freeResource" : {
+          "type" : "object",
+          "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
         },
         "hardware" : {
           "type" : "object",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/clusterframework/types/ResourceProfile.java
@@ -384,6 +384,32 @@ public class ResourceProfile implements Serializable {
 		);
 	}
 
+	@Nonnull
+	public ResourceProfile multiply(final int multiplier) {
+		checkArgument(multiplier >= 0, "multiplier must be >= 0");
+		if (equals(ANY)) {
+			return ANY;
+		}
+
+		if (this.equals(UNKNOWN)) {
+			return UNKNOWN;
+		}
+
+		Map<String, Resource> resultExtendedResource = new HashMap<>(extendedResources.size());
+		for (Map.Entry<String, Resource> entry : extendedResources.entrySet()) {
+			resultExtendedResource.put(entry.getKey(), entry.getValue().multiply(multiplier));
+		}
+
+		return new ResourceProfile(
+			cpuCores.multiply(multiplier),
+			taskHeapMemory.multiply(multiplier),
+			taskOffHeapMemory.multiply(multiplier),
+			managedMemory.multiply(multiplier),
+			networkMemory.multiply(multiplier),
+			resultExtendedResource
+		);
+	}
+
 	@Override
 	public String toString() {
 		if (this.equals(UNKNOWN)) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/StandaloneSessionClusterEntrypoint.java
@@ -37,7 +37,7 @@ public class StandaloneSessionClusterEntrypoint extends SessionClusterEntrypoint
 
 	@Override
 	protected DefaultDispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory(Configuration configuration) {
-		return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(StandaloneResourceManagerFactory.INSTANCE);
+		return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(StandaloneResourceManagerFactory.getInstance());
 	}
 
 	public static void main(String[] args) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/SlotManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/SlotManagerMetricGroup.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+
+/**
+ * Metric group which is used by the {@link SlotManager} to register metrics.
+ */
+public class SlotManagerMetricGroup extends AbstractImitatingJobManagerMetricGroup {
+	SlotManagerMetricGroup(MetricRegistry registry, String hostname) {
+		super(registry, hostname);
+	}
+
+	public static SlotManagerMetricGroup create(MetricRegistry metricRegistry, String hostname) {
+		return new SlotManagerMetricGroup(metricRegistry, hostname);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
@@ -41,6 +41,10 @@ public class UnregisteredMetricGroups {
 		return new UnregisteredResourceManagerMetricGroup();
 	}
 
+	public static SlotManagerMetricGroup createUnregisteredSlotManagerMetricGroup() {
+		return new UnregisteredSlotManagerMetricGroup();
+	}
+
 	public static JobManagerMetricGroup createUnregisteredJobManagerMetricGroup() {
 		return new UnregisteredJobManagerMetricGroup();
 	}
@@ -83,6 +87,17 @@ public class UnregisteredMetricGroups {
 		private static final String UNREGISTERED_HOST = "UnregisteredHost";
 
 		UnregisteredResourceManagerMetricGroup() {
+			super(NoOpMetricRegistry.INSTANCE, UNREGISTERED_HOST);
+		}
+	}
+
+	/**
+	 * A safe drop-in replacement for {@link SlotManagerMetricGroup SlotManagerMetricGroups}.
+	 */
+	public static class UnregisteredSlotManagerMetricGroup extends SlotManagerMetricGroup {
+		private static final String UNREGISTERED_HOST = "UnregisteredHost";
+
+		UnregisteredSlotManagerMetricGroup() {
 			super(NoOpMetricRegistry.INSTANCE, UNREGISTERED_HOST);
 		}
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -417,7 +417,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 	@Nonnull
 	DispatcherResourceManagerComponentFactory createDispatcherResourceManagerComponentFactory() {
-		return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(StandaloneResourceManagerFactory.INSTANCE);
+		return DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(StandaloneResourceManagerFactory.getInstance());
 	}
 
 	@VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -41,7 +41,7 @@ import javax.annotation.Nullable;
  *
  * @param <T> type of the {@link ResourceIDRetrievable}
  */
-public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievable> implements ResourceManagerFactory<T> {
+public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievable> extends ResourceManagerFactory<T> {
 
 	@Override
 	public ResourceManager<T> createResourceManager(
@@ -54,7 +54,7 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		return createActiveResourceManager(
+		return super.createResourceManager(
 			createActiveResourceManagerConfiguration(configuration),
 			resourceId,
 			rpcService,
@@ -66,19 +66,8 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 			resourceManagerMetricGroup);
 	}
 
-	private static Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
+	private Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
 		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			originalConfiguration, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
 	}
-
-	protected abstract ResourceManager<T> createActiveResourceManager(
-		Configuration configuration,
-		ResourceID resourceId,
-		RpcService rpcService,
-		HighAvailabilityServices highAvailabilityServices,
-		HeartbeatServices heartbeatServices,
-		FatalErrorHandler fatalErrorHandler,
-		ClusterInformation clusterInformation,
-		@Nullable String webInterfaceUrl,
-		ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -26,7 +26,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
-import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 
@@ -53,7 +53,8 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 			FatalErrorHandler fatalErrorHandler,
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
-			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
+			MetricRegistry metricRegistry,
+			String hostname) throws Exception {
 		return super.createResourceManager(
 			createActiveResourceManagerConfiguration(configuration),
 			resourceId,
@@ -63,7 +64,8 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 			fatalErrorHandler,
 			clusterInformation,
 			webInterfaceUrl,
-			resourceManagerMetricGroup);
+			metricRegistry,
+			hostname);
 	}
 
 	private Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -223,7 +223,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 			leaderElectionService.start(this);
 			jobLeaderIdService.start(new JobLeaderIdActionsImpl());
 
-			registerSlotAndTaskExecutorMetrics();
+			registerTaskExecutorMetrics();
 		} catch (Exception e) {
 			handleStartResourceManagerServicesException(e);
 		}
@@ -772,13 +772,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		}
 	}
 
-	private void registerSlotAndTaskExecutorMetrics() {
-		resourceManagerMetricGroup.gauge(
-			MetricNames.TASK_SLOTS_AVAILABLE,
-			() -> (long) slotManager.getNumberFreeSlots());
-		resourceManagerMetricGroup.gauge(
-			MetricNames.TASK_SLOTS_TOTAL,
-			() -> (long) slotManager.getNumberRegisteredSlots());
+	private void registerTaskExecutorMetrics() {
 		resourceManagerMetricGroup.gauge(
 			MetricNames.NUM_REGISTERED_TASK_MANAGERS,
 			() -> (long) taskExecutors.size());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -535,6 +536,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 					taskManagerHeartbeatManager.getLastHeartbeatFrom(resourceId),
 					slotManager.getNumberRegisteredSlotsOf(taskExecutor.getInstanceID()),
 					slotManager.getNumberFreeSlotsOf(taskExecutor.getInstanceID()),
+					slotManager.getRegisteredResourceOf(taskExecutor.getInstanceID()),
+					slotManager.getFreeResourceOf(taskExecutor.getInstanceID()),
 					taskExecutor.getHardwareDescription()));
 		}
 
@@ -557,6 +560,8 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 				taskManagerHeartbeatManager.getLastHeartbeatFrom(resourceId),
 				slotManager.getNumberRegisteredSlotsOf(instanceId),
 				slotManager.getNumberFreeSlotsOf(instanceId),
+				slotManager.getRegisteredResourceOf(instanceId),
+				slotManager.getFreeResourceOf(instanceId),
 				taskExecutor.getHardwareDescription());
 
 			return CompletableFuture.completedFuture(taskManagerInfo);
@@ -567,12 +572,16 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 	public CompletableFuture<ResourceOverview> requestResourceOverview(Time timeout) {
 		final int numberSlots = slotManager.getNumberRegisteredSlots();
 		final int numberFreeSlots = slotManager.getNumberFreeSlots();
+		final ResourceProfile totalResource = slotManager.getRegisteredResource();
+		final ResourceProfile freeResource = slotManager.getFreeResource();
 
 		return CompletableFuture.completedFuture(
 			new ResourceOverview(
 				taskExecutors.size(),
 				numberSlots,
-				numberFreeSlots));
+				numberFreeSlots,
+				totalResource,
+				freeResource));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerFactory.java
@@ -24,7 +24,9 @@ import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.util.ConfigurationException;
@@ -47,10 +49,14 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
 			FatalErrorHandler fatalErrorHandler,
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
-			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
+			MetricRegistry metricRegistry,
+			String hostname) throws Exception {
+
+		final ResourceManagerMetricGroup resourceManagerMetricGroup = ResourceManagerMetricGroup.create(metricRegistry, hostname);
+		final SlotManagerMetricGroup slotManagerMetricGroup = SlotManagerMetricGroup.create(metricRegistry, hostname);
 
 		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = createResourceManagerRuntimeServices(
-			configuration, rpcService, highAvailabilityServices);
+			configuration, rpcService, highAvailabilityServices, slotManagerMetricGroup);
 
 		return createResourceManager(
 			configuration,
@@ -80,11 +86,14 @@ public abstract class ResourceManagerFactory<T extends ResourceIDRetrievable> {
 	private ResourceManagerRuntimeServices createResourceManagerRuntimeServices(
 			Configuration configuration,
 			RpcService rpcService,
-			HighAvailabilityServices highAvailabilityServices) throws ConfigurationException {
+			HighAvailabilityServices highAvailabilityServices,
+			SlotManagerMetricGroup slotManagerMetricGroup) throws ConfigurationException {
+
 		return ResourceManagerRuntimeServices.fromConfiguration(
 			createResourceManagerRuntimeServicesConfiguration(configuration),
 			highAvailabilityServices,
-			rpcService.getScheduledExecutor());
+			rpcService.getScheduledExecutor(),
+			slotManagerMetricGroup);
 	}
 
 	protected abstract ResourceManagerRuntimeServicesConfiguration createResourceManagerRuntimeServicesConfiguration(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -50,7 +50,7 @@ public class ResourceManagerRuntimeServices {
 	public static ResourceManagerRuntimeServices fromConfiguration(
 			ResourceManagerRuntimeServicesConfiguration configuration,
 			HighAvailabilityServices highAvailabilityServices,
-			ScheduledExecutor scheduledExecutor) throws Exception {
+			ScheduledExecutor scheduledExecutor) {
 
 		final SlotManager slotManager = createSlotManager(configuration, scheduledExecutor);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerRuntimeServices.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerImpl;
 import org.apache.flink.util.Preconditions;
@@ -50,9 +51,13 @@ public class ResourceManagerRuntimeServices {
 	public static ResourceManagerRuntimeServices fromConfiguration(
 			ResourceManagerRuntimeServicesConfiguration configuration,
 			HighAvailabilityServices highAvailabilityServices,
-			ScheduledExecutor scheduledExecutor) {
+			ScheduledExecutor scheduledExecutor,
+			SlotManagerMetricGroup slotManagerMetricGroup) {
 
-		final SlotManager slotManager = createSlotManager(configuration, scheduledExecutor);
+		final SlotManager slotManager = new SlotManagerImpl(
+			scheduledExecutor,
+			configuration.getSlotManagerConfiguration(),
+			slotManagerMetricGroup);
 
 		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
 			highAvailabilityServices,
@@ -60,9 +65,5 @@ public class ResourceManagerRuntimeServices {
 			configuration.getJobTimeout());
 
 		return new ResourceManagerRuntimeServices(slotManager, jobLeaderIdService);
-	}
-
-	private static SlotManager createSlotManager(ResourceManagerRuntimeServicesConfiguration configuration, ScheduledExecutor scheduledExecutor) {
-		return new SlotManagerImpl(scheduledExecutor, configuration.getSlotManagerConfiguration());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceOverview.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceOverview.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
 import java.io.Serializable;
 
 /**
@@ -27,7 +29,7 @@ public class ResourceOverview implements Serializable {
 
 	private static final long serialVersionUID = 7618746920569224557L;
 
-	private static final ResourceOverview EMPTY_RESOURCE_OVERVIEW = new ResourceOverview(0, 0, 0);
+	private static final ResourceOverview EMPTY_RESOURCE_OVERVIEW = new ResourceOverview(0, 0, 0, ResourceProfile.ZERO, ResourceProfile.ZERO);
 
 	private final int numberTaskManagers;
 
@@ -35,10 +37,16 @@ public class ResourceOverview implements Serializable {
 
 	private final int numberFreeSlots;
 
-	public ResourceOverview(int numberTaskManagers, int numberRegisteredSlots, int numberFreeSlots) {
+	private final ResourceProfile totalResource;
+
+	private final ResourceProfile freeResource;
+
+	public ResourceOverview(int numberTaskManagers, int numberRegisteredSlots, int numberFreeSlots, ResourceProfile totalResource, ResourceProfile freeResource) {
 		this.numberTaskManagers = numberTaskManagers;
 		this.numberRegisteredSlots = numberRegisteredSlots;
 		this.numberFreeSlots = numberFreeSlots;
+		this.totalResource = totalResource;
+		this.freeResource = freeResource;
 	}
 
 	public int getNumberTaskManagers() {
@@ -51,6 +59,14 @@ public class ResourceOverview implements Serializable {
 
 	public int getNumberFreeSlots() {
 		return numberFreeSlots;
+	}
+
+	public ResourceProfile getTotalResource() {
+		return totalResource;
+	}
+
+	public ResourceProfile getFreeResource() {
+		return freeResource;
 	}
 
 	public static ResourceOverview empty() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -30,32 +30,35 @@ import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTra
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ConfigurationException;
 
 import javax.annotation.Nullable;
 
 /**
  * {@link ResourceManagerFactory} which creates a {@link StandaloneResourceManager}.
  */
-public enum StandaloneResourceManagerFactory implements ResourceManagerFactory<ResourceID> {
-	INSTANCE;
+public final class StandaloneResourceManagerFactory extends ResourceManagerFactory<ResourceID> {
+
+	private static final StandaloneResourceManagerFactory INSTANCE = new StandaloneResourceManagerFactory();
+
+	private StandaloneResourceManagerFactory() {}
+
+	public static StandaloneResourceManagerFactory getInstance() {
+		return INSTANCE;
+	}
 
 	@Override
-	public ResourceManager<ResourceID> createResourceManager(
-			Configuration configuration,
-			ResourceID resourceId,
-			RpcService rpcService,
-			HighAvailabilityServices highAvailabilityServices,
-			HeartbeatServices heartbeatServices,
-			FatalErrorHandler fatalErrorHandler,
-			ClusterInformation clusterInformation,
-			@Nullable String webInterfaceUrl,
-			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration resourceManagerRuntimeServicesConfiguration =
-			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, ArbitraryWorkerResourceSpecFactory.INSTANCE);
-		final ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
-			resourceManagerRuntimeServicesConfiguration,
-			highAvailabilityServices,
-			rpcService.getScheduledExecutor());
+	protected ResourceManager<ResourceID> createResourceManager(
+		Configuration configuration,
+		ResourceID resourceId,
+		RpcService rpcService,
+		HighAvailabilityServices highAvailabilityServices,
+		HeartbeatServices heartbeatServices,
+		FatalErrorHandler fatalErrorHandler,
+		ClusterInformation clusterInformation,
+		@Nullable String webInterfaceUrl,
+		ResourceManagerMetricGroup resourceManagerMetricGroup,
+		ResourceManagerRuntimeServices resourceManagerRuntimeServices) {
 
 		final Time standaloneClusterStartupPeriodTime = ConfigurationUtils.getStandaloneClusterStartupPeriodTime(configuration);
 
@@ -72,5 +75,11 @@ public enum StandaloneResourceManagerFactory implements ResourceManagerFactory<R
 			resourceManagerMetricGroup,
 			standaloneClusterStartupPeriodTime,
 			AkkaUtils.getTimeoutAsTime(configuration));
+	}
+
+	@Override
+	protected ResourceManagerRuntimeServicesConfiguration createResourceManagerRuntimeServicesConfiguration(
+			Configuration configuration) throws ConfigurationException {
+		return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, ArbitraryWorkerResourceSpecFactory.INSTANCE);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -58,6 +59,14 @@ public interface SlotManager extends AutoCloseable {
 	 * and the corresponding value is number of pending workers of that resource spec.
 	 */
 	Map<WorkerResourceSpec, Integer> getRequiredResources();
+
+	ResourceProfile getRegisteredResource();
+
+	ResourceProfile getRegisteredResourceOf(InstanceID instanceID);
+
+	ResourceProfile getFreeResource();
+
+	ResourceProfile getFreeResourceOf(InstanceID instanceID);
 
 	int getNumberPendingSlotRequests();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -214,6 +214,34 @@ public class SlotManagerImpl implements SlotManager {
 			Collections.emptyMap();
 	}
 
+	@Override
+	public ResourceProfile getRegisteredResource() {
+		return getResourceFromNumSlots(getNumberRegisteredSlots());
+	}
+
+	@Override
+	public ResourceProfile getRegisteredResourceOf(InstanceID instanceID) {
+		return getResourceFromNumSlots(getNumberRegisteredSlotsOf(instanceID));
+	}
+
+	@Override
+	public ResourceProfile getFreeResource() {
+		return getResourceFromNumSlots(getNumberFreeSlots());
+	}
+
+	@Override
+	public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
+		return getResourceFromNumSlots(getNumberFreeSlotsOf(instanceID));
+	}
+
+	private ResourceProfile getResourceFromNumSlots(int numSlots) {
+		if (numSlots < 0 || defaultSlotResourceProfile == null) {
+			return ResourceProfile.UNKNOWN;
+		} else {
+			return defaultSlotResourceProfile.multiply(numSlots);
+		}
+	}
+
 	@VisibleForTesting
 	public int getNumberPendingTaskManagerSlots() {
 		return pendingSlots.size();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ResourceProfileInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/ResourceProfileInfo.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.api.common.resources.Resource;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Contains information of a {@link ResourceProfile}.
+ */
+public class ResourceProfileInfo implements ResponseBody {
+
+	public static final String FIELD_NAME_CPU = "cpuCores";
+
+	public static final String FIELD_NAME_TASK_HEAP = "taskHeapMemory";
+
+	public static final String FIELD_NAME_TASK_OFFHEAP = "taskOffHeapMemory";
+
+	public static final String FIELD_NAME_MANAGED = "managedMemory";
+
+	public static final String FIELD_NAME_NETWORK = "networkMemory";
+
+	public static final String FIELD_NAME_EXTENDED = "extendedResources";
+
+	@JsonProperty(FIELD_NAME_CPU)
+	private final double cpu;
+
+	@JsonProperty(FIELD_NAME_TASK_HEAP)
+	private final int taskHeapMB;
+
+	@JsonProperty(FIELD_NAME_TASK_OFFHEAP)
+	private final int taskOffHeapMB;
+
+	@JsonProperty(FIELD_NAME_MANAGED)
+	private final int managedMB;
+
+	@JsonProperty(FIELD_NAME_NETWORK)
+	private final int networkMB;
+
+	@JsonProperty(FIELD_NAME_EXTENDED)
+	private final Map<String, Double> extendedResources;
+
+	@JsonCreator
+	public ResourceProfileInfo(
+			@JsonProperty(FIELD_NAME_CPU) double cpu,
+			@JsonProperty(FIELD_NAME_TASK_HEAP) int taskHeapMB,
+			@JsonProperty(FIELD_NAME_TASK_OFFHEAP) int taskOffHeapMB,
+			@JsonProperty(FIELD_NAME_MANAGED) int managedMB,
+			@JsonProperty(FIELD_NAME_NETWORK) int networkMB,
+			@JsonProperty(FIELD_NAME_EXTENDED) Map<String, Double> extendedResources) {
+		this.cpu = cpu;
+		this.taskHeapMB = taskHeapMB;
+		this.taskOffHeapMB = taskOffHeapMB;
+		this.managedMB = managedMB;
+		this.networkMB = networkMB;
+		this.extendedResources = extendedResources;
+	}
+
+	/**
+	 * The ResourceProfile must not be UNKNOWN.
+	 */
+	private ResourceProfileInfo(ResourceProfile resourceProfile) {
+		this(resourceProfile.getCpuCores().getValue().doubleValue(),
+			resourceProfile.getTaskHeapMemory().getMebiBytes(),
+			resourceProfile.getTaskOffHeapMemory().getMebiBytes(),
+			resourceProfile.getManagedMemory().getMebiBytes(),
+			resourceProfile.getNetworkMemory().getMebiBytes(),
+			getExetendedResources(resourceProfile.getExtendedResources()));
+	}
+
+	private ResourceProfileInfo() {
+		this(-1.0, -1, -1, -1, -1, Collections.emptyMap());
+	}
+
+	public static ResourceProfileInfo fromResrouceProfile(ResourceProfile resourceProfile) {
+		return resourceProfile.equals(ResourceProfile.UNKNOWN) ? new ResourceProfileInfo() : new ResourceProfileInfo(resourceProfile);
+	}
+
+	private static Map<String, Double> getExetendedResources(Map<String, Resource> exetendedResources) {
+		return exetendedResources.entrySet().stream()
+			.collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getValue().doubleValue()));
+	}
+
+	public double getCpu() {
+		return cpu;
+	}
+
+	public int getTaskHeapMB() {
+		return taskHeapMB;
+	}
+
+	public int getTaskOffHeapMB() {
+		return taskOffHeapMB;
+	}
+
+	public int getManagedMB() {
+		return managedMB;
+	}
+
+	public int getNetworkMB() {
+		return networkMB;
+	}
+
+	public Map<String, Double>getExtendedResources() {
+		return Collections.unmodifiableMap(extendedResources);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ResourceProfileInfo that = (ResourceProfileInfo) o;
+		return cpu == that.cpu &&
+			taskHeapMB == that.taskHeapMB &&
+			taskOffHeapMB == that.taskOffHeapMB &&
+			managedMB == that.managedMB &&
+			networkMB == that.networkMB &&
+			Objects.equals(extendedResources, that.extendedResources);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(
+			cpu,
+			taskHeapMB,
+			taskOffHeapMB,
+			managedMB,
+			networkMB,
+			extendedResources);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerDetailsInfo.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.rest.messages.taskmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDDeserializer;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.util.Preconditions;
@@ -49,6 +50,8 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			@JsonProperty(FIELD_NAME_LAST_HEARTBEAT) long lastHeartbeat,
 			@JsonProperty(FIELD_NAME_NUMBER_SLOTS) int numberSlots,
 			@JsonProperty(FIELD_NAME_NUMBER_AVAILABLE_SLOTS) int numberAvailableSlots,
+			@JsonProperty(FIELD_NAME_TOTAL_RESOURCE) ResourceProfileInfo totalResource,
+			@JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE) ResourceProfileInfo freeResource,
 			@JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription,
 			@JsonProperty(FIELD_NAME_METRICS) TaskManagerMetricsInfo taskManagerMetrics) {
 		super(
@@ -58,6 +61,8 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			lastHeartbeat,
 			numberSlots,
 			numberAvailableSlots,
+			totalResource,
+			freeResource,
 			hardwareDescription);
 
 		this.taskManagerMetrics = Preconditions.checkNotNull(taskManagerMetrics);
@@ -71,6 +76,8 @@ public class TaskManagerDetailsInfo extends TaskManagerInfo {
 			taskManagerInfo.getLastHeartbeat(),
 			taskManagerInfo.getNumberSlots(),
 			taskManagerInfo.getNumberAvailableSlots(),
+			taskManagerInfo.getTotalResource(),
+			taskManagerInfo.getFreeResource(),
 			taskManagerInfo.getHardwareDescription(),
 			taskManagerMetrics);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfo.java
@@ -19,7 +19,9 @@
 package org.apache.flink.runtime.rest.messages.taskmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.rest.messages.ResourceProfileInfo;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.ResourceIDSerializer;
@@ -51,6 +53,10 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 
 	public static final String FIELD_NAME_NUMBER_AVAILABLE_SLOTS = "freeSlots";
 
+	public static final String FIELD_NAME_TOTAL_RESOURCE = "totalResource";
+
+	public static final String FIELD_NAME_AVAILABLE_RESOURCE = "freeResource";
+
 	public static final String FIELD_NAME_HARDWARE = "hardware";
 
 	private static final long serialVersionUID = 1L;
@@ -74,6 +80,12 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 	@JsonProperty(FIELD_NAME_NUMBER_AVAILABLE_SLOTS)
 	private final int numberAvailableSlots;
 
+	@JsonProperty(FIELD_NAME_TOTAL_RESOURCE)
+	private final ResourceProfileInfo totalResource;
+
+	@JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE)
+	private final ResourceProfileInfo freeResource;
+
 	@JsonProperty(FIELD_NAME_HARDWARE)
 	private final HardwareDescription hardwareDescription;
 
@@ -85,6 +97,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			@JsonProperty(FIELD_NAME_LAST_HEARTBEAT) long lastHeartbeat,
 			@JsonProperty(FIELD_NAME_NUMBER_SLOTS) int numberSlots,
 			@JsonProperty(FIELD_NAME_NUMBER_AVAILABLE_SLOTS) int numberAvailableSlots,
+			@JsonProperty(FIELD_NAME_TOTAL_RESOURCE) ResourceProfileInfo totalResource,
+			@JsonProperty(FIELD_NAME_AVAILABLE_RESOURCE) ResourceProfileInfo freeResource,
 			@JsonProperty(FIELD_NAME_HARDWARE) HardwareDescription hardwareDescription) {
 		this.resourceId = Preconditions.checkNotNull(resourceId);
 		this.address = Preconditions.checkNotNull(address);
@@ -92,7 +106,30 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 		this.lastHeartbeat = lastHeartbeat;
 		this.numberSlots = numberSlots;
 		this.numberAvailableSlots = numberAvailableSlots;
+		this.totalResource = totalResource;
+		this.freeResource = freeResource;
 		this.hardwareDescription = Preconditions.checkNotNull(hardwareDescription);
+	}
+
+	public TaskManagerInfo(
+			ResourceID resourceId,
+			String address,
+			int dataPort,
+			long lastHeartbeat,
+			int numberSlots,
+			int numberAvailableSlots,
+			ResourceProfile totalResource,
+			ResourceProfile freeResource,
+			HardwareDescription hardwareDescription) {
+		this(resourceId,
+			address,
+			dataPort,
+			lastHeartbeat,
+			numberSlots,
+			numberAvailableSlots,
+			ResourceProfileInfo.fromResrouceProfile(totalResource),
+			ResourceProfileInfo.fromResrouceProfile(freeResource),
+			hardwareDescription);
 	}
 
 	public ResourceID getResourceId() {
@@ -119,6 +156,14 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 		return numberAvailableSlots;
 	}
 
+	public ResourceProfileInfo getTotalResource() {
+		return totalResource;
+	}
+
+	public ResourceProfileInfo getFreeResource() {
+		return freeResource;
+	}
+
 	public HardwareDescription getHardwareDescription() {
 		return hardwareDescription;
 	}
@@ -136,6 +181,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			lastHeartbeat == that.lastHeartbeat &&
 			numberSlots == that.numberSlots &&
 			numberAvailableSlots == that.numberAvailableSlots &&
+			Objects.equals(totalResource, that.totalResource) &&
+			Objects.equals(freeResource, that.freeResource) &&
 			Objects.equals(resourceId, that.resourceId) &&
 			Objects.equals(address, that.address) &&
 			Objects.equals(hardwareDescription, that.hardwareDescription);
@@ -150,6 +197,8 @@ public class TaskManagerInfo implements ResponseBody, Serializable {
 			lastHeartbeat,
 			numberSlots,
 			numberAvailableSlots,
+			totalResource,
+			freeResource,
 			hardwareDescription);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/clusterframework/types/ResourceProfileTest.java
@@ -376,6 +376,39 @@ public class ResourceProfileTest extends TestLogger {
 	}
 
 	@Test
+	public void testMultiply() {
+		final int by = 3;
+		final ResourceProfile rp1 = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.addExtendedResource("gpu", new GPUResource(1.0))
+			.build();
+
+		ResourceProfile rp2 = rp1;
+		for (int i = 1; i < by; ++i) {
+			rp2 = rp2.merge(rp1);
+		}
+
+		assertEquals(rp2, rp1.multiply(by));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMultiplyNegative() {
+		final ResourceProfile rp = ResourceProfile.newBuilder()
+			.setCpuCores(1.0)
+			.setTaskHeapMemoryMB(100)
+			.setTaskOffHeapMemoryMB(100)
+			.setNetworkMemoryMB(100)
+			.setManagedMemoryMB(100)
+			.addExtendedResource("gpu", new GPUResource(1.0))
+			.build();
+		rp.multiply(-2);
+	}
+
+	@Test
 	public void testFromSpecWithSerializationCopy() throws Exception {
 		final ResourceSpec copiedSpec = CommonTestUtils.createCopySerializable(ResourceSpec.UNKNOWN);
 		final ResourceProfile profile = ResourceProfile.fromResourceSpec(copiedSpec);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -78,7 +78,8 @@ public class ResourceManagerHATest extends TestLogger {
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,
-			rpcService.getScheduledExecutor());
+			rpcService.getScheduledExecutor(),
+			UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup());
 
 		TestingFatalErrorHandler testingFatalErrorHandler = new TestingFatalErrorHandler();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
@@ -33,6 +35,7 @@ public class SlotManagerBuilder {
 	private boolean waitResultConsumedBeforeRelease;
 	private WorkerResourceSpec defaultWorkerResourceSpec;
 	private int numSlotsPerWorker;
+	private SlotManagerMetricGroup slotManagerMetricGroup;
 
 	private SlotManagerBuilder() {
 		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -43,6 +46,7 @@ public class SlotManagerBuilder {
 		this.waitResultConsumedBeforeRelease = true;
 		this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
 		this.numSlotsPerWorker = 1;
+		this.slotManagerMetricGroup = UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
 	}
 
 	public static SlotManagerBuilder newBuilder() {
@@ -89,6 +93,11 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setSlotManagerMetricGroup(SlotManagerMetricGroup slotManagerMetricGroup) {
+		this.slotManagerMetricGroup = slotManagerMetricGroup;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
@@ -101,6 +110,7 @@ public class SlotManagerBuilder {
 
 		return new SlotManagerImpl(
 			scheduledExecutor,
-			slotManagerConfiguration);
+			slotManagerConfiguration,
+			slotManagerMetricGroup);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -70,6 +71,26 @@ public class TestingSlotManager implements SlotManager {
 	@Override
 	public Map<WorkerResourceSpec, Integer> getRequiredResources() {
 		return getRequiredResourcesSupplier.get();
+	}
+
+	@Override
+	public ResourceProfile getRegisteredResource() {
+		return ResourceProfile.ZERO;
+	}
+
+	@Override
+	public ResourceProfile getRegisteredResourceOf(InstanceID instanceID) {
+		return ResourceProfile.ZERO;
+	}
+
+	@Override
+	public ResourceProfile getFreeResource() {
+		return ResourceProfile.ZERO;
+	}
+
+	@Override
+	public ResourceProfile getFreeResourceOf(InstanceID instanceID) {
+		return ResourceProfile.ZERO;
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.blob.TransientBlobKey;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -307,7 +308,7 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 
 	@Override
 	public CompletableFuture<ResourceOverview> requestResourceOverview(Time timeout) {
-		return CompletableFuture.completedFuture(new ResourceOverview(1, 1, 1));
+		return CompletableFuture.completedFuture(new ResourceOverview(1, 1, 1, ResourceProfile.ZERO, ResourceProfile.ZERO));
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/ResourceProfileInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/ResourceProfileInfoTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Test for (un)marshalling of the {@link ResourceProfileInfo}.
+ */
+public class ResourceProfileInfoTest extends RestResponseMarshallingTestBase<ResourceProfileInfo> {
+
+	private static final Random random = new Random();
+
+	@Override
+	protected Class<ResourceProfileInfo> getTestResponseClass() {
+		return ResourceProfileInfo.class;
+	}
+
+	@Override
+	protected ResourceProfileInfo getTestResponseInstance() throws Exception {
+		return createRandomResourceProfileInfo();
+	}
+
+	private static ResourceProfileInfo createRandomResourceProfileInfo() {
+		final Map<String, Double> extendedResources = new HashMap<>();
+		extendedResources.put("randome-key-1", random.nextDouble());
+		extendedResources.put("randome-key-2", random.nextDouble());
+
+		return new ResourceProfileInfo(
+			random.nextDouble(),
+			random.nextInt(),
+			random.nextInt(),
+			random.nextInt(),
+			random.nextInt(),
+			extendedResources);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerInfoTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.rest.messages.taskmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
 
@@ -50,6 +51,8 @@ public class TaskManagerInfoTest extends RestResponseMarshallingTestBase<TaskMan
 			random.nextLong(),
 			random.nextInt(),
 			random.nextInt(),
+			ResourceProfile.ZERO,
+			ResourceProfile.ZERO,
 			new HardwareDescription(
 				random.nextInt(),
 				random.nextLong(),

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -128,7 +128,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 		config.setInteger(JobManagerOptions.PORT, jobManagerPort);
 
 		final DispatcherResourceManagerComponentFactory resourceManagerComponentFactory = DefaultDispatcherResourceManagerComponentFactory.createSessionComponentFactory(
-			StandaloneResourceManagerFactory.INSTANCE);
+			StandaloneResourceManagerFactory.getInstance());
 		DispatcherResourceManagerComponent dispatcherResourceManagerComponent = null;
 
 		final ScheduledExecutorService ioExecutor = TestingUtils.defaultExecutor();

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -71,21 +70,18 @@ public class WorkerSpecContainerResourceAdapter {
 		containerMemoryToContainerResource = new HashMap<>();
 	}
 
-	@VisibleForTesting
 	Optional<Resource> tryComputeContainerResource(final WorkerResourceSpec workerResourceSpec) {
 		return Optional.ofNullable(workerSpecToContainerResource.computeIfAbsent(
 			Preconditions.checkNotNull(workerResourceSpec),
 			this::createAndMapContainerResource));
 	}
 
-	@VisibleForTesting
 	Set<WorkerResourceSpec> getWorkerSpecs(final Resource containerResource, final MatchingStrategy matchingStrategy) {
 		return getEquivalentContainerResource(containerResource, matchingStrategy).stream()
 			.flatMap(resource -> containerResourceToWorkerSpecs.getOrDefault(resource, Collections.emptySet()).stream())
 			.collect(Collectors.toSet());
 	}
 
-	@VisibleForTesting
 	Set<Resource> getEquivalentContainerResource(final Resource containerResource, final MatchingStrategy matchingStrategy) {
 		// Yarn might ignore the requested vcores, depending on its configurations.
 		// In such cases, we should also not matching vcores.

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServices;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesConfiguration;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.yarn.YarnResourceManager;
 import org.apache.flink.yarn.YarnWorkerNode;
 
@@ -51,7 +52,7 @@ public class YarnResourceManagerFactory extends ActiveResourceManagerFactory<Yar
 	}
 
 	@Override
-	public ResourceManager<YarnWorkerNode> createActiveResourceManager(
+	public ResourceManager<YarnWorkerNode> createResourceManager(
 			Configuration configuration,
 			ResourceID resourceId,
 			RpcService rpcService,
@@ -60,13 +61,8 @@ public class YarnResourceManagerFactory extends ActiveResourceManagerFactory<Yar
 			FatalErrorHandler fatalErrorHandler,
 			ClusterInformation clusterInformation,
 			@Nullable String webInterfaceUrl,
-			ResourceManagerMetricGroup resourceManagerMetricGroup) throws Exception {
-		final ResourceManagerRuntimeServicesConfiguration rmServicesConfiguration =
-			ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, YarnWorkerResourceSpecFactory.INSTANCE);
-		final ResourceManagerRuntimeServices rmRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
-			rmServicesConfiguration,
-			highAvailabilityServices,
-			rpcService.getScheduledExecutor());
+			ResourceManagerMetricGroup resourceManagerMetricGroup,
+			ResourceManagerRuntimeServices resourceManagerRuntimeServices) {
 
 		return new YarnResourceManager(
 			rpcService,
@@ -75,12 +71,18 @@ public class YarnResourceManagerFactory extends ActiveResourceManagerFactory<Yar
 			System.getenv(),
 			highAvailabilityServices,
 			heartbeatServices,
-			rmRuntimeServices.getSlotManager(),
+			resourceManagerRuntimeServices.getSlotManager(),
 			ResourceManagerPartitionTrackerImpl::new,
-			rmRuntimeServices.getJobLeaderIdService(),
+			resourceManagerRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,
 			webInterfaceUrl,
 			resourceManagerMetricGroup);
+	}
+
+	@Override
+	protected ResourceManagerRuntimeServicesConfiguration createResourceManagerRuntimeServicesConfiguration(
+		Configuration configuration) throws ConfigurationException {
+		return ResourceManagerRuntimeServicesConfiguration.fromConfiguration(configuration, YarnWorkerResourceSpecFactory.INSTANCE);
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is one step of FLINK-14106, extending SlotManager related metrics and status for future dynamic slot allocation (FLIP-56).

This PR is based on #11353. 

## Brief change log
- 5ee2a8ece3eefb4726618ed31a05a2e11737b57a..0c5eb8c3d46d2142f9dd64acfaba9d27102ad3f2: Commits of previous PR.
- c3fa43cd7d373b6c2af04fb7cd30b795e7655663..b0f8eee4771b9946c1c8111646472a1bc80d1683: Code clean-ups and deduplication.
- bd76ce844d650f22f6a80918052cee1da8cf658a: Introduce SlotManagerMetricGroup for registering related metrics inside SlotManager.
- 24081b78e049484820c6d899cffa49d1da70ebe9: Introduce multiplication for Resource.
- 2c562dbbb873a57b801df8a5b23420513c3fa51d: Introduce multiplication for ResourceProfile.
- 39d4e9f80c3870df67b2d6065e889e581174a4f3: Extend ResourceOverview and TaskManager(Details)Info for registered/free resources.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
