### PR TITLE
[FLINK-16541][doc] Fix document of table.exec.shuffle-mode

### DIFF
--- a/docs/_includes/generated/execution_config_configuration.html
+++ b/docs/_includes/generated/execution_config_configuration.html
@@ -56,9 +56,9 @@ By default no operator is disabled.</td>
             <td><h5>table.exec.shuffle-mode</h5><br> <span class="label label-primary">Batch</span></td>
             <td style="word-wrap: break-word;">"batch"</td>
             <td>String</td>
-            <td>Sets exec shuffle mode. Only batch or pipeline can be set.
+            <td>Sets exec shuffle mode. Only batch or pipelined can be set.
 batch: the job will run stage by stage. 
-pipeline: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when the sender holds resource to wait to send data to the receiver.</td>
+pipelined: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when the sender holds resource to wait to send data to the receiver.</td>
         </tr>
         <tr>
             <td><h5>table.exec.sort.async-merge-enabled</h5><br> <span class="label label-primary">Batch</span></td>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -217,8 +217,8 @@ public class ExecutionConfigOptions {
 	public static final ConfigOption<String> TABLE_EXEC_SHUFFLE_MODE =
 		key("table.exec.shuffle-mode")
 			.defaultValue("batch")
-			.withDescription("Sets exec shuffle mode. Only batch or pipeline can be set.\n" +
+			.withDescription("Sets exec shuffle mode. Only batch or pipelined can be set.\n" +
 				"batch: the job will run stage by stage. \n" +
-				"pipeline: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when " +
+				"pipelined: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when " +
 				"the sender holds resource to wait to send data to the receiver.");
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the document of the `table.exec.shuffle-mode` table config.

## Brief change log

 - Change `pipeline` option to `pipelined` in the document.