### PR TITLE
[FLINK-16795][AZP] Increase e2e test timeout by 20min

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -143,7 +143,7 @@ jobs:
   #condition: or(eq(variables['MODE'], 'e2e'), eq(${{parameters.run_end_to_end}}, 'true'))
   # We are running this in a separate pool
   pool: ${{parameters.e2e_pool_definition}}
-  timeoutInMinutes: 200
+  timeoutInMinutes: 220
   cancelTimeoutInMinutes: 1
   workspace:
     clean: all


### PR DESCRIPTION
## What is the purpose of the change

We recently saw that e2e tests were timing out. This change increases the timeout by 20 minutes
