### PR TITLE
[FLINK-16554][task] split StreamTask

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AsyncCheckpointRunnable.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.core.fs.FileSystemSafetyNet;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This runnable executes the asynchronous parts of all involved backend snapshots for the subtask.
+ */
+final class AsyncCheckpointRunnable implements Runnable, Closeable {
+
+	public static final Logger LOG = LoggerFactory.getLogger(AsyncCheckpointRunnable.class);
+	private final String taskName;
+	private final CloseableRegistry closeableRegistry;
+	private final Environment taskEnvironment;
+
+	private enum AsyncCheckpointState {
+		RUNNING,
+		DISCARDED,
+		COMPLETED
+	}
+
+	private final AsyncExceptionHandler asyncExceptionHandler;
+	private final Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress;
+	private final CheckpointMetaData checkpointMetaData;
+	private final CheckpointMetrics checkpointMetrics;
+	private final long asyncStartNanos;
+	private final AtomicReference<AsyncCheckpointState> asyncCheckpointState = new AtomicReference<>(AsyncCheckpointState.RUNNING);
+
+	AsyncCheckpointRunnable(
+			Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
+			CheckpointMetaData checkpointMetaData,
+			CheckpointMetrics checkpointMetrics,
+			long asyncStartNanos,
+			String taskName,
+			CloseableRegistry closeableRegistry,
+			Environment taskEnvironment,
+			AsyncExceptionHandler asyncExceptionHandler) {
+
+		this.operatorSnapshotsInProgress = checkNotNull(operatorSnapshotsInProgress);
+		this.checkpointMetaData = checkNotNull(checkpointMetaData);
+		this.checkpointMetrics = checkNotNull(checkpointMetrics);
+		this.asyncStartNanos = asyncStartNanos;
+		this.taskName = checkNotNull(taskName);
+		this.closeableRegistry = checkNotNull(closeableRegistry);
+		this.taskEnvironment = checkNotNull(taskEnvironment);
+		this.asyncExceptionHandler = checkNotNull(asyncExceptionHandler);
+	}
+
+	@Override
+	public void run() {
+		FileSystemSafetyNet.initializeSafetyNetForThread();
+		try {
+			closeableRegistry.registerCloseable(this);
+
+			TaskStateSnapshot jobManagerTaskOperatorSubtaskStates = new TaskStateSnapshot(operatorSnapshotsInProgress.size());
+			TaskStateSnapshot localTaskOperatorSubtaskStates = new TaskStateSnapshot(operatorSnapshotsInProgress.size());
+
+			for (Map.Entry<OperatorID, OperatorSnapshotFutures> entry : operatorSnapshotsInProgress.entrySet()) {
+
+				OperatorID operatorID = entry.getKey();
+				OperatorSnapshotFutures snapshotInProgress = entry.getValue();
+
+				// finalize the async part of all by executing all snapshot runnables
+				OperatorSnapshotFinalizer finalizedSnapshots =
+					new OperatorSnapshotFinalizer(snapshotInProgress);
+
+				jobManagerTaskOperatorSubtaskStates.putSubtaskStateByOperatorID(
+					operatorID,
+					finalizedSnapshots.getJobManagerOwnedState());
+
+				localTaskOperatorSubtaskStates.putSubtaskStateByOperatorID(
+					operatorID,
+					finalizedSnapshots.getTaskLocalState());
+			}
+
+			final long asyncEndNanos = System.nanoTime();
+			final long asyncDurationMillis = (asyncEndNanos - asyncStartNanos) / 1_000_000L;
+
+			checkpointMetrics.setAsyncDurationMillis(asyncDurationMillis);
+
+			if (asyncCheckpointState.compareAndSet(AsyncCheckpointState.RUNNING, AsyncCheckpointState.COMPLETED)) {
+
+				reportCompletedSnapshotStates(
+					jobManagerTaskOperatorSubtaskStates,
+					localTaskOperatorSubtaskStates,
+					asyncDurationMillis);
+
+			} else {
+				LOG.debug("{} - asynchronous part of checkpoint {} could not be completed because it was closed before.",
+					taskName,
+					checkpointMetaData.getCheckpointId());
+			}
+		} catch (Exception e) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("{} - asynchronous part of checkpoint {} could not be completed.",
+					taskName,
+					checkpointMetaData.getCheckpointId(),
+					e);
+			}
+			handleExecutionException(e);
+		} finally {
+			closeableRegistry.unregisterCloseable(this);
+			FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
+		}
+	}
+
+	private void reportCompletedSnapshotStates(
+		TaskStateSnapshot acknowledgedTaskStateSnapshot,
+		TaskStateSnapshot localTaskStateSnapshot,
+		long asyncDurationMillis) {
+
+		boolean hasAckState = acknowledgedTaskStateSnapshot.hasState();
+		boolean hasLocalState = localTaskStateSnapshot.hasState();
+
+		Preconditions.checkState(hasAckState || !hasLocalState,
+			"Found cached state but no corresponding primary state is reported to the job " +
+				"manager. This indicates a problem.");
+
+		// we signal stateless tasks by reporting null, so that there are no attempts to assign empty state
+		// to stateless tasks on restore. This enables simple job modifications that only concern
+		// stateless without the need to assign them uids to match their (always empty) states.
+		taskEnvironment.getTaskStateManager().reportTaskStateSnapshots(
+			checkpointMetaData,
+			checkpointMetrics,
+			hasAckState ? acknowledgedTaskStateSnapshot : null,
+			hasLocalState ? localTaskStateSnapshot : null);
+
+		LOG.debug("{} - finished asynchronous part of checkpoint {}. Asynchronous duration: {} ms",
+			taskName, checkpointMetaData.getCheckpointId(), asyncDurationMillis);
+
+		LOG.trace("{} - reported the following states in snapshot for checkpoint {}: {}.",
+			taskName, checkpointMetaData.getCheckpointId(), acknowledgedTaskStateSnapshot);
+	}
+
+	private void handleExecutionException(Exception e) {
+
+		boolean didCleanup = false;
+		AsyncCheckpointState currentState = asyncCheckpointState.get();
+
+		while (AsyncCheckpointState.DISCARDED != currentState) {
+
+			if (asyncCheckpointState.compareAndSet(currentState, AsyncCheckpointState.DISCARDED)) {
+
+				didCleanup = true;
+
+				try {
+					cleanup();
+				} catch (Exception cleanupException) {
+					e.addSuppressed(cleanupException);
+				}
+
+				Exception checkpointException = new Exception(
+					"Could not materialize checkpoint " + checkpointMetaData.getCheckpointId() + " for operator " +
+						taskName + '.',
+					e);
+
+				// We only report the exception for the original cause of fail and cleanup.
+				// Otherwise this followup exception could race the original exception in failing the task.
+				try {
+					taskEnvironment.declineCheckpoint(checkpointMetaData.getCheckpointId(), checkpointException);
+				} catch (Exception unhandled) {
+					AsynchronousException asyncException = new AsynchronousException(unhandled);
+					asyncExceptionHandler.handleAsyncException("Failure in asynchronous checkpoint materialization", asyncException);
+				}
+
+				currentState = AsyncCheckpointState.DISCARDED;
+			} else {
+				currentState = asyncCheckpointState.get();
+			}
+		}
+
+		if (!didCleanup) {
+			LOG.trace("Caught followup exception from a failed checkpoint thread. This can be ignored.", e);
+		}
+	}
+
+	@Override
+	public void close() {
+		if (asyncCheckpointState.compareAndSet(AsyncCheckpointState.RUNNING, AsyncCheckpointState.DISCARDED)) {
+
+			try {
+				cleanup();
+			} catch (Exception cleanupException) {
+				LOG.warn("Could not properly clean up the async checkpoint runnable.", cleanupException);
+			}
+		} else {
+			logFailedCleanupAttempt();
+		}
+	}
+
+	private void cleanup() throws Exception {
+		LOG.debug(
+			"Cleanup AsyncCheckpointRunnable for checkpoint {} of {}.",
+			checkpointMetaData.getCheckpointId(),
+			taskName);
+
+		Exception exception = null;
+
+		// clean up ongoing operator snapshot results and non partitioned state handles
+		for (OperatorSnapshotFutures operatorSnapshotResult : operatorSnapshotsInProgress.values()) {
+			if (operatorSnapshotResult != null) {
+				try {
+					operatorSnapshotResult.cancel();
+				} catch (Exception cancelException) {
+					exception = ExceptionUtils.firstOrSuppressed(cancelException, exception);
+				}
+			}
+		}
+
+		if (null != exception) {
+			throw exception;
+		}
+	}
+
+	private void logFailedCleanupAttempt() {
+		LOG.debug("{} - asynchronous checkpointing operation for checkpoint {} has " +
+				"already been completed. Thus, the state handles are not cleaned up.",
+			taskName,
+			checkpointMetaData.getCheckpointId());
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointingOperation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CheckpointingOperation.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+
+final class CheckpointingOperation {
+
+	public static final Logger LOG = LoggerFactory.getLogger(CheckpointingOperation.class);
+
+	static void execute(
+			CheckpointMetaData checkpointMetaData,
+			CheckpointOptions checkpointOptions,
+			CheckpointMetrics checkpointMetrics,
+			CheckpointStreamFactory storageLocation,
+			OperatorChain<?, ?> operatorChain,
+			String taskName,
+			CloseableRegistry closeableRegistry,
+			ExecutorService threadPool,
+			Environment environment,
+			AsyncExceptionHandler asyncExceptionHandler) throws Exception {
+
+		Preconditions.checkNotNull(checkpointMetaData);
+		Preconditions.checkNotNull(checkpointOptions);
+		Preconditions.checkNotNull(checkpointMetrics);
+		Preconditions.checkNotNull(storageLocation);
+		Preconditions.checkNotNull(operatorChain);
+		Preconditions.checkNotNull(closeableRegistry);
+		Preconditions.checkNotNull(threadPool);
+		Preconditions.checkNotNull(environment);
+		Preconditions.checkNotNull(asyncExceptionHandler);
+
+		long startSyncPartNano = System.nanoTime();
+
+		HashMap<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress = new HashMap<>(operatorChain.getNumberOfOperators());
+		try {
+			for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
+				StreamOperator<?> op = operatorWrapper.getStreamOperator();
+				OperatorSnapshotFutures snapshotInProgress = op.snapshotState(
+					checkpointMetaData.getCheckpointId(),
+					checkpointMetaData.getTimestamp(),
+					checkpointOptions,
+					storageLocation);
+				operatorSnapshotsInProgress.put(op.getOperatorID(), snapshotInProgress);
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Finished synchronous checkpoints for checkpoint {} on task {}",
+					checkpointMetaData.getCheckpointId(), taskName);
+			}
+
+			long startAsyncPartNano = System.nanoTime();
+
+			checkpointMetrics.setSyncDurationMillis((startAsyncPartNano - startSyncPartNano) / 1_000_000);
+
+			// we are transferring ownership over snapshotInProgressList for cleanup to the thread, active on submit
+			threadPool.execute(new AsyncCheckpointRunnable(
+				operatorSnapshotsInProgress,
+				checkpointMetaData,
+				checkpointMetrics,
+				startAsyncPartNano,
+				taskName,
+				closeableRegistry,
+				environment,
+				asyncExceptionHandler));
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("{} - finished synchronous part of checkpoint {}. " +
+						"Alignment duration: {} ms, snapshot duration {} ms",
+					taskName, checkpointMetaData.getCheckpointId(),
+					checkpointMetrics.getAlignmentDurationNanos() / 1_000_000,
+					checkpointMetrics.getSyncDurationMillis());
+			}
+		} catch (Exception ex) {
+			// Cleanup to release resources
+			for (OperatorSnapshotFutures operatorSnapshotResult : operatorSnapshotsInProgress.values()) {
+				if (null != operatorSnapshotResult) {
+					try {
+						operatorSnapshotResult.cancel();
+					} catch (Exception e) {
+						LOG.warn("Could not properly cancel an operator snapshot result.", e);
+					}
+				}
+			}
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("{} - did NOT finish synchronous part of checkpoint {}. " +
+						"Alignment duration: {} ms, snapshot duration {} ms",
+					taskName, checkpointMetaData.getCheckpointId(),
+					checkpointMetrics.getAlignmentDurationNanos() / 1_000_000,
+					checkpointMetrics.getSyncDurationMillis());
+			}
+
+			if (checkpointOptions.getCheckpointType().isSynchronous()) {
+				// in the case of a synchronous checkpoint, we always rethrow the exception,
+				// so that the task fails.
+				// this is because the intention is always to stop the job after this checkpointing
+				// operation, and without the failure, the task would go back to normal execution.
+				throw ex;
+			} else {
+				environment.declineCheckpoint(checkpointMetaData.getCheckpointId(), ex);
+			}
+		}
+	}
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.CloseableRegistry;
-import org.apache.flink.core.fs.FileSystemSafetyNet;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
@@ -30,7 +29,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
@@ -52,7 +50,6 @@ import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
-import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskmanager.DispatcherThreadFactory;
 import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.runtime.util.FatalExitExceptionHandler;
