### PR TITLE
[FLINK-16650][python] Support LocalZonedTimestampType for Python UDF in blink planner

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -415,8 +415,8 @@ class LocalZonedTimestampCoderImpl(TimestampCoderImpl):
     def internal_to_timestamp(self, milliseconds, nanoseconds):
         second, microsecond = (milliseconds // 1000,
                                milliseconds % 1000 * 1000 + nanoseconds // 1000)
-        return datetime.datetime.utcfromtimestamp(second).astimezone(self.timezone).replace(
-            microsecond=microsecond)
+        return self.timezone.localize(
+            datetime.datetime.utcfromtimestamp(second).replace(microsecond=microsecond))
 
 
 class ArrowCoderImpl(StreamCoderImpl):

--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -406,6 +406,19 @@ class TimestampCoderImpl(StreamCoderImpl):
         return datetime.datetime.utcfromtimestamp(second).replace(microsecond=microsecond)
 
 
+class LocalZonedTimestampCoderImpl(TimestampCoderImpl):
+
+    def __init__(self, precision, timezone):
+        super(LocalZonedTimestampCoderImpl, self).__init__(precision)
+        self.timezone = timezone
+
+    def internal_to_timestamp(self, milliseconds, nanoseconds):
+        second, microsecond = (milliseconds // 1000,
+                               milliseconds % 1000 * 1000 + nanoseconds // 1000)
+        return datetime.datetime.utcfromtimestamp(second).astimezone(self.timezone).replace(
+            microsecond=microsecond)
+
+
 class ArrowCoderImpl(StreamCoderImpl):
 
     def __init__(self, schema):

--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -413,10 +413,9 @@ class LocalZonedTimestampCoderImpl(TimestampCoderImpl):
         self.timezone = timezone
 
     def internal_to_timestamp(self, milliseconds, nanoseconds):
-        second, microsecond = (milliseconds // 1000,
-                               milliseconds % 1000 * 1000 + nanoseconds // 1000)
         return self.timezone.localize(
-            datetime.datetime.utcfromtimestamp(second).replace(microsecond=microsecond))
+            super(LocalZonedTimestampCoderImpl, self).internal_to_timestamp(
+                milliseconds, nanoseconds))
 
 
 class ArrowCoderImpl(StreamCoderImpl):

--- a/flink-python/pyflink/fn_execution/sdk_worker_main.py
+++ b/flink-python/pyflink/fn_execution/sdk_worker_main.py
@@ -15,16 +15,24 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+import os
 import sys
 
 # force to register the operations to SDK Harness
+from apache_beam.options.pipeline_options import PipelineOptions
+
 import pyflink.fn_execution.operations # noqa # pylint:  disable=unused-import
 
 # force to register the coders to SDK Harness
 import pyflink.fn_execution.coders # noqa # pylint: disable=unused-import
 
 import apache_beam.runners.worker.sdk_worker_main
+
+if 'PIPELINE_OPTIONS' in os.environ:
+    pipeline_options = apache_beam.runners.worker.sdk_worker_main._parse_pipeline_options(
+        os.environ['PIPELINE_OPTIONS'])
+else:
+    pipeline_options = PipelineOptions.from_dictionary({})
 
 if __name__ == '__main__':
     apache_beam.runners.worker.sdk_worker_main.main(sys.argv)

--- a/flink-python/pyflink/fn_execution/tests/test_coders_common.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders_common.py
@@ -22,7 +22,8 @@ import unittest
 
 from pyflink.fn_execution.coders import BigIntCoder, TinyIntCoder, BooleanCoder, \
     SmallIntCoder, IntCoder, FloatCoder, DoubleCoder, BinaryCoder, CharCoder, DateCoder, \
-    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder, FlattenRowCoder, RowCoder
+    TimeCoder, TimestampCoder, ArrayCoder, MapCoder, DecimalCoder, FlattenRowCoder, RowCoder, \
+    LocalZonedTimestampCoder
 
 
 class CodersTest(unittest.TestCase):
@@ -92,6 +93,17 @@ class CodersTest(unittest.TestCase):
         self.check_coder(coder, datetime.datetime(2019, 9, 10, 18, 30, 20, 123000))
         coder = TimestampCoder(6)
         self.check_coder(coder, datetime.datetime(2019, 9, 10, 18, 30, 20, 123456))
+
+    def test_local_zoned_timestamp_coder(self):
+        import datetime
+        import pytz
+        timezone = pytz.timezone("Asia/Shanghai")
+        coder = LocalZonedTimestampCoder(3, timezone)
+        self.check_coder(coder,
+                         timezone.localize(datetime.datetime(2019, 9, 10, 18, 30, 20, 123000)))
+        coder = LocalZonedTimestampCoder(6, timezone)
+        self.check_coder(coder,
+                         timezone.localize(datetime.datetime(2019, 9, 10, 18, 30, 20, 123456)))
 
     def test_array_coder(self):
         element_coder = BigIntCoder()

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -538,6 +538,22 @@ class TypesTests(unittest.TestCase):
         ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
         self.assertEqual(0, lztst.to_sql_type(ts))
 
+        import os
+        import pytz
+        import time
+        timezone = pytz.timezone("Asia/Tokyo")
+        orig_tz = os.environ.get('TZ', None)
+        try:
+            os.environ['TZ'] = 'Asia/Shanghai'
+            time.tzset()
+            ts_tokyo = timezone.localize(ts)
+            self.assertEqual(-3600000000, lztst.to_sql_type(ts_tokyo))
+        finally:
+            del os.environ['TZ']
+            if orig_tz is not None:
+                os.environ['TZ'] = orig_tz
+            time.tzset()
+
         if sys.version_info >= (3, 6):
             ts2 = lztst.from_sql_type(0)
             self.assertEqual(ts.astimezone(), ts2.astimezone())

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -535,11 +535,11 @@ class TypesTests(unittest.TestCase):
 
     def test_local_zoned_timestamp_type(self):
         lztst = DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE()
-        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000, tzinfo=UTCOffsetTimezone(1))
-        self.assertEqual(-3600000000, lztst.to_sql_type(ts))
+        ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
+        self.assertEqual(0, lztst.to_sql_type(ts))
 
         if sys.version_info >= (3, 6):
-            ts2 = lztst.from_sql_type(-3600000000)
+            ts2 = lztst.from_sql_type(0)
             self.assertEqual(ts.astimezone(), ts2.astimezone())
 
     def test_zoned_timestamp_type(self):

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -33,7 +33,8 @@ from pyflink.table.types import (_infer_schema_from_data, _infer_type,
                                  _array_type_mappings, _merge_type,
                                  _create_type_verifier, UserDefinedType, DataTypes, Row, RowField,
                                  RowType, ArrayType, BigIntType, VarCharType, MapType, DataType,
-                                 _to_java_type, _from_java_type, ZonedTimestampType)
+                                 _to_java_type, _from_java_type, ZonedTimestampType,
+                                 LocalZonedTimestampType)
 
 
 class ExamplePointUDT(UserDefinedType):
