### PR TITLE
[FLINK-16711][parquet] Parquet columnar row reader read footer from wrong end

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReader.java
@@ -117,7 +117,7 @@ public class ParquetColumnarRowSplitReader implements Closeable {
 		this.selectedTypes = selectedTypes;
 		this.batchSize = batchSize;
 		// then we need to apply the predicate push down filter
-		ParquetMetadata footer = readFooter(conf, path, range(splitStart, splitLength));
+		ParquetMetadata footer = readFooter(conf, path, range(splitStart, splitStart + splitLength));
 		MessageType fileSchema = footer.getFileMetaData().getSchema();
 		FilterCompat.Filter filter = getFilter(conf);
 		List<BlockMetaData> blocks = filterRowGroups(filter, footer.getBlocks(), fileSchema);


### PR DESCRIPTION

## What is the purpose of the change

Fix `ParquetColumnarRowSplitReader` read footer bug

## Brief change log

`readFooter(conf, path, range(splitStart, splitLength))`
Should be:
`readFooter(conf, path, range(splitStart, splitStart + splitLength))`

## Verifying this change

- Can not re-produce in test.
- Manually test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)