### PR TITLE
[FLINK-16526][table-planner-blink] Fix exception when computed column expression references a keyword column name

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -78,10 +78,13 @@ import org.apache.flink.util.StringUtils;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlDialect;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.validate.SqlValidator;
 
 import java.util.HashMap;
@@ -102,8 +105,8 @@ import java.util.stream.Collectors;
  * {@link org.apache.flink.table.delegation.Planner}.
  */
 public class SqlToOperationConverter {
-	private FlinkPlannerImpl flinkPlanner;
-	private CatalogManager catalogManager;
+	private final FlinkPlannerImpl flinkPlanner;
+	private final CatalogManager catalogManager;
 
 	//~ Constructors -----------------------------------------------------------
 
@@ -514,7 +517,7 @@ public class SqlToOperationConverter {
 				builder.field(call.operand(1).toString(),
 					TypeConversions.fromLogicalToDataType(
 						FlinkTypeFactory.toLogicalType(validatedType)),
-					validatedExpr.toString());
+					getQuotedSqlString(validatedExpr));
 				// add computed column into all field list
 				String fieldName = call.operand(1).toString();
 				allFieldNamesToTypes.put(fieldName, validatedType);
@@ -533,10 +536,20 @@ public class SqlToOperationConverter {
 			DataType exprDataType = TypeConversions.fromLogicalToDataType(
 				FlinkTypeFactory.toLogicalType(validatedType));
 			// use the qualified SQL expression string
-			builder.watermark(rowtimeAttribute, validated.toString(), exprDataType);
+			builder.watermark(rowtimeAttribute, getQuotedSqlString(validated), exprDataType);
 		});
 
 		return builder.build();
+	}
+
+	private String getQuotedSqlString(SqlNode sqlNode) {
+		SqlParser.Config parserConfig = flinkPlanner.config().getParserConfig();
+		SqlDialect dialect = new CalciteSqlDialect(SqlDialect.EMPTY_CONTEXT
+			.withQuotedCasing(parserConfig.unquotedCasing())
+			.withConformance(parserConfig.conformance())
+			.withUnquotedCasing(parserConfig.unquotedCasing())
+			.withIdentifierQuoteString(parserConfig.quoting().string));
+		return sqlNode.toSqlString(dialect).getSql();
 	}
 
 	private PlannerQueryOperation toQueryOperation(FlinkPlannerImpl planner, SqlNode validated) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -46,7 +46,7 @@ import scala.collection.JavaConverters._
   * The main difference is that we do not create a new RelOptPlanner in the ready() method.
   */
 class FlinkPlannerImpl(
-    config: FrameworkConfig,
+    val config: FrameworkConfig,
     catalogReaderSupplier: JFunction[JBoolean, CalciteCatalogReader],
     typeFactory: FlinkTypeFactory,
     cluster: RelOptCluster) {

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -19,26 +19,22 @@ limitations under the License.
   <TestCase name="testDataStreamScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM DataStreamTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, DataStreamTable]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 DataStreamScan(table=[[default_catalog, default_database, DataStreamTable]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testDDLTableScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM src WHERE a > 1]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -47,7 +43,6 @@ LogicalProject(ts=[$0], a=[$1], b=[$2])
    +- LogicalWatermarkAssigner(rowtime=[ts], watermark=[-($0, 1:INTERVAL SECOND)])
       +- LogicalTableScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -55,52 +50,44 @@ Calc(select=[ts, a, b], where=[>(a, 1)])
 +- WatermarkAssigner(rowtime=[ts], watermark=[-(ts, 1:INTERVAL SECOND)])
    +- TableSourceScan(table=[[default_catalog, default_database, src, source: [CollectionTableSource(ts, a, b)]]], fields=[ts, a, b])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testTableSourceScan">
     <Resource name="sql">
       <![CDATA[SELECT * FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[$2])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testDDLWithComputedColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM t1]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)])
 +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
 +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testDDLWithWatermarkComputedColumn">
     <Resource name="sql">
       <![CDATA[SELECT * FROM t1]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -109,7 +96,6 @@ LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4])
    +- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)], d=[TO_TIMESTAMP($1)], e=[my_udf($0)])
       +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -117,7 +103,26 @@ WatermarkAssigner(rowtime=[d], watermark=[-(d, 1:INTERVAL SECOND)])
 +- Calc(select=[a, b, +(a, 1) AS c, TO_TIMESTAMP(b) AS d, my_udf(a) AS e])
    +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testKeywordsWithWatermarkComputedColumn">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM t1]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$3], current_time=[$4], json_row=[$5], timestamp=[$6])
