### PR TITLE
 [FLINK-16035] Updated Stream/BatchTableEnvironment.java to use Java's Expression DSL

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -461,7 +461,7 @@ public class CassandraConnectorITCase extends WriteAheadSinkTestBase<Tuple3<Stri
 
 		DataStreamSource<Row> source = env.fromCollection(rowCollection);
 
-		tEnv.registerDataStream("testFlinkTable", source);
+		tEnv.createTemporaryView("testFlinkTable", source);
 		tEnv.registerTableSink(
 			"cassandraTable",
 			new CassandraAppendTableSink(builder, injectTableName(INSERT_DATA_QUERY)).configure(

--- a/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-hbase/src/test/java/org/apache/flink/addons/hbase/HBaseConnectorITCase.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import scala.Option;
 
 import static org.apache.flink.addons.hbase.util.PlannerType.OLD_PLANNER;
+import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_VERSION;
@@ -287,7 +288,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
 		DataStream<Row> ds = execEnv.fromCollection(testData1).returns(testTypeInfo1);
-		tEnv.registerDataStream("src", ds);
+		tEnv.createTemporaryView("src", ds);
 		tEnv.registerTableSink("hbase", tableSink);
 
 		String query = "INSERT INTO hbase SELECT ROW(f1c1), ROW(f2c1, f2c2), rowkey, ROW(f3c1, f3c2, f3c3) FROM src";
@@ -342,7 +343,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(execEnv, streamSettings);
 
 		DataStream<Row> ds = execEnv.fromCollection(testData1).returns(testTypeInfo1);
-		tEnv.registerDataStream("src", ds);
+		tEnv.createTemporaryView("src", ds);
 
 		// register hbase table
 		String quorum = getZookeeperQuorum();
@@ -428,7 +429,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 
 		// prepare a source table
 		DataStream<Row> ds = streamEnv.fromCollection(testData2).returns(testTypeInfo2);
-		Table in = streamTableEnv.fromDataStream(ds, "a, b, c");
+		Table in = streamTableEnv.fromDataStream(ds, $("a"), $("b"), $("c"));
 		streamTableEnv.registerTable("src", in);
 
 		Map<String, String> tableProperties = hbaseTableProperties();
@@ -469,11 +470,11 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 		// prepare a source table
 		String srcTableName = "src";
 		DataStream<Row> ds = streamEnv.fromCollection(testData2).returns(testTypeInfo2);
-		Table in = streamTableEnv.fromDataStream(ds, "a, b, c, proc.proctime");
+		Table in = streamTableEnv.fromDataStream(ds, $("a"), $("b"), $("c"), $("proc").proctime());
 		streamTableEnv.registerTable(srcTableName, in);
 
 		Map<String, String> tableProperties = hbaseTableProperties();
-		TableSource source = TableFactoryService
+		TableSource<?> source = TableFactoryService
 			.find(HBaseTableFactory.class, tableProperties)
 			.createTableSource(tableProperties);
 		streamTableEnv.registerTableSource("hbaseLookup", source);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunctionITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCLookupFunctionITCase.java
@@ -45,6 +45,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * IT case for {@link JDBCLookupFunction}.
  */
@@ -142,7 +144,7 @@ public class JDBCLookupFunctionITCase extends AbstractTestBase {
 					new Tuple2<>(2, 5),
 					new Tuple2<>(3, 5),
 					new Tuple2<>(3, 8)
-				)), "id1, id2");
+				)), $("id1"), $("id2"));
 
 		tEnv.registerTable("T", t);
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCUpsertTableSinkITCase.java
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.api.java.io.jdbc.JdbcTableOutputFormatTest.check;
+import static org.apache.flink.table.api.Expressions.$;
 
 /**
  * IT case for {@link JDBCUpsertTableSink}.
@@ -153,11 +154,12 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
 		Table t = tEnv.fromDataStream(get4TupleDataStream(env).assignTimestampsAndWatermarks(
-				new AscendingTimestampExtractor<Tuple4<Integer, Long, String, Timestamp>>() {
-					@Override
-					public long extractAscendingTimestamp(Tuple4<Integer, Long, String, Timestamp> element) {
-						return element.f0;
-					}}), "id, num, text, ts");
+			new AscendingTimestampExtractor<Tuple4<Integer, Long, String, Timestamp>>() {
+				@Override
+				public long extractAscendingTimestamp(Tuple4<Integer, Long, String, Timestamp> element) {
+					return element.f0;
+				}
+			}), $("id"), $("num"), $("text"), $("ts"));
 
 		tEnv.createTemporaryView("T", t);
 		tEnv.sqlUpdate(
@@ -195,7 +197,7 @@ public class JDBCUpsertTableSinkITCase extends AbstractTestBase {
 		env.getConfig().setParallelism(1);
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
-		Table t = tEnv.fromDataStream(get4TupleDataStream(env), "id, num, text, ts");
+		Table t = tEnv.fromDataStream(get4TupleDataStream(env), $("id"), $("num"), $("text"), $("ts"));
 
 		tEnv.registerTable("T", t);
 

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/StreamSQLExample.java
@@ -28,6 +28,8 @@ import org.apache.flink.table.api.java.StreamTableEnvironment;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Simple example for demonstrating the use of SQL on a Stream Table in Java.
  *
@@ -79,9 +81,9 @@ public class StreamSQLExample {
 			new Order(4L, "beer", 1)));
 
 		// convert DataStream to Table
-		Table tableA = tEnv.fromDataStream(orderA, "user, product, amount");
+		Table tableA = tEnv.fromDataStream(orderA, $("user"), $("product"), $("amount"));
 		// register DataStream as Table
-		tEnv.registerDataStream("OrderB", orderB, "user, product, amount");
+		tEnv.createTemporaryView("OrderB", orderB, $("user"), $("product"), $("amount"));
 
 		// union the two tables
 		Table result = tEnv.sqlQuery("SELECT * FROM " + tableA + " WHERE amount > 2 UNION ALL " +

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/StreamSQLExample.scala
@@ -75,7 +75,7 @@ object StreamSQLExample {
     // convert DataStream to Table
     val tableA = tEnv.fromDataStream(orderA, 'user, 'product, 'amount)
     // register DataStream as Table
-    tEnv.registerDataStream("OrderB", orderB, 'user, 'product, 'amount)
+    tEnv.createTemporaryView("OrderB", orderB, 'user, 'product, 'amount)
 
     // union the two tables
     val result = tEnv.sqlQuery(

--- a/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/utils/DataStreamConversionUtil.java
+++ b/flink-ml-parent/flink-ml-lib/src/main/java/org/apache/flink/ml/common/utils/DataStreamConversionUtil.java
@@ -26,10 +26,14 @@ import org.apache.flink.ml.common.MLEnvironment;
 import org.apache.flink.ml.common.MLEnvironmentFactory;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.types.Row;
+
+import java.util.Arrays;
 
 /**
  * Provide functions of conversions between DataStream and Table.
@@ -101,12 +105,9 @@ public class DataStreamConversionUtil {
 		if (null == colNames || colNames.length == 0) {
 			return session.getStreamTableEnvironment().fromDataStream(data);
 		} else {
-			StringBuilder sbd = new StringBuilder();
-			sbd.append(colNames[0]);
-			for (int i = 1; i < colNames.length; i++) {
-				sbd.append(",").append(colNames[i]);
-			}
-			return session.getStreamTableEnvironment().fromDataStream(data, sbd.toString());
+			return session.getStreamTableEnvironment().fromDataStream(
+				data,
+				Arrays.stream(colNames).map(Expressions::$).toArray(Expression[]::new));
 		}
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -47,6 +47,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Base class for Python scalar function operator test. These test that:
  *
@@ -201,7 +203,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 		StreamTableEnvironment tEnv = createTableEnvironment(env);
 		tEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"));
 		DataStream<Tuple2<Integer, Integer>> ds = env.fromElements(new Tuple2<>(1, 2));
-		Table t = tEnv.fromDataStream(ds, "a, b").select("pyFunc(a, b)");
+		Table t = tEnv.fromDataStream(ds, $("a"), $("b")).select("pyFunc(a, b)");
 		// force generating the physical plan for the given table
 		tEnv.toAppendStream(t, BasicTypeInfo.INT_TYPE_INFO);
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.descriptors.BatchTableDescriptor;
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
+import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.module.ModuleManager;
@@ -92,7 +93,7 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	/**
 	 * Converts the given {@link DataSet} into a {@link Table} with specified field names.
 	 *
-	 * Example:
+	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
@@ -107,6 +108,25 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @return The converted {@link Table}.
 	 */
 	<T> Table fromDataSet(DataSet<T> dataSet, String fields);
+
+	/**
+	 * Converts the given {@link DataSet} into a {@link Table} with specified field names.
+	 *
+	 * Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   Table tab = tableEnv.fromDataSet(set, $("a"), $("b").as("name"), $("timestamp").rowtime());
+	 * }
+	 * </pre>
+	 *
+	 * @param dataSet The {@link DataSet} to be converted.
+	 * @param fields The field names of the resulting {@link Table}.
+	 * @param <T> The type of the {@link DataSet}.
+	 * @return The converted {@link Table}.
+	 */
+	<T> Table fromDataSet(DataSet<T> dataSet, Expression... fields);
 
 	/**
 	 * Creates a view from the given {@link DataSet}.
@@ -201,6 +221,31 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @param <T> The type of the {@link DataSet}.
 	 */
 	<T> void createTemporaryView(String path, DataSet<T> dataSet, String fields);
+
+	/**
+	 * Creates a view from the given {@link DataSet} in a given path with specified field names.
+	 * Registered views can be referenced in SQL queries.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   tableEnv.createTemporaryView("cat.db.myTable", set, $("b").as("name"), $("timestamp").rowtime());
+	 * }
+	 * </pre>
+	 *
+	 * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists, it will
+	 * be inaccessible in the current session. To make the permanent object available again you can drop the
+	 * corresponding temporary object.
+	 *
+	 * @param path The path under which the view is created.
+	 *             See also the {@link TableEnvironment} class description for the format of the path.
+	 * @param dataSet The {@link DataSet} out of which to create the view.
+	 * @param fields The field names of the registered view.
+	 * @param <T> The type of the {@link DataSet}.
+	 */
+	<T> void createTemporaryView(String path, DataSet<T> dataSet, Expression... fields);
 
 	/**
 	 * Converts the given {@link Table} into a {@link DataSet} of a specified type.

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
@@ -93,17 +93,40 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	/**
 	 * Converts the given {@link DataSet} into a {@link Table} with specified field names.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the {@link Table}:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+	 * projected out. This mode can be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataSet<Tuple2<String, Long>> set = ...
-	 *   Table tab = tableEnv.fromDataSet(set, "a, b");
+	 *   // use the original 'f0' field and give a better name to the 'f1' field
+	 *   Table table = tableEnv.fromTable(set, "f0, f1 as name");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   // renames the original fields as 'a' and 'b'
+	 *   Table table = tableEnv.fromDataSet(set, "a, b");
 	 * }
 	 * </pre>
 	 *
 	 * @param dataSet The {@link DataSet} to be converted.
-	 * @param fields The field names of the resulting {@link Table}.
+	 * @param fields The fields expressions to map original fields of the DataSet to the fields of the {@code Table}.
 	 * @param <T> The type of the {@link DataSet}.
 	 * @return The converted {@link Table}.
 	 * @deprecated use {@link #fromDataSet(DataSet, Expression...)}
@@ -114,17 +137,46 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	/**
 	 * Converts the given {@link DataSet} into a {@link Table} with specified field names.
 	 *
-	 * Example:
+	 * <p>There are two modes for mapping original fields to the fields of the {@link Table}:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+	 * projected out. This mode can be used for any input type, including POJOs.
+	 *
+	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataSet<Tuple2<String, Long>> set = ...
-	 *   Table tab = tableEnv.fromDataSet(set, $("a"), $("b").as("name"), $("timestamp").rowtime());
+	 *   Table table = tableEnv.fromDataSet(
+	 *      set,
+	 *      $("f1"), // reorder and use the original field
+	 *      $("f0").as("name") // reorder and give the original field a better name
+	 *   );
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   Table table = tableEnv.fromDataSet(
+	 *      set,
+	 *      $("a"), // renames the first field to 'a'
+	 *      $("b") // renames the second field to 'b'
+	 *   );
 	 * }
 	 * </pre>
 	 *
 	 * @param dataSet The {@link DataSet} to be converted.
-	 * @param fields The field names of the resulting {@link Table}.
+	 * @param fields The fields expressions to map original fields of the DataSet to the fields of the {@code Table}.
 	 * @param <T> The type of the {@link DataSet}.
 	 * @return The converted {@link Table}.
 	 */
