### PR TITLE
[FLINK-16690][task][tests] Refactor StreamTaskTest to reuse TestTaskBuilder and MockStreamTaskBuilder

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TestTaskBuilder.java
@@ -80,6 +80,7 @@ public final class TestTaskBuilder {
 	private KvStateService kvStateService = new KvStateService(new KvStateRegistry(), null, null);
 	private Executor executor = TestingUtils.defaultExecutor();
 	private Configuration taskManagerConfig = new Configuration();
+	private Configuration taskConfig = new Configuration();
 	private ExecutionConfig executionConfig = new ExecutionConfig();
 	private Collection<PermanentBlobKey> requiredJarFileBlobKeys = Collections.emptyList();
 	private List<ResultPartitionDeploymentDescriptor> resultPartitions = Collections.emptyList();
@@ -129,6 +130,11 @@ public final class TestTaskBuilder {
 
 	public TestTaskBuilder setTaskManagerConfig(Configuration taskManagerConfig) {
 		this.taskManagerConfig = taskManagerConfig;
+		return this;
+	}
+
+	public TestTaskBuilder setTaskConfig(Configuration taskConfig) {
+		this.taskConfig = taskConfig;
 		return this;
 	}
 
@@ -186,7 +192,7 @@ public final class TestTaskBuilder {
 			1,
 			1,
 			invokable.getName(),
-			new Configuration());
+			taskConfig);
 
 		final BlobCacheService blobCacheService = new BlobCacheService(
 			mock(PermanentBlobCache.class),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -227,7 +227,7 @@ public abstract class AbstractStreamOperator<OUT>
 				LatencyStats.Granularity.SINGLE);
 		}
 
-		this.runtimeContext = new StreamingRuntimeContext(this, environment, container.getAccumulatorMap());
+		this.runtimeContext = new StreamingRuntimeContext(this, environment, environment.getAccumulatorRegistry().getUserMap());
 
 		stateKeySelector1 = config.getStatePartitioner(0, getUserCodeClassloader());
 		stateKeySelector2 = config.getStatePartitioner(1, getUserCodeClassloader());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperatorLifecycleTest.java
@@ -25,7 +25,9 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.taskmanager.Task;
@@ -141,16 +143,18 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		cfg.setOperatorID(new OperatorID());
 		cfg.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
-		Task task = StreamTaskTest.createTask(SourceStreamTask.class, cfg, taskManagerConfig);
+		try (ShuffleEnvironment shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build()) {
+			Task task = StreamTaskTest.createTask(SourceStreamTask.class, shuffleEnvironment, cfg, taskManagerConfig);
 
-		task.startTaskThread();
+			task.startTaskThread();
 
-		LifecycleTrackingStreamSource.runStarted.await();
+			LifecycleTrackingStreamSource.runStarted.await();
 
-		// wait for clean termination
-		task.getExecutingThread().join();
-		assertEquals(ExecutionState.FINISHED, task.getExecutionState());
-		assertEquals(EXPECTED_CALL_ORDER_FULL, ACTUAL_ORDER_TRACKING);
+			// wait for clean termination
+			task.getExecutingThread().join();
+			assertEquals(ExecutionState.FINISHED, task.getExecutionState());
+			assertEquals(EXPECTED_CALL_ORDER_FULL, ACTUAL_ORDER_TRACKING);
+		}
 	}
 
 	@Test
@@ -164,18 +168,20 @@ public class AbstractUdfStreamOperatorLifecycleTest {
 		cfg.setOperatorID(new OperatorID());
 		cfg.setTimeCharacteristic(TimeCharacteristic.ProcessingTime);
 
-		Task task = StreamTaskTest.createTask(SourceStreamTask.class, cfg, taskManagerConfig);
+		try (ShuffleEnvironment shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build()) {
+			Task task = StreamTaskTest.createTask(SourceStreamTask.class, shuffleEnvironment, cfg, taskManagerConfig);
 
-		task.startTaskThread();
-		LifecycleTrackingStreamSource.runStarted.await();
+			task.startTaskThread();
+			LifecycleTrackingStreamSource.runStarted.await();
 
-		// this should cancel the task even though it is blocked on runFinished
-		task.cancelExecution();
+			// this should cancel the task even though it is blocked on runFinished
+			task.cancelExecution();
 
-		// wait for clean termination
-		task.getExecutingThread().join();
-		assertEquals(ExecutionState.CANCELED, task.getExecutionState());
-		assertEquals(EXPECTED_CALL_ORDER_CANCEL_RUNNING, ACTUAL_ORDER_TRACKING);
+			// wait for clean termination
+			task.getExecutingThread().join();
+			assertEquals(ExecutionState.CANCELED, task.getExecutionState());
+			assertEquals(EXPECTED_CALL_ORDER_CANCEL_RUNNING, ACTUAL_ORDER_TRACKING);
+		}
 	}
 
 	private static class MockSourceFunction extends RichSourceFunction<Long> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationBarrierTest.java
