### PR TITLE
[FLINK-16664][stream] fix wrong check for DataStreamSource#setParallelism()

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -52,7 +52,7 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 
 	@Override
 	public DataStreamSource<T> setParallelism(int parallelism) {
-		OperatorValidationUtils.validateMaxParallelism(parallelism, isParallel);
+		OperatorValidationUtils.validateParallelism(parallelism, isParallel);
 		super.setParallelism(parallelism);
 		return this;
 	}


### PR DESCRIPTION
## What is the purpose of the change

This fixes a regression in the DataStream API for being unable to call
```
DataStreamSource#setParallelism(-1)
```
which should set the cluster/job default. It was introduced by https://github.com/apache/flink/commit/4a5e8c083969cad215819ad6a3a0d2919e8c2d5e.

@xintongsong actually, I'm also a bit unsure on some other things from that commit, like `OperatorValidationUtils#validateMaxParallelism(int, boolean)` using an upper bound of `Integer.MAX_VALUE` instead of `Transformation#UPPER_BOUND_MAX_PARALLELISM`. In the end, it is not too much of a problem since this is actually checked twice in `SingleOutputStreamOperator#setMaxParallelism`, once there and a second time in the transformation which uses the correct upper bound. In the end, that part was only copied from the old code which did not have an upper bound check there and therefore, I did not change this here either.

When merging, please also apply to release-1.10

## Brief change log

- change `DataStreamSource#setParallelism()` to call `OperatorValidationUtils.validateParallelism` instead of `OperatorValidationUtils.validateMaxParallelism`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/flink/11446)
<!-- Reviewable:end -->
