### PR TITLE
[FLINK-14791][coordination] ResourceManager tracks ClusterPartitions

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManager;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
@@ -96,6 +97,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			ClusterInformation clusterInformation,
 			FatalErrorHandler fatalErrorHandler,
@@ -109,6 +111,7 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			clusterInformation,
 			fatalErrorHandler,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesResourceManagerFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -75,6 +76,7 @@ public class KubernetesResourceManagerFactory extends ActiveResourceManagerFacto
 			highAvailabilityServices,
 			heartbeatServices,
 			rmRuntimeServices.getSlotManager(),
+			ResourceManagerPartitionTrackerImpl::new,
 			rmRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -147,6 +148,7 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 				highAvailabilityServices,
 				heartbeatServices,
 				slotManager,
+				NoOpResourceManagerPartitionTracker::get,
 				jobLeaderIdService,
 				clusterInformation,
 				fatalErrorHandler,

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManager.java
@@ -40,6 +40,7 @@ import org.apache.flink.mesos.scheduler.messages.SlaveLost;
 import org.apache.flink.mesos.scheduler.messages.StatusUpdate;
 import org.apache.flink.mesos.util.MesosArtifactServer;
 import org.apache.flink.mesos.util.MesosConfiguration;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.ContainerSpecification;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -49,6 +50,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -155,6 +157,7 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			ClusterInformation clusterInformation,
 			FatalErrorHandler fatalErrorHandler,
@@ -173,10 +176,12 @@ public class MesosResourceManager extends ResourceManager<RegisteredMesosWorkerN
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			clusterInformation,
 			fatalErrorHandler,
-			resourceManagerMetricGroup);
+			resourceManagerMetricGroup,
+			AkkaUtils.getTimeoutAsTime(flinkConfig));
 
 		this.mesosServices = Preconditions.checkNotNull(mesosServices);
 		this.actorSystem = Preconditions.checkNotNull(mesosServices.getLocalActorSystem());

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerFactory.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -87,6 +88,7 @@ public class MesosResourceManagerFactory extends ActiveResourceManagerFactory<Re
 			highAvailabilityServices,
 			heartbeatServices,
 			rmRuntimeServices.getSlotManager(),
+			ResourceManagerPartitionTrackerImpl::new,
 			rmRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