@@ -174,11 +226,34 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataSet} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+	 * projected out. This mode can be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   // use the original 'f0' field and give a better name to the 'f1' field
+	 *   tableEnv.registerDataSet("myTable", set, "f0, f1 as name");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of the {@code fields}
+	 * references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   // renames the original fields as 'a' and 'b'
 	 *   tableEnv.registerDataSet("myTable", set, "a, b");
 	 * }
 	 * </pre>
@@ -192,7 +267,7 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 *
 	 * @param name The name under which the {@link DataSet} is registered in the catalog.
 	 * @param dataSet The {@link DataSet} to register.
-	 * @param fields The field names of the registered view.
+	 * @param fields The fields expressions to map original fields of the DataSet to the fields of the View.
 	 * @param <T> The type of the {@link DataSet} to register.
 	 * @deprecated use {@link #createTemporaryView(String, DataSet, String)}
 	 */
@@ -203,11 +278,34 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataSet} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+	 * projected out. This mode can be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   // use the original 'f0' field and give a better name to the 'f1' field
+	 *   tableEnv.createTemporaryView("cat.db.myTable", set, "f0, f1 as name");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of the {@code fields}
+	 * references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   // renames the original fields as 'a' and 'b'
 	 *   tableEnv.createTemporaryView("cat.db.myTable", set, "a, b");
 	 * }
 	 * </pre>
@@ -219,7 +317,7 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @param path The path under which the view is created.
 	 *             See also the {@link TableEnvironment} class description for the format of the path.
 	 * @param dataSet The {@link DataSet} out of which to create the view.
-	 * @param fields The field names of the registered view.
+	 * @param fields The fields expressions to map original fields of the DataSet to the fields of the View.
 	 * @param <T> The type of the {@link DataSet}.
 	 * @deprecated use {@link #createTemporaryView(String, DataSet, Expression...)}
 	 */
@@ -230,12 +328,43 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataSet} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+	 * projected out. This mode can be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataSet<Tuple2<String, Long>> set = ...
-	 *   tableEnv.createTemporaryView("cat.db.myTable", set, $("b").as("name"), $("timestamp").rowtime());
+	 *   tableEnv.createTemporaryView(
+	 *      "cat.db.myTable",
+	 *      set,
+	 *      $("f1"), // reorder and use the original field
+	 *      $("f0").as("name") // reorder and give the original field a better name
+	 *   );
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataSet<Tuple2<String, Long>> set = ...
+	 *   tableEnv.createTemporaryView(
+	 *      "cat.db.myTable",
+	 *      set,
+	 *      $("a"), // renames the first field to 'a'
+	 *      $("b") // renames the second field to 'b'
+	 *   );
 	 * }
 	 * </pre>
 	 *
@@ -246,7 +375,7 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @param path The path under which the view is created.
 	 *             See also the {@link TableEnvironment} class description for the format of the path.
 	 * @param dataSet The {@link DataSet} out of which to create the view.
-	 * @param fields The field names of the registered view.
+	 * @param fields The fields expressions to map original fields of the DataSet to the fields of the View.
 	 * @param <T> The type of the {@link DataSet}.
 	 */
 	<T> void createTemporaryView(String path, DataSet<T> dataSet, Expression... fields);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/BatchTableEnvironment.java
@@ -106,7 +106,9 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @param fields The field names of the resulting {@link Table}.
 	 * @param <T> The type of the {@link DataSet}.
 	 * @return The converted {@link Table}.
+	 * @deprecated use {@link #fromDataSet(DataSet, Expression...)}
 	 */
+	@Deprecated
 	<T> Table fromDataSet(DataSet<T> dataSet, String fields);
 
 	/**
@@ -219,7 +221,9 @@ public interface BatchTableEnvironment extends TableEnvironment {
 	 * @param dataSet The {@link DataSet} out of which to create the view.
 	 * @param fields The field names of the registered view.
 	 * @param <T> The type of the {@link DataSet}.
+	 * @deprecated use {@link #createTemporaryView(String, DataSet, Expression...)}
 	 */
+	@Deprecated
 	<T> void createTemporaryView(String path, DataSet<T> dataSet, String fields);
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
@@ -33,6 +33,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.java.internal.StreamTableEnvironmentImpl;
 import org.apache.flink.table.descriptors.ConnectorDescriptor;
 import org.apache.flink.table.descriptors.StreamTableDescriptor;
+import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.functions.AggregateFunction;
 import org.apache.flink.table.functions.TableAggregateFunction;
 import org.apache.flink.table.functions.TableFunction;
@@ -211,6 +212,25 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	<T> Table fromDataStream(DataStream<T> dataStream, String fields);
 
 	/**
+	 * Converts the given {@link DataStream} into a {@link Table} with specified field names.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   Table tab = tableEnv.fromDataStream(stream, $("a"), $("b").as("name"), $("timestamp").rowtime());
+	 * }
+	 * </pre>
+	 *
+	 * @param dataStream The {@link DataStream} to be converted.
+	 * @param fields The field expressions of the resulting {@link Table}.
+	 * @param <T> The type of the {@link DataStream}.
+	 * @return The converted {@link Table}.
+	 */
+	<T> Table fromDataStream(DataStream<T> dataStream, Expression... fields);
+
+	/**
 	 * Creates a view from the given {@link DataStream}.
 	 * Registered views can be referenced in SQL queries.
 	 *
@@ -274,7 +294,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param dataStream The {@link DataStream} to register.
 	 * @param fields The field names of the registered view.
 	 * @param <T> The type of the {@link DataStream} to register.
-	 * @deprecated use {@link #createTemporaryView(String, DataStream, String)}
+	 * @deprecated use {@link #createTemporaryView(String, DataStream, Expression...)}
 	 */
 	@Deprecated
 	<T> void registerDataStream(String name, DataStream<T> dataStream, String fields);
@@ -303,6 +323,31 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param <T> The type of the {@link DataStream}.
 	 */
 	<T> void createTemporaryView(String path, DataStream<T> dataStream, String fields);
+
+	/**
+	 * Creates a view from the given {@link DataStream} in a given path with specified field names.
+	 * Registered views can be referenced in SQL queries.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   tableEnv.createTemporaryView("cat.db.myTable", stream, $("a"), $("b").as("name"), $("timestamp").rowtime())
+	 * }
+	 * </pre>
+	 *
+	 * <p>Temporary objects can shadow permanent ones. If a permanent object in a given path exists, it will
+	 * be inaccessible in the current session. To make the permanent object available again you can drop the
+	 * corresponding temporary object.
+	 *
+	 * @param path The path under which the {@link DataStream} is created.
+	 *             See also the {@link TableEnvironment} class description for the format of the path.
+	 * @param dataStream The {@link DataStream} out of which to create the view.
+	 * @param fields The field expressions of the created view.
+	 * @param <T> The type of the {@link DataStream}.
+	 */
+	<T> void createTemporaryView(String path, DataStream<T> dataStream, Expression... fields);
 
 	/**
 	 * Converts the given {@link Table} into an append {@link DataStream} of a specified type.

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
@@ -195,17 +195,45 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	/**
 	 * Converts the given {@link DataStream} into a {@link Table} with specified field names.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the {@link Table}:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+	 * attributes at arbitrary positions using arbitrary names (except those that exist in the
+	 * result schema). In this mode, fields can be reordered and projected out. This mode can
+	 * be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataStream<Tuple2<String, Long>> stream = ...
-	 *   Table tab = tableEnv.fromDataStream(stream, "a, b");
+	 *   // reorder the fields, rename the original 'f0' field to 'name' and add event-time
+	 *   // attribute named 'rowtime'
+	 *   Table table = tableEnv.fromDataStream(stream, "f1, rowtime.rowtime, f0 as 'name'");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. Event-time attributes can
+	 * replace the field on their position in the input data (if it is of correct type) or be
+	 * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   // rename the original fields to 'a' and 'b' and add an event-time attribute named 'rowtime'
+	 *   Table table = tableEnv.fromDataStream(stream, "a, b, rowtime.rowtime");
 	 * }
 	 * </pre>
 	 *
 	 * @param dataStream The {@link DataStream} to be converted.
-	 * @param fields The field names of the resulting {@link Table}.
+	 * @param fields The fields expressions to map original fields of the DataStream to the fields of the {@code Table}.
 	 * @param <T> The type of the {@link DataStream}.
 	 * @return The converted {@link Table}.
 	 * @deprecated use {@link #fromDataStream(DataStream, Expression...)}
@@ -216,17 +244,52 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	/**
 	 * Converts the given {@link DataStream} into a {@link Table} with specified field names.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the {@link Table}:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+	 * attributes at arbitrary positions using arbitrary names (except those that exist in the
+	 * result schema). In this mode, fields can be reordered and projected out. This mode can
+	 * be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataStream<Tuple2<String, Long>> stream = ...
-	 *   Table tab = tableEnv.fromDataStream(stream, $("a"), $("b").as("name"), $("timestamp").rowtime());
+	 *   Table table = tableEnv.fromDataStream(
+	 *      stream,
+	 *      $("f1"), // reorder and use the original field
+	 *      $("rowtime").rowtime(), // add an event-time attribute named 'rowtime'
+	 *      $("f0").as("name") // reorder and give the original field a better name
+	 *   );
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. Event-time attributes can
+	 * replace the field on their position in the input data (if it is of correct type) or be
+	 * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   Table table = tableEnv.fromDataStream(
+	 *      stream,
+	 *      $("a"), // rename the first field to 'a'
+	 *      $("b") // rename the second field to 'b'
+	 *      $("rowtime").rowtime() // add an event-time attribute named 'rowtime'
+	 *   );
 	 * }
 	 * </pre>
 	 *
 	 * @param dataStream The {@link DataStream} to be converted.
-	 * @param fields The field expressions of the resulting {@link Table}.
+	 * @param fields The fields expressions to map original fields of the DataStream to the fields of the {@code Table}.
 	 * @param <T> The type of the {@link DataStream}.
 	 * @return The converted {@link Table}.
 	 */
@@ -276,12 +339,40 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataStream} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+	 * attributes at arbitrary positions using arbitrary names (except those that exist in the
+	 * result schema). In this mode, fields can be reordered and projected out. This mode can
+	 * be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataStream<Tuple2<String, Long>> stream = ...
-	 *   tableEnv.registerDataStream("myTable", stream, "a, b")
+	 *   // reorder the fields, rename the original 'f0' field to 'name' and add event-time
+	 *   // attribute named 'rowtime'
+	 *   tableEnv.registerDataStream("myTable", stream, "f1, rowtime.rowtime, f0 as 'name'");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. Event-time attributes can
+	 * replace the field on their position in the input data (if it is of correct type) or be
+	 * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   // rename the original fields to 'a' and 'b' and add an event-time attribute named 'rowtime'
+	 *   tableEnv.registerDataStream("myTable", stream, "a, b, rowtime.rowtime");
 	 * }
 	 * </pre>
 	 *
