### PR TITLE
[FLINK-16533] [client] ExecutionEnvironment supports execution of existing plan

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ContextEnvironment.java
@@ -20,6 +20,7 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
@@ -52,6 +53,19 @@ public class ContextEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		JobClient jobClient = executeAsync(jobName);
 
+		return getJobExecutionResult(jobClient);
+	}
+
+	@Override
+	public JobExecutionResult execute(Plan plan) throws Exception {
+		JobClient jobClient = executeAsync(plan);
+
+		System.out.println("Job has been submitted with JobID " + jobClient.getJobID());
+
+		return getJobExecutionResult(jobClient);
+	}
+
+	private JobExecutionResult getJobExecutionResult(JobClient jobClient) throws Exception {
 		JobExecutionResult jobExecutionResult;
 		if (getConfiguration().getBoolean(DeploymentOptions.ATTACHED)) {
 			CompletableFuture<JobExecutionResult> jobExecutionResultFuture =

--- a/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/CollectionEnvironment.java
@@ -33,9 +33,13 @@ public class CollectionEnvironment extends ExecutionEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Plan p = createProgramPlan(jobName);
 
+		return execute(p);
+	}
+
+	public JobExecutionResult execute(Plan plan) throws Exception {
 		// We need to reverse here. Object-Reuse enabled, means safe mode is disabled.
 		CollectionExecutor exec = new CollectionExecutor(getConfig());
-		this.lastJobExecutionResult = exec.execute(p);
+		this.lastJobExecutionResult = exec.execute(plan);
 		return this.lastJobExecutionResult;
 	}
 

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1032,7 +1032,7 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Get the registered cached files
+	 * Get the registered cached files.
 	 */
 	@Internal
 	public List<Tuple2<String, DistributedCacheEntry>> getCacheFile() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.utils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.operators.OperatorInformation;
+import org.apache.flink.api.java.operators.DataSink;
+import org.apache.flink.api.java.operators.OperatorTranslation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
+import org.apache.flink.util.Visitor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator that generates a {@link Plan} from a graph of {@link Operator}s.
+ */
+public class PlanGenerator {
+	private static final Logger LOG = LoggerFactory.getLogger(PlanGenerator.class);
+	private final List<DataSink<?>> sinks;
+	private final ExecutionConfig config;
+	private final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile;
+	private final String jobName;
+
+	public PlanGenerator(
+		List<DataSink<?>> sinks,
+		ExecutionConfig config,
+		List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile,
+		String jobName) {
+		this.sinks = sinks;
+		this.config = config;
+		this.cacheFile = cacheFile;
+		this.jobName = jobName;
+	}
+
+	public Plan generate() {
+		OperatorTranslation translator = new OperatorTranslation();
+		Plan plan = translator.translateToPlan(sinks, jobName);
+
+		if (config.getParallelism() > 0) {
+			plan.setDefaultParallelism(config.getParallelism());
+		}
+		plan.setExecutionConfig(config);
+
+		// Check plan for GenericTypeInfo's and register the types at the serializers.
+		if (!config.isAutoTypeRegistrationDisabled()) {
+			plan.accept(new Visitor<Operator<?>>() {
+
+				private final Set<Class<?>> registeredTypes = new HashSet<>();
+				private final Set<org.apache.flink.api.common.operators.Operator<?>> visitedOperators = new HashSet<>();
+
+				@Override
+				public boolean preVisit(org.apache.flink.api.common.operators.Operator<?> visitable) {
+					if (!visitedOperators.add(visitable)) {
+						return false;
+					}
+					OperatorInformation<?> opInfo = visitable.getOperatorInfo();
+					Serializers.recursivelyRegisterType(opInfo.getOutputType(), config, registeredTypes);
+					return true;
+				}
+
+				@Override
+				public void postVisit(org.apache.flink.api.common.operators.Operator<?> visitable) {
+				}
+			});
+		}
+
+		try {
+			registerCachedFilesWithPlan(plan);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
+		}
+
+		// All types are registered now. Print information.
+		int registeredTypes = config.getRegisteredKryoTypes().size() +
+			config.getRegisteredPojoTypes().size() +
+			config.getRegisteredTypesWithKryoSerializerClasses().size() +
+			config.getRegisteredTypesWithKryoSerializers().size();
+		int defaultKryoSerializers = config.getDefaultKryoSerializers().size() +
+			config.getDefaultKryoSerializerClasses().size();
+		LOG.info("The job has {} registered types and {} default Kryo serializers", registeredTypes,
+			defaultKryoSerializers);
+
+		if (config.isForceKryoEnabled() && config.isForceAvroEnabled()) {
+			LOG.warn("In the ExecutionConfig, both Avro and Kryo are enforced. Using Kryo serializer");
+		}
+		if (config.isForceKryoEnabled()) {
+			LOG.info("Using KryoSerializer for serializing POJOs");
+		}
+		if (config.isForceAvroEnabled()) {
+			LOG.info("Using AvroSerializer for serializing POJOs");
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Registered Kryo types: {}", config.getRegisteredKryoTypes().toString());
+			LOG.debug("Registered Kryo with Serializers types: {}",
+				config.getRegisteredTypesWithKryoSerializers().entrySet().toString());
+			LOG.debug("Registered Kryo with Serializer Classes types: {}",
+				config.getRegisteredTypesWithKryoSerializerClasses().entrySet().toString());
+			LOG.debug("Registered Kryo default Serializers: {}",
+				config.getDefaultKryoSerializers().entrySet().toString());
+			LOG.debug("Registered Kryo default Serializers Classes {}",
+				config.getDefaultKryoSerializerClasses().entrySet().toString());
+			LOG.debug("Registered POJO types: {}", config.getRegisteredPojoTypes().toString());
+
+			// print information about static code analysis
+			LOG.debug("Static code analysis mode: {}", config.getCodeAnalysisMode());
+		}
+
+		return plan;
+	}
+
+	private void registerCachedFilesWithPlan(Plan p) throws IOException {
+		for (Tuple2<String, DistributedCache.DistributedCacheEntry> entry : cacheFile) {
+			p.registerCachedFile(entry.f0, entry.f1);
+		}
+	}
+}

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.utils;
+
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSink;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link PlanGenerator}.
+ */
+public class PlanGeneratorTest {
+
+	@Test
+	public void testGenerate() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(10);
+		env.registerCachedFile("/tmp/cache", "my_cache");
+
+		DataSink<?> sink = env
+			.fromElements(1, 3, 5)
+			.map((MapFunction<Integer, String>) value -> String.valueOf(value + 1))
+			.writeAsText("/tmp/csv");
+
+		PlanGenerator generator = new PlanGenerator(
+			Collections.singletonList(sink), env.getConfig(), env.getCacheFile(), "test");
+		Plan plan = generator.generate();
+		assertEquals(1, plan.getDataSinks().size());
+		assertEquals(10, plan.getDefaultParallelism());
+		assertEquals(env.getConfig(), plan.getExecutionConfig());
+		assertEquals("test", plan.getJobName());
+		assertEquals(1, plan.getCachedFiles().size());
+	}
+}