@@ -543,12 +544,16 @@ class TypesTests(unittest.TestCase):
         import time
         timezone = pytz.timezone("Asia/Tokyo")
         orig_tz = os.environ.get('TZ', None)
+        orig_epoch = LocalZonedTimestampType.EPOCH_ORDINAL
         try:
+            import calendar
             os.environ['TZ'] = 'Asia/Shanghai'
             time.tzset()
+            LocalZonedTimestampType.EPOCH_ORDINAL = calendar.timegm(time.localtime(0)) * 10 ** 6
             ts_tokyo = timezone.localize(ts)
             self.assertEqual(-3600000000, lztst.to_sql_type(ts_tokyo))
         finally:
+            LocalZonedTimestampType.EPOCH_ORDINAL = orig_epoch
             del os.environ['TZ']
             if orig_tz is not None:
                 os.environ['TZ'] = orig_tz

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -539,25 +539,17 @@ class TypesTests(unittest.TestCase):
         ts = datetime.datetime(1970, 1, 1, 0, 0, 0, 0000)
         self.assertEqual(0, lztst.to_sql_type(ts))
 
-        import os
         import pytz
-        import time
+        # suppose the timezone of the data is +9:00
         timezone = pytz.timezone("Asia/Tokyo")
-        orig_tz = os.environ.get('TZ', None)
         orig_epoch = LocalZonedTimestampType.EPOCH_ORDINAL
         try:
-            import calendar
-            os.environ['TZ'] = 'Asia/Shanghai'
-            time.tzset()
-            LocalZonedTimestampType.EPOCH_ORDINAL = calendar.timegm(time.localtime(0)) * 10 ** 6
+            # suppose the local timezone is +8:00
+            LocalZonedTimestampType.EPOCH_ORDINAL = 28800000000
             ts_tokyo = timezone.localize(ts)
             self.assertEqual(-3600000000, lztst.to_sql_type(ts_tokyo))
         finally:
             LocalZonedTimestampType.EPOCH_ORDINAL = orig_epoch
-            del os.environ['TZ']
-            if orig_tz is not None:
-                os.environ['TZ'] = orig_tz
-            time.tzset()
 
         if sys.version_info >= (3, 6):
             ts2 = lztst.from_sql_type(0)

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -568,8 +568,8 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
 
     def test_data_types_only_supported_in_blink_planner(self):
         timezone = self.t_env.get_config().get_local_timezone()
-        local_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 123000).astimezone(
-            pytz.timezone(timezone))
+        local_datetime = pytz.timezone(timezone).localize(
+            datetime.datetime(1970, 1, 1, 0, 0, 0, 123000))
 
         def local_zoned_timestamp_func(local_zoned_timestamp_param):
             assert local_zoned_timestamp_param == local_datetime, \

--- a/flink-python/pyflink/table/tests/test_udf.py
+++ b/flink-python/pyflink/table/tests/test_udf.py
@@ -15,6 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import datetime
+
+import pytz
+
 from pyflink.table import DataTypes
 from pyflink.table.udf import ScalarFunction, udf
 from pyflink.testing import source_sink_utils
@@ -561,6 +565,36 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedFunctionTests,
             # test non-callable function
             self.t_env.register_function(
                 "non-callable-udf", udf(Plus(), DataTypes.BIGINT(), DataTypes.BIGINT()))
+
+    def test_data_types_only_supported_in_blink_planner(self):
+        timezone = self.t_env.get_config().get_local_timezone()
+        local_datetime = datetime.datetime(1970, 1, 1, 0, 0, 0, 123000).astimezone(
+            pytz.timezone(timezone))
+
+        def local_zoned_timestamp_func(local_zoned_timestamp_param):
+            assert local_zoned_timestamp_param == local_datetime, \
+                'local_zoned_timestamp_param is wrong value %s !' % local_zoned_timestamp_param
+            return local_zoned_timestamp_param
+
+        self.t_env.register_function(
+            "local_zoned_timestamp_func",
+            udf(local_zoned_timestamp_func,
+                [DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)],
+                DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)))
+
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a'], [DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)])
+        self.t_env.register_table_sink("Results", table_sink)
+
+        t = self.t_env.from_elements(
+            [(local_datetime,)],
+            DataTypes.ROW([DataTypes.FIELD("a", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3))]))
+
+        t.select("local_zoned_timestamp_func(local_zoned_timestamp_func(a))") \
+            .insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1970-01-01T00:00:00.123Z"])
 
 
 class PyFlinkBlinkBatchUserDefinedFunctionTests(UserDefinedFunctionTests,

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -492,16 +492,9 @@ class LocalZonedTimestampType(AtomicType):
 
     def to_sql_type(self, dt):
         if dt is not None:
-            if dt.tzinfo is not None:
-                offset = dt.utcoffset()
-                offset = offset if offset else datetime.timedelta()
-                offset_microseconds =\
-                    (offset.days * 86400 + offset.seconds) * 10 ** 6 + offset.microseconds
-            else:
-                offset_microseconds = self.EPOCH_ORDINAL
             seconds = (calendar.timegm(dt.utctimetuple()) if dt.tzinfo
                        else time.mktime(dt.timetuple()))
-            return int(seconds) * 10 ** 6 + dt.microsecond + offset_microseconds
+            return int(seconds) * 10 ** 6 + dt.microsecond + self.EPOCH_ORDINAL
 
     def from_sql_type(self, ts):
         if ts is not None:

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -225,7 +225,7 @@ run sdist.
         python_requires='>=3.5',
         install_requires=['py4j==0.10.8.1', 'python-dateutil==2.8.0', 'apache-beam==2.19.0',
                           'cloudpickle==1.2.2', 'avro-python3>=1.8.1,<=1.9.1', 'jsonpickle==1.2',
-                          'pandas>=0.23.4,<=0.25.3', 'pyarrow>=0.15.1,<=0.16.0'],
+                          'pandas>=0.23.4,<=0.25.3', 'pyarrow>=0.15.1,<=0.16.0', 'pytz>=2018.3'],
         tests_require=['pytest==4.4.1'],
         description='Apache Flink Python API',
         long_description=long_description,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperator.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Python {@link ScalarFunction} operator for the blink planner.
