### PR TITLE
[FLINK-16573] Ensure Kinesis RecordFetcher threads shutdown on cancel

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/RecordEmitter.java
@@ -205,6 +205,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						}
 					}
 				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
+				}
 			}
 
 			// wait until ready to emit min or another queue receives elements
@@ -222,6 +226,10 @@ public abstract class RecordEmitter<T extends TimestampedValue> implements Runna
 						min = null;
 						continue runLoop;
 					}
+				}
+				if (!running) {
+					// Make sure we can exit this loop so the thread can shut down
+					break runLoop;
 				}
 			}
 


### PR DESCRIPTION


## What is the purpose of the change

Ensure that the Kinesis RecordFetcher threads shut down on cancel.

The threads may not shut down correctly because they do not check for the
running flag in the inner loops. The threads also do not get interrupted because
they are not connected to the main task thread.

These threads keep lingering around after the job has shut down:

```
Thread 23168: (state = BLOCKED)
 - java.lang.Object.wait(long) @bci=0 (Compiled frame; information may be imprecise)
 - org.apache.flink.streaming.connectors.kinesis.util.RecordEmitter.emitRecords() @bci=140, line=209 (Compiled frame)
 - org.apache.flink.streaming.connectors.kinesis.util.RecordEmitter.run() @bci=18, line=177 (Interpreted frame)
 - java.lang.Thread.run() @bci=11, line=748 (Compiled frame)
```

## Brief change log

- Check for the `running` flag in the inner loops which showed up in the stack traces we took

## Verifying this change

I'm going to verify this change on a cluster.
