### PR TITLE
[FLINK-16676][python][test] Fix ValidationPipelineTest.test_pipeline_from_invalid_json failure on Azure

### DIFF
--- a/flink-python/pyflink/ml/tests/test_pipeline.py
+++ b/flink-python/pyflink/ml/tests/test_pipeline.py
@@ -84,20 +84,14 @@ class ValidationPipelineTest(MLTestCase):
             p.load_json(invalid_json)
         exception_str = str(context.exception)
 
-        # only assert key error message as the whole message is very long.
+        # NOTE: only check the general error message since the detailed error message
+        # would be different in different environment.
         self.assertTrue(
             'Cannot load the JSON as either a Java Pipeline or a Python Pipeline.'
             in exception_str)
-        self.assertTrue(
-            'Python Pipeline load failed due to: Expecting value: line 1 column 2 (char 1).'
-            in exception_str)
-        self.assertTrue(
-            'Java Pipeline load failed due to: An error occurred while calling o0.loadJson.'
-            in exception_str)
-        self.assertTrue(
-            'Caused by: org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.'
-            'JsonParseException: Unrecognized token \'a\''
-            in exception_str)
+        self.assertTrue('Python Pipeline load failed due to:' in exception_str)
+        self.assertTrue('Java Pipeline load failed due to:' in exception_str)
+        self.assertTrue('JsonParseException' in exception_str)
 
 
 class SelfDescribe(WithParams):


### PR DESCRIPTION
Fix ValidationPipelineTest.test_pipeline_from_invalid_json failure.

The problem is the detailed error message would be different in different environments.
In travis:
```
An error occurred while calling o0.loadJson.
```
but in Azure:
```
An error occurred while calling o1095.loadJson
```
To solve the problem, we can check the general error message instead of the very detailed one in the test.