### PR TITLE
[FLINK-16782] Avoid unnecessary check on expired entry when ReturnExpiredIfNotCleanedUp

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/AbstractTtlDecorator.java
@@ -62,7 +62,7 @@ abstract class AbstractTtlDecorator<T> {
 	}
 
 	<V> V getUnexpired(TtlValue<V> ttlValue) {
-		return ttlValue == null || (expired(ttlValue) && !returnExpired) ? null : ttlValue.getUserValue();
+		return ttlValue == null || (!returnExpired && expired(ttlValue)) ? null : ttlValue.getUserValue();
 	}
 
 	<V> boolean expired(TtlValue<V> ttlValue) {


### PR DESCRIPTION
## What is the purpose of the change

Current implementation of getting unexpired value would always check whether this ttl value is expired first, however, this could be improved if we check `returnExpired` first.


## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
