### PR TITLE
[FLINK-16206][sql] Support JSON_ARRAYAGG for blink planner

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonArrayAggAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonArrayAggAggFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.functions.AggregateFunction;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * built-in JsonArrayAgg aggregate function.
+ */
+public class JsonArrayAggAggFunction<T> extends
+	AggregateFunction<T, List<Object>> {
+
+	@Override
+	public boolean isDeterministic() {
+		return false;
+	}
+
+	@Override
+	public List<Object> createAccumulator() {
+		return new ArrayList<>();
+	}
+
+	public void accumulate(List<Object> acc, Object value) throws Exception {
+		acc.add(value);
+	}
+
+	public void resetAccumulator(List<Object> acc) {
+		acc.clear();
+	}
+
+	@Override
+	public TypeInformation<T> getResultType() {
+		return super.getResultType();
+	}
+
+	@Override
+	public T getValue(List<Object> accumulator) {
+		return null;
+	}
+
+	/**
+	 * Built-in String JsonObjectAgg aggregate function.
+	 */
+	public static class StringJsonArrayAggAggFunction extends JsonArrayAggAggFunction<String> {
+
+		private ObjectMapper objectMapper = new ObjectMapper();
+
+		@Override
+		public TypeInformation<String> getResultType() {
+			return Types.STRING;
+		}
+
+		@Override
+		public String getValue(List<Object> acc) {
+			try {
+				return objectMapper.writeValueAsString(acc);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonArrayAggWithRetractAggFunction.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/aggfunctions/JsonArrayAggWithRetractAggFunction.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.aggfunctions;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.table.functions.AggregateFunction;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * built-in JsonArrayAgg aggregate function.
+ */
+public class JsonArrayAggWithRetractAggFunction<T> extends
+	AggregateFunction<T, List<Object>> {
+
+	@Override
+	public List<Object> createAccumulator() {
+		return new ArrayList<>();
+	}
+
+	public void accumulate(List<Object> acc, Object value) throws Exception {
+		acc.add(value);
+	}
+
+	public void resetAccumulator(List<Object> acc) {
+		acc.clear();
+	}
+
+	public void retract(List<Object> acc, Object value) {
+		if (acc.indexOf(value) == -1) {
+			acc.add(value);
+		} else {
+			acc.remove(value);
+		}
+	}
+
+	@Override
+	public TypeInformation<T> getResultType() {
+		return super.getResultType();
+	}
+
+	@Override
+	public T getValue(List<Object> accumulator) {
+		return null;
+	}
+
+	/**
+	 * Built-in String JsonObjectAgg aggregate function.
+	 */
+	public static class StringJsonArrayAggWithRetractAggFunction extends
+		JsonArrayAggWithRetractAggFunction<String> {
+
+		private ObjectMapper objectMapper = new ObjectMapper();
+
+		@Override
+		public TypeInformation<String> getResultType() {
+			return Types.STRING;
+		}
+
+		@Override
+		public String getValue(List<Object> acc) {
+			try {
+				return objectMapper.writeValueAsString(acc);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/AggFunctionFactory.scala
@@ -43,6 +43,9 @@ import org.apache.calcite.sql.fun._
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind, SqlRankFunction}
 import java.util
 
+import org.apache.flink.table.planner.functions.aggfunctions.JsonArrayAggAggFunction.StringJsonArrayAggAggFunction
+import org.apache.flink.table.planner.functions.aggfunctions.JsonArrayAggWithRetractAggFunction.StringJsonArrayAggWithRetractAggFunction
+
 import scala.collection.JavaConversions._
 
 /**
@@ -121,6 +124,9 @@ class AggFunctionFactory(
 
       case a: SqlAggFunction if a.getKind == SqlKind.COLLECT =>
         createCollectAggFunction(argTypes)
+
+      case _: SqlJsonArrayAggAggFunction if call.getArgList.size() == 1 =>
+        createJsonArrayAggAggFunction(argTypes, index)
 
       case udagg: AggSqlFunction =>
         // Can not touch the literals, Calcite make them in previous RelNode.
@@ -651,5 +657,15 @@ class AggFunctionFactory(
       case t => TypeInfoLogicalTypeConverter.fromLogicalTypeToTypeInfo(t)
     }
     new CollectAggFunction(elementTypeInfo)
+  }
+
+  private def createJsonArrayAggAggFunction(
+      argTypes: Array[LogicalType],
+      index: Int): UserDefinedFunction = {
+    if (needRetraction(index)) {
+      new StringJsonArrayAggWithRetractAggFunction
+    } else {
+      new StringJsonArrayAggAggFunction
+    }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/AggregateITCase.scala
@@ -398,4 +398,60 @@ class AggregateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     val expected = mutable.MutableList("1,1", "2,3", "3,6", "4,10", "5,15", "6,21")
     assertEquals(expected.sorted, sink.getRetractResults.sorted)
   }
+
+  @Test
+  def testJsonArrayAgg(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data .+=((1, "foo", "bar"))
+    data .+=((1, "foo2", null))
+    data .+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_arrayagg(c) FROM MyTable
+         |GROUP BY a
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "[\"bar\",null]",
+      "[\"bar3\",\"true\"]")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
+
+  @Test
+  def testJsonArrayAggWithRetract(): Unit = {
+    val data = new mutable.MutableList[(Int, String, String)]
+    data .+=((1, "foo", "bar"))
+    data .+=((1, "foo2", null))
+    data .+=((3, "foo3", "bar3"))
+    data .+=((3, "foo3", "true"))
+    val t = failingDataSource(data).toTable(tEnv, 'a, 'b, 'c)
+    tEnv.registerTable("MyTable", t)
+
+    val sqlQuery =
+      s"""
+         |SELECT json_arrayagg(c) FROM
+         |(SELECT b,c,json_arrayagg(c) FROM MyTable
+         |GROUP BY b,c)
+         |GROUP BY c
+    """.stripMargin
+
+    val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
+    val sink = new TestingRetractSink()
+    result.addSink(sink)
+    env.execute()
+    val expected = List(
+      "[\"bar\"]",
+      "[\"bar3\"]",
+      "[\"true\"]",
+      "[null]")
+    assertEquals(expected.sorted, sink.getRetractResults.sorted)
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change

Support `JSON_ARRAYAGG` function for blink planner

## Brief change log

*(for example:)*

- Introduce `JSON_ARRAYAGG` to `FlinkSqlOperatorTable`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `AggregateITCase.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)