### PR TITLE
[FLINK-16494][k8s] Switch to enum type for config option KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -34,9 +34,9 @@
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-policy</h5></td>
-            <td style="word-wrap: break-word;">"IfNotPresent"</td>
-            <td>String</td>
-            <td>Kubernetes image pull policy. Valid values are Always, Never, and IfNotPresent. The default policy is IfNotPresent to avoid putting pressure to image repository.</td>
+            <td style="word-wrap: break-word;">IfNotPresent</td>
+            <td><p>Enum</p>Possible values: [IfNotPresent, Always, Never]</td>
+            <td>The Kubernetes container image pull policy (IfNotPresent or Always or Never). The default policy is IfNotPresent to avoid putting pressure to image repository.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.container.image.pull-secrets</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -66,11 +66,11 @@ public class KubernetesConfigOptions {
 		.withDescription("The number of cpu used by task manager. By default, the cpu is set " +
 			"to the number of slots per TaskManager");
 
-	public static final ConfigOption<String> CONTAINER_IMAGE_PULL_POLICY =
+	public static final ConfigOption<ImagePullPolicy> CONTAINER_IMAGE_PULL_POLICY =
 		key("kubernetes.container.image.pull-policy")
-		.stringType()
-		.defaultValue("IfNotPresent")
-		.withDescription("Kubernetes image pull policy. Valid values are Always, Never, and IfNotPresent. " +
+		.enumType(ImagePullPolicy.class)
+		.defaultValue(ImagePullPolicy.IfNotPresent)
+		.withDescription("The Kubernetes container image pull policy (IfNotPresent or Always or Never). " +
 			"The default policy is IfNotPresent to avoid putting pressure to image repository.");
 
 	public static final ConfigOption<List<String>> CONTAINER_IMAGE_PULL_SECRETS =
@@ -154,6 +154,15 @@ public class KubernetesConfigOptions {
 		ClusterIP,
 		NodePort,
 		LoadBalancer
+	}
+
+	/**
+	 * The container image pull policy.
+	 */
+	public enum ImagePullPolicy {
+		IfNotPresent,
+		Always,
+		Never
 	}
 
 	/** This class is not meant to be instantiated. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -83,7 +83,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
 		return new ContainerBuilder(container)
 				.withName(kubernetesJobManagerParameters.getJobManagerMainContainerName())
 				.withImage(kubernetesJobManagerParameters.getImage())
-				.withImagePullPolicy(kubernetesJobManagerParameters.getImagePullPolicy())
+				.withImagePullPolicy(kubernetesJobManagerParameters.getImagePullPolicy().name())
 				.withResources(requirements)
 				.withPorts(getContainerPorts())
 				.withEnv(getCustomizedEnvs())

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -77,7 +77,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
 		return new ContainerBuilder(container)
 				.withName(kubernetesTaskManagerParameters.getTaskManagerMainContainerName())
 				.withImage(kubernetesTaskManagerParameters.getImage())
-				.withImagePullPolicy(kubernetesTaskManagerParameters.getImagePullPolicy())
+				.withImagePullPolicy(kubernetesTaskManagerParameters.getImagePullPolicy().name())
 				.withResources(resourceRequirements)
 				.withPorts(new ContainerPortBuilder()
 					.withName(Constants.TASK_MANAGER_RPC_PORT_NAME)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -77,8 +77,8 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
 	}
 
 	@Override
-	public String getImagePullPolicy() {
-		return flinkConfig.getString(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY);
+	public KubernetesConfigOptions.ImagePullPolicy getImagePullPolicy() {
+		return flinkConfig.get(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY);
 	}
 
 	@Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.kubernetes.kubeclient.parameters;
 
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 
 import java.util.Map;
@@ -34,7 +36,7 @@ public interface KubernetesParameters {
 
 	String getImage();
 
-	String getImagePullPolicy();
+	KubernetesConfigOptions.ImagePullPolicy getImagePullPolicy();
 
 	LocalObjectReference[] getImagePullSecrets();
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -46,7 +46,8 @@ public class KubernetesTestBase extends TestLogger {
 	protected static final String NAMESPACE = "test";
 	protected static final String CLUSTER_ID = "my-flink-cluster1";
 	protected static final String CONTAINER_IMAGE = "flink-k8s-test:latest";
-	protected static final String CONTAINER_IMAGE_PULL_POLICY = "IfNotPresent";
+	protected static final KubernetesConfigOptions.ImagePullPolicy CONTAINER_IMAGE_PULL_POLICY =
+		KubernetesConfigOptions.ImagePullPolicy.IfNotPresent;
 
 	@Rule
 	public MixedKubernetesServer server = new MixedKubernetesServer(true, true);
@@ -67,7 +68,7 @@ public class KubernetesTestBase extends TestLogger {
 		flinkConfig.setString(KubernetesConfigOptions.NAMESPACE, NAMESPACE);
 		flinkConfig.setString(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
 		flinkConfig.setString(KubernetesConfigOptions.CONTAINER_IMAGE, CONTAINER_IMAGE);
-		flinkConfig.setString(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY, CONTAINER_IMAGE_PULL_POLICY);
+		flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY, CONTAINER_IMAGE_PULL_POLICY);
 
 		flinkConfDir = temporaryFolder.newFolder().getAbsoluteFile();
 		writeFlinkConfiguration();

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -82,7 +82,7 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
 	@Test
 	public void testMainContainerImage() {
 		assertEquals(CONTAINER_IMAGE, this.resultMainContainer.getImage());
-		assertEquals(CONTAINER_IMAGE_PULL_POLICY, this.resultMainContainer.getImagePullPolicy());
+		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), this.resultMainContainer.getImagePullPolicy());
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -85,7 +85,7 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 
 	@Test
 	public void testMainContainerImagePullPolicy() {
-		assertEquals(CONTAINER_IMAGE_PULL_POLICY, this.resultMainContainer.getImagePullPolicy());
+		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), this.resultMainContainer.getImagePullPolicy());
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -109,7 +109,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 		final Container resultedMainContainer = resultPodSpec.getContainers().get(0);
 		assertEquals(KubernetesJobManagerParameters.JOB_MANAGER_MAIN_CONTAINER_NAME, resultedMainContainer.getName());
 		assertEquals(CONTAINER_IMAGE, resultedMainContainer.getImage());
-		assertEquals(CONTAINER_IMAGE_PULL_POLICY, resultedMainContainer.getImagePullPolicy());
+		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), resultedMainContainer.getImagePullPolicy());
 
 		assertEquals(3, resultedMainContainer.getEnv().size());
 		assertTrue(resultedMainContainer.getEnv()

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -66,7 +66,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 			KubernetesTaskManagerParameters.TASK_MANAGER_MAIN_CONTAINER_NAME,
 			resultMainContainer.getName());
 		assertEquals(CONTAINER_IMAGE, resultMainContainer.getImage());
-		assertEquals(CONTAINER_IMAGE_PULL_POLICY, resultMainContainer.getImagePullPolicy());
+		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), resultMainContainer.getImagePullPolicy());
 		assertEquals(1, resultMainContainer.getPorts().size());
 		assertEquals(1, resultMainContainer.getCommand().size());
 		assertEquals(3, resultMainContainer.getArgs().size());


### PR DESCRIPTION
## What is the purpose of the change

Switch from string type to enum type for config option KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
