### PR TITLE
[FLINK-16537][network] Implement ResultPartition state recovery for unaligned checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReader.java
@@ -18,6 +18,7 @@ package org.apache.flink.runtime.checkpoint.channel;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 
 import java.io.IOException;
 
@@ -42,7 +43,7 @@ public interface ChannelStateReader extends AutoCloseable {
 	 * Put data into the supplied buffer to be injected into
 	 * {@link org.apache.flink.runtime.io.network.partition.ResultSubpartition ResultSubpartition}.
 	 */
-	ReadResult readOutputData(ResultSubpartitionInfo info, Buffer buffer) throws IOException;
+	ReadResult readOutputData(ResultSubpartitionInfo info, BufferBuilder bufferBuilder) throws IOException;
 
 	@Override
 	void close() throws Exception;
@@ -55,7 +56,7 @@ public interface ChannelStateReader extends AutoCloseable {
 		}
 
 		@Override
-		public ReadResult readOutputData(ResultSubpartitionInfo info, Buffer buffer) {
+		public ReadResult readOutputData(ResultSubpartitionInfo info, BufferBuilder bufferBuilder) {
 			return ReadResult.NO_MORE_DATA;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.api.writer;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
@@ -41,6 +42,12 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
 	 * Setup partition, potentially heavy-weight, blocking operation comparing to just creation.
 	 */
 	void setup() throws IOException;
+
+	/**
+	 * Loads the previous output states with the given reader for unaligned checkpoint.
+	 * It should be done before task processing the inputs.
+	 */
+	void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException;
 
 	ResultPartitionID getPartitionId();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -29,7 +29,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * View over a pipelined in-memory only subpartition.
  */
-class PipelinedSubpartitionView implements ResultSubpartitionView {
+public class PipelinedSubpartitionView implements ResultSubpartitionView {
 
 	/** The subpartition this view belongs to. */
 	private final PipelinedSubpartition parent;
@@ -39,7 +39,7 @@ class PipelinedSubpartitionView implements ResultSubpartitionView {
 	/** Flag indicating whether this view has been released. */
 	private final AtomicBoolean isReleased;
 
-	PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
+	public PipelinedSubpartitionView(PipelinedSubpartition parent, BufferAvailabilityListener listener) {
 		this.parent = checkNotNull(parent);
 		this.availabilityListener = checkNotNull(listener);
 		this.isReleased = new AtomicBoolean();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -148,6 +149,13 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 
 		this.bufferPool = bufferPool;
 		partitionManager.registerResultPartition(this);
+	}
+
+	@Override
+	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+		for (ResultSubpartition subpartition : subpartitions) {
+			subpartition.initializeState(stateReader);
+		}
 	}
 
 	public String getOwningTaskName() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
@@ -74,6 +75,9 @@ public abstract class ResultSubpartition {
 	 */
 	protected void onConsumedSubpartition() {
 		parent.onConsumedSubpartition(index);
+	}
+
+	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
@@ -86,6 +87,11 @@ public class ConsumableNotifyingResultPartitionWriterDecorator implements Result
 	@Override
 	public void setup() throws IOException {
 		partitionWriter.setup();
+	}
+
+	@Override
+	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+		partitionWriter.initializeState(stateReader);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -164,7 +164,7 @@ public class BufferBuilderAndConsumerTest {
 	public void buildEmptyBuffer() {
 		Buffer buffer = buildSingleBuffer(createBufferBuilder());
 		assertEquals(0, buffer.getSize());
-		assertContent(buffer);
+		assertContent(buffer, FreeingBufferRecycler.INSTANCE);
 	}
 
 	@Test
@@ -240,7 +240,7 @@ public class BufferBuilderAndConsumerTest {
 		assertTrue(bufferConsumer.isFinished());
 	}
 
-	private static ByteBuffer toByteBuffer(int... data) {
+	public static ByteBuffer toByteBuffer(int... data) {
 		ByteBuffer byteBuffer = ByteBuffer.allocate(data.length * Integer.BYTES);
 		byteBuffer.asIntBuffer().put(data);
 		return byteBuffer;
@@ -250,18 +250,18 @@ public class BufferBuilderAndConsumerTest {
 		assertFalse(actualConsumer.isFinished());
 		Buffer buffer = actualConsumer.build();
 		assertFalse(buffer.isRecycled());
-		assertContent(buffer, expected);
+		assertContent(buffer, FreeingBufferRecycler.INSTANCE, expected);
 		assertEquals(expected.length * Integer.BYTES, buffer.getSize());
 		buffer.recycleBuffer();
 	}
 
-	private static void assertContent(Buffer actualBuffer, int... expected) {
+	public static void assertContent(Buffer actualBuffer, BufferRecycler recycler, int... expected) {
 		IntBuffer actualIntBuffer = actualBuffer.getNioBufferReadable().asIntBuffer();
 		int[] actual = new int[actualIntBuffer.limit()];
 		actualIntBuffer.get(actual);
 		assertArrayEquals(expected, actual);
 
-		assertEquals(FreeingBufferRecycler.INSTANCE, actualBuffer.getRecycler());
+		assertEquals(recycler, actualBuffer.getRecycler());
 	}
 
 	private static BufferBuilder createBufferBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
@@ -36,6 +37,10 @@ public class MockResultPartitionWriter implements ResultPartitionWriter {
 
 	@Override
 	public void setup() {
+	}
+
+	@Override
+	public void initializeState(ChannelStateReader stateReader) {
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpBufferAvailablityListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/NoOpBufferAvailablityListener.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 /**
  * Test implementation of {@link BufferAvailabilityListener}.
  */
-class NoOpBufferAvailablityListener implements BufferAvailabilityListener {
+public class NoOpBufferAvailablityListener implements BufferAvailabilityListener {
 	@Override
 	public void notifyDataAvailable() {
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -19,13 +19,17 @@
 package org.apache.flink.runtime.io.network.partition;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.checkpoint.channel.ResultSubpartitionInfo;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
@@ -42,6 +46,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils.createFilledFinishedBufferConsumer;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
@@ -406,5 +415,121 @@ public class ResultPartitionTest {
 			taskActions,
 			jobId,
 			notifier)[0];
+	}
+
+	@Test
+	public void testInitializeEmptyState() throws Exception {
+		final int totalBuffers = 2;
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 1, 1);
+		final ResultPartition partition = new ResultPartitionBuilder()
+			.setNetworkBufferPool(globalPool)
+			.build();
+		final ChannelStateReader stateReader = ChannelStateReader.NO_OP;
+		try {
+			partition.setup();
+			partition.initializeState(stateReader);
+
+			for (ResultSubpartition subpartition : partition.getAllPartitions()) {
+				// no buffers are added into the queue for empty states
+				assertEquals(0, subpartition.getTotalNumberOfBuffers());
+			}
+
+			// destroy the local pool to verify that all the requested buffers by partition are recycled
+			partition.getBufferPool().lazyDestroy();
+			assertEquals(totalBuffers, globalPool.getNumberOfAvailableMemorySegments());
+		} finally {
+			// cleanup
+			globalPool.destroyAllBufferPools();
+			globalPool.destroy();
+		}
+	}
+
+	@Test
+	public void testInitializeMoreStateThanBuffer() throws Exception {
+		final int totalBuffers = 2; // the total buffers are less than the requirement from total states
+		final int totalStates = 5;
+		final int[] states = {1, 2, 3, 4};
+		final int bufferSize = states.length * Integer.BYTES;
+
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, bufferSize, 1);
+		final ChannelStateReader stateReader = new FiniteChannelStateReader(totalStates, states);
+		final ResultPartition partition = new ResultPartitionBuilder()
+			.setNetworkBufferPool(globalPool)
+			.build();
+		final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+		try {
+			final Callable<Void> partitionConsumeTask = () -> {
+				for (ResultSubpartition subpartition : partition.getAllPartitions()) {
+					final ResultSubpartitionView view = new PipelinedSubpartitionView(
+						(PipelinedSubpartition) subpartition,
+						new NoOpBufferAvailablityListener());
+
+					int numConsumedBuffers = 0;
+					while (numConsumedBuffers != totalStates) {
+						ResultSubpartition.BufferAndBacklog bufferAndBacklog = view.getNextBuffer();
+						if (bufferAndBacklog != null) {
+							Buffer buffer = bufferAndBacklog.buffer();
+							BufferBuilderAndConsumerTest.assertContent(buffer, partition.getBufferPool(), states);
+							buffer.recycleBuffer();
+							numConsumedBuffers++;
+						} else {
+							Thread.sleep(5);
+						}
+					}
+				}
+				return null;
+			};
+			Future<Void> result = executor.submit(partitionConsumeTask);
+
+			partition.setup();
+			partition.initializeState(stateReader);
+
+			// wait the partition consume task finish
+			result.get(20, TimeUnit.SECONDS);
+
+			// destroy the local pool to verify that all the requested buffers by partition are recycled
+			partition.getBufferPool().lazyDestroy();
+			assertEquals(totalBuffers, globalPool.getNumberOfAvailableMemorySegments());
+		} finally {
+			// cleanup
+			executor.shutdown();
+			globalPool.destroyAllBufferPools();
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * The {@link ChannelStateReader} instance for restoring the specific number of states.
+	 */
+	public static final class FiniteChannelStateReader implements ChannelStateReader {
+		private final int totalStates;
+		private int numRestoredStates;
+		private final int[] states;
+
+		public FiniteChannelStateReader(int totalStates, int[] states) {
+			this.totalStates = totalStates;
+			this.states = states;
+		}
+
+		@Override
+		public ReadResult readInputData(InputChannelInfo info, Buffer buffer) {
+			return ReadResult.NO_MORE_DATA;
+		}
+
+		@Override
+		public ReadResult readOutputData(ResultSubpartitionInfo info, BufferBuilder bufferBuilder) {
+			bufferBuilder.appendAndCommit(BufferBuilderAndConsumerTest.toByteBuffer(states));
+
+			if (++numRestoredStates < totalStates) {
+				return ReadResult.HAS_MORE_DATA;
+			} else {
+				return ReadResult.NO_MORE_DATA;
+			}
+		}
+
+		@Override
+		public void close() {
+		}
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.execution.Environment;
@@ -434,6 +435,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			// so that we avoid race conditions in the case that initializeState()
 			// registers a timer, that fires before the open() is called.
 			operatorChain.initializeStateAndOpenOperators(createStreamTaskStateInitializer());
+
+			ResultPartitionWriter[] writers = getEnvironment().getAllWriters();
+			if (writers != null) {
+				//TODO we should get proper state reader from getEnvironment().getTaskStateManager().getChannelStateReader()
+				for (ResultPartitionWriter writer : writers) {
+					writer.initializeState(ChannelStateReader.NO_OP);
+				}
+			}
 		});
 
 		isRunning = true;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.checkpoint.SubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.TestingUncaughtExceptionHandler;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -43,6 +44,7 @@ import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
 import org.apache.flink.runtime.io.network.api.writer.AvailabilityTestResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.RecordWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
+import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
@@ -894,6 +896,30 @@ public class StreamTaskTest extends TestLogger {
 		}
 	}
 
+	@Test
+	public void testInitializeResultPartitionState() throws Exception {
+		int numWriters = 2;
+		RecoveryResultPartition[] partitions = new RecoveryResultPartition[numWriters];
+		for (int i = 0; i < numWriters; i++) {
+			partitions[i] = new RecoveryResultPartition();
+		}
+
+		MockEnvironment mockEnvironment = new MockEnvironmentBuilder().build();
+		mockEnvironment.addOutputs(Arrays.asList(partitions));
+		StreamTask task = new MockStreamTaskBuilder(mockEnvironment).build();
+
+		try {
+			task.beforeInvoke();
+
+			// output recovery should be done before task processing
+			for (RecoveryResultPartition resultPartition : partitions) {
+				assertTrue(resultPartition.isStateInitialized());
+			}
+		} finally {
+			task.cleanUpInvoke();
+		}
+	}
+
 	/**
 	 * Tests that some StreamTask methods are called only in the main task's thread.
 	 * Currently, the main task's thread is the thread that creates the task.
@@ -1720,6 +1746,22 @@ public class StreamTaskTest extends TestLogger {
 		@Override
 		public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
 			throw new UnsupportedOperationException();
+		}
+	}
+
+	private static class RecoveryResultPartition extends MockResultPartitionWriter {
+		private boolean isStateInitialized;
+
+		RecoveryResultPartition() {
+		}
+
+		@Override
+		public void initializeState(ChannelStateReader stateReader) {
+			isStateInitialized = true;
+		}
+
+		boolean isStateInitialized() {
+			return isStateInitialized;
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

During state recovery for unaligned checkpoint, the partition state should also be recovered besides with existing operator states.

The ResultPartition would request buffer from local pool and then interact with ChannelStateReader to fill in the state data. The filled buffer would be inserted into respective ResultSubpartition queue in normal way.

It should guarantee that op can not process any inputs before finishing all the output recovery to avoid mis-order issue.

Note this PR relies on the #11515 which I picked some lines from in a separate commit.

## Brief change log

  - *Define the `initializeState` inside `ResultSubpartition` and `ResultPartitionWriter` interfaces*
  - *Implements the process of `initializeState`*
  - *Invoke `initializeState` in `StreamTask#beforeInvoke`*

## Verifying this change

  - Added unit tests in `StreamTaskTest` 
  - Added unit tests in `ResultPartitionTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
