### PR TITLE
[FLINK-16800][table-common] Deal with nested types in TypeMappingUtils#checkIfCompatible

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.utils;
 
-import com.sun.xml.internal.xsom.impl.scd.Iterators;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;


### PR DESCRIPTION
## What is the purpose of the change

the planner uses TypeMappingUtils#checkIfCompatible to validate logical schema and physical schema are compatible when translate CatalogSinkModifyOperation to Calcite relational expression.  The validation didn't deal with nested types well, which could throw a ValidationException. This PR fix that.

## Brief change log
- d2ad9f8 Deal with nested types in TypeMappingUtils#checkIfCompatible

## Verifying this change

This change is already covered by added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
