### PR TITLE
[FLINK-16821][e2e] Use constant minikube version instead of latest

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -39,7 +39,7 @@ function setup_kubernetes_for_linux {
     # Download minikube.
     if ! [ -x "$(command -v minikube)" ]; then
         echo "Installing minikube ..."
-        curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
+        curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.8.2/minikube-linux-amd64 && \
             chmod +x minikube && sudo mv minikube /usr/local/bin/
     fi
 }


### PR DESCRIPTION

## What is the purpose of the change

The Kubernetes e2e test suddenly started failing. 
The cause was that there's a new minikube version, which has a changed behavior. 


## Brief change log

- Use a fixed minikube version instead of latest

