### PR TITLE
[FLINK-15667][k8s] Support to mount custom Hadoop configurations

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -69,6 +69,12 @@
             <td>The directory that logs of jobmanager and taskmanager be saved in the pod.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.hadoop.conf.config-map.name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the name of an existing ConfigMap that contains custom Hadoop configuration to be mounted on the JobManager(s) and TaskManagers.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.jobmanager.cpu</h5></td>
             <td style="word-wrap: break-word;">1.0</td>
             <td>Double</td>
@@ -103,12 +109,6 @@
             <td style="word-wrap: break-word;">-1.0</td>
             <td>Double</td>
             <td>The number of cpu used by task manager. By default, the cpu is set to the number of slots per TaskManager</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.hadoop.conf.config-map.name</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>String</td>
-            <td>Specify the name of an existing ConfigMap that contains custom Hadoop configuration to be mounted on the JobManager(s) and TaskManagers.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -104,5 +104,11 @@
             <td>Double</td>
             <td>The number of cpu used by task manager. By default, the cpu is set to the number of slots per TaskManager</td>
         </tr>
+        <tr>
+            <td><h5>kubernetes.hadoop.conf.config-map.name</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the name of an existing ConfigMap that contains custom Hadoop configuration to be mounted on the JobManager(s) and TaskManagers.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -147,6 +147,13 @@ public class KubernetesConfigOptions {
 		.defaultValue("/opt/flink/log")
 		.withDescription("The directory that logs of jobmanager and taskmanager be saved in the pod.");
 
+	public static final ConfigOption<String> HADOOP_CONF_CONFIG_MAP =
+		key("kubernetes.hadoop.conf.config-map.name")
+		.stringType()
+		.noDefaultValue()
+		.withDescription("Specify the name of an existing ConfigMap that contains custom Hadoop configuration " +
+			"to be mounted on the JobManager(s) and TaskManagers.");
+
 	/**
 	 * The flink rest service exposed type.
 	 */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -182,8 +182,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
 		return localLogConfFiles;
 	}
 
