### PR TITLE
[FLINK-16712][task] Refactor StreamTask to construct final fields

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/BoundedStreamTask.java
@@ -60,7 +60,7 @@ class BoundedStreamTask<IN, OUT, OP extends OneInputStreamOperator<IN, OUT> & Bo
 	BoundedStreamTask(
 		Environment environment,
 		Iterable<IN> input,
-		Collector<OUT> collector) {
+		Collector<OUT> collector) throws Exception {
 		super(environment, new NeverFireProcessingTimeService());
 		this.input = input.iterator();
 		this.collector = collector;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/AbstractTwoInputStreamTask.java
@@ -47,7 +47,7 @@ public abstract class AbstractTwoInputStreamTask<IN1, IN2, OUT> extends StreamTa
 	 *
 	 * @param env The task environment for this task.
 	 */
-	public AbstractTwoInputStreamTask(Environment env) {
+	public AbstractTwoInputStreamTask(Environment env) throws Exception {
 		super(env);
 
 		input1WatermarkGauge = new WatermarkGauge();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -46,7 +46,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputStreamOperator<OUT>> {
-	public MultipleInputStreamTask(Environment env) {
+	public MultipleInputStreamTask(Environment env) throws Exception {
 		super(env);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -59,7 +59,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	 *
 	 * @param env The task environment for this task.
 	 */
-	public OneInputStreamTask(Environment env) {
+	public OneInputStreamTask(Environment env) throws Exception {
 		super(env);
 	}
 
@@ -76,7 +76,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
 	@VisibleForTesting
 	public OneInputStreamTask(
 			Environment env,
-			@Nullable TimerService timeProvider) {
+			@Nullable TimerService timeProvider) throws Exception {
 		super(env, timeProvider);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceReaderStreamTask.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class SourceReaderStreamTask<T> extends StreamTask<T, SourceReaderOperator<T>> {
 
-	public SourceReaderStreamTask(Environment env) {
+	public SourceReaderStreamTask(Environment env) throws Exception {
 		super(env);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -64,11 +64,11 @@ public class SourceStreamTask<OUT, SRC extends SourceFunction<OUT>, OP extends S
 	 */
 	private volatile boolean isFinished = false;
 
-	public SourceStreamTask(Environment env) {
+	public SourceStreamTask(Environment env) throws Exception {
 		this(env, new Object());
 	}
 
-	private SourceStreamTask(Environment env, Object lock) {
+	private SourceStreamTask(Environment env, Object lock) throws Exception {
 		super(env, null, FatalExitExceptionHandler.INSTANCE, StreamTaskActionExecutor.synchronizedExecutor(lock));
 		this.lock = Preconditions.checkNotNull(lock);
 		this.sourceThread = new LegacySourceFunctionThread();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationHead.java
@@ -50,7 +50,7 @@ public class StreamIterationHead<OUT> extends OneInputStreamTask<OUT, OUT> {
 	private final long iterationWaitTime;
 	private final boolean shouldWait;
 
-	public StreamIterationHead(Environment env) {
+	public StreamIterationHead(Environment env) throws Exception {
 		super(env);
 		final String iterationId = getConfiguration().getIterationId();
 		if (iterationId == null || iterationId.length() == 0) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamIterationTail.java
@@ -43,7 +43,7 @@ public class StreamIterationTail<IN> extends OneInputStreamTask<IN, IN> {
 
 	private static final Logger LOG = LoggerFactory.getLogger(StreamIterationTail.class);
 
-	public StreamIterationTail(Environment environment) {
+	public StreamIterationTail(Environment environment) throws Exception {
 		super(environment);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -168,19 +168,17 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	protected final StreamConfig configuration;
 
 	/** Our state backend. We use this to create checkpoint streams and a keyed state backend. */
-	protected StateBackend stateBackend;
+	protected final StateBackend stateBackend;
 
 	/** The external storage where checkpoint data is persisted. */
-	private CheckpointStorageWorkerView checkpointStorage;
+	private final CheckpointStorageWorkerView checkpointStorage;
 
 	/**
 	 * The internal {@link TimerService} used to define the current
 	 * processing time (default = {@code System.currentTimeMillis()}) and
 	 * register timers for tasks to be executed in the future.
 	 */
-	protected TimerService timerService;
-
-	private final Thread.UncaughtExceptionHandler uncaughtExceptionHandler;
+	protected final TimerService timerService;
 
 	/** The currently active background materialization threads. */
 	private final CloseableRegistry cancelables = new CloseableRegistry();
@@ -199,7 +197,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	private boolean disposedOperators;
 
 	/** Thread pool for async snapshot workers. */
-	private ExecutorService asyncOperationsThreadPool;
+	private final ExecutorService asyncOperationsThreadPool;
 
 	private final RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriter;
 
@@ -214,7 +212,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 *
 	 * @param env The task environment for this task.
 	 */
-	protected StreamTask(Environment env) {
+	protected StreamTask(Environment env) throws Exception {
 		this(env, null);
 	}
 
@@ -224,14 +222,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 * @param env The task environment for this task.
 	 * @param timerService Optionally, a specific timer service to use.
 	 */
-	protected StreamTask(Environment env, @Nullable TimerService timerService) {
+	protected StreamTask(Environment env, @Nullable TimerService timerService) throws Exception {
 		this(env, timerService, FatalExitExceptionHandler.INSTANCE);
 	}
 
 	protected StreamTask(
 			Environment environment,
 			@Nullable TimerService timerService,
-			Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+			Thread.UncaughtExceptionHandler uncaughtExceptionHandler) throws Exception {
 		this(environment, timerService, uncaughtExceptionHandler, StreamTaskActionExecutor.IMMEDIATE);
 	}
 
@@ -251,7 +249,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			Environment environment,
 			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
-			StreamTaskActionExecutor actionExecutor) {
+			StreamTaskActionExecutor actionExecutor) throws Exception {
 		this(environment, timerService, uncaughtExceptionHandler, actionExecutor, new TaskMailboxImpl(Thread.currentThread()));
 	}
 
@@ -260,17 +258,28 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			@Nullable TimerService timerService,
 			Thread.UncaughtExceptionHandler uncaughtExceptionHandler,
 			StreamTaskActionExecutor actionExecutor,
-			TaskMailbox mailbox) {
+			TaskMailbox mailbox) throws Exception {
 
 		super(environment);
 
-		this.timerService = timerService;
-		this.uncaughtExceptionHandler = Preconditions.checkNotNull(uncaughtExceptionHandler);
 		this.configuration = new StreamConfig(getTaskConfiguration());
 		this.recordWriter = createRecordWriterDelegate(configuration, environment);
 		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
 		this.mailboxProcessor = new MailboxProcessor(this::processInput, mailbox, actionExecutor);
 		this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
+		this.asyncOperationsThreadPool = Executors.newCachedThreadPool(
+			new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));
+
+		this.stateBackend = createStateBackend();
+		this.checkpointStorage = stateBackend.createCheckpointStorage(getEnvironment().getJobID());
+
+		// if the clock is not already set, then assign a default TimeServiceProvider
+		if (timerService == null) {
+			ThreadFactory timerThreadFactory = new DispatcherThreadFactory(TRIGGER_THREAD_GROUP, "Time Trigger for " + getName());
+			this.timerService = new SystemProcessingTimeService(this::handleTimerException, timerThreadFactory);
+		} else {
+			this.timerService = timerService;
+		}
 	}
 
 	// ------------------------------------------------------------------------
@@ -403,21 +412,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	protected void beforeInvoke() throws Exception {
 		disposedOperators = false;
 		LOG.debug("Initializing {}.", getName());
-
-		asyncOperationsThreadPool = Executors.newCachedThreadPool(new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));
-
-		stateBackend = createStateBackend();
-		checkpointStorage = stateBackend.createCheckpointStorage(getEnvironment().getJobID());
-
-		// if the clock is not already set, then assign a default TimeServiceProvider
-		if (timerService == null) {
-			ThreadFactory timerThreadFactory =
-				new DispatcherThreadFactory(TRIGGER_THREAD_GROUP, "Time Trigger for " + getName());
-
-			timerService = new SystemProcessingTimeService(
-				this::handleTimerException,
-				timerThreadFactory);
-		}
 
 		operatorChain = new OperatorChain<>(this, recordWriter);
 		headOperator = operatorChain.getHeadOperator();
@@ -636,11 +630,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	@Override
 	protected void finalize() throws Throwable {
 		super.finalize();
-		if (timerService != null) {
-			if (!timerService.isTerminated()) {
-				LOG.info("Timer service is shutting down.");
-				timerService.shutdownService();
-			}
+		if (!timerService.isTerminated()) {
+			LOG.info("Timer service is shutting down.");
+			timerService.shutdownService();
 		}
 
 		cancelables.close();
@@ -879,7 +871,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	private void tryShutdownTimerService() {
 
-		if (timerService != null && !timerService.isTerminated()) {
+		if (!timerService.isTerminated()) {
 
 			try {
 				final long timeoutMs = getEnvironment().getTaskManagerInfo().getConfiguration().
@@ -959,7 +951,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	 */
 	@VisibleForTesting
 	TimerService getTimerService() {
-		Preconditions.checkState(timerService != null, "The timer service has not been initialized.");
 		return timerService;
 	}
 
@@ -974,10 +965,9 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	}
 
 	public ProcessingTimeServiceFactory getProcessingTimeServiceFactory() {
-		return mailboxExecutor -> {
-			Preconditions.checkState(timerService != null, "The timer service has not been initialized.");
-			return new ProcessingTimeServiceImpl(timerService, callback -> deferCallbackToMailbox(mailboxExecutor, callback));
-		};
+		return mailboxExecutor -> new ProcessingTimeServiceImpl(
+			timerService,
+			callback -> deferCallbackToMailbox(mailboxExecutor, callback));
 	}
 
 	/**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -40,7 +40,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 @Internal
 public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTask<IN1, IN2, OUT> {
 
-	public TwoInputStreamTask(Environment env) {
+	public TwoInputStreamTask(Environment env) throws Exception {
 		super(env);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -77,7 +77,7 @@ public class LocalStateForwardingTest extends TestLogger {
 	 * async checkpointing thread to the {@link org.apache.flink.runtime.state.TaskStateManager}.
 	 */
 	@Test
-	public void testReportingFromSnapshotToTaskStateManager() {
+	public void testReportingFromSnapshotToTaskStateManager() throws Exception {
 
 		TestTaskStateManager taskStateManager = new TestTaskStateManager();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTaskTestHarnessBuilder.java
@@ -27,11 +27,11 @@ import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.util.function.FunctionWithException;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
 
 /**
  * Builder to create a {@link StreamTaskMailboxTestHarness} to test {@link MultipleInputStreamTask}.
@@ -42,7 +42,7 @@ public class MultipleInputStreamTaskTestHarnessBuilder<OUT> extends StreamTaskMa
 	private final ArrayList<Integer> inputChannelsPerGate = new ArrayList<>();
 
 	public MultipleInputStreamTaskTestHarnessBuilder(
-			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+			FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 			TypeInformation<OUT> outputType) {
 		super(taskFactory, outputType);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTestHarness.java
@@ -28,9 +28,9 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
+import org.apache.flink.util.function.FunctionWithException;
 
 import java.io.File;
-import java.util.function.Function;
 
 
 /**
@@ -62,7 +62,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	 * of channels per input gate and local recovery disabled.
 	 */
 	public OneInputStreamTaskTestHarness(
-		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 		int numInputGates,
 		int numInputChannelsPerGate,
 		TypeInformation<IN> inputType,
@@ -71,7 +71,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	}
 
 	public OneInputStreamTaskTestHarness(
-		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 		int numInputGates,
 		int numInputChannelsPerGate,
 		TypeInformation<IN> inputType,
@@ -93,7 +93,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	 * of channels per input gate and specified localRecoveryConfig.
 	 */
 	public OneInputStreamTaskTestHarness(
-			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+			FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 			int numInputGates,
 			int numInputChannelsPerGate,
 			TypeInformation<IN> inputType,
@@ -113,7 +113,7 @@ public class OneInputStreamTaskTestHarness<IN, OUT> extends StreamTaskTestHarnes
 	 * Creates a test harness with one input gate that has one input channel.
 	 */
 	public OneInputStreamTaskTestHarness(
-		Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+		FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 		TypeInformation<IN> inputType,
 		TypeInformation<OUT> outputType) {
 		this(taskFactory, 1, 1, inputType, outputType, TestLocalRecoveryConfig.disabled());

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskExecutionDecorationTest.java
@@ -80,7 +80,7 @@ public class StreamTaskExecutionDecorationTest {
 	}
 
 	@Before
-	public void before() {
+	public void before() throws Exception {
 		mailbox = new TaskMailboxImpl();
 		decorator = new CountingStreamTaskActionExecutor();
 		task = new StreamTask<Object, StreamOperator<Object>>(new StreamTaskTest.DeclineDummyEnvironment(), null, FatalExitExceptionHandler.INSTANCE, decorator, mailbox) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarnessBuilder.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElementSerializer;
+import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.Nullable;
 
@@ -50,7 +51,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -59,7 +59,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * Builder class for {@link StreamTaskMailboxTestHarness}.
  */
 public abstract class StreamTaskMailboxTestHarnessBuilder<OUT> {
-	protected final Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory;
+	protected final FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory;
 	protected final TypeSerializer<OUT> outputSerializer;
 	protected final ExecutionConfig executionConfig = new ExecutionConfig();
 
@@ -77,7 +77,7 @@ public abstract class StreamTaskMailboxTestHarnessBuilder<OUT> {
 	private boolean setupCalled = false;
 
 	public StreamTaskMailboxTestHarnessBuilder(
-			Function<Environment, ? extends StreamTask<OUT, ?>> taskFactory,
+			FunctionWithException<Environment, ? extends StreamTask<OUT, ?>, Exception> taskFactory,
 			TypeInformation<OUT> outputType) {
 		this.taskFactory = checkNotNull(taskFactory);
 		outputSerializer = outputType.createSerializer(executionConfig);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskSelectiveReadingTest.java
@@ -188,7 +188,7 @@ public class StreamTaskSelectiveReadingTest {
 
 		private volatile boolean started;
 
-		TestSelectiveReadingTask(Environment env) {
+		TestSelectiveReadingTask(Environment env) throws Exception {
 			super(env);
 			started = false;
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTerminationTest.java
@@ -227,7 +227,7 @@ public class StreamTaskTerminationTest extends TestLogger {
 
 		private boolean isRunning;
 
-		public BlockingStreamTask(Environment env) {
+		public BlockingStreamTask(Environment env) throws Exception {
 			super(env);
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -330,7 +330,7 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	public static class CancelFailingTask extends StreamTask<String, AbstractStreamOperator<String>> {
 
-		public CancelFailingTask(Environment env) {
+		public CancelFailingTask(Environment env) throws Exception {
 			super(env);
 		}
 
@@ -442,7 +442,7 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	public static class CancelThrowingTask extends StreamTask<String, AbstractStreamOperator<String>> {
 
-		public CancelThrowingTask(Environment env) {
+		public CancelThrowingTask(Environment env) throws Exception {
 			super(env);
 		}
 
@@ -1109,7 +1109,7 @@ public class StreamTaskTest extends TestLogger {
 	 */
 	public static class NoOpStreamTask<T, OP extends StreamOperator<T>> extends StreamTask<T, OP> {
 
-		public NoOpStreamTask(Environment environment) {
+		public NoOpStreamTask(Environment environment) throws Exception {
 			super(environment);
 		}
 
@@ -1264,7 +1264,10 @@ public class StreamTaskTest extends TestLogger {
 
 		private final OperatorChain<String, AbstractStreamOperator<String>> overrideOperatorChain;
 
-		MockStreamTask(Environment env, OperatorChain<String, AbstractStreamOperator<String>> operatorChain, Thread.UncaughtExceptionHandler uncaughtExceptionHandler) {
+		MockStreamTask(
+				Environment env,
+				OperatorChain<String, AbstractStreamOperator<String>> operatorChain,
+				Thread.UncaughtExceptionHandler uncaughtExceptionHandler) throws Exception {
 			super(env, null, uncaughtExceptionHandler);
 			this.overrideOperatorChain = operatorChain;
 		}
@@ -1315,7 +1318,9 @@ public class StreamTaskTest extends TestLogger {
 		}
 	}
 
-	private static MockStreamTask createMockStreamTask(Environment env, OperatorChain<String, AbstractStreamOperator<String>> operatorChain) {
+	private static MockStreamTask createMockStreamTask(
+			Environment env,
+			OperatorChain<String, AbstractStreamOperator<String>> operatorChain) throws Exception {
 		return new MockStreamTask(env, operatorChain, FatalExitExceptionHandler.INSTANCE);
 	}
 
@@ -1328,7 +1333,7 @@ public class StreamTaskTest extends TestLogger {
 
 		private static volatile boolean fail;
 
-		public StateBackendTestSource(Environment env) {
+		public StateBackendTestSource(Environment env) throws Exception {
 			super(env);
 		}
 
@@ -1418,7 +1423,7 @@ public class StreamTaskTest extends TestLogger {
 		/** Flag to wait until time trigger has been called. */
 		private transient boolean hasTimerTriggered;
 
-		ThreadInspectingTask(Environment env) {
+		ThreadInspectingTask(Environment env) throws Exception {
 			super(env);
 			Thread currentThread = Thread.currentThread();
 			taskThreadId = currentThread.getId();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointITCase.java
@@ -135,7 +135,7 @@ public class SynchronousCheckpointITCase {
 		// Flag to emit the first event only once.
 		private boolean isRunning;
 
-		public SynchronousCheckpointTestingTask(Environment environment) {
+		public SynchronousCheckpointTestingTask(Environment environment) throws Exception {
 			super(environment);
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SynchronousCheckpointTest.java
@@ -62,8 +62,8 @@ public class SynchronousCheckpointTest {
 
 		taskInvocation = CompletableFuture.runAsync(
 			() -> {
-				streamTaskUnderTest = createTask(eventQueue);
 				try {
+					streamTaskUnderTest = createTask(eventQueue);
 					streamTaskUnderTest.invoke();
 				} catch (RuntimeException e) {
 					throw e;
@@ -133,7 +133,7 @@ public class SynchronousCheckpointTest {
 		}
 	}
 
-	private static StreamTaskUnderTest createTask(Queue<Event> eventQueue) {
+	private static StreamTaskUnderTest createTask(Queue<Event> eventQueue) throws Exception {
 		final DummyEnvironment environment = new DummyEnvironment("test", 1, 0);
 		return new StreamTaskUnderTest(environment, eventQueue);
 	}
@@ -145,7 +145,7 @@ public class SynchronousCheckpointTest {
 
 		StreamTaskUnderTest(
 				final Environment env,
-				Queue<Event> eventQueue) {
+				Queue<Event> eventQueue) throws Exception {
 			super(env);
 			this.eventQueue = checkNotNull(eventQueue);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -469,7 +469,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 	 */
 	public static final class TestStreamTask extends OneInputStreamTask<Object, Object> {
 
-		public TestStreamTask(Environment env) {
+		public TestStreamTask(Environment env) throws Exception {
 			super(env);
 		}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTestHarness.java
@@ -27,10 +27,10 @@ import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.runtime.partitioner.BroadcastPartitioner;
+import org.apache.flink.util.function.FunctionWithException;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
 
 
 /**
@@ -67,7 +67,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 	 * it should be assigned to the first (1), or second (2) input of the task.
 	 */
 	public TwoInputStreamTaskTestHarness(
-			Function<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
+			FunctionWithException<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>, Exception> taskFactory,
 			int numInputGates,
 			int numInputChannelsPerGate,
 			int[] inputGateAssignment,
@@ -92,7 +92,7 @@ public class TwoInputStreamTaskTestHarness<IN1, IN2, OUT> extends StreamTaskTest
 	 * second task input.
 	 */
 	public TwoInputStreamTaskTestHarness(
-			Function<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>> taskFactory,
+			FunctionWithException<Environment, ? extends AbstractTwoInputStreamTask<IN1, IN2, OUT>, Exception> taskFactory,
 			TypeInformation<IN1> inputType1,
 			TypeInformation<IN2> inputType2,
 			TypeInformation<OUT> outputType) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTask.java
@@ -67,7 +67,7 @@ public class MockStreamTask<OUT, OP extends StreamOperator<OUT>> extends StreamT
 		BiConsumer<String, Throwable> handleAsyncException,
 		TaskMailbox taskMailbox,
 		StreamTaskActionExecutor.SynchronizedStreamTaskActionExecutor taskActionExecutor,
-		StreamInputProcessor inputProcessor) {
+		StreamInputProcessor inputProcessor) throws Exception {
 
 		super(environment, timerService, FatalExitExceptionHandler.INSTANCE, taskActionExecutor, taskMailbox);
 		this.name = name;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamTaskBuilder.java
@@ -136,7 +136,7 @@ public class MockStreamTaskBuilder {
 		return this;
 	}
 
-	public MockStreamTask build() {
+	public MockStreamTask build() throws Exception {
 		return new MockStreamTask(
 			environment,
 			name,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/codegen/agg/batch/BatchAggTestBase.scala
@@ -28,9 +28,10 @@ import org.apache.flink.table.planner.utils.BaseRowTestUtil
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
 import org.apache.flink.table.types.logical.{BigIntType, DoubleType, LogicalType, RowType, VarCharType}
+import org.apache.flink.util.function.FunctionWithException
+
 import org.junit.Assert
 import java.util
-import java.util.function
 
 import scala.collection.JavaConverters._
 
@@ -64,7 +65,7 @@ abstract class BatchAggTestBase extends AggTestBase(isBatchMode = true) {
       args: (CodeGenOperatorFactory[BaseRow], RowType, RowType),
       input: Array[BaseRow], expectedOutput: Array[GenericRow]): Unit = {
     val testHarness = new OneInputStreamTaskTestHarness[BaseRow, BaseRow](
-      new function.Function[Environment, OneInputStreamTask[BaseRow, BaseRow]] {
+      new FunctionWithException[Environment, OneInputStreamTask[BaseRow, BaseRow], Exception] {
         override def apply(t: Environment) = new OneInputStreamTask(t)
       }, 1, 1, BaseRowTypeInfo.of(args._2), BaseRowTypeInfo.of(args._3))
     testHarness.memorySize = 32 * 100 * 1024

--- a/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterStopWithSavepointIT.java
@@ -316,7 +316,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 
 		private long synchronousSavepointId = Long.MIN_VALUE;
 
-		public ExceptionOnCallbackStreamTask(final Environment environment) {
+		public ExceptionOnCallbackStreamTask(final Environment environment) throws Exception {
 			super(environment);
 		}
 
@@ -360,7 +360,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 
 		private final transient OneShotLatch finishLatch;
 
-		public NoOpBlockingStreamTask(final Environment environment) {
+		public NoOpBlockingStreamTask(final Environment environment) throws Exception {
 			super(environment);
 			this.finishLatch = new OneShotLatch();
 		}
@@ -387,7 +387,7 @@ public class JobMasterStopWithSavepointIT extends AbstractTestBase {
 
 		private final transient OneShotLatch finishLatch;
 
-		public CheckpointCountingTask(final Environment environment) {
+		public CheckpointCountingTask(final Environment environment) throws Exception {
 			super(environment);
 			this.finishLatch = new OneShotLatch();
 		}


### PR DESCRIPTION

## What is the purpose of the change

At the moment there are four fields initialized in the method of StreamTask#beforeInvoke, such as `stateBackend`, `checkpointStorage`, `timerService`, `asyncOperationsThreadPool`.

In general it is suggested to use final fields to get known benefits. So we can refactor the StreamTask to initialize these fields in the constructor instead.

## Brief change log

  - *Migrate some files initialization from `#beforeInvoke` to constructor.*
  - *Remove the `null` conditions for related fields in `StreamTask`*
  - *Add throw `Exception` for some related classes*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