++- LogicalWatermarkAssigner(rowtime=[timestamp], watermark=[$6])
+   +- LogicalProject(a=[$0], b=[$1], time=[$2], mytime=[$2], current_time=[CURRENT_TIME], json_row=[$3], timestamp=[$3.timestamp])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b, time, json_row)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+WatermarkAssigner(rowtime=[timestamp], watermark=[timestamp])
++- Calc(select=[a, b, time, time AS mytime, CURRENT_TIME() AS current_time, json_row, json_row.timestamp AS timestamp])
+   +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [CollectionTableSource(a, b, time, json_row)]]], fields=[a, b, time, json_row])
+]]>
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -408,11 +408,11 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
       toRow(2, "2019-09-10 9:23:44")
     )
     val expected = List(
-      toRow(1, "1990-02-10 12:34:56", 1),
-      toRow(2, "2019-09-10 9:23:41", 2),
-      toRow(3, "2019-09-10 9:23:42", 3),
-      toRow(1, "2019-09-10 9:23:43", 1),
-      toRow(2, "2019-09-10 9:23:44", 2)
+      toRow(1, "1990-02-10 12:34:56", 1, "1990-02-10 12:34:56"),
+      toRow(2, "2019-09-10 9:23:41", 2, "2019-09-10 9:23:41"),
+      toRow(3, "2019-09-10 9:23:42", 3, "2019-09-10 9:23:42"),
+      toRow(1, "2019-09-10 9:23:43", 1, "2019-09-10 9:23:43"),
+      toRow(2, "2019-09-10 9:23:44", 2, "2019-09-10 9:23:44")
     )
     TestCollectionTableFactory.initData(sourceData)
     tableEnv.registerFunction("my_udf", Func0)
@@ -421,7 +421,8 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |create table t1(
         |  a int,
         |  `time` varchar,
-        |  c as my_udf(a)
+        |  c as my_udf(a),
+        |  d as `time`
         |) with (
         |  'connector' = 'COLLECTION'
         |)
@@ -431,7 +432,8 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |create table t2(
         |  a int,
         |  `time` varchar,
-        |  c int not null
+        |  c int not null,
+        |  d varchar
         |) with (
         |  'connector' = 'COLLECTION'
         |)
@@ -439,7 +441,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     val query =
       """
         |insert into t2
-        |select t1.a, t1.`time`, t1.c from t1
+        |select t1.a, t1.`time`, t1.c, t1.d from t1
       """.stripMargin
     tableEnv.sqlUpdate(sourceDDL)
     tableEnv.sqlUpdate(sinkDDL)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -97,4 +97,27 @@ class TableScanTest extends TableTestBase {
        """.stripMargin)
     util.verifyPlan("SELECT * FROM t1")
   }
+
+  @Test
+  def testKeywordsWithWatermarkComputedColumn(): Unit = {
+    // Create table with field as atom expression.
+    util.tableEnv.registerFunction("my_udf", Func0)
+    util.addTable(
+      s"""
+         |create table t1(
+         |  a int,
+         |  b varchar,
+         |  `time` time,
+         |  mytime as `time`,
+         |  `current_time` as current_time,
+         |  json_row ROW<`timestamp` TIMESTAMP(3)>,
+         |  `timestamp` AS json_row.`timestamp`,
+         |  WATERMARK FOR `timestamp` AS `timestamp`
+         |) with (
+         |  'connector' = 'COLLECTION',
+         |  'is-bounded' = 'false'
+         |)
+       """.stripMargin)
+    util.verifyPlan("SELECT * FROM t1")
+  }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix parse exception when computed column expression references a keyword column name, e.g. 

```sql
json_row          ROW<`timestamp` BIGINT>,
`timestamp`   AS `json_row`.`timestamp`
```

## Brief change log

- Calcite does't quote `SqlIdentifier` in `SqlNode#toString`, so we can't use this method to get a quoted string.
- Use `SqlNode#toSqlString(dialect)` instead.

## Verifying this change

- Added a test in `TableScanTest` to cover this case.
- Update `CatalogTableITCase#testInsertSourceTableWithUserDefinedFuncField` to cover this case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
