### PR TITLE
[FLINK-16606][python] Throw exceptions for the data types which are not currently supported

### DIFF
--- a/flink-python/pyflink/table/tests/test_calc.py
+++ b/flink-python/pyflink/table/tests/test_calc.py
@@ -64,18 +64,17 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
     def test_from_element(self):
         t_env = self.t_env
         field_names = ["a", "b", "c", "d", "e", "f", "g", "h",
-                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s"]
+                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
         field_types = [DataTypes.BIGINT(), DataTypes.DOUBLE(), DataTypes.STRING(),
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
-                       DataTypes.TIMESTAMP(),
-                       DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
-                       DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND()),
+                       DataTypes.TIMESTAMP(3),
+                       DataTypes.INTERVAL(DataTypes.SECOND(3)),
                        DataTypes.ARRAY(DataTypes.DOUBLE()),
                        DataTypes.ARRAY(DataTypes.DOUBLE(False)),
                        DataTypes.ARRAY(DataTypes.STRING()),
                        DataTypes.ARRAY(DataTypes.DATE()),
-                       DataTypes.DECIMAL(10, 0),
+                       DataTypes.DECIMAL(38, 18),
                        DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT()),
                                       DataTypes.FIELD("b", DataTypes.DOUBLE())]),
                        DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()),
