### PR TITLE
[FLINK-16653][network][tests] Introduce ResultPartitionWriterTestBase for simplifying tests

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -18,19 +18,16 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
-import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -39,31 +36,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  * {@link ResultPartitionWriter} that collects output on the List.
  */
 @ThreadSafe
-public abstract class AbstractCollectingResultPartitionWriter implements ResultPartitionWriter {
+public abstract class AbstractCollectingResultPartitionWriter extends MockResultPartitionWriter {
 	private final BufferProvider bufferProvider;
 	private final ArrayDeque<BufferConsumer> bufferConsumers = new ArrayDeque<>();
 
 	public AbstractCollectingResultPartitionWriter(BufferProvider bufferProvider) {
 		this.bufferProvider = checkNotNull(bufferProvider);
-	}
-
-	@Override
-	public void setup() {
-	}
-
-	@Override
-	public ResultPartitionID getPartitionId() {
-		return new ResultPartitionID();
-	}
-
-	@Override
-	public int getNumberOfSubpartitions() {
-		return 1;
-	}
-
-	@Override
-	public int getNumTargetKeyGroups() {
-		return 1;
 	}
 
 	@Override
@@ -108,25 +86,6 @@ public abstract class AbstractCollectingResultPartitionWriter implements ResultP
 	@Override
 	public void flush(int subpartitionIndex) {
 		flushAll();
-	}
-
-	@Override
-	public void close() {
-	}
-
-	@Override
-	public void fail(@Nullable Throwable throwable) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void finish() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public CompletableFuture<?> getAvailableFuture() {
-		return AvailabilityProvider.AVAILABLE;
 	}
 
 	protected abstract void deserializeBuffer(Buffer buffer) throws IOException;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AvailabilityTestResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AvailabilityTestResultPartitionWriter.java
@@ -18,11 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
-import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
-import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-
-import javax.annotation.Nullable;
+import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -30,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
  * A specific result partition writer implementation only used to control the output
  * availability state in tests.
  */
-public class AvailabilityTestResultPartitionWriter implements ResultPartitionWriter {
+public class AvailabilityTestResultPartitionWriter extends MockResultPartitionWriter {
 
 	/** This state is only valid in the first call of {@link #isAvailable()}. */
 	private final boolean isAvailable;
@@ -42,55 +38,6 @@ public class AvailabilityTestResultPartitionWriter implements ResultPartitionWri
 
 	public AvailabilityTestResultPartitionWriter(boolean isAvailable) {
 		this.isAvailable = isAvailable;
-	}
-
-	@Override
-	public void setup() {
-	}
-
-	@Override
-	public ResultPartitionID getPartitionId() {
-		return new ResultPartitionID();
-	}
-
-	@Override
-	public int getNumberOfSubpartitions() {
-		return 1;
-	}
-
-	@Override
-	public int getNumTargetKeyGroups() {
-		return 1;
-	}
-
-	@Override
-	public BufferBuilder getBufferBuilder() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) {
-		return true;
-	}
-
-	@Override
-	public void flushAll() {
-	}
-
-	@Override
-	public void flush(int subpartitionIndex) {
-	}
-
-	@Override
-	public void close() {
-	}
-
-	@Override
-	public void fail(@Nullable Throwable throwable) {
-	}
-
-	@Override
-	public void finish() {
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Dummy behaviours of {@link ResultPartitionWriter} for test purpose.
+ */
+public class MockResultPartitionWriter implements ResultPartitionWriter {
+
+	private final ResultPartitionID partitionId = new ResultPartitionID();
+
+	@Override
+	public void setup() {
+	}
+
+	@Override
+	public ResultPartitionID getPartitionId() {
+		return partitionId;
+	}
+
+	@Override
+	public int getNumberOfSubpartitions() {
+		return 1;
+	}
+
+	@Override
+	public int getNumTargetKeyGroups() {
+		return 1;
+	}
+
+	@Override
+	public boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
+		bufferConsumer.close();
+		return true;
+	}
+
+	@Override
+	public BufferBuilder getBufferBuilder() throws IOException, InterruptedException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void flushAll() {
+	}
+
+	@Override
+	public void flush(int subpartitionIndex) {
+	}
+
+	@Override
+	public void fail(@Nullable Throwable throwable) {
+	}
+
+	@Override
+	public void finish() {
+	}
+
+	@Override
+	public CompletableFuture<?> getAvailableFuture() {
+		return AVAILABLE;
+	}
+
+	@Override
+	public void close() {
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

At the moment there are at-least four implementations of `ResultPartitionWriter` interface used in unit tests. And there are about ten methods to be implemented for `ResultPartitionWriter` and most of them are dummy in tests.

When we want to extend the methods for `ResultPartitionWriter`, the above four dummy implementations in tests have to be adjusted as well, to waste a bit efforts.

Therefore the abstract ResultPartitionWriterTestBase is proposed to implement the basic dummy methods for `ResultPartitionWriter`, and the previous four instances can all extend it to only implement one or two methods based on specific requirements in tests. It will probably only need to adjust the ResultPartitionWriterTestBase when extending the `ResultPartitionWriter` interface.

## Brief change log

  - *Introduce abstract ResultPartitionWriterTestBase to implement `ResultPartitionWriter`*
  - Make previous related `ResultPartitionWriter` instances to extend `ResultPartitionWriterTestBase`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
