### PR TITLE
[hotfix][python] Improve the imports to use full path when importing a PyFlink module

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -27,7 +27,7 @@ import pyarrow as pa
 from apache_beam.coders.coder_impl import StreamCoderImpl, create_InputStream, create_OutputStream
 
 from pyflink.fn_execution.ResettableIO import ResettableIO
-from pyflink.table import Row
+from pyflink.table.types import Row
 
 
 class FlattenRowCoderImpl(StreamCoderImpl):

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -32,7 +32,7 @@ from apache_beam.typehints import typehints
 from pyflink.fn_execution import coder_impl
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.sdk_worker_main import pipeline_options
-from pyflink.table import Row
+from pyflink.table.types import Row
 
 FLINK_SCALAR_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:scalar_function:v1"
 FLINK_TABLE_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:table_function:v1"

--- a/flink-python/pyflink/ml/api/ml_environment.py
+++ b/flink-python/pyflink/ml/api/ml_environment.py
@@ -18,7 +18,7 @@
 
 from pyflink.dataset import ExecutionEnvironment
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import BatchTableEnvironment, StreamTableEnvironment
+from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEnvironment
 
 
 class MLEnvironment(object):

--- a/flink-python/pyflink/ml/api/ml_environment.py
+++ b/flink-python/pyflink/ml/api/ml_environment.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 ################################################################################
 
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.dataset.execution_environment import ExecutionEnvironment
+from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEnvironment
 
 

--- a/flink-python/pyflink/ml/api/ml_environment_factory.py
+++ b/flink-python/pyflink/ml/api/ml_environment_factory.py
@@ -18,9 +18,9 @@
 
 from typing import Optional
 from pyflink.ml.api.ml_environment import MLEnvironment
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.table import BatchTableEnvironment, StreamTableEnvironment
+from pyflink.dataset.execution_environment import ExecutionEnvironment
+from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
+from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEnvironment
 from pyflink.java_gateway import get_gateway
 import threading
 

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -18,7 +18,7 @@
 
 from py4j.compat import long
 
-from pyflink.common import Configuration
+from pyflink.common.configuration import Configuration
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.java_gateway import get_gateway
 from pyflink.table.sql_dialect import SqlDialect

--- a/flink-python/pyflink/table/table_config.py
+++ b/flink-python/pyflink/table/table_config.py
@@ -21,7 +21,7 @@ from py4j.compat import long
 from pyflink.common import Configuration
 from pyflink.common.dependency_manager import DependencyManager
 from pyflink.java_gateway import get_gateway
-from pyflink.table import SqlDialect
+from pyflink.table.sql_dialect import SqlDialect
 
 __all__ = ['TableConfig']
 

--- a/flink-python/pyflink/testing/source_sink_utils.py
+++ b/flink-python/pyflink/testing/source_sink_utils.py
@@ -23,7 +23,7 @@ from py4j.java_gateway import java_import
 
 from pyflink.find_flink_home import _find_flink_source_root
 from pyflink.java_gateway import get_gateway
-from pyflink.table import TableSink
+from pyflink.table.sinks import TableSink
 from pyflink.table.types import _to_java_type
 from pyflink.util import utils
 

--- a/flink-python/pyflink/testing/test_case_utils.py
+++ b/flink-python/pyflink/testing/test_case_utils.py
@@ -29,10 +29,11 @@ from py4j.java_gateway import JavaObject
 from py4j.protocol import Py4JJavaError
 
 from pyflink.table.sources import CsvTableSource
-from pyflink.dataset import ExecutionEnvironment
-from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.dataset.execution_environment import ExecutionEnvironment
+from pyflink.datastream.stream_execution_environment import StreamExecutionEnvironment
 from pyflink.find_flink_home import _find_flink_home, _find_flink_source_root
-from pyflink.table import BatchTableEnvironment, StreamTableEnvironment, EnvironmentSettings
+from pyflink.table.table_environment import BatchTableEnvironment, StreamTableEnvironment
+from pyflink.table.environment_settings import EnvironmentSettings
 from pyflink.java_gateway import get_gateway
 
 


### PR DESCRIPTION

## What is the purpose of the change

*This pull request improves the imports to use full path when importing a module of PyFlink.*

## Brief change log

  - *Updates the imports to use full path when importing a PyFlink module*

## Verifying this change

This change is a code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
