### PR TITLE
[FLINK-16607][python] Update flink-fn-execution.proto adding more schema information

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -464,15 +464,15 @@ def from_proto(field_type):
         return coder
     if field_type_name == type_name.ROW:
         return RowCoder([from_proto(f.type) for f in field_type.row_schema.fields])
-    if field_type_name == type_name.DATETIME:
-        return TimestampCoder(field_type.date_time_type.precision)
+    if field_type_name == type_name.TIMESTAMP:
+        return TimestampCoder(field_type.timestamp_info.precision)
     elif field_type_name == type_name.ARRAY:
         return ArrayCoder(from_proto(field_type.collection_element_type))
     elif field_type_name == type_name.MAP:
-        return MapCoder(from_proto(field_type.map_type.key_type),
-                        from_proto(field_type.map_type.value_type))
+        return MapCoder(from_proto(field_type.map_info.key_type),
+                        from_proto(field_type.map_info.value_type))
     elif field_type_name == type_name.DECIMAL:
-        return DecimalCoder(field_type.decimal_type.precision,
-                            field_type.decimal_type.scale)
+        return DecimalCoder(field_type.decimal_info.precision,
+                            field_type.decimal_info.scale)
     else:
         raise ValueError("field_type %s is not supported." % field_type)

--- a/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
+++ b/flink-python/pyflink/fn_execution/flink_fn_execution_pb2.py
@@ -36,7 +36,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='flink-fn-execution.proto',
   package='org.apache.flink.fn_execution.v1',
   syntax='proto3',
