### PR TITLE
[FLINK-16513][checkpointing] Unaligned checkpoints: checkpoint metadata

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
@@ -27,7 +27,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.io.InputSplitAssigner;
 import org.apache.flink.runtime.checkpoint.OperatorState;
-import org.apache.flink.runtime.checkpoint.StateAssignmentOperation;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.RoundRobinOperatorStateRepartitioner;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
@@ -49,6 +50,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.checkpoint.StateAssignmentOperation.reDistributePartitionableStates;
 
 /**
  * The base input format for reading operator state from a {@link CheckpointMetadata}.
@@ -118,14 +122,12 @@ abstract class OperatorStateInputFormat<OT> extends RichInputFormat<OT, Operator
 	}
 
 	private OperatorStateInputSplit[] getOperatorStateInputSplits(int minNumSplits) {
-		final Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates = new HashMap<>();
-
-		StateAssignmentOperation.reDistributePartitionableStates(
-			Collections.singletonList(operatorState),
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates = reDistributePartitionableStates(
+			singletonList(operatorState),
 			minNumSplits,
-			Collections.singletonList(operatorState.getOperatorID()),
-			newManagedOperatorStates,
-			new HashMap<>());
+			singletonList(operatorState.getOperatorID()),
+			OperatorSubtaskState::getManagedOperatorState,
+			RoundRobinOperatorStateRepartitioner.INSTANCE);
 
 		return CollectionUtil.mapWithIndex(
 			newManagedOperatorStates.values(),

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/OperatorStateInputFormat.java
@@ -45,8 +45,6 @@ import org.apache.flink.util.Preconditions;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/KeyGroupRangeInputSplit.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/input/splits/KeyGroupRangeInputSplit.java
@@ -68,7 +68,9 @@ public final class KeyGroupRangeInputSplit implements InputSplit {
 				StateObjectCollection.empty(),
 				StateObjectCollection.empty(),
 				new StateObjectCollection<>(managedKeyedState),
-				new StateObjectCollection<>(rawKeyedState)
+				new StateObjectCollection<>(rawKeyedState),
+				StateObjectCollection.empty(),
+				StateObjectCollection.empty()
 			),
 			Collections.emptyList()
 		).build();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorStateRepartitioner.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.runtime.state.OperatorStateHandle;
 
 import java.util.List;
 
@@ -27,7 +26,7 @@ import java.util.List;
  * Interface that allows to implement different strategies for repartitioning of operator state as parallelism changes.
  */
 @Internal
-public interface OperatorStateRepartitioner {
+public interface OperatorStateRepartitioner<T> {
 
 	/**
 	 * @param previousParallelSubtaskStates List with one entry of state handles per parallel subtask of an operator, as they
@@ -38,8 +37,8 @@ public interface OperatorStateRepartitioner {
 	 * @return List with one entry per parallel subtask. Each subtask receives now one collection of states that build
 	 * of the new total state for this subtask.
 	 */
-	List<List<OperatorStateHandle>> repartitionState(
-			List<List<OperatorStateHandle>> previousParallelSubtaskStates,
+	List<List<T>> repartitionState(
+			List<List<T>> previousParallelSubtaskStates,
 			int oldParallelism,
 			int newParallelism);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorSubtaskState.java
@@ -19,8 +19,10 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.runtime.state.CompositeStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StateUtil;
@@ -34,6 +36,8 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.emptyIfNull;
 
 /**
  * This class encapsulates the state for one parallel instance of an operator. The complete state of a (logical)
@@ -80,6 +84,12 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 	@Nonnull
 	private final StateObjectCollection<KeyedStateHandle> rawKeyedState;
 
+	@Nonnull
+	private final StateObjectCollection<InputChannelStateHandle> inputChannelState;
+
+	@Nonnull
+	private final StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionState;
+
 	/**
 	 * The state size. This is also part of the deserialized state handle.
 	 * We store it here in order to not deserialize the state handle when
@@ -95,6 +105,22 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 			StateObjectCollection.empty(),
 			StateObjectCollection.empty(),
 			StateObjectCollection.empty(),
+			StateObjectCollection.empty(),
+			StateObjectCollection.empty(),
+			StateObjectCollection.empty());
+	}
+
+	public OperatorSubtaskState(
+			@Nonnull StateObjectCollection<OperatorStateHandle> managedOperatorState,
+			@Nonnull StateObjectCollection<OperatorStateHandle> rawOperatorState,
+			@Nonnull StateObjectCollection<KeyedStateHandle> managedKeyedState,
+			@Nonnull StateObjectCollection<KeyedStateHandle> rawKeyedState) {
+		this(
+			managedOperatorState,
+			rawOperatorState,
+			managedKeyedState,
+			rawKeyedState,
+			StateObjectCollection.empty(),
 			StateObjectCollection.empty());
 	}
 
@@ -102,17 +128,23 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 		@Nonnull StateObjectCollection<OperatorStateHandle> managedOperatorState,
 		@Nonnull StateObjectCollection<OperatorStateHandle> rawOperatorState,
 		@Nonnull StateObjectCollection<KeyedStateHandle> managedKeyedState,
-		@Nonnull StateObjectCollection<KeyedStateHandle> rawKeyedState) {
+		@Nonnull StateObjectCollection<KeyedStateHandle> rawKeyedState,
+		@Nonnull StateObjectCollection<InputChannelStateHandle> inputChannelState,
+		@Nonnull StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionState) {
 
 		this.managedOperatorState = Preconditions.checkNotNull(managedOperatorState);
 		this.rawOperatorState = Preconditions.checkNotNull(rawOperatorState);
 		this.managedKeyedState = Preconditions.checkNotNull(managedKeyedState);
 		this.rawKeyedState = Preconditions.checkNotNull(rawKeyedState);
+		this.inputChannelState = Preconditions.checkNotNull(inputChannelState);
+		this.resultSubpartitionState = Preconditions.checkNotNull(resultSubpartitionState);
 
 		long calculateStateSize = managedOperatorState.getStateSize();
 		calculateStateSize += rawOperatorState.getStateSize();
 		calculateStateSize += managedKeyedState.getStateSize();
 		calculateStateSize += rawKeyedState.getStateSize();
+		calculateStateSize += inputChannelState.getStateSize();
+		calculateStateSize += resultSubpartitionState.getStateSize();
 		stateSize = calculateStateSize;
 	}
 
@@ -121,16 +153,19 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 	 * Collections.
 	 */
 	public OperatorSubtaskState(
-		@Nullable OperatorStateHandle managedOperatorState,
-		@Nullable OperatorStateHandle rawOperatorState,
-		@Nullable KeyedStateHandle managedKeyedState,
-		@Nullable KeyedStateHandle rawKeyedState) {
-
+			@Nullable OperatorStateHandle managedOperatorState,
+			@Nullable OperatorStateHandle rawOperatorState,
+			@Nullable KeyedStateHandle managedKeyedState,
+			@Nullable KeyedStateHandle rawKeyedState,
+			@Nullable StateObjectCollection<InputChannelStateHandle> inputChannelState,
+			@Nullable StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionState) {
 		this(
 			singletonOrEmptyOnNull(managedOperatorState),
 			singletonOrEmptyOnNull(rawOperatorState),
 			singletonOrEmptyOnNull(managedKeyedState),
-			singletonOrEmptyOnNull(rawKeyedState));
+			singletonOrEmptyOnNull(rawKeyedState),
+			emptyIfNull(inputChannelState),
+			emptyIfNull(resultSubpartitionState));
 	}
 
 	private static <T extends StateObject> StateObjectCollection<T> singletonOrEmptyOnNull(T element) {
@@ -171,6 +206,16 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 		return rawKeyedState;
 	}
 
+	@Nonnull
+	public StateObjectCollection<InputChannelStateHandle> getInputChannelState() {
+		return inputChannelState;
+	}
+
+	@Nonnull
+	public StateObjectCollection<ResultSubpartitionStateHandle> getResultSubpartitionState() {
+		return resultSubpartitionState;
+	}
+
 	@Override
 	public void discardState() {
 		try {
@@ -179,11 +224,15 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 						managedOperatorState.size() +
 						rawOperatorState.size() +
 						managedKeyedState.size() +
-						rawKeyedState.size());
+						rawKeyedState.size() +
+						inputChannelState.size() +
+						resultSubpartitionState.size());
 			toDispose.addAll(managedOperatorState);
 			toDispose.addAll(rawOperatorState);
 			toDispose.addAll(managedKeyedState);
 			toDispose.addAll(rawKeyedState);
+			toDispose.addAll(inputChannelState);
+			toDispose.addAll(resultSubpartitionState);
 			StateUtil.bestEffortDiscardAllStateObjects(toDispose);
 		} catch (Exception e) {
 			LOG.warn("Error while discarding operator states.", e);
@@ -236,6 +285,12 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 		if (!getManagedKeyedState().equals(that.getManagedKeyedState())) {
 			return false;
 		}
+		if (!getInputChannelState().equals(that.getInputChannelState())) {
+			return false;
+		}
+		if (!getResultSubpartitionState().equals(that.getResultSubpartitionState())) {
+			return false;
+		}
 		return getRawKeyedState().equals(that.getRawKeyedState());
 	}
 
@@ -245,6 +300,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 		result = 31 * result + getRawOperatorState().hashCode();
 		result = 31 * result + getManagedKeyedState().hashCode();
 		result = 31 * result + getRawKeyedState().hashCode();
+		result = 31 * result + getInputChannelState().hashCode();
+		result = 31 * result + getResultSubpartitionState().hashCode();
 		result = 31 * result + (int) (getStateSize() ^ (getStateSize() >>> 32));
 		return result;
 	}
@@ -256,6 +313,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 			", operatorStateFromStream=" + rawOperatorState +
 			", keyedStateFromBackend=" + managedKeyedState +
 			", keyedStateFromStream=" + rawKeyedState +
+			", inputChannelState=" + inputChannelState +
+			", resultSubpartitionState=" + resultSubpartitionState +
 			", stateSize=" + stateSize +
 			'}';
 	}
