### PR TITLE
[FLINK-16092][docs-zh] Translate dev/table/functions/index.zh.md into Chinese

### DIFF
--- a/docs/dev/table/functions/index.zh.md
+++ b/docs/dev/table/functions/index.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "Functions"
+title: "函数"
 nav-id: table_functions
 nav-parent_id: tableapi
 nav-pos: 60
@@ -24,74 +24,74 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Flink Table API & SQL empowers users to do data transformations with functions.
+Flink 允许用户在 Table API 和 SQL 中使用函数进行数据的转换。
 
 * This will be replaced by the TOC
 {:toc}
 
-Types of Functions
+函数类型
 ------------------
 
-There are two dimensions to classify functions in Flink.
+Flink 中的函数有两个划分标准。
 
-One dimension is system (or built-in) functions v.s. catalog functions. System functions have no namespace and can be
-referenced with just their names. Catalog functions belong to a catalog and database therefore they have catalog and database
-namespaces, they can be referenced by either fully/partially qualified name (`catalog.db.func` or `db.func`) or just the
-function name.
+一个划分标准是：系统（内置）函数和 Catalog 函数。系统函数没有名称空间，只能通过其名称来进行引用。
+Catalog 函数属于 Catalog 和数据库，因此它们拥有 Catalog 和数据库命名空间。
+用户可以通过全/部分限定名（`catalog.db.func` 或 `db.func`）或者函数名
+来对 Catalog 函数进行引用。
 
-The other dimension is temporary functions v.s. persistent functions. Temporary functions are volatile and only live up to
- lifespan of a session, they are always created by users. Persistent functions live across lifespan of sessions, they are either
- provided by the system or persisted in catalogs.
- 
-The two dimensions give Flink users 4 categories of functions:
+另一个划分标准是：临时函数和持久化函数。
+临时函数始终由用户创建，它容易改变并且仅在会话的生命周期内有效。
+持久化函数不是由系统提供，就是存储在 Catalog 中，它在会话的整个生命周期内都有效。
 
-1. Temporary system functions
-2. System functions
-3. Temporary catalog functions
-4. Catalog functions
+这两个划分标准给 Flink 用户提供了 4 种函数：
 
-Note that system functions always precede catalog's, and temporary functions always precede persistent on their own dimension
-in function resolution order explained below.
+1. 临时性系统函数
+2. 系统函数  
+3. 临时性 Catalog 函数
+4. Catalog 函数
 
-Referencing Functions
+请注意，系统函数始终优先于 Catalog 函数解析，临时函数始终优先于持久化函数解析，
+函数解析优先级如下所述。
+
+函数引用
 ---------------------
 
-There are two ways users can reference a function in Flink - referencing function precisely or ambiguously.
+用户在 Flink 中可以通过精确、模糊两种引用方式引用函数。
 
-## Precise Function Reference
+### 精确函数引用
 
-Precise function reference empowers users to use catalog functions specifically, and across catalog and across database, 
-e.g. `select mycatalog.mydb.myfunc(x) from mytable` and `select mydb.myfunc(x) from mytable`.
+精确函数引用允许用户跨 Catalog，跨数据库调用 Catalog 函数。
+例如：`select mycatalog.mydb.myfunc(x) from mytable` 和 `select mydb.myfunc(x) from mytable`。
 
-This is only supported starting from Flink 1.10.
+仅 Flink 1.10 以上版本支持。 
 
-## Ambiguous Function Reference
+### 模糊函数引用
 
-In ambiguous function reference, users just specify the function's name in SQL query, e.g. `select myfunc(x) from mytable`.
+在模糊函数引用中，用户只需在 SQL 查询中指定函数名，例如： `select myfunc(x) from mytable`。
 
 
-Function Resolution Order
+函数解析顺序
 -------------------------
 
-The resolution order only matters when there are functions of different types but the same name, 
-e.g. when there’re three functions all named “myfunc” but are of temporary catalog, catalog, and system function respectively. 
-If there’s no function name collision, functions will just be resolved to the sole one.
+当函数名相同，函数类型不同时，函数解析顺序才有意义。
+例如：当有三个都名为 "myfunc" 的临时性 Catalog 函数，Catalog 函数，和系统函数时，
+如果没有命名冲突，三个函数将会被解析为一个函数。
 
-## Precise Function Reference
+### 精确函数引用
 
-Because system functions don’t have namespaces, a precise function reference in Flink must be pointing to either a temporary catalog 
-function or a catalog function.
+由于系统函数没有命名空间，Flink 中的精确函数引用必须
+指向临时性 Catalog 函数或 Catalog 函数。
 
-The resolution order is:
+解析顺序如下：
 
-1. Temporary catalog function
-2. Catalog function
+1. 临时性 catalog 函数
+2. Catalog 函数
 
-## Ambiguous Function Reference
+### 模糊函数引用
 
-The resolution order is:
+解析顺序如下：
 
-1. Temporary system function
-2. System function
-3. Temporary catalog function, in the current catalog and current database of the session
-4. Catalog function, in the current catalog and current database of the session
+1. 临时性系统函数
+2. 系统函数
+3. 临时性 Catalog 函数, 在会话的当前 Catalog 和当前数据库中
+4. Catalog 函数, 在会话的当前 Catalog 和当前数据库中


### PR DESCRIPTION


## What is the purpose of the change

This pull request translates the overview part of the function document into Chinese.


## Brief change log

  - Translate docs/dev/table/functions/index.zh.md into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  no 
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
