### PR TITLE
[FLINK-16655][FLINK-16657] Introduce embedded executor and use it for Web Submission

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -119,7 +119,8 @@ public enum ClientUtils {
 	public static void executeProgram(
 			PipelineExecutorServiceLoader executorServiceLoader,
 			Configuration configuration,
-			PackagedProgram program) throws ProgramInvocationException {
+			PackagedProgram program,
+			boolean enforceSingleJobExecution) throws ProgramInvocationException {
 		checkNotNull(executorServiceLoader);
 		final ClassLoader userCodeClassLoader = program.getUserCodeClassLoader();
 		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -131,12 +132,14 @@ public enum ClientUtils {
 			ContextEnvironment.setAsContext(
 				executorServiceLoader,
 				configuration,
-				userCodeClassLoader);
+				userCodeClassLoader,
+				enforceSingleJobExecution);
 
 			StreamContextEnvironment.setAsContext(
 				executorServiceLoader,
 				configuration,
-				userCodeClassLoader);
+				userCodeClassLoader,
+				enforceSingleJobExecution);
 
 			try {
 				program.invokeInteractiveModeForExecution();

--- a/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/ClientUtils.java
@@ -120,7 +120,8 @@ public enum ClientUtils {
 			PipelineExecutorServiceLoader executorServiceLoader,
 			Configuration configuration,
 			PackagedProgram program,
-			boolean enforceSingleJobExecution) throws ProgramInvocationException {
+			boolean enforceSingleJobExecution,
+			boolean forbidBlockingJobClient) throws ProgramInvocationException {
 		checkNotNull(executorServiceLoader);
 		final ClassLoader userCodeClassLoader = program.getUserCodeClassLoader();
 		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
@@ -133,13 +134,15 @@ public enum ClientUtils {
 				executorServiceLoader,
 				configuration,
 				userCodeClassLoader,
-				enforceSingleJobExecution);
+				enforceSingleJobExecution,
+				forbidBlockingJobClient);
 
 			StreamContextEnvironment.setAsContext(
 				executorServiceLoader,
 				configuration,
 				userCodeClassLoader,
-				enforceSingleJobExecution);
+				enforceSingleJobExecution,
+				forbidBlockingJobClient);
 
 			try {
 				program.invokeInteractiveModeForExecution();

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -656,7 +656,7 @@ public class CliFrontend {
 	// --------------------------------------------------------------------------------------------
 
 	protected void executeProgram(final Configuration configuration, final PackagedProgram program) throws ProgramInvocationException {
-		ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program);
+		ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program, false);
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontend.java
@@ -656,7 +656,7 @@ public class CliFrontend {
 	// --------------------------------------------------------------------------------------------
 
 	protected void executeProgram(final Configuration configuration, final PackagedProgram program) throws ProgramInvocationException {
-		ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program, false);
+		ClientUtils.executeProgram(DefaultExecutorServiceLoader.INSTANCE, configuration, program, false, false);
 	}
 
 	/**

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DetachedOnlyJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DetachedOnlyJobClientAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link JobClient} that wraps any other job client and transforms it into one that is not allowed
+ * to wait for the job result.
+ *
+ * <p>This is used in web submission, where we do not want the Web UI to have jobs blocking threads while
+ * waiting for their completion.
+ */
+@Internal
+public class DetachedOnlyJobClientAdapter implements JobClient {
+
+	private final JobClient jobClient;
+
+	public DetachedOnlyJobClientAdapter(final JobClient jobClient) {
+		this.jobClient = checkNotNull(jobClient);
+	}
+
+	@Override
+	public JobID getJobID() {
+		return jobClient.getJobID();
+	}
+
+	@Override
+	public CompletableFuture<JobStatus> getJobStatus() {
+		throw new FlinkRuntimeException("The Job Status cannot be requested when in Web Submission.");
+	}
+
+	@Override
+	public CompletableFuture<Void> cancel() {
+		throw new FlinkRuntimeException("Cancelling the job is not supporter by the Job Client when in Web Submission.");
+	}
+
+	@Override
+	public CompletableFuture<String> stopWithSavepoint(boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) {
+		throw new FlinkRuntimeException("Stop with Savepoint is not supporter by the Job Client when in Web Submission.");
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(@Nullable String savepointDirectory) {
+		throw new FlinkRuntimeException("A savepoint cannot be taken through the Job Client when in Web Submission.");
+	}
+
+	@Override
+	public CompletableFuture<Map<String, Object>> getAccumulators(ClassLoader classLoader) {
+		throw new FlinkRuntimeException("The Accumulators cannot be fetched through the Job Client when in Web Submission.");
+	}
+
+	@Override
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult(ClassLoader userClassloader) {
+		throw new FlinkRuntimeException("The Job Result cannot be fetched through the Job Client when in Web Submission.");
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/DetachedOnlyJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/DetachedOnlyJobClientAdapter.java
@@ -60,12 +60,12 @@ public class DetachedOnlyJobClientAdapter implements JobClient {
 
 	@Override
 	public CompletableFuture<Void> cancel() {
-		throw new FlinkRuntimeException("Cancelling the job is not supporter by the Job Client when in Web Submission.");
+		throw new FlinkRuntimeException("Cancelling the job is not supported by the Job Client when in Web Submission.");
 	}
 
 	@Override
 	public CompletableFuture<String> stopWithSavepoint(boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) {
-		throw new FlinkRuntimeException("Stop with Savepoint is not supporter by the Job Client when in Web Submission.");
+		throw new FlinkRuntimeException("Stop with Savepoint is not supported by the Job Client when in Web Submission.");
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/ApplicationRunner.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+
+import java.util.List;
+
+/**
+ * An interface to be implemented by the entities responsible for application
+ * submission for the different deployment environments.
+ *
+ * <p>This interface assumes access to the cluster's {@link DispatcherGateway},
+ * and it does not go through the publicly exposed REST API.
+ */
+@Internal
+public interface ApplicationRunner {
+
+	/**
+	 * Runs the application using the provided {@code dispatcherGateway}.
+	 *
+	 * @param dispatcherGateway the dispatcher of the cluster to run the application.
+	 * @param program the {@link PackagedProgram} containing the user's main method.
+	 * @param configuration the configuration used to run the application.
+	 *
+	 * @return a list of the submitted jobs that belong to the provided application.
+	 */
+	List<JobID> run(final DispatcherGateway dispatcherGateway, final PackagedProgram program, final Configuration configuration);
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
@@ -53,10 +53,15 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DetachedApplicationRunner.class);
 
+	private final boolean forbidBlockingJobClient;
+
 	private final boolean enforceSingleJobExecution;
 
-	public DetachedApplicationRunner(final boolean enforceSingleJobExecution) {
+	public DetachedApplicationRunner(
+			final boolean enforceSingleJobExecution,
+			final boolean forbidBlockingJobClient) {
 		this.enforceSingleJobExecution = enforceSingleJobExecution;
+		this.forbidBlockingJobClient = forbidBlockingJobClient;
 	}
 
 	@Override
@@ -75,7 +80,7 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 				new EmbeddedExecutorServiceLoader(applicationJobIds, dispatcherGateway);
 
 		try {
-			ClientUtils.executeProgram(executorServiceLoader, configuration, program, enforceSingleJobExecution);
+			ClientUtils.executeProgram(executorServiceLoader, configuration, program, enforceSingleJobExecution, forbidBlockingJobClient);
 		} catch (ProgramInvocationException e) {
 			LOG.warn("Could not execute application: ", e);
 			throw new FlinkRuntimeException("Could not execute application.", e);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
@@ -38,7 +38,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An {@link ApplicationRunner} which runs the user specified application using the {@link EmbeddedExecutor}.
@@ -63,7 +62,7 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 	}
 
 	private List<JobID> tryExecuteJobs(final DispatcherGateway dispatcherGateway, final PackagedProgram program, final Configuration configuration) {
-		checkState(!configuration.get(DeploymentOptions.ATTACHED));
+		configuration.set(DeploymentOptions.ATTACHED, false);
 
 		final List<JobID> applicationJobIds = new ArrayList<>();
 		final PipelineExecutorServiceLoader executorServiceLoader =

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
@@ -53,6 +53,12 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DetachedApplicationRunner.class);
 
+	private final boolean enforceSingleJobExecution;
+
+	public DetachedApplicationRunner(final boolean enforceSingleJobExecution) {
+		this.enforceSingleJobExecution = enforceSingleJobExecution;
+	}
+
 	@Override
 	public List<JobID> run(final DispatcherGateway dispatcherGateway, final PackagedProgram program, final Configuration configuration) {
 		checkNotNull(dispatcherGateway);
@@ -69,7 +75,7 @@ public class DetachedApplicationRunner implements ApplicationRunner {
 				new EmbeddedExecutorServiceLoader(applicationJobIds, dispatcherGateway);
 
 		try {
-			ClientUtils.executeProgram(executorServiceLoader, configuration, program);
+			ClientUtils.executeProgram(executorServiceLoader, configuration, program, enforceSingleJobExecution);
 		} catch (ProgramInvocationException e) {
 			LOG.warn("Could not execute application: ", e);
 			throw new FlinkRuntimeException("Could not execute application.", e);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/DetachedApplicationRunner.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.client.ClientUtils;
+import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
+import org.apache.flink.client.deployment.application.executors.EmbeddedExecutorServiceLoader;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An {@link ApplicationRunner} which runs the user specified application using the {@link EmbeddedExecutor}.
+ * This runner invokes methods of the provided {@link DispatcherGateway} directly, and it does not go through
+ * the REST API.
+ *
+ * <p>In addition, this runner does not wait for the application to finish, but it submits the
+ * application in a {@code DETACHED} mode. As a consequence, applications with jobs that rely on
+ * operations like {@code [collect, print, printToErr, count]} will fail.
+ */
+@Internal
+public class DetachedApplicationRunner implements ApplicationRunner {
+
+	private static final Logger LOG = LoggerFactory.getLogger(DetachedApplicationRunner.class);
+
+	@Override
+	public List<JobID> run(final DispatcherGateway dispatcherGateway, final PackagedProgram program, final Configuration configuration) {
+		checkNotNull(dispatcherGateway);
+		checkNotNull(program);
+		checkNotNull(configuration);
+		return tryExecuteJobs(dispatcherGateway, program, configuration);
+	}
+
+	private List<JobID> tryExecuteJobs(final DispatcherGateway dispatcherGateway, final PackagedProgram program, final Configuration configuration) {
+		checkState(!configuration.get(DeploymentOptions.ATTACHED));
+
+		final List<JobID> applicationJobIds = new ArrayList<>();
+		final PipelineExecutorServiceLoader executorServiceLoader =
+				new EmbeddedExecutorServiceLoader(applicationJobIds, dispatcherGateway);
+
+		try {
+			ClientUtils.executeProgram(executorServiceLoader, configuration, program);
+		} catch (ProgramInvocationException e) {
+			LOG.warn("Could not execute application: ", e);
+			throw new FlinkRuntimeException("Could not execute application.", e);
+		}
+
+		return applicationJobIds;
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.accumulators.AccumulatorHelper;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.client.ClientUtils;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.function.FunctionWithException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link JobClient} with the ability to also submit jobs which
+ * uses directly the {@link DispatcherGateway}.
+ */
+@Internal
+public class EmbeddedJobClient implements JobClient {
+
+	private static final Logger LOG = LoggerFactory.getLogger(EmbeddedJobClient.class);
+
+	private final JobID jobId;
+
+	private final DispatcherGateway dispatcherGateway;
+
+	private final Time timeout;
+
+	public EmbeddedJobClient(
+			final JobID jobId,
+			final DispatcherGateway dispatcherGateway,
+			final Time rpcTimeout) {
+		this.jobId = checkNotNull(jobId);
+		this.dispatcherGateway = checkNotNull(dispatcherGateway);
+		this.timeout = checkNotNull(rpcTimeout);
+	}
+
+	public CompletableFuture<JobID> submitJob(
+			final FunctionWithException<InetSocketAddress, BlobClient, IOException> blobClientCreator,
+			final JobGraph jobGraph) {
+		checkNotNull(blobClientCreator);
+		checkNotNull(jobGraph);
+
+		LOG.info("Submitting Job with JobId={}.", jobGraph.getJobID());
+
+		return dispatcherGateway
+				.getBlobServerPort(timeout)
+				.thenApply(blobServerPort -> new InetSocketAddress(dispatcherGateway.getHostname(), blobServerPort))
+				.thenCompose(blobServerAddress -> {
+
+					try {
+						ClientUtils.extractAndUploadJobGraphFiles(jobGraph, () -> blobClientCreator.apply(blobServerAddress));
+					} catch (FlinkException e) {
+						throw new CompletionException(e);
+					}
+
+					return dispatcherGateway.submitJob(jobGraph, timeout);
+				}).thenApply(ack -> jobGraph.getJobID());
+	}
+
+	@Override
+	public JobID getJobID() {
+		return jobId;
+	}
+
+	@Override
+	public CompletableFuture<JobStatus> getJobStatus() {
+		return dispatcherGateway.requestJobStatus(jobId, timeout);
+	}
+
+	@Override
+	public CompletableFuture<Void> cancel() {
+		return dispatcherGateway
+				.cancelJob(jobId, timeout)
+				.thenApply(ignores -> null);
+	}
+
+	@Override
+	public CompletableFuture<String> stopWithSavepoint(final boolean advanceToEndOfEventTime, @Nullable final String savepointDirectory) {
+		return dispatcherGateway.stopWithSavepoint(jobId, savepointDirectory, advanceToEndOfEventTime, timeout);
+	}
+
+	@Override
+	public CompletableFuture<String> triggerSavepoint(@Nullable final String savepointDirectory) {
+		return dispatcherGateway.triggerSavepoint(jobId, savepointDirectory, false, timeout);
+	}
+
+	@Override
+	public CompletableFuture<Map<String, Object>> getAccumulators(final ClassLoader classLoader) {
+		checkNotNull(classLoader);
+
+		return dispatcherGateway.requestJob(jobId, timeout)
+				.thenApply(ArchivedExecutionGraph::getAccumulatorsSerialized)
+				.thenApply(accumulators -> {
+					try {
+						return AccumulatorHelper.deserializeAndUnwrapAccumulators(accumulators, classLoader);
+					} catch (Exception e) {
+						throw new CompletionException("Cannot deserialize and unwrap accumulators properly.", e);
+					}
+				});
+	}
+
+	@Override
+	public CompletableFuture<JobExecutionResult> getJobExecutionResult(final ClassLoader userClassloader) {
+		checkNotNull(userClassloader);
+
+		return dispatcherGateway
+				.requestJobResult(jobId, timeout)
+				.thenApply((jobResult) -> {
+					try {
+						return jobResult.toJobExecutionResult(userClassloader);
+					} catch (Throwable t) {
+						throw new CompletionException(
+								new Exception("Job " + jobId + " failed", t));
+					}
+				});
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -28,9 +28,6 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.util.Map;

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.client.deployment.application.EmbeddedJobClient;
+import org.apache.flink.client.deployment.executors.ExecutorUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.WebOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.runtime.blob.BlobClient;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link PipelineExecutor} that invokes directly methods of the
+ * {@link org.apache.flink.runtime.dispatcher.DispatcherGateway Dispatcher} does
+ * not go through the REST API.
+ */
+@Internal
+public class EmbeddedExecutor implements PipelineExecutor {
+
+	private static final Logger LOG = LoggerFactory.getLogger(EmbeddedExecutor.class);
+
+	public static final String NAME = "embedded";
+
+	private final Collection<JobID> applicationJobIds;
+
+	private final DispatcherGateway dispatcherGateway;
+
+	/**
+	 * Creates an {@link EmbeddedExecutor}.
+	 * @param submittedJobIds a list that going to be filled with the job ids of the
+	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
+	 *                        to the caller.
+	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.
+	 */
+	public EmbeddedExecutor(
+			final Collection<JobID> submittedJobIds,
+			final DispatcherGateway dispatcherGateway) {
+		this.applicationJobIds = checkNotNull(submittedJobIds);
+		this.dispatcherGateway = checkNotNull(dispatcherGateway);
+	}
+
+	@Override
+	public CompletableFuture<JobClient> execute(final Pipeline pipeline, final Configuration configuration) {
+		checkNotNull(pipeline);
+		checkNotNull(configuration);
+
+		final JobGraph jobGraph = ExecutorUtils.getJobGraph(pipeline, configuration);
+		final JobID actualJobId = jobGraph.getJobID();
+
+		this.applicationJobIds.add(actualJobId);
+		LOG.info("Job {} is submitted.", actualJobId);
+
+		final EmbeddedJobClient embeddedClient = new EmbeddedJobClient(
+				actualJobId,
+				dispatcherGateway,
+				Time.milliseconds(configuration.getLong(WebOptions.TIMEOUT)));
+
+		return embeddedClient
+				.submitJob(blobServerAddress -> new BlobClient(blobServerAddress, configuration), jobGraph)
+				.thenApplyAsync(jobID -> embeddedClient);
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -64,7 +64,7 @@ public class EmbeddedExecutor implements PipelineExecutor {
 
 	/**
 	 * Creates an {@link EmbeddedExecutor}.
-	 * @param submittedJobIds a list that going to be filled with the job ids of the
+	 * @param submittedJobIds a list that is going to be filled with the job ids of the
 	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
 	 *                        to the caller.
 	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutor.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.deployment.application.EmbeddedJobClient;
-import org.apache.flink.client.deployment.executors.ExecutorUtils;
+import org.apache.flink.client.deployment.executors.PipelineExecutorUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.core.execution.JobClient;
@@ -81,7 +81,7 @@ public class EmbeddedExecutor implements PipelineExecutor {
 		checkNotNull(pipeline);
 		checkNotNull(configuration);
 
-		final JobGraph jobGraph = ExecutorUtils.getJobGraph(pipeline, configuration);
+		final JobGraph jobGraph = PipelineExecutorUtils.getJobGraph(pipeline, configuration);
 		final JobID actualJobId = jobGraph.getJobID();
 
 		this.submittedJobIds.add(actualJobId);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -41,7 +41,7 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 
 	/**
 	 * Creates an {@link EmbeddedExecutorFactory}.
-	 * @param submittedJobIds a list that going to be filled with the job ids of the
+	 * @param submittedJobIds a list that is going to be filled with the job ids of the
 	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
 	 *                        to the caller.
 	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -35,7 +35,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 
-	private final Collection<JobID> applicationJobIds;
+	private final Collection<JobID> submittedJobIds;
 
 	private final DispatcherGateway dispatcherGateway;
 
@@ -49,7 +49,7 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 	public EmbeddedExecutorFactory(
 			final Collection<JobID> submittedJobIds,
 			final DispatcherGateway dispatcherGateway) {
-		this.applicationJobIds = checkNotNull(submittedJobIds);
+		this.submittedJobIds = checkNotNull(submittedJobIds);
 		this.dispatcherGateway = checkNotNull(dispatcherGateway);
 	}
 
@@ -68,6 +68,6 @@ public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
 	@Override
 	public PipelineExecutor getExecutor(final Configuration configuration) {
 		checkNotNull(configuration);
-		return new EmbeddedExecutor(applicationJobIds, dispatcherGateway);
+		return new EmbeddedExecutor(submittedJobIds, dispatcherGateway);
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.PipelineExecutor;
+import org.apache.flink.core.execution.PipelineExecutorFactory;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An {@link PipelineExecutorFactory} for the {@link EmbeddedExecutor}.
+ */
+@Internal
+public class EmbeddedExecutorFactory implements PipelineExecutorFactory {
+
+	private final Collection<JobID> applicationJobIds;
+
+	private final DispatcherGateway dispatcherGateway;
+
+	/**
+	 * Creates an {@link EmbeddedExecutorFactory}.
+	 * @param submittedJobIds a list that going to be filled with the job ids of the
+	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
+	 *                        to the caller.
+	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.
+	 */
+	public EmbeddedExecutorFactory(
+			final Collection<JobID> submittedJobIds,
+			final DispatcherGateway dispatcherGateway) {
+		this.applicationJobIds = checkNotNull(submittedJobIds);
+		this.dispatcherGateway = checkNotNull(dispatcherGateway);
+	}
+
+	@Override
+	public String getName() {
+		return EmbeddedExecutor.NAME;
+	}
+
+	@Override
+	public boolean isCompatibleWith(final Configuration configuration) {
+		// this is always false because we simply have a special executor loader
+		// for this one that does not check for compatibility.
+		return false;
+	}
+
+	@Override
+	public PipelineExecutor getExecutor(final Configuration configuration) {
+		checkNotNull(configuration);
+		return new EmbeddedExecutor(applicationJobIds, dispatcherGateway);
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
@@ -44,7 +44,7 @@ public class EmbeddedExecutorServiceLoader implements PipelineExecutorServiceLoa
 
 	/**
 	 * Creates an {@link EmbeddedExecutorServiceLoader}.
-	 * @param submittedJobIds a list that going to be filled by the {@link EmbeddedExecutor} with the job ids of the
+	 * @param submittedJobIds a list that is going to be filled by the {@link EmbeddedExecutor} with the job ids of the
 	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
 	 *                        to the caller.
 	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.deployment.application.executors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.PipelineExecutorFactory;
+import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link PipelineExecutorServiceLoader} that always returns an {@link EmbeddedExecutorFactory}.
+ * This is useful when running the user's main on the cluster.
+ */
+@Internal
+public class EmbeddedExecutorServiceLoader implements PipelineExecutorServiceLoader {
+
+	private final Collection<JobID> applicationJobIds;
+
+	private final DispatcherGateway dispatcherGateway;
+
+
+	/**
+	 * Creates an {@link EmbeddedExecutorServiceLoader}.
+	 * @param submittedJobIds a list that going to be filled by the {@link EmbeddedExecutor} with the job ids of the
+	 *                        new jobs that will be submitted. This is essentially used to return the submitted job ids
+	 *                        to the caller.
+	 * @param dispatcherGateway the dispatcher of the cluster which is going to be used to submit jobs.
+	 */
+	public EmbeddedExecutorServiceLoader(
+			final Collection<JobID> submittedJobIds,
+			final DispatcherGateway dispatcherGateway) {
+		this.applicationJobIds = checkNotNull(submittedJobIds);
+		this.dispatcherGateway = checkNotNull(dispatcherGateway);
+	}
+
+	@Override
+	public PipelineExecutorFactory getExecutorFactory(final Configuration configuration) {
+		return new EmbeddedExecutorFactory(applicationJobIds, dispatcherGateway);
+	}
+
+	@Override
+	public Stream<String> getExecutorNames() {
+		return Stream.<String>builder().add(EmbeddedExecutor.NAME).build();
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/executors/EmbeddedExecutorServiceLoader.java
@@ -37,7 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class EmbeddedExecutorServiceLoader implements PipelineExecutorServiceLoader {
 
-	private final Collection<JobID> applicationJobIds;
+	private final Collection<JobID> submittedJobIds;
 
 	private final DispatcherGateway dispatcherGateway;
 
@@ -52,13 +52,13 @@ public class EmbeddedExecutorServiceLoader implements PipelineExecutorServiceLoa
 	public EmbeddedExecutorServiceLoader(
 			final Collection<JobID> submittedJobIds,
 			final DispatcherGateway dispatcherGateway) {
-		this.applicationJobIds = checkNotNull(submittedJobIds);
+		this.submittedJobIds = checkNotNull(submittedJobIds);
 		this.dispatcherGateway = checkNotNull(dispatcherGateway);
 	}
 
 	@Override
 	public PipelineExecutorFactory getExecutorFactory(final Configuration configuration) {
-		return new EmbeddedExecutorFactory(applicationJobIds, dispatcherGateway);
+		return new EmbeddedExecutorFactory(submittedJobIds, dispatcherGateway);
 	}
 
 	@Override

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractJobClusterExecutor.java
@@ -59,7 +59,7 @@ public class AbstractJobClusterExecutor<ClusterID, ClientFactory extends Cluster
 
 	@Override
 	public CompletableFuture<JobClient> execute(@Nonnull final Pipeline pipeline, @Nonnull final Configuration configuration) throws Exception {
-		final JobGraph jobGraph = ExecutorUtils.getJobGraph(pipeline, configuration);
+		final JobGraph jobGraph = PipelineExecutorUtils.getJobGraph(pipeline, configuration);
 
 		try (final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(configuration)) {
 			final ExecutionConfigAccessor configAccessor = ExecutionConfigAccessor.fromConfiguration(configuration);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/AbstractSessionClusterExecutor.java
@@ -54,7 +54,7 @@ public class AbstractSessionClusterExecutor<ClusterID, ClientFactory extends Clu
 
 	@Override
 	public CompletableFuture<JobClient> execute(@Nonnull final Pipeline pipeline, @Nonnull final Configuration configuration) throws Exception {
-		final JobGraph jobGraph = ExecutorUtils.getJobGraph(pipeline, configuration);
+		final JobGraph jobGraph = PipelineExecutorUtils.getJobGraph(pipeline, configuration);
 
 		try (final ClusterDescriptor<ClusterID> clusterDescriptor = clusterClientFactory.createClusterDescriptor(configuration)) {
 			final ClusterID clusterID = clusterClientFactory.getClusterId(configuration);

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/ExecutorUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/ExecutorUtils.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.client.deployment.executors;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.client.cli.ExecutionConfigAccessor;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 
 import javax.annotation.Nonnull;
@@ -49,6 +51,10 @@ public class ExecutorUtils {
 		final ExecutionConfigAccessor executionConfigAccessor = ExecutionConfigAccessor.fromConfiguration(configuration);
 		final JobGraph jobGraph = FlinkPipelineTranslationUtil
 				.getJobGraph(pipeline, configuration, executionConfigAccessor.getParallelism());
+
+		configuration
+				.getOptional(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID)
+				.ifPresent(strJobID -> jobGraph.setJobID(JobID.fromHexString(strJobID)));
 
 		jobGraph.addJars(executionConfigAccessor.getJars());
 		jobGraph.setClasspaths(executionConfigAccessor.getClasspaths());

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/PipelineExecutorUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/PipelineExecutorUtils.java
@@ -33,7 +33,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Utility class with method related to job execution.
  */
-public class ExecutorUtils {
+public class PipelineExecutorUtils {
 
 	/**
 	 * Creates the {@link JobGraph} corresponding to the provided {@link Pipeline}.

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptionsInternal.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptionsInternal.java
@@ -16,23 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.webmonitor.testutils;
+package org.apache.flink.configuration;
 
-import org.apache.flink.api.java.ExecutionEnvironment;
-import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.annotation.Internal;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
 
 /**
- * Simple test program that exposes passed arguments.
+ * Pipeline options that are not meant to be used by the user.
  */
-public class ParameterProgram {
+@Internal
+public class PipelineOptionsInternal {
 
-	public static volatile String[] actualArguments = null;
-
-	public static void main(String[] args) throws Exception {
-		actualArguments = args;
-
-		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.fromElements("hello", "world").output(new DiscardingOutputFormat<>());
-		env.execute();
-	}
+	public static final ConfigOption<String> PIPELINE_FIXED_JOB_ID =
+			key("$internal.pipeline.job-id")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("**DO NOT USE** The static JobId to be used for the specific pipeline. " +
+							"For fault-tolerance, this value needs to stay the same across runs.");
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.webmonitor;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.deployment.application.DetachedApplicationRunner;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
@@ -88,7 +89,8 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			JarRunHeaders.getInstance(),
 			jarDir,
 			configuration,
-			executor);
+			executor,
+			DetachedApplicationRunner::new);
 
 		final JarDeleteHandler jarDeleteHandler = new JarDeleteHandler(
 			leaderRetriever,

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -90,7 +90,7 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			jarDir,
 			configuration,
 			executor,
-			() -> new DetachedApplicationRunner(true));
+			() -> new DetachedApplicationRunner(true, true));
 
 		final JarDeleteHandler jarDeleteHandler = new JarDeleteHandler(
 			leaderRetriever,

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -90,7 +90,7 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 			jarDir,
 			configuration,
 			executor,
-			DetachedApplicationRunner::new);
+			() -> new DetachedApplicationRunner(true));
 
 		final JarDeleteHandler jarDeleteHandler = new JarDeleteHandler(
 			leaderRetriever,

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -19,29 +19,29 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.deployment.application.ApplicationRunner;
+import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.blob.BlobClient;
-import org.apache.flink.runtime.client.ClientUtils;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
-import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.utils.JarHandlerUtils.JarHandlerContext;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nonnull;
 
-import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.flink.runtime.rest.handler.util.HandlerRequestUtils.fromRequestBodyOrQueryParameter;
@@ -58,6 +58,8 @@ public class JarRunHandler extends
 
 	private final Configuration configuration;
 
+	private final ApplicationRunner applicationRunner;
+
 	private final Executor executor;
 
 	public JarRunHandler(
@@ -67,41 +69,40 @@ public class JarRunHandler extends
 			final MessageHeaders<JarRunRequestBody, JarRunResponseBody, JarRunMessageParameters> messageHeaders,
 			final Path jarDir,
 			final Configuration configuration,
-			final Executor executor) {
+			final Executor executor,
+			final Supplier<ApplicationRunner> applicationRunnerSupplier) {
 		super(leaderRetriever, timeout, responseHeaders, messageHeaders);
 
 		this.jarDir = requireNonNull(jarDir);
 		this.configuration = requireNonNull(configuration);
 		this.executor = requireNonNull(executor);
+
+		this.applicationRunner = applicationRunnerSupplier.get();
 	}
 
 	@Override
 	protected CompletableFuture<JarRunResponseBody> handleRequest(
 			@Nonnull final HandlerRequest<JarRunRequestBody, JarRunMessageParameters> request,
 			@Nonnull final DispatcherGateway gateway) throws RestHandlerException {
+
+		final Configuration effectiveConfiguration = new Configuration(configuration);
+		effectiveConfiguration.set(DeploymentOptions.ATTACHED, false);
+		effectiveConfiguration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
+
 		final JarHandlerContext context = JarHandlerContext.fromRequest(request, jarDir, log);
+		context.applyToConfiguration(effectiveConfiguration);
+		SavepointRestoreSettings.toConfiguration(getSavepointRestoreSettings(request), effectiveConfiguration);
 
-		final SavepointRestoreSettings savepointRestoreSettings = getSavepointRestoreSettings(request);
+		final PackagedProgram program = context.toPackagedProgram(effectiveConfiguration);
 
-		final CompletableFuture<JobGraph> jobGraphFuture = getJobGraphAsync(context, savepointRestoreSettings);
-
-		CompletableFuture<Integer> blobServerPortFuture = gateway.getBlobServerPort(timeout);
-
-		CompletableFuture<JobGraph> jarUploadFuture = jobGraphFuture.thenCombine(blobServerPortFuture, (jobGraph, blobServerPort) -> {
-			final InetSocketAddress address = new InetSocketAddress(gateway.getHostname(), blobServerPort);
-			try {
-				ClientUtils.extractAndUploadJobGraphFiles(jobGraph, () -> new BlobClient(address, configuration));
-			} catch (FlinkException e) {
-				throw new CompletionException(e);
-			}
-
-			return jobGraph;
-		});
-
-		CompletableFuture<Acknowledge> jobSubmissionFuture = jarUploadFuture.thenCompose(jobGraph -> gateway.submitJob(jobGraph, timeout));
-
-		return jobSubmissionFuture
-			.thenCombine(jarUploadFuture, (ack, jobGraph) -> new JarRunResponseBody(jobGraph.getJobID()));
+		return CompletableFuture
+				.supplyAsync(() -> applicationRunner.run(gateway, program, effectiveConfiguration), executor)
+				.thenApply(jobIds -> {
+					if (jobIds.isEmpty()) {
+						throw new CompletionException(new ProgramInvocationException("No jobs submitted."));
+					}
+					return new JarRunResponseBody(jobIds.get(0));
+				});
 	}
 
 	private SavepointRestoreSettings getSavepointRestoreSettings(
@@ -129,15 +130,5 @@ public class JarRunHandler extends
 			savepointRestoreSettings = SavepointRestoreSettings.none();
 		}
 		return savepointRestoreSettings;
-	}
-
-	private CompletableFuture<JobGraph> getJobGraphAsync(
-			JarHandlerContext context,
-			final SavepointRestoreSettings savepointRestoreSettings) {
-		return CompletableFuture.supplyAsync(() -> {
-			final JobGraph jobGraph = context.toJobGraph(configuration, false);
-			jobGraph.setSavepointRestoreSettings(savepointRestoreSettings);
-			return jobGraph;
-		}, executor);
 	}
 }

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/utils/JarHandlerUtils.java
@@ -19,12 +19,15 @@
 package org.apache.flink.runtime.webmonitor.handlers.utils;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.client.program.ProgramInvocationException;
+import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
@@ -43,6 +46,7 @@ import org.slf4j.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -55,6 +59,7 @@ import java.util.regex.Pattern;
 import static org.apache.flink.runtime.rest.handler.util.HandlerRequestUtils.fromRequestBodyOrQueryParameter;
 import static org.apache.flink.runtime.rest.handler.util.HandlerRequestUtils.getQueryParameter;
 import static org.apache.flink.shaded.guava18.com.google.common.base.Strings.emptyToNull;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Utils for jar handlers.
@@ -100,7 +105,7 @@ public class JarHandlerUtils {
 			int parallelism = fromRequestBodyOrQueryParameter(
 				requestBody.getParallelism(),
 				() -> getQueryParameter(request, ParallelismQueryParameter.class),
-				ExecutionConfig.PARALLELISM_DEFAULT,
+				CoreOptions.DEFAULT_PARALLELISM.defaultValue(),
 				log);
 
 			JobID jobId = fromRequestBodyOrQueryParameter(
@@ -112,20 +117,43 @@ public class JarHandlerUtils {
 			return new JarHandlerContext(jarFile, entryClass, programArgs, parallelism, jobId);
 		}
 
+		public void applyToConfiguration(final Configuration configuration) {
+			checkNotNull(configuration);
+
+			if (jobId != null) {
+				configuration.set(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID, jobId.toHexString());
+			}
+			configuration.set(CoreOptions.DEFAULT_PARALLELISM, parallelism);
+
+			final PackagedProgram program = toPackagedProgram(configuration);
+			ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, program.getJobJarAndDependencies(), URL::toString);
+			ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, program.getClasspaths(), URL::toString);
+		}
+
 		public JobGraph toJobGraph(Configuration configuration, boolean suppressOutput) {
+			try {
+				final PackagedProgram packagedProgram = toPackagedProgram(configuration);
+				return PackagedProgramUtils.createJobGraph(packagedProgram, configuration, parallelism, jobId, suppressOutput);
+			} catch (final ProgramInvocationException e) {
+				throw new CompletionException(e);
+			}
+		}
+
+		public PackagedProgram toPackagedProgram(Configuration configuration) {
+			checkNotNull(configuration);
+
 			if (!Files.exists(jarFile)) {
 				throw new CompletionException(new RestHandlerException(
-					String.format("Jar file %s does not exist", jarFile), HttpResponseStatus.BAD_REQUEST));
+						String.format("Jar file %s does not exist", jarFile), HttpResponseStatus.BAD_REQUEST));
 			}
 
 			try {
-				final PackagedProgram packagedProgram = PackagedProgram.newBuilder()
-					.setJarFile(jarFile.toFile())
-					.setEntryPointClassName(entryClass)
-					.setConfiguration(configuration)
-					.setArguments(programArgs.toArray(new String[0]))
-					.build();
-				return PackagedProgramUtils.createJobGraph(packagedProgram, configuration, parallelism, jobId, suppressOutput);
+				return PackagedProgram.newBuilder()
+						.setJarFile(jarFile.toFile())
+						.setEntryPointClassName(entryClass)
+						.setConfiguration(configuration)
+						.setArguments(programArgs.toArray(new String[0]))
+						.build();
 			} catch (final ProgramInvocationException e) {
 				throw new CompletionException(e);
 			}

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerTest.java
@@ -49,22 +49,12 @@ public class JarHandlerTest extends TestLogger {
 	@ClassRule
 	public static final TemporaryFolder TMP = new TemporaryFolder();
 
-	enum Type {
-		PLAN,
-		RUN
-	}
-
 	@Test
 	public void testPlanJar() throws Exception {
-		runTest(Type.PLAN, "hello out!", "hello err!");
+		runTest("hello out!", "hello err!");
 	}
 
-	@Test
-	public void testRunJar() throws Exception {
-		runTest(Type.RUN, "(none)", "(none)");
-	}
-
-	private static void runTest(Type type, String expectedCapturedStdOut, String expectedCapturedStdErr) throws Exception {
+	private static void runTest(String expectedCapturedStdOut, String expectedCapturedStdErr) throws Exception {
 		final TestingDispatcherGateway restfulGateway = new TestingDispatcherGateway.Builder().build();
 
 		final JarHandlers handlers = new JarHandlers(TMP.newFolder().toPath(), restfulGateway);
@@ -76,13 +66,7 @@ public class JarHandlerTest extends TestLogger {
 		final String storedJarName = Paths.get(storedJarPath).getFileName().toString();
 
 		try {
-			switch (type) {
-				case RUN:
-					JarHandlers.runJar(handlers.runHandler, storedJarName, restfulGateway);
-					break;
-				case PLAN:
-					JarHandlers.showPlan(handlers.planHandler, storedJarName, restfulGateway);
-			}
+			JarHandlers.showPlan(handlers.planHandler, storedJarName, restfulGateway);
 			Assert.fail("Should have failed with an exception.");
 		} catch (Exception e) {
 			Optional<ProgramInvocationException> expected = ExceptionUtils.findThrowable(e, ProgramInvocationException.class);

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.deployment.application.DetachedApplicationRunner;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -86,7 +87,8 @@ public class JarHandlers {
 			JarRunHeaders.getInstance(),
 			jarDir,
 			new Configuration(),
-			executor);
+			executor,
+			DetachedApplicationRunner::new);
 
 		deleteHandler = new JarDeleteHandler(
 			gatewayRetriever,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -88,7 +88,7 @@ public class JarHandlers {
 			jarDir,
 			new Configuration(),
 			executor,
-			() -> new DetachedApplicationRunner(true));
+			() -> new DetachedApplicationRunner(true, true));
 
 		deleteHandler = new JarDeleteHandler(
 			gatewayRetriever,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlers.java
@@ -88,7 +88,7 @@ public class JarHandlers {
 			jarDir,
 			new Configuration(),
 			executor,
-			DetachedApplicationRunner::new);
+			() -> new DetachedApplicationRunner(true));
 
 		deleteHandler = new JarDeleteHandler(
 			gatewayRetriever,

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -78,6 +78,10 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 
 	private static class ConfigurationVerifyingDetachedApplicationRunner extends DetachedApplicationRunner {
 
+		public ConfigurationVerifyingDetachedApplicationRunner() {
+			super(true);
+		}
+
 		@Override
 		public List<JobID> run(DispatcherGateway dispatcherGateway, PackagedProgram program, Configuration configuration) {
 			assertFalse(configuration.get(DeploymentOptions.ATTACHED));

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -20,7 +20,12 @@ package org.apache.flink.runtime.webmonitor.handlers;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.deployment.application.DetachedApplicationRunner;
+import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
+import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
@@ -39,6 +44,9 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests for the parameter handling of the {@link JarRunHandler}.
@@ -64,7 +72,18 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 			JarRunHeaders.getInstance(),
 			jarDir,
 			new Configuration(),
-			executor);
+			executor,
+			ConfigurationVerifyingDetachedApplicationRunner::new);
+	}
+
+	private static class ConfigurationVerifyingDetachedApplicationRunner extends DetachedApplicationRunner {
+
+		@Override
+		public List<JobID> run(DispatcherGateway dispatcherGateway, PackagedProgram program, Configuration configuration) {
+			assertFalse(configuration.get(DeploymentOptions.ATTACHED));
+			assertEquals(EmbeddedExecutor.NAME, configuration.get(DeploymentOptions.TARGET));
+			return super.run(dispatcherGateway, program, configuration);
+		}
 	}
 
 	@Override
@@ -143,7 +162,7 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 	JobGraph validateDefaultGraph() {
 		JobGraph jobGraph = super.validateDefaultGraph();
 		final SavepointRestoreSettings savepointRestoreSettings = jobGraph.getSavepointRestoreSettings();
-		Assert.assertFalse(savepointRestoreSettings.allowNonRestoredState());
+		assertFalse(savepointRestoreSettings.allowNonRestoredState());
 		Assert.assertNull(savepointRestoreSettings.getRestorePath());
 		return jobGraph;
 	}
@@ -153,7 +172,7 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 		JobGraph jobGraph = super.validateGraph();
 		final SavepointRestoreSettings savepointRestoreSettings = jobGraph.getSavepointRestoreSettings();
 		Assert.assertTrue(savepointRestoreSettings.allowNonRestoredState());
-		Assert.assertEquals(RESTORE_PATH, savepointRestoreSettings.getRestorePath());
+		assertEquals(RESTORE_PATH, savepointRestoreSettings.getRestorePath());
 		return jobGraph;
 	}
 }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerParameterTest.java
@@ -79,7 +79,7 @@ public class JarRunHandlerParameterTest extends JarHandlerParameterTest<JarRunRe
 	private static class ConfigurationVerifyingDetachedApplicationRunner extends DetachedApplicationRunner {
 
 		public ConfigurationVerifyingDetachedApplicationRunner() {
-			super(true);
+			super(true, true);
 		}
 
 		@Override

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarSubmissionITCase.java
@@ -88,7 +88,7 @@ public class JarSubmissionITCase extends TestLogger {
 
 		final JobPlanInfo planResponse = showPlan(planHandler, storedJarName, restfulGateway);
 		// we're only interested in the core functionality so checking for a small detail is sufficient
-		Assert.assertThat(planResponse.getJsonPlan(), containsString("TestProgram.java:29"));
+		Assert.assertThat(planResponse.getJsonPlan(), containsString("TestProgram.java:30"));
 
 		runJar(runHandler, storedJarName, restfulGateway);
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/TestProgram.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/utils/TestProgram.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.webmonitor.handlers.utils;
 
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.DiscardingOutputFormat;
 
 /**
  * Simple test program.
@@ -26,6 +27,7 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 public class TestProgram {
 	public static void main(String[] args) throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
-		env.fromElements("hello", "world").print();
+		env.fromElements("hello", "world").output(new DiscardingOutputFormat<>());
+		env.execute();
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

The `EmbeddedExecutor` is part of the [FLIP-85](https://cwiki.apache.org/confluence/display/FLINK/FLIP-85+Flink+Application+Mode) effort,  which aims at giving the user the option of running his/her `main` method on the cluster, rather than the client. 

Running the user's main method in "Application Mode" implies:
1) launching a dedicated cluster for the application's jobs
2) running the user's main on the cluster, alongside the Dispatcher

The `EmbeddedExecutor` is an `Executor` which is assumed to run alongside the `Dispatcher` of the cluster, on the same machine.  Conceptually, it is like the existing `Executors` for session clusters, with the difference that this time there is no need to go through REST as this will be running already on the same machine as the Dispatcher.

Given that the Web Submission already runs the user's `main` on the cluster, this PR apart from introducing the `EmbeddedExecutor`, it also wires it to the `JarRunHandler` so that:
1) we can test the executor already
2) we get (partially for now) rid of the pattern of throwing `ProgramAbortException` in order to extract the `JobGraph`. 

## Brief change log

See the description above.
It introduces the `EmbeddedExecutor` with a custom `PipelineExecutorLoader` which is only aware of this executor and is used in the `JarRunHandler`. 

The handler now, instead of extracting the `JobGraph` itself and submitting to the `Dispatcher`, now it executes the user's main method and let's the new executor do the job graph extraction and submission. 

To not block any threads on the web frontend, we launch the job in `detached` mode, which is reasonable, as web submission is expected to be a "fire-and-forget" action, and also it is compatible with the current behaviour which does not return the results of operations like `collect()`, `count()` or `print()`. 

The only difference compared to before is that now, a job with a `print()` will throw an exception (as is the case for detached submission from the CLI), rather than execute the job and silently return nothing.

## Verifying this change

It was tested manually on Yarn and local cluster and also it is tested through the updated tests for the `JarRunHandler`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
