### PR TITLE
[FLINK-15953][web] fix restarting status in web

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.config.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.config.ts
@@ -29,6 +29,7 @@ export const COLOR_MAP = {
   RECONCILING: '#eb2f96',
   IN_PROGRESS: '#faad14',
   SCHEDULED: '#722ed1',
-  COMPLETED  : '#1890ff'
+  COMPLETED: '#1890ff',
+  RESTARTING: '#13c2c2'
 };
 export const LONG_MIN_VALUE = -9223372036854776000;


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/FLINK-15953

## Brief change log

support more metric display at once

## Verifying this change

  - *Submit a restarting job*
  - *Go to the dashboard*
  - *check if the restarting status correct*


before:
![FireShot Capture 579 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/76935931-fe0d8d80-692c-11ea-9176-8c3d5b6d67cc.png)



after:
![FireShot Capture 578 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/76936066-36ad6700-692d-11ea-8981-f3295c7cc765.png)




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