@@ -182,6 +183,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				slotManager,
+				NoOpResourceManagerPartitionTracker::get,
 				jobLeaderIdService,
 				new ClusterInformation("localhost", 1234),
 				fatalErrorHandler,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+/**
+ * Container for meta-data of a data set.
+ */
+public final class DataSetMetaInfo {
+
+	private final int numTotalPartitions;
+
+	public DataSetMetaInfo(int numTotalPartitions) {
+		this.numTotalPartitions = numTotalPartitions;
+	}
+
+	public int getNumTotalPartitions() {
+		return numTotalPartitions;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTracker.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Utility for tracking and releasing partitions on the ResourceManager.
+ */
+public interface ResourceManagerPartitionTracker {
+
+	/**
+	 * Processes {@link ClusterPartitionReport} of a task executor. Updates the tracking information for the respective
+	 * task executor. Any partition no longer being hosted on the task executor is considered lost, corrupting the
+	 * corresponding data set.
+	 * For any such data set this method issues partition release calls to all task executors that are hosting
+	 * partitions of this data set.
+	 *
+	 * @param taskExecutorId origin of the report
+	 * @param clusterPartitionReport partition report
+	 */
+	void processTaskExecutorClusterPartitionReport(ResourceID taskExecutorId, ClusterPartitionReport clusterPartitionReport);
+
+	/**
+	 * Processes the shutdown of task executor. Removes all tracking information for the given executor, determines
+	 * datasets that may be corrupted by the shutdown (and implied loss of partitions).
+	 * For any such data set this method issues partition release calls to all task executors that are hosting
+	 * partitions of this data set, and issues release calls.
+	 *
+	 * @param taskExecutorId task executor that shut down
+	 */
+	void processTaskExecutorShutdown(ResourceID taskExecutorId);
+
+	/**
+	 * Issues a release calls to all task executors that are hosting partitions of the given data set.
+	 *
+	 * @param dataSetId data set to release
+	 */
+	CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetId);
+
+	/**
+	 * Returns all data sets for which all partitions are being tracked.
+	 *
+	 * @return completely tracked datasets
+	 */
+	Map<IntermediateDataSetID, DataSetMetaInfo> listDataSets();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+/**
+ * Factory for {@link ResourceManagerPartitionTracker}.
+ */
+@FunctionalInterface
+public interface ResourceManagerPartitionTrackerFactory {
+	ResourceManagerPartitionTracker get(TaskExecutorClusterPartitionReleaser taskExecutorClusterPartitionReleaser);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerImpl.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link ResourceManagerPartitionTracker} implementation.
+ *
+ * <p>Internal tracking info must only be updated upon reception of a {@link ClusterPartitionReport}, as the task
+ * executor state is the source of truth.
+ */
+public class ResourceManagerPartitionTrackerImpl implements ResourceManagerPartitionTracker {
+
+	private static final Logger LOG = LoggerFactory.getLogger(ResourceManagerPartitionTrackerImpl.class);
+
+	private final Map<ResourceID, Set<IntermediateDataSetID>> taskExecutorToDataSets = new HashMap<>();
+	private final Map<IntermediateDataSetID, Map<ResourceID, Set<ResultPartitionID>>> dataSetToTaskExecutors = new HashMap<>();
+	private final Map<IntermediateDataSetID, DataSetMetaInfo> dataSetMetaInfo = new HashMap<>();
+	private final Map<IntermediateDataSetID, CompletableFuture<Void>> partitionReleaseCompletionFutures = new HashMap<>();
+
+	private final TaskExecutorClusterPartitionReleaser taskExecutorClusterPartitionReleaser;
+
+	public ResourceManagerPartitionTrackerImpl(TaskExecutorClusterPartitionReleaser taskExecutorClusterPartitionReleaser) {
+		this.taskExecutorClusterPartitionReleaser = taskExecutorClusterPartitionReleaser;
+	}
+
+	@Override
+	public void processTaskExecutorClusterPartitionReport(ResourceID taskExecutorId, ClusterPartitionReport clusterPartitionReport) {
+		Preconditions.checkNotNull(taskExecutorId);
+		Preconditions.checkNotNull(clusterPartitionReport);
+		LOG.debug("Processing cluster partition report from task executor {}: {}.", taskExecutorId, clusterPartitionReport);
+
+		internalProcessClusterPartitionReport(taskExecutorId, clusterPartitionReport);
+	}
+
+	@Override
+	public void processTaskExecutorShutdown(ResourceID taskExecutorId) {
+		Preconditions.checkNotNull(taskExecutorId);
+		LOG.debug("Processing shutdown of task executor {}.", taskExecutorId);
+
+		internalProcessClusterPartitionReport(taskExecutorId, new ClusterPartitionReport(Collections.emptyList()));
+	}
+
+	@Override
+	public CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetId) {
+		Preconditions.checkNotNull(dataSetId);
+		if (!dataSetMetaInfo.containsKey(dataSetId)) {
+			LOG.debug("Attempted released of unknown data set {}.", dataSetId);
+			return CompletableFuture.completedFuture(null);
+		}
+		LOG.debug("Releasing cluster partitions for data set {}.", dataSetId);
+
+		CompletableFuture<Void> partitionReleaseCompletionFuture = partitionReleaseCompletionFutures.computeIfAbsent(dataSetId, ignored -> new CompletableFuture<>());
+		internalReleasePartitions(Collections.singleton(dataSetId));
+		return partitionReleaseCompletionFuture;
+	}
+
+	private void internalProcessClusterPartitionReport(ResourceID taskExecutorId, ClusterPartitionReport clusterPartitionReport) {
+		final Set<IntermediateDataSetID> dataSetsWithLostPartitions = clusterPartitionReport.getEntries().isEmpty()
+			? processEmptyReport(taskExecutorId)
+			: setHostedDataSetsAndCheckCorruption(taskExecutorId, clusterPartitionReport.getEntries());
+
+		updateDataSetMetaData(clusterPartitionReport);
+
+		checkForFullyLostDatasets(dataSetsWithLostPartitions);
+
+		internalReleasePartitions(dataSetsWithLostPartitions);
+	}
+
+	private void internalReleasePartitions(Set<IntermediateDataSetID> dataSetsToRelease) {
+		Map<ResourceID, Set<IntermediateDataSetID>> releaseCalls = prepareReleaseCalls(dataSetsToRelease);
+		releaseCalls.forEach(taskExecutorClusterPartitionReleaser::releaseClusterPartitions);
+	}
+
+	private Set<IntermediateDataSetID> processEmptyReport(ResourceID taskExecutorId) {
+		Set<IntermediateDataSetID> previouslyHostedDatasets = taskExecutorToDataSets.remove(taskExecutorId);
+		if (previouslyHostedDatasets == null) {
+			// default path for task executors that never have any cluster partitions
+			previouslyHostedDatasets = Collections.emptySet();
+		} else {
+			previouslyHostedDatasets.forEach(dataSetId -> removeInnerKey(dataSetId, taskExecutorId, dataSetToTaskExecutors));
+		}
+		return previouslyHostedDatasets;
+	}
+
+	/**
+	 * Updates the data sets for which the given task executor is hosting partitions and returns data sets that were
+	 * corrupted due to a loss of partitions.
+	 *
+	 * @param taskExecutorId ID of the hosting TaskExecutor
+	 * @param reportEntries  IDs of data sets for which partitions are hosted
+	 * @return corrupted data sets
+	 */
+	private Set<IntermediateDataSetID> setHostedDataSetsAndCheckCorruption(ResourceID taskExecutorId, Collection<ClusterPartitionReport.ClusterPartitionReportEntry> reportEntries) {
+		final Set<IntermediateDataSetID> currentlyHostedDatasets = reportEntries
+			.stream()
+			.map(ClusterPartitionReport.ClusterPartitionReportEntry::getDataSetId)
+			.collect(Collectors.toSet());
+
+		final Set<IntermediateDataSetID> previouslyHostedDataSets = taskExecutorToDataSets.put(
+			taskExecutorId,
+			currentlyHostedDatasets);
+
+		// previously tracked data sets may be corrupted since we may be tracking less partitions than before
+		final Set<IntermediateDataSetID> potentiallyCorruptedDataSets = Optional
+			.ofNullable(previouslyHostedDataSets)
+			.orElse(new HashSet<>(0));
+
+		// update data set -> task executor mapping and find datasets for which lost a partition
+		reportEntries.forEach(hostedPartition -> {
+			final Map<ResourceID, Set<ResultPartitionID>> taskExecutorHosts = dataSetToTaskExecutors.computeIfAbsent(hostedPartition.getDataSetId(), ignored -> new HashMap<>());
+			final Set<ResultPartitionID> previouslyHostedPartitions = taskExecutorHosts.put(taskExecutorId, hostedPartition.getHostedPartitions());
+
+			final boolean noPartitionLost = previouslyHostedPartitions == null || hostedPartition.getHostedPartitions().containsAll(previouslyHostedPartitions);
+			if (noPartitionLost) {
+				potentiallyCorruptedDataSets.remove(hostedPartition.getDataSetId());
+			}
+		});
+
+		// now only contains data sets for which a partition is no longer tracked
+		return potentiallyCorruptedDataSets;
+	}
+
+	private void updateDataSetMetaData(ClusterPartitionReport clusterPartitionReport) {
+		// add meta info for new data sets
+		clusterPartitionReport.getEntries().forEach(entry ->
+			dataSetMetaInfo.compute(entry.getDataSetId(), (dataSetID, dataSetMetaInfo) -> {
+				if (dataSetMetaInfo == null) {
+					return new DataSetMetaInfo(entry.getNumTotalPartitions());
+				} else {
+					// double check that the meta data is consistent
+					Preconditions.checkState(dataSetMetaInfo.getNumTotalPartitions() == entry.getNumTotalPartitions());
+					return dataSetMetaInfo;
+				}
+			}));
+	}
+
+	private void checkForFullyLostDatasets(Set<IntermediateDataSetID> dataSetsWithLostPartitions) {
+		dataSetsWithLostPartitions.forEach(dataSetId -> {
+			if (getHostingTaskExecutors(dataSetId).isEmpty()) {
+				LOG.debug("There are no longer partitions being tracked for dataset {}.", dataSetId);
+				dataSetMetaInfo.remove(dataSetId);
+				Optional.ofNullable(partitionReleaseCompletionFutures.remove(dataSetId)).map(future -> future.complete(null));
+			}
+		});
+	}
+
+	private Map<ResourceID, Set<IntermediateDataSetID>> prepareReleaseCalls(Set<IntermediateDataSetID> dataSetsToRelease) {
+		final Map<ResourceID, Set<IntermediateDataSetID>> releaseCalls = new HashMap<>();
+		dataSetsToRelease.forEach(dataSetToRelease -> {
+			final Set<ResourceID> hostingTaskExecutors = getHostingTaskExecutors(dataSetToRelease);
+			hostingTaskExecutors.forEach(hostingTaskExecutor -> insert(hostingTaskExecutor, dataSetToRelease, releaseCalls));
+		});
+		return releaseCalls;
+	}
+
+	private Set<ResourceID> getHostingTaskExecutors(IntermediateDataSetID dataSetId) {
+		Preconditions.checkNotNull(dataSetId);
+
+		Map<ResourceID, Set<ResultPartitionID>> trackedPartitions = dataSetToTaskExecutors.get(dataSetId);
+		if (trackedPartitions == null) {
+			return Collections.emptySet();
+		} else {
+			return trackedPartitions.keySet();
+		}
+	}
+
+	@Override
+	public Map<IntermediateDataSetID, DataSetMetaInfo> listDataSets() {
+		return dataSetMetaInfo.entrySet().stream()
+			.filter(entry -> {
+				final Map<ResourceID, Set<ResultPartitionID>> taskExecutorToPartitions = dataSetToTaskExecutors.get(entry.getKey());
+				Preconditions.checkState(taskExecutorToPartitions != null, "Have metadata entry for dataset %s, but no partition is tracked.", entry.getKey());
+
+				int numTrackedPartitions = 0;
+				for (Set<ResultPartitionID> hostedPartitions : taskExecutorToPartitions.values()) {
+					numTrackedPartitions += hostedPartitions.size();
+				}
+
+				return numTrackedPartitions == entry.getValue().getNumTotalPartitions();
+			})
+			.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+	}
+
+	/**
+	 * Returns whether all maps are empty; used for checking for resource leaks in case entries aren't properly removed.
+	 *
+	 * @return whether all contained maps are empty
+	 */
+	@VisibleForTesting
+	boolean areAllMapsEmpty() {
+		return taskExecutorToDataSets.isEmpty() && dataSetToTaskExecutors.isEmpty() && dataSetMetaInfo.isEmpty() && partitionReleaseCompletionFutures.isEmpty();
+	}
+
+	private static <K, V> void insert(K key1, V value, Map<K, Set<V>> collection) {
+		collection.compute(key1, (key, values) -> {
+			if (values == null) {
+				values = new HashSet<>();
+			}
+			values.add(value);
+			return values;
+		});
+	}
+
+	private static <K1, K2, V> void removeInnerKey(K1 key1, K2 value, Map<K1, Map<K2, V>> collection) {
+		collection.computeIfPresent(key1, (key, values) -> {
+			values.remove(value);
+			if (values.isEmpty()) {
+				return null;
+			}
+			return values;
+		});
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorClusterPartitionReleaser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/TaskExecutorClusterPartitionReleaser.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.Set;
+
+/**
+ * Interface for releasing cluster partitions on a task executor.
+ */
+@FunctionalInterface
+public interface TaskExecutorClusterPartitionReleaser {
+	void releaseClusterPartitions(ResourceID taskExecutorId, Set<IntermediateDataSetID> dataSetsToRelease);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -29,6 +30,7 @@ import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
@@ -76,6 +78,7 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			ClusterInformation clusterInformation,
 			FatalErrorHandler fatalErrorHandler,
@@ -87,10 +90,12 @@ public abstract class ActiveResourceManager <WorkerType extends ResourceIDRetrie
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			clusterInformation,
 			fatalErrorHandler,
-			resourceManagerMetricGroup);
+			resourceManagerMetricGroup,
+			AkkaUtils.getTimeoutAsTime(flinkConfig));
 
 		this.flinkConfig = flinkConfig;
 		this.env = env;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
@@ -56,11 +57,13 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			ClusterInformation clusterInformation,
 			FatalErrorHandler fatalErrorHandler,
 			ResourceManagerMetricGroup resourceManagerMetricGroup,
-			Time startupPeriodTime) {
+			Time startupPeriodTime,
+			Time rpcTimeout) {
 		super(
 			rpcService,
 			resourceManagerEndpointId,
@@ -68,10 +71,12 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			clusterInformation,
 			fatalErrorHandler,
-			resourceManagerMetricGroup);
+			resourceManagerMetricGroup,
+			rpcTimeout);
 		this.startupPeriodTime = Preconditions.checkNotNull(startupPeriodTime);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -21,10 +21,12 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -63,10 +65,12 @@ public enum StandaloneResourceManagerFactory implements ResourceManagerFactory<R
 			highAvailabilityServices,
 			heartbeatServices,
 			resourceManagerRuntimeServices.getSlotManager(),
+			ResourceManagerPartitionTrackerImpl::new,
 			resourceManagerRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,
 			resourceManagerMetricGroup,
-			standaloneClusterStartupPeriodTime);
+			standaloneClusterStartupPeriodTime,
+			AkkaUtils.getTimeoutAsTime(configuration));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -775,8 +775,9 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 	}
 
 	@Override
