### PR TITLE
[FLINK-16652][orc] BytesColumnVector should init buffer in Hive 3.x

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -138,9 +138,11 @@ public abstract class AbstractOrcColumnVector implements
 			bcv.isNull[0] = true;
 			bcv.isRepeating = true;
 		} else {
-			bcv.fill(value instanceof byte[] ?
+			byte[] bytes = value instanceof byte[] ?
 					(byte[]) value :
-					value.toString().getBytes(StandardCharsets.UTF_8));
+					value.toString().getBytes(StandardCharsets.UTF_8);
+			bcv.initBuffer(bytes.length);
+			bcv.fill(bytes);
 			bcv.isNull[0] = false;
 		}
 		return bcv;


### PR DESCRIPTION

## What is the purpose of the change

BytesColumnVector should init buffer before fill in Hive 3.x.
Otherwise there is a NPE.

## Brief change log

For `BytesColumnVector`, `initBuffer` before `init`.

## Verifying this change

`TableEnvHiveConnectorTest#testDifferentFormats` when hive 3.x

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)