### PR TITLE
[FLINK-16814][core] StringUtils.arrayToString() doesn't convert byte[] correctly

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -143,7 +143,7 @@ public final class StringUtils {
 			return Arrays.toString((Object[]) array);
 		}
 		if (array instanceof byte[]) {
-			return Arrays.toString((byte[]) array);
+			return new String((byte[]) array);
 		}
 		if (array instanceof double[]) {
 			return Arrays.toString((double[]) array);

--- a/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
@@ -46,6 +46,13 @@ public class StringUtilsTest extends TestLogger {
 	}
 
 	@Test
+	public void testByteArrayToString() {
+		byte[] array = "10".getBytes();
+		String controlString = StringUtils.arrayToString(array);
+		assertEquals("10", controlString);
+	}
+
+	@Test
 	public void testStringToHexArray() {
 		String hex = "019f314a";
 		byte[] hexArray = StringUtils.hexStringToByte(hex);


### PR DESCRIPTION
## What is the purpose of the change

StringUtils.arrayToString() doesn't convert byte[] correctly. It uses Arrays.toString() but should be newing a string from the byte[]

## Verifying this change

a new UT is added to cover it

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
