### PR TITLE
[FLINK-16647][table-runtime-blink][hive] Miss file extension when inserting to hive table with compression

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -70,6 +70,8 @@ import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.factories.TableFactory;
 import org.apache.flink.util.StringUtils;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -97,6 +99,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
 import java.net.MalformedURLException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -170,8 +173,17 @@ public class HiveCatalog extends AbstractCatalog {
 		}
 
 		// create HiveConf from hadoop configuration
-		return new HiveConf(HadoopUtils.getHadoopConfiguration(new org.apache.flink.configuration.Configuration()),
-			HiveConf.class);
+		Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(new org.apache.flink.configuration.Configuration());
+
+		// Add mapred-site.xml. We need to read configurations like compression codec.
+		for (String possibleHadoopConfPath : HadoopUtils.possibleHadoopConfPaths(new org.apache.flink.configuration.Configuration())) {
+			File mapredSite = new File(new File(possibleHadoopConfPath), "mapred-site.xml");
+			if (mapredSite.exists()) {
+				hadoopConf.addResource(new Path(mapredSite.getAbsolutePath()));
+				break;
+			}
+		}
+		return new HiveConf(hadoopConf, HiveConf.class);
 	}
 
 	@VisibleForTesting

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShim.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
 import org.apache.hadoop.hive.ql.udf.generic.SimpleGenericUDAFParameterInfo;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Writable;
@@ -140,8 +141,13 @@ public interface HiveShim extends Serializable {
 	/**
 	 * Get Hive's FileSinkOperator.RecordWriter.
 	 */
-	FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jobConf, String outputFormatClzName,
+	FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jobConf, Class outputFormatClz,
 			Class<? extends Writable> outValClz, boolean isCompressed, Properties tableProps, Path outPath);
+
+	/**
+	 * For a given OutputFormat class, get the corresponding {@link HiveOutputFormat} class.
+	 */
+	Class getHiveOutputFormatClass(Class outputFormatClz);
 
 	/**
 	 * Get Hive table schema from deserializer.

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveOutputFormatFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveOutputFormatFactoryTest.java
@@ -54,11 +54,12 @@ public class HiveOutputFormatFactoryTest {
 		SerDeInfo serDeInfo = new SerDeInfo("name", LazySimpleSerDe.class.getName(), Collections.emptyMap());
 		HiveOutputFormatFactory factory = new HiveOutputFormatFactory(
 				new JobConf(),
-				VerifyURIOutputFormat.class.getName(),
+				VerifyURIOutputFormat.class,
 				serDeInfo, schema,
 				new String[0],
 				new Properties(),
-				HiveShimLoader.loadHiveShim(HiveShimLoader.getHiveVersion()));
+				HiveShimLoader.loadHiveShim(HiveShimLoader.getHiveVersion()),
+				false);
 		org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(TEST_URI_SCHEME, TEST_URI_AUTHORITY, "/foo/path");
 		factory.createOutputFormat(path);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputFileConfig.java
@@ -47,14 +47,14 @@ public class OutputFileConfig implements Serializable {
 	/**
 	 * The prefix for the part name.
 	 */
-	String getPartPrefix() {
+	public String getPartPrefix() {
 		return partPrefix;
 	}
 
 	/**
 	 * The suffix for the part name.
 	 */
-	String getPartSuffix() {
+	public String getPartSuffix() {
 		return partSuffix;
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTempFileManager.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTempFileManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,6 +55,7 @@ public class PartitionTempFileManager {
 	private final int taskNumber;
 	private final long checkpointId;
 	private final Path taskTmpDir;
+	private final OutputFileConfig outputFileConfig;
 
 	private transient int nameCounter = 0;
 
@@ -62,9 +64,19 @@ public class PartitionTempFileManager {
 			Path tmpPath,
 			int taskNumber,
 			long checkpointId) throws IOException {
+		this(factory, tmpPath, taskNumber, checkpointId, new OutputFileConfig("", ""));
+	}
+
+	PartitionTempFileManager(
+			FileSystemFactory factory,
+			Path tmpPath,
+			int taskNumber,
+			long checkpointId,
+			OutputFileConfig outputFileConfig) throws IOException {
 		checkArgument(checkpointId != -1, "checkpoint id start with 0.");
 		this.taskNumber = taskNumber;
 		this.checkpointId = checkpointId;
+		this.outputFileConfig = outputFileConfig;
 
 		// generate and clean task temp dir.
 		this.taskTmpDir = new Path(
@@ -85,9 +97,9 @@ public class PartitionTempFileManager {
 	}
 
 	private String newFileName() {
-		return String.format(
-				checkpointName(checkpointId) + "-" + taskName(taskNumber) + "-file-%d",
-				nameCounter++);
+		return String.format("%s%s-%s-file-%d%s",
+				outputFileConfig.getPartPrefix(), checkpointName(checkpointId),
+				taskName(taskNumber), nameCounter++, outputFileConfig.getPartSuffix());
 	}
 
 	private static boolean isTaskDir(String fileName) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To add proper file extension when compression is enabled.

When `hive.exec.compress.output` is on, we write into Hive tables with a compression codec. But we don't append a proper extension to the resulting files, which means these files can't be consumed later on.


## Brief change log

  - Support setting file extension in `FileSystemOutputFormat`, and use the extension in `PartitionTempFileManager`.
  - Decide file extension by calling Hive util method.
  - Refactor code.
  - Add test case.


## Verifying this change

New test case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? NA