-	@VisibleForTesting
-	String getFlinkConfConfigMapName(String clusterId) {
+	public static String getFlinkConfConfigMapName(String clusterId) {
 		return CONFIG_MAP_PREFIX + clusterId;
 	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecorator.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.util.FileUtils;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KeyToPath;
+import io.fabric8.kubernetes.api.model.KeyToPathBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Mount the custom Hadoop Configuration to the JobManager(s)/TaskManagers. We provide two options:
+ * 1. Mount an existing ConfigMap containing custom Hadoop Configuration.
+ * 2. Create and mount a dedicated ConfigMap containing the custom Hadoop configuration from a local directory
+ *    specified via the HADOOP_CONF_DIR or HADOOP_HOME environment variable.
+ */
+public class HadoopConfMountDecorator extends AbstractKubernetesStepDecorator {
+
+	private static final Logger LOG = LoggerFactory.getLogger(HadoopConfMountDecorator.class);
+
+	private final AbstractKubernetesParameters kubernetesParameters;
+
+	public HadoopConfMountDecorator(AbstractKubernetesParameters kubernetesParameters) {
+		this.kubernetesParameters = checkNotNull(kubernetesParameters);
+	}
+
+	@Override
+	public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+		Volume hadoopConfVolume;
+
+		final Optional<String> existingConfigMap = kubernetesParameters.getExistingHadoopConfigurationConfigMap();
+		if (existingConfigMap.isPresent()) {
+			hadoopConfVolume = new VolumeBuilder()
+				.withName(Constants.HADOOP_CONF_VOLUME)
+				.withNewConfigMap()
+					.withName(existingConfigMap.get())
+					.endConfigMap()
+				.build();
+		} else {
+			final Optional<String> localHadoopConfigurationDirectory = kubernetesParameters.getLocalHadoopConfigurationDirectory();
+			if (!localHadoopConfigurationDirectory.isPresent()) {
+				return flinkPod;
+			}
+
+			final List<File> hadoopConfigurationFileItems = getHadoopConfigurationFileItems(localHadoopConfigurationDirectory.get());
+			if (hadoopConfigurationFileItems.isEmpty()) {
+				LOG.warn("Found 0 files in directory {}, skip to mount the Hadoop Configuration ConfigMap.",
+					localHadoopConfigurationDirectory.get());
+				return flinkPod;
+			}
+
+			final List<KeyToPath> keyToPaths = hadoopConfigurationFileItems.stream()
+				.map(file -> new KeyToPathBuilder()
+					.withKey(file.getName())
+					.withPath(file.getName())
+					.build())
+				.collect(Collectors.toList());
+
+			hadoopConfVolume = new VolumeBuilder()
+				.withName(Constants.HADOOP_CONF_VOLUME)
+				.withNewConfigMap()
+					.withName(getHadoopConfConfigMapName(kubernetesParameters.getClusterId()))
+					.withItems(keyToPaths)
+					.endConfigMap()
+				.build();
+		}
+
+		final Pod podWithHadoopConf = new PodBuilder(flinkPod.getPod())
+			.editOrNewSpec()
+				.addNewVolumeLike(hadoopConfVolume)
+					.endVolume()
+				.endSpec()
+			.build();
+
+		final Container containerWithHadoopConf = new ContainerBuilder(flinkPod.getMainContainer())
+			.addNewVolumeMount()
+				.withName(Constants.HADOOP_CONF_VOLUME)
+				.withMountPath(Constants.HADOOP_CONF_DIR_IN_POD)
+				.endVolumeMount()
+			.addNewEnv()
+				.withName(Constants.ENV_HADOOP_CONF_DIR)
+				.withValue(Constants.HADOOP_CONF_DIR_IN_POD)
+				.endEnv()
+			.build();
+
+		return new FlinkPod.Builder(flinkPod)
+			.withPod(podWithHadoopConf)
+			.withMainContainer(containerWithHadoopConf)
+			.build();
+	}
+
+	@Override
+	public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+		if (kubernetesParameters.getExistingHadoopConfigurationConfigMap().isPresent()) {
+			return Collections.emptyList();
+		}
+
+		final Optional<String> localHadoopConfigurationDirectory = kubernetesParameters.getLocalHadoopConfigurationDirectory();
+		if (!localHadoopConfigurationDirectory.isPresent()) {
+			return Collections.emptyList();
+		}
+
+		final List<File> hadoopConfigurationFileItems = getHadoopConfigurationFileItems(localHadoopConfigurationDirectory.get());
+		if (hadoopConfigurationFileItems.isEmpty()) {
+			LOG.warn("Found 0 files in directory {}, skip to create the Hadoop Configuration ConfigMap.", localHadoopConfigurationDirectory.get());
+			return Collections.emptyList();
+		}
+
+		final Map<String, String> data = new HashMap<>();
+		for (File file: hadoopConfigurationFileItems) {
+			data.put(file.getName(), FileUtils.readFileUtf8(file));
+		}
+
+		final ConfigMap hadoopConfigMap = new ConfigMapBuilder()
+			.withApiVersion(Constants.API_VERSION)
+			.withNewMetadata()
+				.withName(getHadoopConfConfigMapName(kubernetesParameters.getClusterId()))
+				.withLabels(kubernetesParameters.getCommonLabels())
+				.endMetadata()
+			.addToData(data)
+			.build();
+
+		return Collections.singletonList(hadoopConfigMap);
+	}
+
+	private List<File> getHadoopConfigurationFileItems(String localHadoopConfigurationDirectory) {
+		final List<String> expectedFileNames = new ArrayList<>();
+		expectedFileNames.add("core-site.xml");
+		expectedFileNames.add("hdfs-site.xml");
+
+		final File directory = new File(localHadoopConfigurationDirectory);
+		if (directory.exists() && directory.isDirectory()) {
+			return Arrays.stream(directory.listFiles())
+				.filter(file -> file.isFile() && expectedFileNames.stream().anyMatch(name -> file.getName().equals(name)))
+				.collect(Collectors.toList());
+		} else {
+			return Collections.emptyList();
+		}
+	}
+
+	public static String getHadoopConfConfigMapName(String clusterId) {
+		return Constants.HADOOP_CONF_CONFIG_MAP_PREFIX + clusterId;
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InitJobManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.JavaCmdJobManagerDecorator;
@@ -58,6 +59,7 @@ public class KubernetesJobManagerFactory {
 			new JavaCmdJobManagerDecorator(kubernetesJobManagerParameters),
 			new InternalServiceDecorator(kubernetesJobManagerParameters),
 			new ExternalServiceDecorator(kubernetesJobManagerParameters),
+			new HadoopConfMountDecorator(kubernetesJobManagerParameters),
 			new FlinkConfMountDecorator(kubernetesJobManagerParameters)};
 
 		for (KubernetesStepDecorator stepDecorator: stepDecorators) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient.factory;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.JavaCmdTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
@@ -40,6 +41,7 @@ public class KubernetesTaskManagerFactory {
 		final KubernetesStepDecorator[] stepDecorators = new KubernetesStepDecorator[] {
 			new InitTaskManagerDecorator(kubernetesTaskManagerParameters),
 			new JavaCmdTaskManagerDecorator(kubernetesTaskManagerParameters),
+			new HadoopConfMountDecorator(kubernetesTaskManagerParameters),
 			new FlinkConfMountDecorator(kubernetesTaskManagerParameters)};
 
 		for (KubernetesStepDecorator stepDecorator: stepDecorators) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A common collection of parameters that is used to construct the JobManager/TaskManager Pods,
@@ -80,4 +81,14 @@ public interface KubernetesParameters {
 	 * Whether the log4j.properties is located.
 	 */
 	boolean hasLog4j();
+
+	/**
+	 * The existing ConfigMap containing custom Hadoop configuration.
+	 */
+	Optional<String> getExistingHadoopConfigurationConfigMap();
+
+	/**
+	 * The local directory to locate the custom Hadoop configuration.
+	 */
+	Optional<String> getLocalHadoopConfigurationDirectory();
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -28,12 +28,16 @@ public class Constants {
 	public static final String APPS_API_VERSION = "apps/v1";
 
 	public static final String CONFIG_FILE_LOGBACK_NAME = "logback.xml";
-
 	public static final String CONFIG_FILE_LOG4J_NAME = "log4j.properties";
 
 	public static final String FLINK_CONF_VOLUME = "flink-config-volume";
-
 	public static final String CONFIG_MAP_PREFIX = "flink-config-";
+
+	public static final String HADOOP_CONF_VOLUME = "hadoop-config-volume";
+	public static final String HADOOP_CONF_CONFIG_MAP_PREFIX = "hadoop-config-";
+	public static final String HADOOP_CONF_DIR_IN_POD = "/opt/hadoop/conf";
+	public static final String ENV_HADOOP_CONF_DIR = "HADOOP_CONF_DIR";
+	public static final String ENV_HADOOP_HOME = "HADOOP_HOME";
 
 	public static final String FLINK_REST_SERVICE_SUFFIX = "-rest";
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
@@ -57,6 +58,8 @@ public class KubernetesTestBase extends TestLogger {
 
 	protected File flinkConfDir;
 
+	protected File hadoopConfDir;
+
 	protected final Configuration flinkConfig = new Configuration();
 
 	protected KubernetesClient kubeClient;
@@ -71,6 +74,8 @@ public class KubernetesTestBase extends TestLogger {
 		flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY, CONTAINER_IMAGE_PULL_POLICY);
 
 		flinkConfDir = temporaryFolder.newFolder().getAbsoluteFile();
+		hadoopConfDir = temporaryFolder.newFolder().getAbsoluteFile();
+
 		writeFlinkConfiguration();
 
 		Map<String, String> map = new HashMap<>();
@@ -90,5 +95,16 @@ public class KubernetesTestBase extends TestLogger {
 		labels.put(Constants.LABEL_TYPE_KEY, Constants.LABEL_TYPE_NATIVE_TYPE);
 		labels.put(Constants.LABEL_APP_KEY, CLUSTER_ID);
 		return labels;
+	}
+
+	protected void setHadoopConfDirEnv() {
+		Map<String, String> map = new HashMap<>();
+		map.put(Constants.ENV_HADOOP_CONF_DIR, hadoopConfDir.toString());
+		CommonTestUtils.setEnv(map, false);
+	}
+
+	protected void generateHadoopConfFileItems() throws IOException {
+		KubernetesTestUtils.createTemporyFile("some data", hadoopConfDir, "core-site.xml");
+		KubernetesTestUtils.createTemporyFile("some data", hadoopConfDir, "hdfs-site.xml");
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/HadoopConfMountDecoratorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
+import org.apache.flink.kubernetes.utils.Constants;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KeyToPath;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * General tests for the {@link HadoopConfMountDecorator}.
+ */
+public class HadoopConfMountDecoratorTest extends KubernetesJobManagerTestBase {
+
+	private static final String EXISTING_HADOOP_CONF_CONFIG_MAP = "hadoop-conf";
+
+	private HadoopConfMountDecorator hadoopConfMountDecorator;
+
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+		this.hadoopConfMountDecorator = new HadoopConfMountDecorator(kubernetesJobManagerParameters);
+	}
+
+	@Test
+	public void testExistingHadoopConfigMap() throws IOException {
+		flinkConfig.set(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP, EXISTING_HADOOP_CONF_CONFIG_MAP);
+		assertEquals(0, hadoopConfMountDecorator.buildAccompanyingKubernetesResources().size());
+
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+		final List<Volume> volumes = resultFlinkPod.getPod().getSpec().getVolumes();
+		assertTrue(volumes.stream().anyMatch(volume -> volume.getConfigMap().getName().equals(EXISTING_HADOOP_CONF_CONFIG_MAP)));
+	}
+
+	@Test
+	public void testExistingConfigMapPrecedeOverHadoopConfEnv() throws IOException {
+		// set existing ConfigMap
+		flinkConfig.set(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP, EXISTING_HADOOP_CONF_CONFIG_MAP);
+
+		// set HADOOP_CONF_DIR
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+
+		assertEquals(0, hadoopConfMountDecorator.buildAccompanyingKubernetesResources().size());
+
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+		final List<Volume> volumes = resultFlinkPod.getPod().getSpec().getVolumes();
+		assertTrue(volumes.stream().anyMatch(volume ->
+			volume.getConfigMap().getName().equals(EXISTING_HADOOP_CONF_CONFIG_MAP)));
+		assertFalse(volumes.stream().anyMatch(volume ->
+			volume.getConfigMap().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));
+	}
+
+	@Test
+	public void testHadoopConfDirectoryUnset() throws IOException {
+		assertEquals(0, hadoopConfMountDecorator.buildAccompanyingKubernetesResources().size());
+
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+		assertEquals(baseFlinkPod.getPod(), resultFlinkPod.getPod());
+		assertEquals(baseFlinkPod.getMainContainer(), resultFlinkPod.getMainContainer());
+	}
+
+	@Test
+	public void testEmptyHadoopConfDirectory() throws IOException {
+		setHadoopConfDirEnv();
+
+		assertEquals(0, hadoopConfMountDecorator.buildAccompanyingKubernetesResources().size());
+
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+		assertEquals(baseFlinkPod.getPod(), resultFlinkPod.getPod());
+		assertEquals(baseFlinkPod.getMainContainer(), resultFlinkPod.getMainContainer());
+	}
+
+	@Test
+	public void testHadoopConfConfigMap() throws IOException {
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+
+		final List<HasMetadata> additionalResources = hadoopConfMountDecorator.buildAccompanyingKubernetesResources();
+		assertEquals(1, additionalResources.size());
+
+		final ConfigMap resultConfigMap = (ConfigMap) additionalResources.get(0);
+
+		assertEquals(Constants.API_VERSION, resultConfigMap.getApiVersion());
+		assertEquals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID),
+			resultConfigMap.getMetadata().getName());
+		assertEquals(getCommonLabels(), resultConfigMap.getMetadata().getLabels());
+
+		Map<String, String> resultDatas = resultConfigMap.getData();
+		assertEquals("some data", resultDatas.get("core-site.xml"));
+		assertEquals("some data", resultDatas.get("hdfs-site.xml"));
+	}
+
+	@Test
+	public void testPodWithHadoopConfVolume() throws IOException {
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+
+		final List<Volume> resultVolumes = resultFlinkPod.getPod().getSpec().getVolumes();
+		assertEquals(1, resultVolumes.size());
+
+		final Volume resultVolume = resultVolumes.get(0);
+		assertEquals(Constants.HADOOP_CONF_VOLUME, resultVolume.getName());
+
+		final ConfigMapVolumeSource resultVolumeConfigMap = resultVolume.getConfigMap();
+		assertEquals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID),
+			resultVolumeConfigMap.getName());
+
+		final Map<String, String> expectedKeyToPaths = new HashMap<String, String>() {
+			{
+				put("hdfs-site.xml", "hdfs-site.xml");
+				put("core-site.xml", "core-site.xml");
+			}
+		};
+		final Map<String, String> resultKeyToPaths = resultVolumeConfigMap.getItems().stream()
+			.collect(Collectors.toMap(KeyToPath::getKey, KeyToPath::getPath));
+		assertEquals(expectedKeyToPaths, resultKeyToPaths);
+	}
+
+	@Test
+	public void testMainContainerWithHadoopConfVolumeMount() throws IOException {
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+		final FlinkPod resultFlinkPod = hadoopConfMountDecorator.decorateFlinkPod(baseFlinkPod);
+
+		final List<VolumeMount> resultVolumeMounts = resultFlinkPod.getMainContainer().getVolumeMounts();
+		assertEquals(1, resultVolumeMounts.size());
+		final VolumeMount resultVolumeMount = resultVolumeMounts.get(0);
+		assertEquals(Constants.HADOOP_CONF_VOLUME, resultVolumeMount.getName());
+		assertEquals(Constants.HADOOP_CONF_DIR_IN_POD, resultVolumeMount.getMountPath());
+
+		final Map<String, String> expectedEnvs = new HashMap<String, String>() {
+			{
+				put(Constants.ENV_HADOOP_CONF_DIR, Constants.HADOOP_CONF_DIR_IN_POD);
+			}
+		};
+		final Map<String, String> resultEnvs = resultFlinkPod.getMainContainer().getEnv()
+			.stream().collect(Collectors.toMap(EnvVar::getName, EnvVar::getValue));
+		assertEquals(expectedEnvs, resultEnvs);
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal
 import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerTestBase;
+import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -57,7 +58,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	private static final String SERVICE_ACCOUNT_NAME = "service-test";
 	private static final String ENTRY_POINT_CLASS = KubernetesSessionClusterEntrypoint.class.getCanonicalName();
 
-	private KubernetesJobManagerSpecification kubernetesJobManagerSpecification;
+	protected KubernetesJobManagerSpecification kubernetesJobManagerSpecification;
 
 	@Before
 	public void setup() throws Exception {
@@ -187,7 +188,8 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 	public void testFlinkConfConfigMap() {
 		final ConfigMap resultConfigMap = (ConfigMap) this.kubernetesJobManagerSpecification.getAccompanyingResources()
 			.stream()
-			.filter(x -> x instanceof ConfigMap)
+			.filter(x -> x instanceof ConfigMap &&
+				x.getMetadata().getName().equals(FlinkConfMountDecorator.getFlinkConfConfigMapName(CLUSTER_ID)))
 			.collect(Collectors.toList())
 			.get(0);
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerHadoopConfTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerHadoopConfTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.factory;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * General tests for the Hadoop configuration setting decorated via {@link KubernetesJobManagerFactory}.
+ */
+public class KubernetesJobManagerHadoopConfTest extends KubernetesJobManagerFactoryTest {
+
+	private static final String EXISTING_HADOOP_CONF_CONFIG_MAP = "hadoop-conf";
+
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+	}
+
+	@Test
+	public void testExistingHadoopConfigMap() throws IOException {
+		flinkConfig.set(KubernetesConfigOptions.HADOOP_CONF_CONFIG_MAP, EXISTING_HADOOP_CONF_CONFIG_MAP);
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+
+		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
+			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));
+
+		final PodSpec podSpec = kubernetesJobManagerSpecification.getDeployment().getSpec().getTemplate().getSpec();
+		assertTrue(podSpec.getVolumes().stream().anyMatch(volume -> volume.getConfigMap().getName().equals(EXISTING_HADOOP_CONF_CONFIG_MAP)));
+	}
+
+	@Test
+	public void testHadoopConfConfigMap() throws IOException {
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+
+		final ConfigMap resultConfigMap = (ConfigMap) kubernetesJobManagerSpecification.getAccompanyingResources()
+			.stream()
+			.filter(x -> x instanceof ConfigMap &&
+				x.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID)))
+			.collect(Collectors.toList())
+			.get(0);
+
+		assertEquals(2, resultConfigMap.getMetadata().getLabels().size());
+
+		final Map<String, String> resultDatas = resultConfigMap.getData();
+		assertEquals(2, resultDatas.size());
+		assertEquals("some data", resultDatas.get("core-site.xml"));
+		assertEquals("some data", resultDatas.get("hdfs-site.xml"));
+	}
+
+	@Test
+	public void testEmptyHadoopConfDirectory() throws IOException {
+		setHadoopConfDirEnv();
+		kubernetesJobManagerSpecification = KubernetesJobManagerFactory.createJobManagerComponent(kubernetesJobManagerParameters);
+
+		assertFalse(kubernetesJobManagerSpecification.getAccompanyingResources().stream()
+			.anyMatch(resource -> resource.getMetadata().getName().equals(HadoopConfMountDecorator.getHadoopConfConfigMapName(CLUSTER_ID))));
+	}
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * General tests for the {@link KubernetesTaskManagerFactory}.
@@ -45,6 +46,9 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "logback.xml");
 		KubernetesTestUtils.createTemporyFile("some data", flinkConfDir, "log4j.properties");
 
+		setHadoopConfDirEnv();
+		generateHadoopConfFileItems();
+
 		this.resultPod =
 			KubernetesTaskManagerFactory.createTaskManagerComponent(kubernetesTaskManagerParameters).getInternalResource();
 	}
