### PR TITLE
[FLINK-16806][operators] Add support for InputSelection to MultipleInputStreamOperator

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
@@ -37,7 +37,7 @@ public class MultipleInputSelectionHandler {
 	public static final int MAX_SUPPORTED_INPUT_COUNT = Long.SIZE;
 
 	@Nullable
-	private final InputSelectable inputSelector;
+	private final InputSelectable inputSelectable;
 
 	private InputSelection inputSelection = InputSelection.ALL;
 
@@ -49,7 +49,7 @@ public class MultipleInputSelectionHandler {
 
 	public MultipleInputSelectionHandler(@Nullable InputSelectable inputSelectable, int inputCount) {
 		checkSupportedInputCount(inputCount);
-		this.inputSelector = inputSelectable;
+		this.inputSelectable = inputSelectable;
 		this.allSelectedMask = (1 << inputCount) - 1;
 		this.availableInputsMask = allSelectedMask;
 		this.notFinishedInputsMask = allSelectedMask;
@@ -98,10 +98,10 @@ public class MultipleInputSelectionHandler {
 	}
 
 	void nextSelection() {
-		if (inputSelector == null) {
+		if (inputSelectable == null) {
 			inputSelection = InputSelection.ALL;
 		} else {
-			inputSelection = inputSelector.nextSelection();
+			inputSelection = inputSelectable.nextSelection();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandler.java
@@ -112,7 +112,7 @@ public class MultipleInputSelectionHandler {
 	}
 
 	boolean shouldSetAvailableForAnotherInput() {
-		return availableInputsMask != allSelectedMask && inputSelection.areAllInputsSelected();
+		return (inputSelection.getInputMask() & allSelectedMask & ~availableInputsMask) != 0;
 	}
 
 	void setAvailableInput(int inputIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/TwoInputSelectionHandler.java
@@ -31,22 +31,22 @@ import javax.annotation.Nullable;
 public class TwoInputSelectionHandler {
 
 	@Nullable
-	private final InputSelectable inputSelector;
+	private final InputSelectable inputSelectable;
 
 	private InputSelection inputSelection;
 
 	private int availableInputsMask;
 
 	public TwoInputSelectionHandler(@Nullable InputSelectable inputSelectable) {
-		this.inputSelector = inputSelectable;
+		this.inputSelectable = inputSelectable;
 		this.availableInputsMask = (int) new InputSelection.Builder().select(1).select(2).build().getInputMask();
 	}
 
 	void nextSelection() {
-		if (inputSelector == null) {
+		if (inputSelectable == null) {
 			inputSelection = InputSelection.ALL;
 		} else {
-			inputSelection = inputSelector.nextSelection();
+			inputSelection = inputSelectable.nextSelection();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -88,11 +88,8 @@ public class MultipleInputStreamTask<OUT> extends StreamTask<OUT, MultipleInputS
 			Collection<InputGate>[] inputGates,
 			TypeSerializer<?>[] inputDeserializers,
 			WatermarkGauge[] inputWatermarkGauges) {
-		if (headOperator instanceof InputSelectable) {
-			throw new UnsupportedOperationException();
-		}
 		MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(
-			null,
+			headOperator instanceof InputSelectable ? (InputSelectable) headOperator : null,
 			inputGates.length);
 
 		InputGate[] unionedInputGates = new InputGate[inputGates.length];

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MultipleInputSelectionHandlerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.streaming.api.operators.InputSelection;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link MultipleInputSelectionHandler}.
+ */
+public class MultipleInputSelectionHandlerTest {
+	@Test
+	public void testShouldSetAvailableForAnotherInput() {
+		InputSelection secondAndThird = new InputSelection.Builder().select(2).select(3).build();
+
+		MultipleInputSelectionHandler selectionHandler = new MultipleInputSelectionHandler(() -> secondAndThird, 3);
+		selectionHandler.nextSelection();
+
+		assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+
+		selectionHandler.setUnavailableInput(0);
+		assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+
+		selectionHandler.setUnavailableInput(2);
+		assertTrue(selectionHandler.shouldSetAvailableForAnotherInput());
+
+		selectionHandler.setAvailableInput(0);
+		assertTrue(selectionHandler.shouldSetAvailableForAnotherInput());
+
+		selectionHandler.setAvailableInput(2);
+		assertFalse(selectionHandler.shouldSetAvailableForAnotherInput());
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -121,9 +121,16 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
 	}
 
 	public void process() throws Exception {
-		while (streamTask.inputProcessor.isAvailable() && streamTask.mailboxProcessor.isMailboxLoopRunning()) {
-			streamTask.runMailboxStep();
+		while (processSingleStep()) {
 		}
+	}
+
+	public boolean processSingleStep() throws Exception {
+		if (streamTask.inputProcessor.isAvailable() && streamTask.mailboxProcessor.isMailboxLoopRunning()) {
+			streamTask.runMailboxStep();
+			return true;
+		}
+		return false;
 	}
 
 	public void endInput() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMultipleInputSelectiveReadingTest.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator;
+import org.apache.flink.streaming.util.TestAnyModeMultipleInputStreamOperator.ToStringInput;
+import org.apache.flink.streaming.util.TestSequentialMultipleInputStreamOperator;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test selective reading.
+ */
+public class StreamTaskMultipleInputSelectiveReadingTest {
+
+	private static final StreamRecord<String>[] INPUT1 = new StreamRecord[] {
+		new StreamRecord<>("Hello-1"),
+		new StreamRecord<>("Hello-2"),
+		new StreamRecord<>("Hello-3")
+	};
+
+	private static final StreamRecord<Integer>[] INPUT2 = new StreamRecord[] {
+		new StreamRecord<>(1),
+		new StreamRecord<>(2),
+		new StreamRecord<>(3),
+		new StreamRecord<>(4)
+	};
+
+	@Test
+	public void testAnyOrderedReading() throws Exception {
+		ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 4"));
+
+		testInputSelection(new TestAnyModeMultipleInputStreamOperator.Factory(), false, expectedOutput, true);
+	}
+
+	@Test
+	public void testAnyUnorderedReading() throws Exception {
+		ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 4"));
+
+		testInputSelection(new TestAnyModeMultipleInputStreamOperator.Factory(), true, expectedOutput, false);
+	}
+
+	@Test
+	public void testSequentialReading() throws Exception {
+		ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 4"));
+
+		testInputSelection(new TestSequentialMultipleInputStreamOperator.Factory(), true, expectedOutput, true);
+	}
+
+	@Test
+	public void testSpecialRuleReading() throws Exception {
+		ArrayDeque<Object> expectedOutput = new ArrayDeque<>();
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-1"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-2"));
+		expectedOutput.add(new StreamRecord<>("[2]: 1"));
+		expectedOutput.add(new StreamRecord<>("[2]: 2"));
+		expectedOutput.add(new StreamRecord<>("[1]: Hello-3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 3"));
+		expectedOutput.add(new StreamRecord<>("[2]: 4"));
+
+		testInputSelection(new SpecialRuleReadingStreamOperatorFactory(3, 4, 2), true, expectedOutput, true);
+	}
+
+	@Test
+	public void testReadFinishedInput() throws Exception {
+		try {
+			testInputSelection(new TestReadFinishedInputStreamOperatorFactory(), true, new ArrayDeque<>(), true);
+			fail("should throw an IOException");
+		} catch (Exception t) {
+			if (!ExceptionUtils.findThrowableWithMessage(t, "Can not make a progress: all selected inputs are already finished").isPresent()) {
+				throw t;
+			}
+		}
+	}
+
+	private void testInputSelection(
+			StreamOperatorFactory<String> streamOperatorFactory,
+			boolean autoProcess,
+			ArrayDeque<Object> expectedOutput,
+			boolean orderedCheck) throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+			new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+				.addInput(BasicTypeInfo.INT_TYPE_INFO)
+				.setupOutputForSingletonOperatorChain(streamOperatorFactory)
+				.build()) {
+
+			testHarness.setAutoProcess(autoProcess);
+			for (StreamRecord<String> record : INPUT1) {
+				testHarness.processElement(record, 0);
+			}
+			for (StreamRecord<Integer> record : INPUT2) {
+				testHarness.processElement(record, 1);
+			}
+
+			testHarness.endInput();
+
+			if (!autoProcess) {
+				testHarness.process();
+			}
+			testHarness.waitForTaskCompletion();
+
+			if (orderedCheck) {
+				assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+			} else {
+				assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+			}
+		}
+	}
+
+	/**
+	 * Setup three inputs only two selected and make sure that neither of the two inputs is starved,
+	 * when one has some data all the time, but the other only rarely.
+	 */
+	@Test
+	public void testInputStarvation() throws Exception {
+		try (StreamTaskMailboxTestHarness<String> testHarness =
+				new MultipleInputStreamTaskTestHarnessBuilder<>(MultipleInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.addInput(BasicTypeInfo.STRING_TYPE_INFO)
+					.setupOutputForSingletonOperatorChain(new TestInputStarvationMultipleInputOperatorFactory())
+					.build()) {
+
+			Queue<StreamRecord> expectedOutput = new ArrayDeque<>();
+
+			testHarness.setAutoProcess(false);
+			// StreamMultipleInputProcessor starts with all inputs available. Let it rotate and refresh properly.
+			testHarness.processSingleStep();
+			assertTrue(testHarness.getOutput().isEmpty());
+
+			testHarness.processElement(new StreamRecord<>("NOT_SELECTED"), 0);
+
+			testHarness.processElement(new StreamRecord<>("1"), 1);
+			testHarness.processElement(new StreamRecord<>("2"), 1);
+			testHarness.processElement(new StreamRecord<>("3"), 1);
+			testHarness.processElement(new StreamRecord<>("4"), 1);
+
+			testHarness.processSingleStep();
+			expectedOutput.add(new StreamRecord<>("[2]: 1"));
+			testHarness.processSingleStep();
+			expectedOutput.add(new StreamRecord<>("[2]: 2"));
+			assertThat(testHarness.getOutput(), contains(expectedOutput.toArray()));
+
+			// InputGate 2 was not available in previous steps, so let's check if we are not starving it
+			testHarness.processElement(new StreamRecord<>("1"), 2);
+			testHarness.processSingleStep();
+			testHarness.processSingleStep();
+
+			// One of those processing single step should pick up InputGate 2, however it's not
+			// important which one. We just must avoid starvation.
+			expectedOutput.add(new StreamRecord<>("[3]: 1"));
+			expectedOutput.add(new StreamRecord<>("[2]: 3"));
+
+			assertThat(testHarness.getOutput(), containsInAnyOrder(expectedOutput.toArray()));
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Utilities
+	// ------------------------------------------------------------------------
+
+	private static class SpecialRuleReadingStreamOperator extends AbstractStreamOperatorV2<String>
+		implements MultipleInputStreamOperator<String>, InputSelectable, BoundedMultiInput {
+
+		private final int input1Records;
+		private final int input2Records;
+		private final int maxContinuousReadingRecords;
+
+		private int input1ReadingRecords;
+		private int input2ReadingRecords;
+
+		private int continuousReadingRecords;
+		private InputSelection inputSelection = InputSelection.FIRST;
+
+		SpecialRuleReadingStreamOperator(StreamOperatorParameters<String> parameters, int input1Records, int input2Records, int maxContinuousReadingRecords) {
+			super(parameters, 2);
+
+			this.input1Records = input1Records;
+			this.input2Records = input2Records;
+			this.maxContinuousReadingRecords = maxContinuousReadingRecords;
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return inputSelection;
+		}
+
+		@Override
+		public void endInput(int inputId) {
+			inputSelection = (inputId == 1) ? InputSelection.SECOND : InputSelection.FIRST;
+		}
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new ToStringInput(this, 1) {
+					@Override
+					public void processElement(StreamRecord element) {
+						super.processElement(element);
+						input1ReadingRecords++;
+						continuousReadingRecords++;
+						if (continuousReadingRecords == maxContinuousReadingRecords) {
+							continuousReadingRecords = 0;
+							if (input2ReadingRecords < input2Records) {
+								inputSelection = InputSelection.SECOND;
+								return;
+							}
+						}
+
+						inputSelection = InputSelection.FIRST;
+					}
+				},
+				new ToStringInput(this, 2) {
+					@Override
+					public void processElement(StreamRecord element) {
+						super.processElement(element);
+						input2ReadingRecords++;
+						continuousReadingRecords++;
+						if (continuousReadingRecords == maxContinuousReadingRecords) {
+							continuousReadingRecords = 0;
+							if (input1ReadingRecords < input1Records) {
+								inputSelection = InputSelection.FIRST;
+								return;
+							}
+						}
+
+						inputSelection = InputSelection.SECOND;
+					}
+				}
+			);
+		}
+	}
+
+	private static class SpecialRuleReadingStreamOperatorFactory extends AbstractStreamOperatorFactory<String> {
+		private final int input1Records;
+		private final int input2Records;
+		private final int maxContinuousReadingRecords;
+
+		public SpecialRuleReadingStreamOperatorFactory(
+				int input1Records,
+				int input2Records,
+				int maxContinuousReadingRecords) {
+			this.input1Records = input1Records;
+			this.input2Records = input2Records;
+			this.maxContinuousReadingRecords = maxContinuousReadingRecords;
+		}
+
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new SpecialRuleReadingStreamOperator(parameters, input1Records, input2Records, maxContinuousReadingRecords);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return SpecialRuleReadingStreamOperator.class;
+		}
+	}
+
+	private static class TestReadFinishedInputStreamOperator extends TestAnyModeMultipleInputStreamOperator {
+		TestReadFinishedInputStreamOperator(StreamOperatorParameters<String> parameters) {
+			super(parameters);
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return InputSelection.FIRST;
+		}
+	}
+
+	private static class TestReadFinishedInputStreamOperatorFactory extends AbstractStreamOperatorFactory<String> {
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new TestReadFinishedInputStreamOperator(parameters);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return TestReadFinishedInputStreamOperator.class;
+		}
+	}
+
+	private static class TestInputStarvationMultipleInputOperator extends AbstractStreamOperatorV2<String>
+		implements MultipleInputStreamOperator<String>, InputSelectable {
+
+		public TestInputStarvationMultipleInputOperator(StreamOperatorParameters<String> parameters) {
+			super(parameters, 3);
+		}
+
+		@Override
+		public InputSelection nextSelection() {
+			return new InputSelection.Builder().select(2).select(3).build();
+		}
+
+		@Override
+		public List<Input> getInputs() {
+			return Arrays.asList(
+				new ToStringInput(this, 1),
+				new ToStringInput(this, 2),
+				new ToStringInput(this, 3));
+		}
+	}
+
+	private static class TestInputStarvationMultipleInputOperatorFactory extends AbstractStreamOperatorFactory<String> {
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new TestInputStarvationMultipleInputOperator(parameters);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return TestInputStarvationMultipleInputOperator.class;
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestAnyModeMultipleInputStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestAnyModeMultipleInputStreamOperator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractInput;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorV2;
+import org.apache.flink.streaming.api.operators.Input;
+import org.apache.flink.streaming.api.operators.InputSelectable;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A test operator class for any mode reading.
+ */
+public class TestAnyModeMultipleInputStreamOperator extends AbstractStreamOperatorV2<String>
+	implements MultipleInputStreamOperator<String>, InputSelectable {
+
+	public TestAnyModeMultipleInputStreamOperator(StreamOperatorParameters<String> parameters) {
+		super(parameters, 2);
+	}
+
+	@Override
+	public InputSelection nextSelection() {
+		return InputSelection.ALL;
+	}
+
+	@Override
+	public List<Input> getInputs() {
+		return Arrays.asList(
+			new ToStringInput(this, 1),
+			new ToStringInput(this, 2));
+	}
+
+	/**
+	 * Factory to construct {@link TestAnyModeMultipleInputStreamOperator}.
+	 */
+	public static class Factory extends AbstractStreamOperatorFactory<String> {
+
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new TestAnyModeMultipleInputStreamOperator(parameters);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return TestAnyModeMultipleInputStreamOperator.class;
+		}
+	}
+
+	/**
+	 * {@link AbstractInput} that converts argument to string pre-pending input id.
+	 */
+	public static class ToStringInput<T> extends AbstractInput<T, String> {
+		public ToStringInput(AbstractStreamOperatorV2<String> owner, int inputId) {
+			super(owner, inputId);
+		}
+
+		@Override
+		public void processElement(StreamRecord<T> element) {
+			output.collect(element.replace(String.format("[%d]: %s", inputId, element.getValue())));
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestSequentialMultipleInputStreamOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/TestSequentialMultipleInputStreamOperator.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.InputSelection;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/**
+ * A test operator class for sequential reading.
+ */
+public class TestSequentialMultipleInputStreamOperator extends TestAnyModeMultipleInputStreamOperator
+	implements BoundedMultiInput {
+
+	private InputSelection inputSelection = InputSelection.FIRST;
+
+	public TestSequentialMultipleInputStreamOperator(StreamOperatorParameters<String> parameters) {
+		super(parameters);
+	}
+
+	@Override
+	public InputSelection nextSelection() {
+		return inputSelection;
+	}
+
+	@Override
+	public void endInput(int inputId) {
+		if (inputId == 1) {
+			inputSelection = InputSelection.SECOND;
+		}
+	}
+
+	/**
+	 * Factory to construct {@link TestSequentialMultipleInputStreamOperator}.
+	 */
+	public static class Factory extends AbstractStreamOperatorFactory<String> {
+
+		@Override
+		public <T extends StreamOperator<String>> T createStreamOperator(StreamOperatorParameters<String> parameters) {
+			return (T) new TestSequentialMultipleInputStreamOperator(parameters);
+		}
+
+		@Override
+		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+			return TestSequentialMultipleInputStreamOperator.class;
+		}
+	}
+}


### PR DESCRIPTION
This PR adds support for InputSelection to MultipleInputStreamOperator.

## Brief change log

Please check individual commit messages.

## Verifying this change

This change is covered by existing tests like `MultipleInputITCase` and adds couple of new tests to cover the new feature.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