@@ -294,7 +385,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 *
 	 * @param name The name under which the {@link DataStream} is registered in the catalog.
 	 * @param dataStream The {@link DataStream} to register.
-	 * @param fields The field names of the registered view.
+	 * @param fields The fields expressions to map original fields of the DataStream to the fields of the View.
 	 * @param <T> The type of the {@link DataStream} to register.
 	 * @deprecated use {@link #createTemporaryView(String, DataStream, Expression...)}
 	 */
@@ -305,12 +396,40 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataStream} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+	 * attributes at arbitrary positions using arbitrary names (except those that exist in the
+	 * result schema). In this mode, fields can be reordered and projected out. This mode can
+	 * be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataStream<Tuple2<String, Long>> stream = ...
-	 *   tableEnv.createTemporaryView("cat.db.myTable", stream, "a, b")
+	 *   // reorder the fields, rename the original 'f0' field to 'name' and add event-time
+	 *   // attribute named 'rowtime'
+	 *   tableEnv.createTemporaryView("cat.db.myTable", stream, "f1, rowtime.rowtime, f0 as 'name'");
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. Event-time attributes can
+	 * replace the field on their position in the input data (if it is of correct type) or be
+	 * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   // rename the original fields to 'a' and 'b' and add an event-time attribute named 'rowtime'
+	 *   tableEnv.createTemporaryView("cat.db.myTable", stream, "a, b, rowtime.rowtime");
 	 * }
 	 * </pre>
 	 *
@@ -321,7 +440,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param path The path under which the {@link DataStream} is created.
 	 *             See also the {@link TableEnvironment} class description for the format of the path.
 	 * @param dataStream The {@link DataStream} out of which to create the view.
-	 * @param fields The field names of the created view.
+	 * @param fields The fields expressions to map original fields of the DataStream to the fields of the View.
 	 * @param <T> The type of the {@link DataStream}.
 	 * @deprecated use {@link #createTemporaryView(String, DataStream, Expression...)}
 	 */
@@ -332,12 +451,49 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * Creates a view from the given {@link DataStream} in a given path with specified field names.
 	 * Registered views can be referenced in SQL queries.
 	 *
+	 * <p>There are two modes for mapping original fields to the fields of the View:
+	 *
+	 * <p>1. Reference input fields by name:
+	 * All fields in the schema definition are referenced by name
+	 * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+	 * attributes at arbitrary positions using arbitrary names (except those that exist in the
+	 * result schema). In this mode, fields can be reordered and projected out. This mode can
+	 * be used for any input type, including POJOs.
+	 *
 	 * <p>Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   DataStream<Tuple2<String, Long>> stream = ...
-	 *   tableEnv.createTemporaryView("cat.db.myTable", stream, $("a"), $("b").as("name"), $("timestamp").rowtime())
+	 *   tableEnv.createTemporaryView(
+	 *      "cat.db.myTable",
+	 *      stream,
+	 *      $("f1"), // reorder and use the original field
+	 *      $("rowtime").rowtime(), // add an event-time attribute named 'rowtime'
+	 *      $("f0").as("name") // reorder and give the original field a better name
+	 *   );
+	 * }
+	 * </pre>
+	 *
+	 * <p>2. Reference input fields by position:
+	 * In this mode, fields are simply renamed. Event-time attributes can
+	 * replace the field on their position in the input data (if it is of correct type) or be
+	 * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+	 * used if the input type has a defined field order (tuple, case class, Row) and none of
+	 * the {@code fields} references a field of the input type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   DataStream<Tuple2<String, Long>> stream = ...
+	 *   tableEnv.createTemporaryView(
+	 *      "cat.db.myTable",
+	 *      stream,
+	 *      $("a"), // rename the first field to 'a'
+	 *      $("b") // rename the second field to 'b'
+	 *      $("rowtime").rowtime() // adds an event-time attribute named 'rowtime'
+	 *   );
 	 * }
 	 * </pre>
 	 *
@@ -348,7 +504,7 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param path The path under which the {@link DataStream} is created.
 	 *             See also the {@link TableEnvironment} class description for the format of the path.
 	 * @param dataStream The {@link DataStream} out of which to create the view.
-	 * @param fields The field expressions of the created view.
+	 * @param fields The fields expressions to map original fields of the DataStream to the fields of the View.
 	 * @param <T> The type of the {@link DataStream}.
 	 */
 	<T> void createTemporaryView(String path, DataStream<T> dataStream, Expression... fields);

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/StreamTableEnvironment.java
@@ -208,7 +208,9 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param fields The field names of the resulting {@link Table}.
 	 * @param <T> The type of the {@link DataStream}.
 	 * @return The converted {@link Table}.
+	 * @deprecated use {@link #fromDataStream(DataStream, Expression...)}
 	 */
+	@Deprecated
 	<T> Table fromDataStream(DataStream<T> dataStream, String fields);
 
 	/**
@@ -321,7 +323,9 @@ public interface StreamTableEnvironment extends TableEnvironment {
 	 * @param dataStream The {@link DataStream} out of which to create the view.
 	 * @param fields The field names of the created view.
 	 * @param <T> The type of the {@link DataStream}.
+	 * @deprecated use {@link #createTemporaryView(String, DataStream, Expression...)}
 	 */
+	@Deprecated
 	<T> void createTemporaryView(String path, DataStream<T> dataStream, String fields);
 
 	/**

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/api/java/internal/StreamTableEnvironmentImpl.java
@@ -66,6 +66,7 @@ import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.typeutils.FieldInfoUtils;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -213,9 +214,14 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 	@Override
 	public <T> Table fromDataStream(DataStream<T> dataStream, String fields) {
 		List<Expression> expressions = ExpressionParser.parseExpressionList(fields);
+		return fromDataStream(dataStream, expressions.toArray(new Expression[0]));
+	}
+
+	@Override
+	public <T> Table fromDataStream(DataStream<T> dataStream, Expression... fields) {
 		JavaDataStreamQueryOperation<T> queryOperation = asQueryOperation(
 			dataStream,
-			Optional.of(expressions));
+			Optional.of(Arrays.asList(fields)));
 
 		return createTable(queryOperation);
 	}
@@ -237,6 +243,14 @@ public final class StreamTableEnvironmentImpl extends TableEnvironmentImpl imple
 
 	@Override
 	public <T> void createTemporaryView(String path, DataStream<T> dataStream, String fields) {
+		createTemporaryView(path, fromDataStream(dataStream, fields));
+	}
+
+	@Override
+	public <T> void createTemporaryView(
+			String path,
+			DataStream<T> dataStream,
+			Expression... fields) {
 		createTemporaryView(path, fromDataStream(dataStream, fields));
 	}
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/operations/JavaDataStreamQueryOperation.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/operations/JavaDataStreamQueryOperation.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.expressions.Expression;
 
 import javax.annotation.Nullable;
 
@@ -45,7 +46,7 @@ public class JavaDataStreamQueryOperation<E> implements QueryOperation {
 
 	/**
 	 * The table identifier registered under the environment. The identifier might be null when
-	 * the it is from {@link StreamTableEnvironment#fromDataStream(DataStream, String)}. But the
+	 * the it is from {@link StreamTableEnvironment#fromDataStream(DataStream, Expression...)}. But the
 	 * identifier should be not null if is from {@link StreamTableEnvironment#createTemporaryView(String, DataStream)}
 	 * with a registered name.
 	 */

--- a/flink-table/flink-table-api-scala-bridge/src/main/java/org/apache/flink/table/operations/ScalaDataStreamQueryOperation.java
+++ b/flink-table/flink-table-api-scala-bridge/src/main/java/org/apache/flink/table/operations/ScalaDataStreamQueryOperation.java
@@ -45,7 +45,7 @@ public class ScalaDataStreamQueryOperation<E> implements QueryOperation {
 	/**
 	 * The table identifier registered under the environment. The identifier might be null when
 	 * the it is from {@code StreamTableEnvironment#fromDataStream(DataStream)}. But the identifier
-	 * should be not null if is from {@code StreamTableEnvironment#registerDataStream(String, DataStream)}
+	 * should be not null if is from {@code StreamTableEnvironment#createTemporaryView(String, DataStream)}
 	 * with a registered name.
 	 */
 	@Nullable

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/BatchTableEnvironment.scala
@@ -80,15 +80,43 @@ trait BatchTableEnvironment extends TableEnvironment {
   /**
     * Converts the given [[DataSet]] into a [[Table]] with specified field names.
     *
+    * There are two modes for mapping original fields to the fields of the [[Table]]:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+    * projected out. This mode can be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val set: DataSet[(String, Long)] = ...
-    *   val tab: Table = tableEnv.fromDataSet(set, 'a, 'b)
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   val table: Table = tableEnv.fromDataSet(
+    *      set,
+    *      $"f1", // reorder and use the original field
+    *      $"f0" as "name" // reorder and give the original field a better name
+    *   )
+    * }}}
+    *
+    * 2. Reference input fields by position:
+    * In this mode, fields are simply renamed. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   val table: Table = tableEnv.fromDataSet(
+    *      set,
+    *      $"a", // renames the first field to 'a'
+    *      $"b" // renames the second field to 'b'
+    *   )
     * }}}
     *
     * @param dataSet The [[DataSet]] to be converted.
-    * @param fields The field names of the resulting [[Table]].
+    * @param fields The fields expressions to map original fields of the DataSet to the fields of
+    *               the [[Table]].
     * @tparam T The type of the [[DataSet]].
     * @return The converted [[Table]].
     */
@@ -137,11 +165,40 @@ trait BatchTableEnvironment extends TableEnvironment {
     * Creates a view from the given [[DataSet]] in a given path with specified field names.
     * Registered views can be referenced in SQL queries.
     *
+    * There are two modes for mapping original fields to the fields of the View:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+    * projected out. This mode can be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val set: DataSet[(String, Long)] = ...
-    *   tableEnv.registerDataSet("myTable", set, 'a, 'b)
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   tableEnv.registerDataSet(
+    *      "myTable",
+    *      set,
+    *      $"f1", // reorder and use the original field
+    *      $"f0" as "name" // reorder and give the original field a better name
+    *   );
+    * }}}
+    *
+    * 2. Reference input fields by position:
+    * In this mode, fields are simply renamed. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   tableEnv.registerDataSet(
+    *      "myTable",
+    *      set,
+    *      $"a", // renames the first field to 'a'
+    *      $"b" // renames the second field to 'b'
+    *   )
     * }}}
     *
     * The view is registered in the namespace of the current catalog and database. To register the
