### PR TITLE
[FLINK-16480][e2e] On failure, add e2e logs into artifact

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -225,7 +225,7 @@ printf "========================================================================
 
 LOG4J_PROPERTIES=${END_TO_END_DIR}/../tools/log4j-travis.properties
 
-MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -DlogBackupDir=${ARTIFACTS_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 MVN_COMMON_OPTIONS="-nsu -B -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dmaven.wagon.http.pool=false -Dfast -Pskip-webui-build"
 e2e_modules=$(find flink-end-to-end-tests -mindepth 2 -maxdepth 5 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')
 e2e_modules="${e2e_modules},$(find flink-walkthroughs -mindepth 2 -maxdepth 2 -name 'pom.xml' -printf '%h\n' | sort -u | tr '\n' ',')"

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -42,11 +42,10 @@ if [ ! -z "$TF_BUILD" ] ; then
 	# compress and register logs for publication on exit
 	function compress_logs {
 		echo "COMPRESSING build artifacts."
-		ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tgz
-		tar -zcvf ${ARTIFACTS_FILE} $ARTIFACTS_DIR
-		mkdir artifact-dir
-		cp ${ARTIFACTS_FILE} artifact-dir/
-		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/artifact-dir"
+		COMPRESSED_ARCHIVE=${BUILD_BUILDNUMBER}.tgz
+		mkdir compressed-archive-dir
+		tar -zcvf compressed-archive-dir/${COMPRESSED_ARCHIVE} $ARTIFACTS_DIR
+		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/compressed-archive-dir"
 	}
 	on_exit compress_logs
 fi

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -34,6 +34,23 @@ fi
 
 source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 
+# On Azure CI, set artifacts dir
+if [ ! -z "$TF_BUILD" ] ; then
+	export ARTIFACTS_DIR="${END_TO_END_DIR}/artifacts"
+	mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
+
+	# compress and register logs for publication on exit
+	function compress_logs {
+		echo "COMPRESSING build artifacts."
+		ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tgz
+		tar -zcvf ${ARTIFACTS_FILE} $ARTIFACTS_DIR
+		mkdir artifact-dir
+		cp ${ARTIFACTS_FILE} artifact-dir/
+		echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/artifact-dir"
+	}
+	on_exit compress_logs
+fi
+
 FLINK_DIR="`( cd \"$FLINK_DIR\" && pwd -P)`" # absolutized and normalized
 
 echo "flink-end-to-end-test directory: $END_TO_END_DIR"
@@ -206,17 +223,8 @@ printf "\n\n====================================================================
 printf "Running Java end-to-end tests\n"
 printf "==============================================================================\n"
 
-HERE="`dirname \"$0\"`"
-HERE="`( cd \"${HERE}\" && pwd -P)`"
-if [ -z "${HERE}" ] ; then
-	# error; for some reason, the path is not accessible
-	# to the script (e.g. permissions re-evaled after suid)
-	exit 1  # fail
-fi
-ARTIFACTS_DIR="${HERE}/artifacts"
-mkdir -p $ARTIFACTS_DIR || { echo "FAILURE: cannot create log directory '${ARTIFACTS_DIR}'." ; exit 1; }
 
-LOG4J_PROPERTIES=${HERE}/../tools/log4j-travis.properties
+LOG4J_PROPERTIES=${END_TO_END_DIR}/../tools/log4j-travis.properties
 
 MVN_LOGGING_OPTIONS="-Dlog.dir=${ARTIFACTS_DIR} -Dlog4j.configurationFile=file://$LOG4J_PROPERTIES -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 MVN_COMMON_OPTIONS="-nsu -B -Dflink.forkCount=2 -Dflink.forkCountTestPackage=2 -Dmaven.wagon.http.pool=false -Dfast -Pskip-webui-build"
@@ -228,14 +236,5 @@ mvn ${MVN_COMMON_OPTIONS} ${MVN_LOGGING_OPTIONS} ${PROFILE} verify -pl ${e2e_mod
 
 EXIT_CODE=$?
 
-# On Azure, publish ARTIFACTS_FILE as a build artifact
-if [ ! -z "$TF_BUILD" ] ; then
-	echo "COMPRESSING build artifacts."
-	ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tgz
-	tar -zcvf ${ARTIFACTS_FILE} $ARTIFACTS_DIR
-	mkdir artifact-dir
-	cp ${ARTIFACTS_FILE} artifact-dir/
-	echo "##vso[task.setvariable variable=ARTIFACT_DIR]$(pwd)/artifact-dir"
-fi
 
 exit $EXIT_CODE

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -74,14 +74,12 @@ function post_test_validation {
         echo "Checking of logs skipped."
     fi
 
-    local failed=0
     # Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.
     # Do not clean up if either fails.
     if [[ ${exit_code} == 0 ]]; then
         if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
             exit_code=1
-            failed=1
         else
             printf "\n[PASS] '${description}' passed after ${time_elapsed}! Test exited with exit code 0.\n\n"
         fi
@@ -91,20 +89,18 @@ function post_test_validation {
         else
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"
         fi
-        failed=1
-    fi
-
-    # make logs available if ARTIFACTS_DIR is set and there's an error
-    if [[ ${ARTIFACTS_DIR} != "" && ${failed} == 1 ]]; then
-        mkdir ${ARTIFACTS_DIR}/e2e-flink-logs 
-        cp $FLINK_DIR/log/* ${ARTIFACTS_DIR}/e2e-flink-logs/
-        echo "Published e2e logs into debug logs artifact:"
-        ls ${ARTIFACTS_DIR}/e2e-flink-logs/
     fi
 
     if [[ ${exit_code} == 0 ]]; then
         cleanup
     else
+        # make logs available if ARTIFACTS_DIR is set
+        if [[ ${ARTIFACTS_DIR} != "" ]]; then
+            mkdir ${ARTIFACTS_DIR}/e2e-flink-logs 
+            cp $FLINK_DIR/log/* ${ARTIFACTS_DIR}/e2e-flink-logs/
+            echo "Published e2e logs into debug logs artifact:"
+            ls ${ARTIFACTS_DIR}/e2e-flink-logs/
+        fi
         exit "${exit_code}"
     fi
 }

--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -74,12 +74,14 @@ function post_test_validation {
         echo "Checking of logs skipped."
     fi
 
+    local failed=0
     # Investigate exit_code for failures of test executable as well as EXIT_CODE for failures of the test.
     # Do not clean up if either fails.
     if [[ ${exit_code} == 0 ]]; then
         if [[ ${EXIT_CODE} != 0 ]]; then
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code 0 but the logs contained errors, exceptions or non-empty .out files\n\n"
             exit_code=1
+            failed=1
         else
             printf "\n[PASS] '${description}' passed after ${time_elapsed}! Test exited with exit code 0.\n\n"
         fi
@@ -89,6 +91,15 @@ function post_test_validation {
         else
             printf "\n[FAIL] '${description}' failed after ${time_elapsed}! Test exited with exit code ${exit_code}\n\n"
         fi
+        failed=1
+    fi
+
+    # make logs available if ARTIFACTS_DIR is set and there's an error
+    if [[ ${ARTIFACTS_DIR} != "" && ${failed} == 1 ]]; then
+        mkdir ${ARTIFACTS_DIR}/e2e-flink-logs 
+        cp $FLINK_DIR/log/* ${ARTIFACTS_DIR}/e2e-flink-logs/
+        echo "Published e2e logs into debug logs artifact:"
+        ls ${ARTIFACTS_DIR}/e2e-flink-logs/
     fi
 
     if [[ ${exit_code} == 0 ]]; then
@@ -120,4 +131,4 @@ function cleanup {
 }
 
 trap cleanup SIGINT
-trap cleanup_proc EXIT
+on_exit cleanup_proc

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -180,7 +180,7 @@ jobs:
         IT_CASE_S3_SECRET_KEY: $(SECRET_S3_SECRET_KEY)
       # upload debug artifacts
     - task: PublishPipelineArtifact@1
-      condition: and(succeededOrFailed(), not(eq('$(ARTIFACT_DIR)', '')))
+      condition: and(succeededOrFailed(), not(eq(variables['ARTIFACT_DIR'], '')))
       displayName: Upload Logs
       inputs:
         path: $(ARTIFACT_DIR)


### PR DESCRIPTION
## What is the purpose of the change

Some e2e tests have the checking of logs for exceptions and errors disabled. When these tests fail, there is no way of getting the JM / TM logs.
With this change, these logs are included.


## Brief change log

- we register a on_exit hook / trap if we detect an azure environment which compresses the build artifact, when the build exists (for whatever reason)
- On error, and if ARTIFACTS_DIR is set, the test runner is copying the logs into ARTIFACTS_DIR.

