### PR TITLE
[FLINK-16718][tests] Fix ByteBuf leak in KvStateServerHandlerTest

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/network/KvStateServerHandlerTest.java
@@ -170,6 +170,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		assertEquals(MessageType.REQUEST_RESULT, MessageSerializer.deserializeHeader(buf));
 		long deserRequestId = MessageSerializer.getRequestId(buf);
 		KvStateResponse response = serializer.deserializeResponse(buf);
+		buf.release();
 
 		assertEquals(requestId, deserRequestId);
 
@@ -217,6 +218,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		RequestFailure response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 
 		assertEquals(requestId, response.getRequestId());
 
@@ -278,6 +280,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		RequestFailure response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 
 		assertEquals(requestId, response.getRequestId());
 
@@ -363,6 +366,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		RequestFailure response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 
 		assertTrue(response.getCause().getMessage().contains("Expected test Exception"));
 
@@ -392,6 +396,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.SERVER_FAILURE, MessageSerializer.deserializeHeader(buf));
 		Throwable response = MessageSerializer.deserializeServerFailure(buf);
+		buf.release();
 
 		assertTrue(response.getMessage().contains("Expected test Exception"));
 
@@ -454,6 +459,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		RequestFailure response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 
 		assertTrue(response.getCause().getMessage().contains("RejectedExecutionException"));
 
@@ -490,6 +496,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.SERVER_FAILURE, MessageSerializer.deserializeHeader(buf));
 		Throwable response = MessageSerializer.deserializeServerFailure(buf);
+		buf.release();
 
 		assertEquals(0L, stats.getNumRequests());
 		assertEquals(0L, stats.getNumFailed());
@@ -505,6 +512,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.SERVER_FAILURE, MessageSerializer.deserializeHeader(buf));
 		response = MessageSerializer.deserializeServerFailure(buf);
+		buf.release();
 
 		assertTrue("Unexpected failure cause " + response.getClass().getName(), response instanceof IllegalArgumentException);
 
@@ -544,6 +552,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 
 		channel.writeInbound(unexpected);
 		assertEquals("Buffer not recycled", 0L, unexpected.refCnt());
+		channel.finishAndReleaseAll();
 	}
 
 	/**
@@ -610,6 +619,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		RequestFailure response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 		assertEquals(182828L, response.getRequestId());
 		assertTrue(response.getCause().getMessage().contains("IOException"));
 
@@ -626,6 +636,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 		// Verify the response
 		assertEquals(MessageType.REQUEST_FAILURE, MessageSerializer.deserializeHeader(buf));
 		response = MessageSerializer.deserializeRequestFailure(buf);
+		buf.release();
 		assertEquals(182829L, response.getRequestId());
 		assertTrue(response.getCause().getMessage().contains("IOException"));
 
@@ -696,6 +707,7 @@ public class KvStateServerHandlerTest extends TestLogger {
 
 		Object msg = readInboundBlocking(channel);
 		assertTrue("Not ChunkedByteBuf", msg instanceof ChunkedByteBuf);
+		((ChunkedByteBuf) msg).close();
 	}
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

*This fixes `ByteBuf` leaks in `KvStateServerHandlerTest`.*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *KvStateServerHandlerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
