### PR TITLE
[FLINK-16399]Timing the data cached by ExecutionGraphCache

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/legacy/ExecutionGraphCache.java
@@ -28,8 +28,8 @@ import org.apache.flink.util.Preconditions;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 


### PR DESCRIPTION
## What is the purpose of the change
fix [https://issues.apache.org/jira/browse/FLINK-16399](https://issues.apache.org/jira/browse/FLINK-16399)

## Brief change log
Clear the ExecutionGraphCache cache periodically with a separate thread

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (no)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
- The serializers: (no)
- The runtime per-record code paths (performance sensitive): (no)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, - - Yarn/Mesos, ZooKeeper: (no)
- The S3 file system connector: (no)