@@ -153,7 +210,8 @@ trait BatchTableEnvironment extends TableEnvironment {
     *
     * @param name The name under which the [[DataSet]] is registered in the catalog.
     * @param dataSet The [[DataSet]] to register.
-    * @param fields The field names of the registered table.
+    * @param fields The fields expressions to map original fields of the DataSet to the fields of
+    *               the View.
     * @tparam T The type of the [[DataSet]] to register.
     * @deprecated use [[createTemporaryView]]
     */
@@ -164,11 +222,40 @@ trait BatchTableEnvironment extends TableEnvironment {
     * Creates a view from the given [[DataSet]] in a given path with specified field names.
     * Registered views can be referenced in SQL queries.
     *
+    * There are two modes for mapping original fields to the fields of the View:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). In this mode, fields can be reordered and
+    * projected out. This mode can be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val set: DataSet[(String, Long)] = ...
-    *   tableEnv.createTemporaryView("cat.db.myTable", set, 'a, 'b)
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   tableEnv.createTemporaryView(
+    *      "cat.db.myTable",
+    *      set,
+    *      $"f1", // reorder and use the original field
+    *      $"f0" as "name" // reorder and give the original field a better name
+    *   )
+    * }}}
+    *
+    * 2. Reference input fields by position:
+    * In this mode, fields are simply renamed. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val set: DataSet<Tuple2<String, Long>> = ...
+    *   tableEnv.createTemporaryView(
+    *      "cat.db.myTable",
+    *      set,
+    *      $"a", // renames the first field to 'a'
+    *      $"b" // renames the second field to 'b'
+    *   )
     * }}}
     *
     * Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
@@ -179,7 +266,8 @@ trait BatchTableEnvironment extends TableEnvironment {
     *             See also the [[TableEnvironment]] class description for the format of the
     *             path.
     * @param dataSet The [[DataSet]] out of which to create the view.
-    * @param fields The field names of the created view.
+    * @param fields The fields expressions to map original fields of the DataSet to the fields of
+    *               the View.
     * @tparam T The type of the [[DataSet]].
     */
   def createTemporaryView[T](path: String, dataSet: DataSet[T], fields: Expression*): Unit

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/scala/StreamTableEnvironment.scala
@@ -98,15 +98,49 @@ trait StreamTableEnvironment extends TableEnvironment {
   /**
     * Converts the given [[DataStream]] into a [[Table]] with specified field names.
     *
+    * There are two modes for mapping original fields to the fields of the [[Table]]:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+    * attributes at arbitrary positions using arbitrary names (except those that exist in the
+    * result schema). In this mode, fields can be reordered and projected out. This mode can
+    * be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val stream: DataStream[(String, Long)] = ...
-    *   val tab: Table = tableEnv.fromDataStream(stream, 'a, 'b)
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   val table: Table = tableEnv.fromDataStream(
+    *      stream,
+    *      $"f1", // reorder and use the original field
+    *      $"rowtime".rowtime, // add an event-time attribute named 'rowtime'
+    *      $"f0".as "name" // reorder and give the original field a better name
+    *   )
+    * }}}
+    *
+    * <p>2. Reference input fields by position:
+    * In this mode, fields are simply renamed. Event-time attributes can
+    * replace the field on their position in the input data (if it is of correct type) or be
+    * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   val table: Table = tableEnv.fromDataStream(
+    *      stream,
+    *      $"a", // rename the first field to 'a'
+    *      $"b" // rename the second field to 'b'
+    *      $"rowtime".rowtime // add an event-time attribute named 'rowtime'
+    *   )
     * }}}
     *
     * @param dataStream The [[DataStream]] to be converted.
-    * @param fields The field names of the resulting [[Table]].
+    * @param fields The fields expressions to map original fields of the DataStream to the fields of
+    *               the [[Table]].
     * @tparam T The type of the [[DataStream]].
     * @return The converted [[Table]].
     */
@@ -156,11 +190,46 @@ trait StreamTableEnvironment extends TableEnvironment {
     * Creates a view from the given [[DataStream]] in a given path with specified field names.
     * Registered views can be referenced in SQL queries.
     *
+    * There are two modes for mapping original fields to the fields of the View:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+    * attributes at arbitrary positions using arbitrary names (except those that exist in the
+    * result schema). In this mode, fields can be reordered and projected out. This mode can
+    * be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val stream: DataStream[(String, Long)] = ...
-    *   tableEnv.registerDataStream("myTable", stream, 'a, 'b)
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   tableEnv.registerDataStream(
+    *      "myTable",
+    *      stream,
+    *      $"f1", // reorder and use the original field
+    *      $"rowtime".rowtime, // add an event-time attribute named 'rowtime'
+    *      $"f0" as "name" // reorder and give the original field a better name
+    *   )
+    * }}}
+    *
+    * 2. Reference input fields by position:
+    * In this mode, fields are simply renamed. Event-time attributes can
+    * replace the field on their position in the input data (if it is of correct type) or be
+    * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   tableEnv.registerDataStream(
+    *      "myTable",
+    *      stream,
+    *      $"a", // rename the first field to 'a'
+    *      $"b" // rename the second field to 'b'
+    *      $"rowtime".rowtime // adds an event-time attribute named 'rowtime'
+    *   )
     * }}}
     *
     * The view is registered in the namespace of the current catalog and database. To register the
