### PR TITLE
[FLINK-16480] Improve error reporting on AZP

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -26,7 +26,7 @@ export FLINK_VERSION=$(mvn --file ${END_TO_END_DIR}/pom.xml org.apache.maven.plu
 # Arguments:
 #   $1: description of the test
 #   $2: command to execute
-#   $3: check logs for erors & exceptions
+#   $3: check logs for errors & exceptions unless this parameter == skip_check_exceptions or the exit code != 0
 #######################################
 function run_test {
     local description="$1"
@@ -46,7 +46,7 @@ function run_test {
 
     function test_error() {
       echo "[FAIL] Test script contains errors."
-      post_test_validation 1 "$description" "$skip_check_exceptions"
+      post_test_validation 1 "$description"
     }
     # set a trap to catch a test execution error
     trap 'test_error' ERR
@@ -66,12 +66,13 @@ function post_test_validation {
 
     local time_elapsed=$(end_timer)
 
-    if [[ "${skip_check_exceptions}" != "skip_check_exceptions" ]]; then
+    if [[ ${exit_code} != 0 || ${EXIT_CODE} != 0 || "${skip_check_exceptions}" != "skip_check_exceptions" ]]; then
+        echo "Checking logs (exit_code=$exit_code, EXIT_CODE=$EXIT_CODE, skip_check_exceptions=$skip_check_exceptions)"
         check_logs_for_errors
         check_logs_for_exceptions
         check_logs_for_non_empty_out_files
     else
-        echo "Checking of logs skipped."
+        echo "Checking of logs skipped (exit_code=$exit_code, EXIT_CODE=$EXIT_CODE, skip_check_exceptions=$skip_check_exceptions)"
     fi
 
     # Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -171,7 +171,7 @@ jobs:
       displayName: Run e2e tests
       # upload debug artifacts
     - task: PublishPipelineArtifact@1
-      condition: and(succeededOrFailed(), not(eq('$(ARTIFACT_DIR)', '')))
+      condition: and(succeededOrFailed(), not(eq(variables['ARTIFACT_DIR'], '')))
       displayName: Upload Logs
       inputs:
         path: $(ARTIFACT_DIR)

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -54,7 +54,7 @@ print_system_info() {
 print_system_info
 
 # enable core dumps
-sudo ulimit -c unlimited
+ulimit -c unlimited
 
 STAGE=$1
 echo "Current stage: \"$STAGE\""

--- a/tools/azure_controller.sh
+++ b/tools/azure_controller.sh
@@ -53,6 +53,8 @@ print_system_info() {
 
 print_system_info
 
+# enable core dumps
+sudo ulimit -c unlimited
 
 STAGE=$1
 echo "Current stage: \"$STAGE\""

--- a/tools/travis/common-logging.sh
+++ b/tools/travis/common-logging.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Maximum times to retry uploading artifacts file to transfer.sh
+TRANSFER_UPLOAD_MAX_RETRIES=2
+
+# The delay between two retries to upload artifacts file to transfer.sh. The default exponential
+# backoff algorithm should be too long for the last several retries.
+TRANSFER_UPLOAD_RETRY_DELAY=5
+
+# E.g. travis-artifacts/apache/flink/1595/1595.1
+UPLOAD_TARGET_PATH="travis-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/"
+# These variables are stored as secure variables in '.travis.yml', which are generated per repo via
+# the travis command line tool.
+UPLOAD_BUCKET=$ARTIFACTS_AWS_BUCKET
+UPLOAD_ACCESS_KEY=$ARTIFACTS_AWS_ACCESS_KEY
+UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
+
+
+SCRIPT_DIR="`dirname \"$0\"`"
+SCRIPT_DIR="`( cd \"${SCRIPT_DIR}\" && pwd -P)`"
+export FLINK_ROOT="`( cd \"${SCRIPT_DIR}/..\" && pwd -P)`"
+if [ -z "${FLINK_ROOT}" ] ; then
+	# error; for some reason, the path is not accessible
+	# to the script (e.g. permissions re-evaled after suid)
+	exit 1  # fail
+fi
+
+prepare_artifacts() {
+	export ARTIFACTS_DIR="${SCRIPT_DIR}/artifacts"
+
+	mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
+}
+
+upload_artifacts() {
+	ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}.tar.gz
+	if [ ! -z "$TF_BUILD" ] ; then
+		# set proper artifacts file name on Azure Pipelines
+		ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tar.gz
+		if [ ! -z "$MODULE" ] ; then
+			ARTIFACTS_FILE=${BUILD_BUILDNUMBER}-$(echo $MODULE | tr -dc '[:alnum:]\n\r').tar.gz
+		fi
+	fi
+
+	echo "PRODUCED build artifacts."
+
+	ls $ARTIFACTS_DIR
+
+	echo "COMPRESSING build artifacts."
+
+	cd $ARTIFACTS_DIR
+	dmesg > container.log
+	tar -zcvf $ARTIFACTS_FILE *
+
+	# Upload to secured S3
+	if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
+
+		# Install artifacts tool
+		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+
+		PATH=$HOME/bin/artifacts:$HOME/bin:$PATH
+
+		echo "UPLOADING build artifacts."
+
+		# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
+		# re-creates the whole directory structure from root.
+		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH $ARTIFACTS_FILE
+	fi
+
+	# On Azure, publish ARTIFACTS_FILE as a build artifact
+	if [ ! -z "$TF_BUILD" ] ; then
+		ARTIFACT_DIR="$FLINK_ROOT/artifact-dir"
+		mkdir $ARTIFACT_DIR
+		cp $ARTIFACTS_FILE $ARTIFACT_DIR/
+		
+		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$ARTIFACT_DIR"
+		echo "##vso[task.setvariable variable=ARTIFACT_NAME]$(echo $MODULE | tr -dc '[:alnum:]\n\r')"
+	fi
+
+	# upload to https://transfer.sh
+	echo "Uploading to transfer.sh"
+	curl --retry ${TRANSFER_UPLOAD_MAX_RETRIES} --retry-delay ${TRANSFER_UPLOAD_RETRY_DELAY} --upload-file $ARTIFACTS_FILE --max-time 60 https://transfer.sh
+}
+
+
+################ Utilities for handling logs ##################
+
+collect_coredumps() {
+	echo "Searching for .dump, .dumpstream and related files in $FLINK_ROOT"
+	for file in `find $FLINK_ROOT -type f -regextype posix-extended -iregex '.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
+		echo "Copying $file to artifacts"
+		cp $file $ARTIFACTS_DIR/
+	done
+}
+
+# locate YARN logs and put them into artifacts directory
+put_yarn_logs_to_artifacts() {
+	# Make sure to be in project root
+	echo "Searching for YARN container logs in '$FLINK_ROOT/flink-yarn-tests/target'"
+	for file in `find $FLINK_ROOT/flink-yarn-tests/target -type f -name '*.log'`; do
+		TARGET_FILE=`echo "$file" | grep -Eo "container_[0-9_]+/(.*).log"`
+		TARGET_DIR=`dirname	 "$TARGET_FILE"`
+		mkdir -p "$ARTIFACTS_DIR/yarn-tests/$TARGET_DIR"
+		cp $file "$ARTIFACTS_DIR/yarn-tests/$TARGET_FILE"
+	done
+}
+

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -26,10 +26,10 @@ if [ -z "$HERE" ] ; then
 fi
 
 source "${HERE}/travis/stage.sh"
+source "${HERE}/travis/common-logging.sh"
 
-ARTIFACTS_DIR="${HERE}/artifacts"
-
-mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
+# exports $ARTIFACTS_DIR
+prepare_artifacts
 
 echo "Build for commit ${TRAVIS_COMMIT} of ${TRAVIS_REPO_SLUG} [build ID: ${TRAVIS_BUILD_ID}, job number: $TRAVIS_JOB_NUMBER]." | tee "${ARTIFACTS_DIR}/build_info"
 
@@ -42,13 +42,6 @@ MAX_NO_OUTPUT=${1:-300}
 
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20
-
-# Maximum times to retry uploading artifacts file to transfer.sh
-TRANSFER_UPLOAD_MAX_RETRIES=2
-
-# The delay between two retries to upload artifacts file to transfer.sh. The default exponential
-# backoff algorithm should be too long for the last several retries.
-TRANSFER_UPLOAD_RETRY_DELAY=5
 
 LOG4J_PROPERTIES=${HERE}/log4j-travis.properties
 
@@ -85,21 +78,6 @@ MVN_OUT="${ARTIFACTS_DIR}/mvn.out"
 
 TRACE_OUT="${ARTIFACTS_DIR}/jps-traces.out"
 
-# E.g. travis-artifacts/apache/flink/1595/1595.1
-UPLOAD_TARGET_PATH="travis-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/"
-# These variables are stored as secure variables in '.travis.yml', which are generated per repo via
-# the travis command line tool.
-UPLOAD_BUCKET=$ARTIFACTS_AWS_BUCKET
-UPLOAD_ACCESS_KEY=$ARTIFACTS_AWS_ACCESS_KEY
-UPLOAD_SECRET_KEY=$ARTIFACTS_AWS_SECRET_KEY
-
-ARTIFACTS_FILE=${TRAVIS_JOB_NUMBER}.tar.gz
-
-if [ ! -z "$TF_BUILD" ] ; then
-	# set proper artifacts file name on Azure Pipelines
-	ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tar.gz
-fi
-
 if [ $TEST == $STAGE_PYTHON ]; then
 	CMD=$PYTHON_TEST
 	CMD_PID=$PYTHON_PID
@@ -117,47 +95,6 @@ fi
 # =============================================================================
 # FUNCTIONS
 # =============================================================================
-
-upload_artifacts_s3() {
-	echo "PRODUCED build artifacts."
-
-	ls $ARTIFACTS_DIR
-
-	echo "COMPRESSING build artifacts."
-
-	cd $ARTIFACTS_DIR
-	dmesg > container.log
-	tar -zcvf $ARTIFACTS_FILE *
-
-	# Upload to secured S3
-	if [ -n "$UPLOAD_BUCKET" ] && [ -n "$UPLOAD_ACCESS_KEY" ] && [ -n "$UPLOAD_SECRET_KEY" ]; then
-
-		# Install artifacts tool
-		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-
-		PATH=$HOME/bin/artifacts:$HOME/bin:$PATH
-
-		echo "UPLOADING build artifacts."
-
-		# Upload everything in $ARTIFACTS_DIR. Use relative path, otherwise the upload tool
-		# re-creates the whole directory structure from root.
-		artifacts upload --bucket $UPLOAD_BUCKET --key $UPLOAD_ACCESS_KEY --secret $UPLOAD_SECRET_KEY --target-paths $UPLOAD_TARGET_PATH $ARTIFACTS_FILE
-	fi
-
-	# On Azure, publish ARTIFACTS_FILE as a build artifact
-	if [ ! -z "$TF_BUILD" ] ; then
-		ARTIFACT_DIR="$(pwd)/artifact-dir"
-		mkdir $ARTIFACT_DIR
-		cp $ARTIFACTS_FILE $ARTIFACT_DIR/
-		
-		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$ARTIFACT_DIR"
-		echo "##vso[task.setvariable variable=ARTIFACT_NAME]$(echo $MODULE | tr -dc '[:alnum:]\n\r')"
-	fi
-
-	# upload to https://transfer.sh
-	echo "Uploading to transfer.sh"
-	curl --retry ${TRANSFER_UPLOAD_MAX_RETRIES} --retry-delay ${TRANSFER_UPLOAD_RETRY_DELAY} --upload-file $ARTIFACTS_FILE --max-time 60 https://transfer.sh
-}
 
 print_stacktraces () {
 	echo "=============================================================================="
@@ -177,25 +114,6 @@ print_stacktraces () {
 	done
 }
 
-collect_coredumps() {
-	echo "Searching for .dump, .dumpstream and related files in $($HERE/../)"
-	for file in `find . -type f -regextype posix-extended -iregex '.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
-		echo "Copying $file to artifacts"
-		cp $file $ARTIFACTS_DIR/
-	done
-}
-
-# locate YARN logs and put them into artifacts directory
-put_yarn_logs_to_artifacts() {
-	# Make sure to be in project root
-	cd $HERE/../
-	for file in `find ./flink-yarn-tests/target -type f -name '*.log'`; do
-		TARGET_FILE=`echo "$file" | grep -Eo "container_[0-9_]+/(.*).log"`
-		TARGET_DIR=`dirname	 "$TARGET_FILE"`
-		mkdir -p "$ARTIFACTS_DIR/yarn-tests/$TARGET_DIR"
-		cp $file "$ARTIFACTS_DIR/yarn-tests/$TARGET_FILE"
-	done
-}
 
 mod_time () {
 	if [[ `uname` == 'Darwin' ]]; then
@@ -289,7 +207,7 @@ esac
 
 collect_coredumps
 
-upload_artifacts_s3
+upload_artifacts
 
 # since we are in flink/tools/artifacts
 # we are going back to

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -177,6 +177,14 @@ print_stacktraces () {
 	done
 }
 
+collect_coredumps() {
+	echo "Searching for .dump, .dumpstream and related files in $($HERE/../)"
+	for file in `find . -type f -regextype posix-extended -iregex '.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
+		echo "Copying $file to artifacts"
+		cp $file $ARTIFACTS_DIR/
+	done
+}
+
 # locate YARN logs and put them into artifacts directory
 put_yarn_logs_to_artifacts() {
 	# Make sure to be in project root
@@ -278,6 +286,8 @@ case $TEST in
 		put_yarn_logs_to_artifacts
 	;;
 esac
+
+collect_coredumps
 
 upload_artifacts_s3
 


### PR DESCRIPTION
## What is the purpose of the change

While debugging unstable e2e tests and crashing JVMs remotely, I came up with a bunch of improvements to our testing scripts, which I would like to add to the main repo.


## Brief change log

The following changes are contained here:
- [FLINK-16480][e2e] Always checks logs when test has failed: The e2e tests now check the logs for exceptions / errors etc when a test has failed (before, logs where not checked in error cases for some tests)
- [FLINK-16480][AZP] fix log upload condition the log upload failed for e2e tests, when a bash e2e test failed.
- [FLINK-16480] Collect debug files when JVM crashes (for IT cases): we now collect coredumps, jvm stacktraces, and other debugging files
-  [FLINK-16480][e2e] Collect java crashreports for e2e tests as well: same for e2e tests. This includes a refactoring of the log collection tools into a separate file.

## Verifying this change

This run properly collects coredumps etc of a test that used to fail on master a few days ago: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=6137&view=results

## Does this pull request potentially affect one of the following parts:

affects only tests

