### PR TITLE
[FLINK-16454][build] Update the copyright with 2020 year in NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Flink
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-cassandra/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-cassandra
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch2/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-elasticsearch2
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-elasticsearch5
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-kinesis
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-connector-twitter/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-twitter/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-connector-twitter
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-elasticsearch6
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.10
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.11/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.9
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.9/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka-0.9
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-connector-kafka
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-dist
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-examples-streaming-state-machine
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-azure-fs-hadoop
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-fs-hadoop-shaded
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-oss-fs-hadoop
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-s3-fs-presto
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-swift-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-swift-fs-hadoop
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-avro-confluent-registry
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-mesos/src/main/resources/META-INF/NOTICE
+++ b/flink-mesos/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-mesos
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-datadog/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-datadog
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-graphite/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-graphite
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-influxdb
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-metrics-prometheus
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-python
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-runtime-web/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime-web/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-runtime-web
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-runtime/src/main/resources/META-INF/NOTICE
+++ b/flink-runtime/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-runtime
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-shaded-curator/src/main/resources/META-INF/NOTICE
+++ b/flink-shaded-curator/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-shaded-curator
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-sql-client
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner-blink/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-planner-blink
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-planner/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-planner
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-table-runtime-blink
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-test-utils-parent/flink-test-utils/src/main/resources/META-INF/NOTICE
+++ b/flink-test-utils-parent/flink-test-utils/src/main/resources/META-INF/NOTICE
@@ -1,5 +1,5 @@
 flink-test-utils
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tools/releasing/NOTICE-binary_PREAMBLE.txt
+++ b/tools/releasing/NOTICE-binary_PREAMBLE.txt
@@ -4,7 +4,7 @@
 // ------------------------------------------------------------------
 
 Apache Flink
-Copyright 2014-2019 The Apache Software Foundation
+Copyright 2014-2020 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 


### PR DESCRIPTION
## What is the purpose of the change

back-port from #11412

## Brief change log

Update the copyright from 2014-2019 to 2014-2020 in NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
