### PR TITLE
[FLINK-16629] Ignore Streaming bucketing end-to-end test with Hadoop 2.4.1

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -150,7 +150,8 @@ run_test "DataSet allround end-to-end test" "$END_TO_END_DIR/test-scripts/test_b
 run_test "Batch SQL end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_sql.sh"
 run_test "Streaming SQL end-to-end test (Old planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh old" "skip_check_exceptions"
 run_test "Streaming SQL end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_streaming_sql.sh blink" "skip_check_exceptions"
-if [[ $PROFILE == *"include-hadoop"* ]]; then
+# skip test if hadoop version is 2.4.1 (FLINK-16629)
+if [[ $PROFILE == *"include-hadoop"* && $PROFILE != *"hadoop.version=2.4.1"* ]]; then
 	run_test "Streaming bucketing end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_bucketing.sh" "skip_check_exceptions"
 fi
 run_test "Streaming File Sink end-to-end test" "$END_TO_END_DIR/test-scripts/test_streaming_file_sink.sh" "skip_check_exceptions"


### PR DESCRIPTION
## What is the purpose of the change

The stream bucketing end to end test does not work on Hadoop 2.4.1 because it is lacking the `truncate()` method of Hadoop --> We need to exclude it.




## Verifying this change

Validated here: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=208&view=logs&j=1f3ed471-1849-5d3c-a34c-19792af4ad16


