### PR TITLE
[FLINK-16620] - Add attempt information in taskNameWithSubtask

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/TaskInfo.java
@@ -71,7 +71,7 @@ public class TaskInfo {
 		this.indexOfSubtask = indexOfSubtask;
 		this.numberOfParallelSubtasks = numberOfParallelSubtasks;
 		this.attemptNumber = attemptNumber;
-		this.taskNameWithSubtasks = taskName + " (" + (indexOfSubtask + 1) + '/' + numberOfParallelSubtasks + ')';
+		this.taskNameWithSubtasks = taskName + " (" + (indexOfSubtask + 1) + '/' + numberOfParallelSubtasks + ')' + "#" + attemptNumber;
 		this.allocationIDAsString = checkNotNull(allocationIDAsString);
 	}
 
@@ -122,9 +122,9 @@ public class TaskInfo {
 	}
 
 	/**
-	 * Returns the name of the task, appended with the subtask indicator, such as "MyTask (3/6)",
+	 * Returns the name of the task, appended with the subtask indicator, such as "MyTask (3/6)#1",
 	 * where 3 would be ({@link #getIndexOfThisSubtask()} + 1), and 6 would be
-	 * {@link #getNumberOfParallelSubtasks()}.
+	 * {@link #getNumberOfParallelSubtasks()}, and 1 would be {@link #getAttemptNumber()}.
 	 *
 	 * @return The name of the task, with subtask indicator.
 	 */

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -101,9 +101,9 @@ public interface RuntimeContext {
 	int getAttemptNumber();
 
 	/**
-	 * Returns the name of the task, appended with the subtask indicator, such as "MyTask (3/6)",
+	 * Returns the name of the task, appended with the subtask indicator, such as "MyTask (3/6)#1",
 	 * where 3 would be ({@link #getIndexOfThisSubtask()} + 1), and 6 would be
-	 * {@link #getNumberOfParallelSubtasks()}.
+	 * {@link #getNumberOfParallelSubtasks()}, and 1 would be {@link #getAttemptNumber()}.
 	 *
 	 * @return The name of the task, with subtask indicator.
 	 */


### PR DESCRIPTION

 ## What is the purpose of the change

Currently many places like #Task and #StreamTask is using #TaskInfo#taskNameWithSubtasks to represent an execution in logging, which is not precise and sometimes brings trouble to developers when debugging an execution with several attempts. It'd be more user-friendly if we can add attempt information in #TaskInfo#taskNameWithSubtask. More cases are discussed in https://issues.apache.org/jira/browse/FLINK-16620.

## Brief change log

Add " - execution #attemptNumber" in #TaskInfo#taskNameWithSubtasks.

## Verifying this change

This change is to improve logging information without any test coverage.

## Does this pull request potentially affect one of the following parts:

This change will affect logging information which uses #TaskInfo#taskNameWithSubtasks to represent an execution. We can find many such usages in #StreamTask and #Task.

## Documentation

No need.