### PR TITLE
[FLINK-16205][sql] Support JSON_OBJECTAGG for blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonObjectAggAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonObjectAggAggFunction.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import java.util.HashMap;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.functions.AggregateFunction;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * built-in JsonObjectAgg aggregate function.
+ */
+public class JsonObjectAggAggFunction<T> extends
+	AggregateFunction<T, HashMap<String, Object>> {
+
+	@Override
+	public boolean isDeterministic() {
+		return false;
+	}
+
+	@Override
+	public HashMap<String, Object> createAccumulator() {
+		return new HashMap<>();
+	}
+
+	public void accumulate(
+		HashMap<String, Object> acc,
+		String key, Object value) throws Exception {
+		if (!key.isEmpty()) {
+			if (value != null) {
+				acc.put(key, value);
+			} else {
+				acc.put(key, null);
+			}
+		}
+	}
+
+	public void resetAccumulator(HashMap<String, Object> acc) {
+		acc.clear();
+	}
+
+	@Override
+	public TypeInformation<T> getResultType() {
+		return super.getResultType();
+	}
+
+	@Override
+	public T getValue(HashMap<String, Object> accumulator) {
+		return null;
+	}
+
+	/**
+	 * Built-in String JsonObjectAgg aggregate function.
+	 */
+	public static class StringJsonObjectAggAggFunction extends JsonObjectAggAggFunction<String> {
+
+		private ObjectMapper objectMapper = new ObjectMapper();
+
+		@Override
+		public TypeInformation<String> getResultType() {
+			return Types.STRING;
+		}
+
+		@Override
+		public String getValue(HashMap<String, Object> acc) {
+			try {
+				return objectMapper.writeValueAsString(acc);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonObjectAggWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonObjectAggWithRetractAggFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import java.util.HashMap;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.table.functions.AggregateFunction;
+
+/**
+ * built-in JsonObjectAgg aggregate function.
+ */
+public class JsonObjectAggWithRetractAggFunction<T> extends
+	AggregateFunction<T, HashMap<String, Object>> {
+
+	@Override
+	public HashMap<String, Object> createAccumulator() {
+		return new HashMap<>();
+	}
+
+	public void accumulate(
+		HashMap<String, Object> acc,
+		String key, Object value) throws Exception {
+		if (!key.isEmpty()) {
+			if (value != null) {
+				acc.put(key, value);
+			} else {
+				acc.put(key, null);
+			}
+		}
+	}
+
+	public void resetAccumulator(HashMap<String, Object> acc) {
+		acc.clear();
+	}
+
+	public void retract(HashMap<String, Object> acc, String key, Object value) {
+		if (!key.isEmpty()) {
+			acc.put(key, value);
+		}
+	}
+
+	@Override
+	public TypeInformation<T> getResultType() {
+		return super.getResultType();
+	}
+
+	@Override
+	public T getValue(HashMap<String, Object> accumulator) {
+		return null;
+	}
+
+	/**
+	 * Built-in String JsonObjectAgg aggregate function.
+	 */
+	public static class StringJsonObjectAggWithRetractAggFunction extends
+		JsonObjectAggWithRetractAggFunction<String> {
+
+		private ObjectMapper objectMapper = new ObjectMapper();
+
+		@Override
+		public TypeInformation<String> getResultType() {
+			return Types.STRING;
+		}
+
+		@Override
+		public String getValue(HashMap<String, Object> acc) {
+			try {
+				return objectMapper.writeValueAsString(acc);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -1223,4 +1223,60 @@ class AggregateITCase(
     results.addSink(sink).setParallelism(1)
     env.execute()
   }
+
+  @Test
+  def testJsonObjectAgg(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data .+=((1, "foo", "bar"))
+    data .+=((1, "foo2", null))
+    data .+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_objectagg(b:c) FROM MyTable
+         |GROUP BY a
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "{\"foo\":\"bar\",\"foo2\":null}",
+      "{\"foo3\":\"true\"}")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJsonObjectAggWithRetract(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data .+=((1, "foo", "bar"))
+    data .+=((1, "foo2", null))
+    data .+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_objectagg(b:c) FROM
+         |(SELECT b,c,json_objectagg(b:c) FROM MyTable
+         |GROUP BY b,c)
+         |GROUP BY c
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "{\"foo\":\"bar\"}",
+      "{\"foo2\":null}",
+      "{\"foo3\":\"bar3\"}",
+      "{\"foo3\":\"true\"}")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
@@ -398,4 +398,60 @@ class AggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val expected = mutable.MutableList("1,1", "2,3", "3,6", "4,10", "5,15", "6,21")
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
+  @Test
+  def testJsonObjectAgg(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data.+=((1, "foo", "bar"))
+    data.+=((1, "foo2", null))
+    data.+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_objectagg(b:c) FROM MyTable
+         |GROUP BY a
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "{\"foo\":\"bar\",\"foo2\":null}",
+      "{\"foo3\":\"true\"}")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJsonObjectAggWithRetract(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data .+=((1, "foo", "bar"))
+    data .+=((1, "foo2", null))
+    data .+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_objectagg(b:c) FROM
+         |(SELECT b,c,json_objectagg(b:c) FROM MyTable
+         |GROUP BY b,c)
+         |GROUP BY c
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "{\"foo\":\"bar\"}",
+      "{\"foo2\":null}",
+      "{\"foo3\":\"bar3\"}",
+      "{\"foo3\":\"true\"}")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Support `JSON_OBJECTAGG` function for blink planner

## Brief change log

*(for example:)*

- Introduce `JSON_OBJECTAGG` to `FlinkSqlOperatorTable`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `AggregateITCase.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)