-  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xfc\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1a\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\x80\t\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapType\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a!\n\x0c\x44\x61teTimeType\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalType\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\xec\x03\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_type\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapTypeH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12O\n\x0e\x64\x61te_time_type\x18\x06 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.Schema.DateTimeTypeH\x00\x12L\n\x0c\x64\x65\x63imal_type\x18\x07 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalTypeH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\xea\x01\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\x0c\n\x08\x44\x41TETIME\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
+  serialized_pb=_b('\n\x18\x66link-fn-execution.proto\x12 org.apache.flink.fn_execution.v1\"\xfc\x01\n\x13UserDefinedFunction\x12\x0f\n\x07payload\x18\x01 \x01(\x0c\x12K\n\x06inputs\x18\x02 \x03(\x0b\x32;.org.apache.flink.fn_execution.v1.UserDefinedFunction.Input\x1a\x86\x01\n\x05Input\x12\x44\n\x03udf\x18\x01 \x01(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunctionH\x00\x12\x15\n\x0binputOffset\x18\x02 \x01(\x05H\x00\x12\x17\n\rinputConstant\x18\x03 \x01(\x0cH\x00\x42\x07\n\x05input\"[\n\x14UserDefinedFunctions\x12\x43\n\x04udfs\x18\x01 \x03(\x0b\x32\x35.org.apache.flink.fn_execution.v1.UserDefinedFunction\"\xe6\x0f\n\x06Schema\x12>\n\x06\x66ields\x18\x01 \x03(\x0b\x32..org.apache.flink.fn_execution.v1.Schema.Field\x1a\x97\x01\n\x07MapInfo\x12\x44\n\x08key_type\x18\x01 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x12\x46\n\nvalue_type\x18\x02 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\x1a\x1d\n\x08TimeInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\"\n\rTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a,\n\x17LocalZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a\'\n\x12ZonedTimestampInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x1a/\n\x0b\x44\x65\x63imalInfo\x12\x11\n\tprecision\x18\x01 \x01(\x05\x12\r\n\x05scale\x18\x02 \x01(\x05\x1a\x1c\n\nBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1f\n\rVarBinaryInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1a\n\x08\x43harInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\x1d\n\x0bVarCharInfo\x12\x0e\n\x06length\x18\x01 \x01(\x05\x1a\xb0\x08\n\tFieldType\x12\x44\n\ttype_name\x18\x01 \x01(\x0e\x32\x31.org.apache.flink.fn_execution.v1.Schema.TypeName\x12\x10\n\x08nullable\x18\x02 \x01(\x08\x12U\n\x17\x63ollection_element_type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldTypeH\x00\x12\x44\n\x08map_info\x18\x04 \x01(\x0b\x32\x30.org.apache.flink.fn_execution.v1.Schema.MapInfoH\x00\x12>\n\nrow_schema\x18\x05 \x01(\x0b\x32(.org.apache.flink.fn_execution.v1.SchemaH\x00\x12L\n\x0c\x64\x65\x63imal_info\x18\x06 \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.DecimalInfoH\x00\x12\x46\n\ttime_info\x18\x07 \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.TimeInfoH\x00\x12P\n\x0etimestamp_info\x18\x08 \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.TimestampInfoH\x00\x12\x66\n\x1alocal_zoned_timestamp_info\x18\t \x01(\x0b\x32@.org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfoH\x00\x12[\n\x14zoned_timestamp_info\x18\n \x01(\x0b\x32;.org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfoH\x00\x12J\n\x0b\x62inary_info\x18\x0b \x01(\x0b\x32\x33.org.apache.flink.fn_execution.v1.Schema.BinaryInfoH\x00\x12Q\n\x0fvar_binary_info\x18\x0c \x01(\x0b\x32\x36.org.apache.flink.fn_execution.v1.Schema.VarBinaryInfoH\x00\x12\x46\n\tchar_info\x18\r \x01(\x0b\x32\x31.org.apache.flink.fn_execution.v1.Schema.CharInfoH\x00\x12M\n\rvar_char_info\x18\x0e \x01(\x0b\x32\x34.org.apache.flink.fn_execution.v1.Schema.VarCharInfoH\x00\x42\x0b\n\ttype_info\x1al\n\x05\x46ield\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12@\n\x04type\x18\x03 \x01(\x0b\x32\x32.org.apache.flink.fn_execution.v1.Schema.FieldType\"\x9b\x02\n\x08TypeName\x12\x07\n\x03ROW\x10\x00\x12\x0b\n\x07TINYINT\x10\x01\x12\x0c\n\x08SMALLINT\x10\x02\x12\x07\n\x03INT\x10\x03\x12\n\n\x06\x42IGINT\x10\x04\x12\x0b\n\x07\x44\x45\x43IMAL\x10\x05\x12\t\n\x05\x46LOAT\x10\x06\x12\n\n\x06\x44OUBLE\x10\x07\x12\x08\n\x04\x44\x41TE\x10\x08\x12\x08\n\x04TIME\x10\t\x12\r\n\tTIMESTAMP\x10\n\x12\x0b\n\x07\x42OOLEAN\x10\x0b\x12\n\n\x06\x42INARY\x10\x0c\x12\r\n\tVARBINARY\x10\r\x12\x08\n\x04\x43HAR\x10\x0e\x12\x0b\n\x07VARCHAR\x10\x0f\x12\t\n\x05\x41RRAY\x10\x10\x12\x07\n\x03MAP\x10\x11\x12\x0c\n\x08MULTISET\x10\x12\x12\x19\n\x15LOCAL_ZONED_TIMESTAMP\x10\x13\x12\x13\n\x0fZONED_TIMESTAMP\x10\x14\x42-\n\x1forg.apache.flink.fnexecution.v1B\nFlinkFnApib\x06proto3')
 )
 
 
@@ -88,7 +88,7 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='DATETIME', index=10, number=10,
+      name='TIMESTAMP', index=10, number=10,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
@@ -123,11 +123,19 @@ _SCHEMA_TYPENAME = _descriptor.EnumDescriptor(
       name='MULTISET', index=18, number=18,
       options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='LOCAL_ZONED_TIMESTAMP', index=19, number=19,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='ZONED_TIMESTAMP', index=20, number=20,
+      options=None,
+      type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=1329,
-  serialized_end=1563,
+  serialized_start=2150,
+  serialized_end=2433,
 )
 _sym_db.RegisterEnumDescriptor(_SCHEMA_TYPENAME)
 
@@ -248,22 +256,22 @@ _USERDEFINEDFUNCTIONS = _descriptor.Descriptor(
 )
 
 