@@ -60,8 +57,6 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
-import org.apache.flink.streaming.api.operators.OperatorSnapshotFinalizer;
-import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializerImpl;
@@ -77,7 +72,6 @@ import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorFactory;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
-import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
@@ -87,9 +81,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.Closeable;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
@@ -99,7 +91,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Base class for all streaming tasks. A task is the unit of local processing that is deployed
@@ -928,14 +919,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 				checkpointMetaData.getCheckpointId(),
 				checkpointOptions.getTargetLocation());
 
-		CheckpointingOperation checkpointingOperation = new CheckpointingOperation(
-			this,
+		CheckpointingOperation.execute(
 			checkpointMetaData,
 			checkpointOptions,
+			checkpointMetrics,
 			storage,
-			checkpointMetrics);
-
-		checkpointingOperation.executeCheckpointing();
+			operatorChain,
+			getName(),
+			getCancelables(),
+			getAsyncOperationsThreadPool(),
+			getEnvironment(),
+			this);
 	}
 
 	// ------------------------------------------------------------------------
@@ -1053,344 +1047,11 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		}
 	}
 
-	/**
-	 * This runnable executes the asynchronous parts of all involved backend snapshots for the subtask.
-	 */
-	@VisibleForTesting
-	protected static final class AsyncCheckpointRunnable implements Runnable, Closeable {
-
-		private final StreamTask<?, ?> owner;
-
-		private final Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress;
-
-		private final CheckpointMetaData checkpointMetaData;
-		private final CheckpointMetrics checkpointMetrics;
-
-		private final long asyncStartNanos;
-
-		private final AtomicReference<CheckpointingOperation.AsyncCheckpointState> asyncCheckpointState = new AtomicReference<>(
-			CheckpointingOperation.AsyncCheckpointState.RUNNING);
-
-		AsyncCheckpointRunnable(
-			StreamTask<?, ?> owner,
-			Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
-			CheckpointMetaData checkpointMetaData,
-			CheckpointMetrics checkpointMetrics,
-			long asyncStartNanos) {
-
-			this.owner = Preconditions.checkNotNull(owner);
-			this.operatorSnapshotsInProgress = Preconditions.checkNotNull(operatorSnapshotsInProgress);
-			this.checkpointMetaData = Preconditions.checkNotNull(checkpointMetaData);
-			this.checkpointMetrics = Preconditions.checkNotNull(checkpointMetrics);
-			this.asyncStartNanos = asyncStartNanos;
-		}
-
-		@Override
-		public void run() {
-			FileSystemSafetyNet.initializeSafetyNetForThread();
-			try {
-
-				TaskStateSnapshot jobManagerTaskOperatorSubtaskStates =
-					new TaskStateSnapshot(operatorSnapshotsInProgress.size());
-
-				TaskStateSnapshot localTaskOperatorSubtaskStates =
-					new TaskStateSnapshot(operatorSnapshotsInProgress.size());
-
-				for (Map.Entry<OperatorID, OperatorSnapshotFutures> entry : operatorSnapshotsInProgress.entrySet()) {
-
-					OperatorID operatorID = entry.getKey();
-					OperatorSnapshotFutures snapshotInProgress = entry.getValue();
-
-					// finalize the async part of all by executing all snapshot runnables
-					OperatorSnapshotFinalizer finalizedSnapshots =
-						new OperatorSnapshotFinalizer(snapshotInProgress);
-
-					jobManagerTaskOperatorSubtaskStates.putSubtaskStateByOperatorID(
-						operatorID,
-						finalizedSnapshots.getJobManagerOwnedState());
-
-					localTaskOperatorSubtaskStates.putSubtaskStateByOperatorID(
-						operatorID,
-						finalizedSnapshots.getTaskLocalState());
-				}
-
-				final long asyncEndNanos = System.nanoTime();
-				final long asyncDurationMillis = (asyncEndNanos - asyncStartNanos) / 1_000_000L;
-
-				checkpointMetrics.setAsyncDurationMillis(asyncDurationMillis);
-
-				if (asyncCheckpointState.compareAndSet(CheckpointingOperation.AsyncCheckpointState.RUNNING,
-					CheckpointingOperation.AsyncCheckpointState.COMPLETED)) {
-
-					reportCompletedSnapshotStates(
-						jobManagerTaskOperatorSubtaskStates,
-						localTaskOperatorSubtaskStates,
-						asyncDurationMillis);
-
-				} else {
-					LOG.debug("{} - asynchronous part of checkpoint {} could not be completed because it was closed before.",
-						owner.getName(),
-						checkpointMetaData.getCheckpointId());
-				}
-			} catch (Exception e) {
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("{} - asynchronous part of checkpoint {} could not be completed.",
-						owner.getName(),
-						checkpointMetaData.getCheckpointId(),
-						e);
-				}
-				handleExecutionException(e);
-			} finally {
-				owner.cancelables.unregisterCloseable(this);
-				FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
-			}
-		}
-
-		private void reportCompletedSnapshotStates(
-			TaskStateSnapshot acknowledgedTaskStateSnapshot,
-			TaskStateSnapshot localTaskStateSnapshot,
-			long asyncDurationMillis) {
-
-			TaskStateManager taskStateManager = owner.getEnvironment().getTaskStateManager();
-
-			boolean hasAckState = acknowledgedTaskStateSnapshot.hasState();
-			boolean hasLocalState = localTaskStateSnapshot.hasState();
-
-			Preconditions.checkState(hasAckState || !hasLocalState,
-				"Found cached state but no corresponding primary state is reported to the job " +
-					"manager. This indicates a problem.");
-
-			// we signal stateless tasks by reporting null, so that there are no attempts to assign empty state
-			// to stateless tasks on restore. This enables simple job modifications that only concern
-			// stateless without the need to assign them uids to match their (always empty) states.
-			taskStateManager.reportTaskStateSnapshots(
-				checkpointMetaData,
-				checkpointMetrics,
-				hasAckState ? acknowledgedTaskStateSnapshot : null,
-				hasLocalState ? localTaskStateSnapshot : null);
-
-			LOG.debug("{} - finished asynchronous part of checkpoint {}. Asynchronous duration: {} ms",
-				owner.getName(), checkpointMetaData.getCheckpointId(), asyncDurationMillis);
-
-			LOG.trace("{} - reported the following states in snapshot for checkpoint {}: {}.",
-				owner.getName(), checkpointMetaData.getCheckpointId(), acknowledgedTaskStateSnapshot);
-		}
-
-		private void handleExecutionException(Exception e) {
-
-			boolean didCleanup = false;
-			CheckpointingOperation.AsyncCheckpointState currentState = asyncCheckpointState.get();
-
-			while (CheckpointingOperation.AsyncCheckpointState.DISCARDED != currentState) {
-
-				if (asyncCheckpointState.compareAndSet(
-					currentState,
-					CheckpointingOperation.AsyncCheckpointState.DISCARDED)) {
-
-					didCleanup = true;
-
-					try {
-						cleanup();
-					} catch (Exception cleanupException) {
-						e.addSuppressed(cleanupException);
-					}
-
-					Exception checkpointException = new Exception(
-						"Could not materialize checkpoint " + checkpointMetaData.getCheckpointId() + " for operator " +
-							owner.getName() + '.',
-						e);
-
-					// We only report the exception for the original cause of fail and cleanup.
-					// Otherwise this followup exception could race the original exception in failing the task.
-					try {
-						owner.getEnvironment().declineCheckpoint(checkpointMetaData.getCheckpointId(), checkpointException);
-					} catch (Exception unhandled) {
-						AsynchronousException asyncException = new AsynchronousException(unhandled);
-						owner.handleAsyncException("Failure in asynchronous checkpoint materialization", asyncException);
-					}
-
-					currentState = CheckpointingOperation.AsyncCheckpointState.DISCARDED;
-				} else {
-					currentState = asyncCheckpointState.get();
-				}
-			}
-
-			if (!didCleanup) {
-				LOG.trace("Caught followup exception from a failed checkpoint thread. This can be ignored.", e);
-			}
-		}
-
-		@Override
-		public void close() {
-			if (asyncCheckpointState.compareAndSet(
-				CheckpointingOperation.AsyncCheckpointState.RUNNING,
-				CheckpointingOperation.AsyncCheckpointState.DISCARDED)) {
-
-				try {
-					cleanup();
-				} catch (Exception cleanupException) {
-					LOG.warn("Could not properly clean up the async checkpoint runnable.", cleanupException);
-				}
-			} else {
-				logFailedCleanupAttempt();
-			}
-		}
-
-		private void cleanup() throws Exception {
-			LOG.debug(
-				"Cleanup AsyncCheckpointRunnable for checkpoint {} of {}.",
-				checkpointMetaData.getCheckpointId(),
-				owner.getName());
-
-			Exception exception = null;
-
-			// clean up ongoing operator snapshot results and non partitioned state handles
-			for (OperatorSnapshotFutures operatorSnapshotResult : operatorSnapshotsInProgress.values()) {
-				if (operatorSnapshotResult != null) {
-					try {
-						operatorSnapshotResult.cancel();
-					} catch (Exception cancelException) {
-						exception = ExceptionUtils.firstOrSuppressed(cancelException, exception);
-					}
-				}
-			}
-
-			if (null != exception) {
-				throw exception;
-			}
-		}
-
-		private void logFailedCleanupAttempt() {
-			LOG.debug("{} - asynchronous checkpointing operation for checkpoint {} has " +
-					"already been completed. Thus, the state handles are not cleaned up.",
-				owner.getName(),
-				checkpointMetaData.getCheckpointId());
-		}
-	}
-
 	public CloseableRegistry getCancelables() {
 		return cancelables;
 	}
 
 	// ------------------------------------------------------------------------
