### PR TITLE
[FLINK-16160][table-common] Support computed column, proctime and watermark in Schema descriptor

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -73,7 +73,7 @@ public class HiveTableFactoryTest {
 
 		Map<String, String> properties = new HashMap<>();
 		properties.put(CatalogConfig.IS_GENERIC, String.valueOf(true));
-		properties.put("connector", "COLLECTION");
+		properties.put("connector.type", "COLLECTION");
 
 		catalog.createDatabase("mydb", new CatalogDatabaseImpl(new HashMap<>(), ""), true);
 		ObjectPath path = new ObjectPath("mydb", "mytable");

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -210,7 +210,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 	 *     col2 varchar,
 	 *     col3 as to_timestamp(col2)
 	 *   ) with (
-	 *     'connector' = 'csv'
+	 *     'connector.type' = 'csv'
 	 *   )
 	 * </pre>
 	 * we would return a query like:

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -230,7 +230,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				")\n" +
 				"PARTITIONED BY (a, h)\n" +
 				"  with (\n" +
-				"    'connector' = 'kafka', \n" +
+				"    'connector.type' = 'kafka', \n" +
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n",
 			"CREATE TABLE `TBL1` (\n" +
@@ -244,7 +244,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				")\n" +
 				"PARTITIONED BY (`A`, `H`)\n" +
 				"WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -264,7 +264,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"comment 'test table comment ABC.'\n" +
 				"PARTITIONED BY (a, h)\n" +
 				"  with (\n" +
-				"    'connector' = 'kafka', \n" +
+				"    'connector.type' = 'kafka', \n" +
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n",
 			"CREATE TABLE `TBL1` (\n" +
@@ -279,7 +279,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"COMMENT 'test table comment ABC.'\n" +
 				"PARTITIONED BY (`A`, `H`)\n" +
 				"WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -300,7 +300,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"comment 'test table comment ABC.'\n" +
 				"PARTITIONED BY (a, h)\n" +
 				"  with (\n" +
-				"    'connector' = 'kafka', \n" +
+				"    'connector.type' = 'kafka', \n" +
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n",
 			"CREATE TABLE `TBL1` (\n" +
@@ -316,7 +316,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"COMMENT 'test table comment ABC.'\n" +
 				"PARTITIONED BY (`A`, `H`)\n" +
 				"WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -329,7 +329,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  watermark FOR ts AS ts - interval '3' second\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		check(sql,
@@ -338,7 +338,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  `ID`  VARCHAR,\n" +
 				"  WATERMARK FOR `TS` AS (`TS` - INTERVAL '3' SECOND)\n" +
 				") WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -351,7 +351,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  WATERMARK FOR ts AS ts + interval '1' second\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		check(sql,
@@ -360,7 +360,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  `TS` AS `TO_TIMESTAMP`(`LOG_TS`),\n" +
 				"  WATERMARK FOR `TS` AS (`TS` + INTERVAL '1' SECOND)\n" +
 				") WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -372,14 +372,14 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"  WATERMARK FOR f1.q2.t1 AS NOW()\n" +
 				")\n" +
 				"  with (\n" +
-				"    'connector' = 'kafka', \n" +
+				"    'connector.type' = 'kafka', \n" +
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n",
 			"CREATE TABLE `TBL1` (\n" +
 				"  `F1`  ROW< `Q1` BIGINT, `Q2` ROW< `T1` TIMESTAMP, `T2` VARCHAR >, `Q3` BOOLEAN >,\n" +
 				"  WATERMARK FOR `F1`.`Q2`.`T1` AS `NOW`()\n" +
 				") WITH (\n" +
-				"  'connector' = 'kafka',\n" +
+				"  'connector.type' = 'kafka',\n" +
 				"  'kafka.topic' = 'log.test'\n" +
 				")");
 	}
