### PR TITLE
[FLINK-16796][python] Fix The Bug of Python UDTF in SQL Query

### DIFF
--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -50,6 +50,25 @@ class UserDefinedTableFunctionTests(object):
                            ["1,0,null", "1,1,null", "2,0,null", "2,1,null", "3,0,0", "3,0,1",
                             "3,0,2", "3,1,1", "3,1,2", "3,2,2", "3,3,null"])
 
+    def test_table_function_with_sql_query(self):
+        table_sink = source_sink_utils.TestAppendSink(
+            ['a', 'b', 'c'],
+            [DataTypes.BIGINT(), DataTypes.BIGINT(), DataTypes.BIGINT()])
+        self.t_env.register_table_sink("Results", table_sink)
+        self.t_env.register_function(
+            "multi_emit", udtf(MultiEmit(), [DataTypes.BIGINT(), DataTypes.BIGINT()],
+                               [DataTypes.BIGINT(), DataTypes.BIGINT()]))
+
+        t = self.t_env.from_elements([(1, 1, 3), (2, 1, 6), (3, 2, 9)], ['a', 'b', 'c'])
+        self.t_env.register_table("MyTable", t)
+        self.t_env.sql_query(
+            "SELECT a, x, y FROM MyTable LEFT JOIN LATERAL TABLE(multi_emit(a, b)) as T(x, y)"
+            " ON TRUE") \
+            .insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual, ["1,1,0", "2,2,0", "3,3,0", "3,3,1"])
+
 
 class PyFlinkStreamUserDefinedTableFunctionTests(UserDefinedTableFunctionTests,
                                                  PyFlinkStreamTableTestCase):

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.common
 
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
+import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexInputRef, RexNode}
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
@@ -67,7 +67,10 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonTableFunctionInfo = createPythonFunctionInfo(pythonRexCall, inputNodes)
     val udtfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect { case inputRef: RexInputRef => inputRef.getIndex }
+      .collect {
+        case inputRef: RexInputRef => inputRef.getIndex
+        case fac: RexFieldAccess => fac.getField.getIndex
+      }
     (udtfInputOffsets, pythonTableFunctionInfo)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.plan.nodes
 
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
+import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexInputRef, RexNode}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.functions.python.PythonFunctionInfo
@@ -60,7 +60,10 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonTableFunctionInfo = createPythonFunctionInfo(pythonRexCall, inputNodes)
     val udtfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect { case inputRef: RexInputRef => inputRef.getIndex }
+      .collect {
+        case inputRef: RexInputRef => inputRef.getIndex
+        case fac: RexFieldAccess => fac.getField.getIndex
+      }
     (udtfInputOffsets, pythonTableFunctionInfo)
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of Python UDTF in SQL Query*

## Brief change log

  - *Add logic to collect RexFieldAccess in UDTF*

## Verifying this change

This change added tests and can be verified as follows:

  - *Add test_table_function_with_sql_query in test_udtf.py*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
