### PR TITLE
[FLINK-16166][build] Append additional javadoc options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1737,7 +1737,7 @@ under the License.
 					<configuration>
 						<quiet>true</quiet>
 						<detectOfflineLinks>false</detectOfflineLinks>
-						<additionalJOptions>
+						<additionalJOptions combine.children="append">
 							<additionalJOption>-Xdoclint:none</additionalJOption>
 						</additionalJOptions>
 					</configuration>


### PR DESCRIPTION
Ensures that additional options can be specified for the `javadoc-plugin` in profiles/modules.
Without this change the javadoc-plugin configuration in the java 11 profile overrides the doclint option, since the `additionalJOptions` attribute is an array which are merged by index.