### PR TITLE
[FLINK-16684] Fix StreamingFileSink builder compilation for Scala

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -165,9 +165,9 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.RowFormatBuilder<IN, String, ? extends RowFormatBuilder<IN, String, ?>> forRowFormat(
+	public static <IN> StreamingFileSink.DefaultRowFormatBuilder<IN> forRowFormat(
 			final Path basePath, final Encoder<IN> encoder) {
-		return new StreamingFileSink.RowFormatBuilder<>(basePath, encoder, new DateTimeBucketAssigner<>());
+		return new DefaultRowFormatBuilder<>(basePath, encoder, new DateTimeBucketAssigner<>());
 	}
 
 	/**
@@ -178,9 +178,9 @@ public class StreamingFileSink<IN>
 	 * @return The builder where the remaining of the configuration parameters for the sink can be configured.
 	 * In order to instantiate the sink, call {@link RowFormatBuilder#build()} after specifying the desired parameters.
 	 */
-	public static <IN> StreamingFileSink.BulkFormatBuilder<IN, String, ? extends BulkFormatBuilder<IN, String, ?>> forBulkFormat(
+	public static <IN> StreamingFileSink.DefaultBulkFormatBuilder<IN> forBulkFormat(
 			final Path basePath, final BulkWriter.Factory<IN> writerFactory) {
-		return new StreamingFileSink.BulkFormatBuilder<>(basePath, writerFactory, new DateTimeBucketAssigner<>());
+		return new StreamingFileSink.DefaultBulkFormatBuilder<>(basePath, writerFactory, new DateTimeBucketAssigner<>());
 	}
 
 	/**
@@ -297,6 +297,18 @@ public class StreamingFileSink<IN>
 	}
 
 	/**
+	 * Builder for the vanilla {@link StreamingFileSink} using a row format.
+	 * @param <IN> record type
+	 */
+	public static final class DefaultRowFormatBuilder<IN> extends RowFormatBuilder<IN, String, DefaultRowFormatBuilder<IN>> {
+		private static final long serialVersionUID = -8503344257202146718L;
+
+		private DefaultRowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, String> bucketAssigner) {
+			super(basePath, encoder, bucketAssigner);
+		}
+	}
+
+	/**
 	 * A builder for configuring the sink for bulk-encoding formats, e.g. Parquet/ORC.
 	 */
 	@PublicEvolving
@@ -391,6 +403,19 @@ public class StreamingFileSink<IN>
 					rollingPolicy,
 					subtaskIndex,
 					outputFileConfig);
+		}
+	}
+
+	/**
+	 * Builder for the vanilla {@link StreamingFileSink} using a bulk format.
+	 * @param <IN> record type
+	 */
+	public static final class DefaultBulkFormatBuilder<IN> extends BulkFormatBuilder<IN, String, DefaultBulkFormatBuilder<IN>> {
+
+		private static final long serialVersionUID = 7493169281036370228L;
+
+		private DefaultBulkFormatBuilder(Path basePath, BulkWriter.Factory<IN> writerFactory, BucketAssigner<IN, String> assigner) {
+			super(basePath, writerFactory, assigner);
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkWriterTest.java
@@ -236,7 +236,7 @@ public class BulkWriterTest extends TestLogger {
 	/**
 	 * A {@link BulkWriter.Factory} used for the tests.
 	 */
-	private static class TestBulkWriterFactory implements BulkWriter.Factory<Tuple2<String, Integer>> {
+	public static final class TestBulkWriterFactory implements BulkWriter.Factory<Tuple2<String, Integer>> {
 
 		private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/functions/sink/filesystem/StreamingFileSinkTest.scala
+++ b/flink-streaming-scala/src/test/scala/org/apache/flink/streaming/api/scala/functions/sink/filesystem/StreamingFileSinkTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.scala.functions.sink.filesystem
+
+import org.apache.flink.api.common.serialization.SimpleStringEncoder
+import org.apache.flink.core.fs.Path
+import org.apache.flink.streaming.api.functions.sink.filesystem.BulkWriterTest.TestBulkWriterFactory
+import org.apache.flink.streaming.api.functions.sink.filesystem.{OutputFileConfig, StreamingFileSink}
+import org.junit.Test
+
+/**
+ * Tests for the [[org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink]]
+ */
+class StreamingFileSinkTest {
+
+  /**
+   * Tests that the StreamingFileSink builder work with the Scala APIs.
+   */
+  @Test
+  def testStreamingFileSinkRowFormatBuilderCompiles(): Unit = {
+    StreamingFileSink.forRowFormat(new Path("foobar"), new SimpleStringEncoder[String]())
+      .withBucketCheckInterval(10L)
+      .withOutputFileConfig(OutputFileConfig.builder().build())
+      .build()
+  }
+
+  /**
+   * Tests that the StreamingFileSink builder work with the Scala APIs.
+   */
+  @Test
+  def testStreamingFileSinkBulkFormatBuilderCompiles(): Unit = {
+    StreamingFileSink.forBulkFormat(new Path("foobar"), new TestBulkWriterFactory())
+      .withBucketCheckInterval(10L)
+      .withOutputFileConfig(OutputFileConfig.builder().build())
+      .build()
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This commit introduces a new type name for the row and bulk format
StreamingFileSink builders in order to solve the compilation problem
of Scala when using generic types with the self-type idiom.

## Verifying this change

Added `StreamingFileSinkTest.testStreamingFileSinkRowFormatBuilderCompiles` and `StreamingFileSinkTest.testStreamingFileSinkBulkFormatBuilderCompiles`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
