### PR TITLE
[FLINK-16813][jdbc]  JDBCInputFormat doesn't correctly map Short

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 
@@ -151,11 +152,11 @@ public class JDBCTableSource implements
 	}
 
 	private JDBCInputFormat getInputFormat() {
-		final RowTypeInfo rowTypeInfo = (RowTypeInfo) fromDataTypeToLegacyInfo(producedDataType);
+		final RowType rowType = (RowType) producedDataType.getLogicalType();
 		JDBCInputFormat.JDBCInputFormatBuilder builder = JDBCInputFormat.buildJDBCInputFormat()
 				.setDrivername(options.getDriverName())
 				.setDBUrl(options.getDbURL())
-				.setRowTypeInfo(new RowTypeInfo(rowTypeInfo.getFieldTypes(), rowTypeInfo.getFieldNames()));
+				.setRowType(rowType);
 		options.getUsername().ifPresent(builder::setUsername);
 		options.getPassword().ifPresent(builder::setPassword);
 
@@ -163,6 +164,7 @@ public class JDBCTableSource implements
 			builder.setFetchSize(readOptions.getFetchSize());
 		}
 
+		final RowTypeInfo rowTypeInfo = (RowTypeInfo) fromDataTypeToLegacyInfo(producedDataType);
 		final JDBCDialect dialect = options.getDialect();
 		String query = dialect.getSelectFromStatement(
 			options.getTableName(), rowTypeInfo.getFieldNames(), new String[0]);

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcTypeUtil.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcTypeUtil.java
@@ -24,11 +24,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.inference.TypeTransformations;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.HashMap;
@@ -114,20 +112,11 @@ class JdbcTypeUtil {
 	 */
 	static TableSchema normalizeTableSchema(TableSchema schema) {
 		TableSchema.Builder physicalSchemaBuilder = TableSchema.builder();
+
 		schema.getTableColumns()
 			.forEach(c -> {
 				if (!c.isGenerated()) {
-					LogicalTypeRoot root = c.getType().getLogicalType().getTypeRoot();
-					final DataType type;
-					if (root == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
-						type = c.getType().bridgedTo(Timestamp.class);
-					} else if (root == LogicalTypeRoot.DATE) {
-						type = c.getType().bridgedTo(Date.class);
-					} else if (root == LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE) {
-						type = c.getType().bridgedTo(Time.class);
-					} else {
-						type = c.getType();
-					}
+					final DataType type = DataTypeUtils.transform(c.getType(), TypeTransformations.timeToSqlTypes());
 					physicalSchemaBuilder.field(c.getName(), type);
 				}
 			});

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.api.java.io.jdbc.dialect;
 
+import org.apache.flink.api.java.io.jdbc.source.row.converter.JDBCRowConverter;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -37,6 +39,13 @@ public interface JDBCDialect extends Serializable {
 	 * @return True if the dialect can be applied on the given jdbc url.
 	 */
 	boolean canHandle(String url);
+
+	/**
+	 * Get a row converter for the database according to the given row type.
+	 * @param rowType the given row type
+	 * @return a row converter for the database
+	 */
+	JDBCRowConverter getRowConverter(RowType rowType);
 
 	/**
 	 * Check if this dialect instance support a specific data type in table schema.

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -18,11 +18,16 @@
 
 package org.apache.flink.api.java.io.jdbc.dialect;
 
+import org.apache.flink.api.java.io.jdbc.source.row.converter.DerbyRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.JDBCRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.MySQLRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.PostgresRowConverter;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 
@@ -143,6 +148,11 @@ public final class JDBCDialects {
 		}
 
 		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new DerbyRowConverter(rowType);
+		}
+
+		@Override
 		public Optional<String> defaultDriverName() {
 			return Optional.of("org.apache.derby.jdbc.EmbeddedDriver");
 		}
@@ -223,6 +233,11 @@ public final class JDBCDialects {
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:mysql:");
+		}
+
+		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new MySQLRowConverter(rowType);
 		}
 
 		@Override
@@ -324,6 +339,11 @@ public final class JDBCDialects {
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:postgresql:");
+		}
+
+		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new PostgresRowConverter(rowType);
 		}
 
 		@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base for all row converters.
+ */
+public abstract class AbstractJDBCRowConverter implements JDBCRowConverter {
+
+	protected final RowType rowType;
+
+	public AbstractJDBCRowConverter(RowType rowType) {
+		this.rowType = checkNotNull(rowType);
+	}
+
+	@Override
+	public Row setRow(ResultSet resultSet, Row reuse) throws SQLException {
+		for (int pos = 0; pos < rowType.getFieldCount(); pos++) {
+			LogicalTypeRoot root = rowType.getTypeAt(pos).getTypeRoot();
+			Object v = resultSet.getObject(pos + 1);
+			if (root == LogicalTypeRoot.SMALLINT) {
+				reuse.setField(pos, ((Integer) v).shortValue());
+			} else {
+				reuse.setField(pos, v);
+			}
+		}
+
+		return reuse;
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/DerbyRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/DerbyRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for Derby.
+ */
+public class DerbyRowConverter extends AbstractJDBCRowConverter {
+
+	public DerbyRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.types.Row;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Convert row from JDBC result set to a Flink row.
+ */
+public interface JDBCRowConverter {
+
+	/**
+	 * Set {@link Row} with data retrieved from {@link ResultSet}.
+	 *
+	 * @param resultSet ResultSet from JDBC
+	 * @param reuse The row to set
+	 */
+	Row setRow(ResultSet resultSet, Row reuse) throws SQLException;
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/MySQLRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/MySQLRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for MySQL.
+ */
+public class MySQLRowConverter extends AbstractJDBCRowConverter {
+
+	public MySQLRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for Postgres.
+ */
+public class PostgresRowConverter extends AbstractJDBCRowConverter {
+
+	public PostgresRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -38,7 +38,7 @@ import java.sql.Statement;
 import java.sql.Types;
 
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.OUTPUT_TABLE;
-import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE_INFO;
+import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE;
 import static org.hamcrest.core.StringContains.containsString;
 
 /**
@@ -83,7 +83,7 @@ public class JDBCFullTest extends JDBCDataTestBase {
 				.setDrivername(getDbMetadata().getDriverClass())
 				.setDBUrl(getDbMetadata().getUrl())
 				.setQuery(JdbcTestFixture.SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO);
+				.setRowType(ROW_TYPE);
 
 		if (exploitParallelism) {
 			final int fetchSize = 1;

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -35,7 +35,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE_INFO;
+import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.SELECT_ALL_BOOKS;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.SELECT_EMPTY;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.TEST_DATA;
@@ -72,7 +72,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername("org.apache.derby.jdbc.idontexist")
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.finish();
 		jdbcInputFormat.openInputFormat();
 	}
@@ -83,7 +83,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl("jdbc:der:iamanerror:mory:ebookshop")
 				.setQuery(SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.finish();
 		jdbcInputFormat.openInputFormat();
 	}
@@ -94,7 +94,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery("iamnotsql")
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.finish();
 		jdbcInputFormat.openInputFormat();
 	}
@@ -104,7 +104,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 		jdbcInputFormat = JDBCInputFormat.buildJDBCInputFormat()
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setQuery(SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.finish();
 	}
 
@@ -114,7 +114,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.setFetchSize(-7)
 			.finish();
 	}
@@ -125,7 +125,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.setFetchSize(Integer.MIN_VALUE)
 			.finish();
 	}
@@ -136,7 +136,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.finish();
 		jdbcInputFormat.openInputFormat();
 
@@ -153,7 +153,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.setFetchSize(desiredFetchSize)
 			.finish();
 		jdbcInputFormat.openInputFormat();
@@ -167,7 +167,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.finish();
 		jdbcInputFormat.openInputFormat();
 
@@ -186,7 +186,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
-			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowType(ROW_TYPE)
 			.setAutoCommit(desiredAutoCommit)
 			.finish();
 
@@ -201,7 +201,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
 				.finish();
 		//this query does not exploit parallelism
@@ -232,7 +232,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(JdbcTestFixture.SELECT_ALL_BOOKS_SPLIT_BY_ID)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.setParametersProvider(pramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
 				.finish();
@@ -268,7 +268,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(JdbcTestFixture.SELECT_ALL_BOOKS_SPLIT_BY_ID)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.setParametersProvider(pramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
 				.finish();
@@ -304,7 +304,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(JdbcTestFixture.SELECT_ALL_BOOKS_SPLIT_BY_AUTHOR)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.setParametersProvider(paramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
 				.finish();
@@ -344,7 +344,7 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setDrivername(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getDriverClass())
 				.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 				.setQuery(SELECT_EMPTY)
-				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowType(ROW_TYPE)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
 				.finish();
 		try {

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -27,6 +28,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 /**
  * Test data and helper objects for JDBC tests.
@@ -96,12 +99,12 @@ public class JdbcTestFixture {
 		}
 	}
 
-	static final RowTypeInfo ROW_TYPE_INFO = new RowTypeInfo(
+	static final RowType ROW_TYPE = (RowType) fromLegacyInfoToDataType(new RowTypeInfo(
 		BasicTypeInfo.INT_TYPE_INFO,
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
-		BasicTypeInfo.INT_TYPE_INFO);
+		BasicTypeInfo.INT_TYPE_INFO)).getLogicalType();
 
 	private static String getCreateQuery(String tableName) {
 		return "CREATE TABLE " + tableName + " (" +

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -78,6 +78,39 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		assertEquals("[1]", results.toString());
 	}
 
+	@Test
+	public void testPrimitiveTypes() throws Exception {
+		TableEnvironment tEnv = getTableEnvWithPgCatalog();
+
+		List<Row> results = TableUtils.collectToList(
+			tEnv.sqlQuery(String.format("select * from %s", TABLE_PRIMITIVE_TYPE)));
+
+		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01]", results.toString());
+	}
+
+	@Test
+	public void testArrayTypes() throws Exception {
+		TableEnvironment tEnv = getTableEnvWithPgCatalog();
+
+		List<Row> results = TableUtils.collectToList(
+			tEnv.sqlQuery(String.format("select * from %s", TABLE_ARRAY_TYPE)));
+
+		assertEquals("[" +
+				"[1, 2, 3]," +
+				"[[92, 120, 51, 50], [92, 120, 51, 51], [92, 120, 51, 52]]," +
+				"[3, 4, 5]," +
+				"[4, 5, 6]," +
+				"[5.5, 6.6, 7.7]," +
+				"[6.6, 7.7, 8.8]," +
+				"[7.70000, 8.80000, 9.90000]," +
+				"[true, false, true]," +
+				"[a, b, c]," +
+				"[b, c, d]," +
+				"[b  , c  , d  ]," +
+				"[b, c, d]]",
+			results.toString());
+	}
+
 	private TableEnvironment getTableEnvWithPgCatalog() {
 		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
 		TableEnvironment tableEnv = TableEnvironment.create(settings);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -85,7 +85,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		List<Row> results = TableUtils.collectToList(
 			tEnv.sqlQuery(String.format("select * from %s", TABLE_PRIMITIVE_TYPE)));
 
-		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01]", results.toString());
+		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03]", results.toString());
 	}
 
 	@Test
@@ -107,7 +107,10 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 				"[a, b, c]," +
 				"[b, c, d]," +
 				"[b  , c  , d  ]," +
-				"[b, c, d]]",
+				"[b, c, d]," +
+				"[2016-06-22T19:10:25, 2019-06-22T19:10:25]," +
+				"[2015-01-01, 2020-01-01]," +
+				"[00:51:03, 00:59:03]]",
 			results.toString());
 	}
 

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.flink.api.java.io.jdbc.catalog.PostgresCatalog.DEFAULT_DATABASE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -61,20 +62,20 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	public void testDbExists() throws Exception {
 		assertFalse(catalog.databaseExists("nonexistent"));
 
-		assertTrue(catalog.databaseExists(PostgresCatalog.DEFAULT_DATABASE));
+		assertTrue(catalog.databaseExists(DEFAULT_DATABASE));
 	}
 
 	// ------ tables ------
 
 	@Test
 	public void testListTables() throws DatabaseNotExistException {
-		List<String> actual = catalog.listTables(PostgresCatalog.DEFAULT_DATABASE);
+		List<String> actual = catalog.listTables(DEFAULT_DATABASE);
 
-		assertEquals(Arrays.asList("public.t1", "public.t4", "public.t5"), actual);
+		assertEquals(Arrays.asList("public.dt", "public.dt2", "public.t1", "public.t4", "public.t5"), actual);
 
 		actual = catalog.listTables(TEST_DB);
 
-		assertEquals(Arrays.asList("public.datatypes", "public.t2", "test_schema.t3"), actual);
+		assertEquals(Arrays.asList("public.t2", "test_schema.t3"), actual);
 	}
 
 	@Test
@@ -87,7 +88,7 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	public void testTableExists() {
 		assertFalse(catalog.tableExists(new ObjectPath(TEST_DB, "nonexist")));
 
-		assertTrue(catalog.tableExists(new ObjectPath(PostgresCatalog.DEFAULT_DATABASE, TABLE1)));
+		assertTrue(catalog.tableExists(new ObjectPath(DEFAULT_DATABASE, TABLE1)));
 		assertTrue(catalog.tableExists(new ObjectPath(TEST_DB, TABLE2)));
 		assertTrue(catalog.tableExists(new ObjectPath(TEST_DB, "test_schema.t3")));
 	}
@@ -140,9 +141,16 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	}
 
 	@Test
-	public void testDataTypes() throws TableNotExistException {
-		CatalogBaseTable table = catalog.getTable(new ObjectPath(TEST_DB, "datatypes"));
+	public void testPrimitiveDataTypes() throws TableNotExistException {
+		CatalogBaseTable table = catalog.getTable(new ObjectPath(DEFAULT_DATABASE, TABLE_PRIMITIVE_TYPE));
 
-		assertEquals(getDataTypesTable().schema, table.getSchema());
+		assertEquals(getPrimitiveTable().schema, table.getSchema());
+	}
+
+	@Test
+	public void tesArrayDataTypes() throws TableNotExistException {
+		CatalogBaseTable table = catalog.getTable(new ObjectPath(DEFAULT_DATABASE, TABLE_ARRAY_TYPE));
+
+		assertEquals(getArrayTable().schema, table.getSchema());
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -151,8 +151,7 @@ public class PostgresCatalogTestBase {
 		);
 	}
 
-	// TODO: add back timestamptz and time types.
-	//  Flink currently doens't support converting time's precision and PostgresDialect doesn't support timestamptz
+	// TODO: add back timestamptz once blink planner supports timestamp with timezone
 	public static TestTable getPrimitiveTable() {
 		return new TestTable(
 			TableSchema.builder()
@@ -171,7 +170,7 @@ public class PostgresCatalogTestBase {
 				.field("timestamp", DataTypes.TIMESTAMP(5))
 //				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
 				.field("date", DataTypes.DATE())
-//				.field("time", DataTypes.TIME())
+				.field("time", DataTypes.TIME(0))
 				.build(),
 			"int integer, " +
 				"bytea bytea, " +
@@ -187,8 +186,8 @@ public class PostgresCatalogTestBase {
 				"character_varying character varying(20), " +
 				"timestamp timestamp(5), " +
 //				"timestamptz timestamptz(4), " +
-				"date date",
-//				"time time, " +
+				"date date, " +
+				"time time(0)",
 			"1," +
 				"'2'," +
 				"3," +
@@ -203,13 +202,12 @@ public class PostgresCatalogTestBase {
 				"'d'," +
 				"'2016-06-22 19:10:25'," +
 //				"'2006-06-22 19:10:25',
-				"'2015-01-01'"
-//				"'00:51:02.746572',
+				"'2015-01-01'," +
+				"'00:51:02.746572'"
 		);
 	}
 
-	// TODO: add back timestamptz and time types.
-	//  Flink currently doens't support converting time's precision and PostgresDialect doesn't support timestamptz
+	// TODO: add back timestamptz once blink planner supports timestamp with timezone
 	public static TestTable getArrayTable() {
 		return new TestTable(
 			TableSchema.builder()
@@ -225,10 +223,10 @@ public class PostgresCatalogTestBase {
 				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
 				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
 				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
-//				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
+				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
 //				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
-//				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
-//				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME()))
+				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
+				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME(0)))
 				.build(),
 
 				"int_arr integer[], " +
@@ -242,11 +240,11 @@ public class PostgresCatalogTestBase {
 				"text_arr text[], " +
 				"char_arr char[], " +
 				"character_arr character(3)[], " +
-				"character_varying_arr character varying(20)[]",
-//				"timestamp_arr timestamp(5)[], " +
+				"character_varying_arr character varying(20)[], " +
+				"timestamp_arr timestamp(5)[], " +
 //				"timestamptz_arr timestamptz(4)[], " +
-//				"date_arr date[]",
-//				"time_arr time[]",
+				"date_arr date[], " +
+				"time_arr time(0)[]",
 
 				String.format("'{1,2,3}'," +
 				"'{2,3,4}'," +
@@ -259,11 +257,11 @@ public class PostgresCatalogTestBase {
 				"'{a,b,c}'," +
 				"'{b,c,d}'," +
 				"'{b,c,d}'," +
-				"'{b,c,d}'"
-//				"'{\"2016-06-22 19:10:25\", \"2019-06-22 19:10:25\"}'," +
+				"'{b,c,d}'," +
+				"'{\"2016-06-22 19:10:25\", \"2019-06-22 19:10:25\"}'," +
 //				"'{\"2006-06-22 19:10:25\", \"2009-06-22 19:10:25\"}'," +
-//				"'{\"2015-01-01\", \"2020-01-01\"}'"
-//				"'{\"00:51:02.746572\", \"00:59:02.746572\"}'");
+				"'{\"2015-01-01\", \"2020-01-01\"}'," +
+				"'{\"00:51:02.746572\", \"00:59:02.746572\"}'"
 		));
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -56,6 +56,8 @@ public class PostgresCatalogTestBase {
 	protected static final String TABLE3 = "t3";
 	protected static final String TABLE4 = "t4";
 	protected static final String TABLE5 = "t5";
+	protected static final String TABLE_PRIMITIVE_TYPE = "dt";
+	protected static final String TABLE_ARRAY_TYPE = "dt2";
 
 	protected static String baseUrl;
 	protected static PostgresCatalog catalog;
@@ -81,14 +83,18 @@ public class PostgresCatalogTestBase {
 		createTable(PostgresTablePath.fromFlinkTableName(TABLE4), getSimpleTable().pgSchemaSql);
 		createTable(PostgresTablePath.fromFlinkTableName(TABLE5), getSimpleTable().pgSchemaSql);
 
-		executeSQL(DEFAULT_DATABASE, String.format("insert into public.%s values (1);", TABLE1));
-
-		// table: testdb.public.t2
-		// table: testdb.test_schema.t3
-		// table: testdb.public.datatypes
+		// table: test.public.t2
+		// table: test.test_schema.t3
+		// table: postgres.public.dt
+		// table: postgres.public.dT2
 		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName(TABLE2), getSimpleTable().pgSchemaSql);
 		createTable(TEST_DB, new PostgresTablePath(TEST_SCHEMA, TABLE3), getSimpleTable().pgSchemaSql);
-		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName("datatypes"), getDataTypesTable().pgSchemaSql);
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE_PRIMITIVE_TYPE), getPrimitiveTable().pgSchemaSql);
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE_ARRAY_TYPE), getArrayTable().pgSchemaSql);
+
+		executeSQL(DEFAULT_DATABASE, String.format("insert into public.%s values (%s);", TABLE1, getSimpleTable().values));
+		executeSQL(DEFAULT_DATABASE, String.format("insert into %s values (%s);", TABLE_PRIMITIVE_TYPE, getPrimitiveTable().values));
+		executeSQL(DEFAULT_DATABASE, String.format("insert into %s values (%s);", TABLE_ARRAY_TYPE, getArrayTable().values));
 	}
 
 	public static void createTable(PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
@@ -126,10 +132,12 @@ public class PostgresCatalogTestBase {
 	public static class TestTable {
 		TableSchema schema;
 		String pgSchemaSql;
+		String values;
 
-		public TestTable(TableSchema schema, String pgSchemaSql) {
+		public TestTable(TableSchema schema, String pgSchemaSql, String values) {
 			this.schema = schema;
 			this.pgSchemaSql = pgSchemaSql;
+			this.values = values;
 		}
 	}
 
@@ -138,78 +146,124 @@ public class PostgresCatalogTestBase {
 			TableSchema.builder()
 				.field("id", DataTypes.INT())
 				.build(),
-			"id integer"
+			"id integer",
+			"1"
 		);
 	}
 
-	public static TestTable getDataTypesTable() {
+	// TODO: add back timestamptz and time types.
+	//  Flink currently doens't support converting time's precision and PostgresDialect doesn't support timestamptz
+	public static TestTable getPrimitiveTable() {
 		return new TestTable(
 			TableSchema.builder()
 				.field("int", DataTypes.INT())
-				.field("int_arr", DataTypes.ARRAY(DataTypes.INT()))
 				.field("bytea", DataTypes.BYTES())
-				.field("bytea_arr", DataTypes.ARRAY(DataTypes.BYTES()))
 				.field("short", DataTypes.SMALLINT())
-				.field("short_arr", DataTypes.ARRAY(DataTypes.SMALLINT()))
 				.field("long", DataTypes.BIGINT())
-				.field("long_arr", DataTypes.ARRAY(DataTypes.BIGINT()))
 				.field("real", DataTypes.FLOAT())
-				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
 				.field("double_precision", DataTypes.DOUBLE())
-				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
 				.field("numeric", DataTypes.DECIMAL(10, 5))
-				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
 				.field("boolean", DataTypes.BOOLEAN())
-				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
 				.field("text", DataTypes.STRING())
-				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
 				.field("char", DataTypes.CHAR(1))
-				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
 				.field("character", DataTypes.CHAR(3))
-				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
 				.field("character_varying", DataTypes.VARCHAR(20))
-				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
 				.field("timestamp", DataTypes.TIMESTAMP(5))
-				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
-				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
-				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
+//				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
 				.field("date", DataTypes.DATE())
-				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
-				.field("time", DataTypes.TIME(3))
-				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME(3)))
+//				.field("time", DataTypes.TIME())
 				.build(),
 			"int integer, " +
-				"int_arr integer[], " +
 				"bytea bytea, " +
-				"bytea_arr bytea[], " +
 				"short smallint, " +
-				"short_arr smallint[], " +
 				"long bigint, " +
-				"long_arr bigint[], " +
 				"real real, " +
-				"real_arr real[], " +
 				"double_precision double precision, " +
-				"double_precision_arr double precision[], " +
 				"numeric numeric(10, 5), " +
-				"numeric_arr numeric(10, 5)[], " +
 				"boolean boolean, " +
-				"boolean_arr boolean[], " +
 				"text text, " +
-				"text_arr text[], " +
 				"char char, " +
-				"char_arr char[], " +
 				"character character(3), " +
-				"character_arr character(3)[], " +
 				"character_varying character varying(20), " +
-				"character_varying_arr character varying(20)[], " +
 				"timestamp timestamp(5), " +
-				"timestamp_arr timestamp(5)[], " +
-				"timestamptz timestamptz(4), " +
-				"timestamptz_arr timestamptz(4)[], " +
-				"date date, " +
-				"date_arr date[], " +
-				"time time(3), " +
-				"time_arr time(3)[]"
+//				"timestamptz timestamptz(4), " +
+				"date date",
+//				"time time, " +
+			"1," +
+				"'2'," +
+				"3," +
+				"4," +
+				"5.5," +
+				"6.6," +
+				"7.7," +
+				"true," +
+				"'a'," +
+				"'b'," +
+				"'c'," +
+				"'d'," +
+				"'2016-06-22 19:10:25'," +
+//				"'2006-06-22 19:10:25',
+				"'2015-01-01'"
+//				"'00:51:02.746572',
 		);
+	}
+
+	// TODO: add back timestamptz and time types.
+	//  Flink currently doens't support converting time's precision and PostgresDialect doesn't support timestamptz
+	public static TestTable getArrayTable() {
+		return new TestTable(
+			TableSchema.builder()
+				.field("int_arr", DataTypes.ARRAY(DataTypes.INT()))
+				.field("bytea_arr", DataTypes.ARRAY(DataTypes.BYTES()))
+				.field("short_arr", DataTypes.ARRAY(DataTypes.SMALLINT()))
+				.field("long_arr", DataTypes.ARRAY(DataTypes.BIGINT()))
+				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
+				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
+				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
+				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
+				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
+				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
+				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
+				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
+//				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
+//				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
+//				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
+//				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME()))
+				.build(),
+
+				"int_arr integer[], " +
+				"bytea_arr bytea[], " +
+				"short_arr smallint[], " +
+				"long_arr bigint[], " +
+				"real_arr real[], " +
+				"double_precision_arr double precision[], " +
+				"numeric_arr numeric(10, 5)[], " +
+				"boolean_arr boolean[], " +
+				"text_arr text[], " +
+				"char_arr char[], " +
+				"character_arr character(3)[], " +
+				"character_varying_arr character varying(20)[]",
+//				"timestamp_arr timestamp(5)[], " +
+//				"timestamptz_arr timestamptz(4)[], " +
+//				"date_arr date[]",
+//				"time_arr time[]",
+
+				String.format("'{1,2,3}'," +
+				"'{2,3,4}'," +
+				"'{3,4,5}'," +
+				"'{4,5,6}'," +
+				"'{5.5,6.6,7.7}'," +
+				"'{6.6,7.7,8.8}'," +
+				"'{7.7,8.8,9.9}'," +
+				"'{true,false,true}'," +
+				"'{a,b,c}'," +
+				"'{b,c,d}'," +
+				"'{b,c,d}'," +
+				"'{b,c,d}'"
+//				"'{\"2016-06-22 19:10:25\", \"2019-06-22 19:10:25\"}'," +
+//				"'{\"2006-06-22 19:10:25\", \"2009-06-22 19:10:25\"}'," +
+//				"'{\"2015-01-01\", \"2020-01-01\"}'"
+//				"'{\"00:51:02.746572\", \"00:59:02.746572\"}'");
+		));
 	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -139,8 +139,16 @@ public final class StringUtils {
 		if (array instanceof long[]) {
 			return Arrays.toString((long[]) array);
 		}
-		if (array instanceof Object[]) {
-			return Arrays.toString((Object[]) array);
+		// for array of byte array
+		if (array instanceof byte[][]) {
+			byte[][] b = (byte[][]) array;
+			String[] strs = new String[b.length];
+
+			for (int i = 0; i < b.length; i++) {
+				strs[i] = Arrays.toString(b[i]);
+			}
+
+			return Arrays.toString(strs);
 		}
 		if (array instanceof byte[]) {
 			return Arrays.toString((byte[]) array);
@@ -159,6 +167,10 @@ public final class StringUtils {
 		}
 		if (array instanceof short[]) {
 			return Arrays.toString((short[]) array);
+		}
+		if (array instanceof Object[]) {
+			Object[] a = (Object[]) array;
+			return Arrays.toString((Object[]) array);
 		}
 
 		if (array.getClass().isArray()) {


### PR DESCRIPTION
## What is the purpose of the change

commit 1: make StringUtils.arrayToString() convert array of byte array correctly 
commit 2: fix bug that JDBCInputFormat doesn't correctly map Short
commit 3: extract jdbc row conversion logic to JDBCDialect as row conversion api
commit 4: add Postgres specific row conversion logic
commit 5: add e2e tests for reading from Postgres with JDBCTableSource and PostgresCatalog

## Brief change log

## Verifying this change
UT and IT added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
