### PR TITLE
[FLINK-16635] Remove pinned dependency for okio and okhttp from flink-metrics-influxdb

### DIFF
--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -89,21 +89,6 @@ under the License.
 		</dependency>
 	</dependencies>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.squareup.okhttp3</groupId>
-				<artifactId>okhttp</artifactId>
-				<version>3.11.0</version>
-			</dependency>
-			<dependency>
-				<groupId>com.squareup.okio</groupId>
-				<artifactId>okio</artifactId>
-				<version>1.14.0</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -57,7 +57,7 @@ under the License.
 		<dependency>
 			<groupId>org.influxdb</groupId>
 			<artifactId>influxdb-java</artifactId>
-			<version>2.16</version>
+			<version>2.17</version>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -6,13 +6,13 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.squareup.moshi:moshi:1.5.0
-- com.squareup.okhttp3:logging-interceptor:3.11.0
-- com.squareup.okhttp3:okhttp:3.14.3
+- com.squareup.moshi:moshi:1.8.0
+- com.squareup.okhttp3:logging-interceptor:3.14.4
+- com.squareup.okhttp3:okhttp:3.14.4
 - com.squareup.okio:okio:1.17.2
-- com.squareup.retrofit2:converter-moshi:2.4.0
-- com.squareup.retrofit2:retrofit:2.4.0
+- com.squareup.retrofit2:converter-moshi:2.6.2
+- com.squareup.retrofit2:retrofit:2.6.2
 
 This project bundles the following dependencies under the MIT license. (https://opensource.org/licenses/MIT)
 
-- org.influxdb:influxdb-java:2.14
+- org.influxdb:influxdb-java:2.17

--- a/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-influxdb/src/main/resources/META-INF/NOTICE
@@ -8,8 +8,8 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.squareup.moshi:moshi:1.5.0
 - com.squareup.okhttp3:logging-interceptor:3.11.0
-- com.squareup.okhttp3:okhttp:3.11.0
-- com.squareup.okio:okio:1.14.0
+- com.squareup.okhttp3:okhttp:3.14.3
+- com.squareup.okio:okio:1.17.2
 - com.squareup.retrofit2:converter-moshi:2.4.0
 - com.squareup.retrofit2:retrofit:2.4.0
 


### PR DESCRIPTION
## What is the purpose of the change

With FLINK-12147 we bumped the influxdb-java version from 2.14 to 2.16. At the same
time we still have okio and okhttp fixed to an incompatible version. This commit
removes the dependency management entries for these dependencies so that the
influxdb reporter bundles the correct dependencies.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
