### PR TITLE
[FLINK-16608][python] Support primitive data types for vectorized Python UDF

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -413,6 +413,11 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.utf8(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARBINARY:
                 return pa.field(field.name, pa.binary(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DECIMAL:
+                return pa.field(field.name,
+                                pa.decimal128(field.type.decimal_info.precision,
+                                              field.type.decimal_info.scale),
+                                field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -403,6 +403,8 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.int32(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.BIGINT:
                 return pa.field(field.name, pa.int64(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.BOOLEAN:
+                return pa.field(field.name, pa.bool_(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -409,6 +409,8 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.float32(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DOUBLE:
                 return pa.field(field.name, pa.float64(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARCHAR:
+                return pa.field(field.name, pa.utf8(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -411,6 +411,8 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.float64(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARCHAR:
                 return pa.field(field.name, pa.utf8(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARBINARY:
+                return pa.field(field.name, pa.binary(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -407,6 +407,8 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.bool_(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.FLOAT:
                 return pa.field(field.name, pa.float32(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DOUBLE:
+                return pa.field(field.name, pa.float64(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -405,6 +405,8 @@ class ArrowCoder(DeterministicCoder):
                 return pa.field(field.name, pa.int64(), field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.BOOLEAN:
                 return pa.field(field.name, pa.bool_(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.FLOAT:
+                return pa.field(field.name, pa.float32(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -420,6 +420,15 @@ class ArrowCoder(DeterministicCoder):
                                 field.type.nullable)
             elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DATE:
                 return pa.field(field.name, pa.date32(), field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.TIME:
+                if field.type.time_info.precision == 0:
+                    return pa.field(field.name, pa.time32('s'), field.type.nullable)
+                elif 1 <= field.type.time_type.precision <= 3:
+                    return pa.field(field.name, pa.time32('ms'), field.type.nullable)
+                elif 4 <= field.type.time_type.precision <= 6:
+                    return pa.field(field.name, pa.time64('us'), field.type.nullable)
+                else:
+                    return pa.field(field.name, pa.time64('ns'), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -418,6 +418,8 @@ class ArrowCoder(DeterministicCoder):
                                 pa.decimal128(field.type.decimal_info.precision,
                                               field.type.decimal_info.scale),
                                 field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DATE:
+                return pa.field(field.name, pa.date32(), field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import datetime
 import decimal
 import unittest
 
@@ -127,6 +128,12 @@ class PandasUDFITTests(object):
                 'decimal_param of wrong type %s !' % type(decimal_param[0])
             return decimal_param
 
+        def date_func(date_param):
+            assert isinstance(date_param, pd.Series)
+            assert isinstance(date_param[0], datetime.date), \
+                'date_param of wrong type %s !' % type(date_param[0])
+            return date_param
+
         self.t_env.register_function(
             "tinyint_func",
             udf(tinyint_func, [DataTypes.TINYINT()], DataTypes.TINYINT(), udf_type="pandas"))
@@ -168,18 +175,23 @@ class PandasUDFITTests(object):
             udf(decimal_func, [DataTypes.DECIMAL(38, 18)], DataTypes.DECIMAL(38, 18),
                 udf_type="pandas"))
 
+        self.t_env.register_function(
+            "date_func",
+            udf(date_func, [DataTypes.DATE()], DataTypes.DATE(), udf_type="pandas"))
+
         table_sink = source_sink_utils.TestAppendSink(
-            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'],
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'],
             [DataTypes.TINYINT(), DataTypes.SMALLINT(), DataTypes.INT(), DataTypes.BIGINT(),
              DataTypes.BOOLEAN(), DataTypes.BOOLEAN(), DataTypes.FLOAT(), DataTypes.DOUBLE(),
              DataTypes.STRING(), DataTypes.STRING(), DataTypes.BYTES(), DataTypes.DECIMAL(38, 18),
-             DataTypes.DECIMAL(38, 18)])
+             DataTypes.DECIMAL(38, 18), DataTypes.DATE()])
         self.t_env.register_table_sink("Results", table_sink)
 
         t = self.t_env.from_elements(
             [(1, 32767, -2147483648, 1, True, False, 1.0, 1.0, 'hello', '中文',
               bytearray(b'flink'), decimal.Decimal('1000000000000000000.05'),
-              decimal.Decimal('1000000000000000000.05999999999999999899999999999'))],
+              decimal.Decimal('1000000000000000000.05999999999999999899999999999'),
+              datetime.date(2014, 9, 13))],
             DataTypes.ROW(
                 [DataTypes.FIELD("a", DataTypes.TINYINT()),
                  DataTypes.FIELD("b", DataTypes.SMALLINT()),
@@ -193,7 +205,8 @@ class PandasUDFITTests(object):
                  DataTypes.FIELD("j", DataTypes.STRING()),
                  DataTypes.FIELD("k", DataTypes.BYTES()),
                  DataTypes.FIELD("l", DataTypes.DECIMAL(38, 18)),
-                 DataTypes.FIELD("m", DataTypes.DECIMAL(38, 18))]))
+                 DataTypes.FIELD("m", DataTypes.DECIMAL(38, 18)),
+                 DataTypes.FIELD("n", DataTypes.DATE())]))
 
         t.select("tinyint_func(a),"
                  "smallint_func(b),"
@@ -207,14 +220,15 @@ class PandasUDFITTests(object):
                  "varchar_func(j),"
                  "varbinary_func(k),"
                  "decimal_func(l),"
-                 "decimal_func(m)") \
+                 "decimal_func(m),"
+                 "date_func(n)") \
             .insert_into("Results")
         self.t_env.execute("test")
         actual = source_sink_utils.results()
         self.assert_equals(actual,
                            ["1,32767,-2147483648,1,true,false,1.0,1.0,hello,中文,"
                             "[102, 108, 105, 110, 107],1000000000000000000.050000000000000000,"
-                            "1000000000000000000.059999999999999999"])
+                            "1000000000000000000.059999999999999999,2014-09-13"])
 
 
 class StreamPandasUDFITTests(PandasUDFITTests,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
@@ -37,6 +38,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
@@ -46,6 +48,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
@@ -53,6 +56,7 @@ import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DoubleType;
@@ -62,6 +66,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.types.Row;
 
@@ -74,6 +79,7 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -142,6 +148,8 @@ public final class ArrowUtils {
 			return new FloatWriter((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
 			return new DoubleWriter((Float8Vector) vector);
+		} else if (vector instanceof VarCharVector) {
+			return new VarCharWriter((VarCharVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -178,6 +186,8 @@ public final class ArrowUtils {
 			return new BaseRowFloatWriter((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
 			return new BaseRowDoubleWriter((Float8Vector) vector);
+		} else if (vector instanceof VarCharVector) {
+			return new BaseRowVarCharWriter((VarCharVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -212,6 +222,8 @@ public final class ArrowUtils {
 			return new FloatFieldReader((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
 			return new DoubleFieldReader((Float8Vector) vector);
+		} else if (vector instanceof VarCharVector) {
+			return new VarCharFieldReader((VarCharVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -246,6 +258,8 @@ public final class ArrowUtils {
 			return new ArrowFloatColumnVector((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
 			return new ArrowDoubleColumnVector((Float8Vector) vector);
+		} else if (vector instanceof VarCharVector) {
+			return new ArrowVarCharColumnVector((VarCharVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -289,6 +303,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(DoubleType doubleType) {
 			return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+		}
+
+		@Override
+		public ArrowType visit(VarCharType varCharType) {
+			return ArrowType.Utf8.INSTANCE;
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
@@ -38,6 +39,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowVarBinaryColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
@@ -48,6 +50,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
@@ -56,6 +59,7 @@ import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -66,6 +70,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeDefaultVisitor;
 import org.apache.flink.types.Row;
@@ -79,6 +84,7 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
@@ -150,6 +156,8 @@ public final class ArrowUtils {
 			return new DoubleWriter((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
 			return new VarCharWriter((VarCharVector) vector);
+		} else if (vector instanceof VarBinaryVector) {
+			return new VarBinaryWriter((VarBinaryVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -188,6 +196,8 @@ public final class ArrowUtils {
 			return new BaseRowDoubleWriter((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
 			return new BaseRowVarCharWriter((VarCharVector) vector);
+		} else if (vector instanceof VarBinaryVector) {
+			return new BaseRowVarBinaryWriter((VarBinaryVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -224,6 +234,8 @@ public final class ArrowUtils {
 			return new DoubleFieldReader((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
 			return new VarCharFieldReader((VarCharVector) vector);
+		} else if (vector instanceof VarBinaryVector) {
+			return new VarBinaryFieldReader((VarBinaryVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -260,6 +272,8 @@ public final class ArrowUtils {
 			return new ArrowDoubleColumnVector((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
 			return new ArrowVarCharColumnVector((VarCharVector) vector);
+		} else if (vector instanceof VarBinaryVector) {
+			return new ArrowVarBinaryColumnVector((VarBinaryVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -308,6 +322,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(VarCharType varCharType) {
 			return ArrowType.Utf8.INSTANCE;
+		}
+
+		@Override
+		public ArrowType visit(VarBinaryType varCharType) {
+			return ArrowType.Binary.INSTANCE;
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.DateFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.DecimalFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
@@ -35,6 +36,7 @@ import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowDateColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDecimalColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
@@ -47,6 +49,7 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowDateWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowDecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
@@ -57,6 +60,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.DateWriter;
 import org.apache.flink.table.runtime.arrow.writers.DecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
@@ -67,6 +71,7 @@ import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -84,6 +89,7 @@ import org.apache.flink.types.Row;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
@@ -94,6 +100,7 @@ import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -169,6 +176,8 @@ public final class ArrowUtils {
 		} else if (vector instanceof DecimalVector) {
 			DecimalVector decimalVector = (DecimalVector) vector;
 			return new DecimalWriter(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
+		} else if (vector instanceof DateDayVector) {
+			return new DateWriter((DateDayVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -212,6 +221,8 @@ public final class ArrowUtils {
 		} else if (vector instanceof DecimalVector) {
 			DecimalVector decimalVector = (DecimalVector) vector;
 			return new BaseRowDecimalWriter(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
+		} else if (vector instanceof DateDayVector) {
+			return new BaseRowDateWriter((DateDayVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -252,6 +263,8 @@ public final class ArrowUtils {
 			return new VarBinaryFieldReader((VarBinaryVector) vector);
 		} else if (vector instanceof DecimalVector) {
 			return new DecimalFieldReader((DecimalVector) vector);
+		} else if (vector instanceof DateDayVector) {
+			return new DateFieldReader((DateDayVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -292,6 +305,8 @@ public final class ArrowUtils {
 			return new ArrowVarBinaryColumnVector((VarBinaryVector) vector);
 		} else if (vector instanceof DecimalVector) {
 			return new ArrowDecimalColumnVector((DecimalVector) vector);
+		} else if (vector instanceof DateDayVector) {
+			return new ArrowDateColumnVector((DateDayVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -350,6 +365,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(DecimalType decimalType) {
 			return new ArrowType.Decimal(decimalType.getPrecision(), decimalType.getScale());
+		}
+
+		@Override
+		public ArrowType visit(DateType dateType) {
+			return new ArrowType.Date(DateUnit.DAY);
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -24,12 +24,14 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
@@ -37,16 +39,19 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -59,10 +64,12 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -125,6 +132,8 @@ public final class ArrowUtils {
 			return new BigIntWriter((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
 			return new BooleanWriter((BitVector) vector);
+		} else if (vector instanceof Float4Vector) {
+			return new FloatWriter((Float4Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -157,6 +166,8 @@ public final class ArrowUtils {
 			return new BaseRowBigIntWriter((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
 			return new BaseRowBooleanWriter((BitVector) vector);
+		} else if (vector instanceof Float4Vector) {
+			return new BaseRowFloatWriter((Float4Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -187,6 +198,8 @@ public final class ArrowUtils {
 			return new BigIntFieldReader((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
 			return new BooleanFieldReader((BitVector) vector);
+		} else if (vector instanceof Float4Vector) {
+			return new FloatFieldReader((Float4Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -217,6 +230,8 @@ public final class ArrowUtils {
 			return new ArrowBigIntColumnVector((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
 			return new ArrowBooleanColumnVector((BitVector) vector);
+		} else if (vector instanceof Float4Vector) {
+			return new ArrowFloatColumnVector((Float4Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -250,6 +265,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(BooleanType booleanType) {
 			return ArrowType.Bool.INSTANCE;
+		}
+
+		@Override
+		public ArrowType visit(FloatType floatType) {
+			return new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
@@ -31,6 +32,7 @@ import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
@@ -39,18 +41,21 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -65,6 +70,7 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
 import org.apache.arrow.vector.TinyIntVector;
@@ -134,6 +140,8 @@ public final class ArrowUtils {
 			return new BooleanWriter((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
 			return new FloatWriter((Float4Vector) vector);
+		} else if (vector instanceof Float8Vector) {
+			return new DoubleWriter((Float8Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -168,6 +176,8 @@ public final class ArrowUtils {
 			return new BaseRowBooleanWriter((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
 			return new BaseRowFloatWriter((Float4Vector) vector);
+		} else if (vector instanceof Float8Vector) {
+			return new BaseRowDoubleWriter((Float8Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -200,6 +210,8 @@ public final class ArrowUtils {
 			return new BooleanFieldReader((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
 			return new FloatFieldReader((Float4Vector) vector);
+		} else if (vector instanceof Float8Vector) {
+			return new DoubleFieldReader((Float8Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -232,6 +244,8 @@ public final class ArrowUtils {
 			return new ArrowBooleanColumnVector((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
 			return new ArrowFloatColumnVector((Float4Vector) vector);
+		} else if (vector instanceof Float8Vector) {
+			return new ArrowDoubleColumnVector((Float8Vector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -270,6 +284,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(FloatType floatType) {
 			return new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+		}
+
+		@Override
+		public ArrowType visit(DoubleType doubleType) {
+			return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -23,25 +23,30 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -52,6 +57,7 @@ import org.apache.flink.types.Row;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.SmallIntVector;
@@ -117,6 +123,8 @@ public final class ArrowUtils {
 			return new IntWriter((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
 			return new BigIntWriter((BigIntVector) vector);
+		} else if (vector instanceof BitVector) {
+			return new BooleanWriter((BitVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -147,6 +155,8 @@ public final class ArrowUtils {
 			return new BaseRowIntWriter((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
 			return new BaseRowBigIntWriter((BigIntVector) vector);
+		} else if (vector instanceof BitVector) {
+			return new BaseRowBooleanWriter((BitVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -175,6 +185,8 @@ public final class ArrowUtils {
 			return new IntFieldReader((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
 			return new BigIntFieldReader((BigIntVector) vector);
+		} else if (vector instanceof BitVector) {
+			return new BooleanFieldReader((BitVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -203,6 +215,8 @@ public final class ArrowUtils {
 			return new ArrowIntColumnVector((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
 			return new ArrowBigIntColumnVector((BigIntVector) vector);
+		} else if (vector instanceof BitVector) {
+			return new ArrowBooleanColumnVector((BitVector) vector);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -231,6 +245,11 @@ public final class ArrowUtils {
 		@Override
 		public ArrowType visit(BigIntType bigIntType) {
 			return new ArrowType.Int(8 * 8, true);
+		}
+
+		@Override
+		public ArrowType visit(BooleanType booleanType) {
+			return ArrowType.Bool.INSTANCE;
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/BooleanFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/BooleanFieldReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.arrow.vector.BitVector;
+
+/**
+ * {@link ArrowFieldReader} for Boolean.
+ */
+@Internal
+public final class BooleanFieldReader extends ArrowFieldReader<Boolean> {
+
+	public BooleanFieldReader(BitVector bitVector) {
+		super(bitVector);
+	}
+
+	@Override
+	public Boolean read(int index) {
+		return ((BitVector) getValueVector()).getObject(index);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DateFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DateFieldReader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
+
+import org.apache.arrow.vector.DateDayVector;
+
+import java.sql.Date;
+
+/**
+ * {@link ArrowFieldReader} for Date.
+ */
+@Internal
+public final class DateFieldReader extends ArrowFieldReader<Date> {
+
+	public DateFieldReader(DateDayVector dateDayVector) {
+		super(dateDayVector);
+	}
+
+	@Override
+	public Date read(int index) {
+		if (getValueVector().isNull(index)) {
+			return null;
+		} else {
+			return SqlDateTimeUtils.internalToDate(((DateDayVector) getValueVector()).get(index));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DecimalFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DecimalFieldReader.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.arrow.vector.DecimalVector;
+
+import java.math.BigDecimal;
+
+/**
+ * {@link ArrowFieldReader} for Decimal.
+ */
+@Internal
+public final class DecimalFieldReader extends ArrowFieldReader<BigDecimal> {
+
+	public DecimalFieldReader(DecimalVector decimalVector) {
+		super(decimalVector);
+	}
+
+	@Override
+	public BigDecimal read(int index) {
+		return ((DecimalVector) getValueVector()).getObject(index);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DoubleFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/DoubleFieldReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.arrow.vector.Float8Vector;
+
+/**
+ * {@link ArrowFieldReader} for Double.
+ */
+@Internal
+public final class DoubleFieldReader extends ArrowFieldReader<Double> {
+
+	public DoubleFieldReader(Float8Vector doubleVector) {
+		super(doubleVector);
+	}
+
+	@Override
+	public Double read(int index) {
+		return ((Float8Vector) getValueVector()).getObject(index);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/FloatFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/FloatFieldReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.arrow.vector.Float4Vector;
+
+/**
+ * {@link ArrowFieldReader} for Float.
+ */
+@Internal
+public final class FloatFieldReader extends ArrowFieldReader<Float> {
+
+	public FloatFieldReader(Float4Vector floatVector) {
+		super(floatVector);
+	}
+
+	@Override
+	public Float read(int index) {
+		return ((Float4Vector) getValueVector()).getObject(index);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/TimeFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/TimeFieldReader.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.ValueVector;
+
+import java.sql.Time;
+import java.util.TimeZone;
+
+/**
+ * {@link ArrowFieldReader} for Time.
+ */
+@Internal
+public final class TimeFieldReader extends ArrowFieldReader<Time> {
+
+	// The local time zone.
+	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+	public TimeFieldReader(ValueVector valueVector) {
+		super(valueVector);
+		Preconditions.checkState(
+			valueVector instanceof TimeSecVector ||
+				valueVector instanceof TimeMilliVector ||
+				valueVector instanceof TimeMicroVector ||
+				valueVector instanceof TimeNanoVector);
+	}
+
+	@Override
+	public Time read(int index) {
+		ValueVector valueVector = getValueVector();
+		if (valueVector.isNull(index)) {
+			return null;
+		} else {
+			long timeMilli;
+			if (valueVector instanceof TimeSecVector) {
+				timeMilli = ((TimeSecVector) getValueVector()).get(index) * 1000;
+			} else if (valueVector instanceof TimeMilliVector) {
+				timeMilli = ((TimeMilliVector) getValueVector()).get(index);
+			} else if (valueVector instanceof TimeMicroVector) {
+				timeMilli = ((TimeMicroVector) getValueVector()).get(index) / 1000;
+			} else {
+				timeMilli = ((TimeNanoVector) getValueVector()).get(index) / 1000000;
+			}
+			return new Time(timeMilli - LOCAL_TZ.getOffset(timeMilli));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/VarBinaryFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/VarBinaryFieldReader.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.arrow.vector.VarBinaryVector;
+
+/**
+ * {@link ArrowFieldReader} for VarBinary.
+ */
+@Internal
+public final class VarBinaryFieldReader extends ArrowFieldReader<byte[]> {
+
+	public VarBinaryFieldReader(VarBinaryVector varBinaryVector) {
+		super(varBinaryVector);
+	}
+
+	@Override
+	public byte[] read(int index) {
+		return ((VarBinaryVector) getValueVector()).get(index);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/VarCharFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/VarCharFieldReader.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.util.StringUtf8Utils;
+
+import org.apache.arrow.vector.VarCharVector;
+
+/**
+ * {@link ArrowFieldReader} for VarChar.
+ */
+@Internal
+public final class VarCharFieldReader extends ArrowFieldReader<String> {
+
+	public VarCharFieldReader(VarCharVector varCharVector) {
+		super(varCharVector);
+	}
+
+	@Override
+	public String read(int index) {
+		if (getValueVector().isNull(index)) {
+			return null;
+		} else {
+			byte[] bytes = ((VarCharVector) getValueVector()).get(index);
+			return StringUtf8Utils.decodeUTF8(bytes, 0, bytes.length);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowBooleanColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowBooleanColumnVector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.BooleanColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.BitVector;
+
+/**
+ * Arrow column vector for Boolean.
+ */
+@Internal
+public final class ArrowBooleanColumnVector implements BooleanColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of boolean values of a column to read.
+	 */
+	private final BitVector bitVector;
+
+	public ArrowBooleanColumnVector(BitVector bitVector) {
+		this.bitVector = Preconditions.checkNotNull(bitVector);
+	}
+
+	@Override
+	public boolean getBoolean(int i) {
+		return bitVector.get(i) != 0;
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return bitVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDateColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDateColumnVector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.IntColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.DateDayVector;
+
+/**
+ * Arrow column vector for Date.
+ */
+@Internal
+public final class ArrowDateColumnVector implements IntColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of date values of a column to read.
+	 */
+	private final DateDayVector dateDayVector;
+
+	public ArrowDateColumnVector(DateDayVector dateDayVector) {
+		this.dateDayVector = Preconditions.checkNotNull(dateDayVector);
+	}
+
+	@Override
+	public int getInt(int i) {
+		return dateDayVector.get(i);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return dateDayVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDecimalColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDecimalColumnVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.vector.DecimalColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.DecimalVector;
+
+/**
+ * Arrow column vector for Decimal.
+ */
+@Internal
+public final class ArrowDecimalColumnVector implements DecimalColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of Decimal values of a column to read.
+	 */
+	private final DecimalVector decimalVector;
+
+	public ArrowDecimalColumnVector(DecimalVector decimalVector) {
+		this.decimalVector = Preconditions.checkNotNull(decimalVector);
+	}
+
+	@Override
+	public Decimal getDecimal(int i, int precision, int scale) {
+		return Decimal.fromBigDecimal(decimalVector.getObject(i), precision, scale);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return decimalVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDoubleColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowDoubleColumnVector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.DoubleColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.Float8Vector;
+
+/**
+ * Arrow column vector for Double.
+ */
+@Internal
+public final class ArrowDoubleColumnVector implements DoubleColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of double values of a column to read.
+	 */
+	private final Float8Vector doubleVector;
+
+	public ArrowDoubleColumnVector(Float8Vector doubleVector) {
+		this.doubleVector = Preconditions.checkNotNull(doubleVector);
+	}
+
+	@Override
+	public double getDouble(int i) {
+		return doubleVector.get(i);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return doubleVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowFloatColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowFloatColumnVector.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.FloatColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.Float4Vector;
+
+/**
+ * Arrow column vector for Float.
+ */
+@Internal
+public final class ArrowFloatColumnVector implements FloatColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of float values of a column to read.
+	 */
+	private final Float4Vector floatVector;
+
+	public ArrowFloatColumnVector(Float4Vector floatVector) {
+		this.floatVector = Preconditions.checkNotNull(floatVector);
+	}
+
+	@Override
+	public float getFloat(int i) {
+		return floatVector.get(i);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return floatVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTimeColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTimeColumnVector.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.IntColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * Arrow column vector for Time.
+ */
+@Internal
+public final class ArrowTimeColumnVector implements IntColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of time values of a column to read.
+	 */
+	private final ValueVector valueVector;
+
+	public ArrowTimeColumnVector(ValueVector valueVector) {
+		this.valueVector = Preconditions.checkNotNull(valueVector);
+		Preconditions.checkState(
+			valueVector instanceof TimeSecVector ||
+				valueVector instanceof TimeMilliVector ||
+				valueVector instanceof TimeMicroVector ||
+				valueVector instanceof TimeNanoVector);
+	}
+
+	@Override
+	public int getInt(int i) {
+		if (valueVector instanceof TimeSecVector) {
+			return ((TimeSecVector) valueVector).get(i) * 1000;
+		} else if (valueVector instanceof TimeMilliVector) {
+			return ((TimeMilliVector) valueVector).get(i);
+		} else if (valueVector instanceof TimeMicroVector) {
+			return (int) (((TimeMicroVector) valueVector).get(i) / 1000);
+		} else {
+			return (int) (((TimeNanoVector) valueVector).get(i) / 1000000);
+		}
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return valueVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowVarBinaryColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowVarBinaryColumnVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.BytesColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.VarBinaryVector;
+
+/**
+ * Arrow column vector for VarBinary.
+ */
+@Internal
+public final class ArrowVarBinaryColumnVector implements BytesColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of varbinary values of a column to read.
+	 */
+	private final VarBinaryVector varBinaryVector;
+
+	public ArrowVarBinaryColumnVector(VarBinaryVector varBinaryVector) {
+		this.varBinaryVector = Preconditions.checkNotNull(varBinaryVector);
+	}
+
+	@Override
+	public Bytes getBytes(int i) {
+		byte[] bytes = varBinaryVector.get(i);
+		return new Bytes(bytes, 0, bytes.length);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return varBinaryVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowVarCharColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowVarCharColumnVector.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.vector.BytesColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.VarCharVector;
+
+/**
+ * Arrow column vector for VarChar.
+ */
+@Internal
+public final class ArrowVarCharColumnVector implements BytesColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of varchar values of a column to read.
+	 */
+	private final VarCharVector varCharVector;
+
+	public ArrowVarCharColumnVector(VarCharVector varCharVector) {
+		this.varCharVector = Preconditions.checkNotNull(varCharVector);
+	}
+
+	@Override
+	public Bytes getBytes(int i) {
+		byte[] bytes = varCharVector.get(i);
+		return new Bytes(bytes, 0, bytes.length);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return varCharVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowBooleanWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowBooleanWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.BitVector;
+
+/**
+ * {@link ArrowFieldWriter} for Boolean.
+ */
+@Internal
+public final class BaseRowBooleanWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowBooleanWriter(BitVector bitVector) {
+		super(bitVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((BitVector) getValueVector()).setNull(getCount());
+		} else if (row.getBoolean(ordinal)) {
+			((BitVector) getValueVector()).setSafe(getCount(), 1);
+		} else {
+			((BitVector) getValueVector()).setSafe(getCount(), 0);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDateWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDateWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.DateDayVector;
+
+/**
+ * {@link ArrowFieldWriter} for Date.
+ */
+@Internal
+public final class BaseRowDateWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowDateWriter(DateDayVector dateDayVector) {
+		super(dateDayVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((DateDayVector) getValueVector()).setNull(getCount());
+		} else {
+			((DateDayVector) getValueVector()).setSafe(getCount(), row.getInt(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDecimalWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDecimalWriter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.DecimalVector;
+
+import java.math.BigDecimal;
+
+import static org.apache.flink.table.runtime.typeutils.PythonTypeUtils.fromBigDecimal;
+
+/**
+ * {@link ArrowFieldWriter} for Decimal.
+ */
+@Internal
+public final class BaseRowDecimalWriter extends ArrowFieldWriter<BaseRow> {
+
+	private final int precision;
+	private final int scale;
+
+	public BaseRowDecimalWriter(DecimalVector decimalVector, int precision, int scale) {
+		super(decimalVector);
+		this.precision = precision;
+		this.scale = scale;
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((DecimalVector) getValueVector()).setNull(getCount());
+		} else {
+			BigDecimal bigDecimal = row.getDecimal(ordinal, precision, scale).toBigDecimal();
+			bigDecimal = fromBigDecimal(bigDecimal, precision, scale);
+			if (bigDecimal == null) {
+				((DecimalVector) getValueVector()).setNull(getCount());
+			} else {
+				((DecimalVector) getValueVector()).setSafe(getCount(), bigDecimal);
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDoubleWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowDoubleWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.Float8Vector;
+
+/**
+ * {@link ArrowFieldWriter} for Double.
+ */
+@Internal
+public final class BaseRowDoubleWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowDoubleWriter(Float8Vector doubleVector) {
+		super(doubleVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((Float8Vector) getValueVector()).setNull(getCount());
+		} else {
+			((Float8Vector) getValueVector()).setSafe(getCount(), row.getDouble(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowFloatWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowFloatWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.Float4Vector;
+
+/**
+ * {@link ArrowFieldWriter} for Float.
+ */
+@Internal
+public final class BaseRowFloatWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowFloatWriter(Float4Vector floatVector) {
+		super(floatVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((Float4Vector) getValueVector()).setNull(getCount());
+		} else {
+			((Float4Vector) getValueVector()).setSafe(getCount(), row.getFloat(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowTimeWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowTimeWriter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * {@link ArrowFieldWriter} for Time.
+ */
+@Internal
+public final class BaseRowTimeWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowTimeWriter(ValueVector valueVector) {
+		super(valueVector);
+		Preconditions.checkState(
+			valueVector instanceof TimeSecVector ||
+				valueVector instanceof TimeMilliVector ||
+				valueVector instanceof TimeMicroVector ||
+				valueVector instanceof TimeNanoVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		ValueVector valueVector = getValueVector();
+		if (row.isNullAt(ordinal)) {
+			((BaseFixedWidthVector) valueVector).setNull(getCount());
+		} else if (valueVector instanceof TimeSecVector) {
+			((TimeSecVector) valueVector).setSafe(getCount(), row.getInt(ordinal) / 1000);
+		} else if (valueVector instanceof TimeMilliVector) {
+			((TimeMilliVector) valueVector).setSafe(getCount(), row.getInt(ordinal));
+		} else if (valueVector instanceof TimeMicroVector) {
+			((TimeMicroVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000L);
+		} else {
+			((TimeNanoVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000000L);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowVarBinaryWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowVarBinaryWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.VarBinaryVector;
+
+/**
+ * {@link ArrowFieldWriter} for VarBinary.
+ */
+@Internal
+public final class BaseRowVarBinaryWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowVarBinaryWriter(VarBinaryVector varBinaryVector) {
+		super(varBinaryVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((VarBinaryVector) getValueVector()).setNull(getCount());
+		} else {
+			((VarBinaryVector) getValueVector()).setSafe(getCount(), row.getBinary(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowVarCharWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowVarCharWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+
+import org.apache.arrow.vector.VarCharVector;
+
+/**
+ * {@link ArrowFieldWriter} for VarChar.
+ */
+@Internal
+public final class BaseRowVarCharWriter extends ArrowFieldWriter<BaseRow> {
+
+	public BaseRowVarCharWriter(VarCharVector varCharVector) {
+		super(varCharVector);
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
+			((VarCharVector) getValueVector()).setNull(getCount());
+		} else {
+			((VarCharVector) getValueVector()).setSafe(getCount(), row.getString(ordinal).getBytes());
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BooleanWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BooleanWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.BitVector;
+
+/**
+ * {@link ArrowFieldWriter} for Boolean.
+ */
+@Internal
+public final class BooleanWriter extends ArrowFieldWriter<Row> {
+
+	public BooleanWriter(BitVector bitVector) {
+		super(bitVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((BitVector) getValueVector()).setNull(getCount());
+		} else if ((boolean) value.getField(ordinal)) {
+			((BitVector) getValueVector()).setSafe(getCount(), 1);
+		} else {
+			((BitVector) getValueVector()).setSafe(getCount(), 0);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DateWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DateWriter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.DateDayVector;
+
+import java.sql.Date;
+
+/**
+ * {@link ArrowFieldWriter} for Date.
+ */
+@Internal
+public final class DateWriter extends ArrowFieldWriter<Row> {
+
+	public DateWriter(DateDayVector dateDayVector) {
+		super(dateDayVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((DateDayVector) getValueVector()).setNull(getCount());
+		} else {
+			((DateDayVector) getValueVector()).setSafe(
+				getCount(), PythonTypeUtils.dateToInternal(((Date) value.getField(ordinal))));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DecimalWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DecimalWriter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.DecimalVector;
+
+import java.math.BigDecimal;
+
+import static org.apache.flink.table.runtime.typeutils.PythonTypeUtils.fromBigDecimal;
+
+/**
+ * {@link ArrowFieldWriter} for Decimal.
+ */
+@Internal
+public final class DecimalWriter extends ArrowFieldWriter<Row> {
+
+	private final int precision;
+	private final int scale;
+
+	public DecimalWriter(DecimalVector decimalVector, int precision, int scale) {
+		super(decimalVector);
+		this.precision = precision;
+		this.scale = scale;
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((DecimalVector) getValueVector()).setNull(getCount());
+		} else {
+			BigDecimal bigDecimal = (BigDecimal) value.getField(ordinal);
+			bigDecimal = fromBigDecimal(bigDecimal, precision, scale);
+			if (bigDecimal == null) {
+				((DecimalVector) getValueVector()).setNull(getCount());
+			} else {
+				((DecimalVector) getValueVector()).setSafe(getCount(), bigDecimal);
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DoubleWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DoubleWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.Float8Vector;
+
+/**
+ * {@link ArrowFieldWriter} for Double.
+ */
+@Internal
+public final class DoubleWriter extends ArrowFieldWriter<Row> {
+
+	public DoubleWriter(Float8Vector doubleVector) {
+		super(doubleVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((Float8Vector) getValueVector()).setNull(getCount());
+		} else {
+			((Float8Vector) getValueVector()).setSafe(getCount(), (double) value.getField(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/FloatWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/FloatWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.Float4Vector;
+
+/**
+ * {@link ArrowFieldWriter} for Float.
+ */
+@Internal
+public final class FloatWriter extends ArrowFieldWriter<Row> {
+
+	public FloatWriter(Float4Vector floatVector) {
+		super(floatVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((Float4Vector) getValueVector()).setNull(getCount());
+		} else {
+			((Float4Vector) getValueVector()).setSafe(getCount(), (float) value.getField(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimeWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimeWriter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.ValueVector;
+
+import java.sql.Time;
+import java.util.TimeZone;
+
+/**
+ * {@link ArrowFieldWriter} for Time.
+ */
+@Internal
+public final class TimeWriter extends ArrowFieldWriter<Row> {
+
+	// The local time zone.
+	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+
+	public TimeWriter(ValueVector valueVector) {
+		super(valueVector);
+		Preconditions.checkState(
+			valueVector instanceof TimeSecVector ||
+				valueVector instanceof TimeMilliVector ||
+				valueVector instanceof TimeMicroVector ||
+				valueVector instanceof TimeNanoVector);
+	}
+
+	@Override
+	public void doWrite(Row row, int ordinal) {
+		ValueVector valueVector = getValueVector();
+		if (row.getField(ordinal) == null) {
+			((BaseFixedWidthVector) getValueVector()).setNull(getCount());
+		} else {
+			Time time = (Time) row.getField(ordinal);
+			long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
+			int timeMilli = (int) (ts % MILLIS_PER_DAY);
+
+			if (valueVector instanceof TimeSecVector) {
+				((TimeSecVector) valueVector).setSafe(getCount(), timeMilli / 1000);
+			} else if (valueVector instanceof TimeMilliVector) {
+				((TimeMilliVector) valueVector).setSafe(getCount(), timeMilli);
+			} else if (valueVector instanceof TimeMicroVector) {
+				((TimeMicroVector) valueVector).setSafe(getCount(), timeMilli * 1000L);
+			} else {
+				((TimeNanoVector) valueVector).setSafe(getCount(), timeMilli * 1000000L);
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarBinaryWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarBinaryWriter.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.VarBinaryVector;
+
+/**
+ * {@link ArrowFieldWriter} for VarBinary.
+ */
+@Internal
+public final class VarBinaryWriter extends ArrowFieldWriter<Row> {
+
+	public VarBinaryWriter(VarBinaryVector varBinaryVector) {
+		super(varBinaryVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((VarBinaryVector) getValueVector()).setNull(getCount());
+		} else {
+			((VarBinaryVector) getValueVector()).setSafe(getCount(), (byte[]) value.getField(ordinal));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarCharWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarCharWriter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.util.StringUtf8Utils;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.VarCharVector;
+
+/**
+ * {@link ArrowFieldWriter} for VarChar.
+ */
+@Internal
+public final class VarCharWriter extends ArrowFieldWriter<Row> {
+
+	public VarCharWriter(VarCharVector varCharVector) {
+		super(varCharVector);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((VarCharVector) getValueVector()).setNull(getCount());
+		} else {
+			((VarCharVector) getValueVector()).setSafe(
+				getCount(), StringUtf8Utils.encodeUTF8(((String) value.getField(ordinal))));
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -113,7 +113,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
 			reader.loadNextBatch();
 			VectorSchemaRoot root = reader.getVectorSchemaRoot();
 			if (arrowReader == null) {
-				arrowReader = ArrowUtils.createRowArrowReader(root);
+				arrowReader = ArrowUtils.createRowArrowReader(root, outputType);
 			}
 			for (int i = 0; i < root.getRowCount(); i++) {
 				CRow input = forwardedInputQueue.poll();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
@@ -112,7 +112,7 @@ public class BaseRowArrowPythonScalarFunctionOperator extends AbstractBaseRowPyt
 			reader.loadNextBatch();
 			VectorSchemaRoot root = reader.getVectorSchemaRoot();
 			if (arrowReader == null) {
-				arrowReader = ArrowUtils.createBaseRowArrowReader(root);
+				arrowReader = ArrowUtils.createBaseRowArrowReader(root, outputType);
 			}
 			for (int i = 0; i < root.getRowCount(); i++) {
 				BaseRow input = forwardedInputQueue.poll();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunner.java
@@ -50,6 +50,6 @@ public class ArrowPythonScalarFunctionRunner extends AbstractArrowPythonScalarFu
 
 	@Override
 	public ArrowWriter<Row> createArrowWriter() {
-		return ArrowUtils.createRowArrowWriter(root);
+		return ArrowUtils.createRowArrowWriter(root, getInputType());
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/BaseRowArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/BaseRowArrowPythonScalarFunctionRunner.java
@@ -50,6 +50,6 @@ public class BaseRowArrowPythonScalarFunctionRunner extends AbstractArrowPythonS
 
 	@Override
 	public ArrowWriter<BaseRow> createArrowWriter() {
-		return ArrowUtils.createBaseRowArrowWriter(root);
+		return ArrowUtils.createBaseRowArrowWriter(root, getInputType());
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DateSerializer.java
@@ -24,10 +24,10 @@ import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 
 import java.io.IOException;
 import java.sql.Date;
-import java.util.TimeZone;
 
 /**
  * Takes int instead of long as the serialized value. It not only reduces the length of
@@ -38,13 +38,6 @@ import java.util.TimeZone;
 public class DateSerializer extends TypeSerializerSingleton<Date> {
 
 	private static final long serialVersionUID = 1L;
-
-	/**
-	 * The local time zone.
-	 */
-	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
-
-	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
 
 	public static final DateSerializer INSTANCE = new DateSerializer();
 
@@ -85,22 +78,12 @@ public class DateSerializer extends TypeSerializerSingleton<Date> {
 		if (record == null) {
 			throw new IllegalArgumentException("The Date record must not be null.");
 		}
-		target.writeInt(dateToInternal(record));
+		target.writeInt(PythonTypeUtils.dateToInternal(record));
 	}
 
 	@Override
 	public Date deserialize(DataInputView source) throws IOException {
-		return internalToDate(source.readInt());
-	}
-
-	private int dateToInternal(Date date) {
-		long ts = date.getTime() + LOCAL_TZ.getOffset(date.getTime());
-		return (int) (ts / MILLIS_PER_DAY);
-	}
-
-	private Date internalToDate(int v) {
-		final long t = v * MILLIS_PER_DAY;
-		return new Date(t - LOCAL_TZ.getOffset(t));
+		return PythonTypeUtils.internalToDate(source.readInt());
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -23,25 +23,30 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -83,6 +88,8 @@ public class ArrowUtilsTest {
 			IntWriter.class, BaseRowIntWriter.class, IntFieldReader.class, ArrowIntColumnVector.class));
 		testFields.add(Tuple7.of("f4", new BigIntType(), new ArrowType.Int(8 * 8, true),
 			BigIntWriter.class, BaseRowBigIntWriter.class, BigIntFieldReader.class, ArrowBigIntColumnVector.class));
+		testFields.add(Tuple7.of("f5", new BooleanType(), new ArrowType.Bool(),
+			BooleanWriter.class, BaseRowBooleanWriter.class, BooleanFieldReader.class, ArrowBooleanColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
@@ -31,6 +32,7 @@ import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
@@ -39,18 +41,21 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -98,6 +103,8 @@ public class ArrowUtilsTest {
 			BooleanWriter.class, BaseRowBooleanWriter.class, BooleanFieldReader.class, ArrowBooleanColumnVector.class));
 		testFields.add(Tuple7.of("f6", new FloatType(), new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
 			FloatWriter.class, BaseRowFloatWriter.class, FloatFieldReader.class, ArrowFloatColumnVector.class));
+		testFields.add(Tuple7.of("f7", new DoubleType(), new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
+			DoubleWriter.class, BaseRowDoubleWriter.class, DoubleFieldReader.class, ArrowDoubleColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -24,12 +24,14 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
@@ -37,16 +39,19 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -56,6 +61,7 @@ import org.apache.flink.types.Row;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -90,6 +96,8 @@ public class ArrowUtilsTest {
 			BigIntWriter.class, BaseRowBigIntWriter.class, BigIntFieldReader.class, ArrowBigIntColumnVector.class));
 		testFields.add(Tuple7.of("f5", new BooleanType(), new ArrowType.Bool(),
 			BooleanWriter.class, BaseRowBooleanWriter.class, BooleanFieldReader.class, ArrowBooleanColumnVector.class));
+		testFields.add(Tuple7.of("f6", new FloatType(), new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+			FloatWriter.class, BaseRowFloatWriter.class, FloatFieldReader.class, ArrowFloatColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
@@ -38,6 +39,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowVarBinaryColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
@@ -48,6 +50,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
@@ -56,6 +59,7 @@ import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -66,6 +70,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
@@ -112,6 +117,8 @@ public class ArrowUtilsTest {
 			DoubleWriter.class, BaseRowDoubleWriter.class, DoubleFieldReader.class, ArrowDoubleColumnVector.class));
 		testFields.add(Tuple7.of("f8", new VarCharType(), ArrowType.Utf8.INSTANCE,
 			VarCharWriter.class, BaseRowVarCharWriter.class, VarCharFieldReader.class, ArrowVarCharColumnVector.class));
+		testFields.add(Tuple7.of("f9", new VarBinaryType(), ArrowType.Binary.INSTANCE,
+			VarBinaryWriter.class, BaseRowVarBinaryWriter.class, VarBinaryFieldReader.class, ArrowVarBinaryColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -103,15 +103,13 @@ public class ArrowUtilsTest {
 			// verify convert from RowType to ArrowType
 			assertEquals(testFields.get(i).f0, fields.get(i).getName());
 			assertEquals(testFields.get(i).f2, fields.get(i).getType());
-			// verify convert from ArrowType to LogicalType
-			assertEquals(testFields.get(i).f1, ArrowUtils.fromArrowFieldToLogicalType(fields.get(i)));
 		}
 	}
 
 	@Test
 	public void testCreateRowArrowReader() {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		RowArrowReader reader = ArrowUtils.createRowArrowReader(root);
+		RowArrowReader reader = ArrowUtils.createRowArrowReader(root, rowType);
 		ArrowFieldReader[] fieldReaders = reader.getFieldReaders();
 		for (int i = 0; i < fieldReaders.length; i++) {
 			assertEquals(testFields.get(i).f5, fieldReaders[i].getClass());
@@ -121,7 +119,7 @@ public class ArrowUtilsTest {
 	@Test
 	public void testCreateBaseRowArrowReader() {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		BaseRowArrowReader reader = ArrowUtils.createBaseRowArrowReader(root);
+		BaseRowArrowReader reader = ArrowUtils.createBaseRowArrowReader(root, rowType);
 		ColumnVector[] columnVectors = reader.getColumnVectors();
 		for (int i = 0; i < columnVectors.length; i++) {
 			assertEquals(testFields.get(i).f6, columnVectors[i].getClass());
@@ -131,7 +129,7 @@ public class ArrowUtilsTest {
 	@Test
 	public void testCreateRowArrowWriter() {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		ArrowWriter<Row> writer = ArrowUtils.createRowArrowWriter(root);
+		ArrowWriter<Row> writer = ArrowUtils.createRowArrowWriter(root, rowType);
 		ArrowFieldWriter<Row>[] fieldWriters = writer.getFieldWriters();
 		for (int i = 0; i < fieldWriters.length; i++) {
 			assertEquals(testFields.get(i).f3, fieldWriters[i].getClass());
@@ -141,7 +139,7 @@ public class ArrowUtilsTest {
 	@Test
 	public void testCreateBaseRowArrowWriter() {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		ArrowWriter<BaseRow> writer = ArrowUtils.createBaseRowArrowWriter(root);
+		ArrowWriter<BaseRow> writer = ArrowUtils.createBaseRowArrowWriter(root, rowType);
 		ArrowFieldWriter<BaseRow>[] fieldWriters = writer.getFieldWriters();
 		for (int i = 0; i < fieldWriters.length; i++) {
 			assertEquals(testFields.get(i).f4, fieldWriters[i].getClass());

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.DateFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.DecimalFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
@@ -35,6 +36,7 @@ import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowDateColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDecimalColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
@@ -47,6 +49,7 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowDateWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowDecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
@@ -57,6 +60,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.DateWriter;
 import org.apache.flink.table.runtime.arrow.writers.DecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
@@ -67,6 +71,7 @@ import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -81,6 +86,7 @@ import org.apache.flink.types.Row;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -126,6 +132,8 @@ public class ArrowUtilsTest {
 			VarBinaryWriter.class, BaseRowVarBinaryWriter.class, VarBinaryFieldReader.class, ArrowVarBinaryColumnVector.class));
 		testFields.add(Tuple7.of("f10", new DecimalType(10, 3), new ArrowType.Decimal(10, 3),
 			DecimalWriter.class, BaseRowDecimalWriter.class, DecimalFieldReader.class, ArrowDecimalColumnVector.class));
+		testFields.add(Tuple7.of("f11", new DateType(), new ArrowType.Date(DateUnit.DAY),
+			DateWriter.class, BaseRowDateWriter.class, DateFieldReader.class, ArrowDateColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.TimeFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
@@ -42,6 +43,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowTimeColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarBinaryColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
@@ -55,6 +57,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowTimeWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
@@ -66,6 +69,7 @@ import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.TimeWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
@@ -79,6 +83,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -88,6 +93,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
@@ -134,6 +140,14 @@ public class ArrowUtilsTest {
 			DecimalWriter.class, BaseRowDecimalWriter.class, DecimalFieldReader.class, ArrowDecimalColumnVector.class));
 		testFields.add(Tuple7.of("f11", new DateType(), new ArrowType.Date(DateUnit.DAY),
 			DateWriter.class, BaseRowDateWriter.class, DateFieldReader.class, ArrowDateColumnVector.class));
+		testFields.add(Tuple7.of("f13", new TimeType(0), new ArrowType.Time(TimeUnit.SECOND, 32),
+			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
+		testFields.add(Tuple7.of("f14", new TimeType(2), new ArrowType.Time(TimeUnit.MILLISECOND, 32),
+			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
+		testFields.add(Tuple7.of("f15", new TimeType(4), new ArrowType.Time(TimeUnit.MICROSECOND, 64),
+			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
+		testFields.add(Tuple7.of("f16", new TimeType(8), new ArrowType.Time(TimeUnit.NANOSECOND, 64),
+			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
@@ -37,6 +38,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
@@ -46,6 +48,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
@@ -53,6 +56,7 @@ import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DoubleType;
@@ -62,6 +66,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -105,6 +110,8 @@ public class ArrowUtilsTest {
 			FloatWriter.class, BaseRowFloatWriter.class, FloatFieldReader.class, ArrowFloatColumnVector.class));
 		testFields.add(Tuple7.of("f7", new DoubleType(), new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE),
 			DoubleWriter.class, BaseRowDoubleWriter.class, DoubleFieldReader.class, ArrowDoubleColumnVector.class));
+		testFields.add(Tuple7.of("f8", new VarCharType(), ArrowType.Utf8.INSTANCE,
+			VarCharWriter.class, BaseRowVarCharWriter.class, VarCharFieldReader.class, ArrowVarCharColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.dataformat.vector.ColumnVector;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.DecimalFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
@@ -34,6 +35,7 @@ import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowDecimalColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
@@ -45,6 +47,7 @@ import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowDecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
@@ -54,6 +57,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.DecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
@@ -63,6 +67,7 @@ import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
@@ -119,6 +124,8 @@ public class ArrowUtilsTest {
 			VarCharWriter.class, BaseRowVarCharWriter.class, VarCharFieldReader.class, ArrowVarCharColumnVector.class));
 		testFields.add(Tuple7.of("f9", new VarBinaryType(), ArrowType.Binary.INSTANCE,
 			VarBinaryWriter.class, BaseRowVarBinaryWriter.class, VarBinaryFieldReader.class, ArrowVarBinaryColumnVector.class));
+		testFields.add(Tuple7.of("f10", new DecimalType(10, 3), new ArrowType.Decimal(10, 3),
+			DecimalWriter.class, BaseRowDecimalWriter.class, DecimalFieldReader.class, ArrowDecimalColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -92,6 +93,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new BooleanType());
 		fieldTypes.add(new FloatType());
 		fieldTypes.add(new DoubleType());
+		fieldTypes.add(new VarCharType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -119,12 +121,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello");
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello");
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -88,6 +89,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new IntType());
 		fieldTypes.add(new BigIntType());
 		fieldTypes.add(new BooleanType());
+		fieldTypes.add(new FloatType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -115,12 +117,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f);
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f);
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f);
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -86,6 +87,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new SmallIntType());
 		fieldTypes.add(new IntType());
 		fieldTypes.add(new BigIntType());
+		fieldTypes.add(new BooleanType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -113,12 +115,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true);
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false);
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false);
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -99,6 +100,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new VarCharType());
 		fieldTypes.add(new VarBinaryType());
 		fieldTypes.add(new DecimalType(10, 3));
+		fieldTypes.add(new DateType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -126,12 +128,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3));
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3));
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3));
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3));
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100);
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100);
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100);
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -99,13 +99,13 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 	public ArrowReader<BaseRow> createArrowReader(InputStream inputStream) throws IOException {
 		ArrowStreamReader reader = new ArrowStreamReader(inputStream, allocator);
 		reader.loadNextBatch();
-		return ArrowUtils.createBaseRowArrowReader(reader.getVectorSchemaRoot());
+		return ArrowUtils.createBaseRowArrowReader(reader.getVectorSchemaRoot(), rowType);
 	}
 
 	@Override
 	public Tuple2<ArrowWriter<BaseRow>, ArrowStreamWriter> createArrowWriter(OutputStream outputStream) throws IOException {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		ArrowWriter<BaseRow> arrowWriter = ArrowUtils.createBaseRowArrowWriter(root);
+		ArrowWriter<BaseRow> arrowWriter = ArrowUtils.createBaseRowArrowWriter(root, rowType);
 		ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(root, null, outputStream);
 		arrowStreamWriter.start();
 		return Tuple2.of(arrowWriter, arrowStreamWriter);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -101,6 +102,10 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new VarBinaryType());
 		fieldTypes.add(new DecimalType(10, 3));
 		fieldTypes.add(new DateType());
+		fieldTypes.add(new TimeType(0));
+		fieldTypes.add(new TimeType(2));
+		fieldTypes.add(new TimeType(4));
+		fieldTypes.add(new TimeType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -128,12 +133,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -90,6 +91,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new BigIntType());
 		fieldTypes.add(new BooleanType());
 		fieldTypes.add(new FloatType());
+		fieldTypes.add(new DoubleType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -117,12 +119,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0);
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0);
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0);
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -22,10 +22,12 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
@@ -96,6 +98,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new DoubleType());
 		fieldTypes.add(new VarCharType());
 		fieldTypes.add(new VarBinaryType());
+		fieldTypes.add(new DecimalType(10, 3));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -123,12 +126,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3));
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3));
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3));
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3));
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
@@ -94,6 +95,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new FloatType());
 		fieldTypes.add(new DoubleType());
 		fieldTypes.add(new VarCharType());
+		fieldTypes.add(new VarBinaryType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -121,12 +123,12 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello");
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello");
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -69,6 +70,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new VarBinaryType());
 		fieldTypes.add(new DecimalType(10, 0));
 		fieldTypes.add(new DateType());
+		fieldTypes.add(new TimeType(0));
+		fieldTypes.add(new TimeType(2));
+		fieldTypes.add(new TimeType(4));
+		fieldTypes.add(new TimeType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -96,10 +101,13 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -66,13 +66,13 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 	public ArrowReader<Row> createArrowReader(InputStream inputStream) throws IOException {
 		ArrowStreamReader reader = new ArrowStreamReader(inputStream, allocator);
 		reader.loadNextBatch();
-		return ArrowUtils.createRowArrowReader(reader.getVectorSchemaRoot());
+		return ArrowUtils.createRowArrowReader(reader.getVectorSchemaRoot(), rowType);
 	}
 
 	@Override
 	public Tuple2<ArrowWriter<Row>, ArrowStreamWriter> createArrowWriter(OutputStream outputStream) throws IOException {
 		VectorSchemaRoot root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator);
-		ArrowWriter<Row> arrowWriter = ArrowUtils.createRowArrowWriter(root);
+		ArrowWriter<Row> arrowWriter = ArrowUtils.createRowArrowWriter(root, rowType);
 		ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(root, null, outputStream);
 		arrowStreamWriter.start();
 		return Tuple2.of(arrowWriter, arrowStreamWriter);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
@@ -61,6 +62,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new FloatType());
 		fieldTypes.add(new DoubleType());
 		fieldTypes.add(new VarCharType());
+		fieldTypes.add(new VarBinaryType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -88,10 +90,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello");
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello");
-		Row row4 = Row.of(null, null, null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.arrow;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
@@ -41,6 +42,7 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,6 +65,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new DoubleType());
 		fieldTypes.add(new VarCharType());
 		fieldTypes.add(new VarBinaryType());
+		fieldTypes.add(new DecimalType(10, 0));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -90,10 +93,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes());
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes());
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1));
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1));
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1));
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.arrow;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -57,6 +58,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new BigIntType());
 		fieldTypes.add(new BooleanType());
 		fieldTypes.add(new FloatType());
+		fieldTypes.add(new DoubleType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -84,10 +86,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f);
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f);
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f);
-		Row row4 = Row.of(null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0);
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0);
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0);
+		Row row4 = Row.of(null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.Row;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -59,6 +60,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new BooleanType());
 		fieldTypes.add(new FloatType());
 		fieldTypes.add(new DoubleType());
+		fieldTypes.add(new VarCharType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -86,10 +88,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0);
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0);
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0);
-		Row row4 = Row.of(null, null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello");
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文");
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello");
+		Row row4 = Row.of(null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.arrow;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -55,6 +56,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new IntType());
 		fieldTypes.add(new BigIntType());
 		fieldTypes.add(new BooleanType());
+		fieldTypes.add(new FloatType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -82,10 +84,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true);
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false);
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true);
-		Row row4 = Row.of(null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f);
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f);
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f);
+		Row row4 = Row.of(null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -19,8 +19,10 @@
 package org.apache.flink.table.runtime.arrow;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
@@ -66,6 +68,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new VarCharType());
 		fieldTypes.add(new VarBinaryType());
 		fieldTypes.add(new DecimalType(10, 0));
+		fieldTypes.add(new DateType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -93,10 +96,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1));
-		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1));
-		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1));
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null);
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100));
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.arrow;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -53,6 +54,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new SmallIntType());
 		fieldTypes.add(new IntType());
 		fieldTypes.add(new BigIntType());
+		fieldTypes.add(new BooleanType());
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -80,12 +82,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 
 	@Override
 	public Row[] getTestData() {
-		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L);
-		Row row2 = Row.of((byte) 1, (short) 2, 3, 4L);
-		Row row3 = Row.of(null, (short) 2, 3, 4L);
-		Row row4 = Row.of((byte) 1, null, 3, 4L);
-		Row row5 = Row.of(null, null, null, null);
-		Row row6 = Row.of(null, null, null, null);
-		return new Row[]{row1, row2, row3, row4, row5, row6};
+		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true);
+		Row row2 = Row.of(null, (short) 2, 3, 4L, false);
+		Row row3 = Row.of((byte) 1, null, 3, 4L, true);
+		Row row4 = Row.of(null, null, null, null, null);
+		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperatorTest.java
@@ -100,7 +100,7 @@ public class ArrowPythonScalarFunctionOperatorTest extends PythonScalarFunctionO
 				getPythonConfig().getMaxArrowBatchSize()) {
 				@Override
 				public ArrowWriter<Row> createArrowWriter() {
-					return ArrowUtils.createRowArrowWriter(root);
+					return ArrowUtils.createRowArrowWriter(root, getInputType());
 				}
 			};
 		}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
@@ -122,7 +122,7 @@ public class BaseRowArrowPythonScalarFunctionOperatorTest
 				getPythonConfig().getMaxArrowBatchSize()) {
 				@Override
 				public ArrowWriter<BaseRow> createArrowWriter() {
-					return ArrowUtils.createBaseRowArrowWriter(root);
+					return ArrowUtils.createBaseRowArrowWriter(root, getInputType());
 				}
 			};
 		}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
@@ -176,7 +176,7 @@ public class ArrowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFun
 			jobBundleFactory) {
 			@Override
 			public ArrowWriter<Row> createArrowWriter() {
-				return ArrowUtils.createRowArrowWriter(root);
+				return ArrowUtils.createRowArrowWriter(root, getInputType());
 			}
 		};
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowWriter;
 import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 
@@ -117,6 +118,9 @@ public class StreamRecordUtils {
 				writer.writeBoolean(j, (Boolean) value);
 			} else if (value instanceof byte[]) {
 				writer.writeBinary(j, (byte[]) value);
+			} else if (value instanceof Decimal) {
+				Decimal decimal = (Decimal) value;
+				writer.writeDecimal(j, decimal, decimal.getPrecision());
 			} else {
 				throw new RuntimeException("Not support yet!");
 			}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -115,6 +115,8 @@ public class StreamRecordUtils {
 				writer.writeLong(j, (Long) value);
 			} else if (value instanceof Boolean) {
 				writer.writeBoolean(j, (Boolean) value);
+			} else if (value instanceof byte[]) {
+				writer.writeBinary(j, (byte[]) value);
 			} else {
 				throw new RuntimeException("Not support yet!");
 			}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds support of BooleanType, FloatType, DoubleType, VarCharType, VarBinaryType, DecimalType, DateType and TimeType for vectorized Python UDF.*

## Verifying this change

  - *Java Tests ArrowUtilsTest, BaseRowArrowReaderWriterTest, RowArrowReaderWriterTest and Python tests PandasUDFITTests.test_all_data_types*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
