### PR TITLE
[FLINK-16317][operators] Provide support for watermarks, key selector and latency marker in MultipleInputStreamOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/MultipleConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/MultipleConnectedStreams.java
@@ -20,7 +20,7 @@ package org.apache.flink.streaming.api.datastream;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
-import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
+import org.apache.flink.streaming.api.transformations.AbstractMultipleInputTransformation;
 
 import static java.util.Objects.requireNonNull;
 
@@ -41,7 +41,7 @@ public class MultipleConnectedStreams {
 		return environment;
 	}
 
-	public <OUT> SingleOutputStreamOperator<OUT> transform(MultipleInputTransformation<OUT> transform) {
+	public <OUT> SingleOutputStreamOperator<OUT> transform(AbstractMultipleInputTransformation<OUT> transform) {
 		return new SingleOutputStreamOperator<>(environment, transform);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -592,14 +592,19 @@ public class StreamGraph implements Pipeline {
 
 	public void setOneInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector, TypeSerializer<?> keySerializer) {
 		StreamNode node = getStreamNode(vertexID);
-		node.setStatePartitioner1(keySelector);
+		node.setStatePartitioners(keySelector);
 		node.setStateKeySerializer(keySerializer);
 	}
 
 	public void setTwoInputStateKey(Integer vertexID, KeySelector<?, ?> keySelector1, KeySelector<?, ?> keySelector2, TypeSerializer<?> keySerializer) {
 		StreamNode node = getStreamNode(vertexID);
-		node.setStatePartitioner1(keySelector1);
-		node.setStatePartitioner2(keySelector2);
+		node.setStatePartitioners(keySelector1, keySelector2);
+		node.setStateKeySerializer(keySerializer);
+	}
+
+	public void setMultipleInputStateKey(Integer vertexID, List<KeySelector<?, ?>> keySelectors, TypeSerializer<?> keySerializer) {
+		StreamNode node = getStreamNode(vertexID);
+		node.setStatePartitioners(keySelectors.stream().toArray(KeySelector[]::new));
 		node.setStateKeySerializer(keySerializer);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -61,8 +61,7 @@ public class StreamNode implements Serializable {
 	private final String operatorName;
 	private @Nullable String slotSharingGroup;
 	private @Nullable String coLocationGroup;
-	private KeySelector<?, ?> statePartitioner1;
-	private KeySelector<?, ?> statePartitioner2;
+	private KeySelector<?, ?>[] statePartitioners = new KeySelector[0];
 	private TypeSerializer<?> stateKeySerializer;
 
 	private transient StreamOperatorFactory<?> operatorFactory;
@@ -304,20 +303,13 @@ public class StreamNode implements Serializable {
 		return operatorName + "-" + id;
 	}
 
-	public KeySelector<?, ?> getStatePartitioner1() {
-		return statePartitioner1;
+	public KeySelector<?, ?>[] getStatePartitioners() {
+		return statePartitioners;
 	}
 
-	public KeySelector<?, ?> getStatePartitioner2() {
-		return statePartitioner2;
-	}
-
-	public void setStatePartitioner1(KeySelector<?, ?> statePartitioner) {
-		this.statePartitioner1 = statePartitioner;
-	}
-
-	public void setStatePartitioner2(KeySelector<?, ?> statePartitioner) {
-		this.statePartitioner2 = statePartitioner;
+	public void setStatePartitioners(KeySelector<?, ?> ...statePartitioners) {
+		checkArgument(statePartitioners.length > 0);
+		this.statePartitioners = statePartitioners;
 	}
 
 	public TypeSerializer<?> getStateKeySerializer() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -524,8 +524,9 @@ public class StreamingJobGraphGenerator {
 			// so we use that one if checkpointing is not enabled
 			config.setCheckpointMode(CheckpointingMode.AT_LEAST_ONCE);
 		}
-		config.setStatePartitioner(0, vertex.getStatePartitioner1());
-		config.setStatePartitioner(1, vertex.getStatePartitioner2());
+		for (int i = 0; i < vertex.getStatePartitioners().length; i++) {
+			config.setStatePartitioner(i, vertex.getStatePartitioners()[i]);
+		}
 		config.setStateKeySerializer(vertex.getStateKeySerializer());
 
 		Class<? extends AbstractInvokable> vertexClass = vertex.getJobVertexClass();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractInput.java
@@ -19,8 +19,12 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import javax.annotation.Nullable;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -30,6 +34,14 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 @Experimental
 public abstract class AbstractInput<IN, OUT> implements Input<IN> {
+	/**
+	 * {@code KeySelector} for extracting a key from an element being processed. This is used to
+	 * scope keyed state to a key. This is null if the operator is not a keyed operator.
+	 *
+	 * <p>This is for elements from the first input.
+	 */
+	@Nullable
+	protected final KeySelector<?, ?> stateKeySelector;
 	protected final AbstractStreamOperatorV2<OUT> owner;
 	protected final int inputId;
 	protected final Output<StreamRecord<OUT>> output;
@@ -38,11 +50,22 @@ public abstract class AbstractInput<IN, OUT> implements Input<IN> {
 		checkArgument(inputId > 0, "Inputs are index from 1");
 		this.owner = owner;
 		this.inputId = inputId;
+		this.stateKeySelector = owner.config.getStatePartitioner(inputId - 1, owner.getUserCodeClassloader());
 		this.output = owner.output;
 	}
 
 	@Override
 	public void processWatermark(Watermark mark) throws Exception {
 		owner.reportWatermark(mark, inputId);
+	}
+
+	@Override
+	public void processLatencyMarker(LatencyMarker latencyMarker) throws Exception {
+		owner.reportOrForwardLatencyMarker(latencyMarker);
+	}
+
+	@Override
+	public void setKeyContextElement(StreamRecord record) throws Exception {
+		owner.internalSetKeyContextElement(record, stateKeySelector);
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2.java
@@ -465,7 +465,7 @@ public abstract class AbstractStreamOperatorV2<OUT> implements StreamOperator<OU
 	}
 
 	protected void reportWatermark(Watermark mark, int inputId) throws Exception {
-		inputWatermarks[inputId] = mark.getTimestamp();
+		inputWatermarks[inputId - 1] = mark.getTimestamp();
 		long newMin = mark.getTimestamp();
 		for (long inputWatermark : inputWatermarks) {
 			newMin = Math.min(inputWatermark, newMin);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/Input.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 
 /**
@@ -40,4 +41,14 @@ public interface Input<IN> {
 	 * @see org.apache.flink.streaming.api.watermark.Watermark
 	 */
 	void processWatermark(Watermark mark) throws Exception;
+
+	/**
+	 * Processes a {@link LatencyMarker} that arrived on the first input of this two-input operator.
+	 * This method is guaranteed to not be called concurrently with other methods of the operator.
+	 *
+	 * @see org.apache.flink.streaming.runtime.streamrecord.LatencyMarker
+	 */
+	void processLatencyMarker(LatencyMarker latencyMarker) throws Exception;
+
+	void setKeyContextElement(StreamRecord<IN> record) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Base class for transformations representing the application of a
+ * {@link org.apache.flink.streaming.api.operators.MultipleInputStreamOperator}
+ * to input {@code Transformations}. The result is again only one stream.
+ *
+ * @param <OUT> The type of the elements that result from this {@code MultipleInputTransformation}
+ */
+@Internal
+public abstract class AbstractMultipleInputTransformation<OUT> extends PhysicalTransformation<OUT> {
+
+	protected final List<Transformation<?>> inputs = new ArrayList<>();
+	protected final StreamOperatorFactory<OUT> operatorFactory;
+
+	public AbstractMultipleInputTransformation(
+			String name,
+			StreamOperatorFactory<OUT> operatorFactory,
+			TypeInformation<OUT> outputType,
+			int parallelism) {
+		super(name, outputType, parallelism);
+		this.operatorFactory = operatorFactory;
+	}
+
+	public List<Transformation<?>> getInputs() {
+		return inputs;
+	}
+
+	/**
+	 * Returns the {@code TypeInformation} for the elements from the inputs.
+	 */
+	public List<TypeInformation<?>> getInputTypes() {
+		return inputs.stream()
+			.map(Transformation::getOutputType)
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns the {@code StreamOperatorFactory} of this Transformation.
+	 */
+	public StreamOperatorFactory<OUT> getOperatorFactory() {
+		return operatorFactory;
+	}
+
+	@Override
+	public Collection<Transformation<?>> getTransitivePredecessors() {
+		return inputs.stream()
+			.flatMap(input -> input.getTransitivePredecessors().stream())
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public final void setChainingStrategy(ChainingStrategy strategy) {
+		operatorFactory.setChainingStrategy(strategy);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
@@ -21,22 +21,40 @@ package org.apache.flink.streaming.api.transformations;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * {@link AbstractMultipleInputTransformation} implementation for non-keyed streams.
+ * {@link AbstractMultipleInputTransformation} implementation for keyed streams.
  */
 @Internal
-public class MultipleInputTransformation<OUT> extends AbstractMultipleInputTransformation<OUT> {
-	public MultipleInputTransformation(
+public class KeyedMultipleInputTransformation<OUT> extends AbstractMultipleInputTransformation<OUT> {
+	private final List<KeySelector<?, ?>> stateKeySelectors = new ArrayList<>();
+	protected final TypeInformation<?> stateKeyType;
+
+	public KeyedMultipleInputTransformation(
 			String name,
 			StreamOperatorFactory<OUT> operatorFactory,
 			TypeInformation<OUT> outputType,
-			int parallelism) {
+			int parallelism,
+			TypeInformation<?> stateKeyType) {
 		super(name, operatorFactory, outputType, parallelism);
+		this.stateKeyType = stateKeyType;
 	}
 
-	public void addInput(Transformation<?> input) {
+	public void addInput(Transformation<?> input, KeySelector<?, ?> keySelector) {
 		inputs.add(input);
+		getStateKeySelectors().add(keySelector);
+	}
+
+	public TypeInformation<?> getStateKeyType() {
+		return stateKeyType;
+	}
+
+	public List<KeySelector<?, ?>> getStateKeySelectors() {
+		return stateKeySelectors;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedMultipleInputTransformation.java
@@ -45,9 +45,10 @@ public class KeyedMultipleInputTransformation<OUT> extends AbstractMultipleInput
 		this.stateKeyType = stateKeyType;
 	}
 
-	public void addInput(Transformation<?> input, KeySelector<?, ?> keySelector) {
+	public KeyedMultipleInputTransformation<OUT> addInput(Transformation<?> input, KeySelector<?, ?> keySelector) {
 		inputs.add(input);
 		getStateKeySelectors().add(keySelector);
+		return this;
 	}
 
 	public TypeInformation<?> getStateKeyType() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
@@ -36,7 +36,8 @@ public class MultipleInputTransformation<OUT> extends AbstractMultipleInputTrans
 		super(name, operatorFactory, outputType, parallelism);
 	}
 
-	public void addInput(Transformation<?> input) {
+	public MultipleInputTransformation<OUT> addInput(Transformation<?> input) {
 		inputs.add(input);
+		return this;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -81,13 +81,14 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 		this.inputSelectionHandler = checkNotNull(inputSelectionHandler);
 
 		List<Input> inputs = streamOperator.getInputs();
-		int operatorsCount = inputs.size();
+		int inputsCount = inputs.size();
 
-		this.inputProcessors = new InputProcessor[operatorsCount];
-		this.streamStatuses = new StreamStatus[operatorsCount];
+		this.inputProcessors = new InputProcessor[inputsCount];
+		this.streamStatuses = new StreamStatus[inputsCount];
 		this.numRecordsIn = numRecordsIn;
 
-		for (int i = 0; i < operatorsCount; i++) {
+		for (int i = 0; i < inputsCount; i++) {
+			streamStatuses[i] = StreamStatus.ACTIVE;
 			StreamTaskNetworkOutput dataOutput = new StreamTaskNetworkOutput<>(
 				inputs.get(i),
 				streamStatusMaintainer,
@@ -282,7 +283,8 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 
 		@Override
 		public void emitWatermark(Watermark watermark) throws Exception {
-			throw new UnsupportedOperationException();
+			inputWatermarkGauge.setCurrentWatermark(watermark.getTimestamp());
+			input.processWatermark(watermark);
 		}
 
 		@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessor.java
@@ -274,8 +274,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 
 		@Override
 		public void emitRecord(StreamRecord<T> record) throws Exception {
-			//TODO: support keyed operators
-			//input.setKeyContextElement(record);
+			input.setKeyContextElement(record);
 			input.processElement(record);
 			numRecordsIn.inc();
 			inputSelectionHandler.nextSelection();
@@ -306,7 +305,7 @@ public final class StreamMultipleInputProcessor implements StreamInputProcessor 
 
 		@Override
 		public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {
-			throw new UnsupportedOperationException();
+			input.processLatencyMarker(latencyMarker);
 		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -63,7 +63,7 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 		for (int i = 0; i < inputDeserializers.length; i++) {
 			inputLists[i] = new ArrayList<>();
 			watermarkGauges[i] = new WatermarkGauge();
-			headOperator.getMetricGroup().gauge(MetricNames.currentInputWatermarkName(i), watermarkGauges[i]);
+			headOperator.getMetricGroup().gauge(MetricNames.currentInputWatermarkName(i + 1), watermarkGauges[i]);
 		}
 
 		MinWatermarkGauge minInputWatermarkGauge = new MinWatermarkGauge(watermarkGauges);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/DataStreamTest.java
@@ -1007,7 +1007,7 @@ public class DataStreamTest extends TestLogger {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
 		DataStreamSink<Long> sink = env.generateSequence(1, 100).print();
-		assertTrue(getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getStatePartitioner1() == null);
+		assertEquals(0, getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getStatePartitioners().length);
 		assertTrue(getStreamGraph(env).getStreamNode(sink.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof ForwardPartitioner);
 
 		KeySelector<Long, Long> key1 = new KeySelector<Long, Long>() {
@@ -1022,10 +1022,10 @@ public class DataStreamTest extends TestLogger {
 
 		DataStreamSink<Long> sink2 = env.generateSequence(1, 100).keyBy(key1).print();
 
-		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
+		assertEquals(1, getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioners().length);
 		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
 		assertNotNull(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStateKeySerializer());
-		assertEquals(key1, getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioner1());
+		assertEquals(key1, getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getStatePartitioners()[0]);
 		assertTrue(getStreamGraph(env).getStreamNode(sink2.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
 
 		KeySelector<Long, Long> key2 = new KeySelector<Long, Long>() {
@@ -1040,8 +1040,8 @@ public class DataStreamTest extends TestLogger {
 
 		DataStreamSink<Long> sink3 = env.generateSequence(1, 100).keyBy(key2).print();
 
-		assertTrue(getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1() != null);
-		assertEquals(key2, getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioner1());
+		assertEquals(1, getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioners().length);
+		assertEquals(key2, getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getStatePartitioners()[0]);
 		assertTrue(getStreamGraph(env).getStreamNode(sink3.getTransformation().getId()).getInEdges().get(0).getPartitioner() instanceof KeyGroupStreamPartitioner);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -331,11 +331,11 @@ public class StreamGraphGeneratorTest extends TestLogger {
 			BasicTypeInfo.STRING_TYPE_INFO,
 			3);
 
-		transform.addInput(source1.getTransformation());
-		transform.addInput(source2.getTransformation());
-		transform.addInput(source3.getTransformation());
+		env.addOperator(transform
+			.addInput(source1.getTransformation())
+			.addInput(source2.getTransformation())
+			.addInput(source3.getTransformation()));
 
-		env.addOperator(transform);
 		StreamGraph streamGraph = env.getStreamGraph();
 		assertEquals(4, streamGraph.getStreamNodes().size());
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2Test.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/AbstractStreamOperatorV2Test.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for the facilities provided by {@link AbstractStreamOperatorV2}.
+ */
+public class AbstractStreamOperatorV2Test extends AbstractStreamOperatorTest {
+	@Override
+	protected KeyedOneInputStreamOperatorTestHarness<Integer, Tuple2<Integer, String>, String> createTestHarness(
+			int maxParalelism,
+			int numSubtasks,
+			int subtaskIndex) throws Exception {
+		return new KeyedOneInputStreamOperatorTestHarness<>(
+			new TestOperatorFactory(),
+			new TestKeySelector(),
+			BasicTypeInfo.INT_TYPE_INFO,
+			maxParalelism,
+			numSubtasks,
+			subtaskIndex);
+	}
+
+	private static class TestOperatorFactory extends AbstractStreamOperatorFactory<String> {
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new SingleInputTestOperator(parameters);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return SingleInputTestOperator.class;
+		}
+	}
+
+	/**
+	 * Testing operator that can respond to commands by either setting/deleting state, emitting
+	 * state or setting timers.
+	 */
+	private static class SingleInputTestOperator
+		extends AbstractStreamOperatorV2<String>
+		implements MultipleInputStreamOperator<String>,
+		Triggerable<Integer, VoidNamespace> {
+
+
+		private static final long serialVersionUID = 1L;
+
+		private transient InternalTimerService<VoidNamespace> timerService;
+
+		private final ValueStateDescriptor<String> stateDescriptor =
+			new ValueStateDescriptor<>("state", StringSerializer.INSTANCE);
+
+		public SingleInputTestOperator(StreamOperatorParameters<String> parameters) {
+			super(parameters, 1);
+		}
+
+		@Override
+		public void open() throws Exception {
+			super.open();
+
+			this.timerService = getInternalTimerService(
+				"test-timers",
+				VoidNamespaceSerializer.INSTANCE,
+				this);
+		}
+
+		@Override
+		public List<Input> getInputs() {
+			return Collections.singletonList(new AbstractInput<Tuple2<Integer, String>, String>(this, 1) {
+				@Override
+				public void processElement(StreamRecord<Tuple2<Integer, String>> element) throws Exception {
+					String[] command = element.getValue().f1.split(":");
+					switch (command[0]) {
+						case "SET_STATE":
+							getPartitionedState(stateDescriptor).update(command[1]);
+							break;
+						case "DELETE_STATE":
+							getPartitionedState(stateDescriptor).clear();
+							break;
+						case "SET_EVENT_TIME_TIMER":
+							timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, Long.parseLong(command[1]));
+							break;
+						case "SET_PROC_TIME_TIMER":
+							timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, Long.parseLong(command[1]));
+							break;
+						case "EMIT_STATE":
+							String stateValue = getPartitionedState(stateDescriptor).value();
+							output.collect(new StreamRecord<>("ON_ELEMENT:" + element.getValue().f0 + ":" + stateValue));
+							break;
+						default:
+							throw new IllegalArgumentException();
+					}
+				}
+			});
+		}
+
+		@Override
+		public void onEventTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+			String stateValue = getPartitionedState(stateDescriptor).value();
+			output.collect(new StreamRecord<>("ON_EVENT_TIME:" + stateValue));
+		}
+
+		@Override
+		public void onProcessingTime(InternalTimer<Integer, VoidNamespace> timer) throws Exception {
+			String stateValue = getPartitionedState(stateDescriptor).value();
+			output.collect(new StreamRecord<>("ON_PROC_TIME:" + stateValue));
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -21,14 +21,21 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
+import org.apache.flink.runtime.metrics.util.InterceptingTaskMetricGroup;
+import org.apache.flink.streaming.api.operators.AbstractInput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
@@ -36,17 +43,25 @@ import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
 import org.apache.flink.streaming.api.operators.co.CoStreamMap;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.InputStatus;
 import org.apache.flink.streaming.runtime.io.StreamMultipleInputProcessor;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
+import org.apache.flink.streaming.runtime.tasks.OneInputStreamTaskTest.WatermarkMetricOperator;
 import org.apache.flink.streaming.util.TestBoundedMultipleInputOperator;
+import org.apache.flink.streaming.util.TestHarnessUtil;
 
+import org.hamcrest.collection.IsEmptyCollection;
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -57,7 +72,6 @@ import static org.junit.Assert.assertEquals;
  * {@link StreamMultipleInputProcessor}.
  */
 public class MultipleInputStreamTaskTest {
-
 	/**
 	 * This test verifies that open() and close() are correctly called. This test also verifies
 	 * that timestamps of emitted elements are correct. {@link CoStreamMap} assigns the input
@@ -257,10 +271,17 @@ public class MultipleInputStreamTaskTest {
 
 		@Override
 		public List<Input> getInputs() {
-			return Arrays.asList(new DuplicatingInput(), new DuplicatingInput(), new DuplicatingInput());
+			return Arrays.asList(
+				new DuplicatingInput(this, 1),
+				new DuplicatingInput(this, 2),
+				new DuplicatingInput(this, 3));
 		}
 
-		class DuplicatingInput implements Input<String> {
+		class DuplicatingInput extends AbstractInput<String, String> {
+			public DuplicatingInput(AbstractStreamOperatorV2<String> owner, int inputId) {
+				super(owner, inputId);
+			}
+
 			@Override
 			public void processElement(StreamRecord<String> element) throws Exception {
 				output.collect(element);
@@ -355,8 +376,244 @@ public class MultipleInputStreamTaskTest {
 		}
 	}
 
-	// This must only be used in one test, otherwise the static fields will be changed
-	// by several tests concurrently
+	@Test
+	public void testWatermark() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.INT_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, 2)
+					.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperatorFactory())
+					.build()) {
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			long initialTime = 0L;
+
+			testHarness.processElement(new Watermark(initialTime), 0, 0);
+			testHarness.processElement(new Watermark(initialTime), 0, 1);
+			testHarness.processElement(new Watermark(initialTime), 1, 0);
+			testHarness.processElement(new Watermark(initialTime), 1, 1);
+
+			testHarness.processElement(new Watermark(initialTime), 2, 0);
+
+			assertThat(testHarness.getOutput(), IsEmptyCollection.empty());
+
+			testHarness.processElement(new Watermark(initialTime), 2, 1);
+
+			// now the watermark should have propagated, Map simply forward Watermarks
+			expectedOutput.add(new Watermark(initialTime));
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// contrary to checkpoint barriers these elements are not blocked by watermarks
+			testHarness.processElement(new StreamRecord<>("Hello", initialTime), 0, 0);
+			testHarness.processElement(new StreamRecord<>(42, initialTime), 1, 1);
+			expectedOutput.add(new StreamRecord<>("Hello", initialTime));
+			expectedOutput.add(new StreamRecord<>("42", initialTime));
+
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			testHarness.processElement(new Watermark(initialTime + 4), 0, 0);
+			testHarness.processElement(new Watermark(initialTime + 3), 0, 1);
+			testHarness.processElement(new Watermark(initialTime + 3), 1, 0);
+			testHarness.processElement(new Watermark(initialTime + 4), 1, 1);
+			testHarness.processElement(new Watermark(initialTime + 3), 2, 0);
+			testHarness.processElement(new Watermark(initialTime + 2), 2, 1);
+
+			// check whether we get the minimum of all the watermarks, this must also only occur in
+			// the output after the two StreamRecords
+			expectedOutput.add(new Watermark(initialTime + 2));
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// advance watermark from one of the inputs, now we should get a new one since the
+			// minimum increases
+			testHarness.processElement(new Watermark(initialTime + 4), 2, 1);
+			expectedOutput.add(new Watermark(initialTime + 3));
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// advance the other two inputs, now we should get a new one since the
+			// minimum increases again
+			testHarness.processElement(new Watermark(initialTime + 4), 0, 1);
+			testHarness.processElement(new Watermark(initialTime + 4), 1, 0);
+			testHarness.processElement(new Watermark(initialTime + 4), 2, 0);
+			expectedOutput.add(new Watermark(initialTime + 4));
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			List<String> resultElements = TestHarnessUtil.getRawElementsFromOutput(testHarness.getOutput());
+			assertEquals(2, resultElements.size());
+		}
+	}
+
+	/**
+	 * This test verifies that watermarks and stream statuses are correctly forwarded. This also checks whether
+	 * watermarks are forwarded only when we have received watermarks from all inputs. The
+	 * forwarded watermark must be the minimum of the watermarks of all active inputs.
+	 */
+	@Test
+	public void testWatermarkAndStreamStatusForwarding() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.INT_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, 2)
+					.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperatorFactory())
+					.build()) {
+			ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+
+			long initialTime = 0L;
+
+			// test whether idle input channels are acknowledged correctly when forwarding watermarks
+			testHarness.processElement(StreamStatus.IDLE, 0, 1);
+			testHarness.processElement(StreamStatus.IDLE, 1, 1);
+			testHarness.processElement(StreamStatus.IDLE, 2, 0);
+			testHarness.processElement(new Watermark(initialTime + 6), 0, 0);
+			testHarness.processElement(new Watermark(initialTime + 6), 1, 0);
+			testHarness.processElement(new Watermark(initialTime + 5), 2, 1); // this watermark should be advanced first
+			testHarness.processElement(StreamStatus.IDLE, 2, 1); // once this is acknowledged,
+
+			expectedOutput.add(new Watermark(initialTime + 5));
+			// We don't expect to see Watermark(6) here because the idle status of one
+			// input doesn't propagate to the other input. That is, if input 1 is at WM 6 and input
+			// two was at WM 5 before going to IDLE then the output watermark will not jump to WM 6.
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// make all input channels idle and check that the operator's idle status is forwarded
+			testHarness.processElement(StreamStatus.IDLE, 0, 0);
+			testHarness.processElement(StreamStatus.IDLE, 1, 0);
+			expectedOutput.add(StreamStatus.IDLE);
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// make some input channels active again and check that the operator's active status is forwarded only once
+			testHarness.processElement(StreamStatus.ACTIVE, 1, 0);
+			testHarness.processElement(StreamStatus.ACTIVE, 0, 1);
+			expectedOutput.add(StreamStatus.ACTIVE);
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testWatermarkMetrics() throws Exception {
+		OperatorID headOperatorId = new OperatorID();
+		OperatorID chainedOperatorId = new OperatorID();
+
+		InterceptingOperatorMetricGroup headOperatorMetricGroup = new InterceptingOperatorMetricGroup();
+		InterceptingOperatorMetricGroup chainedOperatorMetricGroup = new InterceptingOperatorMetricGroup();
+		InterceptingTaskMetricGroup taskMetricGroup = new InterceptingTaskMetricGroup() {
+			@Override
+			public OperatorMetricGroup getOrAddOperator(OperatorID id, String name) {
+				if (id.equals(headOperatorId)) {
+					return headOperatorMetricGroup;
+				} else if (id.equals(chainedOperatorId)) {
+					return chainedOperatorMetricGroup;
+				} else {
+					return super.getOrAddOperator(id, name);
+				}
+			}
+		};
+
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.INT_TYPE_INFO)
+					.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO)
+					.setupOperatorChain(headOperatorId, new MapToStringMultipleInputOperatorFactory())
+					.chain(
+						chainedOperatorId,
+						new WatermarkMetricOperator(),
+						BasicTypeInfo.STRING_TYPE_INFO.createSerializer(new ExecutionConfig()))
+					.finish()
+					.setTaskMetricGroup(taskMetricGroup)
+					.build()) {
+			Gauge<Long> taskInputWatermarkGauge = (Gauge<Long>) taskMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
+			Gauge<Long> headInput1WatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.currentInputWatermarkName(1));
+			Gauge<Long> headInput2WatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.currentInputWatermarkName(2));
+			Gauge<Long> headInput3WatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.currentInputWatermarkName(3));
+			Gauge<Long> headInputWatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
+			Gauge<Long> headOutputWatermarkGauge = (Gauge<Long>) headOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
+			Gauge<Long> chainedInputWatermarkGauge = (Gauge<Long>) chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_INPUT_WATERMARK);
+			Gauge<Long> chainedOutputWatermarkGauge = (Gauge<Long>) chainedOperatorMetricGroup.get(MetricNames.IO_CURRENT_OUTPUT_WATERMARK);
+
+			assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput1WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput3WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+
+			testHarness.processElement(new Watermark(1L), 0);
+			assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
+			assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput2WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput3WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+
+			testHarness.processElement(new Watermark(2L), 1);
+			assertEquals(Long.MIN_VALUE, taskInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInputWatermarkGauge.getValue().longValue());
+			assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
+			assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headInput3WatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, headOutputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedInputWatermarkGauge.getValue().longValue());
+			assertEquals(Long.MIN_VALUE, chainedOutputWatermarkGauge.getValue().longValue());
+
+			testHarness.processElement(new Watermark(2L), 2);
+			assertEquals(1L, taskInputWatermarkGauge.getValue().longValue());
+			assertEquals(1L, headInputWatermarkGauge.getValue().longValue());
+			assertEquals(1L, headInput1WatermarkGauge.getValue().longValue());
+			assertEquals(2L, headInput2WatermarkGauge.getValue().longValue());
+			assertEquals(2L, headInput3WatermarkGauge.getValue().longValue());
+			assertEquals(1L, headOutputWatermarkGauge.getValue().longValue());
+			assertEquals(1L, chainedInputWatermarkGauge.getValue().longValue());
+			assertEquals(2L, chainedOutputWatermarkGauge.getValue().longValue());
+
+			testHarness.processElement(new Watermark(4L), 0);
+			testHarness.processElement(new Watermark(3L), 1);
+			assertEquals(2L, taskInputWatermarkGauge.getValue().longValue());
+			assertEquals(2L, headInputWatermarkGauge.getValue().longValue());
+			assertEquals(4L, headInput1WatermarkGauge.getValue().longValue());
+			assertEquals(3L, headInput2WatermarkGauge.getValue().longValue());
+			assertEquals(2L, headInput3WatermarkGauge.getValue().longValue());
+			assertEquals(2L, headOutputWatermarkGauge.getValue().longValue());
+			assertEquals(2L, chainedInputWatermarkGauge.getValue().longValue());
+			assertEquals(4L, chainedOutputWatermarkGauge.getValue().longValue());
+
+			testHarness.endInput();
+			testHarness.waitForTaskCompletion();
+		}
+	}
+
+	/**
+	 * Tests the checkpoint related metrics are registered into {@link TaskIOMetricGroup}
+	 * correctly while generating the {@link TwoInputStreamTask}.
+	 */
+	@Test
+	public void testCheckpointBarrierMetrics() throws Exception {
+		final Map<String, Metric> metrics = new ConcurrentHashMap<>();
+		final TaskMetricGroup taskMetricGroup = new StreamTaskTestHarness.TestTaskMetricGroup(metrics);
+
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.INT_TYPE_INFO, 2)
+					.addInput(BasicTypeInfo.DOUBLE_TYPE_INFO, 2)
+					.setupOutputForSingletonOperatorChain(new MapToStringMultipleInputOperatorFactory())
+					.setTaskMetricGroup(taskMetricGroup)
+					.build()) {
+
+			assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_ALIGNMENT_TIME));
+			assertThat(metrics, IsMapContaining.hasKey(MetricNames.CHECKPOINT_START_DELAY_TIME));
+
+			testHarness.endInput();
+			testHarness.waitForTaskCompletion();
+		}
+	}
+
 	private static class MapToStringMultipleInputOperator
 			extends AbstractStreamOperatorV2<String> implements MultipleInputStreamOperator<String> {
 		private static final long serialVersionUID = 1L;
@@ -389,16 +646,20 @@ public class MultipleInputStreamTaskTest {
 		@Override
 		public List<Input> getInputs() {
 			return Arrays.asList(
-				new MapToStringInput<String>(),
-				new MapToStringInput<Integer>(),
-				new MapToStringInput<Double>());
+				new MapToStringInput<String>(this, 1),
+				new MapToStringInput<Integer>(this, 2),
+				new MapToStringInput<Double>(this, 3));
 		}
 
 		public boolean wasCloseCalled() {
 			return closeCalled;
 		}
 
-		public class MapToStringInput<T> implements Input<T> {
+		public class MapToStringInput<T> extends AbstractInput<T, String> {
+			public MapToStringInput(AbstractStreamOperatorV2<String> owner, int inputId) {
+				super(owner, inputId);
+			}
+
 			@Override
 			public void processElement(StreamRecord<T> element) throws Exception {
 				if (!openCalled) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
 import org.apache.flink.runtime.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
-import org.apache.flink.streaming.api.functions.co.CoMapFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
@@ -412,21 +411,6 @@ public class MultipleInputStreamTaskTest {
 					output.collect(new StreamRecord<>(element.getValue().toString()));
 				}
 			}
-		}
-	}
-
-	private static class IdentityMap implements CoMapFunction<String, Integer, String> {
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public String map1(String value) {
-			return value;
-		}
-
-		@Override
-		public String map2(Integer value) {
-
-			return value.toString();
 		}
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.streaming.api.graph.StreamEdge;
@@ -28,6 +29,8 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.util.function.FunctionWithException;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -52,6 +55,14 @@ public class MultipleInputStreamTaskTestHarnessBuilder<OUT> extends StreamTaskMa
 	}
 
 	public MultipleInputStreamTaskTestHarnessBuilder<OUT> addInput(TypeInformation<?> inputType, int inputChannels) {
+		return addInput(inputType, inputChannels, null);
+	}
+
+	public MultipleInputStreamTaskTestHarnessBuilder<OUT> addInput(
+			TypeInformation<?> inputType,
+			int inputChannels,
+			@Nullable KeySelector<?, ?> keySelector) {
+		streamConfig.setStatePartitioner(inputSerializers.size(), keySelector);
 		inputSerializers.add(inputType.createSerializer(executionConfig));
 		inputChannelsPerGate.add(inputChannels);
 		return this;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -185,5 +185,10 @@ public abstract class StreamTaskMailboxTestHarnessBuilder<OUT> {
 		this.taskMetricGroup = taskMetricGroup;
 		return this;
 	}
+
+	public StreamTaskMailboxTestHarnessBuilder<OUT> setKeyType(TypeInformation<?> keyType) {
+		streamConfig.setStateKeySerializer(keyType.createSerializer(executionConfig));
+		return this;
+	}
 }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -210,7 +210,7 @@ public class TwoInputStreamTaskTest {
 		testHarness.processElement(new Watermark(initialTime + 6), 0, 0);
 		testHarness.processElement(new Watermark(initialTime + 5), 1, 1); // this watermark should be advanced first
 		testHarness.processElement(StreamStatus.IDLE, 1, 1); // once this is acknowledged,
-		                                                     // watermark (initial + 6) should be forwarded
+
 		testHarness.waitForInputProcessing();
 		expectedOutput.add(new Watermark(initialTime + 5));
 		// We don't expect to see Watermark(6) here because the idle status of one

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/KeyedOneInputStreamOperatorTestHarness.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.heap.HeapKeyedStateBackend;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 
 /**
  * Extension of {@link OneInputStreamOperatorTestHarness} that allows the operator to get
@@ -42,11 +44,28 @@ public class KeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 			int maxParallelism,
 			int numSubtasks,
 			int subtaskIndex) throws Exception {
-		super(operator, maxParallelism, numSubtasks, subtaskIndex);
+		this(SimpleOperatorFactory.of(operator), keySelector, keyType, maxParallelism, numSubtasks, subtaskIndex);
+	}
+
+	public KeyedOneInputStreamOperatorTestHarness(
+			StreamOperatorFactory<OUT> operatorFactory,
+			final KeySelector<IN, K> keySelector,
+			TypeInformation<K> keyType,
+			int maxParallelism,
+			int numSubtasks,
+			int subtaskIndex) throws Exception {
+		super(operatorFactory, maxParallelism, numSubtasks, subtaskIndex);
 
 		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);
 		config.setStatePartitioner(0, keySelector);
 		config.setStateKeySerializer(keyType.createSerializer(executionConfig));
+	}
+
+	public KeyedOneInputStreamOperatorTestHarness(
+		StreamOperatorFactory<OUT> operatorFactory,
+		final KeySelector<IN, K> keySelector,
+		TypeInformation<K> keyType) throws Exception {
+		this(operatorFactory, keySelector, keyType, 1, 1, 0);
 	}
 
 	public KeyedOneInputStreamOperatorTestHarness(
@@ -58,10 +77,9 @@ public class KeyedOneInputStreamOperatorTestHarness<K, IN, OUT>
 
 	public KeyedOneInputStreamOperatorTestHarness(
 			final OneInputStreamOperator<IN, OUT> operator,
-			final  KeySelector<IN, K> keySelector,
+			final KeySelector<IN, K> keySelector,
 			final TypeInformation<K> keyType,
 			final MockEnvironment environment) throws Exception {
-
 		super(operator, environment);
 
 		ClosureCleaner.clean(keySelector, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, false);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -185,6 +185,7 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 		else {
 			checkState(inputs.size() == 1);
 			Input input = inputs.get(0);
+			input.setKeyContextElement(element);
 			input.processElement(element);
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OneInputStreamOperatorTestHarness.java
@@ -22,13 +22,21 @@ import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.Preconditions;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A test harness for testing a {@link OneInputStreamOperator}.
@@ -39,6 +47,9 @@ import java.util.Collection;
  */
 public class OneInputStreamOperatorTestHarness<IN, OUT>
 		extends AbstractStreamOperatorTestHarness<OUT> {
+
+	/** Empty if the {@link #operator} is not {@link MultipleInputStreamOperator}. */
+	private final List<Input> inputs = new ArrayList<>();
 
 	private long currentWatermark;
 
@@ -51,14 +62,13 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	}
 
 	public OneInputStreamOperatorTestHarness(
-		OneInputStreamOperator<IN, OUT> operator,
-		int maxParallelism,
-		int parallelism,
-		int subtaskIndex,
-		TypeSerializer<IN> typeSerializerIn,
-		OperatorID operatorID) throws Exception {
-		this(operator, maxParallelism, parallelism, subtaskIndex, operatorID);
-
+			OneInputStreamOperator<IN, OUT> operator,
+			int maxParallelism,
+			int parallelism,
+			int subtaskIndex,
+			TypeSerializer<IN> typeSerializerIn,
+			OperatorID operatorID) throws Exception {
+		this(SimpleOperatorFactory.of(operator), maxParallelism, parallelism, subtaskIndex, operatorID);
 		config.setTypeSerializersIn(Preconditions.checkNotNull(typeSerializerIn));
 	}
 
@@ -84,16 +94,24 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 			int maxParallelism,
 			int parallelism,
 			int subtaskIndex) throws Exception {
-		this(operator, maxParallelism, parallelism, subtaskIndex, new OperatorID());
+		this(SimpleOperatorFactory.of(operator), maxParallelism, parallelism, subtaskIndex);
 	}
 
 	public OneInputStreamOperatorTestHarness(
-			OneInputStreamOperator<IN, OUT> operator,
+			StreamOperatorFactory<OUT> operatorFactory,
+			int maxParallelism,
+			int parallelism,
+			int subtaskIndex) throws Exception {
+		this(operatorFactory, maxParallelism, parallelism, subtaskIndex, new OperatorID());
+	}
+
+	public OneInputStreamOperatorTestHarness(
+			StreamOperatorFactory<OUT> operatorFactory,
 			int maxParallelism,
 			int parallelism,
 			int subtaskIndex,
 			OperatorID operatorID) throws Exception {
-		super(operator, maxParallelism, parallelism, subtaskIndex, operatorID);
+		super(operatorFactory, maxParallelism, parallelism, subtaskIndex, operatorID);
 	}
 
 	public OneInputStreamOperatorTestHarness(
@@ -142,6 +160,15 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 		super(factory, maxParallelism, parallelism, subtaskIndex, operatorID);
 	}
 
+	@Override
+	public void setup(TypeSerializer<OUT> outputSerializer) {
+		super.setup(outputSerializer);
+		if (operator instanceof MultipleInputStreamOperator) {
+			checkState(inputs.isEmpty());
+			inputs.addAll(((MultipleInputStreamOperator) operator).getInputs());
+		}
+	}
+
 	public OneInputStreamOperator<IN, OUT> getOneInputOperator() {
 		return (OneInputStreamOperator<IN, OUT>) this.operator;
 	}
@@ -151,14 +178,20 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 	}
 
 	public void processElement(StreamRecord<IN> element) throws Exception {
-		operator.setKeyContextElement1(element);
-		getOneInputOperator().processElement(element);
+		if (inputs.isEmpty()) {
+			operator.setKeyContextElement1(element);
+			getOneInputOperator().processElement(element);
+		}
+		else {
+			checkState(inputs.size() == 1);
+			Input input = inputs.get(0);
+			input.processElement(element);
+		}
 	}
 
 	public void processElements(Collection<StreamRecord<IN>> elements) throws Exception {
 		for (StreamRecord<IN> element: elements) {
-			operator.setKeyContextElement1(element);
-			getOneInputOperator().processElement(element);
+			processElement(element);
 		}
 	}
 
@@ -168,7 +201,14 @@ public class OneInputStreamOperatorTestHarness<IN, OUT>
 
 	public void processWatermark(Watermark mark) throws Exception {
 		currentWatermark = mark.getTimestamp();
-		getOneInputOperator().processWatermark(mark);
+		if (inputs.isEmpty()) {
+			getOneInputOperator().processWatermark(mark);
+		}
+		else {
+			checkState(inputs.size() == 1);
+			Input input = inputs.get(0);
+			input.processWatermark(mark);
+		}
 	}
 
 	public void endInput() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedMultipleInputOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestBoundedMultipleInputOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.streaming.api.operators.AbstractInput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
 import org.apache.flink.streaming.api.operators.Input;
@@ -46,9 +47,9 @@ public class TestBoundedMultipleInputOperator extends AbstractStreamOperatorV2<S
 	@Override
 	public List<Input> getInputs() {
 		return Arrays.asList(
-			new TestInput(1),
-			new TestInput(2),
-			new TestInput(3)
+			new TestInput(this, 1),
+			new TestInput(this, 2),
+			new TestInput(this, 3)
 		);
 	}
 
@@ -63,16 +64,14 @@ public class TestBoundedMultipleInputOperator extends AbstractStreamOperatorV2<S
 		super.close();
 	}
 
-	class TestInput implements Input<String> {
-		private final int inputIndex;
-
-		public TestInput(int inputIndex) {
-			this.inputIndex = inputIndex;
+	class TestInput extends AbstractInput<String, String> {
+		public TestInput(AbstractStreamOperatorV2<String> owner, int inputId) {
+			super(owner, inputId);
 		}
 
 		@Override
 		public void processElement(StreamRecord<String> element) throws Exception {
-			output.collect(element.replace("[" + name + "-" + inputIndex + "]: " + element.getValue()));
+			output.collect(element.replace("[" + name + "-" + inputId + "]: " + element.getValue()));
 		}
 	}
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessOperatorWithWatermarkDelayTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/operators/KeyedProcessOperatorWithWatermarkDelayTest.scala
@@ -38,7 +38,7 @@ class KeyedProcessOperatorWithWatermarkDelayTest extends TestLogger {
     val operator = new KeyedProcessOperatorWithWatermarkDelay[Integer, Integer, String](
       new EmptyProcessFunction, 100)
     val testHarness = new KeyedOneInputStreamOperatorTestHarness[Integer, Integer, String](
-      operator, new IdentityKeySelector, BasicTypeInfo.INT_TYPE_INFO)
+      operator, new IdentityKeySelector[Integer], BasicTypeInfo.INT_TYPE_INFO)
 
     testHarness.setup()
     testHarness.open()

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
@@ -72,11 +72,10 @@ public class MultipleInputITCase extends AbstractTestBase {
 			BasicTypeInfo.LONG_TYPE_INFO,
 			1);
 
-		transform.addInput(source1.getTransformation());
-		transform.addInput(source2.getTransformation());
-		transform.addInput(source3.getTransformation());
-
-		env.addOperator(transform);
+		env.addOperator(transform
+			.addInput(source1.getTransformation())
+			.addInput(source2.getTransformation())
+			.addInput(source3.getTransformation()));
 
 		new MultipleConnectedStreams(env)
 			.transform(transform)
@@ -109,10 +108,10 @@ public class MultipleInputITCase extends AbstractTestBase {
 			BasicTypeInfo.LONG_TYPE_INFO);
 		KeySelector<Long, Long> keySelector = (KeySelector<Long, Long>) value -> value % 3;
 
-		transform.addInput(source1.getTransformation(), keySelector);
-		transform.addInput(source2.getTransformation(), keySelector);
-		transform.addInput(source3.getTransformation(), keySelector);
-		env.addOperator(transform);
+		env.addOperator(transform
+			.addInput(source1.getTransformation(), keySelector)
+			.addInput(source2.getTransformation(), keySelector)
+			.addInput(source3.getTransformation(), keySelector));
 
 		new MultipleConnectedStreams(env)
 			.transform(transform)

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/MultipleInputITCase.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.MultipleConnectedStreams;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.operators.AbstractInput;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
 import org.apache.flink.streaming.api.operators.Input;
@@ -94,15 +95,19 @@ public class MultipleInputITCase extends AbstractTestBase {
 		@Override
 		public List<Input> getInputs() {
 			return Arrays.asList(
-				new SumInput<Integer>(),
-				new SumInput<Long>(),
-				new SumInput<String>());
+				new SumInput<Integer>(this, 1),
+				new SumInput<Long>(this, 2),
+				new SumInput<String>(this, 3));
 		}
 
 		/**
 		 * Summing input for {@link SumAllInputOperator}.
 		 */
-		public class SumInput<T> implements Input<T> {
+		public class SumInput<T> extends AbstractInput<T, Long> {
+			public SumInput(AbstractStreamOperatorV2<Long> owner, int inputId) {
+				super(owner, inputId);
+			}
+
 			@Override
 			public void processElement(StreamRecord<T> element) throws Exception {
 				sum += Long.valueOf(element.getValue().toString());


### PR DESCRIPTION
~This PR is based on https://github.com/apache/flink/pull/11403/ so please ignore couple of first commits.~

This PR adds support for watermarks, key selector and latency markers in MultipleInputStreamOperator.

## Brief change log

Please check individual commit messages.

## Verifying this change

This change added some unit and integration tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