@@ -21,17 +21,14 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.co.CoStreamMap;
 import org.apache.flink.streaming.runtime.io.CheckpointBarrierAlignerTestBase;
 import org.apache.flink.streaming.runtime.io.CheckpointBarrierAlignerTestBase.CheckpointExceptionMatcher;
-import org.apache.flink.streaming.runtime.tasks.StreamTaskTest.NoOpStreamTask;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -143,38 +140,6 @@ public class StreamTaskCancellationBarrierTest {
 		// cancel and shutdown
 		testHarness.endInput();
 		testHarness.waitForTaskCompletion();
-	}
-
-	// ------------------------------------------------------------------------
-	//  test tasks / functions
-	// ------------------------------------------------------------------------
-
-	private static class InitBlockingTask extends NoOpStreamTask<String, AbstractStreamOperator<String>> {
-
-		private final Object lock = new Object();
-		private volatile boolean running = true;
-
-		protected InitBlockingTask(Environment env) {
-			super(env);
-		}
-
-		@Override
-		protected void init() throws Exception {
-			super.init();
-			synchronized (lock) {
-				while (running) {
-					lock.wait();
-				}
-			}
-		}
-
-		@Override
-		protected void cancelTask() throws Exception {
-			running = false;
-			synchronized (lock) {
-				lock.notifyAll();
-			}
-		}
 	}
 
 	private static class IdentityMap implements MapFunction<String, String> {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
@@ -36,7 +35,6 @@ import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 
-import java.util.Map;
 import java.util.function.BiConsumer;
 
 /**
@@ -54,7 +52,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 	private final CheckpointStorageWorkerView checkpointStorage;
 	private final ProcessingTimeService processingTimeService;
 	private final BiConsumer<String, Throwable> handleAsyncException;
-	private final Map<String, Accumulator<?, ?>> accumulatorMap;
 
 	public MockStreamTask(
 		Environment environment,
@@ -68,7 +65,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		CheckpointStorageWorkerView checkpointStorage,
 		TimerService timerService,
 		BiConsumer<String, Throwable> handleAsyncException,
-		Map<String, Accumulator<?, ?>> accumulatorMap,
 		TaskMailbox taskMailbox,
 		StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor
 	) {
@@ -83,7 +79,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		this.checkpointStorage = checkpointStorage;
 		this.processingTimeService = timerService;
 		this.handleAsyncException = handleAsyncException;
-		this.accumulatorMap = accumulatorMap;
 	}
 
 	@Override
@@ -156,11 +151,6 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 	@Override
 	public void handleAsyncException(String message, Throwable exception) {
 		handleAsyncException.accept(message, exception);
-	}
-
-	@Override
-	public Map<String, Accumulator<?, ?>> getAccumulatorMap() {
-		return accumulatorMap;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -26,13 +26,13 @@ import org.apache.flink.runtime.util.FatalExitExceptionHandler;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.runtime.io.StreamInputProcessor;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceFactory;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.streaming.runtime.tasks.TimerService;
-import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 
 import java.util.function.BiConsumer;
@@ -66,8 +66,9 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		TimerService timerService,
 		BiConsumer<String, Throwable> handleAsyncException,
 		TaskMailbox taskMailbox,
-		StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor
-	) {
+		StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor,
+		StreamInputProcessor inputProcessor) {
+
 		super(environment, timerService, FatalExitExceptionHandler.INSTANCE, taskActionExecutor, taskMailbox);
 		this.name = name;
 		this.checkpointLock = checkpointLock;
@@ -79,15 +80,11 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		this.checkpointStorage = checkpointStorage;
 		this.processingTimeService = timerService;
 		this.handleAsyncException = handleAsyncException;
+		this.inputProcessor = inputProcessor;
 	}
 
 	@Override
 	public void init() {
-	}
-
-	@Override
-	protected void processInput(MailboxDefaultAction.Controller controller) throws Exception {
-		controller.allActionsCompleted();
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -20,7 +20,6 @@ package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.runtime.execution.Environment;
@@ -39,8 +38,6 @@ import org.apache.flink.streaming.runtime.tasks.TimerService;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.function.BiConsumer;
 
 /**
@@ -58,7 +55,6 @@ public class MockStreamTaskBuilder {
 	private TimerService timerService = new TestProcessingTimeService();
 	private StreamTaskStateInitializer streamTaskStateInitializer;
 	private BiConsumer<String, Throwable> handleAsyncException = (message, throwable) -> { };
-	private Map<String, Accumulator<?, ?>> accumulatorMap = Collections.emptyMap();
 	private TaskMailbox taskMailbox = new TaskMailboxImpl();
 	private StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor = StreamTaskActionExecutor.synchronizedExecutor();
 
@@ -143,7 +139,6 @@ public class MockStreamTaskBuilder {
 			checkpointStorage,
 			timerService,
 			handleAsyncException,
-			accumulatorMap,
 			taskMailbox,
 			taskActionExecutor);
 	}


### PR DESCRIPTION

## What is the purpose of the change

We can reuse existing `TestTaskBuilder` and `MockStreamTaskBuilder` for constructing `Task` and `StreamTask` easily in tests to simplify `StreamTaskTest` case.

## Brief change log

see commit messages

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
