### PR TITLE
[FLINK-16565][python][ml] Make Pipeline Json compitable between Java and Python if all PipelineStages are Java ones

### DIFF
--- a/flink-python/pyflink/ml/api/base.py
+++ b/flink-python/pyflink/ml/api/base.py
@@ -314,8 +314,9 @@ class Pipeline(Estimator, Model, Transformer):
                     self.append_stage(JavaModel(j_stage))
                 else:
                     raise TypeError(
-                        "Unexpected Java PipelineStage. It should be a %s, "
+                        "Unexpected Java PipelineStage %s. Class should be a %s, "
                         "%s or a %s." %
-                        (j_transformer_class.getCanonicalName(),
+                        (j_stage_class.getCanonicalName(),
+                         j_transformer_class.getCanonicalName(),
                          j_estimator_class.getCanonicalName(),
                          j_model_class.getCanonicalName()))

--- a/flink-python/pyflink/ml/api/base.py
+++ b/flink-python/pyflink/ml/api/base.py
@@ -23,7 +23,8 @@ from abc import ABCMeta, abstractmethod
 from pyflink.table.table_environment import TableEnvironment
 from pyflink.table.table import Table
 from pyflink.ml.api.param import WithParams, Params
-from py4j.java_gateway import get_field
+from pyflink.java_gateway import get_gateway
+from py4j.java_gateway import get_field, get_java_class as java_class
 
 
 class PipelineStage(WithParams):
@@ -265,11 +266,56 @@ class Pipeline(Estimator, Model, Transformer):
         return input
 
     def to_json(self) -> str:
-        import jsonpickle
-        return str(jsonpickle.encode(self, keys=True))
+        """
+        If all PipelineStages in this Pipeline are Java ones, this method will return a
+        Java json string, which can be loaded either from a Python Pipeline or a Java Pipeline,
+        otherwise, it returns a Python json string which can only be loaded from a Python Pipeline.
+        """
+        # if all PipelineStages are Java ones, we use Java toJson() to generate Json string
+        # so that the string can also be loaded from Java side.
+        if all([type(stage) in [JavaTransformer, JavaEstimator, JavaModel]
+                for stage in self.get_stages()]):
+            j_pipeline = get_gateway().jvm.org.apache.flink.ml.api.core.Pipeline()
+            for stage in self.get_stages():
+                stage._convert_params_to_java(stage._j_obj)
+                j_pipeline.appendStage(stage._j_obj)
+            return j_pipeline.toJson()
+        else:
+            import jsonpickle
+            return str(jsonpickle.encode(self, keys=True))
 
     def load_json(self, json: str) -> None:
-        import jsonpickle
-        pipeline = jsonpickle.decode(json, keys=True)
-        for stage in pipeline.get_stages():
-            self.append_stage(stage)
+        """
+        This method can either load from a Java Pipeline json or a Python Pipeline json.
+        """
+        # noinspection PyBroadException
+        try:
+            # try to load json with Python method
+            import jsonpickle
+            pipeline = jsonpickle.decode(json, keys=True)
+            for stage in pipeline.get_stages():
+                self.append_stage(stage)
+        except Exception:
+            # if can't load json with Python method, try to load with Java method
+            gw = get_gateway()
+            j_pipeline = gw.jvm.org.apache.flink.ml.api.core.Pipeline()
+            j_pipeline.loadJson(json)
+
+            for j_stage in j_pipeline.getStages():
+                j_stage_class = j_stage.getClass()
+                j_transformer_class = java_class(gw.jvm.org.apache.flink.ml.api.core.Transformer)
+                j_estimator_class = java_class(gw.jvm.org.apache.flink.ml.api.core.Estimator)
+                j_model_class = java_class(gw.jvm.org.apache.flink.ml.api.core.Model)
+                if j_transformer_class.isAssignableFrom(j_stage_class):
+                    self.append_stage(JavaTransformer(j_stage))
+                elif j_estimator_class.isAssignableFrom(j_stage_class):
+                    self.append_stage(JavaEstimator(j_stage))
+                elif j_model_class.isAssignableFrom(j_stage_class):
+                    self.append_stage(JavaModel(j_stage))
+                else:
+                    raise TypeError(
+                        "Unexpected Java PipelineStage. It should be a %s, "
+                        "%s or a %s." %
+                        (j_transformer_class.getCanonicalName(),
+                         j_estimator_class.getCanonicalName(),
+                         j_model_class.getCanonicalName()))

--- a/flink-python/pyflink/ml/tests/test_pipeline.py
+++ b/flink-python/pyflink/ml/tests/test_pipeline.py
@@ -21,6 +21,7 @@ from pyflink.ml.api import JavaTransformer, Transformer, Estimator, Model, \
     Pipeline, JavaEstimator, JavaModel
 from pyflink.ml.api.param.base import WithParams, ParamInfo, TypeConverters
 from pyflink import keyword
+from pyflink.testing.test_case_utils import MLTestCase
 
 
 class PipelineTest(unittest.TestCase):
@@ -70,6 +71,33 @@ class PipelineTest(unittest.TestCase):
 
         pipeline_model = pipeline_new.fit(None, None)
         self.assertEqual("a_ja_mb_mjb_mc_d", PipelineTest.describe_pipeline(pipeline_model))
+
+
+class ValidationPipelineTest(MLTestCase):
+
+    def test_pipeline_from_invalid_json(self):
+        invalid_json = '[a:aa]'
+
+        # load json
+        p = Pipeline()
+        with self.assertRaises(RuntimeError) as context:
+            p.load_json(invalid_json)
+        exception_str = str(context.exception)
+
+        # only assert key error message as the whole message is very long.
+        self.assertTrue(
+            'Cannot load the JSON as either a Java Pipeline or a Python Pipeline.'
+            in exception_str)
+        self.assertTrue(
+            'Python Pipeline load failed due to: Expecting value: line 1 column 2 (char 1).'
+            in exception_str)
+        self.assertTrue(
+            'Java Pipeline load failed due to: An error occurred while calling o0.loadJson.'
+            in exception_str)
+        self.assertTrue(
+            'Caused by: org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.'
+            'JsonParseException: Unrecognized token \'a\''
+            in exception_str)
 
 
 class SelfDescribe(WithParams):

--- a/flink-python/pyflink/ml/tests/test_pipeline_it_case.py
+++ b/flink-python/pyflink/ml/tests/test_pipeline_it_case.py
@@ -171,16 +171,11 @@ class PythonPipelineTest(MLTestCase):
         self.assert_equals(actual, ["false", "true"])
 
     def test_pipeline_from_and_to_java_json(self):
-
-        def get_java_pipeline_json():
-            wrapper = WrapperTransformer(selected_cols=["a", "b"])
-            wrapper._convert_params_to_java(wrapper._j_obj)
-            j_pipeline = get_gateway().jvm.org.apache.flink.ml.api.core.Pipeline()
-            j_pipeline.appendStage(wrapper._j_obj)
-            return j_pipeline.toJson()
-
-        # generate java json
-        java_json = get_java_pipeline_json()
+        # json generated from Java api
+        java_json = '[{"stageClassName":"org.apache.flink.ml.pipeline.' \
+                    'UserDefinedPipelineStages$SelectColumnTransformer",' \
+                    '"stageJson":"{\\"selectedCols\\":\\"[\\\\\\"a\\\\\\",' \
+                    '\\\\\\"b\\\\\\"]\\"}"}]'
 
         # load json
         p = Pipeline()


### PR DESCRIPTION

## What is the purpose of the change

Make Pipeline Json compitable between Java and Python if all PipelineStages are Java ones. 


## Brief change log

  - In `Pipeline.load_json()`, also try to load json with Java method if can't load json with Python method.
  - In `Pipeline.to_json()`, returns a Java json string if all PipelineStages in this Pipeline are Java ones.


## Verifying this change

This change added tests and can be verified as follows:

  - Added integration test(`test_pipeline_from_and_to_java_json`) for testing load_json and to_json

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PythonDocs)
