### PR TITLE
[FLINK-16125][kafka] Make property zookeeper.connect required for kafka 0.8 connector and optional for other versions

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/table/descriptors/KafkaValidator.java
@@ -118,7 +118,12 @@ public class KafkaValidator extends ConnectorDescriptorValidator {
 			|| properties.containsKey(CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER)
 			|| properties.containsKey(CONNECTOR_PROPERTIES_GROUP_ID)) {
 
-			properties.validateString(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT, false);
+			if (properties.getString(CONNECTOR_VERSION).equals(CONNECTOR_VERSION_VALUE_08)) {
+				properties.validateString(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT, false);
+			} else {
+				properties.validateString(CONNECTOR_PROPERTIES_ZOOKEEPER_CONNECT, true);
+			}
+
 			properties.validateString(CONNECTOR_PROPERTIES_BOOTSTRAP_SERVER, false);
 			properties.validateString(CONNECTOR_PROPERTIES_GROUP_ID, true);
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the bug that the connector option zookeeper.connect is set to be required for all kafka connector versions, which should be only for 0.8. 


## Brief change log

- Add a version checking in validation, and set zookeeper.connect property optional except version 0.8.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
