### PR TITLE
[FLINK-16501][sql] Support IS JSON predication for Table API in blink…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -43,6 +43,7 @@ import static org.apache.flink.table.expressions.ApiExpressionUtils.toMonthInter
 import static org.apache.flink.table.expressions.ApiExpressionUtils.typeLiteral;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedCall;
 import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.IS_NOT_JSON_ARRAY;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 //CHECKSTYLE.OFF: AvoidStarImport|ImportOrder
@@ -1279,6 +1280,38 @@ public abstract class BaseExpressions<InType, OutType> {
 	 */
 	public OutType sha2(InType hashLength) {
 		return toApiSpecificExpression(unresolvedCall(SHA2, toExpr(), objectToExpression(hashLength)));
+	}
+
+	public OutType isJsonValue() {
+		return toApiSpecificExpression(unresolvedCall(IS_JSON_VALUE, toExpr()));
+	}
+
+	public OutType isJsonObject() {
+		return toApiSpecificExpression(unresolvedCall(IS_JSON_OBJECT, toExpr()));
+	}
+
+	public OutType isJsonArray() {
+		return toApiSpecificExpression(unresolvedCall(IS_JSON_ARRAY, toExpr()));
+	}
+
+	public OutType isJsonScalar() {
+		return toApiSpecificExpression(unresolvedCall(IS_JSON_SCALAR, toExpr()));
+	}
+
+	public OutType isNotJsonValue() {
+		return toApiSpecificExpression(unresolvedCall(IS_NOT_JSON_VALUE, toExpr()));
+	}
+
+	public OutType isNotJsonObject() {
+		return toApiSpecificExpression(unresolvedCall(IS_NOT_JSON_OBJECT, toExpr()));
+	}
+
+	public OutType isNotJsonArray() {
+		return toApiSpecificExpression(unresolvedCall(IS_NOT_JSON_ARRAY, toExpr()));
+	}
+
+	public OutType isNotJsonScalar() {
+		return toApiSpecificExpression(unresolvedCall(IS_NOT_JSON_SCALAR, toExpr()));
 	}
 }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -896,6 +896,63 @@ public final class BuiltInFunctionDefinitions {
 			.outputTypeStrategy(TypeStrategies.MISSING)
 			.build();
 
+	// json
+	public static final BuiltInFunctionDefinition IS_JSON_VALUE =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isJsonValue")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_JSON_OBJECT =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isJsonObject")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_JSON_ARRAY =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isJsonArray")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_JSON_SCALAR =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isJsonScalar")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_NOT_JSON_VALUE =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isNotJsonValue")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_NOT_JSON_OBJECT =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isNotJsonObject")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_NOT_JSON_ARRAY =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isNotJsonArray")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
+	public static final BuiltInFunctionDefinition IS_NOT_JSON_SCALAR =
+		new BuiltInFunctionDefinition.Builder()
+			.name("isNotJsonScalar")
+			.kind(SCALAR)
+			.outputTypeStrategy(TypeStrategies.MISSING)
+			.build();
+
 	public static final Set<FunctionDefinition> WINDOW_PROPERTIES = new HashSet<>(Arrays.asList(
 		WINDOW_START, WINDOW_END, PROCTIME, ROWTIME
 	));

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -148,6 +148,24 @@ public class DirectConvertRule implements CallExpressionConvertRule {
 		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.SHA1, FlinkSqlOperatorTable.SHA1);
 		DEFINITION_OPERATOR_MAP.put(
 			BuiltInFunctionDefinitions.STREAM_RECORD_TIMESTAMP, FlinkSqlOperatorTable.STREAMRECORD_TIMESTAMP);