@@ -80,13 +81,15 @@ public class BaseRowPythonScalarFunctionOperator extends AbstractBaseRowPythonSc
 	@Override
 	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 			FnDataReceiver<byte[]> resultReceiver,
-			PythonEnvironmentManager pythonEnvironmentManager) {
+			PythonEnvironmentManager pythonEnvironmentManager,
+			Map<String, String> jobOptions) {
 		return new BaseRowPythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			scalarFunctions,
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
-			userDefinedFunctionOutputType);
+			userDefinedFunctionOutputType,
+			jobOptions);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperator.java
@@ -34,6 +34,7 @@ import org.apache.flink.types.Row;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Python {@link ScalarFunction} operator for the legacy planner.
@@ -81,13 +82,15 @@ public class PythonScalarFunctionOperator extends AbstractRowPythonScalarFunctio
 	@Override
 	public PythonFunctionRunner<Row> createPythonFunctionRunner(
 			FnDataReceiver<byte[]> resultReceiver,
-			PythonEnvironmentManager pythonEnvironmentManager) {
+			PythonEnvironmentManager pythonEnvironmentManager,
+			Map<String, String> jobOptions) {
 		return new PythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			scalarFunctions,
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
-			userDefinedFunctionOutputType);
+			userDefinedFunctionOutputType,
+			jobOptions);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -38,6 +38,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Arrow Python {@link ScalarFunction} operator for the old planner.
@@ -93,7 +94,8 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
 	@Override
 	public PythonFunctionRunner<Row> createPythonFunctionRunner(
 		FnDataReceiver<byte[]> resultReceiver,
-		PythonEnvironmentManager pythonEnvironmentManager) {
+		PythonEnvironmentManager pythonEnvironmentManager,
+		Map<String, String> jobOptions) {
 		return new ArrowPythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
@@ -101,7 +103,8 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
 			userDefinedFunctionOutputType,
-			getPythonConfig().getMaxArrowBatchSize());
+			getPythonConfig().getMaxArrowBatchSize(),
+			jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
@@ -37,6 +37,7 @@ import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Arrow Python {@link ScalarFunction} operator for the blink planner.
@@ -92,7 +93,8 @@ public class BaseRowArrowPythonScalarFunctionOperator extends AbstractBaseRowPyt
 	@Override
 	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 		FnDataReceiver<byte[]> resultReceiver,
-		PythonEnvironmentManager pythonEnvironmentManager) {
+		PythonEnvironmentManager pythonEnvironmentManager,
+		Map<String, String> jobOptions) {
 		return new BaseRowArrowPythonScalarFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
@@ -100,7 +102,8 @@ public class BaseRowArrowPythonScalarFunctionOperator extends AbstractBaseRowPyt
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
 			userDefinedFunctionOutputType,
-			getPythonConfig().getMaxArrowBatchSize());
+			getPythonConfig().getMaxArrowBatchSize(),
+			jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperator.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Python {@link TableFunction} operator for the blink planner.
@@ -117,14 +118,16 @@ public class BaseRowPythonTableFunctionOperator
 	@Override
 	public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 		FnDataReceiver<byte[]> resultReceiver,
-		PythonEnvironmentManager pythonEnvironmentManager) {
+		PythonEnvironmentManager pythonEnvironmentManager,
+		Map<String, String> jobOptions) {
 		return new BaseRowPythonTableFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			tableFunction,
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
-			userDefinedFunctionOutputType);
+			userDefinedFunctionOutputType,
+			jobOptions);
 	}
 
 	private Projection<BaseRow, BinaryRow> createUdtfInputProjection() {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperator.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * The Python {@link TableFunction} operator for the legacy planner.
@@ -131,13 +132,15 @@ public class PythonTableFunctionOperator extends AbstractPythonTableFunctionOper
 	@Override
 	public PythonFunctionRunner<Row> createPythonFunctionRunner(
 		FnDataReceiver<byte[]> resultReceiver,
-		PythonEnvironmentManager pythonEnvironmentManager) {
+		PythonEnvironmentManager pythonEnvironmentManager,
+		Map<String, String> jobOptions) {
 		return new PythonTableFunctionRunner(
 			getRuntimeContext().getTaskName(),
 			resultReceiver,
 			tableFunction,
 			pythonEnvironmentManager,
 			userDefinedFunctionInputType,
-			userDefinedFunctionOutputType);
+			userDefinedFunctionOutputType,
+			jobOptions);
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonStatelessFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/AbstractPythonStatelessFunctionRunner.java
@@ -51,6 +51,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
 
@@ -86,8 +87,9 @@ public abstract class AbstractPythonStatelessFunctionRunner<IN> extends Abstract
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
-		String functionUrn) {
-		super(taskName, resultReceiver, environmentManager, StateRequestHandler.unsupported());
+		String functionUrn,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, environmentManager, StateRequestHandler.unsupported(), jobOptions);
 		this.functionUrn = functionUrn;
 		this.inputType = Preconditions.checkNotNull(inputType);
 		this.outputType = Preconditions.checkNotNull(outputType);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/AbstractGeneralPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/AbstractGeneralPythonScalarFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.util.WindowedValue;
 
