### PR TITLE
[FLINK-16743][table] Introduce datagen, print, blackhole connectors

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGenerator.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+
+import java.io.Serializable;
+import java.util.Iterator;
+
+/**
+ * Stateful and re-scalable data generator.
+ */
+@Experimental
+public interface DataGenerator<T> extends Serializable, Iterator<T> {
+
+	/**
+	 * Open and initialize state for {@link DataGenerator}.
+	 * See {@link CheckpointedFunction#initializeState}.
+	 *
+	 * @param name The state of {@link DataGenerator} should related to this name, make sure
+	 *             the name of state is different.
+	 */
+	void open(
+			String name,
+			FunctionInitializationContext context,
+			RuntimeContext runtimeContext) throws Exception;
+
+	/**
+	 * Snapshot state for {@link DataGenerator}.
+	 * See {@link CheckpointedFunction#snapshotState}.
+	 */
+	default void snapshotState(FunctionSnapshotContext context) throws Exception {}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+/**
+ * A data generator source that abstract data generator. It can used to easy startup/test
+ * for streaming job and performance testing.
+ * It is stateful, re-scalable, possibly in parallel.
+ */
+@Experimental
+public class DataGeneratorSource<T> extends RichParallelSourceFunction<T> implements CheckpointedFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	private final DataGenerator<T> generator;
+	private final long rowsPerSecond;
+
+	transient volatile boolean isRunning;
+
+	/**
+	 * Creates a source that emits records by {@link DataGenerator} without controlling emit rate.
+	 *
+	 * @param generator data generator.
+	 */
+	public DataGeneratorSource(DataGenerator<T> generator) {
+		this(generator, Long.MAX_VALUE);
+	}
+
+	/**
+	 * Creates a source that emits records by {@link DataGenerator}.
+	 *
+	 * @param generator data generator.
+	 * @param rowsPerSecond Control the emit rate.
+	 */
+	public DataGeneratorSource(DataGenerator<T> generator, long rowsPerSecond) {
+		this.generator = generator;
+		this.rowsPerSecond = rowsPerSecond;
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		this.generator.open("TOP_FIELD", context, getRuntimeContext());
+		this.isRunning = true;
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		this.generator.snapshotState(context);
+	}
+
+	@Override
+	public void run(SourceContext<T> ctx) throws Exception {
+		double taskRowsPerSecond = (double) rowsPerSecond / getRuntimeContext().getNumberOfParallelSubtasks();
+		long readTimeIncrement = (long) (1000 / taskRowsPerSecond);
+		long nextReadTime = System.currentTimeMillis();
+
+		while (isRunning && generator.hasNext()) {
+			synchronized (ctx.getCheckpointLock()) {
+				ctx.collect(this.generator.next());
+			}
+
+			if (readTimeIncrement > 0) {
+				nextReadTime += readTimeIncrement;
+				try {
+					long toWaitMs = nextReadTime - System.currentTimeMillis();
+					while (toWaitMs > 0) {
+						Thread.sleep(toWaitMs);
+						toWaitMs = nextReadTime - System.currentTimeMillis();
+					}
+				} catch (InterruptedException ignored) {
+				}
+			}
+		}
+	}
+
+	@Override
+	public void cancel() {
+		isRunning = false;
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/RandomGenerator.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+
+import org.apache.commons.math3.random.RandomDataGenerator;
+
+/**
+ * Random generator.
+ */
+@Experimental
+public abstract class RandomGenerator<T> implements DataGenerator<T> {
+
+	protected transient RandomDataGenerator random;
+
+	@Override
+	public void open(
+			String name,
+			FunctionInitializationContext context,
+			RuntimeContext runtimeContext) throws Exception {
+		this.random = new RandomDataGenerator();
+	}
+
+	@Override
+	public boolean hasNext() {
+		return true;
+	}
+
+	public static RandomGenerator<Long> longGenerator(long min, long max) {
+		return new RandomGenerator<Long>() {
+			@Override
+			public Long next() {
+				return random.nextLong(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<Integer> intGenerator(int min, int max) {
+		return new RandomGenerator<Integer>() {
+			@Override
+			public Integer next() {
+				return random.nextInt(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<Short> shortGenerator(short min, short max) {
+		return new RandomGenerator<Short>() {
+			@Override
+			public Short next() {
+				return (short) random.nextInt(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<Byte> byteGenerator(byte min, byte max) {
+		return new RandomGenerator<Byte>() {
+			@Override
+			public Byte next() {
+				return (byte) random.nextInt(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<Float> floatGenerator(float min, float max) {
+		return new RandomGenerator<Float>() {
+			@Override
+			public Float next() {
+				return (float) random.nextUniform(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<Double> doubleGenerator(double min, double max) {
+		return new RandomGenerator<Double>() {
+			@Override
+			public Double next() {
+				return random.nextUniform(min, max);
+			}
+		};
+	}
+
+	public static RandomGenerator<String> stringGenerator(int len) {
+		return new RandomGenerator<String>() {
+			@Override
+			public String next() {
+				return random.nextHexString(len);
+			}
+		};
+	}
+
+	public static RandomGenerator<Boolean> booleanGenerator() {
+		return new RandomGenerator<Boolean>() {
+			@Override
+			public Boolean next() {
+				return random.nextInt(0, 1) == 0;
+			}
+		};
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * A stateful, re-scalable {@link DataGenerator} that emits each number from a given interval
+ * exactly once, possibly in parallel.
+ */
+@Experimental
+public abstract class SequenceGenerator<T> implements DataGenerator<T> {
+
+	private final long start;
+	private final long end;
+
+	private transient ListState<Long> checkpointedState;
+	protected transient Deque<Long> valuesToEmit;
+
+	/**
+	 * Creates a DataGenerator that emits all numbers from the given interval exactly once.
+	 *
+	 * @param start Start of the range of numbers to emit.
+	 * @param end End of the range of numbers to emit.
+	 */
+	public SequenceGenerator(long start, long end) {
+		this.start = start;
+		this.end = end;
+	}
+
+	@Override
+	public void open(
+			String name,
+			FunctionInitializationContext context,
+			RuntimeContext runtimeContext) throws Exception {
+		Preconditions.checkState(this.checkpointedState == null,
+				"The " + getClass().getSimpleName() + " has already been initialized.");
+
+		this.checkpointedState = context.getOperatorStateStore().getListState(
+				new ListStateDescriptor<>(
+						name + "-sequence-state",
+						LongSerializer.INSTANCE));
+		this.valuesToEmit = new ArrayDeque<>();
+		if (context.isRestored()) {
+			// upon restoring
+
+			for (Long v : this.checkpointedState.get()) {
+				this.valuesToEmit.add(v);
+			}
+		} else {
+			// the first time the job is executed
+			final int stepSize = runtimeContext.getNumberOfParallelSubtasks();
+			final int taskIdx = runtimeContext.getIndexOfThisSubtask();
+			final long congruence = start + taskIdx;
+
+			long totalNoOfElements = Math.abs(end - start + 1);
+			final int baseSize = safeDivide(totalNoOfElements, stepSize);
+			final int toCollect = (totalNoOfElements % stepSize > taskIdx) ? baseSize + 1 : baseSize;
+
+			for (long collected = 0; collected < toCollect; collected++) {
+				this.valuesToEmit.add(collected * stepSize + congruence);
+			}
+		}
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		Preconditions.checkState(this.checkpointedState != null,
+				"The " + getClass().getSimpleName() + " state has not been properly initialized.");
+
+		this.checkpointedState.clear();
+		for (Long v : this.valuesToEmit) {
+			this.checkpointedState.add(v);
+		}
+	}
+
+	@Override
+	public boolean hasNext() {
+		return !this.valuesToEmit.isEmpty();
+	}
+
+	private static int safeDivide(long left, long right) {
+		Preconditions.checkArgument(right > 0);
+		Preconditions.checkArgument(left >= 0);
+		Preconditions.checkArgument(left <= Integer.MAX_VALUE * right);
+		return (int) (left / right);
+	}
+
+	public static SequenceGenerator<Long> longGenerator(long start, long end) {
+		return new SequenceGenerator<Long>(start, end) {
+			@Override
+			public Long next() {
+				return valuesToEmit.poll();
+			}
+		};
+	}
+
+	public static SequenceGenerator<Integer> intGenerator(int start, int end) {
+		return new SequenceGenerator<Integer>(start, end) {
+			@Override
+			public Integer next() {
+				return valuesToEmit.poll().intValue();
+			}
+		};
+	}
+
+	public static SequenceGenerator<Short> shortGenerator(short start, short end) {
+		return new SequenceGenerator<Short>(start, end) {
+			@Override
+			public Short next() {
+				return valuesToEmit.poll().shortValue();
+			}
+		};
+	}
+
+	public static SequenceGenerator<Byte> byteGenerator(byte start, byte end) {
+		return new SequenceGenerator<Byte>(start, end) {
+			@Override
+			public Byte next() {
+				return valuesToEmit.poll().byteValue();
+			}
+		};
+	}
+
+	public static SequenceGenerator<Float> floatGenerator(short start, short end) {
+		return new SequenceGenerator<Float>(start, end) {
+			@Override
+			public Float next() {
+				return valuesToEmit.poll().floatValue();
+			}
+		};
+	}
+
+	public static SequenceGenerator<Double> doubleGenerator(int start, int end) {
+		return new SequenceGenerator<Double>(start, end) {
+			@Override
+			public Double next() {
+				return valuesToEmit.poll().doubleValue();
+			}
+		};
+	}
+
+	public static SequenceGenerator<String> stringGenerator(long start, long end) {
+		return new SequenceGenerator<String>(start, end) {
+			@Override
+			public String next() {
+				return valuesToEmit.poll().toString();
+			}
+		};
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/pom.xml
+++ b/flink-table/flink-table-api-java-bridge/pom.xml
@@ -67,5 +67,18 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<type>test-jar</type>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
 	</dependencies>
 </project>

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BlackHoleTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/BlackHoleTableSinkFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.TableSinkFactory;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+
+/**
+ * Factory base for creating configured instances of {@link CsvTableSink} in a stream environment.
+ */
+@Experimental
+public class BlackHoleTableSinkFactory implements TableSinkFactory<Tuple2<Boolean, Row>> {
+
+	public static final String CONNECTOR_TYPE_VALUE = "blackhole";
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
+		context.put(CONNECTOR_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		return properties;
+	}
+
+	@Override
+	public TableSink<Tuple2<Boolean, Row>> createTableSink(Context context) {
+		return new RetractStreamTableSink<Row>() {
+
+			@Override
+			public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames,
+					TypeInformation<?>[] fieldTypes) {
+				return this;
+			}
+
+			@Override
+			public TypeInformation<Row> getRecordType() {
+				return context.getTable().getSchema().toRowType();
+			}
+
+			@Override
+			public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
+				return dataStream.addSink(new SinkFunction<Tuple2<Boolean, Row>>() {
+
+					@Override
+					public void invoke(Tuple2<Boolean, Row> value, Context context) {
+					}
+				}).setParallelism(dataStream.getParallelism());
+			}
+		};
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSinkFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/PrintTableSinkFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.TableSinkFactory;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+
+/**
+ * Factory base for creating configured instances of {@link CsvTableSink} in a stream environment.
+ */
+@Experimental
+public class PrintTableSinkFactory implements TableSinkFactory<Tuple2<Boolean, Row>> {
+
+	public static final String CONNECTOR_TYPE_VALUE = "print";
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
+		context.put(CONNECTOR_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		return properties;
+	}
+
+	@Override
+	public TableSink<Tuple2<Boolean, Row>> createTableSink(Context context) {
+		return new RetractStreamTableSink<Row>() {
+
+			@Override
+			public TableSink<Tuple2<Boolean, Row>> configure(String[] fieldNames,
+					TypeInformation<?>[] fieldTypes) {
+				return this;
+			}
+
+			@Override
+			public TypeInformation<Row> getRecordType() {
+				return context.getTable().getSchema().toRowType();
+			}
+
+			@Override
+			public DataStreamSink<?> consumeDataStream(DataStream<Tuple2<Boolean, Row>> dataStream) {
+				return dataStream.addSink(new SinkFunction<Tuple2<Boolean, Row>>() {
+
+					@Override
+					public void invoke(Tuple2<Boolean, Row> value, Context context) {
+						System.out.println(value);
+					}
+				}).setParallelism(dataStream.getParallelism());
+			}
+		};
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSource.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.datagen;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
+import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
+import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+/**
+ * A {@link StreamTableSource} that emits each number from a given interval exactly once,
+ * possibly in parallel. See {@link StatefulSequenceSource}.
+ */
+public class DataGenTableSource implements StreamTableSource<Row> {
+
+	private final DataGenerator[] fieldGenerators;
+	private final TableSchema schema;
+	private final long rowsPerSecond;
+
+	public DataGenTableSource(DataGenerator[] fieldGenerators, TableSchema schema, long rowsPerSecond) {
+		this.fieldGenerators = fieldGenerators;
+		this.schema = schema;
+		this.rowsPerSecond = rowsPerSecond;
+	}
+
+	@Override
+	public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
+		return execEnv.addSource(createSource());
+	}
+
+	@VisibleForTesting
+	public DataGeneratorSource<Row> createSource() {
+		return new DataGeneratorSource<>(new RowGenerator(), rowsPerSecond);
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return schema;
+	}
+
+	@Override
+	public DataType getProducedDataType() {
+		return schema.toRowDataType();
+	}
+
+	private class RowGenerator implements DataGenerator<Row> {
+
+		@Override
+		public void open(
+				String name,
+				FunctionInitializationContext context,
+				RuntimeContext runtimeContext) throws Exception {
+			for (int i = 0; i < fieldGenerators.length; i++) {
+				fieldGenerators[i].open(schema.getFieldName(i).get(), context, runtimeContext);
+			}
+		}
+
+		@Override
+		public boolean hasNext() {
+			for (DataGenerator generator : fieldGenerators) {
+				if (!generator.hasNext()) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		@Override
+		public Row next() {
+			Row row = new Row(schema.getFieldCount());
+			for (int i = 0; i < fieldGenerators.length; i++) {
+				row.setField(i, fieldGenerators[i].next());
+			}
+			return row;
+		}
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
@@ -163,36 +163,40 @@ public class DataGenTableSourceFactory implements TableSourceFactory<Row> {
 	private DataGenerator createSequenceGenerator(String name, DataType type, DescriptorProperties params) {
 		String startKey = SCHEMA + "." + name + "." + GENERATOR + "." + START;
 		String endKey = SCHEMA + "." + name + "." + GENERATOR + "." + END;
+
+		params.validateExclusion(startKey);
+		params.validateExclusion(endKey);
+
 		switch (type.getLogicalType().getTypeRoot()) {
 			case CHAR:
 			case VARCHAR:
 				return SequenceGenerator.stringGenerator(
-						params.getOptionalLong(startKey).orElse(Long.MIN_VALUE),
-						params.getOptionalLong(endKey).orElse(Long.MAX_VALUE));
+						params.getLong(startKey),
+						params.getLong(endKey));
 			case TINYINT:
 				return SequenceGenerator.byteGenerator(
-						params.getOptionalByte(startKey).orElse(Byte.MIN_VALUE),
-						params.getOptionalByte(endKey).orElse(Byte.MAX_VALUE));
+						params.getByte(startKey),
+						params.getByte(endKey));
 			case SMALLINT:
 				return SequenceGenerator.shortGenerator(
-						params.getOptionalShort(startKey).orElse(Short.MIN_VALUE),
-						params.getOptionalShort(endKey).orElse(Short.MAX_VALUE));
+						params.getShort(startKey),
+						params.getShort(endKey));
 			case INTEGER:
 				return SequenceGenerator.intGenerator(
-						params.getOptionalInt(startKey).orElse(Integer.MIN_VALUE),
-						params.getOptionalInt(endKey).orElse(Integer.MAX_VALUE));
+						params.getInt(startKey),
+						params.getInt(endKey));
 			case BIGINT:
 				return SequenceGenerator.longGenerator(
-						params.getOptionalLong(startKey).orElse(Long.MIN_VALUE),
-						params.getOptionalLong(endKey).orElse(Long.MAX_VALUE));
+						params.getLong(startKey),
+						params.getLong(endKey));
 			case FLOAT:
 				return SequenceGenerator.floatGenerator(
-						params.getOptionalShort(startKey).orElse(Short.MIN_VALUE),
-						params.getOptionalShort(endKey).orElse(Short.MAX_VALUE));
+						params.getShort(startKey),
+						params.getShort(endKey));
 			case DOUBLE:
 				return SequenceGenerator.doubleGenerator(
-						params.getOptionalInt(startKey).orElse(Integer.MIN_VALUE),
-						params.getOptionalInt(endKey).orElse(Integer.MAX_VALUE));
+						params.getInt(startKey),
+						params.getInt(endKey));
 			default:
 				throw new ValidationException("Unsupported type: " + type);
 		}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
@@ -164,8 +164,12 @@ public class DataGenTableSourceFactory implements TableSourceFactory<Row> {
 		String startKey = SCHEMA + "." + name + "." + GENERATOR + "." + START;
 		String endKey = SCHEMA + "." + name + "." + GENERATOR + "." + END;
 
-		params.validateExclusion(startKey);
-		params.validateExclusion(endKey);
+		if (!params.containsKey(startKey)) {
+			throw new ValidationException("Could not find required property '" + startKey + "'.");
+		}
+		if (!params.containsKey(endKey)) {
+			throw new ValidationException("Could not find required property '" + endKey + "'.");
+		}
 
 		switch (type.getLogicalType().getTypeRoot()) {
 			case CHAR:

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sources/datagen/DataGenTableSourceFactory.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sources.datagen;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
+import org.apache.flink.streaming.api.functions.source.datagen.RandomGenerator;
+import org.apache.flink.streaming.api.functions.source.datagen.SequenceGenerator;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.TableSourceFactory;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.TABLE_SCHEMA_EXPR;
+import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
+import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
+import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
+import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+
+/**
+ * Factory for creating configured instances of {@link DataGenTableSource} in a stream environment.
+ */
+@Experimental
+public class DataGenTableSourceFactory implements TableSourceFactory<Row> {
+
+	public static final String CONNECTOR_TYPE_VALUE = "datagen";
+	public static final String CONNECTOR_ROWS_PER_SECOND = "connector.rows-per-second";
+
+	public static final String GENERATOR = "generator";
+	public static final String START = "start";
+	public static final String END = "end";
+	public static final String MIN = "min";
+	public static final String MAX = "max";
+	public static final String LENGTH = "length";
+
+	public static final String SEQUENCE = "sequence";
+	public static final String RANDOM = "random";
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
+		context.put(CONNECTOR_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+		// connector
+		properties.add(SCHEMA + ".*");
+		properties.add(CONNECTOR_ROWS_PER_SECOND);
+		// schema
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+		properties.add(SCHEMA + ".#." + TABLE_SCHEMA_EXPR);
+		// watermark
+		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_ROWTIME);
+		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_EXPR);
+		properties.add(SCHEMA + "." + WATERMARK + ".#."  + WATERMARK_STRATEGY_DATA_TYPE);
+		return properties;
+	}
+
+	@Override
+	public TableSource<Row> createTableSource(Context context) {
+		DescriptorProperties params = new DescriptorProperties();
+		params.putProperties(context.getTable().getProperties());
+
+		TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(context.getTable().getSchema());
+
+		DataGenerator[] fieldGenerators = new DataGenerator[tableSchema.getFieldCount()];
+		for (int i = 0; i < fieldGenerators.length; i++) {
+			fieldGenerators[i] = createDataGenerator(
+					tableSchema.getFieldName(i).get(),
+					tableSchema.getFieldDataType(i).get(),
+					params);
+		}
+
+		return new DataGenTableSource(fieldGenerators, tableSchema, params.getLong(CONNECTOR_ROWS_PER_SECOND));
+	}
+
+	private DataGenerator createDataGenerator(String name, DataType type, DescriptorProperties params) {
+		String genType = params.getOptionalString(SCHEMA + "." + name + "." + GENERATOR).orElse(RANDOM);
+		switch (genType) {
+			case RANDOM:
+				return createRandomGenerator(name, type, params);
+			case SEQUENCE:
+				return createSequenceGenerator(name, type, params);
+			default:
+				throw new ValidationException("Unsupported generator type: " + genType);
+		}
+	}
+
+	private DataGenerator createRandomGenerator(String name, DataType type, DescriptorProperties params) {
+		String lenKey = SCHEMA + "." + name + "." + GENERATOR + "." + LENGTH;
+		String minKey = SCHEMA + "." + name + "." + GENERATOR + "." + MIN;
+		String maxKey = SCHEMA + "." + name + "." + GENERATOR + "." + MAX;
+		switch (type.getLogicalType().getTypeRoot()) {
+			case BOOLEAN:
+				return RandomGenerator.booleanGenerator();
+			case CHAR:
+			case VARCHAR:
+				int length = params.getOptionalInt(lenKey).orElse(100);
+				return RandomGenerator.stringGenerator(length);
+			case TINYINT:
+				return RandomGenerator.byteGenerator(
+						params.getOptionalByte(minKey).orElse(Byte.MIN_VALUE),
+						params.getOptionalByte(maxKey).orElse(Byte.MAX_VALUE));
+			case SMALLINT:
+				return RandomGenerator.shortGenerator(
+						params.getOptionalShort(minKey).orElse(Short.MIN_VALUE),
+						params.getOptionalShort(maxKey).orElse(Short.MAX_VALUE));
+			case INTEGER:
+				return RandomGenerator.intGenerator(
+						params.getOptionalInt(minKey).orElse(Integer.MIN_VALUE),
+						params.getOptionalInt(maxKey).orElse(Integer.MAX_VALUE));
+			case BIGINT:
+				return RandomGenerator.longGenerator(
+						params.getOptionalLong(minKey).orElse(Long.MIN_VALUE),
+						params.getOptionalLong(maxKey).orElse(Long.MAX_VALUE));
+			case FLOAT:
+				return RandomGenerator.floatGenerator(
+						params.getOptionalFloat(minKey).orElse(Float.MIN_VALUE),
+						params.getOptionalFloat(maxKey).orElse(Float.MAX_VALUE));
+			case DOUBLE:
+				return RandomGenerator.doubleGenerator(
+						params.getOptionalDouble(minKey).orElse(Double.MIN_VALUE),
+						params.getOptionalDouble(maxKey).orElse(Double.MAX_VALUE));
+			default:
+				throw new ValidationException("Unsupported type: " + type);
+		}
+	}
+
+	private DataGenerator createSequenceGenerator(String name, DataType type, DescriptorProperties params) {
+		String startKey = SCHEMA + "." + name + "." + GENERATOR + "." + START;
+		String endKey = SCHEMA + "." + name + "." + GENERATOR + "." + END;
+		switch (type.getLogicalType().getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+				return SequenceGenerator.stringGenerator(
+						params.getOptionalLong(startKey).orElse(Long.MIN_VALUE),
+						params.getOptionalLong(endKey).orElse(Long.MAX_VALUE));
+			case TINYINT:
+				return SequenceGenerator.byteGenerator(
+						params.getOptionalByte(startKey).orElse(Byte.MIN_VALUE),
+						params.getOptionalByte(endKey).orElse(Byte.MAX_VALUE));
+			case SMALLINT:
+				return SequenceGenerator.shortGenerator(
+						params.getOptionalShort(startKey).orElse(Short.MIN_VALUE),
+						params.getOptionalShort(endKey).orElse(Short.MAX_VALUE));
+			case INTEGER:
+				return SequenceGenerator.intGenerator(
+						params.getOptionalInt(startKey).orElse(Integer.MIN_VALUE),
+						params.getOptionalInt(endKey).orElse(Integer.MAX_VALUE));
+			case BIGINT:
+				return SequenceGenerator.longGenerator(
+						params.getOptionalLong(startKey).orElse(Long.MIN_VALUE),
+						params.getOptionalLong(endKey).orElse(Long.MAX_VALUE));
+			case FLOAT:
+				return SequenceGenerator.floatGenerator(
+						params.getOptionalShort(startKey).orElse(Short.MIN_VALUE),
+						params.getOptionalShort(endKey).orElse(Short.MAX_VALUE));
+			case DOUBLE:
+				return SequenceGenerator.doubleGenerator(
+						params.getOptionalInt(startKey).orElse(Integer.MIN_VALUE),
+						params.getOptionalInt(endKey).orElse(Integer.MAX_VALUE));
+			default:
+				throw new ValidationException("Unsupported type: " + type);
+		}
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-api-java-bridge/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+org.apache.flink.table.sources.datagen.DataGenTableSourceFactory
+org.apache.flink.table.sinks.PrintTableSinkFactory
+org.apache.flink.table.sinks.BlackHoleTableSinkFactory
 org.apache.flink.table.sources.CsvBatchTableSourceFactory
 org.apache.flink.table.sources.CsvAppendTableSourceFactory
 org.apache.flink.table.sinks.CsvBatchTableSinkFactory

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.datagen.DataGenTableSource;
+import org.apache.flink.table.sources.datagen.DataGenTableSourceFactory;
+import org.apache.flink.types.Row;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.CONNECTOR_ROWS_PER_SECOND;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.CONNECTOR_TYPE_VALUE;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.END;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.GENERATOR;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.LENGTH;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.MAX;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.MIN;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.RANDOM;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.SEQUENCE;
+import static org.apache.flink.table.sources.datagen.DataGenTableSourceFactory.START;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link DataGenTableSourceFactory}.
+ */
+public class DataGenTableSourceFactoryTest {
+
+	private static final TableSchema TEST_SCHEMA = TableSchema.builder()
+		.field("f0", DataTypes.STRING())
+		.field("f1", DataTypes.BIGINT())
+		.field("f2", DataTypes.BIGINT())
+		.build();
+
+	@Test
+	public void testSource() throws Exception {
+		DescriptorProperties descriptor = new DescriptorProperties();
+		descriptor.putString(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
+		descriptor.putLong(CONNECTOR_ROWS_PER_SECOND, 100);
+
+		descriptor.putString(SCHEMA + ".f0." + GENERATOR, RANDOM);
+		descriptor.putLong(SCHEMA + ".f0." + GENERATOR + "." + LENGTH, 20);
+
+		descriptor.putString(SCHEMA + ".f1." + GENERATOR, RANDOM);
+		descriptor.putLong(SCHEMA + ".f1." + GENERATOR + "." + MIN, 10);
+		descriptor.putLong(SCHEMA + ".f1." + GENERATOR + "." + MAX, 100);
+
+		descriptor.putString(SCHEMA + ".f2." + GENERATOR, SEQUENCE);
+		descriptor.putLong(SCHEMA + ".f2." + GENERATOR + "." + START, 50);
+		descriptor.putLong(SCHEMA + ".f2." + GENERATOR + "." + END, 60);
+
+		TableSource source = TableFactoryService.find(
+				TableSourceFactory.class, descriptor.asMap())
+				.createTableSource(new TableSourceFactoryContextImpl(
+						ObjectIdentifier.of("", "", ""),
+						new CatalogTableImpl(TEST_SCHEMA, descriptor.asMap(), ""),
+						new Configuration()));
+
+		assertTrue(source instanceof DataGenTableSource);
+		assertEquals(TEST_SCHEMA.toRowDataType(), source.getProducedDataType());
+
+		DataGenTableSource dataGenTableSource = (DataGenTableSource) source;
+		DataGeneratorSource<Row> gen = dataGenTableSource.createSource();
+
+		StreamSource<Row, DataGeneratorSource<Row>> src = new StreamSource<>(gen);
+		AbstractStreamOperatorTestHarness<Row> testHarness =
+				new AbstractStreamOperatorTestHarness<>(src, 1, 1, 0);
+		testHarness.open();
+
+		List<Row> results = new ArrayList<>();
+
+		gen.run(new SourceFunction.SourceContext<Row>() {
+
+			private Object lock = new Object();
+
+			@Override
+			public void collect(Row element) {
+				results.add(element);
+			}
+
+			@Override
+			public void collectWithTimestamp(Row element, long timestamp) {
+			}
+
+			@Override
+			public void emitWatermark(Watermark mark) {
+			}
+
+			@Override
+			public void markAsTemporarilyIdle() {
+			}
+
+			@Override
+			public Object getCheckpointLock() {
+				return lock;
+			}
+
+			@Override
+			public void close() {
+			}
+		});
+
+		Assert.assertEquals(11, results.size());
+		for (int i = 0; i < results.size(); i++) {
+			Row row = results.get(i);
+			Assert.assertEquals(20, row.getField(0).toString().length());
+			long f1 = (long) row.getField(1);
+			Assert.assertTrue(f1 >= 10 && f1 <= 100);
+			Assert.assertEquals(i + 50, (long) row.getField(2));
+		}
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/TableSinkFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/TableSinkFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.factories;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.sinks.BlackHoleTableSinkFactory;
+import org.apache.flink.table.sinks.PrintTableSinkFactory;
+import org.apache.flink.table.sinks.RetractStreamTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.sources.datagen.DataGenTableSourceFactory;
+
+import org.junit.Test;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link DataGenTableSourceFactory}.
+ */
+public class TableSinkFactoryTest {
+
+	private static final TableSchema TEST_SCHEMA = TableSchema.builder()
+		.field("f0", DataTypes.STRING())
+		.field("f1", DataTypes.BIGINT())
+		.field("f2", DataTypes.BIGINT())
+		.build();
+
+	@Test
+	public void testPrint() {
+		DescriptorProperties descriptor = new DescriptorProperties();
+		descriptor.putString(CONNECTOR_TYPE, "print");
+
+		TableSinkFactory factory = TableFactoryService.find(
+				TableSinkFactory.class, descriptor.asMap());
+
+		assertTrue(factory instanceof PrintTableSinkFactory);
+
+		TableSink sink = factory.createTableSink(new TableSinkFactoryContextImpl(
+				ObjectIdentifier.of("", "", ""),
+				new CatalogTableImpl(TEST_SCHEMA, descriptor.asMap(), ""),
+				new Configuration()));
+
+		assertTrue(sink instanceof RetractStreamTableSink);
+
+		RetractStreamTableSink retractSink = (RetractStreamTableSink) sink;
+
+		assertEquals(TEST_SCHEMA.toRowType(), retractSink.getRecordType());
+	}
+
+	@Test
+	public void testBlackHole() {
+		DescriptorProperties descriptor = new DescriptorProperties();
+		descriptor.putString(CONNECTOR_TYPE, "blackhole");
+
+		TableSinkFactory factory = TableFactoryService.find(
+				TableSinkFactory.class, descriptor.asMap());
+
+		assertTrue(factory instanceof BlackHoleTableSinkFactory);
+
+		TableSink sink = factory.createTableSink(new TableSinkFactoryContextImpl(
+				ObjectIdentifier.of("", "", ""),
+				new CatalogTableImpl(TEST_SCHEMA, descriptor.asMap(), ""),
+				new Configuration()));
+
+		assertTrue(sink instanceof RetractStreamTableSink);
+
+		RetractStreamTableSink retractSink = (RetractStreamTableSink) sink;
+
+		assertEquals(TEST_SCHEMA.toRowType(), retractSink.getRecordType());
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Introduce built-in connectors for better startup, test, production-debug, and etc...

1.datagen source:
- easy startup/test for streaming job
- performance testing

2.print sink:
- easy test for streaming job
- be very useful in production debugging

3.blackhole sink
- very useful for high performance testing of Flink
- I've also run into users trying UDF to output, not sink, so they need this sink as well.

## Brief change log

Introduce:
- DataGeneratorSource
- DataGenTableSourceFactory
- PrintTableSinkFactory
- BlackHoleTableSinkFactory


## Verifying this change

- `DataGenTableSourceFactoryTest`
- `TableSinkFactoryTest`
- `DataGeneratorSourceTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
