### PR TITLE
[FLINK-15416][network] add task manager netty client retry mechenism

### DIFF
--- a/docs/_includes/generated/all_taskmanager_network_section.html
+++ b/docs/_includes/generated/all_taskmanager_network_section.html
@@ -57,6 +57,12 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/docs/_includes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/_includes/generated/netty_shuffle_environment_configuration.html
@@ -75,6 +75,12 @@
             <td>The number of Netty client threads.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.retries</h5></td>
+            <td style="word-wrap: break-word;">0</td>
+            <td>Integer</td>
+            <td>The number of retry attempts for network communication. Currently it's only used for establishing input/output channel connections</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.netty.num-arenas</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -248,6 +248,14 @@ public class NettyShuffleEnvironmentOptions {
 			.withDescription("The Netty client connection timeout.");
 
 	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+	public static final ConfigOption<Integer> NETWORK_RETRIES =
+		key("taskmanager.network.retries")
+			.defaultValue(0)
+			.withDeprecatedKeys("taskmanager.network.retries")
+			.withDescription("The number of retry attempts for network communication." +
+				" Currently it's only used for establishing input/output channel connections");
+
+	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
 	public static final ConfigOption<Integer> SEND_RECEIVE_BUFFER_SIZE =
 		key("taskmanager.network.netty.sendReceiveBufferSize")
 			.defaultValue(0) // default: 0 => Netty's default

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -116,6 +116,10 @@ public class NettyConfig {
 		return config.getInteger(NettyShuffleEnvironmentOptions.CLIENT_CONNECT_TIMEOUT_SECONDS);
 	}
 
+	public int getNetworkRetries() {
+		return config.getInteger(NettyShuffleEnvironmentOptions.NETWORK_RETRIES);
+	}
+
 	public int getSendAndReceiveBufferSize() {
 		return config.getInteger(NettyShuffleEnvironmentOptions.SEND_RECEIVE_BUFFER_SIZE);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConnectionManager.java
@@ -49,7 +49,7 @@ public class NettyConnectionManager implements ConnectionManager {
 		this.client = new NettyClient(nettyConfig);
 		this.bufferPool = new NettyBufferPool(nettyConfig.getNumberOfArenas());
 
-		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client);
+		this.partitionRequestClientFactory = new PartitionRequestClientFactory(client, nettyConfig.getNetworkRetries());
 
 		this.nettyProtocol = new NettyProtocol(checkNotNull(partitionProvider), checkNotNull(taskEventPublisher));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -85,6 +85,8 @@ class PartitionRequestClientFactory {
 				}
 			});
 