-_SCHEMA_MAPTYPE = _descriptor.Descriptor(
-  name='MapType',
-  full_name='org.apache.flink.fn_execution.v1.Schema.MapType',
+_SCHEMA_MAPINFO = _descriptor.Descriptor(
+  name='MapInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.MapInfo',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key_type', full_name='org.apache.flink.fn_execution.v1.Schema.MapType.key_type', index=0,
+      name='key_type', full_name='org.apache.flink.fn_execution.v1.Schema.MapInfo.key_type', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value_type', full_name='org.apache.flink.fn_execution.v1.Schema.MapType.value_type', index=1,
+      name='value_type', full_name='org.apache.flink.fn_execution.v1.Schema.MapInfo.value_type', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -285,15 +293,15 @@ _SCHEMA_MAPTYPE = _descriptor.Descriptor(
   serialized_end=637,
 )
 
-_SCHEMA_DATETIMETYPE = _descriptor.Descriptor(
-  name='DateTimeType',
-  full_name='org.apache.flink.fn_execution.v1.Schema.DateTimeType',
+_SCHEMA_TIMEINFO = _descriptor.Descriptor(
+  name='TimeInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.TimeInfo',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.DateTimeType.precision', index=0,
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.TimeInfo.precision', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -312,25 +320,115 @@ _SCHEMA_DATETIMETYPE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=639,
-  serialized_end=672,
+  serialized_end=668,
 )
 
-_SCHEMA_DECIMALTYPE = _descriptor.Descriptor(
-  name='DecimalType',
-  full_name='org.apache.flink.fn_execution.v1.Schema.DecimalType',
+_SCHEMA_TIMESTAMPINFO = _descriptor.Descriptor(
+  name='TimestampInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.TimestampInfo',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.DecimalType.precision', index=0,
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.TimestampInfo.precision', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=670,
+  serialized_end=704,
+)
+
+_SCHEMA_LOCALZONEDTIMESTAMPINFO = _descriptor.Descriptor(
+  name='LocalZonedTimestampInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfo.precision', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=706,
+  serialized_end=750,
+)
+
+_SCHEMA_ZONEDTIMESTAMPINFO = _descriptor.Descriptor(
+  name='ZonedTimestampInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfo.precision', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=752,
+  serialized_end=791,
+)
+
+_SCHEMA_DECIMALINFO = _descriptor.Descriptor(
+  name='DecimalInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.DecimalInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='precision', full_name='org.apache.flink.fn_execution.v1.Schema.DecimalInfo.precision', index=0,
       number=1, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='scale', full_name='org.apache.flink.fn_execution.v1.Schema.DecimalType.scale', index=1,
+      name='scale', full_name='org.apache.flink.fn_execution.v1.Schema.DecimalInfo.scale', index=1,
       number=2, type=5, cpp_type=1, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -348,8 +446,128 @@ _SCHEMA_DECIMALTYPE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=674,
-  serialized_end=721,
+  serialized_start=793,
+  serialized_end=840,
+)
+
+_SCHEMA_BINARYINFO = _descriptor.Descriptor(
+  name='BinaryInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.BinaryInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='length', full_name='org.apache.flink.fn_execution.v1.Schema.BinaryInfo.length', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=842,
+  serialized_end=870,
+)
+
+_SCHEMA_VARBINARYINFO = _descriptor.Descriptor(
+  name='VarBinaryInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.VarBinaryInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='length', full_name='org.apache.flink.fn_execution.v1.Schema.VarBinaryInfo.length', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=872,
+  serialized_end=903,
+)
+
+_SCHEMA_CHARINFO = _descriptor.Descriptor(
+  name='CharInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.CharInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='length', full_name='org.apache.flink.fn_execution.v1.Schema.CharInfo.length', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=905,
+  serialized_end=931,
+)
+
+_SCHEMA_VARCHARINFO = _descriptor.Descriptor(
+  name='VarCharInfo',
+  full_name='org.apache.flink.fn_execution.v1.Schema.VarCharInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='length', full_name='org.apache.flink.fn_execution.v1.Schema.VarCharInfo.length', index=0,
+      number=1, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=933,
+  serialized_end=962,
 )
 
 _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
@@ -381,7 +599,7 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='map_type', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.map_type', index=3,
+      name='map_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.map_info', index=3,
       number=4, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -395,15 +613,64 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='date_time_type', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.date_time_type', index=5,
+      name='decimal_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.decimal_info', index=5,
       number=6, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='decimal_type', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.decimal_type', index=6,
+      name='time_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.time_info', index=6,
       number=7, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='timestamp_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.timestamp_info', index=7,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='local_zoned_timestamp_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.local_zoned_timestamp_info', index=8,
+      number=9, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='zoned_timestamp_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.zoned_timestamp_info', index=9,
+      number=10, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='binary_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.binary_info', index=10,
+      number=11, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='var_binary_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.var_binary_info', index=11,
+      number=12, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='char_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.char_info', index=12,
+      number=13, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='var_char_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.var_char_info', index=13,
+      number=14, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -423,8 +690,8 @@ _SCHEMA_FIELDTYPE = _descriptor.Descriptor(
       name='type_info', full_name='org.apache.flink.fn_execution.v1.Schema.FieldType.type_info',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=724,
-  serialized_end=1216,
+  serialized_start=965,
+  serialized_end=2037,
 )
 
 _SCHEMA_FIELD = _descriptor.Descriptor(
@@ -467,8 +734,8 @@ _SCHEMA_FIELD = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1218,
-  serialized_end=1326,
+  serialized_start=2039,
+  serialized_end=2147,
 )
 
 _SCHEMA = _descriptor.Descriptor(
@@ -488,7 +755,7 @@ _SCHEMA = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_SCHEMA_MAPTYPE, _SCHEMA_DATETIMETYPE, _SCHEMA_DECIMALTYPE, _SCHEMA_FIELDTYPE, _SCHEMA_FIELD, ],
+  nested_types=[_SCHEMA_MAPINFO, _SCHEMA_TIMEINFO, _SCHEMA_TIMESTAMPINFO, _SCHEMA_LOCALZONEDTIMESTAMPINFO, _SCHEMA_ZONEDTIMESTAMPINFO, _SCHEMA_DECIMALINFO, _SCHEMA_BINARYINFO, _SCHEMA_VARBINARYINFO, _SCHEMA_CHARINFO, _SCHEMA_VARCHARINFO, _SCHEMA_FIELDTYPE, _SCHEMA_FIELD, ],
   enum_types=[
     _SCHEMA_TYPENAME,
   ],
@@ -499,7 +766,7 @@ _SCHEMA = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=411,
-  serialized_end=1563,
+  serialized_end=2433,
 )
 
 _USERDEFINEDFUNCTION_INPUT.fields_by_name['udf'].message_type = _USERDEFINEDFUNCTION
@@ -515,33 +782,68 @@ _USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input'].fields.append(
 _USERDEFINEDFUNCTION_INPUT.fields_by_name['inputConstant'].containing_oneof = _USERDEFINEDFUNCTION_INPUT.oneofs_by_name['input']
 _USERDEFINEDFUNCTION.fields_by_name['inputs'].message_type = _USERDEFINEDFUNCTION_INPUT
 _USERDEFINEDFUNCTIONS.fields_by_name['udfs'].message_type = _USERDEFINEDFUNCTION
-_SCHEMA_MAPTYPE.fields_by_name['key_type'].message_type = _SCHEMA_FIELDTYPE
-_SCHEMA_MAPTYPE.fields_by_name['value_type'].message_type = _SCHEMA_FIELDTYPE
-_SCHEMA_MAPTYPE.containing_type = _SCHEMA
-_SCHEMA_DATETIMETYPE.containing_type = _SCHEMA
-_SCHEMA_DECIMALTYPE.containing_type = _SCHEMA
+_SCHEMA_MAPINFO.fields_by_name['key_type'].message_type = _SCHEMA_FIELDTYPE
+_SCHEMA_MAPINFO.fields_by_name['value_type'].message_type = _SCHEMA_FIELDTYPE
+_SCHEMA_MAPINFO.containing_type = _SCHEMA
+_SCHEMA_TIMEINFO.containing_type = _SCHEMA
+_SCHEMA_TIMESTAMPINFO.containing_type = _SCHEMA
+_SCHEMA_LOCALZONEDTIMESTAMPINFO.containing_type = _SCHEMA
+_SCHEMA_ZONEDTIMESTAMPINFO.containing_type = _SCHEMA
+_SCHEMA_DECIMALINFO.containing_type = _SCHEMA
+_SCHEMA_BINARYINFO.containing_type = _SCHEMA
+_SCHEMA_VARBINARYINFO.containing_type = _SCHEMA
+_SCHEMA_CHARINFO.containing_type = _SCHEMA
+_SCHEMA_VARCHARINFO.containing_type = _SCHEMA
 _SCHEMA_FIELDTYPE.fields_by_name['type_name'].enum_type = _SCHEMA_TYPENAME
 _SCHEMA_FIELDTYPE.fields_by_name['collection_element_type'].message_type = _SCHEMA_FIELDTYPE
-_SCHEMA_FIELDTYPE.fields_by_name['map_type'].message_type = _SCHEMA_MAPTYPE
+_SCHEMA_FIELDTYPE.fields_by_name['map_info'].message_type = _SCHEMA_MAPINFO
 _SCHEMA_FIELDTYPE.fields_by_name['row_schema'].message_type = _SCHEMA
-_SCHEMA_FIELDTYPE.fields_by_name['date_time_type'].message_type = _SCHEMA_DATETIMETYPE
-_SCHEMA_FIELDTYPE.fields_by_name['decimal_type'].message_type = _SCHEMA_DECIMALTYPE
+_SCHEMA_FIELDTYPE.fields_by_name['decimal_info'].message_type = _SCHEMA_DECIMALINFO
+_SCHEMA_FIELDTYPE.fields_by_name['time_info'].message_type = _SCHEMA_TIMEINFO
+_SCHEMA_FIELDTYPE.fields_by_name['timestamp_info'].message_type = _SCHEMA_TIMESTAMPINFO
+_SCHEMA_FIELDTYPE.fields_by_name['local_zoned_timestamp_info'].message_type = _SCHEMA_LOCALZONEDTIMESTAMPINFO
+_SCHEMA_FIELDTYPE.fields_by_name['zoned_timestamp_info'].message_type = _SCHEMA_ZONEDTIMESTAMPINFO
+_SCHEMA_FIELDTYPE.fields_by_name['binary_info'].message_type = _SCHEMA_BINARYINFO
+_SCHEMA_FIELDTYPE.fields_by_name['var_binary_info'].message_type = _SCHEMA_VARBINARYINFO
+_SCHEMA_FIELDTYPE.fields_by_name['char_info'].message_type = _SCHEMA_CHARINFO
+_SCHEMA_FIELDTYPE.fields_by_name['var_char_info'].message_type = _SCHEMA_VARCHARINFO
 _SCHEMA_FIELDTYPE.containing_type = _SCHEMA
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _SCHEMA_FIELDTYPE.fields_by_name['collection_element_type'])
 _SCHEMA_FIELDTYPE.fields_by_name['collection_element_type'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _SCHEMA_FIELDTYPE.fields_by_name['map_type'])
-_SCHEMA_FIELDTYPE.fields_by_name['map_type'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+  _SCHEMA_FIELDTYPE.fields_by_name['map_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['map_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
   _SCHEMA_FIELDTYPE.fields_by_name['row_schema'])
 _SCHEMA_FIELDTYPE.fields_by_name['row_schema'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _SCHEMA_FIELDTYPE.fields_by_name['date_time_type'])
-_SCHEMA_FIELDTYPE.fields_by_name['date_time_type'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+  _SCHEMA_FIELDTYPE.fields_by_name['decimal_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['decimal_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
-  _SCHEMA_FIELDTYPE.fields_by_name['decimal_type'])
-_SCHEMA_FIELDTYPE.fields_by_name['decimal_type'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+  _SCHEMA_FIELDTYPE.fields_by_name['time_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['time_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['timestamp_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['timestamp_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['local_zoned_timestamp_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['local_zoned_timestamp_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['zoned_timestamp_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['zoned_timestamp_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['binary_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['binary_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['var_binary_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['var_binary_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['char_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['char_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
+_SCHEMA_FIELDTYPE.oneofs_by_name['type_info'].fields.append(
+  _SCHEMA_FIELDTYPE.fields_by_name['var_char_info'])
+_SCHEMA_FIELDTYPE.fields_by_name['var_char_info'].containing_oneof = _SCHEMA_FIELDTYPE.oneofs_by_name['type_info']
 _SCHEMA_FIELD.fields_by_name['type'].message_type = _SCHEMA_FIELDTYPE
 _SCHEMA_FIELD.containing_type = _SCHEMA
 _SCHEMA.fields_by_name['fields'].message_type = _SCHEMA_FIELD
@@ -575,24 +877,73 @@ _sym_db.RegisterMessage(UserDefinedFunctions)
 
 Schema = _reflection.GeneratedProtocolMessageType('Schema', (_message.Message,), dict(
 
-  MapType = _reflection.GeneratedProtocolMessageType('MapType', (_message.Message,), dict(
-    DESCRIPTOR = _SCHEMA_MAPTYPE,
+  MapInfo = _reflection.GeneratedProtocolMessageType('MapInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_MAPINFO,
     __module__ = 'flink_fn_execution_pb2'
-    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.MapType)
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.MapInfo)
     ))
   ,
 
-  DateTimeType = _reflection.GeneratedProtocolMessageType('DateTimeType', (_message.Message,), dict(
-    DESCRIPTOR = _SCHEMA_DATETIMETYPE,
+  TimeInfo = _reflection.GeneratedProtocolMessageType('TimeInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_TIMEINFO,
     __module__ = 'flink_fn_execution_pb2'
-    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.DateTimeType)
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.TimeInfo)
     ))
   ,
 
-  DecimalType = _reflection.GeneratedProtocolMessageType('DecimalType', (_message.Message,), dict(
-    DESCRIPTOR = _SCHEMA_DECIMALTYPE,
+  TimestampInfo = _reflection.GeneratedProtocolMessageType('TimestampInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_TIMESTAMPINFO,
     __module__ = 'flink_fn_execution_pb2'
-    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.DecimalType)
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.TimestampInfo)
+    ))
+  ,
+
+  LocalZonedTimestampInfo = _reflection.GeneratedProtocolMessageType('LocalZonedTimestampInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_LOCALZONEDTIMESTAMPINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.LocalZonedTimestampInfo)
+    ))
+  ,
+
+  ZonedTimestampInfo = _reflection.GeneratedProtocolMessageType('ZonedTimestampInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_ZONEDTIMESTAMPINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.ZonedTimestampInfo)
+    ))
+  ,
+
+  DecimalInfo = _reflection.GeneratedProtocolMessageType('DecimalInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_DECIMALINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.DecimalInfo)
+    ))
+  ,
+
+  BinaryInfo = _reflection.GeneratedProtocolMessageType('BinaryInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_BINARYINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.BinaryInfo)
+    ))
+  ,
+
+  VarBinaryInfo = _reflection.GeneratedProtocolMessageType('VarBinaryInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_VARBINARYINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.VarBinaryInfo)
+    ))
+  ,
+
+  CharInfo = _reflection.GeneratedProtocolMessageType('CharInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_CHARINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.CharInfo)
+    ))
+  ,
+
+  VarCharInfo = _reflection.GeneratedProtocolMessageType('VarCharInfo', (_message.Message,), dict(
+    DESCRIPTOR = _SCHEMA_VARCHARINFO,
+    __module__ = 'flink_fn_execution_pb2'
+    # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema.VarCharInfo)
     ))
   ,
 
@@ -614,9 +965,16 @@ Schema = _reflection.GeneratedProtocolMessageType('Schema', (_message.Message,),
   # @@protoc_insertion_point(class_scope:org.apache.flink.fn_execution.v1.Schema)
   ))
 _sym_db.RegisterMessage(Schema)
-_sym_db.RegisterMessage(Schema.MapType)
-_sym_db.RegisterMessage(Schema.DateTimeType)
-_sym_db.RegisterMessage(Schema.DecimalType)
+_sym_db.RegisterMessage(Schema.MapInfo)
+_sym_db.RegisterMessage(Schema.TimeInfo)
+_sym_db.RegisterMessage(Schema.TimestampInfo)
+_sym_db.RegisterMessage(Schema.LocalZonedTimestampInfo)
+_sym_db.RegisterMessage(Schema.ZonedTimestampInfo)
+_sym_db.RegisterMessage(Schema.DecimalInfo)
+_sym_db.RegisterMessage(Schema.BinaryInfo)
+_sym_db.RegisterMessage(Schema.VarBinaryInfo)
+_sym_db.RegisterMessage(Schema.CharInfo)
+_sym_db.RegisterMessage(Schema.VarCharInfo)
 _sym_db.RegisterMessage(Schema.FieldType)
 _sym_db.RegisterMessage(Schema.Field)
 

--- a/flink-python/pyflink/proto/flink-fn-execution.proto
+++ b/flink-python/pyflink/proto/flink-fn-execution.proto
@@ -64,7 +64,7 @@ message Schema {
     DOUBLE = 7;
     DATE = 8;
     TIME = 9;
-    DATETIME = 10;
+    TIMESTAMP = 10;
     BOOLEAN = 11;
     BINARY = 12;
     VARBINARY = 13;
@@ -73,20 +73,50 @@ message Schema {
     ARRAY = 16;
     MAP = 17;
     MULTISET = 18;
+    LOCAL_ZONED_TIMESTAMP = 19;
+    ZONED_TIMESTAMP = 20;
   }
 
-  message MapType {
+  message MapInfo {
     FieldType key_type = 1;
     FieldType value_type = 2;
   }
 
-  message DateTimeType {
+  message TimeInfo {
     int32 precision = 1;
   }
 
-  message DecimalType {
+  message TimestampInfo {
+    int32 precision = 1;
+  }
+
+  message LocalZonedTimestampInfo {
+    int32 precision = 1;
+  }
+
+  message ZonedTimestampInfo {
+    int32 precision = 1;
+  }
+
+  message DecimalInfo {
     int32 precision = 1;
     int32 scale = 2;
+  }
+
+  message BinaryInfo {
+    int32 length = 1;
+  }
+
+  message VarBinaryInfo {
+    int32 length = 1;
+  }
+
+  message CharInfo {
+    int32 length = 1;
+  }
+
+  message VarCharInfo {
+    int32 length = 1;
   }
 
   message FieldType {
@@ -94,10 +124,17 @@ message Schema {
     bool nullable = 2;
     oneof type_info {
       FieldType collection_element_type = 3;
-      MapType map_type = 4;
+      MapInfo map_info = 4;
       Schema row_schema = 5;
-      DateTimeType date_time_type = 6;
-      DecimalType decimal_type = 7;
+      DecimalInfo decimal_info = 6;
+      TimeInfo time_info = 7;
+      TimestampInfo timestamp_info = 8;
+      LocalZonedTimestampInfo local_zoned_timestamp_info = 9;
+      ZonedTimestampInfo zoned_timestamp_info = 10;
+      BinaryInfo binary_info = 11;
+      VarBinaryInfo var_binary_info = 12;
+      CharInfo char_info = 13;
+      VarCharInfo var_char_info = 14;
     }
   }
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -353,6 +353,7 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(BinaryType binaryType) {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.BINARY)
+				.setBinaryInfo(FlinkFnApi.Schema.BinaryInfo.newBuilder().setLength(binaryType.getLength()))
 				.setNullable(binaryType.isNullable())
 				.build();
 		}
@@ -361,6 +362,7 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(VarBinaryType varBinaryType) {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.VARBINARY)
+				.setVarBinaryInfo(FlinkFnApi.Schema.VarBinaryInfo.newBuilder().setLength(varBinaryType.getLength()))
 				.setNullable(varBinaryType.isNullable())
 				.build();
 		}
@@ -369,6 +371,7 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(CharType charType) {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.CHAR)
+				.setCharInfo(FlinkFnApi.Schema.CharInfo.newBuilder().setLength(charType.getLength()))
 				.setNullable(charType.isNullable())
 				.build();
 		}
@@ -377,6 +380,7 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(VarCharType varCharType) {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.VARCHAR)
+				.setVarCharInfo(FlinkFnApi.Schema.VarCharInfo.newBuilder().setLength(varCharType.getLength()))
 				.setNullable(varCharType.isNullable())
 				.build();
 		}
@@ -393,6 +397,7 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(TimeType timeType) {
 			return FlinkFnApi.Schema.FieldType.newBuilder()
 				.setTypeName(FlinkFnApi.Schema.TypeName.TIME)
+				.setTimeInfo(FlinkFnApi.Schema.TimeInfo.newBuilder().setPrecision(timeType.getPrecision()))
 				.setNullable(timeType.isNullable())
 				.build();
 		}
@@ -401,13 +406,13 @@ public final class PythonTypeUtils {
 		public FlinkFnApi.Schema.FieldType visit(TimestampType timestampType) {
 			FlinkFnApi.Schema.FieldType.Builder builder =
 				FlinkFnApi.Schema.FieldType.newBuilder()
-					.setTypeName(FlinkFnApi.Schema.TypeName.DATETIME)
+					.setTypeName(FlinkFnApi.Schema.TypeName.TIMESTAMP)
 					.setNullable(timestampType.isNullable());
 
-			FlinkFnApi.Schema.DateTimeType.Builder dateTimeBuilder =
-				FlinkFnApi.Schema.DateTimeType.newBuilder()
+			FlinkFnApi.Schema.TimestampInfo.Builder timestampInfoBuilder =
+				FlinkFnApi.Schema.TimestampInfo.newBuilder()
 					.setPrecision(timestampType.getPrecision());
-			builder.setDateTimeType(dateTimeBuilder.build());
+			builder.setTimestampInfo(timestampInfoBuilder);
 			return builder.build();
 		}
 
@@ -418,11 +423,11 @@ public final class PythonTypeUtils {
 					.setTypeName(FlinkFnApi.Schema.TypeName.DECIMAL)
 					.setNullable(decimalType.isNullable());
 
-			FlinkFnApi.Schema.DecimalType.Builder decimalTypeBuilder =
-				FlinkFnApi.Schema.DecimalType.newBuilder()
+			FlinkFnApi.Schema.DecimalInfo.Builder decimalInfoBuilder =
+				FlinkFnApi.Schema.DecimalInfo.newBuilder()
 					.setPrecision(decimalType.getPrecision())
 					.setScale(decimalType.getScale());
-			builder.setDecimalType(decimalTypeBuilder);
+			builder.setDecimalInfo(decimalInfoBuilder);
 			return builder.build();
 		}
 
@@ -445,11 +450,11 @@ public final class PythonTypeUtils {
 					.setTypeName(FlinkFnApi.Schema.TypeName.MAP)
 					.setNullable(mapType.isNullable());
 
-			FlinkFnApi.Schema.MapType.Builder mapBuilder =
-				FlinkFnApi.Schema.MapType.newBuilder()
+			FlinkFnApi.Schema.MapInfo.Builder mapBuilder =
+				FlinkFnApi.Schema.MapInfo.newBuilder()
 					.setKeyType(mapType.getKeyType().accept(this))
 					.setValueType(mapType.getValueType().accept(this));
-			builder.setMapType(mapBuilder.build());
+			builder.setMapInfo(mapBuilder.build());
 			return builder.build();
 		}
 
@@ -484,11 +489,11 @@ public final class PythonTypeUtils {
 							.setNullable(logicalType.isNullable());
 					// Because we can't get precision and scale from legacy BIG_DEC_TYPE_INFO,
 					// we set the precision and scale to default value compatible with python.
-					FlinkFnApi.Schema.DecimalType.Builder decimalTypeBuilder =
-						FlinkFnApi.Schema.DecimalType.newBuilder()
+					FlinkFnApi.Schema.DecimalInfo.Builder decimalTypeBuilder =
+						FlinkFnApi.Schema.DecimalInfo.newBuilder()
 							.setPrecision(38)
 							.setScale(18);
-					builder.setDecimalType(decimalTypeBuilder);
+					builder.setDecimalInfo(decimalTypeBuilder);
 					return builder.build();
 				}
 			}


### PR DESCRIPTION

## What is the purpose of the change

*Currently the following information is missing in flink-fn-execution.proto:*
  - the length for CharType/VarCharType/BinaryType/VarBinaryType
  - the precision for TimeType
  - LocalZonedTimeStampType/ZonedTimestampType is missing

This pull request will add the missing information.


## Brief change log

  - *Update flink-fn-execution.proto add the missing schema information*
  - *Update the code generated file flink_fn_execution_pb2.py*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
