### PR TITLE
[FLINK-16524][python] Optimize the result of FlattenRowCoder and ArrowCoder to generator to eliminate unnecessary function calls

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -138,7 +138,7 @@ class TableFunctionRowCoderImpl(StreamCoderImpl):
 
     def __init__(self, flatten_row_coder):
         self._flatten_row_coder = flatten_row_coder
-        self._field_count = flatten_row_coder._filed_count
+        self._field_count = flatten_row_coder._field_count
 
     def encode_to_stream(self, iter_value, out_stream, nested):
         for value in iter_value:

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -23,7 +23,8 @@ import datetime
 import decimal
 import pyarrow as pa
 from apache_beam.coders import Coder
-from apache_beam.coders.coders import FastCoder
+from apache_beam.coders.coders import FastCoder, LengthPrefixCoder
+from apache_beam.portability import common_urns
 from apache_beam.typehints import typehints
 
 from pyflink.fn_execution import coder_impl
@@ -413,6 +414,25 @@ class ArrowCoder(DeterministicCoder):
     def __repr__(self):
         return 'ArrowCoder[%s]' % self._schema
 
+
+class CustomLengthPrefixCoder(LengthPrefixCoder):
+    """
+    CustomLengthPrefixCoder will replace LengthPrefixCoder in Beam for performance optimization.
+    We need to get whole in_stream in decode_to_stream. However, LengthPrefixCoder of Beam will
+    only support partial in_stream of one input row data.
+    """
+    def __init__(self, value_coder):
+        super(CustomLengthPrefixCoder, self).__init__(value_coder)
+
+    def _create_impl(self):
+        return coder_impl.CustomLengthPrefixCoderImpl(self._value_coder.get_impl())
+
+    def __repr__(self):
+        return 'CustomLengthPrefixCoder[%s]' % self._value_coder
+
+
+Coder.register_structured_urn(
+    common_urns.coders.LENGTH_PREFIX.urn, CustomLengthPrefixCoder)
 
 type_name = flink_fn_execution_pb2.Schema.TypeName
 _type_name_mappings = {

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -415,24 +415,23 @@ class ArrowCoder(DeterministicCoder):
         return 'ArrowCoder[%s]' % self._schema
 
 
-class CustomLengthPrefixCoder(LengthPrefixCoder):
+class PassThroughLengthPrefixCoder(LengthPrefixCoder):
     """
-    CustomLengthPrefixCoder will replace LengthPrefixCoder in Beam for performance optimization.
-    We need to get whole in_stream in decode_to_stream. However, LengthPrefixCoder of Beam will
-    only support partial in_stream of one input row data.
+    Coder which doesn't prefix the length of the encoded object as the length prefix will be handled
+    by the wrapped value coder.
     """
     def __init__(self, value_coder):
-        super(CustomLengthPrefixCoder, self).__init__(value_coder)
+        super(PassThroughLengthPrefixCoder, self).__init__(value_coder)
 
     def _create_impl(self):
-        return coder_impl.CustomLengthPrefixCoderImpl(self._value_coder.get_impl())
+        return coder_impl.PassThroughLengthPrefixCoderImpl(self._value_coder.get_impl())
 
     def __repr__(self):
-        return 'CustomLengthPrefixCoder[%s]' % self._value_coder
+        return 'PassThroughLengthPrefixCoder[%s]' % self._value_coder
 
 
 Coder.register_structured_urn(
-    common_urns.coders.LENGTH_PREFIX.urn, CustomLengthPrefixCoder)
+    common_urns.coders.LENGTH_PREFIX.urn, PassThroughLengthPrefixCoder)
 
 type_name = flink_fn_execution_pb2.Schema.TypeName
 _type_name_mappings = {

--- a/flink-python/pyflink/fn_execution/tests/test_coders_common.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders_common.py
@@ -117,7 +117,12 @@ class CodersTest(unittest.TestCase):
         field_coder = BigIntCoder()
         field_count = 10
         coder = FlattenRowCoder([field_coder for _ in range(field_count)])
-        self.check_coder(coder, [None if i % 2 == 0 else i for i in range(field_count)])
+        v = [[None if i % 2 == 0 else i for i in range(field_count)]]
+        generator_result = coder.decode(coder.encode(v))
+        result = []
+        for item in generator_result:
+            result.append(item)
+        self.assertEqual(v, result)
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/fn_execution/tests/test_coders_common.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders_common.py
@@ -22,7 +22,7 @@ import unittest
 
 from pyflink.fn_execution.coders import BigIntCoder, TinyIntCoder, BooleanCoder, \
     SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder, \
-    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder, FlattenRowCoder
+    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder, FlattenRowCoder, RowCoder
 
 
 class CodersTest(unittest.TestCase):
@@ -123,6 +123,14 @@ class CodersTest(unittest.TestCase):
         for item in generator_result:
             result.append(item)
         self.assertEqual(v, result)
+
+    def test_row_coder(self):
+        from pyflink.table import Row
+        field_coder = BigIntCoder()
+        field_count = 10
+        coder = RowCoder([field_coder for _ in range(field_count)])
+        v = Row(*[None if i % 2 == 0 else i for i in range(field_count)])
+        self.check_coder(coder, v)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will optimize the result of FlattenRowCoder and ArrowCoder to generator to eliminate unnecessary function calls*

## Brief change log

  - *Add PassThroughLengthPrefixCoderImpl and PassThroughLengthPrefixCoder*
  - *Change the result of FlattenRowCoder and ArrowCoder to generator*
  - *Change the func of Operations to map*

## Verifying this change

This change added tests and can be verified as follows:

  - *It is performance improvement feature, so current test is enough*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)


## How does this patch test
### Test Code


    @udf(input_types=[DataTypes.INT(False)], result_type=DataTypes.INT(False))
    def inc(x):
        return x

    t_env.register_function("inc", inc)

    # num_rows = 100000000
    num_rows = 100000
    num_columns = 10

    select_list = ["inc(c%s)" % i for i in range(num_columns)]
    t_env.register_table_sink(
        "sink",
        PrintTableSink(
            ["c%s" % i for i in range(num_columns)],
            [DataTypes.INT(False)] * num_columns))

    t_env.from_table_source(MultiRowColumnTableSource(num_rows, num_columns)) \
        .select(','.join(select_list)) \
        .insert_into("sink")

    beg_time = time.time()
    t_env.execute("perf_test")
    print("consume time: " + str(time.time() - beg_time))


## Test Results
num rows, num colums |  Consume Time(Before) | Consume Time(After)
10kw,1                         |     711s                               |   441s
10kw,10                       |     1454s                            |   1221s