@@ -264,6 +323,8 @@ public class OperatorSubtaskState implements CompositeStateHandle {
 		return managedOperatorState.hasState()
 			|| rawOperatorState.hasState()
 			|| managedKeyedState.hasState()
-			|| rawKeyedState.hasState();
+			|| rawKeyedState.hasState()
+			|| inputChannelState.hasState()
+			|| resultSubpartitionState.hasState();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/RoundRobinOperatorStateRepartitioner.java
@@ -39,9 +39,9 @@ import java.util.stream.Collectors;
  * Current default implementation of {@link OperatorStateRepartitioner} that redistributes state in round robin fashion.
  */
 @Internal
-public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepartitioner {
+public class RoundRobinOperatorStateRepartitioner implements OperatorStateRepartitioner<OperatorStateHandle> {
 
-	public static final OperatorStateRepartitioner INSTANCE = new RoundRobinOperatorStateRepartitioner();
+	public static final OperatorStateRepartitioner<OperatorStateHandle> INSTANCE = new RoundRobinOperatorStateRepartitioner();
 	private static final boolean OPTIMIZE_MEMORY_USE = false;
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -36,13 +37,14 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
+import static java.util.Collections.emptyList;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -100,11 +102,9 @@ public class StateAssignmentOperation {
 				}
 				operatorStates.add(operatorState);
 			}
-			if (statelessTask) { // skip tasks where no operator has any state
-				continue;
+			if (!statelessTask) { // skip tasks where no operator has any state
+				assignAttemptState(executionJobVertex, operatorStates);
 			}
-
-			assignAttemptState(executionJobVertex, operatorStates);
 		}
 
 	}
@@ -143,22 +143,21 @@ public class StateAssignmentOperation {
 		 * op2   state2,0	  state2,1 	   state2,2		state2,3
 		 * op3   state3,0	  state3,1 	   state3,2		state3,3
 		 */
-		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates =
-			new HashMap<>(expectedNumberOfSubTasks);
-		Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates =
-			new HashMap<>(expectedNumberOfSubTasks);
-
-		reDistributePartitionableStates(
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates = reDistributePartitionableStates(
 			operatorStates,
 			newParallelism,
 			operatorIDs,
-			newManagedOperatorStates,
-			newRawOperatorStates);
+			OperatorSubtaskState::getManagedOperatorState,
+			RoundRobinOperatorStateRepartitioner.INSTANCE);
+		Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates = reDistributePartitionableStates(
+			operatorStates,
+			newParallelism,
+			operatorIDs,
+			OperatorSubtaskState::getRawOperatorState,
+			RoundRobinOperatorStateRepartitioner.INSTANCE);
 
-		Map<OperatorInstanceID, List<KeyedStateHandle>> newManagedKeyedState =
-			new HashMap<>(expectedNumberOfSubTasks);
-		Map<OperatorInstanceID, List<KeyedStateHandle>> newRawKeyedState =
-			new HashMap<>(expectedNumberOfSubTasks);
+		Map<OperatorInstanceID, List<KeyedStateHandle>> newManagedKeyedState = new HashMap<>(expectedNumberOfSubTasks);
+		Map<OperatorInstanceID, List<KeyedStateHandle>> newRawKeyedState = new HashMap<>(expectedNumberOfSubTasks);
 
 		reDistributeKeyedStates(
 			operatorStates,
@@ -246,10 +245,10 @@ public class StateAssignmentOperation {
 			checkState(!subRawKeyedState.containsKey(instanceID));
 		}
 		return new OperatorSubtaskState(
-			new StateObjectCollection<>(subManagedOperatorState.getOrDefault(instanceID, Collections.emptyList())),
-			new StateObjectCollection<>(subRawOperatorState.getOrDefault(instanceID, Collections.emptyList())),
-			new StateObjectCollection<>(subManagedKeyedState.getOrDefault(instanceID, Collections.emptyList())),
-			new StateObjectCollection<>(subRawKeyedState.getOrDefault(instanceID, Collections.emptyList())));
+			new StateObjectCollection<>(subManagedOperatorState.getOrDefault(instanceID, emptyList())),
+			new StateObjectCollection<>(subRawOperatorState.getOrDefault(instanceID, emptyList())),
+			new StateObjectCollection<>(subManagedKeyedState.getOrDefault(instanceID, emptyList())),
+			new StateObjectCollection<>(subRawKeyedState.getOrDefault(instanceID, emptyList())));
 	}
 
 	public void checkParallelismPreconditions(List<OperatorState> operatorStates, ExecutionJobVertex executionJobVertex) {
@@ -302,8 +301,8 @@ public class StateAssignmentOperation {
 				subManagedKeyedState = operatorState.getState(subTaskIndex).getManagedKeyedState().asList();
 				subRawKeyedState = operatorState.getState(subTaskIndex).getRawKeyedState().asList();
 			} else {
-				subManagedKeyedState = Collections.emptyList();
-				subRawKeyedState = Collections.emptyList();
+				subManagedKeyedState = emptyList();
+				subRawKeyedState = emptyList();
 			}
 		} else {
 			subManagedKeyedState = getManagedKeyedStateHandles(operatorState, keyGroupPartitions.get(subTaskIndex));
@@ -311,79 +310,54 @@ public class StateAssignmentOperation {
 		}
 
 		if (subManagedKeyedState.isEmpty() && subRawKeyedState.isEmpty()) {
-			return new Tuple2<>(Collections.emptyList(), Collections.emptyList());
+			return new Tuple2<>(emptyList(), emptyList());
 		} else {
 			return new Tuple2<>(subManagedKeyedState, subRawKeyedState);
 		}
 	}
 
-	public static void reDistributePartitionableStates(
+	public static <T extends StateObject> Map<OperatorInstanceID, List<T>>  reDistributePartitionableStates(
 			List<OperatorState> oldOperatorStates,
 			int newParallelism,
 			List<OperatorID> newOperatorIDs,
-			Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates,
-			Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates) {
+			Function<OperatorSubtaskState, StateObjectCollection<T>> extracthandle,
+			OperatorStateRepartitioner<T> stateRepartitioner) {
 
 		//TODO: rewrite this method to only use OperatorID
 		checkState(newOperatorIDs.size() == oldOperatorStates.size(),
 			"This method still depends on the order of the new and old operators");
 
 		// The nested list wraps as the level of operator -> subtask -> state object collection
-		List<List<List<OperatorStateHandle>>> oldManagedOperatorStates = new ArrayList<>(oldOperatorStates.size());
-		List<List<List<OperatorStateHandle>>> oldRawOperatorStates = new ArrayList<>(oldOperatorStates.size());
+		List<List<List<T>>> oldStates = splitManagedAndRawOperatorStates(oldOperatorStates, extracthandle);
 
-		splitManagedAndRawOperatorStates(oldOperatorStates, oldManagedOperatorStates, oldRawOperatorStates);
-		OperatorStateRepartitioner opStateRepartitioner = RoundRobinOperatorStateRepartitioner.INSTANCE;
-
+		Map<OperatorInstanceID, List<T>> result = new HashMap<>();
 		for (int operatorIndex = 0; operatorIndex < newOperatorIDs.size(); operatorIndex++) {
-			OperatorState operatorState = oldOperatorStates.get(operatorIndex);
-			int oldParallelism = operatorState.getParallelism();
-
-			OperatorID operatorID = newOperatorIDs.get(operatorIndex);
-
-			newManagedOperatorStates.putAll(applyRepartitioner(
-				operatorID,
-				opStateRepartitioner,
-				oldManagedOperatorStates.get(operatorIndex),
-				oldParallelism,
-				newParallelism));
-
-			newRawOperatorStates.putAll(applyRepartitioner(
-				operatorID,
-				opStateRepartitioner,
-				oldRawOperatorStates.get(operatorIndex),
-				oldParallelism,
+			result.putAll(applyRepartitioner(
+				newOperatorIDs.get(operatorIndex),
+				stateRepartitioner,
+				oldStates.get(operatorIndex),
+				oldOperatorStates.get(operatorIndex).getParallelism(),
 				newParallelism));
 		}
+
+		return result;
 	}
 
-	private static void splitManagedAndRawOperatorStates(
-		List<OperatorState> operatorStates,
-		List<List<List<OperatorStateHandle>>> managedOperatorStates,
-		List<List<List<OperatorStateHandle>>> rawOperatorStates) {
+	private static <T extends StateObject> List<List<List<T>>> splitManagedAndRawOperatorStates(
+			List<OperatorState> operatorStates,
+			Function<OperatorSubtaskState, StateObjectCollection<T>> extracthandle) {
+		List<List<List<T>>> result = new ArrayList<>();
 
 		for (OperatorState operatorState : operatorStates) {
+			List<List<T>> statePerSubtask = new ArrayList<>(operatorState.getParallelism());
 
-			final int parallelism = operatorState.getParallelism();
-			List<List<OperatorStateHandle>> managedOpStatePerSubtasks = new ArrayList<>(parallelism);
-			List<List<OperatorStateHandle>> rawOpStatePerSubtasks = new ArrayList<>(parallelism);
-
-			for (int subTaskIndex = 0; subTaskIndex < parallelism; subTaskIndex++) {
-				OperatorSubtaskState operatorSubtaskState = operatorState.getState(subTaskIndex);
-				if (operatorSubtaskState == null) {
-					managedOpStatePerSubtasks.add(Collections.emptyList());
-					rawOpStatePerSubtasks.add(Collections.emptyList());
-				} else {
-					StateObjectCollection<OperatorStateHandle> managed = operatorSubtaskState.getManagedOperatorState();
-					StateObjectCollection<OperatorStateHandle> raw = operatorSubtaskState.getRawOperatorState();
-
-					managedOpStatePerSubtasks.add(managed.asList());
-					rawOpStatePerSubtasks.add(raw.asList());
-				}
+			for (int subTaskIndex = 0; subTaskIndex < operatorState.getParallelism(); subTaskIndex++) {
+				OperatorSubtaskState subtaskState = operatorState.getState(subTaskIndex);
+				statePerSubtask.add(subtaskState == null ? emptyList() : extracthandle.apply(subtaskState).asList());
 			}
-			managedOperatorStates.add(managedOpStatePerSubtasks);
-			rawOperatorStates.add(rawOpStatePerSubtasks);
+			result.add(statePerSubtask);
 		}
+		return result;
 	}
 
 	/**
@@ -395,8 +369,8 @@ public class StateAssignmentOperation {
 	 * @return all managedKeyedStateHandles which have intersection with given KeyGroupRange
 	 */
 	public static List<KeyedStateHandle> getManagedKeyedStateHandles(
-		OperatorState operatorState,
-		KeyGroupRange subtaskKeyGroupRange) {
+			OperatorState operatorState,
+			KeyGroupRange subtaskKeyGroupRange) {
 
 		final int parallelism = operatorState.getParallelism();
 
@@ -430,8 +404,8 @@ public class StateAssignmentOperation {
 	 * @return all rawKeyedStateHandles which have intersection with given KeyGroupRange
 	 */
 	public static List<KeyedStateHandle> getRawKeyedStateHandles(
-		OperatorState operatorState,
-		KeyGroupRange subtaskKeyGroupRange) {
+			OperatorState operatorState,
+			KeyGroupRange subtaskKeyGroupRange) {
 
 		final int parallelism = operatorState.getParallelism();
 
@@ -460,9 +434,9 @@ public class StateAssignmentOperation {
 	 * Extracts certain key group ranges from the given state handles and adds them to the collector.
 	 */
 	private static void extractIntersectingState(
-		Collection<KeyedStateHandle> originalSubtaskStateHandles,
-		KeyGroupRange rangeToExtract,
-		List<KeyedStateHandle> extractedStateCollector) {
+			Collection<KeyedStateHandle> originalSubtaskStateHandles,
+			KeyGroupRange rangeToExtract,
+			List<KeyedStateHandle> extractedStateCollector) {
 
 		for (KeyedStateHandle keyedStateHandle : originalSubtaskStateHandles) {
 
@@ -568,20 +542,20 @@ public class StateAssignmentOperation {
 		}
 	}
 
-	public static Map<OperatorInstanceID, List<OperatorStateHandle>> applyRepartitioner(
-		OperatorID operatorID,
-		OperatorStateRepartitioner opStateRepartitioner,
-		List<List<OperatorStateHandle>> chainOpParallelStates,
-		int oldParallelism,
-		int newParallelism) {
+	public static <T extends StateObject> Map<OperatorInstanceID, List<T>> applyRepartitioner(
+			OperatorID operatorID,
+			OperatorStateRepartitioner<T> opStateRepartitioner,
+			List<List<T>> chainOpParallelStates,
+			int oldParallelism,
+			int newParallelism) {
 
-		List<List<OperatorStateHandle>> states = applyRepartitioner(
+		List<List<T>> states = applyRepartitioner(
 			opStateRepartitioner,
 			chainOpParallelStates,
 			oldParallelism,
 			newParallelism);
 
-		Map<OperatorInstanceID, List<OperatorStateHandle>> result = new HashMap<>(states.size());
+		Map<OperatorInstanceID, List<T>> result = new HashMap<>(states.size());
 
 		for (int subtaskIndex = 0; subtaskIndex < states.size(); subtaskIndex++) {
 			checkNotNull(states.get(subtaskIndex) != null, "states.get(subtaskIndex) is null");
@@ -602,14 +576,14 @@ public class StateAssignmentOperation {
 	 * @return repartitioned state
 	 */
 	// TODO rewrite based on operator id
-	public static List<List<OperatorStateHandle>> applyRepartitioner(
-		OperatorStateRepartitioner opStateRepartitioner,
-		List<List<OperatorStateHandle>> chainOpParallelStates,
-		int oldParallelism,
-		int newParallelism) {
+	public static <T> List<List<T>> applyRepartitioner(
+			OperatorStateRepartitioner<T> opStateRepartitioner,
+			List<List<T>> chainOpParallelStates,
+			int oldParallelism,
+			int newParallelism) {
 
 		if (chainOpParallelStates == null) {
-			return Collections.emptyList();
+			return emptyList();
 		}
 
 		return opStateRepartitioner.repartitionState(
@@ -625,8 +599,8 @@ public class StateAssignmentOperation {
 	 * <p>This is publicly visible to be used in tests.
 	 */
 	public static List<KeyedStateHandle> getKeyedStateHandles(
-		Collection<? extends KeyedStateHandle> keyedStateHandles,
-		KeyGroupRange subtaskKeyGroupRange) {
+			Collection<? extends KeyedStateHandle> keyedStateHandles,
+			KeyGroupRange subtaskKeyGroupRange) {
 
 		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>(keyedStateHandles.size());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateObjectCollection.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateObjectCollection.java
@@ -196,6 +196,10 @@ public class StateObjectCollection<T extends StateObject> implements Collection<
 		return (StateObjectCollection<T>) EMPTY;
 	}
 
+	public static <T extends StateObject> StateObjectCollection<T> emptyIfNull(StateObjectCollection<T> collection) {
+		return collection == null ? empty() : collection;
+	}
+
 	public static <T extends StateObject> StateObjectCollection<T> singleton(T stateObject) {
 		return new StateObjectCollection<>(Collections.singleton(stateObject));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/InputChannelInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/InputChannelInfo.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint.channel;
 import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Identifies {@link org.apache.flink.runtime.io.network.partition.consumer.InputChannel} in a given subtask.
@@ -44,5 +45,27 @@ public class InputChannelInfo implements Serializable {
 
 	public int getInputChannelIdx() {
 		return inputChannelIdx;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final InputChannelInfo that = (InputChannelInfo) o;
+		return gateIdx == that.gateIdx && inputChannelIdx == that.inputChannelIdx;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(gateIdx, inputChannelIdx);
+	}
+
+	@Override
+	public String toString() {
+		return "InputChannelInfo{" + "gateIdx=" + gateIdx + ", inputChannelIdx=" + inputChannelIdx + '}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionInfo.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.checkpoint.channel;
 import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Identifies {@link org.apache.flink.runtime.io.network.partition.ResultSubpartition ResultSubpartition} in a given subtask.
@@ -45,5 +46,27 @@ public class ResultSubpartitionInfo implements Serializable {
 
 	public int getSubPartitionIdx() {
 		return subPartitionIdx;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		final ResultSubpartitionInfo that = (ResultSubpartitionInfo) o;
+		return partitionIdx == that.partitionIdx && subPartitionIdx == that.subPartitionIdx;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(partitionIdx, subPartitionIdx);
+	}
+
+	@Override
+	public String toString() {
+		return "ResultSubpartitionInfo{" + "partitionIdx=" + partitionIdx + ", subPartitionIdx=" + subPartitionIdx + '}';
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/ChannelStateHandleSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/ChannelStateHandleSerializer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint.metadata;
+
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
+import org.apache.flink.runtime.state.AbstractChannelStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.FunctionWithException;
+import org.apache.flink.util.function.TriFunctionWithException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.runtime.checkpoint.metadata.MetadataV2V3SerializerBase.deserializeStreamStateHandle;
+import static org.apache.flink.runtime.checkpoint.metadata.MetadataV2V3SerializerBase.serializeStreamStateHandle;
+
+class ChannelStateHandleSerializer {
+
+	public void serialize(ResultSubpartitionStateHandle handle, DataOutputStream dataOutputStream) throws IOException {
+		serializeChannelStateHandle(handle, dataOutputStream, (info, out) -> {
+			out.writeInt(info.getPartitionIdx());
+			out.writeInt(info.getSubPartitionIdx());
+		});
+	}
+
+	ResultSubpartitionStateHandle deserializeResultSubpartitionStateHandle(DataInputStream dis) throws IOException {
+		return deserializeChannelStateHandle(
+			is -> new ResultSubpartitionInfo(is.readInt(), is.readInt()),
+			(streamStateHandle, longs, info) -> new ResultSubpartitionStateHandle(info, streamStateHandle, longs),
+			dis);
+	}
+
+	public void serialize(InputChannelStateHandle handle, DataOutputStream dos) throws IOException {
+		serializeChannelStateHandle(handle, dos, (info, dataOutputStream) -> {
+			dos.writeInt(info.getGateIdx());
+			dos.writeInt(info.getInputChannelIdx());
+		});
+	}
+
+	InputChannelStateHandle deserializeInputChannelStateHandle(DataInputStream dis) throws IOException {
+		return deserializeChannelStateHandle(
+			is -> new InputChannelInfo(is.readInt(), is.readInt()),
+			(streamStateHandle, longs, inputChannelInfo) -> new InputChannelStateHandle(inputChannelInfo, streamStateHandle, longs),
+			dis);
+	}
+
+	private static <I> void serializeChannelStateHandle(
+			AbstractChannelStateHandle<I> handle,
+			DataOutputStream dos,
+			BiConsumerWithException<I, DataOutputStream, IOException> infoWriter) throws IOException {
+		infoWriter.accept(handle.getInfo(), dos);
+		dos.writeInt(handle.getOffsets().size());
+		for (long offset : handle.getOffsets()) {
+			dos.writeLong(offset);
+		}
+		serializeStreamStateHandle(handle.getDelegate(), dos);
+	}
+
+	private static <Info, Handle extends AbstractChannelStateHandle<Info>> Handle deserializeChannelStateHandle(
+			FunctionWithException<DataInputStream, Info, IOException> infoReader,
+			TriFunctionWithException<StreamStateHandle, List<Long>, Info, Handle, IOException> handleBuilder,
+			DataInputStream dis) throws IOException {
+		final Info info = infoReader.apply(dis);
+		int offsetsSize = dis.readInt();
+		final List<Long> offsets = new ArrayList<>(offsetsSize);
+		for (int i = 0; i < offsetsSize; i++) {
+			offsets.add(dis.readLong());
+		}
+		return handleBuilder.apply(deserializeStreamStateHandle(dis), offsets, info);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2V3SerializerBase.java
@@ -26,18 +26,21 @@ import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.Nullable;
 
@@ -215,8 +218,8 @@ public abstract class MetadataV2V3SerializerBase {
 	// ------------------------------------------------------------------------
 
 	protected void serializeSubtaskState(OperatorSubtaskState subtaskState, DataOutputStream dos) throws IOException {
-		serializeStateCol(subtaskState.getManagedOperatorState(), dos, MetadataV2V3SerializerBase::serializeOperatorStateHandle);
-		serializeStateCol(subtaskState.getRawOperatorState(), dos, MetadataV2V3SerializerBase::serializeOperatorStateHandle);
+		serializeSingleton(subtaskState.getManagedOperatorState(), dos, MetadataV2V3SerializerBase::serializeOperatorStateHandle);
+		serializeSingleton(subtaskState.getRawOperatorState(), dos, MetadataV2V3SerializerBase::serializeOperatorStateHandle);
 		serializeKeyedStateCol(subtaskState.getManagedKeyedState(), dos);
 		serializeKeyedStateCol(subtaskState.getRawKeyedState(), dos);
 	}
@@ -225,7 +228,7 @@ public abstract class MetadataV2V3SerializerBase {
 		serializeKeyedStateHandle(extractSingleton(managedKeyedState), dos);
 	}
 
-	private <T extends StateObject> void serializeStateCol(
+	private <T extends StateObject> void serializeSingleton(
 			StateObjectCollection<T> stateObjectCollection,
 			DataOutputStream dos,
 			BiConsumerWithException<T, DataOutputStream, IOException> cons) throws IOException {
@@ -248,11 +251,17 @@ public abstract class MetadataV2V3SerializerBase {
 		final KeyedStateHandle managedKeyedState = deserializeKeyedStateHandle(dis);
 		final KeyedStateHandle rawKeyedState = deserializeKeyedStateHandle(dis);
 
+		StateObjectCollection<InputChannelStateHandle> inputChannelState = deserializeInputChannelStateHandle(dis);
+
+		StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionState = deserializeResultSubpartitionStateHandle(dis);
+
 		return new OperatorSubtaskState(
 			managedOperatorState,
 			rawOperatorState,
 			managedKeyedState,
-			rawKeyedState);
+			rawKeyedState,
+			inputChannelState,
+			resultSubpartitionState);
 	}
 
 	@VisibleForTesting
@@ -494,4 +503,28 @@ public abstract class MetadataV2V3SerializerBase {
 			throw new IllegalStateException("Expected singleton collection, but found size: " + collection.size());
 		}
 	}
+
+	protected StateObjectCollection<ResultSubpartitionStateHandle> deserializeResultSubpartitionStateHandle(DataInputStream dis) throws IOException {
+		return StateObjectCollection.empty();
+	}
+
+	protected StateObjectCollection<InputChannelStateHandle> deserializeInputChannelStateHandle(DataInputStream dis) throws IOException {
+		return StateObjectCollection.empty();
+	}
+
+	protected void serializeResultSubpartitionStateHandle(ResultSubpartitionStateHandle resultSubpartitionStateHandle, DataOutputStream dos) throws IOException {
+	}
+
+	protected void serializeInputChannelStateHandle(InputChannelStateHandle inputChannelStateHandle, DataOutputStream dos) throws IOException {
+	}
+
+	static <T extends StateObject> StateObjectCollection<T> deserializeCollection(DataInputStream dis, FunctionWithException<DataInputStream, T, IOException> s) throws IOException {
+		int size = dis.readInt();
+		List<T> result = new ArrayList<>();
+		for (int i = 0; i < size; i++) {
+			result.add(s.apply(dis));
+		}
+		return new StateObjectCollection<>(result);
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractChannelStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractChannelStateHandle.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.List;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Abstract channel state handle.
+ * @param <Info> type of channel info (e.g. {@link org.apache.flink.runtime.checkpoint.channel.InputChannelInfo InputChannelInfo}).
+ */
+@Internal
+public abstract class AbstractChannelStateHandle<Info> implements StateObject {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Info info;
+	private final StreamStateHandle delegate;
+	/**
+	 * Start offsets in a {@link org.apache.flink.core.fs.FSDataInputStream stream} {@link StreamStateHandle#openInputStream obtained} from {@link #delegate}.
+	 */
+	private final List<Long> offsets;
+
+	AbstractChannelStateHandle(StreamStateHandle delegate, List<Long> offsets, Info info) {
+		this.info = checkNotNull(info);
+		this.delegate = checkNotNull(delegate);
+		this.offsets = checkNotNull(offsets);
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		delegate.discardState();
+	}
+
+	@Override
+	public long getStateSize() {
+		return delegate.getStateSize();
+	}
+
+	public List<Long> getOffsets() {
+		return offsets;
+	}
+
+	public StreamStateHandle getDelegate() {
+		return delegate;
+	}
+
+	public Info getInfo() {
+		return info;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof AbstractChannelStateHandle)) {
+			return false;
+		}
+		final AbstractChannelStateHandle<?> that = (AbstractChannelStateHandle<?>) o;
+		return info.equals(that.info) && delegate.equals(that.delegate) && offsets.equals(that.offsets);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(info, delegate, offsets);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/InputChannelStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/InputChannelStateHandle.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.state;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +15,22 @@ package org.apache.flink.runtime.state;
  * limitations under the License.
  */
 
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+
+import java.util.List;
 
 /**
  * {@link StateObject Handle} to an {@link org.apache.flink.runtime.io.network.partition.consumer.InputChannel InputChannel} state.
  */
-public interface InputChannelStateHandle extends StateObject {
-	InputChannelInfo getInputChannelInfo();
+@Internal
+public class InputChannelStateHandle extends AbstractChannelStateHandle<InputChannelInfo> {
+
+	private static final long serialVersionUID = 1L;
+
+	public InputChannelStateHandle(InputChannelInfo info, StreamStateHandle delegate, List<Long> offset) {
+		super(delegate, offset, info);
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ResultSubpartitionStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ResultSubpartitionStateHandle.java
@@ -1,4 +1,3 @@
-package org.apache.flink.runtime.state;
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -16,11 +15,22 @@ package org.apache.flink.runtime.state;
  * limitations under the License.
  */
 
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
+
+import java.util.List;
 
 /**
  * {@link StateObject Handle} to a {@link org.apache.flink.runtime.io.network.partition.ResultSubpartition ResultSubpartition} state.
  */
-public interface ResultSubpartitionStateHandle extends StateObject {
-	ResultSubpartitionInfo getResultSubpartitionInfo();
+@Internal
+public class ResultSubpartitionStateHandle extends AbstractChannelStateHandle<ResultSubpartitionInfo> {
+
+	private static final long serialVersionUID = 1L;
+
+	public ResultSubpartitionStateHandle(ResultSubpartitionInfo info, StreamStateHandle delegate, List<Long> offset) {
+		super(delegate, offset, info);
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ChannelStateNoRescalingPartitionerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ChannelStateNoRescalingPartitionerTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.checkpoint;
+
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.AbstractChannelStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
+import org.apache.flink.runtime.state.testutils.EmptyStreamStateHandle;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.checkpoint.StateAssignmentOperation.channelStateNonRescalingRepartitioner;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.empty;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
+import static org.junit.Assert.fail;
+
+/**
+ * Simple test for
+ * {@link org.apache.flink.runtime.checkpoint.StateAssignmentOperation#channelStateNonRescalingRepartitioner channelStateNonRescalingRepartitioner}.
+ * It checks whether partitioner fails or not using property-based approach.
+ */
+@RunWith(Parameterized.class)
+public class ChannelStateNoRescalingPartitionerTest {
+
+	@Parameters(name = "oldParallelism: {0}, newParallelism: {1}, offsetSize: {2}")
+	public static Collection<Object[]> parameters() {
+		List<Object[]> params = new ArrayList<>();
+		int[] parLevels = {1, 2};
+		int[] offsetSizes = {0, 1, 2};
+		final List<Function<OperatorSubtaskState, ?>> extractors = Arrays.asList(
+			OperatorSubtaskState::getInputChannelState,
+			OperatorSubtaskState::getResultSubpartitionState
+		);
+		// generate all possible combinations of the above parameters
+		for (int oldParallelism : parLevels) {
+			for (int newParallelism : parLevels) {
+				for (int offsetSize : offsetSizes) {
+					for (Function<OperatorSubtaskState, ?> stateExtractor : extractors) {
+						params.add(new Object[]{oldParallelism, newParallelism, offsetSize, stateExtractor});
+					}
+				}
+			}
+		}
+		return params;
+	}
+
+	private static final OperatorID OPERATOR_ID = new OperatorID();
+
+	private final int oldParallelism;
+	private final int newParallelism;
+	private final int offsetsSize;
+	private final Function<OperatorSubtaskState, ? extends StateObjectCollection<?>> extractState;
+
+	public ChannelStateNoRescalingPartitionerTest(int oldParallelism, int newParallelism, int offsetsSize, Function<OperatorSubtaskState, ? extends StateObjectCollection<?>> extractState) {
+		this.oldParallelism = oldParallelism;
+		this.newParallelism = newParallelism;
+		this.offsetsSize = offsetsSize;
+		this.extractState = extractState;
+	}
+
+	@Test
+	public <T extends AbstractChannelStateHandle<?>> void testNoRescaling() {
+		OperatorState state = new OperatorState(OPERATOR_ID, oldParallelism, oldParallelism);
+		state.putState(0, new OperatorSubtaskState(
+			empty(),
+			empty(),
+			empty(),
+			empty(),
+			singleton(new InputChannelStateHandle(new InputChannelInfo(0, 0), new EmptyStreamStateHandle(), getOffset())),
+			singleton(new ResultSubpartitionStateHandle(new ResultSubpartitionInfo(0, 0), new EmptyStreamStateHandle(), getOffset()))));
+		try {
+			// noinspection unchecked
+			StateAssignmentOperation.reDistributePartitionableStates(
+				singletonList(state),
+				newParallelism,
+				singletonList(OPERATOR_ID),
+				(Function<OperatorSubtaskState, StateObjectCollection<T>>) this.extractState,
+				channelStateNonRescalingRepartitioner("test"));
+		} catch (IllegalArgumentException e) {
+			if (!shouldFail()) {
+				throw e;
+			} else {
+				return;
+			}
+		}
+		if (shouldFail()) {
+			fail("expected to fail for: oldParallelism=" + oldParallelism + ", newParallelism=" + newParallelism + ", offsetsSize=" + offsetsSize + ", extractState=" + extractState);
+		}
+	}
+
+	private boolean shouldFail() {
+		return oldParallelism != newParallelism && offsetsSize > 0;
+	}
+
+	private List<Long> getOffset() {
+		List<Long> offsets = new ArrayList<>(offsetsSize);
+		for (int i = 0; i < offsetsSize; i++) {
+			offsets.add(0L);
+		}
+		return offsets;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -26,9 +26,11 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -89,12 +91,16 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 		KeyedStateHandle rawKeyedHandle = mock(KeyedStateHandle.class);
 		OperatorStateHandle managedOpHandle = mock(OperatorStreamStateHandle.class);
 		OperatorStateHandle rawOpHandle = mock(OperatorStreamStateHandle.class);
+		InputChannelStateHandle inputChannelStateHandle = mock(InputChannelStateHandle.class);
+		ResultSubpartitionStateHandle resultSubpartitionStateHandle = mock(ResultSubpartitionStateHandle.class);
 
 		final OperatorSubtaskState operatorSubtaskState = spy(new OperatorSubtaskState(
 			managedOpHandle,
 			rawOpHandle,
 			managedKeyedHandle,
-			rawKeyedHandle));
+			rawKeyedHandle,
+			StateObjectCollection.singleton(inputChannelStateHandle),
+			StateObjectCollection.singleton(resultSubpartitionStateHandle)));
 
 		TaskStateSnapshot subtaskState = spy(new TaskStateSnapshot());
 		subtaskState.putSubtaskStateByOperatorID(new OperatorID(), operatorSubtaskState);
@@ -116,6 +122,8 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 		verify(operatorSubtaskState.getRawOperatorState().iterator().next()).discardState();
 		verify(operatorSubtaskState.getManagedKeyedState().iterator().next()).discardState();
 		verify(operatorSubtaskState.getRawKeyedState().iterator().next()).discardState();
+		verify(operatorSubtaskState.getInputChannelState().iterator().next()).discardState();
+		verify(operatorSubtaskState.getResultSubpartitionState().iterator().next()).discardState();
 	}
 
 	private static final class FailingCompletedCheckpointStore implements CompletedCheckpointStore {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -91,8 +91,15 @@ import static org.mockito.Mockito.when;
 /**
  * Tests for restoring checkpoint.
  */
+@SuppressWarnings("checkstyle:EmptyLineSeparator")
 public class CheckpointCoordinatorRestoringTest extends TestLogger {
 	private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
+
+	private enum TestScaleType {
+		INCREASE_PARALLELISM,
+		DECREASE_PARALLELISM,
+		SAME_PARALLELISM;
+	}
 
 	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
 
@@ -655,17 +662,17 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 	@Test
 	public void testStateRecoveryWhenTopologyChangeOut() throws Exception {
-		testStateRecoveryWithTopologyChange(0);
+		testStateRecoveryWithTopologyChange(TestScaleType.INCREASE_PARALLELISM);
 	}
 
 	@Test
 	public void testStateRecoveryWhenTopologyChangeIn() throws Exception {
-		testStateRecoveryWithTopologyChange(1);
+		testStateRecoveryWithTopologyChange(TestScaleType.DECREASE_PARALLELISM);
 	}
 
 	@Test
 	public void testStateRecoveryWhenTopologyChange() throws Exception {
-		testStateRecoveryWithTopologyChange(2);
+		testStateRecoveryWithTopologyChange(TestScaleType.SAME_PARALLELISM);
 	}
 
 	private static Tuple2<JobVertexID, OperatorID> generateIDPair() {
@@ -685,12 +692,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 	 *
 	 * [operator5,operator1,operator3] * newParallelism1 -> [operator3, operator6] * newParallelism2
 	 * </p>
-	 * scaleType:
-	 * 0  increase parallelism
-	 * 1  decrease parallelism
-	 * 2  same parallelism
 	 */
-	public void testStateRecoveryWithTopologyChange(int scaleType) throws Exception {
+	public void testStateRecoveryWithTopologyChange(TestScaleType scaleType) throws Exception {
 
 		/*
 		 * Old topology
@@ -776,9 +779,9 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		Tuple2<JobVertexID, OperatorID> id6 = generateIDPair();
 		int newParallelism2 = parallelism2;
 
-		if (scaleType == 0) {
+		if (scaleType == TestScaleType.INCREASE_PARALLELISM) {
 			newParallelism2 = 20;
-		} else if (scaleType == 1) {
+		} else if (scaleType == TestScaleType.DECREASE_PARALLELISM) {
 			newParallelism2 = 8;
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -443,7 +443,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			OperatorStateHandle opStateBackend = generatePartitionableStateHandle(jobVertexID1, index, 2, 8, false);
 			KeyGroupsStateHandle keyedStateBackend = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), false);
 			KeyGroupsStateHandle keyedStateRaw = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), true);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, null, keyedStateBackend, keyedStateRaw);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, null, keyedStateBackend, keyedStateRaw, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID1), operatorSubtaskState);
 
@@ -468,7 +468,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			expectedOpStatesBackend.add(new ChainedStateHandle<>(Collections.singletonList(opStateBackend)));
 			expectedOpStatesRaw.add(new ChainedStateHandle<>(Collections.singletonList(opStateRaw)));
 
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, opStateRaw, keyedStateBackend, keyedStateRaw);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(opStateBackend, opStateRaw, keyedStateBackend, keyedStateRaw, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID2), operatorSubtaskState);
 
@@ -603,7 +603,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 		for (int index = 0; index < jobVertex1.getParallelism(); index++) {
 			KeyGroupsStateHandle keyGroupState = generateKeyGroupState(jobVertexID1, keyGroupPartitions1.get(index), false);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID1), operatorSubtaskState);
 			AcknowledgeCheckpoint acknowledgeCheckpoint = new AcknowledgeCheckpoint(
@@ -618,7 +618,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 		for (int index = 0; index < jobVertex2.getParallelism(); index++) {
 			KeyGroupsStateHandle keyGroupState = generateKeyGroupState(jobVertexID2, keyGroupPartitions2.get(index), false);
-			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null);
+			OperatorSubtaskState operatorSubtaskState = new OperatorSubtaskState(null, null, keyGroupState, null, null, null);
 			TaskStateSnapshot taskOperatorSubtaskStates = new TaskStateSnapshot();
 			taskOperatorSubtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID2), operatorSubtaskState);
 			AcknowledgeCheckpoint acknowledgeCheckpoint = new AcknowledgeCheckpoint(
@@ -727,6 +727,8 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					subManagedOperatorState,
 					subRawOperatorState,
 					null,
+					null,
+					null,
 					null);
 				taskState.putState(index, subtaskState);
 			}
@@ -764,7 +766,9 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					subManagedOperatorState,
 					subRawOperatorState,
 					subManagedKeyedState,
-					subRawKeyedState);
+					subRawKeyedState,
+					null,
+					null);
 				operatorState.putState(index, subtaskState);
 			}
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -167,11 +167,13 @@ public class CheckpointCoordinatorTestingUtils {
 			++idx;
 		}
 
-		ByteStreamStateHandle streamStateHandle = new ByteStreamStateHandle(
-			String.valueOf(UUID.randomUUID()),
-			serializationWithOffsets.f0);
+		return new OperatorStreamStateHandle(offsetsMap, generateByteStreamStateHandle(serializationWithOffsets.f0));
+	}
 
-		return new OperatorStreamStateHandle(offsetsMap, streamStateHandle);
+	private static ByteStreamStateHandle generateByteStreamStateHandle(byte[] bytes) {
+		return new ByteStreamStateHandle(
+			String.valueOf(UUID.randomUUID()),
+			bytes);
 	}
 
 	static Tuple2<byte[], List<long[]>> serializeTogetherAndTrackOffsets(
@@ -471,7 +473,7 @@ public class CheckpointCoordinatorTestingUtils {
 
 		TaskStateSnapshot subtaskStates = spy(new TaskStateSnapshot());
 		OperatorSubtaskState subtaskState = spy(new OperatorSubtaskState(
-			partitionableState, null, partitionedKeyGroupState, null)
+			partitionableState, null, partitionedKeyGroupState, null, null, null)
 		);
 
 		subtaskStates.putSubtaskStateByOperatorID(OperatorID.fromJobVertexID(jobVertexID), subtaskState);
@@ -508,9 +510,7 @@ public class CheckpointCoordinatorTestingUtils {
 
 		KeyGroupRangeOffsets keyGroupRangeOffsets = new KeyGroupRangeOffsets(keyGroupRange, serializedDataWithOffsets.f1.get(0));
 
-		ByteStreamStateHandle allSerializedStatesHandle = new ByteStreamStateHandle(
-			String.valueOf(UUID.randomUUID()),
-			serializedDataWithOffsets.f0);
+		ByteStreamStateHandle allSerializedStatesHandle = generateByteStreamStateHandle(serializedDataWithOffsets.f0);
 
 		return new KeyGroupsStateHandle(keyGroupRangeOffsets, allSerializedStatesHandle);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -38,7 +38,11 @@ import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -61,6 +65,7 @@ public class CheckpointMetadataLoadingTest {
 	 */
 	@Test
 	public void testLoadAndValidateSavepoint() throws Exception {
+		final Random rnd = new Random();
 		File tmp = tmpFolder.newFolder();
 
 		int parallelism = 128128;
@@ -69,12 +74,12 @@ public class CheckpointMetadataLoadingTest {
 		OperatorID operatorID = OperatorID.fromJobVertexID(jobVertexID);
 
 		OperatorSubtaskState subtaskState = new OperatorSubtaskState(
-				new OperatorStreamStateHandle(
-				Collections.emptyMap(),
-				new ByteStreamStateHandle("testHandler", new byte[0])),
+				new OperatorStreamStateHandle(Collections.emptyMap(), new ByteStreamStateHandle("testHandler", new byte[0])),
 				null,
 				null,
-				null);
+				null,
+				singleton(createNewInputChannelStateHandle(10, rnd)),
+				singleton(createNewResultSubpartitionStateHandle(10, rnd)));
 
 		OperatorState state = new OperatorState(operatorID, parallelism, parallelism);
 		state.putState(0, subtaskState);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -148,18 +148,13 @@ public class StateAssignmentOperationTest extends TestLogger {
 		Map<String, Integer> stateInfoCounts
 	) {
 		final Map<OperatorInstanceID, List<OperatorStateHandle>> newManagedOperatorStates =
-			new HashMap<>(newParallelism);
-
-		final Map<OperatorInstanceID, List<OperatorStateHandle>> newRawOperatorStates =
-			new HashMap<>(newParallelism);
-
-		StateAssignmentOperation.reDistributePartitionableStates(
-			Collections.singletonList(operatorState),
-			newParallelism,
-			Collections.singletonList(operatorID),
-			newManagedOperatorStates,
-			newRawOperatorStates
-		);
+			StateAssignmentOperation.reDistributePartitionableStates(
+				Collections.singletonList(operatorState),
+				newParallelism,
+				Collections.singletonList(operatorID),
+				OperatorSubtaskState::getManagedOperatorState,
+				RoundRobinOperatorStateRepartitioner.INSTANCE
+			);
 
 		// Verify the repartitioned managed operator states per sub-task.
 		for (List<OperatorStateHandle> operatorStateHandles : newManagedOperatorStates.values()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperationTest.java
@@ -18,8 +18,17 @@
 
 package org.apache.flink.runtime.checkpoint;
 
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.JobException;
+import org.apache.flink.runtime.client.JobExecutionException;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.OperatorInstanceID;
+import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -31,8 +40,21 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewKeyedStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewOperatorStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
 
 /**
  * Tests to verify state assignment operation.
@@ -47,12 +69,12 @@ public class StateAssignmentOperationTest extends TestLogger {
 		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap1 = new HashMap<>(1);
 		metaInfoMap1.put("t-1", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
 		OperatorStateHandle osh1 = new OperatorStreamStateHandle(metaInfoMap1, new ByteStreamStateHandle("test1", new byte[30]));
-		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null));
+		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null, null, null));
 
 		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap2 = new HashMap<>(1);
 		metaInfoMap2.put("t-2", new OperatorStateHandle.StateMetaInfo(new long[]{0, 15}, OperatorStateHandle.Mode.SPLIT_DISTRIBUTE));
 		OperatorStateHandle osh2 = new OperatorStreamStateHandle(metaInfoMap2, new ByteStreamStateHandle("test2", new byte[40]));
-		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null));
+		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null, null, null));
 
 		verifyOneKindPartitionableStateRescale(operatorState, operatorID);
 	}
@@ -66,12 +88,12 @@ public class StateAssignmentOperationTest extends TestLogger {
 		metaInfoMap1.put("t-3", new OperatorStateHandle.StateMetaInfo(new long[]{0}, OperatorStateHandle.Mode.UNION));
 		metaInfoMap1.put("t-4", new OperatorStateHandle.StateMetaInfo(new long[]{22, 44}, OperatorStateHandle.Mode.UNION));
 		OperatorStateHandle osh1 = new OperatorStreamStateHandle(metaInfoMap1, new ByteStreamStateHandle("test1", new byte[50]));
-		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null));
+		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null, null, null));
 
 		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap2 = new HashMap<>(1);
 		metaInfoMap2.put("t-3", new OperatorStateHandle.StateMetaInfo(new long[]{0}, OperatorStateHandle.Mode.UNION));
 		OperatorStateHandle osh2 = new OperatorStreamStateHandle(metaInfoMap2, new ByteStreamStateHandle("test2", new byte[20]));
-		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null));
+		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null, null, null));
 
 		verifyOneKindPartitionableStateRescale(operatorState, operatorID);
 	}
@@ -85,13 +107,13 @@ public class StateAssignmentOperationTest extends TestLogger {
 		metaInfoMap1.put("t-5", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.BROADCAST));
 		metaInfoMap1.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.BROADCAST));
 		OperatorStateHandle osh1 = new OperatorStreamStateHandle(metaInfoMap1, new ByteStreamStateHandle("test1", new byte[60]));
-		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null));
+		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null, null, null));
 
 		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap2 = new HashMap<>(2);
 		metaInfoMap2.put("t-5", new OperatorStateHandle.StateMetaInfo(new long[]{0, 10, 20}, OperatorStateHandle.Mode.BROADCAST));
 		metaInfoMap2.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{30, 40, 50}, OperatorStateHandle.Mode.BROADCAST));
 		OperatorStateHandle osh2 = new OperatorStreamStateHandle(metaInfoMap2, new ByteStreamStateHandle("test2", new byte[60]));
-		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null));
+		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null, null, null));
 
 		verifyOneKindPartitionableStateRescale(operatorState, operatorID);
 	}
@@ -113,7 +135,7 @@ public class StateAssignmentOperationTest extends TestLogger {
 		metaInfoMap1.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{101, 123, 127}, OperatorStateHandle.Mode.BROADCAST));
 
 		OperatorStateHandle osh1 = new OperatorStreamStateHandle(metaInfoMap1, new ByteStreamStateHandle("test1", new byte[130]));
-		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null));
+		operatorState.putState(0, new OperatorSubtaskState(osh1, null, null, null, null, null));
 
 		Map<String, OperatorStateHandle.StateMetaInfo> metaInfoMap2 = new HashMap<>(3);
 		metaInfoMap2.put("t-1", new OperatorStateHandle.StateMetaInfo(new long[]{0}, OperatorStateHandle.Mode.UNION));
@@ -122,7 +144,7 @@ public class StateAssignmentOperationTest extends TestLogger {
 		metaInfoMap2.put("t-6", new OperatorStateHandle.StateMetaInfo(new long[]{57, 79, 83}, OperatorStateHandle.Mode.BROADCAST));
 
 		OperatorStateHandle osh2 = new OperatorStreamStateHandle(metaInfoMap2, new ByteStreamStateHandle("test2", new byte[86]));
-		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null));
+		operatorState.putState(1, new OperatorSubtaskState(osh2, null, null, null, null, null));
 
 		// rescale up case, parallelism 2 --> 3
 		verifyCombinedPartitionableStateRescale(operatorState, operatorID, 2, 3);
@@ -277,6 +299,80 @@ public class StateAssignmentOperationTest extends TestLogger {
 		Assert.assertEquals(newParallelism, stateInfoCounts.get("t-4").intValue());
 		Assert.assertEquals(newParallelism, stateInfoCounts.get("t-5").intValue());
 		Assert.assertEquals(newParallelism, stateInfoCounts.get("t-6").intValue());
+	}
+
+	/**
+	 * Check that channel and operator states are assigned to the same tasks on recovery.
+	 */
+	@Test
+	public void testChannelStateAssignmentStability() throws JobException, JobExecutionException {
+		int numOperators = 10; // note: each operator is places into a separate vertex
+		int numSubTasks = 100;
+
+		Set<OperatorID> operatorIds = buildOperatorIds(numOperators);
+		Map<OperatorID, OperatorState> states = buildOperatorStates(operatorIds, numSubTasks);
+		Map<OperatorID, ExecutionJobVertex> vertices = buildVertices(operatorIds, numSubTasks);
+
+		new StateAssignmentOperation(0, new HashSet<>(vertices.values()), states, false).assignStates();
+
+		for (OperatorID operatorId : operatorIds) {
+			for (int subtaskIdx = 0; subtaskIdx < numSubTasks; subtaskIdx++) {
+				Assert.assertEquals(
+					states.get(operatorId).getState(subtaskIdx),
+					getAssignedState(vertices.get(operatorId), operatorId, subtaskIdx));
+			}
+		}
+	}
+
+	private Set<OperatorID> buildOperatorIds(int operators) {
+		Set<OperatorID> set = new HashSet<>();
+		for (int j = 0; j < operators; j++) {
+			set.add(new OperatorID());
+		}
+		return set;
+	}
+
+	private Map<OperatorID, OperatorState> buildOperatorStates(Set<OperatorID> operators, int numSubTasks) {
+		Random random = new Random();
+		return operators.stream().collect(Collectors.toMap(Function.identity(), operatorID -> {
+			OperatorState state = new OperatorState(operatorID, numSubTasks, numSubTasks);
+			for (int i = 0; i < numSubTasks; i++) {
+				state.putState(i, new OperatorSubtaskState(
+					new StateObjectCollection<>(asList(createNewOperatorStateHandle(10, random), createNewOperatorStateHandle(10, random))),
+					new StateObjectCollection<>(asList(createNewOperatorStateHandle(10, random), createNewOperatorStateHandle(10, random))),
+					StateObjectCollection.singleton(createNewKeyedStateHandle(KeyGroupRange.of(i, i))),
+					StateObjectCollection.singleton(createNewKeyedStateHandle(KeyGroupRange.of(i, i))),
+					new StateObjectCollection<>(asList(createNewInputChannelStateHandle(10, random), createNewInputChannelStateHandle(10, random))),
+					new StateObjectCollection<>(asList(createNewResultSubpartitionStateHandle(10, random), createNewResultSubpartitionStateHandle(10, random)))));
+			}
+			return state;
+		}));
+	}
+
+	private Map<OperatorID, ExecutionJobVertex> buildVertices(Set<OperatorID> operators, int parallelism) throws JobException, JobExecutionException {
+		ExecutionGraph graph = TestingExecutionGraphBuilder.newBuilder().build();
+		return operators.stream().collect(Collectors.toMap(Function.identity(), operatorID -> {
+			JobVertex jobVertex = new JobVertex(
+				operatorID.toHexString(),
+				new JobVertexID(),
+				emptyList(),
+				singletonList(operatorID),
+				singletonList(operatorID));
+			try {
+				return new ExecutionJobVertex(graph, jobVertex, parallelism, 1, Time.seconds(1), 1L, 1L);
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}));
+	}
+
+	private OperatorSubtaskState getAssignedState(ExecutionJobVertex executionJobVertex, OperatorID operatorId, int subtaskIdx) {
+		return executionJobVertex
+				.getTaskVertices()[subtaskIdx]
+				.getCurrentExecutionAttempt()
+				.getTaskRestore()
+				.getTaskStateSnapshot()
+				.getSubtaskStateByOperatorID(operatorId);
 	}
 
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -22,14 +22,17 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
@@ -43,6 +46,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.empty;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -117,11 +124,19 @@ public class CheckpointTestUtils {
 					keyedStateStream = createDummyKeyGroupStateHandle(random);
 				}
 
+				StateObjectCollection<InputChannelStateHandle> inputChannelStateHandles =
+					random.nextBoolean() ? singleton(createNewInputChannelStateHandle(random.nextInt(5), random)) : empty();
+
+				StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionStateHandles =
+					random.nextBoolean() ? singleton(createNewResultSubpartitionStateHandle(random.nextInt(5), random)) : empty();
+
 				taskState.putState(subtaskIdx, new OperatorSubtaskState(
 						operatorStateHandleBackend,
 						operatorStateHandleStream,
 						keyedStateStream,
-						keyedStateBackend));
+						keyedStateBackend,
+						inputChannelStateHandles,
+						resultSubpartitionStateHandles));
 			}
 
 			taskStates.add(taskState);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -167,6 +167,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -182,6 +183,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -2022,17 +2026,18 @@ public class JobMasterTest extends TestLogger {
 	}
 
 	private Collection<OperatorState> createOperatorState(OperatorID... operatorIds) {
+		Random random = new Random();
 		Collection<OperatorState> operatorStates = new ArrayList<>(operatorIds.length);
 
 		for (OperatorID operatorId : operatorIds) {
 			final OperatorState operatorState = new OperatorState(operatorId, 1, 42);
 			final OperatorSubtaskState subtaskState = new OperatorSubtaskState(
-				new OperatorStreamStateHandle(
-					Collections.emptyMap(),
-					new ByteStreamStateHandle("foobar", new byte[0])),
+				new OperatorStreamStateHandle(Collections.emptyMap(), new ByteStreamStateHandle("foobar", new byte[0])),
 				null,
 				null,
-				null);
+				null,
+				singleton(createNewInputChannelStateHandle(10, random)),
+				singleton(createNewResultSubpartitionStateHandle(10, random)));
 			operatorState.putState(0, subtaskState);
 			operatorStates.add(operatorState);
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/CheckpointMessagesTest.java
@@ -37,7 +37,11 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Random;
 
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -49,6 +53,7 @@ public class CheckpointMessagesTest {
 
 	@Test
 	public void testConfirmTaskCheckpointed() {
+		final Random rnd = new Random();
 		try {
 			AcknowledgeCheckpoint noState = new AcknowledgeCheckpoint(
 					new JobID(), new ExecutionAttemptID(), 569345L);
@@ -62,7 +67,9 @@ public class CheckpointMessagesTest {
 					CheckpointCoordinatorTestingUtils.generatePartitionableStateHandle(new JobVertexID(), 0, 2, 8, false),
 					null,
 					CheckpointCoordinatorTestingUtils.generateKeyGroupState(keyGroupRange, Collections.singletonList(new MyHandle())),
-					null
+					null,
+					singleton(createNewInputChannelStateHandle(10, rnd)),
+					singleton(createNewResultSubpartitionStateHandle(10, rnd))
 				)
 			);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskStateManagerImplTest.java
@@ -82,10 +82,10 @@ public class TaskStateManagerImplTest extends TestLogger {
 		KeyGroupRange keyGroupRange = new KeyGroupRange(0,1);
 		// Remote state of operator 1 has only managed keyed state.
 		OperatorSubtaskState jmOperatorSubtaskState_1 =
-			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null);
+			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null, null, null);
 		// Remote state of operator 1 has only raw keyed state.
 		OperatorSubtaskState jmOperatorSubtaskState_2 =
-			new OperatorSubtaskState(null, null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange));
+			new OperatorSubtaskState(null, null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null, null);
 
 		jmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_1, jmOperatorSubtaskState_1);
 		jmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_2, jmOperatorSubtaskState_2);
@@ -94,7 +94,7 @@ public class TaskStateManagerImplTest extends TestLogger {
 
 		// Only operator 1 has a local alternative for the managed keyed state.
 		OperatorSubtaskState tmOperatorSubtaskState_1 =
-			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null);
+			new OperatorSubtaskState(null, null, StateHandleDummyUtil.createNewKeyedStateHandle(keyGroupRange), null, null, null);
 
 		tmTaskStateSnapshot.putSubtaskStateByOperatorID(operatorID_1, tmOperatorSubtaskState_1);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizer.java
@@ -19,9 +19,12 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
 
 import javax.annotation.Nonnull;
@@ -55,18 +58,26 @@ public class OperatorSnapshotFinalizer {
 		SnapshotResult<OperatorStateHandle> operatorRaw =
 			FutureUtils.runIfNotDoneAndGet(snapshotFutures.getOperatorStateRawFuture());
 
+		SnapshotResult<StateObjectCollection<InputChannelStateHandle>> inputChannel = snapshotFutures.getInputChannelStateFuture().get();
+
+		SnapshotResult<StateObjectCollection<ResultSubpartitionStateHandle>> resultSubpartition = snapshotFutures.getResultSubpartitionStateFuture().get();
+
 		jobManagerOwnedState = new OperatorSubtaskState(
 			operatorManaged.getJobManagerOwnedSnapshot(),
 			operatorRaw.getJobManagerOwnedSnapshot(),
 			keyedManaged.getJobManagerOwnedSnapshot(),
-			keyedRaw.getJobManagerOwnedSnapshot()
+			keyedRaw.getJobManagerOwnedSnapshot(),
+			inputChannel.getJobManagerOwnedSnapshot(),
+			resultSubpartition.getJobManagerOwnedSnapshot()
 		);
 
 		taskLocalState = new OperatorSubtaskState(
 			operatorManaged.getTaskLocalSnapshot(),
 			operatorRaw.getTaskLocalSnapshot(),
 			keyedManaged.getTaskLocalSnapshot(),
-			keyedRaw.getTaskLocalSnapshot()
+			keyedRaw.getTaskLocalSnapshot(),
+			inputChannel.getTaskLocalSnapshot(),
+			resultSubpartition.getTaskLocalSnapshot()
 		);
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFinalizerTest.java
@@ -29,10 +29,19 @@ import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.deepDummyCopy;
+import static org.apache.flink.runtime.state.SnapshotResult.withLocalState;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link OperatorSnapshotFinalizer}.
@@ -43,68 +52,60 @@ public class OperatorSnapshotFinalizerTest extends TestLogger {
 	 * Test that the runnable futures are executed and the result is correctly extracted.
 	 */
 	@Test
-	public void testRunAndExtract() throws Exception{
+	public void testRunAndExtract() throws Exception {
 
 		Random random = new Random(0x42);
 
-		KeyedStateHandle keyedTemplate =
-			StateHandleDummyUtil.createNewKeyedStateHandle(new KeyGroupRange(0, 0));
-		OperatorStateHandle operatorTemplate =
-			StateHandleDummyUtil.createNewOperatorStateHandle(2, random);
+		KeyedStateHandle keyedTemplate = StateHandleDummyUtil.createNewKeyedStateHandle(new KeyGroupRange(0, 0));
+		OperatorStateHandle operatorTemplate = StateHandleDummyUtil.createNewOperatorStateHandle(2, random);
 
-		SnapshotResult<KeyedStateHandle> snapKeyMan = SnapshotResult.withLocalState(
-			StateHandleDummyUtil.deepDummyCopy(keyedTemplate),
-			StateHandleDummyUtil.deepDummyCopy(keyedTemplate));
+		SnapshotResult<KeyedStateHandle> manKeyed = withLocalState(deepDummyCopy(keyedTemplate), deepDummyCopy(keyedTemplate));
+		SnapshotResult<KeyedStateHandle> rawKeyed = withLocalState(deepDummyCopy(keyedTemplate), deepDummyCopy(keyedTemplate));
+		SnapshotResult<OperatorStateHandle> manOper = withLocalState(deepDummyCopy(operatorTemplate), deepDummyCopy(operatorTemplate));
+		SnapshotResult<OperatorStateHandle> rawOper = withLocalState(deepDummyCopy(operatorTemplate), deepDummyCopy(operatorTemplate));
 
-		SnapshotResult<KeyedStateHandle> snapKeyRaw = SnapshotResult.withLocalState(
-			StateHandleDummyUtil.deepDummyCopy(keyedTemplate),
-			StateHandleDummyUtil.deepDummyCopy(keyedTemplate));
+		OperatorSnapshotFutures snapshotFutures = new OperatorSnapshotFutures(
+			new PseudoNotDoneFuture<>(manKeyed),
+			new PseudoNotDoneFuture<>(rawKeyed),
+			new PseudoNotDoneFuture<>(manOper),
+			new PseudoNotDoneFuture<>(rawOper));
 
-		SnapshotResult<OperatorStateHandle> snapOpMan = SnapshotResult.withLocalState(
-			StateHandleDummyUtil.deepDummyCopy(operatorTemplate),
-			StateHandleDummyUtil.deepDummyCopy(operatorTemplate));
-
-		SnapshotResult<OperatorStateHandle> snapOpRaw = SnapshotResult.withLocalState(
-			StateHandleDummyUtil.deepDummyCopy(operatorTemplate),
-			StateHandleDummyUtil.deepDummyCopy(operatorTemplate));
-
-		DoneFuture<SnapshotResult<KeyedStateHandle>> managedKeyed = new PseudoNotDoneFuture<>(snapKeyMan);
-		DoneFuture<SnapshotResult<KeyedStateHandle>> rawKeyed = new PseudoNotDoneFuture<>(snapKeyRaw);
-		DoneFuture<SnapshotResult<OperatorStateHandle>> managedOp = new PseudoNotDoneFuture<>(snapOpMan);
-		DoneFuture<SnapshotResult<OperatorStateHandle>> rawOp = new PseudoNotDoneFuture<>(snapOpRaw);
-
-		Assert.assertFalse(managedKeyed.isDone());
-		Assert.assertFalse(rawKeyed.isDone());
-		Assert.assertFalse(managedOp.isDone());
-		Assert.assertFalse(rawOp.isDone());
-
-		OperatorSnapshotFutures futures = new OperatorSnapshotFutures(managedKeyed, rawKeyed, managedOp, rawOp);
-		OperatorSnapshotFinalizer operatorSnapshotFinalizer = new OperatorSnapshotFinalizer(futures);
-
-		Assert.assertTrue(managedKeyed.isDone());
-		Assert.assertTrue(rawKeyed.isDone());
-		Assert.assertTrue(managedOp.isDone());
-		Assert.assertTrue(rawOp.isDone());
-
-		OperatorSubtaskState jobManagerOwnedState = operatorSnapshotFinalizer.getJobManagerOwnedState();
-		Assert.assertTrue(checkResult(snapKeyMan.getJobManagerOwnedSnapshot(), jobManagerOwnedState.getManagedKeyedState()));
-		Assert.assertTrue(checkResult(snapKeyRaw.getJobManagerOwnedSnapshot(), jobManagerOwnedState.getRawKeyedState()));
-		Assert.assertTrue(checkResult(snapOpMan.getJobManagerOwnedSnapshot(), jobManagerOwnedState.getManagedOperatorState()));
-		Assert.assertTrue(checkResult(snapOpRaw.getJobManagerOwnedSnapshot(), jobManagerOwnedState.getRawOperatorState()));
-
-		OperatorSubtaskState taskLocalState = operatorSnapshotFinalizer.getTaskLocalState();
-		Assert.assertTrue(checkResult(snapKeyMan.getTaskLocalSnapshot(), taskLocalState.getManagedKeyedState()));
-		Assert.assertTrue(checkResult(snapKeyRaw.getTaskLocalSnapshot(), taskLocalState.getRawKeyedState()));
-		Assert.assertTrue(checkResult(snapOpMan.getTaskLocalSnapshot(), taskLocalState.getManagedOperatorState()));
-		Assert.assertTrue(checkResult(snapOpRaw.getTaskLocalSnapshot(), taskLocalState.getRawOperatorState()));
-	}
-
-	private <T extends StateObject> boolean checkResult(T expected, StateObjectCollection<T> actual) {
-		if (expected == null) {
-			return actual.isEmpty();
+		for (Future<?> f : snapshotFutures.getAllFutures()) {
+			assertFalse(f.isDone());
 		}
 
-		return actual.size() == 1 && expected == actual.iterator().next();
+		OperatorSnapshotFinalizer finalizer = new OperatorSnapshotFinalizer(snapshotFutures);
+
+		for (Future<?> f : snapshotFutures.getAllFutures()) {
+			assertTrue(f.isDone());
+		}
+
+		Map<SnapshotResult<?>, Function<OperatorSubtaskState, ? extends StateObject>> map = new HashMap<>();
+		map.put(manKeyed, headExtractor(OperatorSubtaskState::getManagedKeyedState));
+		map.put(rawKeyed, headExtractor(OperatorSubtaskState::getRawKeyedState));
+		map.put(manOper, headExtractor(OperatorSubtaskState::getManagedOperatorState));
+		map.put(rawOper, headExtractor(OperatorSubtaskState::getRawOperatorState));
+
+		for (Map.Entry<SnapshotResult<?>, Function<OperatorSubtaskState, ? extends StateObject>> e : map.entrySet()) {
+			assertEquals(e.getKey().getJobManagerOwnedSnapshot(), e.getValue().apply(finalizer.getJobManagerOwnedState()));
+		}
+		for (Map.Entry<SnapshotResult<?>, Function<OperatorSubtaskState, ? extends StateObject>> e : map.entrySet()) {
+			assertEquals(e.getKey().getTaskLocalSnapshot(), e.getValue().apply(finalizer.getTaskLocalState()));
+		}
+	}
+
+	private static <T extends StateObject> Function<OperatorSubtaskState, T> headExtractor(
+			Function<OperatorSubtaskState, StateObjectCollection<T>> collectionExtractor) {
+		return collectionExtractor.andThen(col -> col == null || col.isEmpty() ? null : col.iterator().next());
+	}
+
+	private void checkResult(Object expected, StateObjectCollection<?> actual) {
+		if (expected == null) {
+			assertTrue(actual == null || actual.isEmpty());
+		} else {
+			assertEquals(1, actual.size());
+			assertEquals(expected, actual.iterator().next());
+		}
 	}
 
 	static class PseudoNotDoneFuture<T> extends DoneFuture<T> {
@@ -125,6 +126,15 @@ public class OperatorSnapshotFinalizerTest extends TestLogger {
 		@Override
 		public boolean isDone() {
 			return done;
+		}
+
+		@Override
+		public T get() {
+			try {
+				return super.get();
+			} finally {
+				this.done = true;
+			}
 		}
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/OperatorSnapshotFuturesTest.java
@@ -49,28 +49,20 @@ public class OperatorSnapshotFuturesTest extends TestLogger {
 		operatorSnapshotResult.cancel();
 
 		KeyedStateHandle keyedManagedStateHandle = mock(KeyedStateHandle.class);
-		SnapshotResult<KeyedStateHandle> keyedStateManagedResult =
-			SnapshotResult.of(keyedManagedStateHandle);
-		RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture =
-			spy(DoneFuture.of(keyedStateManagedResult));
+		SnapshotResult<KeyedStateHandle> keyedStateManagedResult = SnapshotResult.of(keyedManagedStateHandle);
+		RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateManagedFuture = spy(DoneFuture.of(keyedStateManagedResult));
 
 		KeyedStateHandle keyedRawStateHandle = mock(KeyedStateHandle.class);
-		SnapshotResult<KeyedStateHandle> keyedStateRawResult =
-			SnapshotResult.of(keyedRawStateHandle);
-		RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture =
-			spy(DoneFuture.of(keyedStateRawResult));
+		SnapshotResult<KeyedStateHandle> keyedStateRawResult = SnapshotResult.of(keyedRawStateHandle);
+		RunnableFuture<SnapshotResult<KeyedStateHandle>> keyedStateRawFuture = spy(DoneFuture.of(keyedStateRawResult));
 
 		OperatorStateHandle operatorManagedStateHandle = mock(OperatorStreamStateHandle.class);
-		SnapshotResult<OperatorStateHandle> operatorStateManagedResult =
-			SnapshotResult.of(operatorManagedStateHandle);
-		RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateManagedFuture =
-			spy(DoneFuture.of(operatorStateManagedResult));
+		SnapshotResult<OperatorStateHandle> operatorStateManagedResult = SnapshotResult.of(operatorManagedStateHandle);
+		RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateManagedFuture = spy(DoneFuture.of(operatorStateManagedResult));
 
 		OperatorStateHandle operatorRawStateHandle = mock(OperatorStreamStateHandle.class);
-		SnapshotResult<OperatorStateHandle> operatorStateRawResult =
-			SnapshotResult.of(operatorRawStateHandle);
-		RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateRawFuture =
-			spy(DoneFuture.of(operatorStateRawResult));
+		SnapshotResult<OperatorStateHandle> operatorStateRawResult = SnapshotResult.of(operatorRawStateHandle);
+		RunnableFuture<SnapshotResult<OperatorStateHandle>> operatorStateRawFuture = spy(DoneFuture.of(operatorStateRawResult));
 
 		operatorSnapshotResult = new OperatorSnapshotFutures(
 			keyedStateManagedFuture,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -66,6 +66,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
 
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewInputChannelStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateHandleDummyUtil.createNewResultSubpartitionStateHandle;
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -184,7 +187,9 @@ public class StreamTaskStateInitializerImplTest {
 						OperatorStateHandle.Mode.SPLIT_DISTRIBUTE)),
 				CheckpointTestUtils.createDummyStreamStateHandle(random)),
 			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
-			CheckpointTestUtils.createDummyKeyGroupStateHandle(random));
+			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
+			singleton(createNewInputChannelStateHandle(10, random)),
+			singleton(createNewResultSubpartitionStateHandle(10, random)));
 
 		taskStateSnapshot.putSubtaskStateByOperatorID(operatorID, operatorSubtaskState);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/LocalStateForwardingTest.java
@@ -33,10 +33,12 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
 import org.apache.flink.runtime.state.DoneFuture;
+import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.LocalRecoveryDirectoryProviderImpl;
 import org.apache.flink.runtime.state.OperatorStateHandle;
+import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.TaskLocalStateStore;
@@ -62,6 +64,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -101,6 +104,8 @@ public class LocalStateForwardingTest extends TestLogger {
 		osFuture.setKeyedStateRawFuture(createSnapshotResult(KeyedStateHandle.class));
 		osFuture.setOperatorStateManagedFuture(createSnapshotResult(OperatorStateHandle.class));
 		osFuture.setOperatorStateRawFuture(createSnapshotResult(OperatorStateHandle.class));
+		osFuture.setInputChannelStateFuture(createSnapshotCollectionResult(InputChannelStateHandle.class));
+		osFuture.setResultSubpartitionStateFuture(createSnapshotCollectionResult(ResultSubpartitionStateHandle.class));
 
 		OperatorID operatorID = new OperatorID();
 		snapshots.put(operatorID, osFuture);
@@ -130,6 +135,8 @@ public class LocalStateForwardingTest extends TestLogger {
 		performCheck(osFuture.getKeyedStateRawFuture(), jmState.getRawKeyedState(), tmState.getRawKeyedState());
 		performCheck(osFuture.getOperatorStateManagedFuture(), jmState.getManagedOperatorState(), tmState.getManagedOperatorState());
 		performCheck(osFuture.getOperatorStateRawFuture(), jmState.getRawOperatorState(), tmState.getRawOperatorState());
+		performCollectionCheck(osFuture.getInputChannelStateFuture(), jmState.getInputChannelState(), tmState.getInputChannelState());
+		performCollectionCheck(osFuture.getResultSubpartitionStateFuture(), jmState.getResultSubpartitionState(), tmState.getResultSubpartitionState());
 	}
 
 	/**
@@ -232,7 +239,27 @@ public class LocalStateForwardingTest extends TestLogger {
 			tmState.iterator().next());
 	}
 
+	private static <T extends StateObject> void performCollectionCheck(
+			Future<SnapshotResult<StateObjectCollection<T>>> resultFuture,
+			StateObjectCollection<T> jmState,
+			StateObjectCollection<T> tmState) {
+
+		SnapshotResult<StateObjectCollection<T>> snapshotResult;
+		try {
+			snapshotResult = resultFuture.get();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		Assert.assertEquals(snapshotResult.getJobManagerOwnedSnapshot(), jmState);
+		Assert.assertEquals(snapshotResult.getTaskLocalSnapshot(), tmState);
+	}
+
 	private static <T extends StateObject> RunnableFuture<SnapshotResult<T>> createSnapshotResult(Class<T> clazz) {
 		return DoneFuture.of(SnapshotResult.withLocalState(mock(clazz), mock(clazz)));
+	}
+
+	private static <T extends StateObject> RunnableFuture<SnapshotResult<StateObjectCollection<T>>> createSnapshotCollectionResult(Class<T> clazz) {
+		return DoneFuture.of(SnapshotResult.withLocalState(singleton(mock(clazz)), singleton(mock(clazz))));
 	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/RestoreStreamTaskTest.java
@@ -167,6 +167,8 @@ public class RestoreStreamTaskTest extends TestLogger {
 			Collections.emptyMap(),
 			Collections.emptyMap(),
 			Collections.emptyMap(),
+			Collections.emptyMap(),
+			Collections.emptyMap(),
 			Collections.emptyMap());
 
 		stateHandles.putSubtaskStateByOperatorID(headOperatorID, emptyHeadOperatorState);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -138,6 +137,7 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.flink.runtime.checkpoint.StateObjectCollection.singleton;
 import static org.apache.flink.streaming.util.StreamTaskUtil.waitTaskIsRunning;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.instanceOf;
@@ -506,6 +506,8 @@ public class StreamTaskTest extends TestLogger {
 			ExceptionallyDoneFuture.of(failingCause),
 			DoneFuture.of(SnapshotResult.empty()),
 			DoneFuture.of(SnapshotResult.empty()),
+			DoneFuture.of(SnapshotResult.empty()),
+			DoneFuture.of(SnapshotResult.empty()),
 			DoneFuture.of(SnapshotResult.empty()));
 
 		final TestingUncaughtExceptionHandler uncaughtExceptionHandler = new TestingUncaughtExceptionHandler();
@@ -645,7 +647,9 @@ public class StreamTaskTest extends TestLogger {
 			DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
 			DoneFuture.of(SnapshotResult.of(rawKeyedStateHandle)),
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
-			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
+			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)),
+			DoneFuture.of(SnapshotResult.empty()),
+			DoneFuture.of(SnapshotResult.empty()));
 
 		try (MockEnvironment mockEnvironment = new MockEnvironmentBuilder()
 			.setTaskName("mock-task")
@@ -681,10 +685,10 @@ public class StreamTaskTest extends TestLogger {
 			OperatorSubtaskState subtaskState = subtaskStates.getSubtaskStateMappings().iterator().next().getValue();
 
 			// check that the subtask state contains the expected state handles
-			assertEquals(StateObjectCollection.singleton(managedKeyedStateHandle), subtaskState.getManagedKeyedState());
-			assertEquals(StateObjectCollection.singleton(rawKeyedStateHandle), subtaskState.getRawKeyedState());
-			assertEquals(StateObjectCollection.singleton(managedOperatorStateHandle), subtaskState.getManagedOperatorState());
-			assertEquals(StateObjectCollection.singleton(rawOperatorStateHandle), subtaskState.getRawOperatorState());
+			assertEquals(singleton(managedKeyedStateHandle), subtaskState.getManagedKeyedState());
+			assertEquals(singleton(rawKeyedStateHandle), subtaskState.getRawKeyedState());
+			assertEquals(singleton(managedOperatorStateHandle), subtaskState.getManagedOperatorState());
+			assertEquals(singleton(rawOperatorStateHandle), subtaskState.getRawOperatorState());
 
 			// check that the state handles have not been discarded
 			verify(managedKeyedStateHandle, never()).discardState();
@@ -728,7 +732,9 @@ public class StreamTaskTest extends TestLogger {
 			DoneFuture.of(SnapshotResult.of(managedKeyedStateHandle)),
 			rawKeyedStateHandleFuture,
 			DoneFuture.of(SnapshotResult.of(managedOperatorStateHandle)),
-			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)));
+			DoneFuture.of(SnapshotResult.of(rawOperatorStateHandle)),
+			DoneFuture.of(SnapshotResult.empty()),
+			DoneFuture.of(SnapshotResult.empty()));
 
 		final OneInputStreamOperator<String, String> streamOperator = streamOperatorWithSnapshot(operatorSnapshotResult);
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -125,7 +125,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 	private final Object checkpointLock;
 
-	private static final OperatorStateRepartitioner operatorStateRepartitioner =
+	private static final OperatorStateRepartitioner<OperatorStateHandle> operatorStateRepartitioner =
 			RoundRobinOperatorStateRepartitioner.INSTANCE;
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

Currently, Flink only snapshots and stores operator state. For the Unaligned Checkpoints, channel state needs to be stored as well. This PR adds channel state handles to checkpoint metadata and updates state assignment on recovery.

The metadata is added on the `OperatorSubtaskState` level: each operator has in and out channel states. Currently, only head and tail operators in the chain will have `in` and `out` states respectively (topology change is not supported).
An alternative approach (implemented [here](https://github.com/rkhachatryan/flink/tree/uc-state-metadata)) would be to add channel state on the `TaskStateSnapshot` level. While it looks simpler from the Task perspective; it requires some artificial binding in `CompletedCheckpoint` to allow assignment on recovery.

## Brief change log

 - some pre-requisite refactorings
 - add channel state metadata to OperatorSubtaskState
 - adjust StateAssignmentOperation
 - adjust metadata serialization
 - adjust related classes

## Verifying this change

This change is already covered by existing (modified) tests, such as:
 - CheckpointCoordinatorFailureTest
 - LocalStateForwardingTest
 - OperatorSnapshotFinalizerTest
 - OperatorSnapshotFuturesTest
 - RestoreStreamTaskTest
 - StreamTaskTest

And new tests:
- `ChannelStateNoRescalingPartitionerTest`
- `StateAssignmentOperationTest#testChannelStateAssignmentStability`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no (not user-facing)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