-	public void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
+	public CompletableFuture<Acknowledge> releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
 		partitionTracker.stopTrackingAndReleaseClusterPartitions(dataSetsToRelease);
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
 	// ----------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutorGateway.java
@@ -120,8 +120,9 @@ public interface TaskExecutorGateway extends RpcGateway, TaskExecutorOperatorEve
 	 *
 	 * @param dataSetsToRelease data sets for which all cluster partitions should be released
 	 * @param timeout for the partitions release operation
+	 * @return Future acknowledge that the request was received
 	 */
-	void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, @RpcTimeout Time timeout);
+	CompletableFuture<Acknowledge> releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, @RpcTimeout Time timeout);
 
 	/**
 	 * Trigger the checkpoint for the given task. The checkpoint is identified by the checkpoint ID

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/ClusterPartitionReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/partition/ClusterPartitionReport.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.taskexecutor.partition;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -63,6 +64,12 @@ public class ClusterPartitionReport implements Serializable {
 		private final int numTotalPartitions;
 
 		public ClusterPartitionReportEntry(IntermediateDataSetID dataSetId, Set<ResultPartitionID> hostedPartitions, int numTotalPartitions) {
+			Preconditions.checkNotNull(dataSetId);
+			Preconditions.checkNotNull(hostedPartitions);
+			Preconditions.checkArgument(!hostedPartitions.isEmpty());
+			Preconditions.checkArgument(numTotalPartitions > 0);
+			Preconditions.checkState(hostedPartitions.size() <= numTotalPartitions);
+
 			this.dataSetId = dataSetId;
 			this.hostedPartitions = hostedPartitions;
 			this.numTotalPartitions = numTotalPartitions;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpResourceManagerPartitionTracker.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpResourceManagerPartitionTracker.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * No-op {@link ResourceManagerPartitionTracker} implementation; does not track any partition and never regards a data
+ * set corrupted.
+ */
+public enum NoOpResourceManagerPartitionTracker implements ResourceManagerPartitionTracker {
+	INSTANCE;
+
+	@Override
+	public void processTaskExecutorClusterPartitionReport(ResourceID taskExecutorId, ClusterPartitionReport clusterPartitionReport) {
+	}
+
+	@Override
+	public void processTaskExecutorShutdown(ResourceID taskExecutorId) {
+	}
+
+	@Override
+	public CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetId) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public Map<IntermediateDataSetID, DataSetMetaInfo> listDataSets() {
+		return Collections.emptyMap();
+	}
+
+	@SuppressWarnings("unused") // unused parameter allows usage as a ResourceManagerPartitionTrackerFactory
+	public static ResourceManagerPartitionTracker get(TaskExecutorClusterPartitionReleaser ignored) {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTrackerImplTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * Test for the {@link ResourceManagerPartitionTrackerImpl}.
+ */
+public class ResourceManagerPartitionTrackerImplTest extends TestLogger {
+
+	private static final ClusterPartitionReport EMPTY_PARTITION_REPORT = new ClusterPartitionReport(Collections.emptySet());
+
+	private static final ResourceID TASK_EXECUTOR_ID_1 = ResourceID.generate();
+	private static final ResourceID TASK_EXECUTOR_ID_2 = ResourceID.generate();
+	private static final IntermediateDataSetID DATA_SET_ID = new IntermediateDataSetID();
+	private static final ResultPartitionID PARTITION_ID_1 = new ResultPartitionID();
+	private static final ResultPartitionID PARTITION_ID_2 = new ResultPartitionID();
+
+	@Test
+	public void testProcessEmptyClusterPartitionReport() {
+		TestClusterPartitionReleaser partitionReleaser = new TestClusterPartitionReleaser();
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(partitionReleaser);
+
+		reportEmpty(tracker, TASK_EXECUTOR_ID_1);
+		assertThat(partitionReleaser.releaseCalls, empty());
+		assertThat(tracker.areAllMapsEmpty(), is(true));
+	}
+
+	/**
+	 * Verifies that a task executor hosting multiple partitions of a data set receives a release call if a subset of
+	 * its partitions is lost.
+	 */
+	@Test
+	public void testReportProcessingWithPartitionLossOnSameTaskExecutor() {
+		TestClusterPartitionReleaser partitionReleaser = new TestClusterPartitionReleaser();
+		final ResourceManagerPartitionTracker tracker = new ResourceManagerPartitionTrackerImpl(partitionReleaser);
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1, PARTITION_ID_2);
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_2);
+
+		assertThat(partitionReleaser.releaseCalls, contains(Tuple2.of(TASK_EXECUTOR_ID_1, Collections.singleton(DATA_SET_ID))));
+	}
+
+	/**
+	 * Verifies that a task executor hosting partitions of a data set receives a release call if a partition of the
+	 * data set is lost on another task executor.
+	 */
+	@Test
+	public void testReportProcessingWithPartitionLossOnOtherTaskExecutor() {
+		TestClusterPartitionReleaser partitionReleaser = new TestClusterPartitionReleaser();
+		final ResourceManagerPartitionTracker tracker = new ResourceManagerPartitionTrackerImpl(partitionReleaser);
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1);
+		report(tracker, TASK_EXECUTOR_ID_2, DATA_SET_ID, 2, PARTITION_ID_2);
+
+		reportEmpty(tracker, TASK_EXECUTOR_ID_1);
+
+		assertThat(partitionReleaser.releaseCalls, contains(Tuple2.of(TASK_EXECUTOR_ID_2, Collections.singleton(DATA_SET_ID))));
+	}
+
+	@Test
+	public void testListDataSetsBasics() {
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(new TestClusterPartitionReleaser());
+
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 1, PARTITION_ID_1);
+
+		final Map<IntermediateDataSetID, DataSetMetaInfo> listing = tracker.listDataSets();
+		assertThat(listing, hasKey(DATA_SET_ID));
+		DataSetMetaInfo metaInfo = listing.get(DATA_SET_ID);
+		assertThat(metaInfo.getNumTotalPartitions(), is(1));
+
+		reportEmpty(tracker, TASK_EXECUTOR_ID_1);
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		assertThat(tracker.areAllMapsEmpty(), is(true));
+	}
+
+	@Test
+	public void testListDataSetsMultiplePartitionsOnSingleTaskExecutor() {
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(new TestClusterPartitionReleaser());
+
+		// data set consists of 2 partitions but only 1 is being tracked -> incomplete and should not be listed (yet)
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1);
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		// start tracking another partitions, but we lost partition 1 so the data set is still incomplete
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_2);
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		// dataset is considered complete since all partitions are being tracked
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1, PARTITION_ID_2);
+		final Map<IntermediateDataSetID, DataSetMetaInfo> listing = tracker.listDataSets();
+		assertThat(listing, hasKey(DATA_SET_ID));
+
+		// dataset is no longer considered complete since partition 2 was lost
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1);
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		assertThat(tracker.areAllMapsEmpty(), is(false));
+	}
+
+	@Test
+	public void testListDataSetsMultiplePartitionsAcrossTaskExecutors() {
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(new TestClusterPartitionReleaser());
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1);
+		report(tracker, TASK_EXECUTOR_ID_2, DATA_SET_ID, 2, PARTITION_ID_2);
+		final Map<IntermediateDataSetID, DataSetMetaInfo> listing = tracker.listDataSets();
+		assertThat(listing, hasKey(DATA_SET_ID));
+
+		reportEmpty(tracker, TASK_EXECUTOR_ID_1);
+		assertThat(tracker.listDataSets().size(), is(0));
+
+		assertThat(tracker.areAllMapsEmpty(), is(false));
+	}
+
+	@Test
+	public void testReleasePartition() {
+		TestClusterPartitionReleaser partitionReleaser = new TestClusterPartitionReleaser();
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(partitionReleaser);
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 2, PARTITION_ID_1);
+		report(tracker, TASK_EXECUTOR_ID_2, DATA_SET_ID, 2, PARTITION_ID_2);
+
+		final CompletableFuture<Void> partitionReleaseFuture = tracker.releaseClusterPartitions(DATA_SET_ID);
+
+		assertThat(partitionReleaser.releaseCalls, containsInAnyOrder(
+			Tuple2.of(TASK_EXECUTOR_ID_1, Collections.singleton(DATA_SET_ID)),
+			Tuple2.of(TASK_EXECUTOR_ID_2, Collections.singleton(DATA_SET_ID))));
+
+		// the data set should still be tracked, since the partition release was not confirmed yet by the task executors
+		assertThat(tracker.listDataSets().keySet(), contains(DATA_SET_ID));
+
+		// ack the partition release
+		reportEmpty(tracker, TASK_EXECUTOR_ID_1, TASK_EXECUTOR_ID_2);
+
+		assertThat(partitionReleaseFuture.isDone(), is(true));
+		assertThat(tracker.areAllMapsEmpty(), is(true));
+	}
+
+	@Test
+	public void testShutdownProcessing() {
+		TestClusterPartitionReleaser partitionReleaser = new TestClusterPartitionReleaser();
+		final ResourceManagerPartitionTrackerImpl tracker = new ResourceManagerPartitionTrackerImpl(partitionReleaser);
+
+		tracker.processTaskExecutorShutdown(TASK_EXECUTOR_ID_1);
+		assertThat(partitionReleaser.releaseCalls, empty());
+
+		report(tracker, TASK_EXECUTOR_ID_1, DATA_SET_ID, 3, PARTITION_ID_1, PARTITION_ID_2);
+		report(tracker, TASK_EXECUTOR_ID_2, DATA_SET_ID, 3, new ResultPartitionID());
+
+		tracker.processTaskExecutorShutdown(TASK_EXECUTOR_ID_1);
+
+		assertThat(partitionReleaser.releaseCalls, contains(Tuple2.of(TASK_EXECUTOR_ID_2, Collections.singleton(DATA_SET_ID))));
+
+		assertThat(tracker.areAllMapsEmpty(), is(false));
+
+		tracker.processTaskExecutorShutdown(TASK_EXECUTOR_ID_2);
+
+		assertThat(tracker.areAllMapsEmpty(), is(true));
+	}
+
+	private static void reportEmpty(ResourceManagerPartitionTracker tracker, ResourceID... taskExecutorIds) {
+		for (ResourceID taskExecutorId : taskExecutorIds) {
+			tracker.processTaskExecutorClusterPartitionReport(
+				taskExecutorId,
+				EMPTY_PARTITION_REPORT);
+		}
+	}
+
+	private static void report(ResourceManagerPartitionTracker tracker, ResourceID taskExecutorId, IntermediateDataSetID dataSetId, int numTotalPartitions, ResultPartitionID... partitionIds) {
+		tracker.processTaskExecutorClusterPartitionReport(
+			taskExecutorId,
+			createClusterPartitionReport(dataSetId, numTotalPartitions, partitionIds));
+	}
+
+	private static ClusterPartitionReport createClusterPartitionReport(IntermediateDataSetID dataSetId, int numTotalPartitions, ResultPartitionID... partitionId) {
+		return new ClusterPartitionReport(Collections.singletonList(
+			new ClusterPartitionReport.ClusterPartitionReportEntry(
+				dataSetId,
+				new HashSet<>(Arrays.asList(partitionId)),
+				numTotalPartitions)));
+	}
+
+	private static class TestClusterPartitionReleaser implements TaskExecutorClusterPartitionReleaser {
+
+		final List<Tuple2<ResourceID, Set<IntermediateDataSetID>>> releaseCalls = new ArrayList<>();
+
+		@Override
+		public void releaseClusterPartitions(ResourceID taskExecutorId, Set<IntermediateDataSetID> dataSetsToRelease) {
+			releaseCalls.add(Tuple2.of(taskExecutorId, dataSetsToRelease));
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/StandaloneResourceManagerWithUUIDFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/StandaloneResourceManagerWithUUIDFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerFactory;
@@ -33,6 +34,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerRuntimeServicesCo
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
 
 import javax.annotation.Nullable;
 
@@ -69,10 +71,12 @@ public enum StandaloneResourceManagerWithUUIDFactory implements ResourceManagerF
 			highAvailabilityServices,
 			heartbeatServices,
 			resourceManagerRuntimeServices.getSlotManager(),
+			NoOpResourceManagerPartitionTracker::get,
 			resourceManagerRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,
 			resourceManagerMetricGroup,
-			standaloneClusterStartupPeriodTime);
+			standaloneClusterStartupPeriodTime,
+			RpcUtils.INF_TIMEOUT);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -23,10 +23,12 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerConfiguration;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
@@ -87,11 +89,13 @@ public class ResourceManagerHATest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				resourceManagerRuntimeServices.getSlotManager(),
+				NoOpResourceManagerPartitionTracker::get,
 				resourceManagerRuntimeServices.getJobLeaderIdService(),
 				new ClusterInformation("localhost", 1234),
 				testingFatalErrorHandler,
 				UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-				Time.minutes(5L)) {
+				Time.minutes(5L),
+				RpcUtils.INF_TIMEOUT) {
 
 				@Override
 				public void revokeLeadership() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerJobMasterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServicesBuilder;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
@@ -147,11 +148,13 @@ public class ResourceManagerJobMasterTest extends TestLogger {
 			haServices,
 			heartbeatServices,
 			slotManager,
+			NoOpResourceManagerPartitionTracker::get,
 			jobLeaderIdService,
 			new ClusterInformation("localhost", 1234),
 			testingFatalErrorHandler,
 			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-			Time.minutes(5L));
+			Time.minutes(5L),
+			RpcUtils.INF_TIMEOUT);
 
 		resourceManager.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerPartitionLifecycleTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.heartbeat.HeartbeatServices;
