### PR TITLE
[FLINK-16604][web] fix column key in JM configuration is too narrow

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job-manager/configuration/job-manager-configuration.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job-manager/configuration/job-manager-configuration.component.html
@@ -22,7 +22,7 @@
   [nzShowPagination]="false">
   <thead>
     <tr>
-      <th>Key</th>
+      <th nzWidth="30%">Key</th>
       <th>Value</th>
     </tr>
   </thead>


### PR DESCRIPTION
## What is the purpose of the change

fix https://issues.apache.org/jira/browse/FLINK-16604

## Brief change log

support more metric display at once

## Verifying this change

  - *Set a JM configuration with long value*
  - *Go to the JM configuration page*
  - *check if column key is too narrow fixed*


before:

![FireShot Capture 585 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/76941058-4da48700-6936-11ea-8765-60d72a3f0f21.png)


after:

![FireShot Capture 584 - Apache Flink Web Dashboard - localhost](https://user-images.githubusercontent.com/1506722/76941036-42e9f200-6936-11ea-9e5e-bef78d6b73e0.png)




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
