### PR TITLE
[FLINK-16547][yarn] Respect the config option of FileJobGraphRetriever#JOB_GRAPH_FILE_PATH

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -789,6 +789,41 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		paths.add(remotePathJar);
 		classPathBuilder.append(flinkJarPath.getName()).append(File.pathSeparator);
 
+		// write job graph to tmp file and add it to local resource
+		// TODO: server use user main method to generate job graph
+		if (jobGraph != null) {
+			File tmpJobGraphFile = null;
+			try {
+				tmpJobGraphFile = File.createTempFile(appId.toString(), null);
+				try (FileOutputStream output = new FileOutputStream(tmpJobGraphFile);
+					ObjectOutputStream obOutput = new ObjectOutputStream(output)) {
+					obOutput.writeObject(jobGraph);
+				}
+
+				final String jobGraphFilename = "job.graph";
+				flinkConfiguration.setString(JOB_GRAPH_FILE_PATH, jobGraphFilename);
+
+				Path pathFromYarnURL = setupSingleLocalResource(
+					jobGraphFilename,
+					fs,
+					appId,
+					new Path(tmpJobGraphFile.toURI()),
+					localResources,
+					homeDir,
+					"",
+					fileReplication);
+				paths.add(pathFromYarnURL);
+				classPathBuilder.append(jobGraphFilename).append(File.pathSeparator);
+			} catch (Exception e) {
+				LOG.warn("Add job graph to local resource fail.");
+				throw e;
+			} finally {
+				if (tmpJobGraphFile != null && !tmpJobGraphFile.delete()) {
+					LOG.warn("Fail to delete temporary file {}.", tmpJobGraphFile.toPath());
+				}
+			}
+		}
+
 		// Upload the flink configuration
 		// write out configuration file
 		File tmpConfigurationFile = null;
@@ -818,41 +853,6 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		if (userJarInclusion == YarnConfigOptions.UserJarInclusion.LAST) {
 			for (String userClassPath : userClassPaths) {
 				classPathBuilder.append(userClassPath).append(File.pathSeparator);
-			}
-		}
-
-		// write job graph to tmp file and add it to local resource
-		// TODO: server use user main method to generate job graph
-		if (jobGraph != null) {
-			File tmpJobGraphFile = null;
-			try {
-				tmpJobGraphFile = File.createTempFile(appId.toString(), null);
-				try (FileOutputStream output = new FileOutputStream(tmpJobGraphFile);
-					ObjectOutputStream obOutput = new ObjectOutputStream(output);){
-					obOutput.writeObject(jobGraph);
-				}
-
-				final String jobGraphFilename = "job.graph";
-				flinkConfiguration.setString(JOB_GRAPH_FILE_PATH, jobGraphFilename);
-
-				Path pathFromYarnURL = setupSingleLocalResource(
-						jobGraphFilename,
-						fs,
-						appId,
-						new Path(tmpJobGraphFile.toURI()),
-						localResources,
-						homeDir,
-						"",
-						fileReplication);
-				paths.add(pathFromYarnURL);
-				classPathBuilder.append(jobGraphFilename).append(File.pathSeparator);
-			} catch (Exception e) {
-				LOG.warn("Add job graph to local resource fail");
-				throw e;
-			} finally {
-				if (tmpJobGraphFile != null && !tmpJobGraphFile.delete()) {
-					LOG.warn("Fail to delete temporary file {}.", tmpJobGraphFile.toPath());
-				}
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, in `YarnClusterDescriptor#startAppMaster,` we first write out and upload the Flink Configuration file, then start to write out the JobGraph file and set its name into the Flink Configuration object, the setting is not written into the Flink Configuration file so that it does not take effect in the cluster side.

This ticket proposes to write out the JobGraph file before the Configuration file to ensure that the setting of FileJobGraphRetriever.JOB_GRAPH_FILE_PATH works on the cluster side.

## Verifying this change

This change is a trivial rework without any test coverage and could be verified manually by submitting a per job to the yarn cluster successfully.
`./bin/flink run -d -e yarn-per-job examples/streaming/WordCount.jar`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
