### PR TITLE
[FLINK-16798] Fix TM inherit logs from BashJavaUtils.

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -632,16 +632,20 @@ runBashJavaUtilsCmd() {
     echo "$output"
 }
 
-extractExecutionParams() {
-    local execution_config=$1
+extractExecutionResults() {
+    local output="$1"
     local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
+    local execution_results
 
-    if ! [[ $execution_config =~ ^${EXECUTION_PREFIX}.* ]]; then
-        echo "[ERROR] Unexpected result: $execution_config" 1>&2
-        echo "[ERROR] The last line of the BashJavaUtils outputs is expected to be the execution result, following the prefix '${EXECUTION_PREFIX}'" 1>&2
+    IFS=$'\n' execution_results=($(echo "${output}" | grep ${EXECUTION_PREFIX}))
+    if [[ ${#execution_results[@]} -le 0 ]]; then
+        echo "[ERROR] The output does not contain execution results, which is expected following the prefix '${EXECUTION_PREFIX}'" 1>&2
         echo "$output" 1>&2
         exit 1
     fi
 
-    echo ${execution_config} | sed "s/$EXECUTION_PREFIX//"
+    for result in ${execution_results[@]}
+    do
+        echo ${result} | sed "s/$EXECUTION_PREFIX//"
+    done
 }

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -36,6 +36,5 @@ FLINK_DIST_JAR=`find $FLINK_TARGET_DIR -name 'flink-dist*.jar'`
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
-output=$(runBashJavaUtilsCmd GET_TM_RESOURCE_PARAMS ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:$FLINK_DIST_JAR}" | tail -n 2)
-extractExecutionParams "$(echo "$output" | head -n 1)"
-extractExecutionParams "$(echo "$output" | tail -n 1)"
+output=$(runBashJavaUtilsCmd GET_TM_RESOURCE_PARAMS ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:$FLINK_DIST_JAR}")
+extractExecutionResults "${output}"

--- a/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
+++ b/flink-dist/src/test/java/org/apache/flink/dist/BashJavaUtilsITCase.java
@@ -43,7 +43,7 @@ public class BashJavaUtilsITCase extends JavaBashTestBase {
 		List<String> lines = Arrays.asList(executeScript(commands).split(System.lineSeparator()));
 
 		assertEquals(2, lines.size());
-		ConfigurationUtils.parseTmResourceJvmParams(lines.get(lines.size() - 2));
-		ConfigurationUtils.parseTmResourceDynamicConfigs(lines.get(lines.size() - 1));
+		ConfigurationUtils.parseTmResourceJvmParams(lines.get(0));
+		ConfigurationUtils.parseTmResourceDynamicConfigs(lines.get(1));
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/BashJavaUtils.java
@@ -40,7 +40,7 @@ public class BashJavaUtils {
 
 		switch (Command.valueOf(args[0])) {
 			case GET_TM_RESOURCE_PARAMS:
-				getTmResourceParams(args);
+				getTmResourceParams(Arrays.copyOfRange(args, 1, args.length));
 				break;
 			default:
 				// unexpected, Command#valueOf should fail if a unknown command is passed in
@@ -60,7 +60,7 @@ public class BashJavaUtils {
 	}
 
 	private static Configuration getConfigurationForStandaloneTaskManagers(String[] args) throws Exception {
-		Configuration configuration = TaskManagerRunner.loadConfiguration(Arrays.copyOfRange(args, 1, args.length));
+		Configuration configuration = TaskManagerRunner.loadConfiguration(args);
 		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
 			configuration, TaskManagerOptions.TOTAL_FLINK_MEMORY);
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the problem that logs generated in BashJavaUtils is thrown away, failed to be inherited by the TM JVM process.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
