### PR TITLE
[FLINK-16586][network] Build ResultSubpartitionInfo and InputChannelInfo in respective constructors

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptor.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * A task deployment descriptor contains all the information necessary to deploy a task on a task manager.
@@ -134,10 +134,10 @@ public final class TaskDeploymentDescriptor implements Serializable {
 	private final int attemptNumber;
 
 	/** The list of produced intermediate result partition deployment descriptors. */
-	private final Collection<ResultPartitionDeploymentDescriptor> producedPartitions;
+	private final List<ResultPartitionDeploymentDescriptor> producedPartitions;
 
 	/** The list of consumed intermediate result partitions. */
-	private final Collection<InputGateDeploymentDescriptor> inputGates;
+	private final List<InputGateDeploymentDescriptor> inputGates;
 
 	/** Slot number to run the sub task in on the target machine. */
 	private final int targetSlotNumber;
@@ -156,8 +156,8 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		int attemptNumber,
 		int targetSlotNumber,
 		@Nullable JobManagerTaskRestore taskRestore,
-		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
-		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+		List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
+		List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 
 		this.jobId = Preconditions.checkNotNull(jobId);
 
@@ -256,11 +256,11 @@ public final class TaskDeploymentDescriptor implements Serializable {
 		return targetSlotNumber;
 	}
 
-	public Collection<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
+	public List<ResultPartitionDeploymentDescriptor> getProducedPartitions() {
 		return producedPartitions;
 	}
 
-	public Collection<InputGateDeploymentDescriptor> getInputGates() {
+	public List<InputGateDeploymentDescriptor> getInputGates() {
 		return inputGates;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -185,14 +186,15 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 	@Override
 	public Collection<ResultPartition> createResultPartitionWriters(
 			ShuffleIOOwnerContext ownerContext,
-			Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
+			List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
 		synchronized (lock) {
 			Preconditions.checkState(!isClosed, "The NettyShuffleEnvironment has already been shut down.");
 
 			ResultPartition[] resultPartitions = new ResultPartition[resultPartitionDeploymentDescriptors.size()];
 			int counter = 0;
 			for (ResultPartitionDeploymentDescriptor rpdd : resultPartitionDeploymentDescriptors) {
-				resultPartitions[counter++] = resultPartitionFactory.create(ownerContext.getOwnerName(), rpdd);
+				resultPartitions[counter] = resultPartitionFactory.create(ownerContext.getOwnerName(), counter, rpdd);
+				counter++;
 			}
 
 			registerOutputMetrics(config.isNetworkDetailedMetrics(), ownerContext.getOutputGroup(), resultPartitions);
@@ -204,7 +206,7 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 	public Collection<SingleInputGate> createInputGates(
 			ShuffleIOOwnerContext ownerContext,
 			PartitionProducerStateProvider partitionProducerStateProvider,
-			Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+			List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 		synchronized (lock) {
 			Preconditions.checkState(!isClosed, "The NettyShuffleEnvironment has already been shut down.");
 
@@ -217,6 +219,7 @@ public class NettyShuffleEnvironment implements ShuffleEnvironment<ResultPartiti
 			for (InputGateDeploymentDescriptor igdd : inputGateDeploymentDescriptors) {
 				SingleInputGate inputGate = singleInputGateFactory.create(
 					ownerContext.getOwnerName(),
+					counter,
 					igdd,
 					partitionProducerStateProvider,
 					inputChannelMetrics);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ReleaseOnConsumptionResultPartition.java
@@ -48,6 +48,7 @@ public class ReleaseOnConsumptionResultPartition extends ResultPartition {
 
 	ReleaseOnConsumptionResultPartition(
 			String owningTaskName,
+			int partitionIndex,
 			ResultPartitionID partitionId,
 			ResultPartitionType partitionType,
 			ResultSubpartition[] subpartitions,
@@ -57,6 +58,7 @@ public class ReleaseOnConsumptionResultPartition extends ResultPartition {
 			FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 		super(
 			owningTaskName,
+			partitionIndex,
 			partitionId,
 			partitionType,
 			subpartitions,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.FunctionWithException;
 
 import org.slf4j.Logger;
@@ -76,6 +77,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 	private final String owningTaskName;
 
+	private final int partitionIndex;
+
 	protected final ResultPartitionID partitionId;
 
 	/** Type of this partition. Defines the concrete subpartition implementation to use. */
@@ -106,6 +109,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 	public ResultPartition(
 		String owningTaskName,
+		int partitionIndex,
 		ResultPartitionID partitionId,
 		ResultPartitionType partitionType,
 		ResultSubpartition[] subpartitions,
@@ -115,6 +119,8 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		FunctionWithException<BufferPoolOwner, BufferPool, IOException> bufferPoolFactory) {
 
 		this.owningTaskName = checkNotNull(owningTaskName);
+		Preconditions.checkArgument(0 <= partitionIndex, "The partition index must be positive.");
+		this.partitionIndex = partitionIndex;
 		this.partitionId = checkNotNull(partitionId);
 		this.partitionType = checkNotNull(partitionType);
 		this.subpartitions = checkNotNull(subpartitions);
@@ -150,6 +156,10 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 	public ResultPartitionID getPartitionId() {
 		return partitionId;
+	}
+
+	int getPartitionIndex() {
+		return partitionIndex;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -90,9 +90,11 @@ public class ResultPartitionFactory {
 
 	public ResultPartition create(
 			String taskNameWithSubtaskAndId,
+			int partitionIndex,
 			ResultPartitionDeploymentDescriptor desc) {
 		return create(
 			taskNameWithSubtaskAndId,
+			partitionIndex,
 			desc.getShuffleDescriptor().getResultPartitionID(),
 			desc.getPartitionType(),
 			desc.getNumberOfSubpartitions(),
@@ -103,6 +105,7 @@ public class ResultPartitionFactory {
 	@VisibleForTesting
 	public ResultPartition create(
 			String taskNameWithSubtaskAndId,
+			int partitionIndex,
 			ResultPartitionID id,
 			ResultPartitionType type,
 			int numberOfSubpartitions,
@@ -117,6 +120,7 @@ public class ResultPartitionFactory {
 		ResultPartition partition = forcePartitionReleaseOnConsumption || !type.isBlocking()
 			? new ReleaseOnConsumptionResultPartition(
 				taskNameWithSubtaskAndId,
+				partitionIndex,
 				id,
 				type,
 				subpartitions,
@@ -126,6 +130,7 @@ public class ResultPartitionFactory {
 				bufferPoolFactory)
 			: new ResultPartition(
 				taskNameWithSubtaskAndId,
+				partitionIndex,
 				id,
 				type,
 				subpartitions,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 
@@ -34,6 +35,9 @@ public abstract class ResultSubpartition {
 	/** The index of the subpartition at the parent partition. */
 	protected final int index;
 
+	/** The info of the subpartition to identify it globally within a task. */
+	protected final ResultSubpartitionInfo subpartitionInfo;
+
 	/** The parent partition this subpartition belongs to. */
 	protected final ResultPartition parent;
 
@@ -42,6 +46,7 @@ public abstract class ResultSubpartition {
 	public ResultSubpartition(int index, ResultPartition parent) {
 		this.index = index;
 		this.parent = parent;
+		this.subpartitionInfo = new ResultSubpartitionInfo(parent.getPartitionIndex(), index);
 	}
 
 	/**
@@ -50,6 +55,11 @@ public abstract class ResultSubpartition {
 	 */
 	protected boolean canBeCompressed(Buffer buffer) {
 		return parent.bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
+	}
+
+	@VisibleForTesting
+	ResultSubpartitionInfo getSubpartitionInfo() {
+		return subpartitionInfo;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -46,6 +48,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class InputChannel {
 
 	protected final int channelIndex;
+
+	/** The info of the input channel to identify it globally within a task. */
+	protected final InputChannelInfo channelInfo;
 
 	protected final ResultPartitionID partitionId;
 
@@ -88,6 +93,7 @@ public abstract class InputChannel {
 
 		this.inputGate = checkNotNull(inputGate);
 		this.channelIndex = channelIndex;
+		this.channelInfo = new InputChannelInfo(inputGate.getGateIndex(), channelIndex);
 		this.partitionId = checkNotNull(partitionId);
 
 		this.initialBackoff = initial;
@@ -104,6 +110,11 @@ public abstract class InputChannel {
 
 	int getChannelIndex() {
 		return channelIndex;
+	}
+
+	@VisibleForTesting
+	InputChannelInfo getChannelInfo() {
+		return channelInfo;
 	}
 
 	public ResultPartitionID getPartitionId() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.SupplierWithException;
 
 import org.slf4j.Logger;
@@ -109,6 +110,8 @@ public class SingleInputGate extends InputGate {
 	/** The name of the owning task, for logging purposes. */
 	private final String owningTaskName;
 
+	private final int gateIndex;
+
 	/**
 	 * The ID of the consumed intermediate result. Each input gate consumes partitions of the
 	 * intermediate result specified by this ID. This ID also identifies the input gate at the
@@ -175,6 +178,7 @@ public class SingleInputGate extends InputGate {
 
 	public SingleInputGate(
 		String owningTaskName,
+		int gateIndex,
 		IntermediateDataSetID consumedResultId,
 		final ResultPartitionType consumedPartitionType,
 		int consumedSubpartitionIndex,
@@ -184,6 +188,8 @@ public class SingleInputGate extends InputGate {
 		@Nullable BufferDecompressor bufferDecompressor) {
 
 		this.owningTaskName = checkNotNull(owningTaskName);
+		Preconditions.checkArgument(0 <= gateIndex, "The gate index must be positive.");
+		this.gateIndex = gateIndex;
 
 		this.consumedResultId = checkNotNull(consumedResultId);
 		this.consumedPartitionType = checkNotNull(consumedPartitionType);
@@ -252,6 +258,10 @@ public class SingleInputGate extends InputGate {
 	@Override
 	public int getNumberOfInputChannels() {
 		return numberOfInputChannels;
+	}
+
+	public int getGateIndex() {
+		return gateIndex;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -108,6 +108,7 @@ public class SingleInputGateFactory {
 	 */
 	public SingleInputGate create(
 			@Nonnull String owningTaskName,
+			int gateIndex,
 			@Nonnull InputGateDeploymentDescriptor igdd,
 			@Nonnull PartitionProducerStateProvider partitionProducerStateProvider,
 			@Nonnull InputChannelMetrics metrics) {
@@ -125,6 +126,7 @@ public class SingleInputGateFactory {
 
 		SingleInputGate inputGate = new SingleInputGate(
 			owningTaskName,
+			gateIndex,
 			igdd.getConsumedResultId(),
 			igdd.getConsumedPartitionType(),
 			igdd.getConsumedSubpartitionIndex(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironment.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Interface for the implementation of shuffle service local environment.
@@ -121,11 +122,11 @@ public interface ShuffleEnvironment<P extends ResultPartitionWriter, G extends I
 	 *
 	 * @param ownerContext the owner context relevant for partition creation
 	 * @param resultPartitionDeploymentDescriptors descriptors of the partition, produced by the owner
-	 * @return collection of the {@link ResultPartitionWriter ResultPartitionWriters}
+	 * @return list of the {@link ResultPartitionWriter ResultPartitionWriters}
 	 */
 	Collection<P> createResultPartitionWriters(
 		ShuffleIOOwnerContext ownerContext,
-		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors);
+		List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors);
 
 	/**
 	 * Release local resources occupied by the given partitions.
@@ -154,12 +155,12 @@ public interface ShuffleEnvironment<P extends ResultPartitionWriter, G extends I
 	 * @param ownerContext the owner context relevant for gate creation
 	 * @param partitionProducerStateProvider producer state provider to query whether the producer is ready for consumption
 	 * @param inputGateDeploymentDescriptors descriptors of the input gates to consume
-	 * @return collection of the {@link InputGate InputGates}
+	 * @return list of the {@link InputGate InputGates}
 	 */
 	Collection<G> createInputGates(
 		ShuffleIOOwnerContext ownerContext,
 		PartitionProducerStateProvider partitionProducerStateProvider,
-		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors);
+		List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors);
 
 	/**
 	 * Update a gate with the newly available partition information, previously unknown.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -95,6 +95,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -286,8 +287,8 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 		AllocationID slotAllocationId,
 		int subtaskIndex,
 		int attemptNumber,
-		Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
-		Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
+		List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors,
+		List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors,
 		int targetSlotNumber,
 		MemoryManager memManager,
 		IOManager ioManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/TaskDeploymentDescriptorBuilder.java
@@ -34,8 +34,8 @@ import org.apache.flink.util.SerializedValue;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Builder for {@link TaskDeploymentDescriptor}.
@@ -48,8 +48,8 @@ public class TaskDeploymentDescriptorBuilder {
 	private AllocationID allocationId;
 	private int subtaskIndex;
 	private int attemptNumber;
-	private Collection<ResultPartitionDeploymentDescriptor> producedPartitions;
-	private Collection<InputGateDeploymentDescriptor> inputGates;
+	private List<ResultPartitionDeploymentDescriptor> producedPartitions;
+	private List<InputGateDeploymentDescriptor> inputGates;
 	private int targetSlotNumber;
 
 	@Nullable
@@ -116,12 +116,12 @@ public class TaskDeploymentDescriptorBuilder {
 	}
 
 	public TaskDeploymentDescriptorBuilder setProducedPartitions(
-			Collection<ResultPartitionDeploymentDescriptor> producedPartitions) {
+			List<ResultPartitionDeploymentDescriptor> producedPartitions) {
 		this.producedPartitions = producedPartitions;
 		return this;
 	}
 
-	public TaskDeploymentDescriptorBuilder setInputGates(Collection<InputGateDeploymentDescriptor> inputGates) {
+	public TaskDeploymentDescriptorBuilder setInputGates(List<InputGateDeploymentDescriptor> inputGates) {
 		this.inputGates = inputGates;
 		return this;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -331,7 +331,9 @@ public class InputGateFairnessTest {
 				int consumedSubpartitionIndex,
 				int numberOfInputChannels) {
 
-			super(owningTaskName,
+			super(
+				owningTaskName,
+				0,
 				consumedResultId,
 				ResultPartitionType.PIPELINED,
 				consumedSubpartitionIndex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -40,6 +40,8 @@ public class ResultPartitionBuilder {
 
 	private BoundedBlockingSubpartitionType blockingSubpartitionType = BoundedBlockingSubpartitionType.AUTO;
 
+	private int partitionIndex = 0;
+
 	private int numberOfSubpartitions = 1;
 
 	private int numTargetKeyGroups = 1;
@@ -64,6 +66,11 @@ public class ResultPartitionBuilder {
 	private boolean blockingShuffleCompressionEnabled = false;
 
 	private String compressionCodec = "LZ4";
+
+	public ResultPartitionBuilder setResultPartitionIndex(int partitionIndex) {
+		this.partitionIndex = partitionIndex;
+		return this;
+	}
 
 	public ResultPartitionBuilder setResultPartitionId(ResultPartitionID partitionId) {
 		this.partitionId = partitionId;
@@ -167,6 +174,7 @@ public class ResultPartitionBuilder {
 
 		return resultPartitionFactory.create(
 			"Result Partition task",
+			partitionIndex,
 			partitionId,
 			partitionType,
 			numberOfSubpartitions,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -112,6 +112,6 @@ public class ResultPartitionFactoryTest extends TestLogger {
 			true
 		);
 
-		return factory.create("test", descriptor);
+		return factory.create("test", 0, descriptor);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -74,6 +75,27 @@ public class ResultPartitionTest {
 	@AfterClass
 	public static void shutdown() throws Exception {
 		fileChannelManager.close();
+	}
+
+	@Test
+	public void testResultSubpartitionInfo() {
+		final int numPartitions = 2;
+		final int numSubpartitions = 3;
+
+		for (int i = 0; i < numPartitions; i++) {
+			final ResultPartition partition = new ResultPartitionBuilder()
+				.setResultPartitionIndex(i)
+				.setNumberOfSubpartitions(numSubpartitions)
+				.build();
+
+			ResultSubpartition[] subpartitions = partition.getAllPartitions();
+			for (int j = 0; j < subpartitions.length; j++) {
+				ResultSubpartitionInfo subpartitionInfo = subpartitions[j].getSubpartitionInfo();
+
+				assertEquals(i, subpartitionInfo.getPartitionIdx());
+				assertEquals(j, subpartitionInfo.getSubPartitionIdx());
+			}
+		}
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/TaskExecutorPartitionTrackerImplTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.CoreMatchers.not;
@@ -168,7 +169,7 @@ public class TaskExecutorPartitionTrackerImplTest extends TestLogger {
 		}
 
 		@Override
-		public Collection<ResultPartition> createResultPartitionWriters(ShuffleIOOwnerContext ownerContext, Collection<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
+		public Collection<ResultPartition> createResultPartitionWriters(ShuffleIOOwnerContext ownerContext, List<ResultPartitionDeploymentDescriptor> resultPartitionDeploymentDescriptors) {
 			return backingShuffleEnvironment.createResultPartitionWriters(ownerContext, resultPartitionDeploymentDescriptors);
 		}
 
@@ -186,7 +187,7 @@ public class TaskExecutorPartitionTrackerImplTest extends TestLogger {
 		}
 
 		@Override
-		public Collection<SingleInputGate> createInputGates(ShuffleIOOwnerContext ownerContext, PartitionProducerStateProvider partitionProducerStateProvider, Collection<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
+		public Collection<SingleInputGate> createInputGates(ShuffleIOOwnerContext ownerContext, PartitionProducerStateProvider partitionProducerStateProvider, List<InputGateDeploymentDescriptor> inputGateDeploymentDescriptors) {
 			return backingShuffleEnvironment.createInputGates(ownerContext, partitionProducerStateProvider, inputGateDeploymentDescriptors);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -42,6 +42,8 @@ public class SingleInputGateBuilder {
 
 	private int consumedSubpartitionIndex = 0;
 
+	private int gateIndex = 0;
+
 	private int numberOfChannels = 1;
 
 	private PartitionProducerStateProvider partitionProducerStateProvider = NO_OP_PRODUCER_CHECKER;
@@ -66,6 +68,11 @@ public class SingleInputGateBuilder {
 
 	SingleInputGateBuilder setConsumedSubpartitionIndex(int consumedSubpartitionIndex) {
 		this.consumedSubpartitionIndex = consumedSubpartitionIndex;
+		return this;
+	}
+
+	SingleInputGateBuilder setSingleInputGateIndex(int gateIndex) {
+		this.gateIndex = gateIndex;
 		return this;
 	}
 
@@ -98,6 +105,7 @@ public class SingleInputGateBuilder {
 	public SingleInputGate build() {
 		return new SingleInputGate(
 			"Single Input Gate",
+			gateIndex,
 			intermediateDataSetID,
 			partitionType,
 			consumedSubpartitionIndex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSubmissionTest.java
@@ -82,6 +82,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -753,8 +754,8 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 		ExecutionAttemptID eid,
 		Class<? extends AbstractInvokable> abstractInvokable,
 		int maxNumberOfSubtasks,
-		Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
-		Collection<InputGateDeploymentDescriptor> inputGates
+		List<ResultPartitionDeploymentDescriptor> producedPartitions,
+		List<InputGateDeploymentDescriptor> inputGates
 	) throws IOException {
 		Preconditions.checkNotNull(producedPartitions);
 		Preconditions.checkNotNull(inputGates);
@@ -782,8 +783,8 @@ public class TaskExecutorSubmissionTest extends TestLogger {
 			Configuration jobConfiguration,
 			Configuration taskConfiguration,
 			String invokableClassName,
-			Collection<ResultPartitionDeploymentDescriptor> producedPartitions,
-			Collection<InputGateDeploymentDescriptor> inputGates,
+			List<ResultPartitionDeploymentDescriptor> producedPartitions,
+			List<InputGateDeploymentDescriptor> inputGates,
 			Collection<PermanentBlobKey> requiredJarFiles,
 			Collection<URL> requiredClasspaths,
 			int targetSlotNumber) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -83,7 +83,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -65,9 +65,9 @@ import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -255,7 +255,7 @@ public class TaskTest extends TestLogger {
 			shuffleDescriptor,
 			1,
 			false);
-		testExecutionFailsInNetworkRegistration(Collections.singleton(dummyPartition), Collections.emptyList());
+		testExecutionFailsInNetworkRegistration(Collections.singletonList(dummyPartition), Collections.emptyList());
 	}
 
 	@Test
@@ -266,12 +266,12 @@ public class TaskTest extends TestLogger {
 			ResultPartitionType.PIPELINED,
 			0,
 			new ShuffleDescriptor[] { dummyChannel });
-		testExecutionFailsInNetworkRegistration(Collections.emptyList(), Collections.singleton(dummyGate));
+		testExecutionFailsInNetworkRegistration(Collections.emptyList(), Collections.singletonList(dummyGate));
 	}
 
 	private void testExecutionFailsInNetworkRegistration(
-			Collection<ResultPartitionDeploymentDescriptor> resultPartitions,
-			Collection<InputGateDeploymentDescriptor> inputGates) throws Exception {
+			List<ResultPartitionDeploymentDescriptor> resultPartitions,
+			List<InputGateDeploymentDescriptor> inputGates) throws Exception {
 		final String errorMessage = "Network buffer pool has already been destroyed.";
 
 		final ResultPartitionConsumableNotifier consumableNotifier = new NoOpResultPartitionConsumableNotifier();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -61,6 +61,7 @@ import org.apache.flink.util.SerializedValue;
 import java.lang.reflect.Field;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executor;
 
 import static org.mockito.Mockito.mock;
@@ -81,8 +82,8 @@ public final class TestTaskBuilder {
 	private Configuration taskManagerConfig = new Configuration();
 	private ExecutionConfig executionConfig = new ExecutionConfig();
 	private Collection<PermanentBlobKey> requiredJarFileBlobKeys = Collections.emptyList();
-	private Collection<ResultPartitionDeploymentDescriptor> resultPartitions = Collections.emptyList();
-	private Collection<InputGateDeploymentDescriptor> inputGates = Collections.emptyList();
+	private List<ResultPartitionDeploymentDescriptor> resultPartitions = Collections.emptyList();
+	private List<InputGateDeploymentDescriptor> inputGates = Collections.emptyList();
 	private JobID jobId = new JobID();
 	private AllocationID allocationID = new AllocationID();
 	private ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
@@ -141,12 +142,12 @@ public final class TestTaskBuilder {
 		return this;
 	}
 
-	public TestTaskBuilder setResultPartitions(Collection<ResultPartitionDeploymentDescriptor> resultPartitions) {
+	public TestTaskBuilder setResultPartitions(List<ResultPartitionDeploymentDescriptor> resultPartitions) {
 		this.resultPartitions = resultPartitions;
 		return this;
 	}
 
-	public TestTaskBuilder setInputGates(Collection<InputGateDeploymentDescriptor> inputGates) {
+	public TestTaskBuilder setInputGates(List<InputGateDeploymentDescriptor> inputGates) {
 		this.inputGates = inputGates;
 		return this;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -264,10 +264,11 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
 	private InputGate createInputGateWithMetrics(
 		SingleInputGateFactory gateFactory,
 		InputGateDeploymentDescriptor gateDescriptor,
-		int channelIndex) {
+		int gateIndex) {
 
 		final SingleInputGate singleGate = gateFactory.create(
-			"receiving task[" + channelIndex + "]",
+			"receiving task[" + gateIndex + "]",
+			gateIndex,
 			gateDescriptor,
 			SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
 			InputChannelTestUtils.newUnregisteredInputChannelMetrics());


### PR DESCRIPTION
## What is the purpose of the change

In the constructors of `ResultSubpartition` and `InputChannel`, the respective `ResultSubpartitionInfo` and `InputChannelInfo` should be created as well.

These infos would be used for interacting with `ChannelStateReader` and `ChannelStateWriter` future.

## Brief change log

  - *Build `InputChannelInfo` in constructor of `InputChannel`*
  - *Build `ResultSubpartitionInfo` in constructor of `ResultSubpartition`*

## Verifying this change

  - *Added ResultPartitionTest#testResultSubpartitionInfo and SingleInputGateTest#testInputChannelInfo*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
