### PR TITLE
[FLINK-16681][Connectors/JDBC]Jdbc JDBCOutputFormat and JDBCLookupFunction PreparedStatement loss connection, if long time not records to write.

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/SimpleJdbcConnectionProvider.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/SimpleJdbcConnectionProvider.java
@@ -33,12 +33,15 @@ class SimpleJdbcConnectionProvider implements JdbcConnectionProvider, Serializab
 
 	private transient volatile Connection connection;
 
+	private static final int connectionCheckTimeOut = 60;
+
 	public SimpleJdbcConnectionProvider(JdbcConnectionOptions jdbcOptions) {
 		this.jdbcOptions = jdbcOptions;
 	}
 
 	@Override
 	public Connection getConnection() throws SQLException, ClassNotFoundException {
+		connection = null;
 		if (connection == null) {
 			synchronized (this) {
 				if (connection == null) {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
@@ -37,10 +37,12 @@ public class JdbcTestFixture {
 	public static final String INPUT_TABLE = "books";
 	static final String OUTPUT_TABLE = "newbooks";
 	static final String OUTPUT_TABLE_2 = "newbooks2";
+	static final String OUTPUT_TABLE_3 = "newbooks3";
 	static final String SELECT_ALL_BOOKS = "select * from " + INPUT_TABLE;
 	static final String SELECT_ID_BOOKS = "select id from " + INPUT_TABLE;
 	static final String SELECT_ALL_NEWBOOKS = "select * from " + OUTPUT_TABLE;
 	static final String SELECT_ALL_NEWBOOKS_2 = "select * from " + OUTPUT_TABLE_2;
+	static final String SELECT_ALL_NEWBOOKS_3 = "select * from " + OUTPUT_TABLE_3;
 	static final String SELECT_EMPTY = "select * from books WHERE QTY < 0";
 	public static final String INSERT_TEMPLATE = "insert into %s (id, title, author, price, qty) values (?,?,?,?,?)";
 	static final String SELECT_ALL_BOOKS_SPLIT_BY_ID = SELECT_ALL_BOOKS + " WHERE id BETWEEN ? AND ?";
@@ -143,6 +145,7 @@ public class JdbcTestFixture {
 			createTable(conn, JdbcTestFixture.INPUT_TABLE);
 			createTable(conn, OUTPUT_TABLE);
 			createTable(conn, OUTPUT_TABLE_2);
+			createTable(conn, OUTPUT_TABLE_3);
 		}
 	}
 
@@ -173,6 +176,7 @@ public class JdbcTestFixture {
 			stat.executeUpdate("DROP TABLE " + INPUT_TABLE);
 			stat.executeUpdate("DROP TABLE " + OUTPUT_TABLE);
 			stat.executeUpdate("DROP TABLE " + OUTPUT_TABLE_2);
+			stat.executeUpdate("DROP TABLE " + OUTPUT_TABLE_3);
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change
ref:[16681-Fix JDBC PreparedStatement loss connection](https://issues.apache.org/jira/browse/FLINK-16681)



## Brief change log

  - *When the record insert, check the connection is valid , if not ,then rebuild Connection and PreparedStatement*
  - *Add the testJDBCOutputFormatIfConnectionClosed() method in JDBCOutputFormatTest*

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