@@ -53,7 +57,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 	public void testPod() {
 		assertEquals(POD_NAME, this.resultPod.getMetadata().getName());
 		assertEquals(3, this.resultPod.getMetadata().getLabels().size());
-		assertEquals(1, this.resultPod.getSpec().getVolumes().size());
+		assertEquals(2, this.resultPod.getSpec().getVolumes().size());
 	}
 
 	@Test
@@ -67,9 +71,15 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 			resultMainContainer.getName());
 		assertEquals(CONTAINER_IMAGE, resultMainContainer.getImage());
 		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), resultMainContainer.getImagePullPolicy());
+
+		assertEquals(4, resultMainContainer.getEnv().size());
+		assertTrue(resultMainContainer.getEnv()
+			.stream()
+			.anyMatch(envVar -> envVar.getName().equals("key1")));
+
 		assertEquals(1, resultMainContainer.getPorts().size());
 		assertEquals(1, resultMainContainer.getCommand().size());
 		assertEquals(3, resultMainContainer.getArgs().size());
-		assertEquals(1, resultMainContainer.getVolumeMounts().size());
+		assertEquals(2, resultMainContainer.getVolumeMounts().size());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add support for mounting custom Hadoop configurations into the JM/TM Pods. We provide two options for the user to mount those configurations:
- option 1: specify an existing ConfigMap that contains custom Hadoop configurations, one can share a single ConfigMap for more than one Flink clusters.
- option 2: create a dedicated ConfigMap containing Hadoop configurations loaded from the local directory specified by the **HADOOP_CONF_DIR** or **HADOOP_HOME** environment variable, then bind that ConfigMap to the lifecycle of the new Flink cluster. 

## Brief change log
  - Introduce a new `KubernetesStepDecorator` implementation named `HadoopConfMountDecorator`.
  - Add `HadoopConfMountDecorator` to the decorator chains in `KubernetesJobManagerFactory` and `KubernetesTaskManagerFactory`.
  - Introduce a new config option `kubernetes.hadoop.conf.config-map.name`.


## Verifying this change

This change added unit tests and additionally can be verified manually as follows:
  -  Specify an existing Hadoop Configuration ConfigMap when starts a new Flink cluster, make sure that the ConfigMap is mounted into the Pods. Then delete the Deployment and make sure that the existing ConfigMap is not deleted.
  -  Do not specify an existing ConfigMap, instead, export the HADOOP_CONF_DIR that contains Hadoop configuration files when starts a new Flink cluster, make sure that a dedicated ConfigMap is created and mounted into the Pods. 
  -  Do not specify an existing ConfigMap, instead, export the HADOOP_HOME that contains Hadoop configuration files when starts a new Flink cluster, make sure that a dedicated ConfigMap is created and mounted into the Pods. 
  -  Specify an existing ConfigMap and export HADOOP_CONF_DIR when starts a new Flink cluster, make sure that we do not create a dedicated Hadoop ConfigMap and use the existing one. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)