@@ -391,7 +391,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  WATERMARK FOR f1.q0 AS NOW()\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		sql(sql).node(new ValidationMatcher()
@@ -409,7 +409,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  ^WATERMARK^ FOR f1 AS NOW()\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		sql(sql)
@@ -425,7 +425,7 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  WATERMARK FOR f0 AS ^(^SELECT f1 FROM tbl1)\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		sql(sql)

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/CustomConnectorDescriptor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/descriptors/CustomConnectorDescriptor.java
@@ -16,18 +16,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.table.descriptors.python;
+package org.apache.flink.table.descriptors;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.descriptors.ConnectorDescriptor;
-import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.annotation.PublicEvolving;
 
 import java.util.Map;
 
 /**
  * Describes a custom connector to an other system.
  */
-@Internal
+@PublicEvolving
 public class CustomConnectorDescriptor extends ConnectorDescriptor {
 
 	private final DescriptorProperties properties;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Rowtime.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Rowtime.java
@@ -22,12 +22,17 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.table.sources.tsextractors.TimestampExtractor;
 import org.apache.flink.table.sources.wmstrategies.WatermarkStrategy;
+import org.apache.flink.table.types.DataType;
 
 import java.util.Map;
 
 /**
  * Rowtime descriptor for describing an event time attribute in the schema.
+ *
+ * @deprecated This class will be removed in future versions as is inconsistent with watermarks of
+ *              TableSchema. Please use {@link Schema#watermark(String, String, DataType)} instead.
  */
+@Deprecated
 @PublicEvolving
 public class Rowtime implements Descriptor {
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/Schema.java
@@ -246,7 +246,6 @@ public class Schema implements Descriptor {
 			throw new ValidationException("No field defined previously. Use field() before.");
 		}
 		tableSchema.get(lastField).put(SCHEMA_PROCTIME, "true");
-		tableSchema.get(lastField).put(SCHEMA_EXPR, "PROCTIME()");
 		lastField = null;
 		return this;
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -113,7 +113,7 @@ public class SqlToOperationConverterTest {
 			.field("d", DataTypes.VARCHAR(Integer.MAX_VALUE))
 			.build();
 		Map<String, String> properties = new HashMap<>();
-		properties.put("connector", "COLLECTION");
+		properties.put("connector.type", "COLLECTION");
 		final CatalogTable catalogTable =  new CatalogTableImpl(tableSchema, properties, "");
 		catalog.createTable(path1, catalogTable, true);
 		catalog.createTable(path2, catalogTable, true);
@@ -243,7 +243,7 @@ public class SqlToOperationConverterTest {
 			")\n" +
 			"  PARTITIONED BY (a, d)\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
@@ -277,7 +277,7 @@ public class SqlToOperationConverterTest {
 			")\n" +
 			"  PARTITIONED BY (a, d)\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		parse(sql, planner, parser);
@@ -512,7 +512,7 @@ public class SqlToOperationConverterTest {
 			"  g as builtin.`default`.my_udf3(a) || '##'\n" +
 			")\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		functionCatalog.registerTempCatalogScalarFunction(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -416,8 +416,8 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData);
 
-		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
-		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector.type' = 'COLLECTION')";
+		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector.type' = 'COLLECTION')";
 
 		String query = "select t1.a, t1.b, addOne(t1.a, 1) as c from t1";
 
@@ -453,7 +453,7 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData);
 
-		tEnv().sqlUpdate("CREATE TABLE TestTable(i INT NOT NULL, b BIGINT NOT NULL, s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE TestTable(i INT NOT NULL, b BIGINT NOT NULL, s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("PrimitiveScalarFunction", PrimitiveScalarFunction.class);
 		tEnv().sqlUpdate("INSERT INTO TestTable SELECT i, PrimitiveScalarFunction(i, b, s), s FROM TestTable");
@@ -475,7 +475,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 		tEnv().sqlUpdate(
 			"CREATE TABLE TestTable(i INT, r ROW<i INT, s STRING>) " +
-			"WITH ('connector' = 'COLLECTION')");
+			"WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("RowScalarFunction", RowScalarFunction.class);
 		// the names of the function input and r differ
@@ -506,10 +506,10 @@ public class FunctionITCase extends StreamingTestBase {
 
 		tEnv().sqlUpdate(
 			"CREATE TABLE SourceTable(i INT, b BYTES) " +
-			"WITH ('connector' = 'COLLECTION')");
+			"WITH ('connector.type' = 'COLLECTION')");
 		tEnv().sqlUpdate(
 			"CREATE TABLE SinkTable(i INT, s1 STRING, s2 STRING, d DECIMAL(5, 2), s3 STRING) " +
-			"WITH ('connector' = 'COLLECTION')");
+			"WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("ComplexScalarFunction", ComplexScalarFunction.class);
 		tEnv().sqlUpdate(
@@ -545,8 +545,8 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData);
 
-		tEnv().sqlUpdate("CREATE TABLE SourceTable(i INT) WITH ('connector' = 'COLLECTION')");
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(i1 INT, i2 INT, i3 INT) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SourceTable(i INT) WITH ('connector.type' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(i1 INT, i2 INT, i3 INT) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("CustomScalarFunction", CustomScalarFunction.class);
 		tEnv().sqlUpdate(
@@ -563,7 +563,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 	@Test
 	public void testInvalidCustomScalarFunction() {
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("CustomScalarFunction", CustomScalarFunction.class);
 		try {
@@ -602,8 +602,8 @@ public class FunctionITCase extends StreamingTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData);
 
-		tEnv().sqlUpdate("CREATE TABLE SourceTable(s STRING) WITH ('connector' = 'COLLECTION')");
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING> NOT NULL) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SourceTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING, sa ARRAY<STRING> NOT NULL) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("RowTableFunction", RowTableFunction.class);
 		tEnv().sqlUpdate("INSERT INTO SinkTable SELECT t.s, t.sa FROM SourceTable, LATERAL TABLE(RowTableFunction(s)) t");
@@ -622,7 +622,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 		TestCollectionTableFactory.reset();
 
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("DynamicTableFunction", DynamicTableFunction.class);
 		tEnv().sqlUpdate(
@@ -639,7 +639,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 	@Test
 	public void testInvalidUseOfScalarFunction() {
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("PrimitiveScalarFunction", PrimitiveScalarFunction.class);
 		try {
@@ -660,7 +660,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 	@Test
 	public void testInvalidUseOfSystemScalarFunction() {
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		try {
 			tEnv().sqlUpdate(
@@ -680,7 +680,7 @@ public class FunctionITCase extends StreamingTestBase {
 
 	@Test
 	public void testInvalidUseOfTableFunction() {
-		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector' = 'COLLECTION')");
+		tEnv().sqlUpdate("CREATE TABLE SinkTable(s STRING) WITH ('connector.type' = 'COLLECTION')");
 
 		tEnv().createTemporarySystemFunction("RowTableFunction", RowTableFunction.class);
 		try {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -255,9 +255,10 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
   def testClearOperation(): Unit = {
     TestCollectionTableFactory.reset()
     val tableEnv = TableEnvironmentImpl.create(settings)
-    tableEnv.sqlUpdate("create table dest1(x map<int,bigint>) with('connector' = 'COLLECTION')")
-    tableEnv.sqlUpdate("create table dest2(x int) with('connector' = 'COLLECTION')")
-    tableEnv.sqlUpdate("create table src(x int) with('connector' = 'COLLECTION')")
+    tableEnv.sqlUpdate(
+      "create table dest1(x map<int,bigint>) with('connector.type' = 'COLLECTION')")
+    tableEnv.sqlUpdate("create table dest2(x int) with('connector.type' = 'COLLECTION')")
+    tableEnv.sqlUpdate("create table src(x int) with('connector.type' = 'COLLECTION')")
 
     try {
       // it would fail due to query and sink type mismatch

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -104,7 +104,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |create table sinkT(
         |  a bigint
         |) with (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = '$isStreamingMode'
         |)
       """.stripMargin
@@ -157,7 +157,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  c int,
         |  d DECIMAL(10, 3)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -168,7 +168,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  c int,
         |  d DECIMAL(10, 3)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -274,7 +274,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c as a + 1
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -284,7 +284,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -324,7 +324,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  a int,
         |  b varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -334,7 +334,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  a int,
         |  b varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -373,7 +373,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c as to_timestamp(b)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -383,7 +383,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c timestamp(3)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -424,7 +424,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  c as my_udf(a),
         |  d as `time`
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -435,7 +435,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  c int not null,
         |  d varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -474,7 +474,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c as a + 1
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -484,7 +484,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b as c - 1,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -516,7 +516,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c as a + 1
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -526,7 +526,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b as cast(a as varchar(20)) || cast(c as varchar(20)),
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -567,7 +567,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b int,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -578,7 +578,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  c int,
         |  d int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -622,7 +622,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b int,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -631,7 +631,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  a int,
         |  b int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -655,7 +655,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val ddl2 =
@@ -664,7 +664,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  a bigint,
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -684,7 +684,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        | 'connector' = 'COLLECTION'
+        | 'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val ddl2 =
@@ -693,7 +693,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  a bigint,
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -714,7 +714,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -732,7 +732,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -751,7 +751,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'k1' = 'v1'
         |)
       """.stripMargin
@@ -760,7 +760,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     assert(tableEnv.listTables().sameElements(Array[String]("t2")))
     tableEnv.sqlUpdate("alter table t2 set ('k1' = 'a', 'k2' = 'b')")
     val expectedProperties = new util.HashMap[String, String]()
-    expectedProperties.put("connector", "COLLECTION")
+    expectedProperties.put("connector.type", "COLLECTION")
     expectedProperties.put("k1", "a")
     expectedProperties.put("k2", "b")
     val properties = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
@@ -839,7 +839,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     tableEnv.sqlUpdate(ddl1)
@@ -850,7 +850,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     tableEnv.sqlUpdate(ddl2)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableTest.scala
@@ -45,7 +45,7 @@ class CatalogTableTest {
         |  f7 DATE,
         |  f8 VARCHAR(10) NOT NULL
         |) WITH (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     )

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/factories/utils/TestCollectionTableFactory.scala
@@ -28,7 +28,7 @@ import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink, Da
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.TableSchema
-import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE
 import org.apache.flink.table.factories.{TableSinkFactory, TableSourceFactory}
 import org.apache.flink.table.functions.{AsyncTableFunction, TableFunction}
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory.{getCollectionSink, getCollectionSource}
@@ -57,7 +57,7 @@ class TestCollectionTableFactory extends TableSourceFactory[Row] with TableSinkF
 
   override def requiredContext(): JMap[String, String] = {
     val context = new util.HashMap[String, String]()
-    context.put(CONNECTOR, "COLLECTION")
+    context.put(CONNECTOR_TYPE, "COLLECTION")
     context
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
@@ -43,7 +43,7 @@ class TableScanTest extends TableTestBase {
          |  d as to_timestamp(b),
          |  e as my_udf(a)
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'true'
          |)
        """.stripMargin)
@@ -58,7 +58,7 @@ class TableScanTest extends TableTestBase {
          |  e as my_udf(a),
          |  WATERMARK FOR d AS d - INTERVAL '0.001' SECOND
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'true'
          |)
        """.stripMargin)
@@ -80,7 +80,7 @@ class TableScanTest extends TableTestBase {
         |  b DOUBLE,
         |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'true'
         |)
       """.stripMargin)
@@ -135,7 +135,7 @@ class TableScanTest extends TableTestBase {
          |  a int,
          |  b varchar
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'true'
          |)
        """.stripMargin)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/TableScanTest.scala
@@ -97,7 +97,7 @@ class TableScanTest extends TableTestBase {
         |  b DOUBLE,
         |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/WindowAggregateTest.scala
@@ -53,7 +53,7 @@ class WindowAggregateTest(aggStrategy: AggregatePhaseStrategy) extends TableTest
          |  b bigint,
          |  c as proctime()
          |) with (
-         |  'connector' = 'COLLECTION'
+         |  'connector.type' = 'COLLECTION'
          |)
          |""".stripMargin)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/TableFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/TableFactoryTest.scala
@@ -52,7 +52,7 @@ class TableFactoryTest(isBatch: Boolean) extends TableTestBase {
         |  b varchar,
         |  c as a + 1
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -62,7 +62,7 @@ class TableFactoryTest(isBatch: Boolean) extends TableTestBase {
         |  b as c - 1,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/DeduplicateTest.scala
@@ -80,7 +80,7 @@ class DeduplicateTest extends TableTestBase {
         | `ts` TIMESTAMP(3),
         | WATERMARK FOR `ts` AS `ts`
         |) WITH (
-        | 'connector' = 'COLLECTION',
+        | 'connector.type' = 'COLLECTION',
         | 'is-bounded' = 'false'
         |)
       """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -110,7 +110,7 @@ class TableScanTest extends TableTestBase {
         |  proc AS PROCTIME(),
         |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.scala
@@ -50,7 +50,7 @@ class TableScanTest extends TableTestBase {
         |  b DOUBLE,
         |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin)
@@ -70,7 +70,7 @@ class TableScanTest extends TableTestBase {
          |  d as to_timestamp(b),
          |  e as my_udf(a)
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'false'
          |)
        """.stripMargin)
@@ -91,7 +91,7 @@ class TableScanTest extends TableTestBase {
          |  e as my_udf(a),
          |  WATERMARK FOR d AS d - INTERVAL '0.001' SECOND
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'false'
          |)
        """.stripMargin)
@@ -133,7 +133,7 @@ class TableScanTest extends TableTestBase {
          |  `timestamp` AS json_row.`timestamp`,
          |  WATERMARK FOR `timestamp` AS `timestamp`
          |) with (
-         |  'connector' = 'COLLECTION',
+         |  'connector.type' = 'COLLECTION',
          |  'is-bounded' = 'false'
          |)
        """.stripMargin)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.scala
@@ -40,7 +40,7 @@ class WindowAggregateTest extends TableTestBase {
        |  b bigint,
        |  c as proctime()
        |) with (
-       |  'connector' = 'COLLECTION'
+       |  'connector.type' = 'COLLECTION'
        |)
        |""".stripMargin)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TimeAttributeITCase.scala
@@ -62,7 +62,7 @@ class TimeAttributeITCase extends StreamingTestBase {
         |  b DOUBLE,
         |  WATERMARK FOR ts AS ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin
@@ -99,7 +99,7 @@ class TimeAttributeITCase extends StreamingTestBase {
         |  b DOUBLE,
         |  WATERMARK FOR ts AS myFunc(ts, a)
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin
@@ -136,7 +136,7 @@ class TimeAttributeITCase extends StreamingTestBase {
         |  rowtime AS CAST(log_ts AS TIMESTAMP(3)),
         |  WATERMARK FOR rowtime AS rowtime - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin
@@ -170,7 +170,7 @@ class TimeAttributeITCase extends StreamingTestBase {
         |    b DOUBLE>,
         |  WATERMARK FOR col.ts AS col.ts - INTERVAL '0.001' SECOND
         |) WITH (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'is-bounded' = 'false'
         |)
       """.stripMargin

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -424,7 +424,7 @@ public class SqlToOperationConverter {
 	 *     b varchar,
 	 *     c as to_timestamp(b))
 	 *   with (
-	 *     'connector' = 'csv',
+	 *     'connector.type' = 'csv',
 	 *     'k1' = 'v1')
 	 * </pre></blockquote>
 	 *

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/FunctionITCase.java
@@ -426,8 +426,8 @@ public class FunctionITCase extends AbstractTestBase {
 		TestCollectionTableFactory.reset();
 		TestCollectionTableFactory.initData(sourceData, new ArrayList<>(), -1);
 
-		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
-		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector' = 'COLLECTION')";
+		String sourceDDL = "create table t1(a int, b varchar, c int) with ('connector.type' = 'COLLECTION')";
+		String sinkDDL = "create table t2(a int, b varchar, c int) with ('connector.type' = 'COLLECTION')";
 		String query = " insert into t2 select t1.a, t1.b, addOne(t1.a, 1) as c from t1";
 
 		tableEnv.sqlUpdate(sourceDDL);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/sqlexec/SqlToOperationConverterTest.java
@@ -112,7 +112,7 @@ public class SqlToOperationConverterTest {
 			.field("d", DataTypes.VARCHAR(Integer.MAX_VALUE))
 			.build();
 		Map<String, String> properties = new HashMap<>();
-		properties.put("connector", "COLLECTION");
+		properties.put("connector.type", "COLLECTION");
 		final CatalogTable catalogTable =  new CatalogTableImpl(tableSchema, properties, "");
 		catalog.createTable(path1, catalogTable, true);
 		catalog.createTable(path2, catalogTable, true);
@@ -242,7 +242,7 @@ public class SqlToOperationConverterTest {
 			")\n" +
 			"  PARTITIONED BY (a, d)\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);
@@ -303,7 +303,7 @@ public class SqlToOperationConverterTest {
 			")\n" +
 			"  PARTITIONED BY (a, d)\n" +
 			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
+			"    'connector.type' = 'kafka', \n" +
 			"    'kafka.topic' = 'log.test'\n" +
 			")\n";
 		final FlinkPlannerImpl planner = getPlannerBySqlDialect(SqlDialect.HIVE);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -25,7 +25,6 @@ import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, SqlTimeTypeInfo, Typ
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.descriptors.{ConnectorDescriptor, Schema}
-import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
 import org.apache.flink.table.expressions.utils._
 import org.apache.flink.table.runtime.utils.CommonTestData
 import org.apache.flink.table.sources.{CsvTableSource, TableSource}
@@ -375,7 +374,6 @@ class TableSourceTest extends TableTestBase {
     tableEnv.connect(new ConnectorDescriptor("COLLECTION", 1, false) {
       override protected def toConnectorProperties: JMap[String, String] = {
         val context = new JHashMap[String, String]()
-        context.put(CONNECTOR, "COLLECTION")
         context
       }
     }).withSchema(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/TableFactoryTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/TableFactoryTest.scala
@@ -48,7 +48,7 @@ class TableFactoryTest extends TableTestBase {
         |  b varchar,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -57,7 +57,7 @@ class TableFactoryTest extends TableTestBase {
         |  a int,
         |  b int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/catalog/CatalogTableITCase.scala
@@ -113,7 +113,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -123,7 +123,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -149,7 +149,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -159,7 +159,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b varchar,
         |  c as a + 1
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -198,7 +198,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b int,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -209,7 +209,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  c int,
         |  d int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -253,7 +253,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b int,
         |  c int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -262,7 +262,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a int,
         |  b int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -293,7 +293,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  c as proctime,
         |  primary key(a)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -302,7 +302,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a int,
         |  b int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -333,7 +333,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  WATERMARK FOR a AS a - interval '1' SECOND
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -342,7 +342,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a timestamp(3),
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -374,7 +374,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  c as proctime,
         |  primary key(a)
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -383,7 +383,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a int,
         |  b int
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -414,7 +414,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  WATERMARK FOR a AS a - interval '1' SECOND
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val sinkDDL =
@@ -423,7 +423,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a timestamp(3),
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val query =
@@ -448,7 +448,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val ddl2 =
@@ -457,7 +457,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a bigint,
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -477,7 +477,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     val ddl2 =
@@ -486,7 +486,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  a bigint,
         |  b bigint
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -507,7 +507,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -525,7 +525,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
 
@@ -544,7 +544,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION',
+        |  'connector.type' = 'COLLECTION',
         |  'k1' = 'v1'
         |)
       """.stripMargin
@@ -553,7 +553,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
     assert(tableEnv.listTables().sameElements(Array[String]("t2")))
     tableEnv.sqlUpdate("alter table t2 set ('k1' = 'a', 'k2' = 'b')")
     val expectedProperties = new util.HashMap[String, String]()
-    expectedProperties.put("connector", "COLLECTION")
+    expectedProperties.put("connector.type", "COLLECTION")
     expectedProperties.put("k1", "a")
     expectedProperties.put("k2", "b")
     val properties = tableEnv.getCatalog(tableEnv.getCurrentCatalog).get()
@@ -632,7 +632,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     tableEnv.sqlUpdate(ddl1)
@@ -643,7 +643,7 @@ class CatalogTableITCase(isStreaming: Boolean) extends AbstractTestBase {
         |  b bigint,
         |  c varchar
         |) with (
-        |  'connector' = 'COLLECTION'
+        |  'connector.type' = 'COLLECTION'
         |)
       """.stripMargin
     tableEnv.sqlUpdate(ddl2)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/factories/utils/TestCollectionTableFactory.scala
@@ -29,7 +29,7 @@ import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink, Da
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
 import org.apache.flink.table.api.TableSchema
-import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE
 import org.apache.flink.table.descriptors.{DescriptorProperties, Schema}
 import org.apache.flink.table.factories.utils.TestCollectionTableFactory.{getCollectionSink, getCollectionSource}
 import org.apache.flink.table.factories.{BatchTableSinkFactory, BatchTableSourceFactory, StreamTableSinkFactory, StreamTableSourceFactory}
@@ -77,7 +77,7 @@ class TestCollectionTableFactory
 
   override def requiredContext(): JMap[String, String] = {
     val context = new util.HashMap[String, String]()
-    context.put(CONNECTOR, "COLLECTION")
+    context.put(CONNECTOR_TYPE, "COLLECTION")
     context
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/InMemoryTableFactory.scala
@@ -21,9 +21,9 @@ package org.apache.flink.table.utils
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.table.api.TableSchema
 import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.{CONNECTOR_PROPERTY_VERSION, CONNECTOR_TYPE}
-import org.apache.flink.table.descriptors.DescriptorProperties._
+import org.apache.flink.table.descriptors.DescriptorProperties.{TABLE_SCHEMA_EXPR, WATERMARK, WATERMARK_ROWTIME, WATERMARK_STRATEGY_EXPR, WATERMARK_STRATEGY_DATA_TYPE}
 import org.apache.flink.table.descriptors.Rowtime._
-import org.apache.flink.table.descriptors.Schema._
+import org.apache.flink.table.descriptors.Schema.{SCHEMA, SCHEMA_TYPE, SCHEMA_DATA_TYPE, SCHEMA_NAME, SCHEMA_FROM, SCHEMA_PROCTIME}
 import org.apache.flink.table.descriptors.{DescriptorProperties, SchemaValidator}
 import org.apache.flink.table.factories.{StreamTableSinkFactory, StreamTableSourceFactory, TableFactory}
 import org.apache.flink.table.sinks.StreamTableSink
@@ -137,9 +137,9 @@ class InMemoryTableFactory(terminationCount: Int)
     properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_DELAY)
 
     // watermark
-    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
-    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
-    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME)
+    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR)
+    properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE)
 
     // computed column
     properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR)


### PR DESCRIPTION
## What is the purpose of the change

In ConnectTableDescriptor#createTemporaryTable, the proctime/rowtime properties are ignored so the generated catalog table is not correct. This PR fix string-based representation of TableSchema and support computed column, proctime and watermark in Schema descriptor.

## Brief change log

- a3f05f8 Fix misuse of prefix of connector-related properties
- 1ef55e3 Port CustomConnectorDescriptor to flink-table-api-java
- acc308a Fix string-based representation of TableSchema and support computed column, proctime and watermark in Schema descriptor.

## Verifying this change

This change is covered by tests, such as *TimeAttributeITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