--- a/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellEnvironment.java
+++ b/flink-scala-shell/src/main/java/org/apache/flink/api/java/ScalaShellEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.scala.FlinkILoop;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
@@ -72,13 +73,22 @@ public class ScalaShellEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
+		beforeExecute();
+		return super.execute(jobName);
+	}
+
+	@Override
+	public JobExecutionResult execute(Plan plan) throws Exception {
+		beforeExecute();
+		return super.execute(plan);
+	}
+
+	private void beforeExecute()  throws Exception {
 		final Configuration configuration = getConfiguration();
 		checkState(configuration.getBoolean(DeploymentOptions.ATTACHED), "Only ATTACHED mode is supported by the scala shell.");
 
 		final List<URL> updatedJarFiles = getUpdatedJarFiles();
 		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, updatedJarFiles, URL::toString);
-
-		return super.execute(jobName);
 	}
 
 	private List<URL> getUpdatedJarFiles() throws MalformedURLException {

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/CollectionTestEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.flink.test.util;
 
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironmentFactory;
@@ -45,6 +46,13 @@ public class CollectionTestEnvironment extends CollectionEnvironment {
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
 		JobExecutionResult result = super.execute(jobName);
+		this.lastJobExecutionResult = result;
+		return result;
+	}
+
+	@Override
+	public JobExecutionResult execute(Plan plan) throws Exception {
+		JobExecutionResult result = super.execute(plan);
 		this.lastJobExecutionResult = result;
 		return result;
 	}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestEnvironment.java
@@ -97,8 +97,13 @@ public class TestEnvironment extends ExecutionEnvironment {
 
 	@Override
 	public JobExecutionResult execute(String jobName) throws Exception {
-		OptimizedPlan op = compileProgram(jobName);
+		Plan p = createProgramPlan(jobName);
+		return execute(p);
+	}
 
+	@Override
+	public JobExecutionResult execute(Plan plan) throws Exception {
+		OptimizedPlan op = compileProgram(plan);
 		JobGraphGenerator jgg = new JobGraphGenerator();
 		JobGraph jobGraph = jgg.compileJobGraph(op);
 
@@ -112,11 +117,9 @@ public class TestEnvironment extends ExecutionEnvironment {
 		return this.lastJobExecutionResult;
 	}
 
-	private OptimizedPlan compileProgram(String jobName) {
-		Plan p = createProgramPlan(jobName);
-
+	private OptimizedPlan compileProgram(Plan plan) {
 		Optimizer pc = new Optimizer(new DataStatistics(), new Configuration());
-		return pc.compile(p);
+		return pc.compile(plan);
 	}
 
 	public void setAsContext() {


### PR DESCRIPTION

## What is the purpose of the change

*Add two methods in ExecutionEnvironment to support execution of existing plan:
public class ExecutionEnvironment {
    @Internal
    public JobExecutionResult execute(Plan plan) throws Exception {
    .....
    }

    @Internal
    public JobClient executeAsync(Plan plan) throws Exception {
    .....
    }
}

Those added methods are internal, and are similar to StreamExecutionEnvironment#execute(StreamGraph) and StreamExecutionEnvironment#executeAsync(StreamGraph)*

## Brief change log

  - *add execute(Plan) and executeAsync(Plan) in ExecutionEnvironment, and adapt it's sub-classes to implement new methods*
  - *Extract plan generation logic to PlanGenerator*


## Verifying this change


This change added tests and can be verified as follows:

  - *Added PlanGeneratorTest for plan generation*
  - *Extended ExecutionEnvironmentITCase for execution of existing plan*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