+import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
+import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.registration.RegistrationResponse;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
+import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManagerBuilder;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
+import org.apache.flink.runtime.taskexecutor.TaskExecutorHeartbeatPayload;
+import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
+import org.apache.flink.runtime.taskexecutor.partition.ClusterPartitionReport;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for the partition-lifecycle logic in the {@link ResourceManager}.
+ */
+public class ResourceManagerPartitionLifecycleTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.minutes(2L);
+
+	private static TestingRpcService rpcService;
+
+	private TestingHighAvailabilityServices highAvailabilityServices;
+
+	private TestingLeaderElectionService resourceManagerLeaderElectionService;
+
+	private TestingFatalErrorHandler testingFatalErrorHandler;
+
+	private TestingResourceManager resourceManager;
+
+	@BeforeClass
+	public static void setupClass() {
+		rpcService = new TestingRpcService();
+	}
+
+	@Before
+	public void setup() throws Exception {
+		highAvailabilityServices = new TestingHighAvailabilityServices();
+		resourceManagerLeaderElectionService = new TestingLeaderElectionService();
+		highAvailabilityServices.setResourceManagerLeaderElectionService(resourceManagerLeaderElectionService);
+		testingFatalErrorHandler = new TestingFatalErrorHandler();
+	}
+
+	@After
+	public void after() throws Exception {
+		if (resourceManager != null) {
+			RpcUtils.terminateRpcEndpoint(resourceManager, TIMEOUT);
+		}
+
+		if (highAvailabilityServices != null) {
+			highAvailabilityServices.closeAndCleanupAllData();
+		}
+
+		if (testingFatalErrorHandler.hasExceptionOccurred()) {
+			testingFatalErrorHandler.rethrowError();
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (rpcService != null) {
+			RpcUtils.terminateRpcServices(TIMEOUT, rpcService);
+		}
+	}
+
+	@Test
+	public void testClusterPartitionReportHandling() throws Exception {
+		final CompletableFuture<Collection<IntermediateDataSetID>> clusterPartitionReleaseFuture = new CompletableFuture<>();
+		runTest(
+			builder -> builder.setReleaseClusterPartitionsConsumer(clusterPartitionReleaseFuture::complete),
+			(resourceManagerGateway, taskManagerId1, ignored) -> {
+				IntermediateDataSetID dataSetID = new IntermediateDataSetID();
+				ResultPartitionID resultPartitionID = new ResultPartitionID();
+
+				resourceManagerGateway.heartbeatFromTaskManager(
+					taskManagerId1,
+					createTaskExecutorHeartbeatPayload(dataSetID, 2, resultPartitionID, new ResultPartitionID()));
+
+				// send a heartbeat containing 1 partition less -> partition loss -> should result in partition release
+				resourceManagerGateway.heartbeatFromTaskManager(
+					taskManagerId1,
+					createTaskExecutorHeartbeatPayload(dataSetID, 2, resultPartitionID));
+
+				Collection<IntermediateDataSetID> intermediateDataSetIDS = clusterPartitionReleaseFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+				assertThat(intermediateDataSetIDS, contains(dataSetID));
+			});
+	}
+
+	@Test
+	public void testTaskExecutorShutdownHandling() throws Exception {
+		final CompletableFuture<Collection<IntermediateDataSetID>> clusterPartitionReleaseFuture = new CompletableFuture<>();
+		runTest(
+			builder -> builder.setReleaseClusterPartitionsConsumer(clusterPartitionReleaseFuture::complete),
+			(resourceManagerGateway, taskManagerId1, taskManagerId2) -> {
+				IntermediateDataSetID dataSetID = new IntermediateDataSetID();
+
+				resourceManagerGateway.heartbeatFromTaskManager(
+					taskManagerId1,
+					createTaskExecutorHeartbeatPayload(dataSetID, 2, new ResultPartitionID()));
+
+				// we need a partition on another task executor so that there's something to release when one task executor goes down
+				resourceManagerGateway.heartbeatFromTaskManager(
+					taskManagerId2,
+					createTaskExecutorHeartbeatPayload(dataSetID, 2, new ResultPartitionID()));
+
+				resourceManagerGateway.disconnectTaskManager(taskManagerId2, new RuntimeException("test exception"));
+				Collection<IntermediateDataSetID> intermediateDataSetIDS = clusterPartitionReleaseFuture.get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+				assertThat(intermediateDataSetIDS, contains(dataSetID));
+			});
+	}
+
+	private void runTest(TaskExecutorSetup taskExecutorBuilderSetup, TestAction testAction) throws Exception {
+		final ResourceManagerGateway resourceManagerGateway = createAndStartResourceManager();
+
+		TestingTaskExecutorGatewayBuilder testingTaskExecutorGateway1Builder = new TestingTaskExecutorGatewayBuilder();
+		taskExecutorBuilderSetup.accept(testingTaskExecutorGateway1Builder);
+		final TaskExecutorGateway taskExecutorGateway1 = testingTaskExecutorGateway1Builder
+			.setAddress(UUID.randomUUID().toString())
+			.createTestingTaskExecutorGateway();
+		rpcService.registerGateway(taskExecutorGateway1.getAddress(), taskExecutorGateway1);
+
+		final TaskExecutorGateway taskExecutorGateway2 = new TestingTaskExecutorGatewayBuilder()
+			.setAddress(UUID.randomUUID().toString())
+			.createTestingTaskExecutorGateway();
+		rpcService.registerGateway(taskExecutorGateway2.getAddress(), taskExecutorGateway2);
+
+		final ResourceID taskManagerId1 = ResourceID.generate();
+		final ResourceID taskManagerId2 = ResourceID.generate();
+		registerTaskExecutor(resourceManagerGateway, taskManagerId1, taskExecutorGateway1.getAddress());
+		registerTaskExecutor(resourceManagerGateway, taskManagerId2, taskExecutorGateway2.getAddress());
+
+		testAction.accept(resourceManagerGateway, taskManagerId1, taskManagerId2);
+	}
+
+	private void registerTaskExecutor(ResourceManagerGateway resourceManagerGateway, ResourceID taskExecutorId, String taskExecutorAddress) throws Exception {
+		final TaskExecutorRegistration taskExecutorRegistration = new TaskExecutorRegistration(
+			taskExecutorAddress,
+			taskExecutorId,
+			1234,
+			new HardwareDescription(42, 1337L, 1337L, 0L),
+			ResourceProfile.ZERO,
+			ResourceProfile.ZERO);
+		final CompletableFuture<RegistrationResponse> registrationFuture = resourceManagerGateway.registerTaskExecutor(
+			taskExecutorRegistration,
+			TestingUtils.TIMEOUT());
+
+		assertThat(registrationFuture.get(), instanceOf(RegistrationResponse.Success.class));
+	}
+
+	private ResourceManagerGateway createAndStartResourceManager() throws Exception {
+		final SlotManager slotManager = SlotManagerBuilder.newBuilder()
+			.setScheduledExecutor(rpcService.getScheduledExecutor())
+			.build();
+		final JobLeaderIdService jobLeaderIdService = new JobLeaderIdService(
+			highAvailabilityServices,
+			rpcService.getScheduledExecutor(),
+			TestingUtils.infiniteTime());
+
+		final TestingResourceManager resourceManager = new TestingResourceManager(
+			rpcService,
+			ResourceManager.RESOURCE_MANAGER_NAME + UUID.randomUUID(),
+			ResourceID.generate(),
+			highAvailabilityServices,
+			new HeartbeatServices(100000L, 1000000L),
+			slotManager,
+			ResourceManagerPartitionTrackerImpl::new,
+			jobLeaderIdService,
+			testingFatalErrorHandler,
+			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup());
+
+		resourceManager.start();
+
+		// first make the ResourceManager the leader
+		resourceManagerLeaderElectionService.isLeader(ResourceManagerId.generate().toUUID()).get();
+
+		this.resourceManager = resourceManager;
+
+		return resourceManager.getSelfGateway(ResourceManagerGateway.class);
+	}
+
+	private static TaskExecutorHeartbeatPayload createTaskExecutorHeartbeatPayload(IntermediateDataSetID dataSetId, int numTotalPartitions, ResultPartitionID... partitionIds) {
+		return new TaskExecutorHeartbeatPayload(
+			new SlotReport(),
+			new ClusterPartitionReport(Collections.singletonList(
+				new ClusterPartitionReport.ClusterPartitionReportEntry(dataSetId, new HashSet<>(Arrays.asList(partitionIds)), numTotalPartitions)
+			)));
+	}
+
+	@FunctionalInterface
+	private interface TaskExecutorSetup {
+		void accept(TestingTaskExecutorGatewayBuilder taskExecutorGatewayBuilder) throws Exception;
+	}
+
+	@FunctionalInterface
+	private interface TestAction {
+		void accept(ResourceManagerGateway resourceManagerGateway, ResourceID taskExecutorId1, ResourceID taskExecutorId2) throws Exception;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTaskExecutorTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -158,11 +159,13 @@ public class ResourceManagerTaskExecutorTest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				slotManager,
+				NoOpResourceManagerPartitionTracker::get,
 				jobLeaderIdService,
 				new ClusterInformation("localhost", 1234),
 				fatalErrorHandler,
 				UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup(),
-				Time.minutes(5L));
+				Time.minutes(5L),
+				RpcUtils.INF_TIMEOUT);
 
 		resourceManager.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGateway;
 import org.apache.flink.runtime.jobmaster.utils.TestingJobMasterGatewayBuilder;
 import org.apache.flink.runtime.leaderelection.TestingLeaderElectionService;
