### PR TITLE
[FLINK-13000][tests] Remove unused JobID parameters

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
@@ -148,7 +148,7 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 			.setJobGraph(jobGraph)
 			.setRestartStrategy(new FixedDelayRestartStrategy(10, 0))
 			.setFailoverStrategyFactory(AdaptedRestartPipelinedRegionStrategyNG::new)
-			.setSlotProvider(new SimpleSlotProvider(jobGraph.getJobID(), 2, taskManagerGateway))
+			.setSlotProvider(new SimpleSlotProvider(2, taskManagerGateway))
 			.build();
 
 		enableCheckpointing(executionGraph);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest.java
@@ -263,7 +263,7 @@ public class AdaptedRestartPipelinedRegionStrategyNGConcurrentFailoverTest exten
 
 		final JobGraph jg = new JobGraph(TEST_JOB_ID, "testjob", v1, v2);
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(TEST_JOB_ID, DEFAULT_PARALLELISM);
+		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(DEFAULT_PARALLELISM);
 
 		final JobMasterPartitionTracker partitionTracker = new JobMasterPartitionTrackerImpl(
 			jg.getJobID(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphRestartTest.java
@@ -101,7 +101,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 	public void testNoManualRestart() throws Exception {
 		ExecutionGraph eg = TestingExecutionGraphBuilder
 			.newBuilder()
-			.setSlotProvider(new SimpleSlotProvider(TEST_JOB_ID, NUM_TASKS))
+			.setSlotProvider(new SimpleSlotProvider(NUM_TASKS))
 			.setJobGraph(createJobGraph())
 			.build();
 
@@ -558,7 +558,7 @@ public class ExecutionGraphRestartTest extends TestLogger {
 		final int parallelism = 10;
 		final JobVertex vertex = createNoOpVertex(parallelism);
 		final NotCancelAckingTaskGateway taskManagerGateway = new NotCancelAckingTaskGateway();
-		final SlotProvider slots = new SimpleSlotProvider(TEST_JOB_ID, parallelism, taskManagerGateway);
+		final SlotProvider slots = new SimpleSlotProvider(parallelism, taskManagerGateway);
 		final TestRestartStrategy restartStrategy = TestRestartStrategy.manuallyTriggered();
 
 		final JobGraph jobGraph = new JobGraph(TEST_JOB_ID, "Test Job", vertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphSuspendTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -284,16 +283,13 @@ public class ExecutionGraphSuspendTest extends TestLogger {
 	}
 
 	private static ExecutionGraph createExecutionGraph(TaskManagerGateway gateway, int parallelism) throws Exception {
-		final JobID jobId = new JobID();
-
 		final JobVertex vertex = new JobVertex("vertex");
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(parallelism);
 
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobId, parallelism, gateway);
+		final SlotProvider slotProvider = new SimpleSlotProvider(parallelism, gateway);
 
 		ExecutionGraph simpleTestGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			jobId,
 			slotProvider,
 			new FixedDelayRestartStrategy(0, 0),
 			vertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphTestUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.time.Time;
@@ -308,7 +307,7 @@ public class ExecutionGraphTestUtils {
 	public static ExecutionGraph createSimpleTestGraph(RestartStrategy restartStrategy) throws Exception {
 		JobVertex vertex = createNoOpVertex(10);
 
-		return createSimpleTestGraph(new JobID(), new SimpleAckingTaskManagerGateway(), restartStrategy, vertex);
+		return createSimpleTestGraph(new SimpleAckingTaskManagerGateway(), restartStrategy, vertex);
 	}
 
 	/**
@@ -316,15 +315,14 @@ public class ExecutionGraphTestUtils {
 	 *
 	 * <p>The execution graph uses {@link NoRestartStrategy} as the restart strategy.
 	 */
-	public static ExecutionGraph createSimpleTestGraph(JobID jid, JobVertex... vertices) throws Exception {
-		return createSimpleTestGraph(jid, new SimpleAckingTaskManagerGateway(), new NoRestartStrategy(), vertices);
+	public static ExecutionGraph createSimpleTestGraph(JobVertex... vertices) throws Exception {
+		return createSimpleTestGraph(new SimpleAckingTaskManagerGateway(), new NoRestartStrategy(), vertices);
 	}
 
 	/**
 	 * Creates an execution graph containing the given vertices and the given restart strategy.
 	 */
 	public static ExecutionGraph createSimpleTestGraph(
-			JobID jid,
 			TaskManagerGateway taskManagerGateway,
 			RestartStrategy restartStrategy,
 			JobVertex... vertices) throws Exception {
@@ -334,39 +332,35 @@ public class ExecutionGraphTestUtils {
 			numSlotsNeeded += vertex.getParallelism();
 		}
 
-		SlotProvider slotProvider = new SimpleSlotProvider(jid, numSlotsNeeded, taskManagerGateway);
+		SlotProvider slotProvider = new SimpleSlotProvider(numSlotsNeeded, taskManagerGateway);
 
-		return createSimpleTestGraph(jid, slotProvider, restartStrategy, vertices);
+		return createSimpleTestGraph(slotProvider, restartStrategy, vertices);
 	}
 
 	public static ExecutionGraph createSimpleTestGraph(
-			JobID jid,
 			SlotProvider slotProvider,
 			RestartStrategy restartStrategy,
 			JobVertex... vertices) throws Exception {
 
-		return createExecutionGraph(jid, slotProvider, restartStrategy, TestingUtils.defaultExecutor(), vertices);
+		return createExecutionGraph(slotProvider, restartStrategy, TestingUtils.defaultExecutor(), vertices);
 	}
 
 	public static ExecutionGraph createExecutionGraph(
-			JobID jid,
 			SlotProvider slotProvider,
 			RestartStrategy restartStrategy,
 			ScheduledExecutorService executor,
 			JobVertex... vertices) throws Exception {
 
-			return createExecutionGraph(jid, slotProvider, restartStrategy, executor, Time.seconds(10L), vertices);
+			return createExecutionGraph(slotProvider, restartStrategy, executor, Time.seconds(10L), vertices);
 	}
 
 	public static ExecutionGraph createExecutionGraph(
-			JobID jid,
 			SlotProvider slotProvider,
 			RestartStrategy restartStrategy,
 			ScheduledExecutorService executor,
 			Time timeout,
 			JobVertex... vertices) throws Exception {
 
-		checkNotNull(jid);
 		checkNotNull(restartStrategy);
 		checkNotNull(vertices);
 		checkNotNull(timeout);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.JobManagerTaskRestore;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -101,7 +100,6 @@ public class ExecutionTest extends TestLogger {
 		slotProvider.addSlot(jobVertexId, 0, slotFuture);
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -159,7 +157,6 @@ public class ExecutionTest extends TestLogger {
 		slotProvider.addSlot(jobVertexId, 0, CompletableFuture.completedFuture(slot));
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -205,7 +202,6 @@ public class ExecutionTest extends TestLogger {
 		slotProvider.addSlot(jobVertexId, 0, CompletableFuture.completedFuture(slot));
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -253,7 +249,6 @@ public class ExecutionTest extends TestLogger {
 		slotProvider.addSlot(jobVertexId, 0, slotFuture);
 
 		final ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -361,7 +356,6 @@ public class ExecutionTest extends TestLogger {
 			slotOwner);
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -410,7 +404,6 @@ public class ExecutionTest extends TestLogger {
 			slotOwner);
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -459,7 +452,6 @@ public class ExecutionTest extends TestLogger {
 			(LogicalSlot logicalSlot) -> returnedSlotFuture.complete(logicalSlot.getSlotRequestId()));
 
 		ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);
@@ -526,7 +518,6 @@ public class ExecutionTest extends TestLogger {
 			return slotFuture;
 		});
 		final ExecutionGraph executionGraph = ExecutionGraphTestUtils.createSimpleTestGraph(
-			new JobID(),
 			slotProvider,
 			new NoRestartStrategy(),
 			jobVertex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionVertexInputConstraintTest.java
@@ -247,7 +247,7 @@ public class ExecutionVertexInputConstraintTest extends TestLogger {
 		}
 
 		final JobGraph jobGraph = new JobGraph(orderedVertices.toArray(new JobVertex[0]));
-		final SlotProvider slotProvider = new SimpleSlotProvider(jobGraph.getJobID(), numSlots);
+		final SlotProvider slotProvider = new SimpleSlotProvider(numSlots);
 
 		return TestingExecutionGraphBuilder
 			.newBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -42,8 +41,6 @@ public class FinalizeOnMasterTest extends TestLogger {
 
 	@Test
 	public void testFinalizeIsCalledUponSuccess() throws Exception {
-		final JobID jid = new JobID();
-
 		final JobVertex vertex1 = spy(new JobVertex("test vertex 1"));
 		vertex1.setInvokableClass(NoOpInvokable.class);
 		vertex1.setParallelism(3);
@@ -52,7 +49,7 @@ public class FinalizeOnMasterTest extends TestLogger {
 		vertex2.setInvokableClass(NoOpInvokable.class);
 		vertex2.setParallelism(2);
 
-		final ExecutionGraph eg = createSimpleTestGraph(jid, vertex1, vertex2);
+		final ExecutionGraph eg = createSimpleTestGraph(vertex1, vertex2);
 		eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 		eg.scheduleForExecution();
 		assertEquals(JobStatus.RUNNING, eg.getState());
@@ -71,13 +68,11 @@ public class FinalizeOnMasterTest extends TestLogger {
 
 	@Test
 	public void testFinalizeIsNotCalledUponFailure() throws Exception {
-		final JobID jid = new JobID();
-
 		final JobVertex vertex = spy(new JobVertex("test vertex 1"));
 		vertex.setInvokableClass(NoOpInvokable.class);
 		vertex.setParallelism(1);
 
-		final ExecutionGraph eg = createSimpleTestGraph(jid, vertex);
+		final ExecutionGraph eg = createSimpleTestGraph(vertex);
 		eg.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 		eg.scheduleForExecution();
 		assertEquals(JobStatus.RUNNING, eg.getState());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/GlobalModVersionTest.java
@@ -161,7 +161,7 @@ public class GlobalModVersionTest extends TestLogger {
 
 		JobGraph jg = new JobGraph(jid, "testjob", jv);
 
-		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(jid, parallelism);
+		final SimpleSlotProvider slotProvider = new SimpleSlotProvider(parallelism);
 
 		// build a simple execution graph with on job vertex, parallelism 2
 		final ExecutionGraph graph = TestingExecutionGraphBuilder

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/utils/SimpleSlotProvider.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.executiongraph.utils;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -48,7 +47,6 @@ import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * A testing utility slot provider that simply has a predefined pool of slots.
@@ -61,12 +59,11 @@ public class SimpleSlotProvider implements SlotProvider, SlotOwner {
 
 	private final HashMap<SlotRequestId, SlotContext> allocatedSlots;
 
-	public SimpleSlotProvider(JobID jobId, int numSlots) {
-		this(jobId, numSlots, new SimpleAckingTaskManagerGateway());
+	public SimpleSlotProvider(int numSlots) {
+		this(numSlots, new SimpleAckingTaskManagerGateway());
 	}
 
-	public SimpleSlotProvider(JobID jobId, int numSlots, TaskManagerGateway taskManagerGateway) {
-		checkNotNull(jobId, "jobId");
+	public SimpleSlotProvider(int numSlots, TaskManagerGateway taskManagerGateway) {
 		checkArgument(numSlots >= 0, "numSlots must be >= 0");
 
 		this.slots = new ArrayDeque<>(numSlots);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/ExecutionGraphToInputsLocationsRetrieverAdapterTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -64,7 +63,7 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
 		consumer.connectNewDataSetAsInput(producer1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 		consumer.connectNewDataSetAsInput(producer2, DistributionPattern.ALL_TO_ALL, ResultPartitionType.PIPELINED);
 
-		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), producer1, producer2, consumer);
+		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(producer1, producer2, consumer);
 		final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
 				new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -93,7 +92,7 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
 	public void testGetEmptyTaskManagerLocationIfVertexNotScheduled() throws Exception {
 		final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
 
-		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), jobVertex);
+		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
 		final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
 				new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -112,7 +111,7 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
 		final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
 
 		final TestingLogicalSlot testingLogicalSlot = new TestingLogicalSlotBuilder().createTestingLogicalSlot();
-		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), jobVertex);
+		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
 		final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
 				new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 
@@ -136,7 +135,7 @@ public class ExecutionGraphToInputsLocationsRetrieverAdapterTest extends TestLog
 	public void testGetNonExistingExecutionVertexWillThrowException() throws Exception {
 		final JobVertex jobVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
 
-		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(new JobID(), jobVertex);
+		final ExecutionGraph eg = ExecutionGraphTestUtils.createSimpleTestGraph(jobVertex);
 		final ExecutionGraphToInputsLocationsRetrieverAdapter inputsLocationsRetriever =
 				new ExecutionGraphToInputsLocationsRetrieverAdapter(eg);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.adapter;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionEdge;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
@@ -82,7 +81,6 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 		jobVertices[0].setInputDependencyConstraint(ALL);
 		jobVertices[1].setInputDependencyConstraint(ANY);
 		executionGraph = createSimpleTestGraph(
-			new JobID(),
 			taskManagerGateway,
 			triggeredRestartStrategy,
 			jobVertices);
@@ -176,7 +174,6 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 		jobVertices[1].updateCoLocationGroup(coLocationGroup);
 
 		return createSimpleTestGraph(
-			new JobID(),
 			taskManagerGateway,
 			triggeredRestartStrategy,
 			jobVertices);


### PR DESCRIPTION
Removes unused JobID parameters from the `SimpleSlotProvider` and `ExecutionGraphTestUtils#createSimpleTestGraph`.