-
-	private static final class CheckpointingOperation {
-
-		private final StreamTask<?, ?> owner;
-
-		private final CheckpointMetaData checkpointMetaData;
-		private final CheckpointOptions checkpointOptions;
-		private final CheckpointMetrics checkpointMetrics;
-		private final CheckpointStreamFactory storageLocation;
-
-		private final OperatorChain<?, ?> operatorChain;
-
-		private long startSyncPartNano;
-		private long startAsyncPartNano;
-
-		// ------------------------
-
-		private final Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress;
-
-		public CheckpointingOperation(
-				StreamTask<?, ?> owner,
-				CheckpointMetaData checkpointMetaData,
-				CheckpointOptions checkpointOptions,
-				CheckpointStreamFactory checkpointStorageLocation,
-				CheckpointMetrics checkpointMetrics) {
-
-			this.owner = Preconditions.checkNotNull(owner);
-			this.checkpointMetaData = Preconditions.checkNotNull(checkpointMetaData);
-			this.checkpointOptions = Preconditions.checkNotNull(checkpointOptions);
-			this.checkpointMetrics = Preconditions.checkNotNull(checkpointMetrics);
-			this.storageLocation = Preconditions.checkNotNull(checkpointStorageLocation);
-			this.operatorChain = owner.operatorChain;
-			this.operatorSnapshotsInProgress = new HashMap<>(operatorChain.getNumberOfOperators());
-		}
-
-		public void executeCheckpointing() throws Exception {
-			startSyncPartNano = System.nanoTime();
-
-			try {
-				for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
-					checkpointStreamOperator(operatorWrapper.getStreamOperator());
-				}
-
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("Finished synchronous checkpoints for checkpoint {} on task {}",
-						checkpointMetaData.getCheckpointId(), owner.getName());
-				}
-
-				startAsyncPartNano = System.nanoTime();
-
-				checkpointMetrics.setSyncDurationMillis((startAsyncPartNano - startSyncPartNano) / 1_000_000);
-
-				// we are transferring ownership over snapshotInProgressList for cleanup to the thread, active on submit
-				AsyncCheckpointRunnable asyncCheckpointRunnable = new AsyncCheckpointRunnable(
-					owner,
-					operatorSnapshotsInProgress,
-					checkpointMetaData,
-					checkpointMetrics,
-					startAsyncPartNano);
-
-				owner.cancelables.registerCloseable(asyncCheckpointRunnable);
-				owner.asyncOperationsThreadPool.execute(asyncCheckpointRunnable);
-
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("{} - finished synchronous part of checkpoint {}. " +
-							"Alignment duration: {} ms, snapshot duration {} ms",
-						owner.getName(), checkpointMetaData.getCheckpointId(),
-						checkpointMetrics.getAlignmentDurationNanos() / 1_000_000,
-						checkpointMetrics.getSyncDurationMillis());
-				}
-			} catch (Exception ex) {
-				// Cleanup to release resources
-				for (OperatorSnapshotFutures operatorSnapshotResult : operatorSnapshotsInProgress.values()) {
-					if (null != operatorSnapshotResult) {
-						try {
-							operatorSnapshotResult.cancel();
-						} catch (Exception e) {
-							LOG.warn("Could not properly cancel an operator snapshot result.", e);
-						}
-					}
-				}
-
-				if (LOG.isDebugEnabled()) {
-					LOG.debug("{} - did NOT finish synchronous part of checkpoint {}. " +
-							"Alignment duration: {} ms, snapshot duration {} ms",
-						owner.getName(), checkpointMetaData.getCheckpointId(),
-						checkpointMetrics.getAlignmentDurationNanos() / 1_000_000,
-						checkpointMetrics.getSyncDurationMillis());
-				}
-
-				if (checkpointOptions.getCheckpointType().isSynchronous()) {
-					// in the case of a synchronous checkpoint, we always rethrow the exception,
-					// so that the task fails.
-					// this is because the intention is always to stop the job after this checkpointing
-					// operation, and without the failure, the task would go back to normal execution.
-					throw ex;
-				} else {
-					owner.getEnvironment().declineCheckpoint(checkpointMetaData.getCheckpointId(), ex);
-				}
-			}
-		}
-
-		@SuppressWarnings("deprecation")
-		private void checkpointStreamOperator(StreamOperator<?> op) throws Exception {
-				OperatorSnapshotFutures snapshotInProgress = op.snapshotState(
-						checkpointMetaData.getCheckpointId(),
-						checkpointMetaData.getTimestamp(),
-						checkpointOptions,
-						storageLocation);
-				operatorSnapshotsInProgress.put(op.getOperatorID(), snapshotInProgress);
-		}
-
-		private enum AsyncCheckpointState {
-			RUNNING,
-			DISCARDED,
-			COMPLETED
-		}
-	}
 
 	@VisibleForTesting
 	public static <OUT> RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> createRecordWriterDelegate(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -105,13 +105,15 @@ public class LocalStateForwardingTest extends TestLogger {
 		OperatorID operatorID = new OperatorID();
 		snapshots.put(operatorID, osFuture);
 
-		StreamTask.AsyncCheckpointRunnable checkpointRunnable =
-			new StreamTask.AsyncCheckpointRunnable(
-				testStreamTask,
-				snapshots,
-				checkpointMetaData,
-				checkpointMetrics,
-				0L);
+		AsyncCheckpointRunnable checkpointRunnable = new AsyncCheckpointRunnable(
+			snapshots,
+			checkpointMetaData,
+			checkpointMetrics,
+			0L,
+			testStreamTask.getName(),
+			testStreamTask.getCancelables(),
+			testStreamTask.getEnvironment(),
+			testStreamTask);
 
 		checkpointRunnable.run();
 


### PR DESCRIPTION
## What is the purpose of the change

`StreamTask` is currently 1400+ LOC.

We can cut it down to 1100+ by simply extracting these static classes into separate files:

`CheckpointingOperation`
`AsyncCheckpointRunnable`

This will also allow changing some checkpointing logic without touching `StreamTask`.

**NOTE**: The scope of the refactoring is intentionally small (because it's a sensitive part of the system).
**NOTE**: ~~some cleanup is in separate commits to ease reviewing (could be squashed before -merging)~~

## Brief change log

  - *extract `CheckpointingOperation` and `AsyncCheckpointRunnable` into separate files*
  - *don't pass StreamTask as a parameter*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
