### PR TITLE
[FLINK-16691][python][doc] Improve Python UDF documentation to remind users to install PyFlink on the cluster

### DIFF
--- a/docs/dev/table/python/python_udfs.md
+++ b/docs/dev/table/python/python_udfs.md
@@ -24,6 +24,9 @@ under the License.
 
 User-defined functions are important features, because they significantly extend the expressiveness of Python Table API programs.
 
+**NOTE:** 
+Python UDF execution requires Python3.5+ environment with PyFlink installed. Not only for client but also for cluster. 
+
 * This will be replaced by the TOC
 {:toc}
 

--- a/docs/dev/table/python/python_udfs.zh.md
+++ b/docs/dev/table/python/python_udfs.zh.md
@@ -24,6 +24,9 @@ under the License.
 
 User-defined functions are important features, because they significantly extend the expressiveness of Python Table API programs.
 
+**NOTE:** 
+Python UDF execution requires Python3.5+ environment with PyFlink installed. Not only for client but also for cluster.
+
 * This will be replaced by the TOC
 {:toc}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will adjust Python UDF document to remind users to install PyFlink on the cluster*


## Brief change log

  - *Add Note to remind users to install PyFlink on the cluster in doc python_udfs.md and python_udfs.zh.md*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
