### PR TITLE
[FLINK-15579][table-planner-blink] UpsertStreamTableSink should work on batch mode

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecSink.scala
@@ -28,17 +28,18 @@ import org.apache.flink.table.planner.codegen.{CodeGenUtils, CodeGeneratorContex
 import org.apache.flink.table.planner.delegation.BatchPlanner
 import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
+import org.apache.flink.table.planner.plan.utils.UpdatingPlanChecker
 import org.apache.flink.table.planner.sinks.DataStreamTableSink
 import org.apache.flink.table.runtime.types.ClassLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
-import org.apache.flink.table.sinks.{AppendStreamTableSink, RetractStreamTableSink, StreamTableSink, TableSink, UpsertStreamTableSink}
+import org.apache.flink.table.sinks.{RetractStreamTableSink, StreamTableSink, TableSink, UpsertStreamTableSink}
 import org.apache.flink.table.types.DataType
+
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.RelNode
+
 import java.lang.reflect.Modifier
 import java.util
-
-import org.apache.flink.table.planner.plan.utils.UpdatingPlanChecker
 
 import scala.collection.JavaConversions._
 
@@ -87,30 +88,11 @@ class BatchExecSink[T](
             translateToTransformation(withChangeFlag = true, planner)
 
           case upsertSink: UpsertStreamTableSink[T] =>
-            // check for append only table
-            val isAppendOnlyTable = UpdatingPlanChecker.isAppendOnly(this)
-            upsertSink.setIsAppendOnly(isAppendOnlyTable)
-            val tableKeys = {
-              val sinkFieldNames = upsertSink.getTableSchema.getFieldNames
-              UpdatingPlanChecker.getUniqueKeyFields(getInput, planner, sinkFieldNames) match {
-                case Some(keys) => keys.sortBy(_.length).headOption
-                case None => None
-              }
-            }
-
-            // check that we have keys if the table has changes (is not append-only)
-            tableKeys match {
-              case Some(keys) => upsertSink.setKeyFields(keys)
-              case None if isAppendOnlyTable => upsertSink.setKeyFields(null)
-              case None if !isAppendOnlyTable => throw new TableException(
-                "UpsertStreamTableSink requires that Table has" +
-                  " a full primary keys if it is updated.")
-            }
-
+            upsertSink.setIsAppendOnly(true)
+            upsertSink.setKeyFields(
+              UpdatingPlanChecker.getUniqueKeyForUpsertSink(this, planner, upsertSink).orNull)
             translateToTransformation(withChangeFlag = true, planner)
-          case _: AppendStreamTableSink[T] =>
-            // we can insert the bounded DataStream into a StreamTableSink
-            translateToTransformation(withChangeFlag = false, planner)
+
           case _ =>
             translateToTransformation(withChangeFlag = false, planner)
         }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
@@ -17,10 +17,9 @@
  */
 package org.apache.flink.table.planner.plan.utils
 
-import org.apache.flink.table.planner.delegation.StreamPlanner
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
-
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.{RelNode, RelVisitor}
@@ -40,7 +39,7 @@ object UpdatingPlanChecker {
   /** Extracts the unique keys of the table produced by the plan. */
   def getUniqueKeyFields(
       relNode: RelNode,
-      planner: StreamPlanner,
+      planner: PlannerBase,
       sinkFieldNames: Array[String]): Option[Array[Array[String]]] = {
     val fmq = FlinkRelMetadataQuery.reuseOrCreate(planner.getRelBuilder.getCluster.getMetadataQuery)
     val uniqueKeys = fmq.getUniqueKeys(relNode)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/UpdatingPlanChecker.scala
@@ -19,7 +19,10 @@ package org.apache.flink.table.planner.plan.utils
 
 import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
+import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.physical.stream._
+import org.apache.flink.table.sinks.UpsertStreamTableSink
+
 import org.apache.calcite.plan.hep.HepRelVertex
 import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.{RelNode, RelVisitor}
@@ -34,20 +37,6 @@ object UpdatingPlanChecker {
     appendOnlyValidator.go(plan)
 
     appendOnlyValidator.isAppendOnly
-  }
-
-  /** Extracts the unique keys of the table produced by the plan. */
-  def getUniqueKeyFields(
-      relNode: RelNode,
-      planner: PlannerBase,
-      sinkFieldNames: Array[String]): Option[Array[Array[String]]] = {
-    val fmq = FlinkRelMetadataQuery.reuseOrCreate(planner.getRelBuilder.getCluster.getMetadataQuery)
-    val uniqueKeys = fmq.getUniqueKeys(relNode)
-    if (uniqueKeys != null && uniqueKeys.size() > 0) {
-      Some(uniqueKeys.filter(_.nonEmpty).map(_.toArray.map(sinkFieldNames)).toArray)
-    } else {
-      None
-    }
   }
 
   private class AppendOnlyValidator extends RelVisitor {
@@ -65,6 +54,30 @@ object UpdatingPlanChecker {
         case _ =>
           super.visit(node, ordinal, parent)
       }
+    }
+  }
+
+  def getUniqueKeyForUpsertSink(
+      sinkNode: Sink,
+      planner: PlannerBase,
+      sink: UpsertStreamTableSink[_]): Option[Array[String]] = {
+    // extract unique key fields
+    // Now we pick shortest one to sink
+    // TODO UpsertStreamTableSink setKeyFields interface should be Array[Array[String]]
+    val sinkFieldNames = sink.getTableSchema.getFieldNames
+    /** Extracts the unique keys of the table produced by the plan. */
+    val fmq = FlinkRelMetadataQuery.reuseOrCreate(
+      planner.getRelBuilder.getCluster.getMetadataQuery)
+    val uniqueKeys = fmq.getUniqueKeys(sinkNode.getInput)
+    if (uniqueKeys != null && uniqueKeys.size() > 0) {
+      uniqueKeys
+          .filter(_.nonEmpty)
+          .map(_.toArray.map(sinkFieldNames))
+          .toSeq
+          .sortBy(_.length)
+          .headOption
+    } else {
+      None
     }
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/TableSinkITCase.scala
@@ -20,13 +20,16 @@ package org.apache.flink.table.planner.runtime.batch.table
 
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{DataTypes, TableSchema}
-import org.apache.flink.table.planner.runtime.utils.BatchTestBase
+import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestingRetractTableSink, TestingUpsertTableSink}
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil
 import org.apache.flink.table.planner.utils.MemoryTableSourceSinkUtil.{DataTypeAppendStreamTableSink, DataTypeOutputFormatTableSink}
 import org.apache.flink.test.util.TestBaseUtils
 
+import org.junit.Assert._
 import org.junit._
+
+import java.util.TimeZone
 
 import scala.collection.JavaConverters._
 
@@ -115,5 +118,87 @@ class TableSinkITCase extends BatchTestBase {
     TestBaseUtils.compareResultAsText(results, expected)
   }
 
+  private def prepareForUpsertSink(): TestingUpsertTableSink = {
+    val schema = TableSchema.builder()
+        .field("a", DataTypes.INT())
+        .field("b", DataTypes.DOUBLE())
+        .build()
+    val sink = new TestingUpsertTableSink(Array(0), TimeZone.getDefault)
+    tEnv.registerTableSink("testSink", sink.configure(schema.getFieldNames, schema.getFieldTypes))
+    registerCollection("MyTable", simpleData2, simpleType2, "a, b", nullableOfSimpleData2)
+    sink
+  }
 
+  @Test
+  def testUpsertSink(): Unit = {
+    val sink = prepareForUpsertSink()
+    sink.expectedKeys = Some(Array("a"))
+    sink.expectedIsAppendOnly = Some(false)
+
+    tEnv.from("MyTable")
+        .groupBy('a)
+        .select('a, 'b.sum())
+        .insertInto("testSink")
+    tEnv.execute("")
+
+    val result = sink.getUpsertResults.sorted
+    val expected = List(
+      "1,0.1",
+      "2,0.4",
+      "3,1.0",
+      "4,2.2",
+      "5,3.9").sorted
+    assertEquals(expected, result)
+  }
+
+  @Test
+  def testUpsertSinkWithAppend(): Unit = {
+    val sink = prepareForUpsertSink()
+    sink.expectedKeys = None
+    sink.expectedIsAppendOnly = Some(true)
+
+    tEnv.from("MyTable")
+        .select('a, 'b)
+        .where('a < 3)
+        .insertInto("testSink")
+    tEnv.execute("")
+
+    val result = sink.getRawResults.sorted
+    val expected = List(
+      "(true,1,0.1)",
+      "(true,2,0.2)",
+      "(true,2,0.2)").sorted
+    assertEquals(expected, result)
+  }
+
+  private def prepareForRetractSink(): TestingRetractTableSink = {
+    val schema = TableSchema.builder()
+        .field("a", DataTypes.INT())
+        .field("b", DataTypes.DOUBLE())
+        .build()
+    val sink = new TestingRetractTableSink(TimeZone.getDefault)
+    tEnv.registerTableSink("testSink", sink.configure(schema.getFieldNames, schema.getFieldTypes))
+    registerCollection("MyTable", simpleData2, simpleType2, "a, b", nullableOfSimpleData2)
+    sink
+  }
+
+  @Test
+  def testRetractSink(): Unit = {
+    val sink = prepareForRetractSink()
+
+    tEnv.from("MyTable")
+        .groupBy('a)
+        .select('a, 'b.sum())
+        .insertInto("testSink")
+    tEnv.execute("")
+
+    val result = sink.getRawResults.sorted
+    val expected = List(
+      "(true,1,0.1)",
+      "(true,2,0.4)",
+      "(true,3,1.0)",
+      "(true,4,2.2)",
+      "(true,5,3.9)").sorted
+    assertEquals(expected, result)
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

JDBCTableSourceSinkFactory.createStreamTableSink() create JDBCUpsertTableSink. But BatchExecSink can not work with UpsertStreamTableSink.

## Brief change log

Fix `BatchExecSink`.

## Verifying this change

- Tests in `JDBCUpsertTableSinkITCase`
- Tests in `TableSinkITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)