@@ -89,7 +88,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         t_env.register_table_sink("Results", table_sink)
         t = t_env.from_elements(
             [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-              datetime.datetime(1970, 1, 2, 0, 0), datetime.datetime(1970, 1, 2, 0, 0),
+              datetime.datetime(1970, 1, 2, 0, 0),
               datetime.timedelta(days=1, microseconds=10),
               [1.0, None], array.array("d", [1.0, 2.0]),
               ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
@@ -101,7 +100,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'
-                    '1970-01-02 00:00:00.0,86400000,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
+                    '86400000,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
                     '1,1,2.0,{key=1.0},[65, 66, 67, 68],[1.0, 2.0],[3.0, 4.0]']
         self.assert_equals(actual, expected)
 
@@ -110,18 +109,17 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
                                              .new_instance().use_blink_planner()
                                              .in_batch_mode().build())
         field_names = ["a", "b", "c", "d", "e", "f", "g", "h",
-                       "i", "j", "k", "l", "m", "n", "o", "p", "q", "r"]
+                       "i", "j", "k", "l", "m", "n", "o", "p", "q"]
         field_types = [DataTypes.BIGINT(), DataTypes.DOUBLE(), DataTypes.STRING(),
                        DataTypes.STRING(), DataTypes.DATE(),
                        DataTypes.TIME(),
-                       DataTypes.TIMESTAMP(),
-                       DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(),
-                       DataTypes.INTERVAL(DataTypes.DAY(), DataTypes.SECOND()),
+                       DataTypes.TIMESTAMP(3),
+                       DataTypes.INTERVAL(DataTypes.SECOND(3)),
                        DataTypes.ARRAY(DataTypes.DOUBLE()),
                        DataTypes.ARRAY(DataTypes.DOUBLE(False)),
                        DataTypes.ARRAY(DataTypes.STRING()),
                        DataTypes.ARRAY(DataTypes.DATE()),
-                       DataTypes.DECIMAL(10, 0),
+                       DataTypes.DECIMAL(38, 18),
                        DataTypes.ROW([DataTypes.FIELD("a", DataTypes.BIGINT()),
                                       DataTypes.FIELD("b", DataTypes.DOUBLE())]),
                        DataTypes.MAP(DataTypes.STRING(), DataTypes.DOUBLE()),
@@ -135,7 +133,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         t_env.register_table_sink("Results", table_sink)
         t = t_env.from_elements(
             [(1, 1.0, "hi", "hello", datetime.date(1970, 1, 2), datetime.time(1, 0, 0),
-              datetime.datetime(1970, 1, 2, 0, 0), datetime.datetime(1970, 1, 2, 0, 0),
+              datetime.datetime(1970, 1, 2, 0, 0),
               datetime.timedelta(days=1, microseconds=10),
               [1.0, None], array.array("d", [1.0, 2.0]),
               ["abc"], [datetime.date(1970, 1, 2)], Decimal(1), Row("a", "b")(1, 2.0),
@@ -147,7 +145,7 @@ class StreamTableCalcTests(PyFlinkStreamTableTestCase):
         actual = source_sink_utils.results()
 
         expected = ['1,1.0,hi,hello,1970-01-02,01:00:00,1970-01-02 00:00:00.0,'
-                    '1970-01-02 00:00:00.0,86400000,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
+                    '86400000,[1.0, null],[1.0, 2.0],[abc],[1970-01-02],'
                     '1.000000000000000000,1,2.0,{key=1.0},[65, 66, 67, 68],[3.0, 4.0]']
         self.assert_equals(actual, expected)
 

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -766,7 +766,7 @@ class SchemaDescriptorTests(PyFlinkTestCase):
             .field("int_field", DataTypes.INT())\
             .field("long_field", DataTypes.BIGINT())\
             .field("string_field", DataTypes.STRING())\
-            .field("timestamp_field", DataTypes.TIMESTAMP())\
+            .field("timestamp_field", DataTypes.TIMESTAMP(3))\
             .field("time_field", DataTypes.TIME())\
             .field("date_field", DataTypes.DATE())\
             .field("double_field", DataTypes.DOUBLE())\

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -790,7 +790,7 @@ class DataTypeConvertTests(unittest.TestCase):
                       DataTypes.DOUBLE(),
                       DataTypes.DATE(),
                       DataTypes.TIME(),
-                      DataTypes.TIMESTAMP()]
+                      DataTypes.TIMESTAMP(3)]
 
         java_types = [_to_java_type(item) for item in test_types]
 
@@ -802,7 +802,7 @@ class DataTypeConvertTests(unittest.TestCase):
         gateway = get_gateway()
         JDataTypes = gateway.jvm.DataTypes
         java_types = [JDataTypes.TIME(3).notNull(),
-                      JDataTypes.TIMESTAMP().notNull(),
+                      JDataTypes.TIMESTAMP(3).notNull(),
                       JDataTypes.VARBINARY(100).notNull(),
                       JDataTypes.BINARY(2).notNull(),
                       JDataTypes.VARCHAR(30).notNull(),
@@ -812,7 +812,7 @@ class DataTypeConvertTests(unittest.TestCase):
         converted_python_types = [_from_java_type(item) for item in java_types]
 
         expected = [DataTypes.TIME(3, False),
-                    DataTypes.TIMESTAMP().not_null(),
+                    DataTypes.TIMESTAMP(3).not_null(),
                     DataTypes.VARBINARY(100, False),
                     DataTypes.BINARY(2, False),
                     DataTypes.VARCHAR(30, False),

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -176,14 +176,14 @@ class UserDefinedFunctionTests(object):
                                                       DataTypes.SMALLINT(),
                                                       DataTypes.INT(),
                                                       DataTypes.BIGINT(),
-                                                      DataTypes.DECIMAL(20, 10),
+                                                      DataTypes.DECIMAL(38, 18),
                                                       DataTypes.FLOAT(),
                                                       DataTypes.DOUBLE(),
                                                       DataTypes.BOOLEAN(),
                                                       DataTypes.STRING(),
                                                       DataTypes.DATE(),
                                                       DataTypes.TIME(),
-                                                      DataTypes.TIMESTAMP()],
+                                                      DataTypes.TIMESTAMP(3)],
                                          result_type=DataTypes.BIGINT()))
 
         self.t_env.register_function(
@@ -388,10 +388,10 @@ class UserDefinedFunctionTests(object):
             "date_func", udf(date_func, [DataTypes.DATE()], DataTypes.DATE()))
 
         self.t_env.register_function(
-            "time_func", udf(time_func, [DataTypes.TIME(3)], DataTypes.TIME(3)))
+            "time_func", udf(time_func, [DataTypes.TIME()], DataTypes.TIME()))
 
         self.t_env.register_function(
-            "timestamp_func", udf(timestamp_func, [DataTypes.TIMESTAMP()], DataTypes.TIMESTAMP()))
+            "timestamp_func", udf(timestamp_func, [DataTypes.TIMESTAMP(3)], DataTypes.TIMESTAMP(3)))
 
         self.t_env.register_function(
             "array_func", udf(array_func, [DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT()))],