@@ -261,6 +262,7 @@ public class ResourceManagerTest extends TestLogger {
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			NoOpResourceManagerPartitionTracker::get,
 			jobLeaderIdService,
 			testingFatalErrorHandler,
 			UnregisteredMetricGroups.createUnregisteredResourceManagerMetricGroup());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
@@ -30,6 +31,7 @@ import org.apache.flink.runtime.resourcemanager.slotmanager.TestingSlotManagerBu
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
@@ -153,11 +155,13 @@ public class StandaloneResourceManagerTest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				slotManager,
+				NoOpResourceManagerPartitionTracker::get,
 				jobLeaderIdService,
 				clusterInformation,
 				fatalErrorHandler,
 				resourceManagerMetricGroup,
-				startupPeriodTime);
+				startupPeriodTime,
+				RpcUtils.INF_TIMEOUT);
 			this.rmServices = rmServices;
 		}
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -24,11 +24,13 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcUtils;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +49,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			FatalErrorHandler fatalErrorHandler,
 			ResourceManagerMetricGroup resourceManagerMetricGroup) {
@@ -57,10 +60,12 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			new ClusterInformation("localhost", 1234),
 			fatalErrorHandler,
-			resourceManagerMetricGroup);
+			resourceManagerMetricGroup,
+			RpcUtils.INF_TIMEOUT);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGateway.java
@@ -86,6 +86,8 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 
 	private final TriConsumer<JobID, Set<ResultPartitionID>, Set<ResultPartitionID>> releaseOrPromotePartitionsConsumer;
 
