### PR TITLE
[FLINK-15962][network] Reduce the default chunk size to 4M in netty stack

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
+++ b/flink-end-to-end-tests/test-scripts/test_netty_shuffle_memory_control.sh
@@ -33,8 +33,8 @@ set_config_key "taskmanager.numberOfTaskSlots" "20"
 # Sets only one arena per TM for boosting the netty internal memory overhead.
 set_config_key "taskmanager.network.netty.num-arenas" "1"
 
-# Limits the direct memory to be one chunk (16M) plus some margins.
-set_config_key "taskmanager.memory.framework.off-heap.size" "20m"
+# Limits the direct memory to be one chunk (4M) plus some margins.
+set_config_key "taskmanager.memory.framework.off-heap.size" "7m"
 
 # Starts the cluster which includes one TaskManager.
 start_cluster

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyBufferPool.java
@@ -53,7 +53,7 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 
 	/**
 	 * Arenas allocate chunks of pageSize << maxOrder bytes. With these defaults, this results in
-	 * chunks of 16 MB.
+	 * chunks of 4 MB.
 	 *
 	 * @see #MAX_ORDER
 	 */
@@ -61,11 +61,13 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 
 	/**
 	 * Arenas allocate chunks of pageSize << maxOrder bytes. With these defaults, this results in
-	 * chunks of 16 MB.
+	 * chunks of 4 MB, which is smaller than the previous default (16 MB) to further reduce the
+	 * netty memory overhead. According to the test result, after introducing client side zero-copy
+	 * in FLINK-10742, 4 MB is enough to support large-scale netty shuffle.
 	 *
 	 * @see #PAGE_SIZE
 	 */
-	private static final int MAX_ORDER = 11;
+	private static final int MAX_ORDER = 9;
 
 	/**
 	 * Creates Netty's buffer pool with the specified number of direct arenas.
@@ -78,8 +80,8 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 			PREFER_DIRECT,
 			// No heap arenas, please.
 			0,
-			// Number of direct arenas. Each arena allocates a chunk of 16 MB, i.e.
-			// we allocate numDirectArenas * 16 MB of direct memory. This can grow
+			// Number of direct arenas. Each arena allocates a chunk of 4 MB, i.e.
+			// we allocate numDirectArenas * 4 MB of direct memory. This can grow
 			// to multiple chunks per arena during runtime, but this should only
 			// happen with a large amount of connections per task manager. We
 			// control the memory allocations with low/high watermarks when writing
@@ -92,7 +94,7 @@ public class NettyBufferPool extends PooledByteBufAllocator {
 		this.numberOfArenas = numberOfArenas;
 
 		// Arenas allocate chunks of pageSize << maxOrder bytes. With these
-		// defaults, this results in chunks of 16 MB.
+		// defaults, this results in chunks of 4 MB.
 
 		this.chunkSize = PAGE_SIZE << MAX_ORDER;
 


### PR DESCRIPTION
## What is the purpose of the change

Decrease the default Netty chunk size from 16MB to 4MB. Since Netty allocates memory by chunks, a smaller chunk size would decrease the amount of unused direct memory, thus decrease the total direct memory required.

To allow users changes the default behaviors, we also makes the `page size` and `max order` properties of `NettyBufferPool` configurable.

## Brief change log

- ce674a7530f5a1dae64aa226148a92ad58b2be76 introduce the configuration options and change the default chunk size to 4MB.


## Verifying this change

This change added tests and can be verified as follows:

- Unit tests for the configuration checking logic.
- Decrease the required direct memory in E2E test `NettyShuffleMemoryControlTest` from 20M to 7M and verifies that [without the change](https://travis-ci.org/github/gaoyunhaii/flink/builds/664647756) there will be direct memory OOM exception, and [with the change](https://travis-ci.org/github/gaoyunhaii/flink/builds/663384369) there will be no exception.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector:**no**

## Documentation

  - Does this pull request introduce a new feature? **no**
 - If yes, how is the feature documented? **not applicable**