+import java.util.Map;
+
 /**
  * Abstract {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
  *
@@ -51,8 +53,9 @@ public abstract class AbstractGeneralPythonScalarFunctionRunner<IN> extends Abst
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/AbstractPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/AbstractPythonScalarFunctionRunner.java
@@ -31,6 +31,8 @@ import org.apache.flink.util.Preconditions;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * Abstract {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
  *
@@ -49,8 +51,9 @@ public abstract class AbstractPythonScalarFunctionRunner<IN> extends AbstractPyt
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, environmentManager, inputType, outputType, SCALAR_FUNCTION_URN);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, environmentManager, inputType, outputType, SCALAR_FUNCTION_URN, jobOptions);
 		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/BaseRowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/BaseRowPythonScalarFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
  * It takes {@link BaseRow} as the input and outputs a byte array.
@@ -43,8 +45,9 @@ public class BaseRowPythonScalarFunctionRunner extends AbstractGeneralPythonScal
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/PythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/PythonScalarFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link ScalarFunction}s.
  * It takes {@link Row} as the input and outputs a byte array.
@@ -43,8 +45,9 @@ public class PythonScalarFunctionRunner extends AbstractGeneralPythonScalarFunct
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
@@ -36,6 +36,8 @@ import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.util.WindowedValue;
 
+import java.util.Map;
+
 /**
  * Abstract {@link PythonFunctionRunner} used to execute Arrow Python {@link ScalarFunction}s.
  *
@@ -97,8 +99,9 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
-		int maxArrowBatchSize) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
+		int maxArrowBatchSize,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions);
 		this.maxArrowBatchSize = maxArrowBatchSize;
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Arrow Python {@link ScalarFunction}s.
  * It takes {@link Row} as the input type.
@@ -44,8 +46,9 @@ public class ArrowPythonScalarFunctionRunner extends AbstractArrowPythonScalarFu
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
-		int maxArrowBatchSize) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize);
+		int maxArrowBatchSize,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/BaseRowArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/BaseRowArrowPythonScalarFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Arrow Python {@link ScalarFunction}s.
  * It takes {@link BaseRow} as the input type.
@@ -44,8 +46,9 @@ public class BaseRowArrowPythonScalarFunctionRunner extends AbstractArrowPythonS
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
-		int maxBatchSize) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxBatchSize);
+		int maxBatchSize,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxBatchSize, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/AbstractPythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/AbstractPythonTableFunctionRunner.java
@@ -34,6 +34,8 @@ import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.util.WindowedValue;
 
+import java.util.Map;
+
 /**
  * Abstract {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
  *
@@ -58,8 +60,9 @@ public abstract class AbstractPythonTableFunctionRunner<IN> extends AbstractPyth
 		PythonFunctionInfo tableFunction,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, environmentManager, inputType, outputType, TABLE_FUNCTION_URN);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, environmentManager, inputType, outputType, TABLE_FUNCTION_URN, jobOptions);
 		this.tableFunction = Preconditions.checkNotNull(tableFunction);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/BaseRowPythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/BaseRowPythonTableFunctionRunner.java
@@ -30,6 +30,8 @@ import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
  * It takes {@link BaseRow} as the input and outputs a byte array.
@@ -42,8 +44,9 @@ public class BaseRowPythonTableFunctionRunner extends AbstractPythonTableFunctio
 		PythonFunctionInfo tableFunction,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/PythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/PythonTableFunctionRunner.java
@@ -31,6 +31,8 @@ import org.apache.flink.types.Row;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
+import java.util.Map;
+
 /**
  * A {@link PythonFunctionRunner} used to execute Python {@link TableFunction}.
  * It takes {@link Row} as the input and outputs a byte array.
@@ -44,8 +46,9 @@ public class PythonTableFunctionRunner extends AbstractPythonTableFunctionRunner
 		PythonFunctionInfo tableFunction,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType);
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType, jobOptions);
 	}
 
 	@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -52,6 +52,7 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LegacyTypeInformationType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
@@ -268,6 +269,11 @@ public final class PythonTypeUtils {
 			return new SqlTimestampSerializer(timestampType.getPrecision());
 		}
 
+		@Override
+		public TypeSerializer visit(LocalZonedTimestampType localZonedTimestampType) {
+			return new SqlTimestampSerializer(localZonedTimestampType.getPrecision());
+		}
+
 		public TypeSerializer visit(ArrayType arrayType) {
 			LogicalType elementType = arrayType.getElementType();
 			TypeSerializer elementTypeSerializer = elementType.accept(this);
@@ -413,6 +419,20 @@ public final class PythonTypeUtils {
 				FlinkFnApi.Schema.TimestampInfo.newBuilder()
 					.setPrecision(timestampType.getPrecision());
 			builder.setTimestampInfo(timestampInfoBuilder);
+			return builder.build();
+		}
+
+		@Override
+		public FlinkFnApi.Schema.FieldType visit(LocalZonedTimestampType localZonedTimestampType) {
+			FlinkFnApi.Schema.FieldType.Builder builder =
+				FlinkFnApi.Schema.FieldType.newBuilder()
+					.setTypeName(FlinkFnApi.Schema.TypeName.LOCAL_ZONED_TIMESTAMP)
+					.setNullable(localZonedTimestampType.isNullable());
+
+			FlinkFnApi.Schema.LocalZonedTimestampInfo.Builder dateTimeBuilder =
+				FlinkFnApi.Schema.LocalZonedTimestampInfo.newBuilder()
+					.setPrecision(localZonedTimestampType.getPrecision());
+			builder.setLocalZonedTimestampInfo(dateTimeBuilder.build());
 			return builder.build();
 		}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperatorTest.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.util.Collection;
+import java.util.Map;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.baserow;
 
@@ -115,14 +116,16 @@ public class BaseRowPythonScalarFunctionOperatorTest
 		@Override
 		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 				FnDataReceiver<byte[]> resultReceiver,
-				PythonEnvironmentManager pythonEnvironmentManager) {
+				PythonEnvironmentManager pythonEnvironmentManager,
+				Map<String, String> jobOptions) {
 			return new PassThroughPythonScalarFunctionRunner<BaseRow>(
 				getRuntimeContext().getTaskName(),
 				resultReceiver,
 				scalarFunctions,
 				pythonEnvironmentManager,
 				userDefinedFunctionInputType,
-				userDefinedFunctionOutputType) {
+				userDefinedFunctionOutputType,
+				jobOptions) {
 				@Override
 				public TypeSerializer<BaseRow> getInputTypeSerializer() {
 					return (BaseRowSerializer) PythonTypeUtils.toBlinkTypeSerializer(getInputType());

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.types.Row;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -91,14 +92,16 @@ public class PythonScalarFunctionOperatorTest extends PythonScalarFunctionOperat
 		@Override
 		public PythonFunctionRunner<Row> createPythonFunctionRunner(
 				FnDataReceiver<byte[]> resultReceiver,
-				PythonEnvironmentManager pythonEnvironmentManager) {
+				PythonEnvironmentManager pythonEnvironmentManager,
+				Map<String, String> jobOptions) {
 			return new PassThroughPythonScalarFunctionRunner<Row>(
 				getRuntimeContext().getTaskName(),
 				resultReceiver,
 				scalarFunctions,
 				pythonEnvironmentManager,
 				userDefinedFunctionInputType,
-				userDefinedFunctionOutputType) {
+				userDefinedFunctionOutputType,
+				jobOptions) {
 				@Override
 				public TypeSerializer<Row> getInputTypeSerializer() {
 					return (RowSerializer) PythonTypeUtils.toFlinkTypeSerializer(getInputType());

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperatorTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.types.Row;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -89,7 +90,8 @@ public class ArrowPythonScalarFunctionOperatorTest extends PythonScalarFunctionO
 		@Override
 		public PythonFunctionRunner<Row> createPythonFunctionRunner(
 				FnDataReceiver<byte[]> resultReceiver,
-				PythonEnvironmentManager pythonEnvironmentManager) {
+				PythonEnvironmentManager pythonEnvironmentManager,
+				Map<String, String> jobOptions) {
 			return new PassThroughArrowPythonScalarFunctionRunner<Row>(
 				getRuntimeContext().getTaskName(),
 				resultReceiver,
@@ -97,7 +99,8 @@ public class ArrowPythonScalarFunctionOperatorTest extends PythonScalarFunctionO
 				pythonEnvironmentManager,
 				userDefinedFunctionInputType,
 				userDefinedFunctionOutputType,
-				getPythonConfig().getMaxArrowBatchSize()) {
+				getPythonConfig().getMaxArrowBatchSize(),
+				jobOptions) {
 				@Override
 				public ArrowWriter<Row> createArrowWriter() {
 					return ArrowUtils.createRowArrowWriter(root);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 import java.util.Collection;
+import java.util.Map;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.baserow;
 
@@ -111,7 +112,8 @@ public class BaseRowArrowPythonScalarFunctionOperatorTest
 		@Override
 		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 			FnDataReceiver<byte[]> resultReceiver,
-			PythonEnvironmentManager pythonEnvironmentManager) {
+			PythonEnvironmentManager pythonEnvironmentManager,
+			Map<String, String> jobOptions) {
 			return new PassThroughArrowPythonScalarFunctionRunner<BaseRow>(
 				getRuntimeContext().getTaskName(),
 				resultReceiver,
@@ -119,7 +121,8 @@ public class BaseRowArrowPythonScalarFunctionOperatorTest
 				pythonEnvironmentManager,
 				userDefinedFunctionInputType,
 				userDefinedFunctionOutputType,
-				getPythonConfig().getMaxArrowBatchSize()) {
+				getPythonConfig().getMaxArrowBatchSize(),
+				jobOptions) {
 				@Override
 				public ArrowWriter<BaseRow> createArrowWriter() {
 					return ArrowUtils.createBaseRowArrowWriter(root);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperatorTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import java.util.Collection;
+import java.util.Map;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.baserow;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.binaryrow;
@@ -94,7 +95,8 @@ public class BaseRowPythonTableFunctionOperatorTest
 		@Override
 		public PythonFunctionRunner<BaseRow> createPythonFunctionRunner(
 			FnDataReceiver<byte[]> resultReceiver,
-			PythonEnvironmentManager pythonEnvironmentManager) {
+			PythonEnvironmentManager pythonEnvironmentManager,
+			Map<String, String> jobOptions) {
 			return new PassThroughPythonTableFunctionRunner<BaseRow>(resultReceiver) {
 				@Override
 				public BaseRow copy(BaseRow element) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/PythonTableFunctionOperatorTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -77,7 +78,8 @@ public class PythonTableFunctionOperatorTest extends PythonTableFunctionOperator
 		@Override
 		public PythonFunctionRunner<Row> createPythonFunctionRunner(
 			FnDataReceiver<byte[]> resultReceiver,
-			PythonEnvironmentManager pythonEnvironmentManager) {
+			PythonEnvironmentManager pythonEnvironmentManager,
+			Map<String, String> jobOptions) {
 			return new PassThroughPythonTableFunctionRunner<Row>(resultReceiver) {
 				@Override
 				public Row copy(Row element) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/BaseRowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/BaseRowPythonScalarFunctionRunnerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -88,6 +89,7 @@ public class BaseRowPythonScalarFunctionRunnerTest extends AbstractPythonScalarF
 			pythonFunctionInfos,
 			environmentManager,
 			inputType,
-			outputType);
+			outputType,
+			Collections.emptyMap());
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/PythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/PythonScalarFunctionRunnerTest.java
@@ -210,7 +210,8 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			pythonFunctionInfos,
 			environmentManager,
 			inputType,
-			outputType);
+			outputType,
+			Collections.emptyMap());
 	}
 
 	private AbstractGeneralPythonScalarFunctionRunner<Row> createUDFRunner(
@@ -236,6 +237,7 @@ public class PythonScalarFunctionRunnerTest extends AbstractPythonScalarFunction
 			environmentManager,
 			rowType,
 			rowType,
+			Collections.emptyMap(),
 			jobBundleFactory) {
 			@Override
 			public TypeSerializer<Row> getInputTypeSerializer() {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
@@ -173,6 +173,7 @@ public class ArrowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFun
 			inputType,
 			outputType,
 			maxArrowBatchSize,
+			Collections.emptyMap(),
 			jobBundleFactory) {
 			@Override
 			public ArrowWriter<Row> createArrowWriter() {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/table/BaseRowPythonTableFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/table/BaseRowPythonTableFunctionRunnerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -73,6 +74,7 @@ public class BaseRowPythonTableFunctionRunnerTest extends AbstractPythonTableFun
 			pythonFunctionInfo,
 			environmentManager,
 			inputType,
-			outputType);
+			outputType,
+			Collections.emptyMap());
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/table/PythonTableFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/table/PythonTableFunctionRunnerTest.java
@@ -96,7 +96,8 @@ public class PythonTableFunctionRunnerTest extends AbstractPythonTableFunctionRu
 			pythonFunctionInfo,
 			environmentManager,
 			inputType,
-			outputType);
+			outputType,
+			Collections.emptyMap());
 	}
 
 	private AbstractPythonTableFunctionRunner<Row> createUDTFRunner(
@@ -135,7 +136,7 @@ public class PythonTableFunctionRunnerTest extends AbstractPythonTableFunctionRu
 			RowType inputType,
 			RowType outputType,
 			JobBundleFactory jobBundleFactory) {
-			super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType);
+			super(taskName, resultReceiver, tableFunction, environmentManager, inputType, outputType, Collections.emptyMap());
 			this.jobBundleFactory = jobBundleFactory;
 		}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughArrowPythonScalarFunctionRunner.java
@@ -29,6 +29,7 @@ import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.runtime.utils.PythonTestUtils.createMockJobBundleFactory;
 
@@ -49,8 +50,9 @@ public abstract class PassThroughArrowPythonScalarFunctionRunner<IN> extends Abs
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
-		int maxArrowBatchSize) {
-		this(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize, createMockJobBundleFactory());
+		int maxArrowBatchSize,
+		Map<String, String> jobOptions) {
+		this(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize, jobOptions, createMockJobBundleFactory());
 	}
 
 	public PassThroughArrowPythonScalarFunctionRunner(
@@ -61,8 +63,9 @@ public abstract class PassThroughArrowPythonScalarFunctionRunner<IN> extends Abs
 		RowType inputType,
 		RowType outputType,
 		int maxArrowBatchSize,
+		Map<String, String> jobOptions,
 		JobBundleFactory jobBundleFactory) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize);
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, maxArrowBatchSize, jobOptions);
 		this.jobBundleFactory = jobBundleFactory;
 		this.bufferedInputs = new ArrayList<>();
 	}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PassThroughPythonScalarFunctionRunner.java
@@ -29,6 +29,7 @@ import org.apache.beam.vendor.grpc.v1p21p0.com.google.protobuf.Struct;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.runtime.utils.PythonTestUtils.createMockJobBundleFactory;
 
@@ -48,8 +49,9 @@ public abstract class PassThroughPythonScalarFunctionRunner<IN> extends Abstract
 		PythonFunctionInfo[] scalarFunctions,
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
-		RowType outputType) {
-		this(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, createMockJobBundleFactory());
+		RowType outputType,
+		Map<String, String> jobOptions) {
+		this(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions, createMockJobBundleFactory());
 	}
 
 	public PassThroughPythonScalarFunctionRunner(
@@ -59,8 +61,9 @@ public abstract class PassThroughPythonScalarFunctionRunner<IN> extends Abstract
 		PythonEnvironmentManager environmentManager,
 		RowType inputType,
 		RowType outputType,
+		Map<String, String> jobOptions,
 		JobBundleFactory jobBundleFactory) {
-		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType);
+		super(taskName, resultReceiver, scalarFunctions, environmentManager, inputType, outputType, jobOptions);
 		this.jobBundleFactory = jobBundleFactory;
 		this.bufferedInputs = new ArrayList<>();
 	}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
@@ -20,7 +20,8 @@ package org.apache.flink.table.planner.plan.nodes.common
 
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.flink.table.api.TableException
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo}
 import org.apache.flink.table.planner.functions.utils.{ScalarSqlFunction, TableSqlFunction}
@@ -84,4 +85,9 @@ trait CommonPythonBase {
     }
   }
 
+  protected def getConfig(tableConfig: TableConfig): Configuration = {
+    val config = new Configuration(tableConfig.getConfiguration)
+    config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
+    config
+  }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -23,6 +23,7 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -51,7 +52,7 @@ trait CommonPythonCalc extends CommonPythonBase {
   }
 
   private def getPythonScalarFunctionOperator(
-      config: Configuration,
+      tableConfig: TableConfig,
       inputRowTypeInfo: BaseRowTypeInfo,
       outputRowTypeInfo: BaseRowTypeInfo,
       udfInputOffsets: Array[Int],
@@ -71,7 +72,7 @@ trait CommonPythonCalc extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[Array[Int]])
     ctor.newInstance(
-      config,
+      getConfig(tableConfig),
       pythonFunctionInfos,
       inputRowTypeInfo.toRowType,
       outputRowTypeInfo.toRowType,
@@ -84,7 +85,7 @@ trait CommonPythonCalc extends CommonPythonBase {
       inputTransform: Transformation[BaseRow],
       calcProgram: RexProgram,
       name: String,
-      config: Configuration): OneInputTransformation[BaseRow, BaseRow] = {
+      tableConfig: TableConfig): OneInputTransformation[BaseRow, BaseRow] = {
     val pythonRexCalls = calcProgram.getProjectList
       .map(calcProgram.expandLocalRef)
       .collect { case call: RexCall => call }
@@ -106,7 +107,7 @@ trait CommonPythonCalc extends CommonPythonBase {
         pythonRexCalls.map(node => FlinkTypeFactory.toLogicalType(node.getType)): _*)
 
     val pythonOperator = getPythonScalarFunctionOperator(
-      config,
+      tableConfig,
       pythonOperatorInputTypeInfo,
       pythonOperatorResultTyeInfo,
       pythonUdfInputOffsets,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -23,7 +23,6 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -52,7 +51,7 @@ trait CommonPythonCalc extends CommonPythonBase {
   }
 
   private def getPythonScalarFunctionOperator(
-      tableConfig: TableConfig,
+      config: Configuration,
       inputRowTypeInfo: BaseRowTypeInfo,
       outputRowTypeInfo: BaseRowTypeInfo,
       udfInputOffsets: Array[Int],
@@ -72,7 +71,7 @@ trait CommonPythonCalc extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[Array[Int]])
     ctor.newInstance(
-      getConfig(tableConfig),
+      config,
       pythonFunctionInfos,
       inputRowTypeInfo.toRowType,
       outputRowTypeInfo.toRowType,
@@ -85,7 +84,7 @@ trait CommonPythonCalc extends CommonPythonBase {
       inputTransform: Transformation[BaseRow],
       calcProgram: RexProgram,
       name: String,
-      tableConfig: TableConfig): OneInputTransformation[BaseRow, BaseRow] = {
+      config: Configuration): OneInputTransformation[BaseRow, BaseRow] = {
     val pythonRexCalls = calcProgram.getProjectList
       .map(calcProgram.expandLocalRef)
       .collect { case call: RexCall => call }
@@ -107,7 +106,7 @@ trait CommonPythonCalc extends CommonPythonBase {
         pythonRexCalls.map(node => FlinkTypeFactory.toLogicalType(node.getType)): _*)
 
     val pythonOperator = getPythonScalarFunctionOperator(
-      tableConfig,
+      config,
       pythonOperatorInputTypeInfo,
       pythonOperatorResultTyeInfo,
       pythonUdfInputOffsets,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
@@ -25,6 +25,7 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -37,7 +38,7 @@ import scala.collection.mutable
 
 trait CommonPythonCorrelate extends CommonPythonBase {
   private def getPythonTableFunctionOperator(
-      config: Configuration,
+      tableConfig: TableConfig,
       inputRowType: BaseRowTypeInfo,
       outputRowType: BaseRowTypeInfo,
       pythonFunctionInfo: PythonFunctionInfo,
@@ -52,7 +53,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[JoinRelType])
     ctor.newInstance(
-      config,
+      getConfig(tableConfig),
       pythonFunctionInfo,
       inputRowType.toRowType,
       outputRowType.toRowType,
@@ -76,7 +77,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       scan: FlinkLogicalTableFunctionScan,
       name: String,
       outputRowType: RelDataType,
-      config: Configuration,
+      tableConfig: TableConfig,
       joinType: JoinRelType): OneInputTransformation[BaseRow, BaseRow] = {
     val pythonTableFuncRexCall = scan.getCall.asInstanceOf[RexCall]
     val (pythonUdtfInputOffsets, pythonFunctionInfo) =
@@ -85,7 +86,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonOperatorOutputRowType = BaseRowTypeInfo.of(
       FlinkTypeFactory.toLogicalType(outputRowType).asInstanceOf[RowType])
     val pythonOperator = getPythonTableFunctionOperator(
-      config,
+      tableConfig,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
@@ -25,7 +25,6 @@ import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.streaming.api.transformations.OneInputTransformation
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
@@ -38,7 +37,7 @@ import scala.collection.mutable
 
 trait CommonPythonCorrelate extends CommonPythonBase {
   private def getPythonTableFunctionOperator(
-      tableConfig: TableConfig,
+      config: Configuration,
       inputRowType: BaseRowTypeInfo,
       outputRowType: BaseRowTypeInfo,
       pythonFunctionInfo: PythonFunctionInfo,
@@ -53,7 +52,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[JoinRelType])
     ctor.newInstance(
-      getConfig(tableConfig),
+      config,
       pythonFunctionInfo,
       inputRowType.toRowType,
       outputRowType.toRowType,
@@ -77,7 +76,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       scan: FlinkLogicalTableFunctionScan,
       name: String,
       outputRowType: RelDataType,
-      tableConfig: TableConfig,
+      config: Configuration,
       joinType: JoinRelType): OneInputTransformation[BaseRow, BaseRow] = {
     val pythonTableFuncRexCall = scan.getCall.asInstanceOf[RexCall]
     val (pythonUdtfInputOffsets, pythonFunctionInfo) =
@@ -86,7 +85,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonOperatorOutputRowType = BaseRowTypeInfo.of(
       FlinkTypeFactory.toLogicalType(outputRowType).asInstanceOf[RowType])
     val pythonOperator = getPythonTableFunctionOperator(
-      tableConfig,
+      config,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
@@ -58,7 +58,7 @@ class BatchExecPythonCalc(
       inputTransform,
       calcProgram,
       "BatchExecPythonCalc",
-      planner.getTableConfig)
+      getConfig(planner.getTableConfig))
 
     ExecNode.setManagedMemoryWeight(
       ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCalc.scala
@@ -58,7 +58,7 @@ class BatchExecPythonCalc(
       inputTransform,
       calcProgram,
       "BatchExecPythonCalc",
-      planner.getTableConfig.getConfiguration)
+      planner.getTableConfig)
 
     ExecNode.setManagedMemoryWeight(
       ret, getPythonWorkerMemory(planner.getTableConfig.getConfiguration))

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -76,7 +76,7 @@ class BatchExecPythonCorrelate(
       scan,
       "BatchExecPythonCorrelate",
       outputRowType,
-      planner.getTableConfig.getConfiguration,
+      planner.getTableConfig,
       joinType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecPythonCorrelate.scala
@@ -76,7 +76,7 @@ class BatchExecPythonCorrelate(
       scan,
       "BatchExecPythonCorrelate",
       outputRowType,
-      planner.getTableConfig,
+      getConfig(planner.getTableConfig),
       joinType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -57,7 +57,7 @@ class StreamExecPythonCalc(
       inputTransform,
       calcProgram,
       "StreamExecPythonCalc",
-      planner.getTableConfig.getConfiguration)
+      planner.getTableConfig)
 
     if (inputsContainSingleton()) {
       ret.setParallelism(1)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCalc.scala
@@ -57,7 +57,7 @@ class StreamExecPythonCalc(
       inputTransform,
       calcProgram,
       "StreamExecPythonCalc",
-      planner.getTableConfig)
+      getConfig(planner.getTableConfig))
 
     if (inputsContainSingleton()) {
       ret.setParallelism(1)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -81,7 +81,7 @@ class StreamExecPythonCorrelate(
       scan,
       "StreamExecPythonCorrelate",
       outputRowType,
-      planner.getTableConfig,
+      getConfig(planner.getTableConfig),
       joinType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecPythonCorrelate.scala
@@ -81,7 +81,7 @@ class StreamExecPythonCorrelate(
       scan,
       "StreamExecPythonCorrelate",
       outputRowType,
-      planner.getTableConfig.getConfiguration,
+      planner.getTableConfig,
       joinType)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/utils/python/PythonTableUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/utils/python/PythonTableUtils.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.utils.python
 
 import java.nio.charset.StandardCharsets
 import java.sql.{Date, Time, Timestamp}
-import java.time.{LocalDate, LocalDateTime, LocalTime}
+import java.time.{Instant, LocalDate, LocalDateTime, LocalTime}
 import java.util.TimeZone
 import java.util.function.BiConsumer
 
@@ -122,6 +122,12 @@ object PythonTableUtils {
     case _ if dataType == Types.SQL_TIMESTAMP => (obj: Any) => nullSafeConvert(obj) {
       case c: Long => new Timestamp(c / 1000)
       case c: Int => new Timestamp(c.toLong / 1000)
+    }
+
+    case _ if dataType == org.apache.flink.api.common.typeinfo.Types.INSTANT =>
+      (obj: Any) => nullSafeConvert(obj) {
+        case c: Long => Instant.ofEpochMilli(c / 1000)
+        case c: Int => Instant.ofEpochMilli(c.toLong / 1000)
     }
 
     case _ if dataType == Types.INTERVAL_MILLIS() => (obj: Any) => nullSafeConvert(obj) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
@@ -19,7 +19,8 @@ package org.apache.flink.table.plan.nodes
 
 import org.apache.calcite.rex.{RexCall, RexLiteral, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.flink.table.api.TableException
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo}
 import org.apache.flink.table.functions.utils.{ScalarSqlFunction, TableSqlFunction}
@@ -80,5 +81,11 @@ trait CommonPythonBase {
       case tfc: TableSqlFunction =>
         createPythonFunctionInfo(pythonRexCall, inputNodes, tfc.getTableFunction)
     }
+  }
+
+  protected def getConfig(tableConfig: TableConfig): Configuration = {
+    val config = new Configuration(tableConfig.getConfiguration)
+    config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
+    config
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.plan.nodes
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
 import org.apache.flink.table.plan.nodes.CommonPythonCalc.{ARROW_PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, PYTHON_SCALAR_FUNCTION_OPERATOR_NAME}
 import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
@@ -59,7 +60,7 @@ trait CommonPythonCalc extends CommonPythonBase {
   }
 
   private[flink] def getPythonScalarFunctionOperator(
-      config: Configuration,
+      tableConfig: TableConfig,
       inputRowType: RowType,
       outputRowType: RowType,
       calcProgram: RexProgram) = {
@@ -79,7 +80,7 @@ trait CommonPythonCalc extends CommonPythonBase {
     val (udfInputOffsets, pythonFunctionInfos) =
       extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
     ctor.newInstance(
-      config,
+      getConfig(tableConfig),
       pythonFunctionInfos,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -20,7 +20,6 @@ package org.apache.flink.table.plan.nodes
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
 import org.apache.flink.table.plan.nodes.CommonPythonCalc.{ARROW_PYTHON_SCALAR_FUNCTION_OPERATOR_NAME, PYTHON_SCALAR_FUNCTION_OPERATOR_NAME}
 import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
@@ -60,7 +59,7 @@ trait CommonPythonCalc extends CommonPythonBase {
   }
 
   private[flink] def getPythonScalarFunctionOperator(
-      tableConfig: TableConfig,
+      config: Configuration,
       inputRowType: RowType,
       outputRowType: RowType,
       calcProgram: RexProgram) = {
@@ -80,7 +79,7 @@ trait CommonPythonCalc extends CommonPythonBase {
     val (udfInputOffsets, pythonFunctionInfos) =
       extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
     ctor.newInstance(
-      getConfig(tableConfig),
+      config,
       pythonFunctionInfos,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
@@ -21,6 +21,7 @@ import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
+import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.plan.nodes.CommonPythonCorrelate.PYTHON_TABLE_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.runtime.types.CRow
@@ -30,7 +31,7 @@ import scala.collection.mutable
 
 trait CommonPythonCorrelate extends CommonPythonBase {
   protected def getPythonTableFunctionOperator(
-      config: Configuration,
+      tableConfig: TableConfig,
       inputRowType: RowType,
       outputRowType: RowType,
       pythonFunctionInfo: PythonFunctionInfo,
@@ -45,7 +46,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[JoinRelType])
     ctor.newInstance(
-      config,
+      getConfig(tableConfig),
       pythonFunctionInfo,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
@@ -21,7 +21,6 @@ import org.apache.calcite.rel.core.JoinRelType
 import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
-import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.functions.python.PythonFunctionInfo
 import org.apache.flink.table.plan.nodes.CommonPythonCorrelate.PYTHON_TABLE_FUNCTION_OPERATOR_NAME
 import org.apache.flink.table.runtime.types.CRow
@@ -31,7 +30,7 @@ import scala.collection.mutable
 
 trait CommonPythonCorrelate extends CommonPythonBase {
   protected def getPythonTableFunctionOperator(
-      tableConfig: TableConfig,
+      config: Configuration,
       inputRowType: RowType,
       outputRowType: RowType,
       pythonFunctionInfo: PythonFunctionInfo,
@@ -46,7 +45,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
       classOf[Array[Int]],
       classOf[JoinRelType])
     ctor.newInstance(
-      getConfig(tableConfig),
+      config,
       pythonFunctionInfo,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.functions.RichFlatMapFunction
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.table.api.BatchQueryConfig
+import org.apache.flink.table.api.{BatchQueryConfig, TableConfig}
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.functions.python.PythonFunctionInfo
@@ -81,7 +81,7 @@ class DataSetPythonCalc(
     val flatMapFunctionOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       flatMapFunctionResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val flatMapFunction = getPythonScalarFunctionFlatMap(
-      tableEnv.getConfig.getConfiguration,
+      tableEnv.getConfig,
       flatMapFunctionInputRowType,
       flatMapFunctionOutputRowType,
       calcProgram)
@@ -90,7 +90,7 @@ class DataSetPythonCalc(
   }
 
   private[flink] def getPythonScalarFunctionFlatMap(
-    config: Configuration,
+    tableConfig: TableConfig,
     inputRowType: RowType,
     outputRowType: RowType,
     calcProgram: RexProgram) = {
@@ -105,7 +105,7 @@ class DataSetPythonCalc(
     val (udfInputOffsets, pythonFunctionInfos) =
       extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
     ctor.newInstance(
-      config,
+      getConfig(tableConfig),
       pythonFunctionInfos,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.functions.RichFlatMapFunction
 import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.table.api.{BatchQueryConfig, TableConfig}
+import org.apache.flink.table.api.BatchQueryConfig
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
 import org.apache.flink.table.calcite.FlinkTypeFactory
 import org.apache.flink.table.functions.python.PythonFunctionInfo
@@ -81,7 +81,7 @@ class DataSetPythonCalc(
     val flatMapFunctionOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       flatMapFunctionResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val flatMapFunction = getPythonScalarFunctionFlatMap(
-      tableEnv.getConfig,
+      getConfig(tableEnv.getConfig),
       flatMapFunctionInputRowType,
       flatMapFunctionOutputRowType,
       calcProgram)
@@ -90,7 +90,7 @@ class DataSetPythonCalc(
   }
 
   private[flink] def getPythonScalarFunctionFlatMap(
-    tableConfig: TableConfig,
+    config: Configuration,
     inputRowType: RowType,
     outputRowType: RowType,
     calcProgram: RexProgram) = {
@@ -105,7 +105,7 @@ class DataSetPythonCalc(
     val (udfInputOffsets, pythonFunctionInfos) =
       extractPythonScalarFunctionInfos(getPythonRexCalls(calcProgram))
     ctor.newInstance(
-      getConfig(tableConfig),
+      config,
       pythonFunctionInfos,
       inputRowType,
       outputRowType,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -84,7 +84,7 @@ class DataStreamPythonCalc(
     val pythonOperatorOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       pythonOperatorResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val pythonOperator = getPythonScalarFunctionOperator(
-      planner.getConfig.getConfiguration,
+      planner.getConfig,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       calcProgram)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCalc.scala
@@ -84,7 +84,7 @@ class DataStreamPythonCalc(
     val pythonOperatorOutputRowType = TypeConversions.fromLegacyInfoToDataType(
       pythonOperatorResultTypeInfo).getLogicalType.asInstanceOf[RowType]
     val pythonOperator = getPythonScalarFunctionOperator(
-      planner.getConfig,
+      getConfig(planner.getConfig),
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       calcProgram)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -95,7 +95,7 @@ class DataStreamPythonCorrelate(
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
     val pythonOperator = getPythonTableFunctionOperator(
-      planner.getConfig,
+      getConfig(planner.getConfig),
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamPythonCorrelate.scala
@@ -95,7 +95,7 @@ class DataStreamPythonCorrelate(
     val sqlFunction = pythonTableFuncRexCall.getOperator.asInstanceOf[TableSqlFunction]
 
     val pythonOperator = getPythonTableFunctionOperator(
-      planner.getConfig.getConfiguration,
+      planner.getConfig,
       pythonOperatorInputRowType,
       pythonOperatorOutputRowType,
       pythonFunctionInfo,


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds support of LocalZonedTimestampType for Python UDF in blink planner.*

## Brief change log

  - *Update the Python operators to pass the timezone information to the Python process*
  - *Add support of LocalZonedTimestampType in blink planner*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests test_data_types_only_supported_in_blink_planner in test_udf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