@@ -172,7 +241,8 @@ trait StreamTableEnvironment extends TableEnvironment {
     *
     * @param name The name under which the [[DataStream]] is registered in the catalog.
     * @param dataStream The [[DataStream]] to register.
-    * @param fields The field names of the registered view.
+    * @param fields The fields expressions to map original fields of the DataStream to the fields of
+    *               the View.
     * @tparam T The type of the [[DataStream]] to register.
     * @deprecated use [[createTemporaryView]]
     */
@@ -183,11 +253,46 @@ trait StreamTableEnvironment extends TableEnvironment {
     * Creates a view from the given [[DataStream]] in a given path with specified field names.
     * Registered views can be referenced in SQL queries.
     *
+    * There are two modes for mapping original fields to the fields of the View:
+    *
+    * 1. Reference input fields by name:
+    * All fields in the schema definition are referenced by name
+    * (and possibly renamed using an alias (as). Moreover, we can define proctime and rowtime
+    * attributes at arbitrary positions using arbitrary names (except those that exist in the
+    * result schema). In this mode, fields can be reordered and projected out. This mode can
+    * be used for any input type, including POJOs.
+    *
     * Example:
     *
     * {{{
-    *   val stream: DataStream[(String, Long)] = ...
-    *   tableEnv.createTemporaryView("cat.db.myTable", stream, 'a, 'b)
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   tableEnv.createTemporaryView(
+    *      "cat.db.myTable",
+    *      stream,
+    *      $"f1", // reorder and use the original field
+    *      $"rowtime".rowtime, // add an event-time attribute named 'rowtime'
+    *      $"f0" as "name" // reorder and give the original field a better name
+    *   )
+    * }}}
+    *
+    * 2. Reference input fields by position:
+    * In this mode, fields are simply renamed. Event-time attributes can
+    * replace the field on their position in the input data (if it is of correct type) or be
+    * appended at the end. Proctime attributes must be appended at the end. This mode can only be
+    * used if the input type has a defined field order (tuple, case class, Row) and none of
+    * the `fields` references a field of the input type.
+    *
+    * Example:
+    *
+    * {{{
+    *   val stream: DataStream<Tuple2<String, Long>> = ...
+    *   tableEnv.createTemporaryView(
+    *      "cat.db.myTable",
+    *      stream,
+    *      $"a", // rename the first field to 'a'
+    *      $"b" // rename the second field to 'b'
+    *      $"rowtime".rowtime // adds an event-time attribute named 'rowtime'
+    *   )
     * }}}
     *
     * Temporary objects can shadow permanent ones. If a permanent object in a given path exists,
@@ -197,7 +302,8 @@ trait StreamTableEnvironment extends TableEnvironment {
     * @param path The path under which the [[DataStream]] is created.
     *             See also the [[TableEnvironment]] class description for the format of the path.
     * @param dataStream The [[DataStream]] out of which to create the view.
-    * @param fields The field names of the created view.
+    * @param fields The fields expressions to map original fields of the DataStream to the fields of
+    *               the View.
     * @tparam T The type of the [[DataStream]].
     */
   def createTemporaryView[T](path: String, dataStream: DataStream[T], fields: Expression*): Unit

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/TableUtilsStreamingITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/TableUtilsStreamingITCase.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.table.api.Expressions.$;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -58,7 +59,7 @@ public class TableUtilsStreamingITCase {
 			Row.of(2, 21L),
 			Row.of(2, 22L),
 			Row.of(3, 31L));
-		tEnv.registerTable("T", tEnv.fromDataStream(env.fromCollection(sourceData), "a, b"));
+		tEnv.registerTable("T", tEnv.fromDataStream(env.fromCollection(sourceData), $("a"), $("b")));
 
 		String sql = "SELECT b FROM T WHERE a NOT IN (1, 2, 4, 5)";
 		List<Row> expected = Collections.singletonList(Row.of(31L));

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -64,7 +64,7 @@ class TableEnvironmentTest {
     thrown.expect(classOf[ValidationException])
     thrown.expectMessage(
       "Temporary table `default_catalog`.`default_database`.`MyTable` already exists")
-    tableEnv.registerDataStream("MyTable", env.fromElements[(Int, Long)]())
+    tableEnv.createTemporaryView("MyTable", env.fromElements[(Int, Long)]())
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/utils/ExpressionTestBase.scala
@@ -87,7 +87,7 @@ abstract class ExpressionTestBase {
   @Before
   def prepare(): Unit = {
     val ds = env.fromCollection(Collections.emptyList[Row](), typeInfo)
-    tEnv.registerDataStream(tableName, ds)
+    tEnv.createTemporaryView(tableName, ds)
     functions.foreach(f => tEnv.registerFunction(f._1, f._2))
 
     // prepare RelBuilder

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/match/PatternTranslatorTestBase.scala
@@ -68,7 +68,7 @@ abstract class PatternTranslatorTestBase extends TestLogger {
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
-    TableTestUtil.registerDataStream(
+    TableTestUtil.createTemporaryView(
       tEnv, tableName, dataStreamMock.javaStream, Some(Array[Expression]('f0, 'proctime.proctime)))
 
     // prepare RelBuilder

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
 import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.planner.utils._
@@ -44,7 +45,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val sDs = mock(classOf[DataStream[Row]])
     when(sDs.javaStream).thenReturn(jDs)
 
-    val jTab = javaUtil.tableEnv.fromDataStream(jDs, "a, b, c")
+    val jTab = javaUtil.tableEnv.fromDataStream(jDs, $("a"), $("b"), $("c"))
     val sTab = scalaUtil.tableEnv.fromDataStream(sDs, 'a, 'b, 'c)
 
     // test cross join
@@ -112,7 +113,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val sDs = mock(classOf[DataStream[Row]])
     when(sDs.javaStream).thenReturn(jDs)
 
-    val jTab = javaUtil.tableEnv.fromDataStream(jDs, "a, b, c")
+    val jTab = javaUtil.tableEnv.fromDataStream(jDs, $("a"), $("b"), $("c"))
     val sTab = scalaUtil.tableEnv.fromDataStream(sDs, 'a, 'b, 'c)
 
     // test flatMap

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateRemoveITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateRemoveITCase.scala
@@ -214,7 +214,7 @@ class AggregateRemoveITCase(
       (3, 2, "A", "Hi"),
       (5, 2, "B", "Hello"),
       (6, 3, "C", "Hello world")))
-    StreamTableEnvUtil.registerDataStreamInternal[(Int, Int, String, String)](
+    StreamTableEnvUtil.createTemporaryViewInternal[(Int, Int, String, String)](
       tEnv,
       "T",
       ds1.javaStream,
@@ -223,7 +223,7 @@ class AggregateRemoveITCase(
       Some(FlinkStatistic.builder().uniqueKeys(Set(Set("a").asJava).asJava).build())
     )
 
-    StreamTableEnvUtil.registerDataStreamInternal[(Int, Long, String)](
+    StreamTableEnvUtil.createTemporaryViewInternal[(Int, Long, String)](
       tEnv,
       "MyTable",
       env.fromCollection(TestData.smallTupleData3).javaStream,
@@ -232,7 +232,7 @@ class AggregateRemoveITCase(
       Some(FlinkStatistic.builder().uniqueKeys(Set(Set("a").asJava).asJava).build())
     )
 
-    StreamTableEnvUtil.registerDataStreamInternal[(Int, Long, Int, String, Long)](
+    StreamTableEnvUtil.createTemporaryViewInternal[(Int, Long, Int, String, Long)](
       tEnv,
       "MyTable2",
       env.fromCollection(TestData.smallTupleData5).javaStream,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PruneAggregateCallITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/PruneAggregateCallITCase.scala
@@ -99,7 +99,7 @@ class PruneAggregateCallITCase(
 
   private def checkResult(str: String, rows: Seq[Row]): Unit = {
     super.before()
-    StreamTableEnvUtil.registerDataStreamInternal[(Int, Long, String)](
+    StreamTableEnvUtil.createTemporaryViewInternal[(Int, Long, String)](
       tEnv,
       "MyTable",
       failingDataSource(TestData.smallTupleData3).javaStream,
@@ -108,7 +108,7 @@ class PruneAggregateCallITCase(
       Some(FlinkStatistic.UNKNOWN)
     )
 
-    StreamTableEnvUtil.registerDataStreamInternal[(Int, Long, Int, String, Long)](
+    StreamTableEnvUtil.createTemporaryViewInternal[(Int, Long, Int, String, Long)](
       tEnv,
       "MyTable2",
       failingDataSource(TestData.smallTupleData5).javaStream,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTableEnvUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTableEnvUtil.scala
@@ -248,7 +248,7 @@ object BatchTableEnvUtil {
       fieldNullables: Option[Array[Boolean]],
       statistic: Option[FlinkStatistic]): Unit = {
     val fields = fieldNames.map((f: Array[String]) => f.map(ExpressionParser.parseExpression))
-    TableTestUtil.registerDataStream(
+    TableTestUtil.createTemporaryView(
       tEnv,
       name,
       boundedStream,

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTableEnvUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTableEnvUtil.scala
@@ -36,7 +36,7 @@ object StreamTableEnvUtil {
     * @param dataStream The [[DataStream]] to register as table in the catalog.
     * @tparam T the type of the [[DataStream]].
     */
-  def registerDataStreamInternal[T](
+  def createTemporaryViewInternal[T](
       tEnv: StreamTableEnvironment,
       name: String,
       dataStream: DataStream[T],
@@ -47,7 +47,7 @@ object StreamTableEnvUtil {
       case Some(names) => Some(names.map(ExpressionParser.parseExpression))
       case _ => None
     }
-    TableTestUtil.registerDataStream(tEnv, name, dataStream, fields, fieldNullables, statistic)
+    TableTestUtil.createTemporaryView(tEnv, name, dataStream, fields, fieldNullables, statistic)
   }
 
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -173,7 +173,7 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
     val env = new ScalaStreamExecEnv(new LocalStreamEnvironment())
     val dataStream = env.fromElements[T]().javaStream
     val tableEnv = getTableEnv
-    TableTestUtil.registerDataStream(tableEnv, name, dataStream, Some(fields.toArray))
+    TableTestUtil.createTemporaryView(tableEnv, name, dataStream, Some(fields.toArray))
     tableEnv.scan(name)
   }
 
@@ -1130,7 +1130,7 @@ object TableTestUtil {
       .getRelBuilder.queryOperation(table.getQueryOperation).build()
   }
 
-  def registerDataStream[T](
+  def createTemporaryView[T](
       tEnv: TableEnvironment,
       name: String,
       dataStream: DataStream[T],

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/internal/BatchTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/java/internal/BatchTableEnvironmentImpl.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
 import org.apache.flink.table.api.java.BatchTableEnvironment
 import org.apache.flink.table.catalog.CatalogManager
-import org.apache.flink.table.expressions.ExpressionParser
+import org.apache.flink.table.expressions.{Expression, ExpressionParser}
 import org.apache.flink.table.functions.{AggregateFunction, TableFunction}
 import org.apache.flink.table.module.ModuleManager
 
@@ -58,7 +58,13 @@ class BatchTableEnvironmentImpl(
       .parseExpressionList(fields).asScala
       .toArray
 
-    createTable(asQueryOperation(dataSet, Some(exprs)))
+    fromDataSet(dataSet, exprs: _*)
+  }
+
+  override def fromDataSet[T](
+      dataSet: DataSet[T],
+      fields: Expression*): Table = {
+    createTable(asQueryOperation(dataSet, Some(fields.toArray)))
   }
 
   override def registerDataSet[T](name: String, dataSet: DataSet[T]): Unit = {
@@ -80,6 +86,13 @@ class BatchTableEnvironmentImpl(
       dataSet: DataSet[T],
       fields: String): Unit = {
     createTemporaryView(path, fromDataSet(dataSet, fields))
+  }
+
+  override def createTemporaryView[T](
+      path: String,
+      dataSet: DataSet[T],
+      fields: Expression*): Unit = {
+    createTemporaryView(path, fromDataSet(dataSet, fields: _*))
   }
 
   override def toDataSet[T](table: Table, clazz: Class[T]): DataSet[T] = {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/GroupingSetsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/GroupingSetsITCase.java
@@ -61,7 +61,7 @@ public class GroupingSetsITCase extends TableProgramsClusterTestBase {
 		tableEnv = BatchTableEnvironment.create(env, new TableConfig());
 
 		DataSet<Tuple3<Integer, Long, String>> dataSet = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet(TABLE_NAME, dataSet);
+		tableEnv.createTemporaryView(TABLE_NAME, dataSet);
 
 		MapOperator<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>> dataSetWithNulls =
 			dataSet.map(new MapFunction<Tuple3<Integer, Long, String>, Tuple3<Integer, Long, String>>() {
@@ -74,7 +74,7 @@ public class GroupingSetsITCase extends TableProgramsClusterTestBase {
 					return value;
 				}
 			});
-		tableEnv.registerDataSet(TABLE_WITH_NULLS_NAME, dataSetWithNulls);
+		tableEnv.createTemporaryView(TABLE_WITH_NULLS_NAME, dataSetWithNulls);
 	}
 
 	@Test

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/sql/JavaSqlITCase.java
@@ -42,6 +42,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Integration tests for batch SQL.
  */
@@ -78,7 +80,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		Table in = tableEnv.fromDataSet(ds, "a,b,c");
+		Table in = tableEnv.fromDataSet(ds, $("a"), $("b"), $("c"));
 		tableEnv.registerTable("T", in);
 
 		String sqlQuery = "SELECT a, c FROM T";
@@ -102,7 +104,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet("DataSetTable", ds, "x, y, z");
+		tableEnv.createTemporaryView("DataSetTable", ds, $("x"), $("y"), $("z"));
 
 		String sqlQuery = "SELECT x FROM DataSetTable WHERE z LIKE '%Hello%'";
 		Table result = tableEnv.sqlQuery(sqlQuery);
@@ -119,7 +121,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet("AggTable", ds, "x, y, z");
+		tableEnv.createTemporaryView("AggTable", ds, $("x"), $("y"), $("z"));
 
 		String sqlQuery = "SELECT sum(x), min(x), max(x), count(y), avg(x) FROM AggTable";
 		Table result = tableEnv.sqlQuery(sqlQuery);
@@ -138,8 +140,8 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 		DataSet<Tuple3<Integer, Long, String>> ds1 = CollectionDataSets.getSmall3TupleDataSet(env);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 = CollectionDataSets.get5TupleDataSet(env);
 
-		tableEnv.registerDataSet("t1", ds1, "a, b, c");
-		tableEnv.registerDataSet("t2", ds2, "d, e, f, g, h");
+		tableEnv.createTemporaryView("t1", ds1, $("a"), $("b"), $("c"));
+		tableEnv.createTemporaryView("t2", ds2, $("d"), $("e"), $("f"), $("g"), $("h"));
 
 		String sqlQuery = "SELECT c, g FROM t1, t2 WHERE b = e";
 		Table result = tableEnv.sqlQuery(sqlQuery);
@@ -164,7 +166,7 @@ public class JavaSqlITCase extends TableProgramsCollectionTestBase {
 			new MapTypeInfo<>(BasicTypeInfo.STRING_TYPE_INFO, BasicTypeInfo.STRING_TYPE_INFO));
 
 		DataSet<Tuple2<Integer, Map<String, String>>> ds1 = env.fromCollection(rows, ty);
-		tableEnv.registerDataSet("t1", ds1, "a, b");
+		tableEnv.createTemporaryView("t1", ds1, $("a"), $("b"));
 
 		String sqlQuery = "SELECT b['foo'] FROM t1";
 		Table result = tableEnv.sqlQuery(sqlQuery);

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
@@ -80,7 +80,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
 		// Must fail. Table is empty
-		tableEnv.registerTable("", t);
+		tableEnv.createTemporaryView("", t);
 	}
 
 	@Test(expected = ValidationException.class)
@@ -91,7 +91,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
 		// Must fail. Table is empty
-		tableEnv.registerTable("     ", t);
+		tableEnv.createTemporaryView("     ", t);
 	}
 
 	@Test
@@ -101,8 +101,8 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet(tableName, ds);
-		Table t = tableEnv.scan(tableName);
+		tableEnv.createTemporaryView(tableName, ds);
+		Table t = tableEnv.from(tableName);
 
 		Table result = t.select($("f0"), $("f1"));
 
@@ -121,8 +121,8 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet(tableName, ds, "a, b, c");
-		Table t = tableEnv.scan(tableName);
+		tableEnv.createTemporaryView(tableName, ds, $("a"), $("b"), $("c"));
+		Table t = tableEnv.from(tableName);
 
 		Table result = t.select($("a"), $("b"), $("c"));
 
@@ -144,11 +144,11 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
-		tableEnv.registerDataSet("MyTable", ds);
+		tableEnv.createTemporaryView("MyTable", ds);
 		DataSet<Tuple5<Integer, Long, Integer, String, Long>> ds2 =
 				CollectionDataSets.getSmall5TupleDataSet(env);
 		// Must fail. Name is already used for different table.
-		tableEnv.registerDataSet("MyTable", ds2);
+		tableEnv.createTemporaryView("MyTable", ds2);
 	}
 
 	@Test(expected = TableException.class)
@@ -157,7 +157,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. No table registered under that name.
-		tableEnv.scan("nonRegisteredTable");
+		tableEnv.from("nonRegisteredTable");
 	}
 
 	@Test
@@ -168,7 +168,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		DataSet<Tuple3<Integer, Long, String>> ds = CollectionDataSets.get3TupleDataSet(env);
 		Table t = tableEnv.fromDataSet(ds);
-		tableEnv.registerTable(tableName, t);
+		tableEnv.createTemporaryView(tableName, t);
 		Table result = tableEnv.scan(tableName).select($("f0"), $("f1")).filter($("f0").isGreater(7));
 
 		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
@@ -187,7 +187,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table t = tableEnv1.fromDataSet(CollectionDataSets.get3TupleDataSet(env));
 		// Must fail. Table is bound to different TableEnvironment.
-		tableEnv2.registerTable("MyTable", t);
+		tableEnv2.createTemporaryView("MyTable", t);
 	}
 
 	@Test
@@ -196,7 +196,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		Table table = tableEnv
-			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c")
+			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a"), $("b"), $("c"))
 			.select($("a"), $("b"), $("c"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
@@ -216,7 +216,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
-		Table table = tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "f2");
+		Table table = tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("f2"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
 		List<Row> results = ds.collect();
@@ -236,7 +236,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		Table table = tableEnv
-			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c")
+			.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a"), $("b"), $("c"))
 			.select($("a"), $("b"), $("c"));
 
 		TypeInformation<?> ti = new TupleTypeInfo<Tuple3<Integer, Long, String>>(
@@ -268,7 +268,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		data.add(new Tuple4<>("Test me", 4, 3.33, "Hello world"));
 
 		Table table = tableEnv
-			.fromDataSet(env.fromCollection(data), "q, w, e, r")
+			.fromDataSet(env.fromCollection(data), $("q"), $("w"), $("e"), $("r"))
 			.select($("q").as("a"), $("w").as("b"), $("e").as("c"), $("r").as("d"));
 
 		DataSet<SmallPojo2> ds = tableEnv.toDataSet(table, SmallPojo2.class);
@@ -289,11 +289,11 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table table = tableEnv
 			.fromDataSet(env.fromCollection(data),
-				"department AS a, " +
-				"age AS b, " +
-				"salary AS c, " +
-				"name AS d," +
-				"roles as e")
+				$("department").as("a"),
+				$("age").as("b"),
+				$("salary").as("c"),
+				$("name").as("d"),
+				$("roles").as("e"))
 			.select($("a"), $("b"), $("c"), $("d"), $("e"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
@@ -321,7 +321,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 					data,
 					TypeInformation.of(new TypeHint<Either<String, Integer>>() { })
 				),
-				"either")
+				$("either"))
 			.select("either");
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
@@ -344,7 +344,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		data.add(new SmallPojo("Lucy", 42, 6000.00, "HR", new Integer[] {1, 2, 3}));
 
 		Table table = tableEnv
-			.fromDataSet(env.fromCollection(data), "name AS d")
+			.fromDataSet(env.fromCollection(data), $("name").as("d"))
 			.select($("d"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
@@ -368,10 +368,10 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table table = tableEnv
 			.fromDataSet(env.fromCollection(data),
-				"department AS a, " +
-				"age AS b, " +
-				"salary AS c, " +
-				"name AS d")
+				$("department").as("a"),
+				$("age").as("b"),
+				$("salary").as("c"),
+				$("name").as("d"))
 			.select($("a"), $("b"), $("c"), $("d"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
@@ -395,11 +395,11 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table table = tableEnv
 			.fromDataSet(env.fromCollection(data),
-				"department AS a, " +
-				"age AS b, " +
-				"salary AS c, " +
-				"name AS d," +
-				"roles AS e")
+				$("department").as("a"),
+				$("age").as("b"),
+				$("salary").as("c"),
+				$("name").as("d"),
+				$("roles").as("e"))
 			.select($("a"), $("b"), $("c"), $("d"), $("e"));
 
 		DataSet<SmallPojo2> ds = tableEnv.toDataSet(table, SmallPojo2.class);
@@ -423,10 +423,10 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table table = tableEnv
 			.fromDataSet(env.fromCollection(data),
-				"department AS a, " +
-				"age AS b, " +
-				"salary AS c, " +
-				"name AS d")
+				$("department").as("a"),
+				$("age").as("b"),
+				$("salary").as("c"),
+				$("name").as("d"))
 			.select($("a"), $("b"), $("c"), $("d"));
 
 		DataSet<PrivateSmallPojo2> ds = tableEnv.toDataSet(table, PrivateSmallPojo2.class);
@@ -454,10 +454,10 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 
 		Table table = tableEnv
 			.fromDataSet(env.fromCollection(data),
-				"name AS a, " +
-				"age AS b, " +
-				"generic AS c, " +
-				"generic2 AS d")
+				$("name").as("a"),
+				$("age").as("b"),
+				$("generic").as("c"),
+				$("generic2").as("d"))
 			.select($("a"), $("b"), $("c"), $("c").as("c2"), $("d"))
 			.select($("a"), $("b"), $("c"), $("c").isEqual($("c2")), $("d"));
 
@@ -495,7 +495,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		assertTrue(dataSet.getType().getTypeClass().equals(Row.class));
 
 		// Must fail. Cannot import DataSet<Row> with GenericTypeInfo.
-		tableEnv.fromDataSet(dataSet, "nullField");
+		tableEnv.fromDataSet(dataSet, $("nullField"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -504,7 +504,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. Too many field names specified.
-		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, c, d");
+		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a"), $("b"), $("c"), $("d"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -513,7 +513,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. Specified field names are not unique.
-		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a, b, b");
+		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a"), $("b"), $("b"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -522,7 +522,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. as() does only allow field name expressions
-		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a + 1, b, c");
+		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a").plus(1), $("b"), $("c"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -531,7 +531,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail. as() does only allow field name expressions
-		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), "a as foo, b,  c");
+		tableEnv.fromDataSet(CollectionDataSets.get3TupleDataSet(env), $("a").as("foo"), $("b"), $("c"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -540,7 +540,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail since class is not static
-		tableEnv.fromDataSet(env.fromElements(new MyNonStatic()), "name");
+		tableEnv.fromDataSet(env.fromElements(new MyNonStatic()), $("name"));
 	}
 
 	@Test(expected = ValidationException.class)
@@ -549,7 +549,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
 
 		// Must fail since class is not static
-		Table t = tableEnv.fromDataSet(env.fromElements(1, 2, 3), "number");
+		Table t = tableEnv.fromDataSet(env.fromElements(1, 2, 3), $("number"));
 		tableEnv.toDataSet(t, MyNonStatic.class);
 	}
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/stream/sql/JavaSqlITCase.java
@@ -37,6 +37,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Integration tests for streaming SQL.
  */
@@ -63,7 +65,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 
 		DataStream<Row> ds = env.fromCollection(data).returns(typeInfo);
 
-		Table in = tableEnv.fromDataStream(ds, "a,b,c");
+		Table in = tableEnv.fromDataStream(ds, $("a"), $("b"), $("c"));
 		tableEnv.registerTable("MyTableRow", in);
 
 		String sqlQuery = "SELECT a,c FROM MyTableRow";
@@ -88,7 +90,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds = JavaStreamTestData.getSmall3TupleDataSet(env);
-		Table in = tableEnv.fromDataStream(ds, "a,b,c");
+		Table in = tableEnv.fromDataStream(ds, $("a"), $("b"), $("c"));
 		tableEnv.registerTable("MyTable", in);
 
 		String sqlQuery = "SELECT * FROM MyTable";
@@ -113,7 +115,7 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple5<Integer, Long, Integer, String, Long>> ds = JavaStreamTestData.get5TupleDataStream(env);
-		tableEnv.registerDataStream("MyTable", ds, "a, b, c, d, e");
+		tableEnv.createTemporaryView("MyTable", ds, $("a"), $("b"), $("c"), $("d"), $("e"));
 
 		String sqlQuery = "SELECT a, b, e FROM MyTable WHERE c < 4";
 		Table result = tableEnv.sqlQuery(sqlQuery);
@@ -138,11 +140,11 @@ public class JavaSqlITCase extends AbstractTestBase {
 		StreamITCase.clear();
 
 		DataStream<Tuple3<Integer, Long, String>> ds1 = JavaStreamTestData.getSmall3TupleDataSet(env);
-		Table t1 = tableEnv.fromDataStream(ds1, "a,b,c");
+		Table t1 = tableEnv.fromDataStream(ds1, $("a"), $("b"), $("c"));
 		tableEnv.registerTable("T1", t1);
 
 		DataStream<Tuple5<Integer, Long, Integer, String, Long>> ds2 = JavaStreamTestData.get5TupleDataStream(env);
-		tableEnv.registerDataStream("T2", ds2, "a, b, d, c, e");
+		tableEnv.createTemporaryView("T2", ds2, $("a"), $("b"), $("d"), $("c"), $("e"));
 
 		String sqlQuery = "SELECT * FROM T1 " +
 							"UNION ALL " +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/SetOperatorsTest.scala
@@ -20,11 +20,13 @@ package org.apache.flink.table.api.batch.sql
 
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
+
 import org.junit.Test
 
 class SetOperatorsTest extends TableTestBase {
@@ -251,7 +253,7 @@ class SetOperatorsTest extends TableTestBase {
     val typeInfo = Types.ROW(
       new GenericTypeInfo(classOf[NonPojo]),
       new GenericTypeInfo(classOf[NonPojo]))
-    val table = util.addJavaTable(typeInfo, "A", "a, b")
+    val table = util.addJavaTable(typeInfo, "A", $("a"), $("b"))
 
     val expected = binaryNode(
       "DataSetUnion",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -18,16 +18,18 @@
 
 package org.apache.flink.table.api.batch.table
 
-import java.sql.Timestamp
-
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.utils.TableTestBase
 import org.apache.flink.table.utils.TableTestUtil._
+
 import org.junit.Test
+
+import java.sql.Timestamp
 
 class SetOperatorsTest extends TableTestBase {
 
@@ -115,7 +117,7 @@ class SetOperatorsTest extends TableTestBase {
     val typeInfo = Types.ROW(
       new GenericTypeInfo(classOf[NonPojo]),
       new GenericTypeInfo(classOf[NonPojo]))
-    val t = util.addJavaTable(typeInfo, "A", "a, b")
+    val t = util.addJavaTable(typeInfo, "A", $("a"), $("b"))
 
     val in = t.select('a).unionAll(t.select('b))
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -21,10 +21,12 @@ package org.apache.flink.table.api.batch.table.stringexpr
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.java.{DataSet => JDataSet}
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.Expressions.$
+import org.apache.flink.table.api.{Expressions, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils.{PojoTableFunc, TableFunc2, _}
 import org.apache.flink.types.Row
+
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
 
@@ -42,7 +44,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val sDs = mock(classOf[DataSet[Row]])
     when(sDs.javaSet).thenReturn(jDs)
 
-    val jTab = util.javaTableEnv.fromDataSet(jDs, "a, b, c")
+    val jTab = util.javaTableEnv.fromDataSet(jDs, $("a"), $("b"), $("c"))
     val sTab = util.tableEnv.fromDataSet(sDs, 'a, 'b, 'c)
 
     // test cross join

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -25,10 +25,11 @@ import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{StreamExecutionEnvironment => JStreamExecEnv}
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.java.internal.{StreamTableEnvironmentImpl => JStreamTableEnvironmentImpl}
 import org.apache.flink.table.api.java.{StreamTableEnvironment => JStreamTableEnv}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{TableConfig, Types, ValidationException}
+import org.apache.flink.table.api.{Expressions, TableConfig, Types, ValidationException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog}
 import org.apache.flink.table.executor.StreamExecutor
 import org.apache.flink.table.planner.StreamPlanner
@@ -36,10 +37,11 @@ import org.apache.flink.table.runtime.utils.StreamTestData
 import org.apache.flink.table.utils.{CatalogManagerMocks, TableTestBase}
 import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
 import org.apache.flink.types.Row
+
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
-import java.lang.{Integer => JInt, Long => JLong}
 
+import java.lang.{Integer => JInt, Long => JLong}
 import org.apache.flink.table.module.ModuleManager
 
 class StreamTableEnvironmentTest extends TableTestBase {
@@ -170,31 +172,39 @@ class StreamTableEnvironmentTest extends TableTestBase {
   @Test
   def testProctimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, pt.proctime")
+    jTEnv.fromDataStream(ds, $("a"), $("b"), $("c"), $("d"), $("e"), $("pt").proctime())
   }
 
   @Test
   def testReplacingRowtimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a.rowtime, b, c, d, e")
+    jTEnv.fromDataStream(ds, $("a").rowtime(), $("b"), $("c"), $("d"), $("e"))
   }
 
   @Test
   def testAppedingRowtimeAttributeParsed(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, rt.rowtime")
+    jTEnv.fromDataStream(ds, $("a"), $("b"), $("c"), $("d"), $("e"), $("rt").rowtime())
   }
 
   @Test
   def testRowtimeAndProctimeAttributeParsed1(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "a, b, c, d, e, pt.proctime, rt.rowtime")
+    jTEnv.fromDataStream(
+      ds,
+      $("a"),
+      $("b"),
+      $("c"),
+      $("d"),
+      $("e"),
+      $("pt").proctime(),
+      $("rt").rowtime())
   }
 
   @Test
   def testRowtimeAndProctimeAttributeParsed2(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
-    jTEnv.fromDataStream(ds, "rt.rowtime, b, c, d, e, pt.proctime")
+    jTEnv.fromDataStream(ds, $("rt").rowtime(), $("b"), $("c"), $("d"), $("e"), $("pt").proctime())
   }
 
   private def prepareSchemaExpressionParser:

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/UnionTest.scala
@@ -20,11 +20,13 @@ package org.apache.flink.table.api.stream.sql
 
 import org.apache.flink.api.java.typeutils.GenericTypeInfo
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.Types
+import org.apache.flink.table.api.Expressions.$
+import org.apache.flink.table.api.{Expressions, Types}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.CommonTestData.NonPojo
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.TableTestBase
+
 import org.junit.Test
 
 class UnionTest extends TableTestBase {
@@ -63,7 +65,7 @@ class UnionTest extends TableTestBase {
     val typeInfo = Types.ROW(
       new GenericTypeInfo(classOf[NonPojo]),
       new GenericTypeInfo(classOf[NonPojo]))
-    val table = streamUtil.addJavaTable(typeInfo, "A", "a, b")
+    val table = streamUtil.addJavaTable(typeInfo, "A", $("a"), $("b"))
 
     val expected = binaryNode(
       "DataStreamUnion",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
@@ -20,12 +20,14 @@ package org.apache.flink.table.api.stream.table
 
 import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.Types
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.expressions.utils.Func0
 import org.apache.flink.table.utils.{EmptyTableAggFunc, EmptyTableAggFuncWithIntResultType, TableTestBase}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.types.Row
+
 import org.junit.Test
 
 class TableAggregateTest extends TableTestBase {
@@ -152,7 +154,7 @@ class TableAggregateTest extends TableTestBase {
   def testJavaRegisterFunction(): Unit = {
     val util = streamTestUtil()
     val typeInfo = new RowTypeInfo(Types.INT, Types.LONG, Types.STRING)
-    val table = util.addJavaTable[Row](typeInfo, "sourceTable", "a, b, c")
+    val table = util.addJavaTable[Row](typeInfo, "sourceTable", $("a"), $("b"), $("c"))
 
     val func = new EmptyTableAggFunc
     util.javaTableEnv.registerFunction("func", func)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -24,10 +24,12 @@ import org.apache.flink.table.api._
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.utils._
 import org.apache.flink.types.Row
+
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
 import org.apache.flink.streaming.api.datastream.{DataStream => JDataStream}
 import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.table.api.Expressions.$
 
 class CorrelateStringExpressionTest extends TableTestBase {
 
@@ -42,7 +44,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val sDs = mock(classOf[DataStream[Row]])
     when(sDs.javaStream).thenReturn(jDs)
 
-    val jTab = util.javaTableEnv.fromDataStream(jDs, "a, b, c")
+    val jTab = util.javaTableEnv.fromDataStream(jDs, $("a"), $("b"), $("c"))
     val sTab = util.tableEnv.fromDataStream(sDs, 'a, 'b, 'c)
 
     // test cross join
@@ -111,7 +113,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val sDs = mock(classOf[DataStream[Row]])
     when(sDs.javaStream).thenReturn(jDs)
 
-    val jTab = util.javaTableEnv.fromDataStream(jDs, "a, b, c")
+    val jTab = util.javaTableEnv.fromDataStream(jDs, $("a"), $("b"), $("c"))
     val sTab = util.tableEnv.fromDataStream(sDs, 'a, 'b, 'c)
 
     // test flatMap

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableEnvironmentValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/validation/TableEnvironmentValidationTest.scala
@@ -117,10 +117,10 @@ class TableEnvironmentValidationTest extends TableTestBase {
     val tEnv = BatchTableEnvironment.create(env)
 
     val ds1 = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds1)
+    tEnv.createTemporaryView("MyTable", ds1)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
     // Must fail. Name is already in use.
-    tEnv.registerDataSet("MyTable", ds2)
+    tEnv.createTemporaryView("MyTable", ds2)
   }
 
   @Test(expected = classOf[TableException])
@@ -140,7 +140,7 @@ class TableEnvironmentValidationTest extends TableTestBase {
     tEnv.registerTable("MyTable", t1)
     val t2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv)
     // Must fail. Name is already in use.
-    tEnv.registerDataSet("MyTable", t2)
+    tEnv.createTemporaryView("MyTable", t2)
   }
 
   @Test(expected = classOf[TableException])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/expressions/utils/ExpressionTestBase.scala
@@ -88,7 +88,7 @@ abstract class ExpressionTestBase {
 
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env).asInstanceOf[BatchTableEnvironmentImpl]
-    tEnv.registerDataSet(tableName, dataSetMock)
+    tEnv.createTemporaryView(tableName, dataSetMock)
     functions.foreach(f => tEnv.registerFunction(f._1, f._2))
 
     // prepare RelBuilder

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/match/PatternTranslatorTestBase.scala
@@ -60,7 +60,7 @@ abstract class PatternTranslatorTestBase extends TestLogger{
 
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = StreamTableEnvironment.create(env).asInstanceOf[StreamTableEnvironmentImpl]
-    tEnv.registerDataStream(tableName, dataStreamMock, 'f0, 'proctime.proctime)
+    tEnv.createTemporaryView(tableName, dataStreamMock, 'f0, 'proctime.proctime)
 
     val streamPlanner = tEnv.getPlanner.asInstanceOf[StreamPlanner]
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -49,7 +49,7 @@ class AggregateITCase(
     val sqlQuery = "SELECT sum(_1), min(_1), max(_1), count(_1), avg(_1) FROM MyTable"
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -85,7 +85,7 @@ class AggregateITCase(
     val sqlQuery = "SELECT sum(_1) FROM MyTable"
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -240,7 +240,7 @@ class AggregateITCase(
       "SELECT _2, _3, avg(_1) as a, GROUP_ID() as g FROM MyTable GROUP BY GROUPING SETS (_2, _3)"
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
 
@@ -321,7 +321,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -350,7 +350,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -373,7 +373,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("t1", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("t1", ds, 'a, 'b, 'c, 'ts)
 
     val t2 = tEnv.sqlQuery("SELECT b, COLLECT(b) as `set`" +
         "FROM t1 " +
@@ -409,7 +409,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // min time unit is seconds
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -444,7 +444,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -476,7 +476,7 @@ class AggregateITCase(
     val ds = CollectionDataSets.get3TupleDataSet(env)
       // create timestamps
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -519,7 +519,7 @@ class AggregateITCase(
       // create timestamps
       .filter(x => (x._2 % 2) == 0)
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(
@@ -548,7 +548,7 @@ class AggregateITCase(
       // create timestamps
       .filter(x => (x._2 % 2) == 0)
       .map(x => (x._1, x._2, x._3, toTimestamp(x._1 * 1000)))
-    tEnv.registerDataSet("T", ds, 'a, 'b, 'c, 'ts)
+    tEnv.createTemporaryView("T", ds, 'a, 'b, 'c, 'ts)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -96,7 +96,7 @@ class CalcITCase(
     val sqlQuery = "SELECT * FROM MyTable"
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("MyTable", ds, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -300,7 +300,7 @@ class CalcITCase(
       Date.valueOf("1984-07-12"),
       Time.valueOf("14:34:24"),
       Timestamp.valueOf("1984-07-12 14:34:24")))
-    tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("MyTable", ds, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -320,7 +320,7 @@ class CalcITCase(
     val rowValue = ("foo", 12, Timestamp.valueOf("1984-07-12 14:34:24"))
 
     val ds = env.fromElements(rowValue)
-    tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("MyTable", ds, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -345,7 +345,7 @@ class CalcITCase(
     tEnv.registerFunction("hashCode", MyHashCode)
 
     val ds = env.fromElements("a", "b", "c")
-    tEnv.registerDataSet("MyTable", ds, 'text)
+    tEnv.createTemporaryView("MyTable", ds, 'text)
 
     val result = tEnv.sqlQuery("SELECT hashCode(text) FROM MyTable")
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
@@ -152,8 +152,8 @@ class JoinITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
-    tEnv.registerDataSet("Table3", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("Table5", ds2, 'd, 'e, 'f, 'g, 'h)
+    tEnv.createTemporaryView("Table3", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("Table5", ds2, 'd, 'e, 'f, 'g, 'h)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -482,7 +482,7 @@ class JoinITCase(
       (3, 2L, Array("Hello world", "x"))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataSet("T", stream, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", stream, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) as A (s)"
 
@@ -554,7 +554,7 @@ class JoinITCase(
       (3, Array((18, "42.6")))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataSet("T", stream, 'a, 'b)
+    tEnv.createTemporaryView("T", stream, 'a, 'b)
 
     val sqlQuery = "" +
       "SELECT a, b, x, y " +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -48,8 +48,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'd, 'e, 'f)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'd, 'e, 'f)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -68,8 +68,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'd, 'e, 'f)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'd, 'e, 'f)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -90,8 +90,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'd, 'c, 'e)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'd, 'c, 'e)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -111,8 +111,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'd, 'c, 'e)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'd, 'c, 'e)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -147,8 +147,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = env.fromElements((1, 1L, "Hi"))
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -171,8 +171,8 @@ class SetOperatorsITCase(
     val ds1 = env.fromCollection(data1)
     val ds2 = env.fromCollection(data2)
 
-    tEnv.registerDataSet("t1", ds1, 'c)
-    tEnv.registerDataSet("t2", ds2, 'c)
+    tEnv.createTemporaryView("t1", ds1, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -193,8 +193,8 @@ class SetOperatorsITCase(
 
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get5TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'd, 'c, 'e)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'd, 'c, 'e)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -218,8 +218,8 @@ class SetOperatorsITCase(
     data.+=((3, 2L, "Hello world!"))
     val ds2 = env.fromCollection(Random.shuffle(data))
 
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -244,8 +244,8 @@ class SetOperatorsITCase(
     val ds1 = env.fromCollection(data1)
     val ds2 = env.fromCollection(data2)
 
-    tEnv.registerDataSet("t1", ds1, 'c)
-    tEnv.registerDataSet("t2", ds2, 'c)
+    tEnv.createTemporaryView("t1", ds1, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 
@@ -264,8 +264,8 @@ class SetOperatorsITCase(
     val ds1 = CollectionDataSets.getSmall3TupleDataSet(env)
     val ds2 = CollectionDataSets.get3TupleDataSet(env)
 
-    tEnv.registerDataSet("t1", ds1, 'a, 'b, 'c)
-    tEnv.registerDataSet("t2", ds2, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds1, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t2", ds2, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SortITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SortITCase.scala
@@ -57,7 +57,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
       (- x.productElement(0).asInstanceOf[Int], - x.productElement(1).asInstanceOf[Long]))
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val expected = sortExpectedly(tupleDataSetStrings)
     // squash all rows inside a partition into one element
@@ -94,7 +94,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
       - x.productElement(0).asInstanceOf[Int] )
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val expected = sortExpectedly(tupleDataSetStrings, 2, 21)
     // squash all rows inside a partition into one element
@@ -125,7 +125,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
       x.productElement(0).asInstanceOf[Int] )
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val expected = sortExpectedly(tupleDataSetStrings, 2, 7)
     // squash all rows inside a partition into one element
@@ -156,7 +156,7 @@ class SortITCase(mode: TestExecutionMode, configMode: TableConfigMode)
       (x.productElement(1).asInstanceOf[Long], x.productElement(0).asInstanceOf[Int]) )
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds)
+    tEnv.createTemporaryView("MyTable", ds)
 
     val expected = sortExpectedly(tupleDataSetStrings, 0, 5)
     // squash all rows inside a partition into one element

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
@@ -45,7 +45,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet("MyTable", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("MyTable", ds, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a > 9"
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/AggregateITCase.scala
@@ -49,7 +49,7 @@ class AggregationsITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
 
     val inputTable = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv, 'a, 'b)
-    tEnv.registerDataSet("MyTable", inputTable)
+    tEnv.createTemporaryView("MyTable", inputTable)
 
     val result = tEnv.scan("MyTable")
       .where('a.get("_1") > 0)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
@@ -439,7 +439,7 @@ class CalcITCase(
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "ABC"))
 
     val ds = CollectionDataSets.getSmall3TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT c FROM t1 where RichFunc2(c)='ABC#Hello'"
 
@@ -460,7 +460,7 @@ class CalcITCase(
     tEnv.registerFunction("RichFunc3", new RichFunc3)
 
     val ds = CollectionDataSets.getSmall3TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT c FROM t1 where RichFunc3(c)=true"
 
@@ -508,7 +508,7 @@ class CalcITCase(
     UserDefinedFunctionTestUtils.setJobParameters(env, Map("string.value" -> "Abc"))
 
     val ds = CollectionDataSets.getSmall3TupleDataSet(env)
-    tEnv.registerDataSet("t1", ds, 'a, 'b, 'c)
+    tEnv.createTemporaryView("t1", ds, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT c FROM t1 where " +
       "RichFunc2(c)='Abc#Hello' or RichFunc1(a)=3 and b=2"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
@@ -48,7 +48,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet(tableName, ds)
+    tEnv.createTemporaryView(tableName, ds)
     val t = tEnv.scan(tableName).select('_1, '_2, '_3)
 
     val expected = "1,1,Hi\n" + "2,2,Hello\n" + "3,2,Hello world\n" +
@@ -69,7 +69,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet(tableName, ds, 'a, 'b, 'c) // new alias
+    tEnv.createTemporaryView(tableName, ds, 'a, 'b, 'c) // new alias
     val t = tEnv.scan(tableName).select('a, 'b)
 
     val expected = "1,1\n" + "2,2\n" + "3,2\n" + "4,3\n" + "5,3\n" + "6,3\n" +
@@ -87,7 +87,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
 
     val ds = CollectionDataSets.get3TupleDataSet(env)
-    tEnv.registerDataSet(tableName, ds, '_3, '_1, '_2) // new order
+    tEnv.createTemporaryView(tableName, ds, '_3, '_1, '_2) // new order
     val t = tEnv.scan(tableName).select('_1, '_2)
 
     val expected = "1,1\n" + "2,2\n" + "3,2\n" + "4,3\n" + "5,3\n" + "6,3\n" +

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/InsertIntoITCase.scala
@@ -46,7 +46,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val input = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(r => r._2)
 
-    tEnv.registerDataStream("sourceTable", input, 'a, 'b, 'c, 't.rowtime)
+    tEnv.createTemporaryView("sourceTable", input, 'a, 'b, 'c, 't.rowtime)
 
     val fieldNames = Array("d", "e", "t")
     val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING, Types.SQL_TIMESTAMP, Types.LONG)
@@ -82,7 +82,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text)
     tEnv.registerTableSink(
       "targetTable",
       new TestRetractSink().configure(
@@ -122,7 +122,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
     tEnv.registerTableSink(
       "targetTable",
       new TestRetractSink().configure(
@@ -170,7 +170,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text)
     tEnv.registerTableSink(
       "targetTable",
       new TestUpsertSink(Array("cnt", "cTrue"), false).configure(
@@ -217,7 +217,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
     tEnv.registerTableSink(
       "targetTable",
       new TestUpsertSink(Array("wend", "num"), true).configure(
@@ -268,7 +268,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
     tEnv.registerTableSink(
       "targetTable",
       new TestUpsertSink(Array("wstart", "wend", "num"), true).configure(
@@ -320,7 +320,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
     tEnv.registerTableSink(
       "targetTable",
       new TestUpsertSink(null, true).configure(
@@ -370,7 +370,7 @@ class InsertIntoITCase extends StreamingWithStateTestBase {
     val t = StreamTestData.get3TupleDataStream(env)
       .assignAscendingTimestamps(_._1.toLong)
 
-    tEnv.registerDataStream("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
+    tEnv.createTemporaryView("sourceTable", t, 'id, 'num, 'text, 'rowtime.rowtime)
     tEnv.registerTableSink(
       "targetTable",
       new TestUpsertSink(null, true).configure(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -461,7 +461,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = "SELECT * FROM MyTable WHERE _1 = 3"
 
     val t = StreamTestData.getSmall3TupleDataStream(env)
-    tEnv.registerDataStream("MyTable", t)
+    tEnv.createTemporaryView("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -538,7 +538,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
     tEnv.registerTable("T1", t1)
     val t2 = StreamTestData.get3TupleDataStream(env)
-    tEnv.registerDataStream("T2", t2, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T2", t2, 'a, 'b, 'c)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
     result.addSink(new StreamITCase.StringSink[Row])
@@ -560,7 +560,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array(18, 42), Array(Array(1), Array(45)))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", stream, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT a, b, s FROM T, UNNEST(T.b) AS A (s)"
 
@@ -591,7 +591,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array(18, 42), Array(Array(1), Array(45)))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b, 'c)
+    tEnv.createTemporaryView("T", stream, 'a, 'b, 'c)
 
     val sqlQuery = "SELECT a, s FROM T, UNNEST(T.c) AS A (s)"
 
@@ -620,7 +620,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, Array((18, "42.6")))
     )
     val stream = env.fromCollection(data)
-    tEnv.registerDataStream("T", stream, 'a, 'b)
+    tEnv.createTemporaryView("T", stream, 'a, 'b)
 
     val sqlQuery = "SELECT a, b, s, t FROM T, UNNEST(T.b) AS A (s, t) WHERE s > 13"
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.utils
 
-import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.rel.RelNode
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.{LocalEnvironment, DataSet => JDataSet}
 import org.apache.flink.api.scala.{DataSet, ExecutionEnvironment}
@@ -31,7 +29,7 @@ import org.apache.flink.table.api.internal.{TableEnvImpl, TableEnvironmentImpl, 
 import org.apache.flink.table.api.java.internal.{BatchTableEnvironmentImpl => JavaBatchTableEnvironmentImpl, StreamTableEnvironmentImpl => JavaStreamTableEnvironmentImpl}
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.scala.internal.{BatchTableEnvironmentImpl => ScalaBatchTableEnvironmentImpl, StreamTableEnvironmentImpl => ScalaStreamTableEnvironmentImpl}
-import org.apache.flink.table.api.{Table, TableConfig, TableSchema}
+import org.apache.flink.table.api.{ApiExpression, Table, TableConfig, TableSchema}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.executor.StreamExecutor
 import org.apache.flink.table.expressions.Expression
@@ -39,6 +37,9 @@ import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, Tabl
 import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.operations.{DataSetQueryOperation, JavaDataStreamQueryOperation, ScalaDataStreamQueryOperation}
 import org.apache.flink.table.planner.StreamPlanner
+
+import org.apache.calcite.plan.RelOptUtil
+import org.apache.calcite.rel.RelNode
 import org.junit.Assert.assertEquals
 import org.junit.rules.ExpectedException
 import org.junit.{ComparisonFailure, Rule}
@@ -248,13 +249,11 @@ case class BatchTableTestUtil(
     tableEnv.registerTable(name, t)
     t
   }
-
-  def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: String): Table = {
-
+  def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: ApiExpression*): Table = {
     val jDs = mock(classOf[JDataSet[T]])
     when(jDs.getType).thenReturn(typeInfo)
 
-    val t = javaTableEnv.fromDataSet(jDs, fields)
+    val t = javaTableEnv.fromDataSet(jDs, fields: _*)
     javaTableEnv.registerTable(name, t)
     t
   }
@@ -361,9 +360,9 @@ case class StreamTableTestUtil(
     table
   }
 
-  def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: String): Table = {
+  def addJavaTable[T](typeInfo: TypeInformation[T], name: String, fields: ApiExpression*): Table = {
     val stream = javaEnv.addSource(new EmptySource[T], typeInfo)
-    val table = javaTableEnv.fromDataStream(stream, fields)
+    val table = javaTableEnv.fromDataStream(stream, fields: _*)
     javaTableEnv.registerTable(name, table)
     table
   }


### PR DESCRIPTION
## What is the purpose of the change

This PR introduces alternatives for methods that are using the String based expressions in TableEnvironments.

This PR also removes all usages of the String based expressions methods. It is a preparation for deprecating and in result removing those methods in the future.
## Brief change log

It also deprecates the methods in TableEnvironments that accept expressions as Strings.

## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented): documentation will be updated in a separate PR.
