### PR TITLE
[FLINK-16702] develop JDBCCatalogFactory, descriptor, and validator for service discovery

### DIFF
--- a/flink-connectors/flink-jdbc/pom.xml
+++ b/flink-connectors/flink-jdbc/pom.xml
@@ -76,6 +76,14 @@ under the License.
 			<scope>test</scope>
         </dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- A planner dependency won't be necessary once FLIP-32 has been completed. -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/AbstractJDBCCatalog.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/AbstractJDBCCatalog.java
@@ -102,6 +102,21 @@ public abstract class AbstractJDBCCatalog extends AbstractCatalog {
 		LOG.info("Catalog {} closing", getName());
 	}
 
+	// ----- getters ------
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return pwd;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+
 	// ------ table factory ------
 
 	public Optional<TableFactory> getTableFactory() {

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/JDBCCatalog.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/JDBCCatalog.java
@@ -19,7 +19,7 @@
 package org.apache.flink.api.java.io.jdbc.catalog;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -40,7 +40,7 @@ public class JDBCCatalog extends AbstractJDBCCatalog {
 
 	private static final Logger LOG = LoggerFactory.getLogger(JDBCCatalog.class);
 
-	private final Catalog internal;
+	private final AbstractJDBCCatalog internal;
 
 	public JDBCCatalog(String catalogName, String defaultDatabase, String username, String pwd, String baseUrl) {
 		super(catalogName, defaultDatabase, username, pwd, baseUrl);
@@ -80,5 +80,12 @@ public class JDBCCatalog extends AbstractJDBCCatalog {
 		} catch (DatabaseNotExistException e) {
 			return false;
 		}
+	}
+
+	// ------ getters ------
+
+	@VisibleForTesting
+	public AbstractJDBCCatalog getInternal() {
+		return internal;
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresTablePath.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresTablePath.java
@@ -64,13 +64,9 @@ public class PostgresTablePath {
 		return String.format("%s.%s", pgSchemaName, pgTableName);
 	}
 
-	public String getFullPathWithQuotes() {
-		return String.format("`%s.%s`", pgSchemaName, pgTableName);
-	}
-
 	@Override
 	public String toString() {
-		return getFullPathWithQuotes();
+		return getFullPath();
 	}
 
 	@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactory.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.catalog.factory;
+
+import org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.JDBCCatalogValidator;
+import org.apache.flink.table.factories.CatalogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_TYPE;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_BASE_URL;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_PASSWORD;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_USERNAME;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_TYPE_VALUE_JDBC;
+
+/**
+ * Factory for {@link org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog}.
+ */
+public class JDBCCatalogFactory implements CatalogFactory {
+
+	private static final Logger LOG = LoggerFactory.getLogger(JDBCCatalogFactory.class);
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CATALOG_TYPE, CATALOG_TYPE_VALUE_JDBC); // jdbc
+		context.put(CATALOG_PROPERTY_VERSION, "1"); // backwards compatibility
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+
+		// default database
+		properties.add(CATALOG_DEFAULT_DATABASE);
+
+		properties.add(CATALOG_JDBC_BASE_URL);
+		properties.add(CATALOG_JDBC_USERNAME);
+		properties.add(CATALOG_JDBC_PASSWORD);
+
+		return properties;
+	}
+
+	@Override
+	public Catalog createCatalog(String name, Map<String, String> properties) {
+		final DescriptorProperties prop = getValidatedProperties(properties);
+
+		return new JDBCCatalog(
+			name,
+			prop.getString(CATALOG_DEFAULT_DATABASE),
+			prop.getString(CATALOG_JDBC_USERNAME),
+			prop.getString(CATALOG_JDBC_PASSWORD),
+			prop.getString(CATALOG_JDBC_BASE_URL));
+	}
+
+	private static DescriptorProperties getValidatedProperties(Map<String, String> properties) {
+		final DescriptorProperties descriptorProperties = new DescriptorProperties(true);
+		descriptorProperties.putProperties(properties);
+
+		new JDBCCatalogValidator().validate(descriptorProperties);
+
+		return descriptorProperties;
+	}
+
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -349,6 +349,11 @@ public final class JDBCDialects {
 		}
 
 		@Override
+		public String quoteIdentifier(String identifier) {
+			return identifier;
+		}
+
+		@Override
 		public String dialectName() {
 			return "postgresql";
 		}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptor.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptor.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.util.StringUtils;
+
 import java.util.Map;
 
 import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_DEFAULT_DATABASE;
@@ -25,6 +27,7 @@ import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JD
 import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_PASSWORD;
 import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_USERNAME;
 import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_TYPE_VALUE_JDBC;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * Descriptor for {@link org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog}.
@@ -39,6 +42,11 @@ public class JDBCCatalogDescriptor extends CatalogDescriptor {
 	public JDBCCatalogDescriptor(String defaultDatabase, String username, String pwd, String baseUrl) {
 
 		super(CATALOG_TYPE_VALUE_JDBC, 1);
+
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(defaultDatabase));
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(username));
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(pwd));
+		checkArgument(!StringUtils.isNullOrWhitespaceOnly(baseUrl));
 
 		this.defaultDatabase = defaultDatabase;
 		this.username = username;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptor.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.CatalogDescriptorValidator.CATALOG_DEFAULT_DATABASE;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_BASE_URL;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_PASSWORD;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_JDBC_USERNAME;
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_TYPE_VALUE_JDBC;
+
+/**
+ * Descriptor for {@link org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog}.
+ */
+public class JDBCCatalogDescriptor extends CatalogDescriptor {
+
+	private final String defaultDatabase;
+	private final String username;
+	private final String pwd;
+	private final String baseUrl;
+
+	public JDBCCatalogDescriptor(String defaultDatabase, String username, String pwd, String baseUrl) {
+
+		super(CATALOG_TYPE_VALUE_JDBC, 1);
+
+		this.defaultDatabase = defaultDatabase;
+		this.username = username;
+		this.pwd = pwd;
+		this.baseUrl = baseUrl;
+	}
+
+	@Override
+	protected Map<String, String> toCatalogProperties() {
+		final DescriptorProperties properties = new DescriptorProperties();
+
+		properties.putString(CATALOG_DEFAULT_DATABASE, defaultDatabase);
+		properties.putString(CATALOG_JDBC_USERNAME, username);
+		properties.putString(CATALOG_JDBC_PASSWORD, pwd);
+		properties.putString(CATALOG_JDBC_BASE_URL, baseUrl);
+
+		return properties.asMap();
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogValidator.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/table/descriptors/JDBCCatalogValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog;
+
+/**
+ * Validator for {@link JDBCCatalog}.
+ */
+public class JDBCCatalogValidator extends CatalogDescriptorValidator {
+
+	public static final String CATALOG_TYPE_VALUE_JDBC = "jdbc";
+
+	public static final String CATALOG_JDBC_USERNAME = "username";
+	public static final String CATALOG_JDBC_PASSWORD = "password";
+	public static final String CATALOG_JDBC_BASE_URL = "base-url";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		super.validate(properties);
+		properties.validateValue(CATALOG_TYPE, CATALOG_TYPE_VALUE_JDBC, false);
+		properties.validateString(CATALOG_JDBC_BASE_URL, false, 1);
+		properties.validateString(CATALOG_JDBC_USERNAME, false, 1);
+		properties.validateString(CATALOG_JDBC_PASSWORD, false, 1);
+		properties.validateString(CATALOG_DEFAULT_DATABASE, false, 1);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-connectors/flink-jdbc/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.api.java.io.jdbc.JDBCTableSourceSinkFactory
+org.apache.flink.api.java.io.jdbc.catalog.factory.JDBCCatalogFactory

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for {@link PostgresCatalog}.
  */
-public class PostgresCatalogITCase {
+public class PostgresCatalogTest {
 	@Rule
 	public ExpectedException exception = ExpectedException.none();
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
@@ -18,26 +18,14 @@
 
 package org.apache.flink.api.java.io.jdbc.catalog;
 
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 
-import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
-import com.opentable.db.postgres.junit.SingleInstancePostgresRule;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
 
@@ -48,52 +36,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * Test for {@link PostgresCatalog}.
  */
-public class PostgresCatalogTest {
-	@Rule
-	public ExpectedException exception = ExpectedException.none();
-
-	@ClassRule
-	public static SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
-
-	protected static final String TEST_USERNAME = "postgres";
-	protected static final String TEST_PWD = "postgres";
-	protected static final String TEST_DB = "test";
-	protected static final String TEST_SCHEMA = "test_schema";
-	protected static final String TABLE1 = "t1";
-	protected static final String TABLE2 = "t2";
-	protected static final String TABLE3 = "t3";
-
-	protected static String baseUrl;
-	protected static Catalog catalog;
-
-	public static Catalog createCatalog(String name, String defaultDb, String username, String pwd, String jdbcUrl) {
-		return new PostgresCatalog("mypg", PostgresCatalog.DEFAULT_DATABASE, username, pwd, jdbcUrl);
-	}
-
-	@BeforeClass
-	public static void setup() throws SQLException {
-		// jdbc:postgresql://localhost:50807/postgres?user=postgres
-		String embeddedJdbcUrl = pg.getEmbeddedPostgres().getJdbcUrl(TEST_USERNAME, TEST_PWD);
-		// jdbc:postgresql://localhost:50807/
-		baseUrl = embeddedJdbcUrl.substring(0, embeddedJdbcUrl.lastIndexOf("/") + 1);
-
-		catalog = createCatalog("mypg", PostgresCatalog.DEFAULT_DATABASE, TEST_USERNAME, TEST_PWD, baseUrl);
-
-		// create test database and schema
-		createDatabase(TEST_DB);
-		createSchema(TEST_DB, TEST_SCHEMA);
-
-		// create test tables
-		// table: postgres.public.user1
-		createTable(PostgresTablePath.fromFlinkTableName(TABLE1), getSimpleTable().pgSchemaSql);
-
-		// table: testdb.public.user2
-		// table: testdb.testschema.user3
-		// table: testdb.public.datatypes
-		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName(TABLE2), getSimpleTable().pgSchemaSql);
-		createTable(TEST_DB, new PostgresTablePath(TEST_SCHEMA, TABLE3), getSimpleTable().pgSchemaSql);
-		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName("datatypes"), getDataTypesTable().pgSchemaSql);
-	}
+public class PostgresCatalogTest extends PostgresCatalogTestBase {
 
 	// ------ databases ------
 
@@ -127,7 +70,7 @@ public class PostgresCatalogTest {
 	public void testListTables() throws DatabaseNotExistException {
 		List<String> actual = catalog.listTables(PostgresCatalog.DEFAULT_DATABASE);
 
-		assertEquals(Arrays.asList("public.t1"), actual);
+		assertEquals(Arrays.asList("public.t1", "public.t4", "public.t5"), actual);
 
 		actual = catalog.listTables(TEST_DB);
 
@@ -202,124 +145,4 @@ public class PostgresCatalogTest {
 
 		assertEquals(getDataTypesTable().schema, table.getSchema());
 	}
-
-	private static class TestTable {
-		TableSchema schema;
-		String pgSchemaSql;
-
-		public TestTable(TableSchema schema, String pgSchemaSql) {
-			this.schema = schema;
-			this.pgSchemaSql = pgSchemaSql;
-		}
-	}
-
-	private static TestTable getSimpleTable() {
-		return new TestTable(
-			TableSchema.builder()
-				.field("name", DataTypes.INT())
-				.build(),
-			"name integer"
-		);
-	}
-
-	private static TestTable getDataTypesTable() {
-		return new TestTable(
-			TableSchema.builder()
-				.field("int", DataTypes.INT())
-				.field("int_arr", DataTypes.ARRAY(DataTypes.INT()))
-				.field("bytea", DataTypes.BYTES())
-				.field("bytea_arr", DataTypes.ARRAY(DataTypes.BYTES()))
-				.field("short", DataTypes.SMALLINT())
-				.field("short_arr", DataTypes.ARRAY(DataTypes.SMALLINT()))
-				.field("long", DataTypes.BIGINT())
-				.field("long_arr", DataTypes.ARRAY(DataTypes.BIGINT()))
-				.field("real", DataTypes.FLOAT())
-				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
-				.field("double_precision", DataTypes.DOUBLE())
-				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
-				.field("numeric", DataTypes.DECIMAL(10, 5))
-				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
-				.field("boolean", DataTypes.BOOLEAN())
-				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
-				.field("text", DataTypes.STRING())
-				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
-				.field("char", DataTypes.CHAR(1))
-				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
-				.field("character", DataTypes.CHAR(3))
-				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
-				.field("character_varying", DataTypes.VARCHAR(20))
-				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
-				.field("timestamp", DataTypes.TIMESTAMP(5))
-				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
-				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
-				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
-				.field("date", DataTypes.DATE())
-				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
-				.field("time", DataTypes.TIME(3))
-				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME(3)))
-				.build(),
-			"int integer, " +
-				"int_arr integer[], " +
-				"bytea bytea, " +
-				"bytea_arr bytea[], " +
-				"short smallint, " +
-				"short_arr smallint[], " +
-				"long bigint, " +
-				"long_arr bigint[], " +
-				"real real, " +
-				"real_arr real[], " +
-				"double_precision double precision, " +
-				"double_precision_arr double precision[], " +
-				"numeric numeric(10, 5), " +
-				"numeric_arr numeric(10, 5)[], " +
-				"boolean boolean, " +
-				"boolean_arr boolean[], " +
-				"text text, " +
-				"text_arr text[], " +
-				"char char, " +
-				"char_arr char[], " +
-				"character character(3), " +
-				"character_arr character(3)[], " +
-				"character_varying character varying(20), " +
-				"character_varying_arr character varying(20)[], " +
-				"timestamp timestamp(5), " +
-				"timestamp_arr timestamp(5)[], " +
-				"timestamptz timestamptz(4), " +
-				"timestamptz_arr timestamptz(4)[], " +
-				"date date, " +
-				"date_arr date[], " +
-				"time time(3), " +
-				"time_arr time(3)[]"
-		);
-	}
-
-	private static void createTable(PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
-		executeSQL(PostgresCatalog.DEFAULT_DATABASE, String.format("CREATE TABLE %s(%s);", tablePath.getFullPath(), tableSchemaSql));
-	}
-
-	private static void createTable(String db, PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
-		executeSQL(db, String.format("CREATE TABLE %s(%s);", tablePath.getFullPath(), tableSchemaSql));
-	}
-
-	private static void createSchema(String db, String schema) throws SQLException {
-		executeSQL(db, String.format("CREATE SCHEMA %s", schema));
-	}
-
-	private static void createDatabase(String database) throws SQLException {
-		executeSQL(String.format("CREATE DATABASE %s;", database));
-	}
-
-	private static void executeSQL(String sql) throws SQLException {
-		executeSQL("", sql);
-	}
-
-	private static void executeSQL(String db, String sql) throws SQLException {
-		try (Connection conn = DriverManager.getConnection(baseUrl + db, TEST_USERNAME, TEST_PWD);
-				Statement statement = conn.createStatement()) {
-			statement.executeUpdate(sql);
-		} catch (SQLException e) {
-			throw e;
-		}
-	}
-
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.catalog;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
+import com.opentable.db.postgres.junit.SingleInstancePostgresRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.apache.flink.api.java.io.jdbc.catalog.PostgresCatalog.DEFAULT_DATABASE;
+
+/**
+ * Test base for {@link PostgresCatalog}.
+ */
+public class PostgresCatalogTestBase {
+
+	@Rule
+	public ExpectedException exception = ExpectedException.none();
+
+	@ClassRule
+	public static SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+	protected static final String TEST_CATALOG_NAME = "mypg";
+	protected static final String TEST_USERNAME = "postgres";
+	protected static final String TEST_PWD = "postgres";
+	protected static final String TEST_DB = "test";
+	protected static final String TEST_SCHEMA = "test_schema";
+	protected static final String TABLE1 = "t1";
+	protected static final String TABLE2 = "t2";
+	protected static final String TABLE3 = "t3";
+	protected static final String TABLE4 = "t4";
+	protected static final String TABLE5 = "t5";
+
+	protected static String baseUrl;
+	protected static PostgresCatalog catalog;
+
+	@BeforeClass
+	public static void init() throws SQLException {
+		// jdbc:postgresql://localhost:50807/postgres?user=postgres
+		String embeddedJdbcUrl = pg.getEmbeddedPostgres().getJdbcUrl(TEST_USERNAME, TEST_PWD);
+		// jdbc:postgresql://localhost:50807/
+		baseUrl = embeddedJdbcUrl.substring(0, embeddedJdbcUrl.lastIndexOf("/") + 1);
+
+		catalog = new PostgresCatalog(TEST_CATALOG_NAME, PostgresCatalog.DEFAULT_DATABASE, TEST_USERNAME, TEST_PWD, baseUrl);
+
+		// create test database and schema
+		createDatabase(TEST_DB);
+		createSchema(TEST_DB, TEST_SCHEMA);
+
+		// create test tables
+		// table: postgres.public.t1
+		// table: postgres.public.t4
+		// table: postgres.public.t5
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE1), getSimpleTable().pgSchemaSql);
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE4), getSimpleTable().pgSchemaSql);
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE5), getSimpleTable().pgSchemaSql);
+
+		executeSQL(DEFAULT_DATABASE, String.format("insert into public.%s values (1);", TABLE1));
+
+		// table: testdb.public.t2
+		// table: testdb.test_schema.t3
+		// table: testdb.public.datatypes
+		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName(TABLE2), getSimpleTable().pgSchemaSql);
+		createTable(TEST_DB, new PostgresTablePath(TEST_SCHEMA, TABLE3), getSimpleTable().pgSchemaSql);
+		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName("datatypes"), getDataTypesTable().pgSchemaSql);
+	}
+
+	public static void createTable(PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
+		executeSQL(PostgresCatalog.DEFAULT_DATABASE, String.format("CREATE TABLE %s(%s);", tablePath.getFullPath(), tableSchemaSql));
+	}
+
+	public static void createTable(String db, PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
+		executeSQL(db, String.format("CREATE TABLE %s(%s);", tablePath.getFullPath(), tableSchemaSql));
+	}
+
+	public static void createSchema(String db, String schema) throws SQLException {
+		executeSQL(db, String.format("CREATE SCHEMA %s", schema));
+	}
+
+	public static void createDatabase(String database) throws SQLException {
+		executeSQL(String.format("CREATE DATABASE %s;", database));
+	}
+
+	public static void executeSQL(String sql) throws SQLException {
+		executeSQL("", sql);
+	}
+
+	public static void executeSQL(String db, String sql) throws SQLException {
+		try (Connection conn = DriverManager.getConnection(baseUrl + db, TEST_USERNAME, TEST_PWD);
+			Statement statement = conn.createStatement()) {
+			statement.executeUpdate(sql);
+		} catch (SQLException e) {
+			throw e;
+		}
+	}
+
+	/**
+	 * Object holding schema and corresponding sql.
+	 */
+	public static class TestTable {
+		TableSchema schema;
+		String pgSchemaSql;
+
+		public TestTable(TableSchema schema, String pgSchemaSql) {
+			this.schema = schema;
+			this.pgSchemaSql = pgSchemaSql;
+		}
+	}
+
+	public static TestTable getSimpleTable() {
+		return new TestTable(
+			TableSchema.builder()
+				.field("id", DataTypes.INT())
+				.build(),
+			"id integer"
+		);
+	}
+
+	public static TestTable getDataTypesTable() {
+		return new TestTable(
+			TableSchema.builder()
+				.field("int", DataTypes.INT())
+				.field("int_arr", DataTypes.ARRAY(DataTypes.INT()))
+				.field("bytea", DataTypes.BYTES())
+				.field("bytea_arr", DataTypes.ARRAY(DataTypes.BYTES()))
+				.field("short", DataTypes.SMALLINT())
+				.field("short_arr", DataTypes.ARRAY(DataTypes.SMALLINT()))
+				.field("long", DataTypes.BIGINT())
+				.field("long_arr", DataTypes.ARRAY(DataTypes.BIGINT()))
+				.field("real", DataTypes.FLOAT())
+				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
+				.field("double_precision", DataTypes.DOUBLE())
+				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
+				.field("numeric", DataTypes.DECIMAL(10, 5))
+				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
+				.field("boolean", DataTypes.BOOLEAN())
+				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
+				.field("text", DataTypes.STRING())
+				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
+				.field("char", DataTypes.CHAR(1))
+				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
+				.field("character", DataTypes.CHAR(3))
+				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
+				.field("character_varying", DataTypes.VARCHAR(20))
+				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
+				.field("timestamp", DataTypes.TIMESTAMP(5))
+				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
+				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
+				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
+				.field("date", DataTypes.DATE())
+				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
+				.field("time", DataTypes.TIME(3))
+				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME(3)))
+				.build(),
+			"int integer, " +
+				"int_arr integer[], " +
+				"bytea bytea, " +
+				"bytea_arr bytea[], " +
+				"short smallint, " +
+				"short_arr smallint[], " +
+				"long bigint, " +
+				"long_arr bigint[], " +
+				"real real, " +
+				"real_arr real[], " +
+				"double_precision double precision, " +
+				"double_precision_arr double precision[], " +
+				"numeric numeric(10, 5), " +
+				"numeric_arr numeric(10, 5)[], " +
+				"boolean boolean, " +
+				"boolean_arr boolean[], " +
+				"text text, " +
+				"text_arr text[], " +
+				"char char, " +
+				"char_arr char[], " +
+				"character character(3), " +
+				"character_arr character(3)[], " +
+				"character_varying character varying(20), " +
+				"character_varying_arr character varying(20)[], " +
+				"timestamp timestamp(5), " +
+				"timestamp_arr timestamp(5)[], " +
+				"timestamptz timestamptz(4), " +
+				"timestamptz_arr timestamptz(4)[], " +
+				"date date, " +
+				"date_arr date[], " +
+				"time time(3), " +
+				"time_arr time(3)[]"
+		);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactoryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.catalog.factory;
+
+import org.apache.flink.api.java.io.jdbc.catalog.JDBCCatalog;
+import org.apache.flink.api.java.io.jdbc.catalog.PostgresCatalog;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.descriptors.CatalogDescriptor;
+import org.apache.flink.table.descriptors.JDBCCatalogDescriptor;
+import org.apache.flink.table.factories.CatalogFactory;
+import org.apache.flink.table.factories.TableFactoryService;
+
+import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
+import com.opentable.db.postgres.junit.SingleInstancePostgresRule;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link JDBCCatalogFactory}.
+ */
+public class JDBCCatalogFactoryTest {
+	@ClassRule
+	public static SingleInstancePostgresRule pg = EmbeddedPostgresRules.singleInstance();
+
+	protected static String baseUrl;
+	protected static JDBCCatalog catalog;
+
+	protected static final String TEST_CATALOG_NAME = "mypg";
+	protected static final String TEST_USERNAME = "postgres";
+	protected static final String TEST_PWD = "postgres";
+
+	@BeforeClass
+	public static void setup() throws SQLException {
+		// jdbc:postgresql://localhost:50807/postgres?user=postgres
+		String embeddedJdbcUrl = pg.getEmbeddedPostgres().getJdbcUrl(TEST_USERNAME, TEST_PWD);
+		// jdbc:postgresql://localhost:50807/
+		baseUrl = embeddedJdbcUrl.substring(0, embeddedJdbcUrl.lastIndexOf("/") + 1);
+
+		catalog = new JDBCCatalog(
+			TEST_CATALOG_NAME, PostgresCatalog.DEFAULT_DATABASE, TEST_USERNAME, TEST_PWD, baseUrl);
+	}
+
+	@Test
+	public void test() {
+		final CatalogDescriptor catalogDescriptor =
+			new JDBCCatalogDescriptor(PostgresCatalog.DEFAULT_DATABASE, TEST_USERNAME, TEST_PWD, baseUrl);
+
+		final Map<String, String> properties = catalogDescriptor.toProperties();
+
+		final Catalog actualCatalog = TableFactoryService.find(CatalogFactory.class, properties)
+			.createCatalog(TEST_CATALOG_NAME, properties);
+
+		checkEquals(catalog, (JDBCCatalog) actualCatalog);
+	}
+
+	private static void checkEquals(JDBCCatalog c1, JDBCCatalog c2) {
+		assertEquals(c1.getName(), c2.getName());
+		assertEquals(c1.getDefaultDatabase(), c2.getDefaultDatabase());
+		assertEquals(c1.getUsername(), c2.getUsername());
+		assertEquals(c1.getPassword(), c2.getPassword());
+		assertEquals(c1.getBaseUrl(), c2.getBaseUrl());
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactoryTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/factory/JDBCCatalogFactoryTest.java
@@ -36,6 +36,7 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link JDBCCatalogFactory}.
@@ -73,6 +74,8 @@ public class JDBCCatalogFactoryTest {
 			.createCatalog(TEST_CATALOG_NAME, properties);
 
 		checkEquals(catalog, (JDBCCatalog) actualCatalog);
+
+		assertTrue(((JDBCCatalog) actualCatalog).getInternal() instanceof PostgresCatalog);
 	}
 
 	private static void checkEquals(JDBCCatalog c1, JDBCCatalog c2) {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptorTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/table/descriptors/JDBCCatalogDescriptorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.JDBCCatalogValidator.CATALOG_TYPE_VALUE_JDBC;
+
+/**
+ * Test for {@link JDBCCatalogDescriptor}.
+ */
+public class JDBCCatalogDescriptorTest extends DescriptorTestBase {
+
+	private static final String TEST_DB = "db";
+	private static final String TEST_USERNAME = "user";
+	private static final String TEST_PWD = "pwd";
+	private static final String TEST_BASE_URL = "xxx";
+
+	@Override
+	protected List<Descriptor> descriptors() {
+		final Descriptor descriptor = new JDBCCatalogDescriptor(
+			TEST_DB, TEST_USERNAME, TEST_PWD, TEST_BASE_URL);
+
+		return Arrays.asList(descriptor);
+	}
+
+	@Override
+	protected List<Map<String, String>> properties() {
+		final Map<String, String> props = new HashMap<>();
+		props.put("type", CATALOG_TYPE_VALUE_JDBC);
+		props.put("property-version", "1");
+		props.put("default-database", TEST_DB);
+		props.put("username", TEST_USERNAME);
+		props.put("password", TEST_PWD);
+		props.put("base-url", TEST_BASE_URL);
+
+		return Arrays.asList(props);
+	}
+
+	@Override
+	protected DescriptorValidator validator() {
+		return new JDBCCatalogValidator();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

commit 1: develop JDBCCatalogFactory, descriptor, and validator for service discovery
commit 2: rename a class
commit 3: connect PgCatalog to blink planner

## Brief change log

commit 1:
- add JDBCCatalogFactory, JDBCCatalogDescriptor, JDBCCatalogValidator
- add corresponding UTs

commit 3:
- connect pg catalog to blink planner
- added e2e tests to retrieve pg metadata and read/write pg tables 

## Verifying this change

newly added UTs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

docs will be added later
