### PR TITLE
[FLINK-16482][Connectors / Kafka]Flink Job throw CloseException when …

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaConsumerThread.java
@@ -275,7 +275,9 @@ public class KafkaConsumerThread extends Thread {
 		}
 		finally {
 			// make sure the handover is closed if it is not already closed or has an error
-			handover.close();
+			if(running) {
+				handover.close();
+			}
 
 			// make sure the KafkaConsumer is closed
 			try {

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaFetcher.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaFetcher.java
@@ -172,7 +172,8 @@ public class KafkaFetcher<T> extends AbstractFetcher<T, TopicPartition> {
 	public void cancel() {
 		// flag the main thread to exit. A thread interrupt will come anyways.
 		running = false;
-		handover.close();
+		//here should not call the close because it will wakeup after consumerThread shutdown
+		//handover.close();
 		consumerThread.shutdown();
 	}
 


### PR DESCRIPTION
…call the FlinkKafkaConsumer cancel function

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Designed to fix business call FlinkKafkaConsumer's cacel function throw  CloseException

## Brief change log

-Remove the KafkaFetcher call cancel method handover close call code 
   This is redundant code because the  handover maybe will wakeup on the KafkaConsumerThread call shutdown method and here will be throw CloseException when User call the cancel method.

-when call the  handover close method on KafkaConsumerThread run end it should check the running flag if true.
  the use call the cancel it will mark the running flag false then KafkaConsumerThread will break the main loop. it will throw CloseException in this case but the result is not  user excepted

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

  the calls Kafka010FetcherTest  covered this  changing test

  - The S3 file system connector: (yes / no / don't know)
      no
## Documentation

  - Does this pull request introduce a new feature? (yes / no)
    no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
