### PR TITLE
[FLINK-16740][orc] OrcSplitReaderUtil::logicalTypeToOrcType fails to …

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReaderUtil.java
@@ -158,8 +158,8 @@ public class OrcSplitReaderUtil {
 			case DECIMAL:
 				DecimalType decimalType = (DecimalType) type;
 				return TypeDescription.createDecimal()
-						.withPrecision(decimalType.getPrecision())
-						.withScale(decimalType.getScale());
+						.withScale(decimalType.getScale())
+						.withPrecision(decimalType.getPrecision());
 			case TINYINT:
 				return TypeDescription.createByte();
 			case SMALLINT:

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcSplitReaderUtilTest.java
@@ -59,6 +59,7 @@ public class OrcSplitReaderUtilTest {
 										DataTypes.FIELD("int0", DataTypes.INT()),
 										DataTypes.FIELD("int1", DataTypes.INT()))
 						)));
+		test("decimal(4,2)", DataTypes.DECIMAL(4, 2));
 	}
 
 	private void test(String expected, DataType type) {


### PR DESCRIPTION
…create decimal type with precision < 10

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`TypeDescription::DEFAULT_SCALE` is 10. `OrcSplitReaderUtil::logicalTypeToOrcType` sets precision before it sets scale. So if we create a decimal type with precision<10, it'll cause an exception.


## Brief change log

  - Sets scale first in OrcSplitReaderUtil::logicalTypeToOrcType.
  - Add test for decimal type.


## Verifying this change

Added test case

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
