### PR TITLE
[FLINK-15852][cli] Prioritize ExecutorCLI over YarnSessionCLI for activeCLI

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -174,10 +174,7 @@ public class CliFrontend {
 		LOG.info("Running 'run' command.");
 
 		final Options commandOptions = CliFrontendParser.getRunCommandOptions();
-
-		final Options commandLineOptions = CliFrontendParser.mergeOptions(commandOptions, customCommandLineOptions);
-
-		final CommandLine commandLine = CliFrontendParser.parse(commandLineOptions, args, true);
+		final CommandLine commandLine = getCommandLine(commandOptions, args, true);
 
 		final ProgramOptions programOptions = new ProgramOptions(commandLine);
 
@@ -304,10 +301,7 @@ public class CliFrontend {
 		LOG.info("Running 'list' command.");
 
 		final Options commandOptions = CliFrontendParser.getListCommandOptions();
-
-		final Options commandLineOptions = CliFrontendParser.mergeOptions(commandOptions, customCommandLineOptions);
-
-		final CommandLine commandLine = CliFrontendParser.parse(commandLineOptions, args, false);
+		final CommandLine commandLine = getCommandLine(commandOptions, args, false);
 
 		ListOptions listOptions = new ListOptions(commandLine);
 
@@ -427,8 +421,7 @@ public class CliFrontend {
 		LOG.info("Running 'stop-with-savepoint' command.");
 
 		final Options commandOptions = CliFrontendParser.getStopCommandOptions();
-		final Options commandLineOptions = CliFrontendParser.mergeOptions(commandOptions, customCommandLineOptions);
-		final CommandLine commandLine = CliFrontendParser.parse(commandLineOptions, args, false);
+		final CommandLine commandLine = getCommandLine(commandOptions, args, false);
 
 		final StopOptions stopOptions = new StopOptions(commandLine);
 		if (stopOptions.isPrintHelp()) {
@@ -474,10 +467,7 @@ public class CliFrontend {
 		LOG.info("Running 'cancel' command.");
 
 		final Options commandOptions = CliFrontendParser.getCancelCommandOptions();
-
-		final Options commandLineOptions = CliFrontendParser.mergeOptions(commandOptions, customCommandLineOptions);
-
-		final CommandLine commandLine = CliFrontendParser.parse(commandLineOptions, args, false);
+		final CommandLine commandLine = getCommandLine(commandOptions, args, false);
 
 		CancelOptions cancelOptions = new CancelOptions(commandLine);
 
@@ -548,6 +538,11 @@ public class CliFrontend {
 
 			logAndSysout("Cancelled job " + jobId + '.');
 		}
+	}
+
+	public CommandLine getCommandLine(final Options commandOptions, final String[] args, final boolean stopAtNonOptions) throws CliArgsException {
+		final Options commandLineOptions = CliFrontendParser.mergeOptions(commandOptions, customCommandLineOptions);
+		return CliFrontendParser.parse(commandLineOptions, args, stopAtNonOptions);
 	}
 
 	/**
@@ -1021,6 +1016,7 @@ public class CliFrontend {
 
 	public static List<CustomCommandLine> loadCustomCommandLines(Configuration configuration, String configurationDirectory) {
 		List<CustomCommandLine> customCommandLines = new ArrayList<>();
+		customCommandLines.add(new ExecutorCLI(configuration));
 
 		//	Command line interface of the YARN session, with a special initialization here
 		//	to prefix all options with y/yarn.
@@ -1035,8 +1031,6 @@ public class CliFrontend {
 		} catch (NoClassDefFoundError | Exception e) {
 			LOG.warn("Could not load CLI class {}.", flinkYarnSessionCLI, e);
 		}
-
-		customCommandLines.add(new ExecutorCLI(configuration));
 
 		//	Tips: DefaultCLI must be added at last, because getActiveCustomCommandLine(..) will get the
 		//	      active CustomCommandLine in order and DefaultCLI isActive always return true.


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the order in which the `CliFrontend` selects the active CLI command. 

Currently in Flink there are 3 custom command lines, the `DefaultCLI`, the `FlinkYarnSessionCli` and the `ExecutorCLI` and when the user submits his/her CLI command, the `CliFrontend` selects which one to use (i.e. which one is active) for further processing based on criteria specific to each custom command line.

The `FlinkYarnSessionCli` is chosen if there is a file called `.yarn-properties-USERNAME`  (among other criteria) in a specific directory. This file can be written transparently to the user, if he/she used the CLI previously to launch a yarn session cluster. 

The `ExecutorCLI` is activated if and only if there is an explicit `-e` flag specified by the user. 

Given that currently Flink first checks if the yarn cli is active and, if not, it only then checks the `ExecutorCLI`, if this "magic" file exists from a previous run, there is no way for the user to use the `ExecutorCLI` without deleting the "properties" file, which may be useful in the future.

Given that in the case of the `ExecutorCLI`, an explicit action is required by the user to activate it, while this is not the case for the yarn cli, this PR aims at changing the order in which the cli's are checked for being activated or not.

## Brief change log

Changes the order of loading the clis in the `CliFrontend.loadCustomCommandLines()`.

## Verifying this change

Added the `FlinkYarnSessionCliTest.testExecutorCLIisPrioritised()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