+			// Make sure to increment the reference count before handing a client
+			// out to ensure correct bookkeeping for channel closing.
 			if (!client.incrementReferenceCounter()) {
 				destroyPartitionRequestClient(connectionId, client);
 				client = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -19,11 +19,11 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
-import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 import org.apache.flink.util.NetUtils;
 
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -21,8 +21,11 @@ package org.apache.flink.runtime.io.network.netty;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.util.NetUtils;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -39,18 +42,24 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
-@Ignore
 public class PartitionRequestClientFactoryTest {
 
 	private final static int SERVER_PORT = NetUtils.getAvailablePort();
 
-	@Test
+	@Ignore
 	public void testResourceReleaseAfterInterruptedConnect() throws Exception {
 
 		// Latch to synchronize on the connect call.
@@ -127,6 +136,130 @@ public class PartitionRequestClientFactoryTest {
 			if (client != null) {
 				client.shutdown();
 			}
+		}
+	}
+
+	@Test
+	public void testNettyClientConnectRetry() throws Exception {
+		NettyTestUtil.NettyServerAndClient serverAndClient = createNettyServerAndClient();
+		UnstableNettyClient unstableNettyClient = new UnstableNettyClient(serverAndClient.client(), 2);
+
+		PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
+		ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
+			serverAndClient.server().getConfig().getServerPort()), 0);
+
+		factory.createPartitionRequestClient(serverAddress);
+
+		serverAndClient.client().shutdown();
+		serverAndClient.server().shutdown();
+	}
+
+	@Test(expected = CompletionException.class)
+	public void testNettyClientConnectRetryFailure() throws Exception {
+		NettyTestUtil.NettyServerAndClient serverAndClient = createNettyServerAndClient();
+		UnstableNettyClient unstableNettyClient = new UnstableNettyClient(serverAndClient.client(), 3);
+
+		try {
+			PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
+			ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
+				serverAndClient.server().getConfig().getServerPort()), 0);
+
+			factory.createPartitionRequestClient(serverAddress);
+
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			serverAndClient.client().shutdown();
+			serverAndClient.server().shutdown();
+		}
+	}
+
+	@Test
+	public void testNettyClientConnectRetryMultipleThread() throws Exception {
+		NettyTestUtil.NettyServerAndClient serverAndClient = createNettyServerAndClient();
+		UnstableNettyClient unstableNettyClient = new UnstableNettyClient(serverAndClient.client(), 2);
+
+		PartitionRequestClientFactory factory = new PartitionRequestClientFactory(unstableNettyClient, 2);
+		ConnectionID serverAddress = new ConnectionID(new InetSocketAddress(InetAddress.getLocalHost(),
+			serverAndClient.server().getConfig().getServerPort()), 0);
+
+		ExecutorService threadPoolExecutor = Executors.newFixedThreadPool(10);
+		List<Future<NettyPartitionRequestClient>> futures = new ArrayList<>();
+
+		for (int i = 0; i < 10; i++) {
+			Future<NettyPartitionRequestClient> future = threadPoolExecutor.submit(new Callable<NettyPartitionRequestClient>() {
+				@Override
+				public NettyPartitionRequestClient call() {
+					NettyPartitionRequestClient client = null;
+					try {
+						client = factory.createPartitionRequestClient(serverAddress);
+					} catch (Exception e) {
+						// catch exception
+						System.out.println(e.getMessage());
+						fail();
+					}
+					return client;
+				}
+			});
+
+			futures.add(future);
+		}
+
+		futures.forEach(runnableFuture -> {
+			NettyPartitionRequestClient client = null;
+			try {
+				client = runnableFuture.get();
+				System.out.println("Result = " + client == null ? "null" : client.toString());
+				assertNotNull(client);
+			} catch (Exception e) {
+				System.out.println(e.getMessage());
+				 fail();
+			}
+		});
+
+		threadPoolExecutor.shutdown();
+		serverAndClient.client().shutdown();
+		serverAndClient.server().shutdown();
+	}
+
+	private NettyTestUtil.NettyServerAndClient createNettyServerAndClient() throws Exception {
+		NettyTestUtil.NettyServerAndClient serverAndClient = NettyTestUtil.initServerAndClient(
+			new NettyProtocol(null, null) {
+
+				@Override
+				public ChannelHandler[] getServerChannelHandlers () {
+					return new ChannelHandler[10];
+				}
+
+				@Override
+				public ChannelHandler[] getClientChannelHandlers () {
+					return new ChannelHandler[]{mock(NetworkClientHandler.class)};
+				}
+			});
+
+		return serverAndClient;
+	}
+
+	private static class UnstableNettyClient extends NettyClient {
+
+		private NettyClient nettyClient;
+
+		private int retry;
+
+		public UnstableNettyClient(NettyClient nettyClient, int retry) {
+			super(null);
+			this.nettyClient = nettyClient;
+			this.retry = retry;
+		}
+
+		@Override
+		ChannelFuture connect(final InetSocketAddress serverSocketAddress) {
+			if (retry > 0) {
+				retry--;
+				throw new ChannelException("Simulate connect failure");
+			}
+
+			return nettyClient.connect(serverSocketAddress);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change
Add retry logic for netty client creation in PartitionRequestClientFactory. It is useful to make flink runtime tolerant physical link issue in the switch. 

## Brief changelog

  - Add a netty client retry config
  - Add retry logic in PartitionRequestClientFactory for building new channel.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
