### PR TITLE
[FLINK-16519] [checkpointing] Remove PowerMockito to avoid LinkageError in CheckpointCoordinatorFailureTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -32,9 +32,6 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.List;
 
@@ -50,8 +47,6 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for failure of checkpoint coordinator.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(PendingCheckpoint.class)
 public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 	/**


### PR DESCRIPTION


## What is the purpose of the change

*CheckpointCoordinatorFailureTest does not depend on PowerMockito any more, remove it to avoid LinkageError*


## Brief change log

  - *Remove PowerMockito from CheckpointCoordinatorFailureTest*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