+	private final Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer;
+
 	private final TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventHandler;
 
 	TestingTaskExecutorGateway(
@@ -101,6 +103,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 			Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction,
 			Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier,
 			TriConsumer<JobID, Set<ResultPartitionID>, Set<ResultPartitionID>> releaseOrPromotePartitionsConsumer,
+			Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer,
 			TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventHandler) {
 
 		this.address = Preconditions.checkNotNull(address);
@@ -115,6 +118,7 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 		this.cancelTaskFunction = cancelTaskFunction;
 		this.canBeReleasedSupplier = canBeReleasedSupplier;
 		this.releaseOrPromotePartitionsConsumer = releaseOrPromotePartitionsConsumer;
+		this.releaseClusterPartitionsConsumer = releaseClusterPartitionsConsumer;
 		this.operatorEventHandler = operatorEventHandler;
 	}
 
@@ -144,7 +148,9 @@ public class TestingTaskExecutorGateway implements TaskExecutorGateway {
 	}
 
 	@Override
-	public void releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
+	public CompletableFuture<Acknowledge> releaseClusterPartitions(Collection<IntermediateDataSetID> dataSetsToRelease, Time timeout) {
+		releaseClusterPartitionsConsumer.accept(dataSetsToRelease);
+		return CompletableFuture.completedFuture(Acknowledge.get());
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutorGatewayBuilder.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -37,6 +38,7 @@ import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.TriConsumer;
 import org.apache.flink.util.function.TriFunction;
 
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -73,6 +75,7 @@ public class TestingTaskExecutorGatewayBuilder {
 	private Function<ExecutionAttemptID, CompletableFuture<Acknowledge>> cancelTaskFunction = NOOP_CANCEL_TASK_FUNCTION;
 	private Supplier<CompletableFuture<Boolean>> canBeReleasedSupplier = () -> CompletableFuture.completedFuture(true);
 	private TriConsumer<JobID, Set<ResultPartitionID>, Set<ResultPartitionID>> releaseOrPromotePartitionsConsumer = NOOP_RELEASE_PARTITIONS_CONSUMER;
+	private Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer = ignored -> {};
 	private TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventHandler = DEFAULT_OPERATOR_EVENT_HANDLER;
 
 	public TestingTaskExecutorGatewayBuilder setAddress(String address) {
@@ -135,6 +138,11 @@ public class TestingTaskExecutorGatewayBuilder {
 		return this;
 	}
 
+	public TestingTaskExecutorGatewayBuilder setReleaseClusterPartitionsConsumer(Consumer<Collection<IntermediateDataSetID>> releaseClusterPartitionsConsumer) {
+		this.releaseClusterPartitionsConsumer = releaseClusterPartitionsConsumer;
+		return this;
+	}
+
 	public TestingTaskExecutorGatewayBuilder setOperatorEventHandler(TriFunction<ExecutionAttemptID, OperatorID, SerializedValue<OperatorEvent>, CompletableFuture<Acknowledge>> operatorEventHandler) {
 		this.operatorEventHandler = operatorEventHandler;
 		return this;
@@ -154,6 +162,7 @@ public class TestingTaskExecutorGatewayBuilder {
 			cancelTaskFunction,
 			canBeReleasedSupplier,
 			releaseOrPromotePartitionsConsumer,
+			releaseClusterPartitionsConsumer,
 			operatorEventHandler);
 	}
 }

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManager;
 import org.apache.flink.runtime.resourcemanager.JobLeaderIdService;
@@ -128,6 +129,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			HighAvailabilityServices highAvailabilityServices,
 			HeartbeatServices heartbeatServices,
 			SlotManager slotManager,
+			ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
 			JobLeaderIdService jobLeaderIdService,
 			ClusterInformation clusterInformation,
 			FatalErrorHandler fatalErrorHandler,
@@ -142,6 +144,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			highAvailabilityServices,
 			heartbeatServices,
 			slotManager,
+			clusterPartitionTrackerFactory,
 			jobLeaderIdService,
 			clusterInformation,
 			fatalErrorHandler,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/entrypoint/YarnResourceManagerFactory.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
+import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ActiveResourceManagerFactory;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -75,6 +76,7 @@ public class YarnResourceManagerFactory extends ActiveResourceManagerFactory<Yar
 			highAvailabilityServices,
 			heartbeatServices,
 			rmRuntimeServices.getSlotManager(),
+			ResourceManagerPartitionTrackerImpl::new,
 			rmRuntimeServices.getJobLeaderIdService(),
 			clusterInformation,
 			fatalErrorHandler,

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnResourceManagerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -205,6 +206,7 @@ public class YarnResourceManagerTest extends TestLogger {
 				highAvailabilityServices,
 				heartbeatServices,
 				slotManager,
+				NoOpResourceManagerPartitionTracker::get,
 				jobLeaderIdService,
 				clusterInformation,
 				fatalErrorHandler,


### PR DESCRIPTION
Based on #10362 (FLINK-14792).

With this PR the ResourceManager tracks cluster partitions hosted on task executors, based on the `ClusterPartitionReports` that are already submitted via TE heartbeats.

The entire partition handling logic is encapsulated in a `ResourceManagerPartitionTracker`; the RM does not really do anything and just informs the tracker about certain events (arrival of a new report, shutdown of a TM, requested release of a partition via the REST API).

The tracker maintains the following mappings
a) data set -> TE
b) TE -> data set
c) TE -> partitions

Mapping a) is required for the release of partitions via the REST API.
Mapping b) is required for figuring out which data sets may be affected by a TE shutdown.
Mapping c) is required for detecting when all partitions of a partition are being tracked and whether a TE has lost a single partition.

The tracker not only tracks partitions but also searches for data sets that have been corrupted by the loss of partitions (e.g.,  because of a TE shutdown). In this case the tracker will issue release calls for the remaining partitions to the hosting task executors.

Note that `ResourceManagerPartitionTracker#listDataSets` and  `#releastPartitions` are unused at this time, but are required for the upcoming REST API.

This PR does _NOT_ handle cases where a partition of a cluster partition is never being tracked, for example because the TE died just after the job finished. In this case we will currently never release partitions of the corresponding data set.
This will be tackled in a follow-up, and requires setting up a timeout for the maximum duration between the first and last registration of a partition.