### PR TITLE
[FLINK-11395][formats] Support for Avro StreamingFileSink

### DIFF
--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroBuilder.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroBuilder.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.avro.file.DataFileWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/**
+ * A builder to create an {@link AvroBulkWriter} from an {@link OutputStream}.
+ */
+@FunctionalInterface
+public interface AvroBuilder<T> extends Serializable {
+
+	/**
+	 * Creates and configures an Avro writer to the given output file.
+	 */
+	DataFileWriter<T> createWriter(OutputStream outputStream) throws IOException;
+
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroBulkWriter.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroBulkWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+
+import org.apache.avro.file.DataFileWriter;
+
+import java.io.IOException;
+
+/**
+ * A simple {@link BulkWriter} implementation that wraps an Avro {@link DataFileWriter}.
+ */
+public class AvroBulkWriter<T> implements BulkWriter<T> {
+
+	/** The underlying Avro writer. */
+	private final DataFileWriter<T> dataFileWriter;
+
+	/**
+	 * Create a new AvroBulkWriter wrapping the given Avro {@link DataFileWriter}.
+	 *
+	 * @param dataFileWriter The underlying Avro writer.
+	 */
+	public AvroBulkWriter(DataFileWriter<T> dataFileWriter) {
+		this.dataFileWriter = dataFileWriter;
+	}
+
+	@Override
+	public void addElement(T element) throws IOException {
+		dataFileWriter.append(element);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		dataFileWriter.flush();
+	}
+
+	@Override
+	public void finish() throws IOException {
+		dataFileWriter.close();
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroWriterFactory.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroWriterFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.FSDataOutputStream;
+
+import org.apache.avro.file.DataFileWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A factory that creates an {@link AvroBulkWriter}. The factory takes a user-supplied
+ * builder to assemble Parquet's writer and then turns it into a Flink {@code BulkWriter}.
+ *
+ * @param <T> The type of record to write.
+ */
+public class AvroWriterFactory<T> implements BulkWriter.Factory<T> {
+	private static final long serialVersionUID = 1L;
+
+	/** The builder to construct the Avro {@link DataFileWriter}. */
+	private final AvroBuilder<T> avroBuilder;
+
+	/**
+	 * Creates a new AvroWriterFactory using the given builder to assemble the
+	 * ParquetWriter.
+	 */
+	public AvroWriterFactory(AvroBuilder<T> avroBuilder) {
+		this.avroBuilder = avroBuilder;
+	}
+
+	@Override
+	public BulkWriter<T> create(FSDataOutputStream out) throws IOException {
+		return new AvroBulkWriter<>(avroBuilder.createWriter(new CloseShieldOutputStream(out)));
+	}
+
+	/**
+	 * Proxy output stream that prevents the underlying output stream from being closed.
+	 */
+	private static class CloseShieldOutputStream extends OutputStream {
+		private final OutputStream out;
+
+		public CloseShieldOutputStream(OutputStream out) {
+			this.out = out;
+		}
+
+		@Override
+		public void write(int b) throws IOException {
+			out.write(b);
+		}
+
+		@Override
+		public void write(byte[] buffer) throws IOException {
+			out.write(buffer);
+		}
+
+		@Override
+		public void write(byte[] buffer, int off, int len) throws IOException {
+			out.write(buffer, off, len);
+		}
+
+		@Override
+		public void flush() throws IOException {
+			out.flush();
+		}
+
+		@Override
+		public void close() throws IOException {
+			// we do not actually close the internal stream here to prevent that the finishing
+			// of the Avro Writer closes the target output stream.
+		}
+	}
+}

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroWriters.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroWriters.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.avro.specific.SpecificData;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
+import org.apache.avro.specific.SpecificRecordBase;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+/**
+ * Convenience builder to create {@link AvroWriterFactory} instances for the different Avro types.
+ */
+public class AvroWriters {
+
+	/**
+	 * A configurator to set the properties of the writer.
+	 */
+	public interface WriterConfigurator<T> extends Serializable {
+
+		/**
+		 * Modifies the properties of the writer.
+		 *
+		 * @param dataFileWriter The writer to modify.
+		 */
+		void configureWriter(DataFileWriter<T> dataFileWriter);
+
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} for an Avro specific type. The Avro writers
+	 * will use the schema of that specific type to build and write the records.
+	 *
+	 * @param type The class of the type to write.
+	 */
+	public static <T extends SpecificRecordBase> AvroWriterFactory<T> forSpecificRecord(Class<T> type) {
+		return forSpecificRecord(type, writer -> {});
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} for an Avro specific type and given <tt>configurator</tt>.
+	 * The Avro writers will use the schema of that specific type to build and write the records.
+	 *
+	 * @param type The class of the type to write.
+	 * @param configurator The configurator to modify the writer properties.
+	 */
+	public static <T extends SpecificRecordBase> AvroWriterFactory<T> forSpecificRecord(
+		Class<T> type,
+		WriterConfigurator<T> configurator) {
+
+		String schemaString = SpecificData.get().getSchema(type).toString();
+		AvroBuilder<T> builder = (out) -> createAvroDataFileWriter(
+			schemaString,
+			AvroRecordType.SPECIFIC,
+			configurator,
+			out);
+		return new AvroWriterFactory<>(builder);
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} that accepts and writes Avro generic types.
+	 * The Avro writers will use the given schema to build and write the records.
+	 *
+	 * @param schema The schema of the generic type.
+	 */
+	public static AvroWriterFactory<GenericRecord> forGenericRecord(Schema schema) {
+		return forGenericRecord(schema, writer -> {});
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} that accepts and writes Avro generic types
+	 * and given <tt>configurator</tt>. The Avro writers will use the given schema to
+	 * build and write the records.
+	 *
+	 * @param schema The schema of the generic type.
+	 * @param configurator The configurator to modify the writer properties.
+	 */
+	public static AvroWriterFactory<GenericRecord> forGenericRecord(
+		Schema schema,
+		WriterConfigurator<GenericRecord> configurator) {
+
+		String schemaString = schema.toString();
+		AvroBuilder<GenericRecord> builder = (out) -> createAvroDataFileWriter(
+			schemaString,
+			AvroRecordType.GENERIC,
+			configurator,
+			out);
+		return new AvroWriterFactory<>(builder);
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} for the given type. The Avro writers will
+	 * use reflection to create the schema for the type and use that schema to write
+	 * the records.
+	 *
+	 * @param type The class of the type to write.
+	 */
+	public static <T> AvroWriterFactory<T> forReflectRecord(Class<T> type) {
+		return forReflectRecord(type, writer -> {});
+	}
+
+	/**
+	 * Creates an {@link AvroWriterFactory} for the given type and given <tt>configurator</tt>.
+	 * The Avro writers will use reflection to create the schema for the type and use that schema
+	 * to write the records.
+	 *
+	 * @param type The class of the type to write.
+	 * @param configurator The configurator to modify the writer properties.
+	 */
+	public static <T> AvroWriterFactory<T> forReflectRecord(
+		Class<T> type,
+		WriterConfigurator<T> configurator) {
+
+		String schemaString = ReflectData.get().getSchema(type).toString();
+		AvroBuilder<T> builder = (out) -> createAvroDataFileWriter(
+			schemaString,
+			AvroRecordType.REFLECT,
+			configurator,
+			out);
+		return new AvroWriterFactory<>(builder);
+	}
+
+	private static <T> DataFileWriter<T> createAvroDataFileWriter(
+		String schemaString,
+		AvroRecordType recordType,
+		WriterConfigurator<T> configurator,
+		OutputStream out) throws IOException {
+
+		Schema schema = new Schema.Parser().parse(schemaString);
+		DatumWriter<T> datumWriter = null;
+
+		switch (recordType) {
+			case SPECIFIC:
+				datumWriter = new SpecificDatumWriter<>(schema);
+				break;
+			case GENERIC:
+				datumWriter = new GenericDatumWriter<>(schema);
+				break;
+			case REFLECT:
+				datumWriter = new ReflectDatumWriter<>(schema);
+				break;
+		}
+
+		DataFileWriter<T> dataFileWriter = new DataFileWriter<>(datumWriter);
+		configurator.configureWriter(dataFileWriter);
+		dataFileWriter.create(schema, out);
+		return dataFileWriter;
+	}
+
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The type of the avro record.
+	 */
+	private enum AvroRecordType {
+		/**
+		 * The record type is subclass of {@link SpecificRecord}, which is usually generated
+		 * from .avro files.
+		 */
+		SPECIFIC,
+
+		/** The record uses {@link GenericRecord} directly. */
+		GENERIC,
+
+		/** The record is of arbitrary type and its schema is deducted with reflection. */
+		REFLECT
+	}
+
+	/** Class is not meant to be instantiated. */
+	private AvroWriters() {}
+}

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroStreamingFileSinkITCase.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.typeutils.GenericRecordAvroTypeInfo;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.util.FiniteTestSource;
+import org.apache.flink.test.util.AbstractTestBase;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.reflect.ReflectDatumReader;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Simple integration test case for writing bulk encoded files with the
+ * {@link StreamingFileSink} with Avro.
+ */
+@RunWith(Parameterized.class)
+public class AvroStreamingFileSinkITCase extends AbstractTestBase {
+
+	/** Whether the writer use compression. */
+	private final boolean compression;
+
+	public AvroStreamingFileSinkITCase(boolean compression) {
+		this.compression = compression;
+	}
+
+	@Parameterized.Parameters(name = "compression = {0}")
+	public static Collection<Object[]> testReadOnlyBuffer() {
+		return Arrays.asList(new Object[][]{
+			{true},
+			{false},
+		});
+	}
+
+	@Rule
+	public final Timeout timeoutPerTest = Timeout.seconds(20);
+
+	@Test
+	public void testWriteAvroSpecific() throws Exception {
+		File folder = TEMPORARY_FOLDER.newFolder();
+
+		List<Address> data = Arrays.asList(
+			new Address(1, "a", "b", "c", "12345"),
+			new Address(2, "p", "q", "r", "12345"),
+			new Address(3, "x", "y", "z", "12345"));
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.enableCheckpointing(100);
+
+		AvroWriterFactory<Address> avroWriterFactory;
+		if (!compression) {
+			avroWriterFactory = AvroWriters.forSpecificRecord(Address.class);
+		} else {
+			avroWriterFactory = AvroWriters.forSpecificRecord(
+				Address.class,
+				writer -> writer.setCodec(CodecFactory.deflateCodec(CodecFactory.DEFAULT_DEFLATE_LEVEL)));
+		}
+
+		DataStream<Address> stream = env.addSource(
+			new FiniteTestSource<>(data),
+			TypeInformation.of(Address.class));
+		stream.addSink(StreamingFileSink.forBulkFormat(
+			Path.fromLocalFile(folder),
+			avroWriterFactory).build());
+
+		env.execute();
+
+		validateResults(folder, new SpecificDatumReader<>(Address.class), data);
+	}
+
+	@Test
+	public void testWriteAvroGeneric() throws Exception {
+		File folder = TEMPORARY_FOLDER.newFolder();
+
+		Schema schema = Address.getClassSchema();
+		Collection<GenericRecord> data = new GenericTestDataCollection();
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.enableCheckpointing(100);
+
+		AvroWriterFactory<GenericRecord> avroWriterFactory;
+		if (!compression) {
+			avroWriterFactory = AvroWriters.forGenericRecord(schema);
+		} else {
+			avroWriterFactory = AvroWriters.forGenericRecord(
+				schema,
+				writer -> writer.setCodec(CodecFactory.deflateCodec(CodecFactory.DEFAULT_DEFLATE_LEVEL)));
+		}
+
+		DataStream<GenericRecord> stream = env.addSource(
+			new FiniteTestSource<>(data),
+			new GenericRecordAvroTypeInfo(schema));
+		stream.addSink(StreamingFileSink.forBulkFormat(
+			Path.fromLocalFile(folder),
+			avroWriterFactory).build());
+
+		env.execute();
+
+		validateResults(folder, new GenericDatumReader<>(schema), new ArrayList<>(data));
+	}
+
+	@Test
+	public void testWriteAvroReflect() throws Exception {
+		File folder = TEMPORARY_FOLDER.newFolder();
+
+		List<Datum> data = Arrays.asList(
+			new Datum("a", 1),
+			new Datum("b", 2),
+			new Datum("c", 3));
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		env.enableCheckpointing(100);
+
+		AvroWriterFactory<Datum> avroWriterFactory;
+		if (!compression) {
+			avroWriterFactory = AvroWriters.forReflectRecord(Datum.class);
+		} else {
+			avroWriterFactory = AvroWriters.forReflectRecord(
+				Datum.class,
+				writer -> writer.setCodec(CodecFactory.deflateCodec(CodecFactory.DEFAULT_DEFLATE_LEVEL)));
+		}
+
+		DataStream<Datum> stream = env.addSource(
+			new FiniteTestSource<>(data),
+			TypeInformation.of(Datum.class));
+		stream.addSink(StreamingFileSink.forBulkFormat(
+			Path.fromLocalFile(folder),
+			avroWriterFactory).build());
+
+		env.execute();
+
+		validateResults(folder, new ReflectDatumReader<>(Datum.class), data);
+	}
+
+	// ------------------------------------------------------------------------
+
+	private static <T> void validateResults(File folder, DatumReader<T> datumReader, List<T> expected) throws Exception {
+		File[] buckets = folder.listFiles();
+		assertNotNull(buckets);
+		assertEquals(1, buckets.length);
+
+		File[] partFiles = buckets[0].listFiles();
+		assertNotNull(partFiles);
+		assertEquals(2, partFiles.length);
+
+		for (File partFile : partFiles) {
+			assertTrue(partFile.length() > 0);
+
+			final List<T> fileContent = readAvroFile(partFile, datumReader);
+			assertEquals(expected, fileContent);
+		}
+	}
+
+	private static <T> List<T> readAvroFile(File file, DatumReader<T> datumReader) throws IOException {
+		ArrayList<T> results = new ArrayList<>();
+
+		try (DataFileReader<T> dataFileReader = new DataFileReader<>(file, datumReader)) {
+			while (dataFileReader.hasNext()) {
+				results.add(dataFileReader.next());
+			}
+		}
+
+		return results;
+	}
+
+	private static class GenericTestDataCollection extends AbstractCollection<GenericRecord> implements Serializable {
+
+		@Override
+		public Iterator<GenericRecord> iterator() {
+			final GenericRecord rec1 = new GenericData.Record(Address.getClassSchema());
+			rec1.put(0, 1);
+			rec1.put(1, "a");
+			rec1.put(2, "b");
+			rec1.put(3, "c");
+			rec1.put(4, "12345");
+
+			final GenericRecord rec2 = new GenericData.Record(Address.getClassSchema());
+			rec2.put(0, 2);
+			rec2.put(1, "x");
+			rec2.put(2, "y");
+			rec2.put(3, "z");
+			rec2.put(4, "98765");
+
+			return Arrays.asList(rec1, rec2).iterator();
+		}
+
+		@Override
+		public int size() {
+			return 2;
+		}
+	}
+
+	// ------------------------------------------------------------------------
+
+	/** Test datum. */
+	public static class Datum implements Serializable {
+
+		public String a;
+		public int b;
+
+		public Datum() {}
+
+		public Datum(String a, int b) {
+			this.a = a;
+			this.b = b;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+
+			Datum datum = (Datum) o;
+			return b == datum.b && (a != null ? a.equals(datum.a) : datum.a == null);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = a != null ? a.hashCode() : 0;
+			result = 31 * result + b;
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR supports Avro writers to the StreamingFileSink.

## Brief change log

  - f5daa5c0432bbc64add6d302841f26e9d919ce98 add the avro writer.


## Verifying this change

  - Added unit test to verify the Avro writer creates right files.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
