### PR TITLE
[FLINK-16663][docs] Interpret versions as strings

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -64,17 +64,17 @@ is_stable: false
 show_outdated_warning: false
 
 previous_docs:
-  1.10: http://ci.apache.org/projects/flink/flink-docs-release-1.10
-  1.9: http://ci.apache.org/projects/flink/flink-docs-release-1.9
-  1.8: http://ci.apache.org/projects/flink/flink-docs-release-1.8
-  1.7: http://ci.apache.org/projects/flink/flink-docs-release-1.7
-  1.6: http://ci.apache.org/projects/flink/flink-docs-release-1.6
-  1.5: http://ci.apache.org/projects/flink/flink-docs-release-1.5
-  1.4: http://ci.apache.org/projects/flink/flink-docs-release-1.4
-  1.3: http://ci.apache.org/projects/flink/flink-docs-release-1.3
-  1.2: http://ci.apache.org/projects/flink/flink-docs-release-1.2
-  1.1: http://ci.apache.org/projects/flink/flink-docs-release-1.1
-  1.0: http://ci.apache.org/projects/flink/flink-docs-release-1.0
+  '1.10': http://ci.apache.org/projects/flink/flink-docs-release-1.10
+  '1.9': http://ci.apache.org/projects/flink/flink-docs-release-1.9
+  '1.8': http://ci.apache.org/projects/flink/flink-docs-release-1.8
+  '1.7': http://ci.apache.org/projects/flink/flink-docs-release-1.7
+  '1.6': http://ci.apache.org/projects/flink/flink-docs-release-1.6
+  '1.5': http://ci.apache.org/projects/flink/flink-docs-release-1.5
+  '1.4': http://ci.apache.org/projects/flink/flink-docs-release-1.4
+  '1.3': http://ci.apache.org/projects/flink/flink-docs-release-1.3
+  '1.2': http://ci.apache.org/projects/flink/flink-docs-release-1.2
+  '1.1': http://ci.apache.org/projects/flink/flink-docs-release-1.1
+  '1.0': http://ci.apache.org/projects/flink/flink-docs-release-1.0
 
 #------------------------------------------------------------------------------
 # BUILD CONFIG


### PR DESCRIPTION
Fixes an issue in our documentation setup where the `previous_version` keys were interpreted as floats, resulting in a clash between `1.1` and `1.10`. With this PR these versions are interpreted as strings, preventing this.

![Untitled](https://user-images.githubusercontent.com/5725237/77516196-399edf00-6e7a-11ea-87f9-d1f1859711b8.png)
