### PR TITLE
[FLINK-16581][table] Minibatch deduplication lack state TTL bug fix

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunction.java
@@ -18,51 +18,47 @@
 
 package org.apache.flink.table.runtime.operators.deduplicate;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.functions.KeyedProcessFunctionWithCleanupState;
 import org.apache.flink.util.Collector;
 
 import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.processFirstRow;
+import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
 
 /**
  * This function is used to deduplicate on keys and keeps only first row.
  */
 public class DeduplicateKeepFirstRowFunction
-		extends KeyedProcessFunctionWithCleanupState<BaseRow, BaseRow, BaseRow> {
+		extends KeyedProcessFunction<BaseRow, BaseRow, BaseRow> {
 
 	private static final long serialVersionUID = 5865777137707602549L;
 
+	private final long minRetentionTime;
 	// state stores a boolean flag to indicate whether key appears before.
 	private ValueState<Boolean> state;
 
-	public DeduplicateKeepFirstRowFunction(long minRetentionTime, long maxRetentionTime) {
-		super(minRetentionTime, maxRetentionTime);
+	public DeduplicateKeepFirstRowFunction(long minRetentionTime) {
+		this.minRetentionTime = minRetentionTime;
 	}
 
 	@Override
 	public void open(Configuration configure) throws Exception {
 		super.open(configure);
-		initCleanupTimeState("DeduplicateFunctionKeepFirstRow");
 		ValueStateDescriptor<Boolean> stateDesc = new ValueStateDescriptor<>("existsState", Types.BOOLEAN);
+		StateTtlConfig ttlConfig = createTtlConfig(minRetentionTime);
+		if (ttlConfig.isEnabled()) {
+			stateDesc.enableTimeToLive(ttlConfig);
+		}
 		state = getRuntimeContext().getState(stateDesc);
 	}
 
 	@Override
 	public void processElement(BaseRow input, Context ctx, Collector<BaseRow> out) throws Exception {
-		long currentTime = ctx.timerService().currentProcessingTime();
-		// register state-cleanup timer
-		registerProcessingCleanupTimer(ctx, currentTime);
 		processFirstRow(input, state, out);
-	}
-
-	@Override
-	public void onTimer(long timestamp, OnTimerContext ctx, Collector<BaseRow> out) throws Exception {
-		if (stateCleaningEnabled) {
-			cleanupState(state);
-		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunction.java
@@ -18,35 +18,37 @@
 
 package org.apache.flink.table.runtime.operators.deduplicate;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.runtime.functions.KeyedProcessFunctionWithCleanupState;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.util.Collector;
 
 import static org.apache.flink.table.runtime.operators.deduplicate.DeduplicateFunctionHelper.processLastRow;
+import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
 
 /**
  * This function is used to deduplicate on keys and keeps only last row.
  */
 public class DeduplicateKeepLastRowFunction
-		extends KeyedProcessFunctionWithCleanupState<BaseRow, BaseRow, BaseRow> {
+		extends KeyedProcessFunction<BaseRow, BaseRow, BaseRow> {
 
 	private static final long serialVersionUID = -291348892087180350L;
 	private final BaseRowTypeInfo rowTypeInfo;
 	private final boolean generateUpdateBefore;
 
+	private final long minRetentionTime;
 	// state stores complete row.
 	private ValueState<BaseRow> state;
 
 	public DeduplicateKeepLastRowFunction(
 			long minRetentionTime,
-			long maxRetentionTime,
 			BaseRowTypeInfo rowTypeInfo,
 			boolean generateUpdateBefore) {
-		super(minRetentionTime, maxRetentionTime);
+		this.minRetentionTime = minRetentionTime;
 		this.rowTypeInfo = rowTypeInfo;
 		this.generateUpdateBefore = generateUpdateBefore;
 	}
@@ -56,26 +58,18 @@ public class DeduplicateKeepLastRowFunction
 		super.open(configure);
 		if (generateUpdateBefore) {
 			// state stores complete row if need generate retraction, otherwise do not need a state
-			initCleanupTimeState("DeduplicateFunctionKeepLastRow");
 			ValueStateDescriptor<BaseRow> stateDesc = new ValueStateDescriptor<>("preRowState", rowTypeInfo);
+			StateTtlConfig ttlConfig = createTtlConfig(minRetentionTime);
+			if (ttlConfig.isEnabled()) {
+				stateDesc.enableTimeToLive(ttlConfig);
+			}
 			state = getRuntimeContext().getState(stateDesc);
 		}
 	}
 
 	@Override
 	public void processElement(BaseRow input, Context ctx, Collector<BaseRow> out) throws Exception {
-		if (generateUpdateBefore) {
-			long currentTime = ctx.timerService().currentProcessingTime();
-			// register state-cleanup timer
-			registerProcessingCleanupTimer(ctx, currentTime);
-		}
 		processLastRow(input, generateUpdateBefore, state, out);
 	}
 
-	@Override
-	public void onTimer(long timestamp, OnTimerContext ctx, Collector<BaseRow> out) throws Exception {
-		if (stateCleaningEnabled) {
-			cleanupState(state);
-		}
-	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/AbstractStreamingJoinOperator.java
@@ -76,7 +76,6 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 	private final boolean filterAllNulls;
 
 	protected final long minRetentionTime;
-	protected final boolean stateCleaningEnabled;
 
 	protected transient JoinConditionWithNullFilters joinCondition;
 	protected transient TimestampedCollector<BaseRow> collector;
@@ -95,7 +94,6 @@ public abstract class AbstractStreamingJoinOperator extends AbstractStreamOperat
 		this.leftInputSideSpec = leftInputSideSpec;
 		this.rightInputSideSpec = rightInputSideSpec;
 		this.minRetentionTime = minRetentionTime;
-		this.stateCleaningEnabled = minRetentionTime > 1;
 		this.nullFilterKeys = NullAwareJoinHelper.getNullFilterKeys(filterNullKeys);
 		this.nullSafe = nullFilterKeys.length == 0;
 		this.filterAllNulls = nullFilterKeys.length == filterNullKeys.length;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingJoinOperator.java
@@ -82,16 +82,14 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
 				"left-records",
 				leftInputSideSpec,
 				leftType,
-				minRetentionTime,
-				stateCleaningEnabled);
+				minRetentionTime);
 		} else {
 			this.leftRecordStateView = JoinRecordStateViews.create(
 				getRuntimeContext(),
 				"left-records",
 				leftInputSideSpec,
 				leftType,
-				minRetentionTime,
-				stateCleaningEnabled);
+				minRetentionTime);
 		}
 
 		if (rightIsOuter) {
@@ -100,16 +98,14 @@ public class StreamingJoinOperator extends AbstractStreamingJoinOperator {
 				"right-records",
 				rightInputSideSpec,
 				rightType,
-				minRetentionTime,
-				stateCleaningEnabled);
+				minRetentionTime);
 		} else {
 			this.rightRecordStateView = JoinRecordStateViews.create(
 				getRuntimeContext(),
 				"right-records",
 				rightInputSideSpec,
 				rightType,
-				minRetentionTime,
-				stateCleaningEnabled);
+				minRetentionTime);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -66,16 +66,14 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 			LEFT_RECORDS_STATE_NAME,
 			leftInputSideSpec,
 			leftType,
-			minRetentionTime,
-			stateCleaningEnabled);
+			minRetentionTime);
 
 		this.rightRecordStateView = JoinRecordStateViews.create(
 			getRuntimeContext(),
 			RIGHT_RECORDS_STATE_NAME,
 			rightInputSideSpec,
 			rightType,
-			minRetentionTime,
-			stateCleaningEnabled);
+			minRetentionTime);
 	}
 
 	/**

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/state/OuterJoinRecordStateViews.java
@@ -37,7 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStateViews.createTtlConfig;
+import static org.apache.flink.table.runtime.util.StateTtlConfigUtil.createTtlConfig;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -53,9 +53,8 @@ public final class OuterJoinRecordStateViews {
 			String stateName,
 			JoinInputSideSpec inputSideSpec,
 			BaseRowTypeInfo recordType,
-			long retentionTime,
-			boolean stateCleaningEnabled) {
-		StateTtlConfig ttlConfig = createTtlConfig(retentionTime, stateCleaningEnabled);
+			long retentionTime) {
+		StateTtlConfig ttlConfig = createTtlConfig(retentionTime);
 		if (inputSideSpec.hasUniqueKey()) {
 			if (inputSideSpec.joinKeyContainsUniqueKey()) {
 				return new OuterJoinRecordStateViews.JoinKeyContainsUniqueKey(ctx, stateName, recordType, ttlConfig);
@@ -86,7 +85,7 @@ public final class OuterJoinRecordStateViews {
 			ValueStateDescriptor<Tuple2<BaseRow, Integer>> recordStateDesc = new ValueStateDescriptor<>(
 				stateName,
 				valueTypeInfo);
-			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+			if (ttlConfig.isEnabled()) {
 				recordStateDesc.enableTimeToLive(ttlConfig);
 			}
 			this.recordState = ctx.getState(recordStateDesc);
@@ -157,7 +156,7 @@ public final class OuterJoinRecordStateViews {
 				stateName,
 				uniqueKeyType,
 				valueTypeInfo);
-			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+			if (ttlConfig.isEnabled()) {
 				recordStateDesc.enableTimeToLive(ttlConfig);
 			}
 			this.recordState = ctx.getMapState(recordStateDesc);
@@ -213,7 +212,7 @@ public final class OuterJoinRecordStateViews {
 				stateName,
 				recordType,
 				tupleTypeInfo);
-			if (!ttlConfig.equals(StateTtlConfig.DISABLED)) {
+			if (ttlConfig.isEnabled()) {
 				recordStateDesc.enableTimeToLive(ttlConfig);
 			}
 			this.recordState = ctx.getMapState(recordStateDesc);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateTtlConfigUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateTtlConfigUtil.java
@@ -35,7 +35,7 @@ public class StateTtlConfigUtil {
 			return StateTtlConfig
 				.newBuilder(Time.milliseconds(retentionTime))
 				.setUpdateType(StateTtlConfig.UpdateType.OnCreateAndWrite)
-				.setStateVisibility(StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
+				.setStateVisibility(StateTtlConfig.StateVisibility.NeverReturnExpired)
 				.build();
 		} else {
 			return StateTtlConfig.DISABLED;

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateTtlConfigUtil.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/util/StateTtlConfigUtil.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.util;
+
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.time.Time;
+
+/**
+ * Utility to create a {@link StateTtlConfig} object.
+ * */
+public class StateTtlConfigUtil {
+
+	/**
+	 * Creates a {@link StateTtlConfig} depends on retentionTime parameter.
+	 * @param retentionTime State ttl time which unit is MILLISECONDS.
+	 */
+	public static StateTtlConfig createTtlConfig(long retentionTime) {
+		if (retentionTime > 0) {
+			return StateTtlConfig
+				.newBuilder(Time.milliseconds(retentionTime))
+				.setUpdateType(StateTtlConfig.UpdateType.OnCreateAndWrite)
+				.setStateVisibility(StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp)
+				.build();
+		} else {
+			return StateTtlConfig.DISABLED;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionTestBase.java
@@ -19,8 +19,6 @@
 package org.apache.flink.table.runtime.operators.deduplicate;
 
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
-import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.runtime.util.BinaryRowKeySelector;
@@ -29,17 +27,12 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.VarCharType;
 
-import java.util.List;
-
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
-
 /**
  * Base class of tests for all kinds of DeduplicateFunction.
  */
 abstract class DeduplicateFunctionTestBase {
 
 	Time minTime = Time.milliseconds(10);
-	long incCleanupKeys = 3;
 	BaseRowTypeInfo inputRowType = new BaseRowTypeInfo(new VarCharType(VarCharType.MAX_LENGTH), new BigIntType(),
 			new IntType());
 
@@ -50,18 +43,5 @@ abstract class DeduplicateFunctionTestBase {
 	BaseRowHarnessAssertor assertor = new BaseRowHarnessAssertor(
 			inputRowType.getFieldTypes(),
 			new GenericRowRecordSortComparator(rowKeyIdx, inputRowType.getLogicalTypes()[rowKeyIdx]));
-
-	public void triggerMoreIncrementalCleanupByOtherOps(
-		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness) throws Exception {
-		for (long i = incCleanupKeys; i < incCleanupKeys * 10; i++) {
-			testHarness.processElement(record("book", i, 20));
-		}
-	}
-
-	public void addRecordToExpectedOutput(List<Object> expectedOutput) {
-		for (long i = incCleanupKeys; i < incCleanupKeys * 10; i++) {
-			expectedOutput.add(record("book", i, 20));
-		}
-	}
 
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
@@ -69,9 +69,6 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 		testHarness.processElement(record("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
-		triggerMoreIncrementalCleanupByOtherOps(testHarness);
-
 		testHarness.processElement(record("book", 1L, 17));
 		testHarness.processElement(record("book", 2L, 18));
 		testHarness.processElement(record("book", 1L, 19));
@@ -80,7 +77,6 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 2L, 11));
-		addRecordToExpectedOutput(expectedOutput);
 		//(1L,12),(2L,11) has retired, so output (1L,17) and (2L,18)
 		expectedOutput.add(record("book", 1L, 17));
 		expectedOutput.add(record("book", 2L, 18));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
@@ -44,8 +44,7 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 
 	@Test
 	public void test() throws Exception {
-		DeduplicateKeepFirstRowFunction func = new DeduplicateKeepFirstRowFunction(minTime.toMilliseconds(),
-				maxTime.toMilliseconds());
+		DeduplicateKeepFirstRowFunction func = new DeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(record("book", 1L, 12));
@@ -60,4 +59,32 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
+	@Test
+	public void testWithStateTtl() throws Exception {
+		DeduplicateKeepFirstRowFunction func = new DeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(record("book", 1L, 12));
+		testHarness.processElement(record("book", 2L, 11));
+		testHarness.processElement(record("book", 1L, 13));
+
+		testHarness.setStateTtlProcessingTime(30);
+		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
+		triggerMoreIncrementalCleanupByOtherOps(testHarness);
+
+		testHarness.processElement(record("book", 1L, 17));
+		testHarness.processElement(record("book", 2L, 18));
+		testHarness.processElement(record("book", 1L, 19));
+
+		// Keep FirstRow in deduplicate will not send retraction
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(record("book", 1L, 12));
+		expectedOutput.add(record("book", 2L, 11));
+		addRecordToExpectedOutput(expectedOutput);
+		//(1L,12),(2L,11) has retired, so output (1L,17) and (2L,18)
+		expectedOutput.add(record("book", 1L, 17));
+		expectedOutput.add(record("book", 2L, 18));
+		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		testHarness.close();
+	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
@@ -96,9 +96,6 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 		testHarness.processElement(record("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
-		triggerMoreIncrementalCleanupByOtherOps(testHarness);
-
 		testHarness.processElement(record("book", 1L, 17));
 		testHarness.processElement(record("book", 2L, 18));
 		testHarness.processElement(record("book", 1L, 19));
@@ -109,7 +106,6 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 		expectedOutput.add(retractRecord("book", 1L, 12));
 		expectedOutput.add(record("book", 1L, 13));
 		expectedOutput.add(record("book", 2L, 11));
-		addRecordToExpectedOutput(expectedOutput);
 		// because (2L,11), (1L,13) retired, so there is no retract message send to downstream
 		expectedOutput.add(record("book", 1L, 17));
 		expectedOutput.add(retractRecord("book", 1L, 17));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepFirstRowFunctionTest.java
@@ -72,7 +72,7 @@ public class MiniBatchDeduplicateKeepFirstRowFunctionTest extends DeduplicateFun
 	}
 
 	@Test
-	public void tesKeepFirstRowWithStateTtl() throws Exception {
+	public void testKeepFirstRowWithStateTtl() throws Exception {
 		MiniBatchDeduplicateKeepFirstRowFunction func = new MiniBatchDeduplicateKeepFirstRowFunction(typeSerializer, minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.setup();
@@ -84,9 +84,6 @@ public class MiniBatchDeduplicateKeepFirstRowFunctionTest extends DeduplicateFun
 		testHarness.processElement(record("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
-		triggerMoreIncrementalCleanupByOtherOps(testHarness);
-
 		testHarness.processElement(record("book", 1L, 17));
 		testHarness.processElement(record("book", 2L, 18));
 		testHarness.processElement(record("book", 1L, 19));
@@ -95,7 +92,6 @@ public class MiniBatchDeduplicateKeepFirstRowFunctionTest extends DeduplicateFun
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 1L, 12));
 		expectedOutput.add(record("book", 2L, 11));
-		addRecordToExpectedOutput(expectedOutput);
 		//(1L,12),(2L,11) has retired, so output (1L,17) and (2L,18)
 		expectedOutput.add(record("book", 1L, 17));
 		expectedOutput.add(record("book", 2L, 18));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
@@ -128,9 +128,6 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 		testHarness.processElement(record("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
-		triggerMoreIncrementalCleanupByOtherOps(testHarness);
-
 		testHarness.processElement(record("book", 1L, 17));
 		testHarness.processElement(record("book", 2L, 18));
 		testHarness.processElement(record("book", 1L, 19));
@@ -138,7 +135,6 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(record("book", 2L, 11));
 		expectedOutput.add(record("book", 1L, 13));
-		addRecordToExpectedOutput(expectedOutput);
 		// because (2L,11), (1L,13) retired, so there is no retract message send to downstream
 		expectedOutput.add(record("book", 1L, 19));
 		expectedOutput.add(record("book", 2L, 18));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunctionTest.java
@@ -43,8 +43,8 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 
 	private TypeSerializer<BaseRow> typeSerializer = inputRowType.createSerializer(new ExecutionConfig());
 
-	private MiniBatchDeduplicateKeepLastRowFunction createFunction(boolean generateUpdateBefore) {
-		return new MiniBatchDeduplicateKeepLastRowFunction(inputRowType, generateUpdateBefore, typeSerializer);
+	private MiniBatchDeduplicateKeepLastRowFunction createFunction(boolean generateUpdateBefore, long minRetentionTime) {
+		return new MiniBatchDeduplicateKeepLastRowFunction(inputRowType, generateUpdateBefore, typeSerializer, minRetentionTime);
 	}
 
 	private OneInputStreamOperatorTestHarness<BaseRow, BaseRow> createTestHarness(
@@ -57,7 +57,7 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 
 	@Test
 	public void testWithoutGenerateUpdateBefore() throws Exception {
-		MiniBatchDeduplicateKeepLastRowFunction func = createFunction(false);
+		MiniBatchDeduplicateKeepLastRowFunction func = createFunction(false, minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(record("book", 1L, 10));
@@ -85,7 +85,7 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 
 	@Test
 	public void testWithGenerateUpdateBefore() throws Exception {
-		MiniBatchDeduplicateKeepLastRowFunction func = createFunction(true);
+		MiniBatchDeduplicateKeepLastRowFunction func = createFunction(true, minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(record("book", 1L, 10));
@@ -111,6 +111,37 @@ public class MiniBatchDeduplicateKeepLastRowFunctionTest extends DeduplicateFunc
 		expectedOutput.add(record("book", 2L, 11));
 		expectedOutput.add(record("book", 3L, 11));
 		testHarness.close();
+		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
+		MiniBatchDeduplicateKeepLastRowFunction func = createFunction(true, minTime.toMilliseconds());
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.setup();
+		testHarness.open();
+
+		testHarness.processElement(record("book", 1L, 10));
+		testHarness.processElement(record("book", 2L, 11));
+		// output is empty because bundle not trigger yet.
+		Assert.assertTrue(testHarness.getOutput().isEmpty());
+		testHarness.processElement(record("book", 1L, 13));
+
+		testHarness.setStateTtlProcessingTime(30);
+		//Incremental cleanup is an eventual clean up, more state access guarantee more expired state cleaned
+		triggerMoreIncrementalCleanupByOtherOps(testHarness);
+
+		testHarness.processElement(record("book", 1L, 17));
+		testHarness.processElement(record("book", 2L, 18));
+		testHarness.processElement(record("book", 1L, 19));
+
+		List<Object> expectedOutput = new ArrayList<>();
+		expectedOutput.add(record("book", 2L, 11));
+		expectedOutput.add(record("book", 1L, 13));
+		addRecordToExpectedOutput(expectedOutput);
+		// because (2L,11), (1L,13) retired, so there is no retract message send to downstream
+		expectedOutput.add(record("book", 1L, 19));
+		expectedOutput.add(record("book", 2L, 18));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change
fix the bug of minibatch deduplication lack state TTL, otherwise, it lead to OOM with long running streaming job
## Brief change log
  - support minibatch deduplication keep first row with state TTL
  - support minibatch deduplication keep last row with state TTL

## Verifying this change

This change added tests and can be verified as follows:
  - MiniBatchDeduplicateKeepLastRowFunctionTest#tesKeepLastRowtProcessingTimeTimerWithStateAndGenerateRetraction
  - MiniBatchDeduplicateKeepFirstRowFunctionTest#tesKeepFirstRowtProcessingTimeTimerWithState
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
