### PR TITLE
[FLINK-16749][k8s] Support to set node selector for jobmanager and taskmanager pod

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -93,6 +93,12 @@
             <td>The labels to be set for JobManager pod. Specified as key:value pairs separated by commas. For example, version:alphav1,deploy:test.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.jobmanager.node-selector</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>The node selector to be set for JobManager pod. Specified as key:value pairs separated by commas. For example, environment:production,disk:ssd.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.jobmanager.service-account</h5></td>
             <td style="word-wrap: break-word;">"default"</td>
             <td>String</td>
@@ -127,6 +133,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>The labels to be set for TaskManager pods. Specified as key:value pairs separated by commas. For example, version:alphav1,deploy:test.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.taskmanager.node-selector</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>The node selector to be set for TaskManager pods. Specified as key:value pairs separated by commas. For example, environment:production,disk:ssd.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -111,12 +111,6 @@
             <td>The type of the rest service (ClusterIP or NodePort or LoadBalancer). When set to ClusterIP, the rest service will not be created.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.service.create-timeout</h5></td>
-            <td style="word-wrap: break-word;">"1 min"</td>
-            <td>String</td>
-            <td>Timeout used for creating the service. The timeout value requires a time-unit specifier (ms/s/min/h/d).</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.taskmanager.annotations</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -115,6 +115,20 @@ public class KubernetesConfigOptions {
 		.withDescription("The labels to be set for TaskManager pods. Specified as key:value pairs separated by commas. " +
 			"For example, version:alphav1,deploy:test.");
 
+	public static final ConfigOption<Map<String, String>> JOB_MANAGER_NODE_SELECTOR =
+		key("kubernetes.jobmanager.node-selector")
+		.mapType()
+		.noDefaultValue()
+		.withDescription("The node selector to be set for JobManager pod. Specified as key:value pairs separated by " +
+			"commas. For example, environment:production,disk:ssd.");
+
+	public static final ConfigOption<Map<String, String>> TASK_MANAGER_NODE_SELECTOR =
+		key("kubernetes.taskmanager.node-selector")
+		.mapType()
+		.noDefaultValue()
+		.withDescription("The node selector to be set for TaskManager pods. Specified as key:value pairs separated by " +
+			"commas. For example, environment:production,disk:ssd.");
+
 	public static final ConfigOption<String> CLUSTER_ID =
 		key("kubernetes.cluster-id")
 		.stringType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -101,17 +101,6 @@ public class KubernetesConfigOptions {
 		.defaultValue("%java% %classpath% %jvmmem% %jvmopts% %logging% %class% %args% %redirects%")
 		.withDescription("Template for the kubernetes jobmanager and taskmanager container start invocation.");
 
-	public static final ConfigOption<String> SERVICE_CREATE_TIMEOUT =
-		key("kubernetes.service.create-timeout")
-		.stringType()
-		.defaultValue("1 min")
-		.withDescription("Timeout used for creating the service. The timeout value requires a time-unit " +
-			"specifier (ms/s/min/h/d).");
-
-  	// ---------------------------------------------------------------------------------
-	// The following config options could be overridden by KubernetesCliOptions.
-	// ---------------------------------------------------------------------------------
-
 	public static final ConfigOption<Map<String, String>> JOB_MANAGER_LABELS =
 		key("kubernetes.jobmanager.labels")
 		.mapType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -65,6 +65,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
 			.editOrNewSpec()
 				.withServiceAccountName(kubernetesJobManagerParameters.getServiceAccount())
 				.withImagePullSecrets(kubernetesJobManagerParameters.getImagePullSecrets())
+				.withNodeSelector(kubernetesJobManagerParameters.getNodeSelector())
 				.endSpec()
 			.build();
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -59,6 +59,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
 				.endMetadata()
 			.editOrNewSpec()
 				.withImagePullSecrets(kubernetesTaskManagerParameters.getImagePullSecrets())
+				.withNodeSelector(kubernetesTaskManagerParameters.getNodeSelector())
 				.endSpec()
 			.build();
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -63,6 +63,12 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
 	}
 
 	@Override
+	public Map<String, String> getNodeSelector() {
+		return Collections.unmodifiableMap(
+			flinkConfig.getOptional(KubernetesConfigOptions.JOB_MANAGER_NODE_SELECTOR).orElse(Collections.emptyMap()));
+	}
+
+	@Override
 	public Map<String, String> getEnvironments() {
 		return ConfigurationUtils.getPrefixedKeyValuePairs(ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX, flinkConfig);
 	}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -53,6 +53,11 @@ public interface KubernetesParameters {
 	Map<String, String> getLabels();
 
 	/**
+	 * A collection of node selector to constrain a pod to only be able to run on particular node(s).
+	 */
+	Map<String, String> getNodeSelector();
+
+	/**
 	 * A collection of customized environments that are attached to the JobManager and TaskManager Container(s).
 	 */
 	Map<String, String> getEnvironments();

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -69,6 +69,12 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 	}
 
 	@Override
+	public Map<String, String> getNodeSelector() {
+		return Collections.unmodifiableMap(
+			flinkConfig.getOptional(KubernetesConfigOptions.TASK_MANAGER_NODE_SELECTOR).orElse(Collections.emptyMap()));
+	}
+
+	@Override
 	public Map<String, String> getEnvironments() {
 		return this.containeredTaskManagerParameters.taskManagerEnv();
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
@@ -58,6 +58,13 @@ public class KubernetesJobManagerTestBase extends KubernetesTestBase {
 		}
 	};
 
+	protected final Map<String, String> nodeSelector = new HashMap<String, String>() {
+		{
+			put("env", "production");
+			put("disk", "ssd");
+		}
+	};
+
 	protected KubernetesJobManagerParameters kubernetesJobManagerParameters;
 
 	protected FlinkPod baseFlinkPod;
@@ -73,6 +80,7 @@ public class KubernetesJobManagerTestBase extends KubernetesTestBase {
 		this.customizedEnvs.forEach((k, v) ->
 				this.flinkConfig.setString(ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX + k, v));
 		this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_LABELS, userLabels);
+		this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_NODE_SELECTOR, nodeSelector);
 
 		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 			.setMasterMemoryMB(JOB_MANAGER_MEMORY)

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -60,6 +60,13 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 		}
 	};
 
