### PR TITLE
[FLINK-15771][FLINK-16583][tests] Fix issues around SQLClientKafkaITCase

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -56,6 +56,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.junit.Assert.assertThat;
+
 /**
  * End-to-end test for the kafka SQL connectors.
  */
@@ -219,15 +222,18 @@ public class SQLClientKafkaITCase extends TestLogger {
 		for (int i = 0; i < maxRetries; i++) {
 			if (Files.exists(result)) {
 				byte[] bytes = Files.readAllBytes(result);
-				String lines = new String(bytes, Charsets.UTF_8);
-				if (lines.split("\n").length == 4) {
+				String[] lines = new String(bytes, Charsets.UTF_8).split("\n");
+				if (lines.length == 4) {
 					success = true;
-					String expected =
-						"2018-03-12 08:00:00.000,Alice,This was a warning.,2,Success constant folding.\n" +
-						"2018-03-12 09:00:00.000,Bob,This was another warning.,1,Success constant folding.\n" +
-						"2018-03-12 09:00:00.000,Steve,This was another info.,2,Success constant folding.\n" +
-						"2018-03-12 09:00:00.000,Alice,This was a info.,1,Success constant folding.\n";
-					Assert.assertEquals(expected, lines);
+					assertThat(
+						lines,
+						arrayContainingInAnyOrder(
+							"2018-03-12 08:00:00.000,Alice,This was a warning.,2,Success constant folding.",
+							"2018-03-12 09:00:00.000,Bob,This was another warning.,1,Success constant folding.",
+							"2018-03-12 09:00:00.000,Steve,This was another info.,2,Success constant folding.",
+							"2018-03-12 09:00:00.000,Alice,This was a info.,1,Success constant folding."
+						)
+					);
 					break;
 				}
 			} else {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/AutoClosableProcess.java
@@ -128,7 +128,7 @@ public class AutoClosableProcess implements AutoCloseable {
 					if (++retries > maxRetries || !globalDeadline.hasTimeLeft()) {
 						String errMsg = String.format(
 							"Process (%s) exceeded timeout (%s) or number of retries (%s).",
-							Arrays.toString(commands), maxRetries, globalTimeout.toMillis());
+							Arrays.toString(commands), globalTimeout.toMillis(), maxRetries);
 						throw new IOException(errMsg, e);
 					}
 				}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/AbstractDownloadCache.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/cache/AbstractDownloadCache.java
@@ -64,9 +64,9 @@ abstract class AbstractDownloadCache implements DownloadCache {
 
 		this.downloadAttemptTimeout = DOWNLOAD_ATTEMPT_TIMEOUT.get(Duration.ofMinutes(2));
 		this.downloadGlobalTimeout = DOWNLOAD_GLOBAL_TIMEOUT.get(Duration.ofMinutes(2));
-		this.downloadMaxRetries = DOWNLOAD_MAX_RETRIES.get(1);
+		this.downloadMaxRetries = DOWNLOAD_MAX_RETRIES.get(3);
 
-		log.info("Download configuration: maxAttempts={}, attemptTimeout={}, globalTimeout={}", downloadMaxRetries, downloadAttemptTimeout, downloadGlobalTimeout);
+		log.info("Download configuration: maxRetries={}, attemptTimeout={}, globalTimeout={}", downloadMaxRetries, downloadAttemptTimeout, downloadGlobalTimeout);
 	}
 
 	@Override

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -271,12 +271,14 @@ public class ExecutionContext<ClusterID> {
 	}
 
 	public Pipeline createPipeline(String name) {
-		if (streamExecEnv != null) {
-			StreamTableEnvironmentImpl streamTableEnv = (StreamTableEnvironmentImpl) tableEnv;
-			return streamTableEnv.getPipeline(name);
-		} else {
-			return execEnv.createProgramPlan(name);
-		}
+		return wrapClassLoader(() -> {
+			if (streamExecEnv != null) {
+				StreamTableEnvironmentImpl streamTableEnv = (StreamTableEnvironmentImpl) tableEnv;
+				return streamTableEnv.getPipeline(name);
+			} else {
+				return execEnv.createProgramPlan(name);
+			}
+		});
 	}
 
 	/** Returns a builder for this {@link ExecutionContext}. */


### PR DESCRIPTION
## What is the purpose of the change

This fixes a couple of issues related to the SQL Client and the SQLClientKafkaITCase.

In particular, it fixes a classloading bug that was introduced in the last release while updating the code for the new `Pipeline` abstractions,

## Brief change log

See commit messages.

## Verifying this change


This change is already covered by existing tests, such as `SQLClientKafkaITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