@@ -414,8 +414,8 @@ class UserDefinedFunctionTests(object):
             [DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.TINYINT(),
              DataTypes.BOOLEAN(), DataTypes.SMALLINT(), DataTypes.INT(),
              DataTypes.FLOAT(), DataTypes.DOUBLE(), DataTypes.BYTES(),
-             DataTypes.STRING(), DataTypes.DATE(), DataTypes.TIME(3),
-             DataTypes.TIMESTAMP(), DataTypes.ARRAY(DataTypes.BIGINT()),
+             DataTypes.STRING(), DataTypes.DATE(), DataTypes.TIME(),
+             DataTypes.TIMESTAMP(3), DataTypes.ARRAY(DataTypes.BIGINT()),
              DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING()),
              DataTypes.DECIMAL(38, 18), DataTypes.DECIMAL(38, 18)])
         self.t_env.register_table_sink("Results", table_sink)
@@ -441,8 +441,8 @@ class UserDefinedFunctionTests(object):
                  DataTypes.FIELD("i", DataTypes.BYTES()),
                  DataTypes.FIELD("j", DataTypes.STRING()),
                  DataTypes.FIELD("k", DataTypes.DATE()),
-                 DataTypes.FIELD("l", DataTypes.TIME(3)),
-                 DataTypes.FIELD("m", DataTypes.TIMESTAMP()),
+                 DataTypes.FIELD("l", DataTypes.TIME()),
+                 DataTypes.FIELD("m", DataTypes.TIMESTAMP(3)),
                  DataTypes.FIELD("n", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.BIGINT()))),
                  DataTypes.FIELD("o", DataTypes.MAP(DataTypes.BIGINT(), DataTypes.STRING())),
                  DataTypes.FIELD("p", DataTypes.DECIMAL(38, 18)),

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1621,33 +1621,77 @@ def _to_java_type(data_type):
                 BigIntType: Types.LONG(),
                 FloatType: Types.FLOAT(),
                 DoubleType: Types.DOUBLE(),
-                DecimalType: Types.DECIMAL(),
                 DateType: Types.SQL_DATE(),
-                TimeType: Types.SQL_TIME(),
-                TimestampType: Types.SQL_TIMESTAMP(),
-                LocalZonedTimestampType: Types.SQL_TIMESTAMP(),
-                CharType: Types.STRING(),
-                VarCharType: Types.STRING(),
-                BinaryType: Types.PRIMITIVE_ARRAY(Types.BYTE()),
-                VarBinaryType: Types.PRIMITIVE_ARRAY(Types.BYTE())
             }
 
-    # NullType
-    if isinstance(data_type, NullType):
-        # null type is still not supported in Java
-        raise NotImplementedError
-
     # basic types
-    elif type(data_type) in _python_java_types_mapping:
+    if type(data_type) in _python_java_types_mapping:
         return _python_java_types_mapping[type(data_type)]
+
+    # DecimalType
+    elif isinstance(data_type, DecimalType):
+        if data_type.precision == 38 and data_type.scale == 18:
+            return Types.DECIMAL()
+        else:
+            raise TypeError("The precision must be 38 and the scale must be 18 for DecimalType, "
+                            "got %s" % repr(data_type))
+
+    # TimeType
+    elif isinstance(data_type, TimeType):
+        if data_type.precision == 0:
+            return Types.SQL_TIME()
+        else:
+            raise TypeError("The precision must be 0 for TimeType, got %s" % repr(data_type))
+
+    # TimestampType
+    elif isinstance(data_type, TimestampType):
+        if data_type.precision == 3:
+            return Types.SQL_TIMESTAMP()
+        else:
+            raise TypeError("The precision must be 3 for TimestampType, got %s" % repr(data_type))
+
+    # LocalZonedTimestampType
+    elif isinstance(data_type, LocalZonedTimestampType):
+        if data_type.precision == 3:
+            return gateway.jvm.org.apache.flink.api.common.typeinfo.Types.INSTANT
+        else:
+            raise TypeError("The precision must be 3 for LocalZonedTimestampType, got %s"
+                            % repr(data_type))
+
+    # VarCharType
+    elif isinstance(data_type, VarCharType):
+        if data_type.length == 0x7fffffff:
+            return Types.STRING()
+        else:
+            raise TypeError("The length limit must be 0x7fffffff(2147483647) for VarCharType, "
+                            "got %s" % repr(data_type))
+
+    # VarBinaryType
+    elif isinstance(data_type, VarBinaryType):
+        if data_type.length == 0x7fffffff:
+            return Types.PRIMITIVE_ARRAY(Types.BYTE())
+        else:
+            raise TypeError("The length limit must be 0x7fffffff(2147483647) for VarBinaryType, "
+                            "got %s" % repr(data_type))
 
     # YearMonthIntervalType
     elif isinstance(data_type, YearMonthIntervalType):
