### PR TITLE
[FLINK-16456][FLINK-16417][e2e] Increase off heap memory for unstable jdk11 e2e tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
+++ b/flink-end-to-end-tests/test-scripts/test_heavy_deployment.sh
@@ -36,6 +36,7 @@ set_config_key "taskmanager.memory.network.max" "128mb"
 set_config_key "taskmanager.network.request-backoff.max" "60000"
 set_config_key "taskmanager.memory.segment-size" "8kb"
 set_config_key "taskmanager.memory.jvm-metaspace.size" "64m"
+set_config_key "taskmanager.memory.framework.off-heap.size" "200m"
 
 set_config_key "taskmanager.numberOfTaskSlots" "20" # 20 slots per TM
 

--- a/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
+++ b/flink-end-to-end-tests/test-scripts/test_high_parallelism_iterations.sh
@@ -32,7 +32,7 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/$TEST/target/$TEST_PROGRAM_NAME.jar
 set_config_key "taskmanager.numberOfTaskSlots" "$SLOTS_PER_TM"
 set_config_key "taskmanager.memory.network.min" "160m"
 set_config_key "taskmanager.memory.network.max" "160m"
-set_config_key "taskmanager.memory.framework.off-heap.size" "160m"
+set_config_key "taskmanager.memory.framework.off-heap.size" "300m"
 
 print_mem_use
 start_cluster


### PR DESCRIPTION
## What is the purpose of the change

Both of these tests run out of memory sometimes. I am increasing the off heap memory for the end to end tests.


## Verifying this change

I have executed the test with this memory configuration 5 times. So far, 5 runs were enough to trigger the failure in one of the runs.