+	protected final Map<String, String> nodeSelector = new HashMap<String, String>() {
+		{
+			put("env", "production");
+			put("disk", "ssd");
+		}
+	};
+
 	protected TaskExecutorProcessSpec taskExecutorProcessSpec;
 
 	protected ContaineredTaskManagerParameters containeredTaskManagerParameters;
@@ -78,6 +85,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesTestBase {
 		customizedEnvs.forEach((k, v) ->
 				flinkConfig.setString(ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + k, v));
 		this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_LABELS, userLabels);
+		this.flinkConfig.set(KubernetesConfigOptions.TASK_MANAGER_NODE_SELECTOR, nodeSelector);
 
 		taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(flinkConfig);
 		containeredTaskManagerParameters = ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec,

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -169,4 +169,9 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
 
 		assertEquals(IMAGE_PULL_SECRETS, resultSecrets);
 	}
+
+	@Test
+	public void testNodeSelector() {
+		assertThat(this.resultPod.getSpec().getNodeSelector(), is(equalTo(nodeSelector)));
+	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -163,4 +163,9 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 
 		assertEquals(IMAGE_PULL_SECRETS, resultSecrets);
 	}
+
+	@Test
+	public void testNodeSelector() {
+		assertThat(this.resultPod.getSpec().getNodeSelector(), is(equalTo(nodeSelector)));
+	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The [node-selector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) is a collection of key/value pairs to constrain a pod to only be able to run on particular node(s). Since affinity and anti-affinity are uncommon use case for Flink, so we leave the support in pod template.

This PR is based on #11489.

## Brief change log

* Support node selector


## Verifying this change

* Unit tests
* Manually test in a real cluster
  * Label a node with specified key/value `l1:v1,l2:v2`
  * Using the config options `-Dkubernetes.jobmanager.node-selector=l1:v1,l2:v2 -Dkubernetes.taskmanager.node-selector=l1:v1,l2:v2` to make the pods only running the specified node

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