-        return Types.INTERVAL_MONTHS()
+        if data_type.resolution == YearMonthIntervalType.YearMonthResolution.MONTH and \
+                data_type.precision == 2:
+            return Types.INTERVAL_MONTHS()
+        else:
+            raise TypeError("The resolution must be YearMonthResolution.MONTH and the precision "
+                            "must be 2 for YearMonthIntervalType, got %s" % repr(data_type))
 
     # DayTimeIntervalType
     elif isinstance(data_type, DayTimeIntervalType):
-        return Types.INTERVAL_MILLIS()
+        if data_type.resolution == DayTimeIntervalType.DayTimeResolution.SECOND and \
+                data_type.day_precision == 2 and data_type.fractional_precision == 3:
+            return Types.INTERVAL_MILLIS()
+        else:
+            raise TypeError("The resolution must be DayTimeResolution.SECOND, the day_precision "
+                            "must be 2 and the fractional_precision must be 3 for "
+                            "DayTimeIntervalType, got %s" % repr(data_type))
 
     # ArrayType
     elif isinstance(data_type, ArrayType):
@@ -1677,7 +1721,7 @@ def _to_java_type(data_type):
             return _to_java_type(data_type.sql_type())
 
     else:
-        raise TypeError("Not supported type: %s" % data_type)
+        raise TypeError("Not supported type: %s" % repr(data_type))
 
 
 def _is_instance_of(java_data_type, java_class):
@@ -1731,7 +1775,7 @@ def _from_java_type(j_data_type):
         elif _is_instance_of(logical_type, gateway.jvm.TimeType):
             data_type = DataTypes.TIME(logical_type.getPrecision(), logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.TimestampType):
-            data_type = DataTypes.TIMESTAMP(nullable=logical_type.isNullable())
+            data_type = DataTypes.TIMESTAMP(precision=3, nullable=logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.BooleanType):
             data_type = DataTypes.BOOLEAN(logical_type.isNullable())
         elif _is_instance_of(logical_type, gateway.jvm.TinyIntType):
@@ -2252,6 +2296,8 @@ class DataTypes(object):
         define such a type as well.
 
         The null type is an extension to the SQL standard.
+
+        .. note:: `NullType` is still not supported yet.
         """
         return NullType()
 
@@ -2263,6 +2309,8 @@ class DataTypes(object):
         :param length: int, the string representation length. It must have a value
                        between 1 and 2147483647(0x7fffffff) (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: `CharType` is still not supported yet.
         """
         return CharType(length, nullable)
 
