### PR TITLE
[FLINK-16805][e2e] Remove pre-commit profile activation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
         vmImage: 'ubuntu-latest'
       e2e_pool_definition:
         vmImage: 'ubuntu-16.04'
-      environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Pe2e-hadoop -Pe2e-pre-commit"
+      environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Pe2e-hadoop"
       run_end_to_end: false
       container: flink-build-container
       jdk: jdk8

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -63,7 +63,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
-          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Pe2e-hadoop -Pe2e-pre-commit"
+          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Pe2e-hadoop"
           run_end_to_end: false
           container: flink-build-container
           jdk: jdk8
@@ -80,7 +80,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
-          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.4.1 -Pskip-hive-tests -Pe2e-hadoop -Pe2e-pre-commit"
+          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.4.1 -Pskip-hive-tests -Pe2e-hadoop"
           run_end_to_end: true
           container: flink-build-container
           jdk: jdk8
@@ -91,7 +91,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
-          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1 -Pe2e-hadoop -Pe2e-pre-commit"
+          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phive-1.2.1 -Pe2e-hadoop"
           run_end_to_end: true
           container: flink-build-container
           jdk: jdk8
@@ -102,7 +102,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-16.04'
-          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11 -Pe2e-hadoop -Pe2e-pre-commit"
+          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11 -Djdk11 -Pe2e-hadoop"
           run_end_to_end: true
           container: flink-build-container
           jdk: jdk11


### PR DESCRIPTION
## What is the purpose of the change

Remove the pre-commit profile from the global PROFILE variable.

## Verifying this change

I verified the change here: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=243&view=logs&j=764762df-f65b-572b-3d5c-65518c777be4&t=764762df-f65b-572b-3d5c-65518c777be4