+
+		// json functions
+		DEFINITION_OPERATOR_MAP
+			.put(BuiltInFunctionDefinitions.IS_JSON_VALUE, FlinkSqlOperatorTable.IS_JSON_VALUE);
+		DEFINITION_OPERATOR_MAP
+			.put(BuiltInFunctionDefinitions.IS_JSON_OBJECT, FlinkSqlOperatorTable.IS_JSON_OBJECT);
+		DEFINITION_OPERATOR_MAP
+			.put(BuiltInFunctionDefinitions.IS_JSON_ARRAY, FlinkSqlOperatorTable.IS_JSON_ARRAY);
+		DEFINITION_OPERATOR_MAP
+			.put(BuiltInFunctionDefinitions.IS_JSON_SCALAR, FlinkSqlOperatorTable.IS_JSON_SCALAR);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.IS_NOT_JSON_VALUE,
+			FlinkSqlOperatorTable.IS_NOT_JSON_VALUE);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.IS_NOT_JSON_OBJECT,
+			FlinkSqlOperatorTable.IS_NOT_JSON_OBJECT);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.IS_NOT_JSON_ARRAY,
+			FlinkSqlOperatorTable.IS_NOT_JSON_ARRAY);
+		DEFINITION_OPERATOR_MAP.put(BuiltInFunctionDefinitions.IS_NOT_JSON_SCALAR,
+			FlinkSqlOperatorTable.IS_NOT_JSON_SCALAR);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/PlannerExpressionConverter.scala
@@ -708,6 +708,12 @@ class PlannerExpressionConverter private extends ApiExpressionVisitor[PlannerExp
             assert(args.isEmpty)
             StreamRecordTimestamp()
 
+          case IS_JSON_VALUE | IS_JSON_OBJECT | IS_JSON_ARRAY
+               | IS_JSON_SCALAR | IS_NOT_JSON_VALUE | IS_NOT_JSON_OBJECT
+               | IS_NOT_JSON_ARRAY | IS_NOT_JSON_SCALAR =>
+            assert(args.size == 1)
+            JsonPredicates(fd.toString, args.head)
+
           case _ =>
             throw new TableException(s"Unsupported function definition: $fd")
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/jsonExpressions.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/jsonExpressions.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.expressions
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo._
+import org.apache.flink.api.common.typeinfo.TypeInformation
+
+case class JsonPredicates(funName: String, child: PlannerExpression)
+  extends UnaryExpression with InputTypeSpec {
+
+  override private[flink] def resultType: TypeInformation[_] = BOOLEAN_TYPE_INFO
+
+  override private[flink] def children: Seq[PlannerExpression] = Seq(child)
+
+  override private[flink] def expectedTypes: Seq[TypeInformation[_]] = Seq(STRING_TYPE_INFO)
+
+  override def toString: String = s"($child).$funName()"
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/JsonFunctionsTest.scala
@@ -91,7 +91,9 @@ class JsonFunctionsTest extends ExpressionTestBase {
    * @param expectedValues array of expected values as result of
    *                       (IS_JSON_VALUE, IS_JSON_OBJECT, IS_JSON_ARRAY, IS_JSON_SCALAR)
    */
-  private def verifyPredicates(candidate: String, expr: Expression, expectedValues: Array[Boolean]): Unit = {
+  private def verifyPredicates(candidate: String,
+     expr: Expression,
+     expectedValues: Array[Boolean]): Unit = {
     assert(expectedValues.length == 4)
 
     testAllApis(


### PR DESCRIPTION
## What is the purpose of the change

Support IS JSON predication for Table API in blink planner

`IS_JSON_VALUE`
`IS_JSON_OBJECT`
`IS_JSON_ARRAY`
`IS_JSON_SCALAR`
`IS_NOT_JSON_VALUE`
`IS_NOT_JSON_OBJECT`
`IS_NOT_JSON_ARRAY`
`IS_NOT_JSON_SCALAR`

## Brief change log

*(for example:)*

- Introduce IS JSON predicates to `BuiltInFunctionDefinitions.java` and `BaseExpressions.java `
- Implement supporting generation logic, including a new `jsonExpressions.scala`
- Add corresponding test cases

## Verifying this change

*(Please pick either of the following options)*

This change added tests in `JsonFunctionsTest.scala` 

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (100MB)*
- *Extended integration test for recovery after master (JobManager) failure*
- *Added test that validates that TaskInfo is transferred only once across recoveries*
- *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / no)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
- The serializers: (yes / no / don't know)
- The runtime per-record code paths (performance sensitive): (yes / no / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
- The S3 file system connector: (yes / no / don't know)

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)