@@ -2274,6 +2322,9 @@ class DataTypes(object):
         :param length: int, the maximum string representation length. It must have a
                        value between 1 and 2147483647(0x7fffffff) (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: The length limit must be 0x7fffffff(2147483647) currently.
+        .. seealso:: :func:`~DataTypes.STRING`
         """
         return VarCharType(length, nullable)
 
@@ -2284,6 +2335,8 @@ class DataTypes(object):
         This is a shortcut for ``DataTypes.VARCHAR(2147483647)``.
 
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. seealso:: :func:`~DataTypes.VARCHAR`
         """
         return DataTypes.VARCHAR(0x7fffffff, nullable)
 
@@ -2305,6 +2358,8 @@ class DataTypes(object):
         :param length: int, the number of bytes. It must have a value between
                        1 and 2147483647(0x7fffffff) (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: `BinaryType` is still not supported yet.
         """
         return BinaryType(length, nullable)
 
@@ -2316,6 +2371,9 @@ class DataTypes(object):
         :param length: int, the maximum number of bytes. It must have a value
                        between 1 and 2147483647(0x7fffffff) (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: The length limit must be 0x7fffffff(2147483647) currently.
+        .. seealso:: :func:`~DataTypes.BYTES`
         """
         return VarBinaryType(length, nullable)
 
@@ -2326,6 +2384,8 @@ class DataTypes(object):
         defined maximum length. This is a shortcut for ``DataTypes.VARBINARY(2147483647)``.
 
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. seealso:: :func:`~DataTypes.VARBINARY`
         """
         return DataTypes.VARBINARY(0x7fffffff, nullable)
 
@@ -2339,6 +2399,8 @@ class DataTypes(object):
         :param scale: the number of digits on right side of dot. It must have
                       a value between 0 and precision (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: The precision must be 38 and the scale must be 18 currently.
         """
         return DecimalType(precision, scale, nullable)
 
@@ -2424,6 +2486,8 @@ class DataTypes(object):
         :param precision: int, the number of digits of fractional seconds. It must
                           have a value between 0 and 9 (both inclusive).
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: The precision must be 0 currently.
         """
         return TimeType(precision, nullable)
 
@@ -2447,6 +2511,8 @@ class DataTypes(object):
         :param precision: int, the number of digits of fractional seconds.
                           It must have a value between 0 and 9 (both inclusive). (default: 6)
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: The precision must be 3 currently.
         """
         return TimestampType(precision, nullable)
 
@@ -2468,6 +2534,9 @@ class DataTypes(object):
         :param precision: int, the number of digits of fractional seconds.
                           It must have a value between 0 and 9 (both inclusive). (default: 6)
         :param nullable: boolean, whether the type can be null (None) or not.
+
+        .. note:: `LocalZonedTimestampType` is currently only supported in blink planner and the
+                  precision must be 3.
         """
         return LocalZonedTimestampType(precision, nullable)
 
@@ -2553,6 +2622,7 @@ class DataTypes(object):
                           between 0 and 9 (both inclusive), (default: 6).
         :return: the specified :class:`Resolution`.
 
+        .. note:: the precision must be 3 currently.
         .. seealso:: :func:`~pyflink.table.DataTypes.INTERVAL`
         """
         return Resolution(Resolution.IntervalUnit.SECOND, precision)
@@ -2646,6 +2716,8 @@ class DataTypes(object):
         :param upper_resolution: :class:`Resolution`, the upper resolution of the interval.
         :param lower_resolution: :class:`Resolution`, the lower resolution of the interval.
 
+        .. note:: the upper_resolution must be `MONTH` for `YearMonthIntervalType`, `SECOND` for
+                  `DayTimeIntervalType` and the lower_resolution must be None currently.
         .. seealso:: :func:`~pyflink.table.DataTypes.SECOND`
         .. seealso:: :func:`~pyflink.table.DataTypes.MINUTE`
         .. seealso:: :func:`~pyflink.table.DataTypes.HOUR`


### PR DESCRIPTION

## What is the purpose of the change

*Currently, there are still cases where a data type isn't supported as the Python data type will be firstly converted to TypeInformation which will lose a few information, e.g,*
 - the precision for TimeType could only be 0
 - the length for VarBinaryType/VarCharType could only be 0x7fffffff
 - the precision/scale for DecimalType could only be 38/18
 - the precision for TimestampType/LocalZonedTimestampType could only be 3
 - the resolution for DayTimeIntervalType could only be `SECOND` and the fractionalPrecision could only be 3
 - the resolution for YearMonthIntervalType could only be `MONTH` and the `yearPrecision` could only be 2
 - the CharType/BinaryType/ZonedTimestampType is not supported

We should throw exceptions for the cases not supported.

## Brief change log

  - *Update the types.py to throw exceptions when a data type is not supported*


## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
