### PR TITLE
[FLINK-16517][Examples] Add an embedded input to enable a long-running WordCount example

### DIFF
--- a/flink-examples/flink-examples-streaming/pom.xml
+++ b/flink-examples/flink-examples-streaming/pom.xml
@@ -283,6 +283,7 @@ under the License.
 								<include>org/apache/flink/streaming/examples/wordcount/WordCount.class</include>
 								<include>org/apache/flink/streaming/examples/wordcount/WordCount$*.class</include>
 								<include>org/apache/flink/streaming/examples/wordcount/util/WordCountData.class</include>
+								<include>org/apache/flink/streaming/examples/wordcount/util/RandomSentenceSource.class</include>
 							</includes>
 						</configuration>
 					</execution>

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/util/RandomSentenceSource.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/wordcount/util/RandomSentenceSource.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.examples.wordcount.util;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+import java.util.Random;
+
+/**
+ * A SourceFunction that generates random data continuously with a configurable interval.
+ */
+public class RandomSentenceSource implements SourceFunction<String> {
+
+	private volatile boolean isRunning = true;
+
+	private final long intervalMs;
+
+	private final Random rand = new Random();
+
+	public RandomSentenceSource(long intervalMs) {
+		if (intervalMs < 0) {
+			System.out.println("intervalMs for RandomSource can't be negative; setting it to 0");
+			this.intervalMs = 0;
+		} else {
+			this.intervalMs = intervalMs;
+		}
+	}
+
+	@Override
+	public void run(SourceContext<String> ctx) throws Exception {
+		while (isRunning) {
+			int index = rand.nextInt(WordCountData.WORDS.length);
+			ctx.collect(WordCountData.WORDS[index]);
+
+			//wait for intervalMs before sending the next data
+			Thread.sleep(intervalMs);
+		}
+	}
+
+	@Override
+	public void cancel() {
+		isRunning = false;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR modifies the current WordCount example to have a SourceFunction that randomly generates input data based on a set of sentences, so the WordCount job can run forever. The generation interval is configurable.

This will be the easiest way to start a long running flink job and can be useful for new users to start using flink quickly, or for developers to test flink easily.

## Brief change log

  - *Added a new SourceFunction `RandomSentenceSource` that generates random data continuously until cancellation*
  - *Modified the WordCount example to use the `RandomSentenceSource` as the input optionally*


## Verifying this change

This change can be verified as follows:

  - *Manually verified the change by running a 1 node cluster with 1 JobManagers and 1 TaskManagers, submitted the new WordCount jobs with `--random` option with different intervals and verified the jobs worked correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
