### PR TITLE
[FLINK-16727][table-planner-blink] Fix cast exception when having time point literal as parameters

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarFunctionCallGen.scala
@@ -47,14 +47,6 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
       operands: Seq[GeneratedExpression],
       returnType: LogicalType): GeneratedExpression = {
     val operandTypes = operands.map(_.resultType).toArray
-    val arguments = operands.map {
-      case expr if expr.literal =>
-        getConverterForDataType(fromLogicalTypeToDataType(expr.resultType))
-            .asInstanceOf[DataFormatConverters.DataFormatConverter[Any, Any]]
-            .toExternal(expr.literalValue.get)
-            .asInstanceOf[AnyRef]
-      case _ => null
-    }.toArray
     // determine function method and result class
     val resultClass = getResultTypeClassOfScalarFunction(scalarFunction, operandTypes)
 
@@ -71,7 +63,7 @@ class ScalarFunctionCallGen(scalarFunction: ScalarFunction) extends CallGenerato
     val resultTerm = ctx.addReusableLocalVariable(resultTypeTerm, "result")
     val evalResult = s"$functionReference.eval(${parameters.map(_.resultTerm).mkString(", ")})"
     val resultExternalType = UserDefinedFunctionUtils.getResultTypeOfScalarFunction(
-      scalarFunction, arguments, operandTypes)
+      scalarFunction, operandTypes)
     val setResult = {
       if (resultClass.isPrimitive && isInternalClass(resultExternalType)) {
         s"$resultTerm = $evalResult;"

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/expressions/call.scala
@@ -179,7 +179,6 @@ case class PlannerScalarFunctionCall(
   override private[flink] def resultType =
     fromDataTypeToTypeInfo(getResultTypeOfScalarFunction(
       scalarFunction,
-      Array(),
       signature))
 
   override private[flink] def validateInput(): ValidationResult = {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
@@ -80,20 +80,8 @@ object ScalarSqlFunction {
       */
     new SqlReturnTypeInference {
       override def inferReturnType(opBinding: SqlOperatorBinding): RelDataType = {
-        val sqlTypes = opBinding.collectOperandTypes().asScala.toArray
         val parameters = getOperandType(opBinding).toArray
-
-        val arguments = sqlTypes.indices.map(i =>
-          if (opBinding.isOperandNull(i, false)) {
-            null
-          } else if (opBinding.isOperandLiteral(i, false)) {
-            opBinding.getOperandLiteralValue(
-              i, getDefaultExternalClassForType(parameters(i))).asInstanceOf[AnyRef]
-          } else {
-            null
-          }
-        ).toArray
-        val resultType = getResultTypeOfScalarFunction(scalarFunction, arguments, parameters)
+        val resultType = getResultTypeOfScalarFunction(scalarFunction, parameters)
         typeFactory.createFieldTypeFromLogicalType(
           fromDataTypeToLogicalType(resultType))
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/functions/utils/UserDefinedFunctionUtils.scala
@@ -615,7 +615,6 @@ object UserDefinedFunctionUtils {
 
   def getResultTypeOfScalarFunction(
       function: ScalarFunction,
-      arguments: Array[AnyRef],
       argTypes: Array[LogicalType]): DataType = {
     val userDefinedTypeInfo = function.getResultType(getEvalMethodSignature(function, argTypes))
     if (userDefinedTypeInfo != null) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/UserDefinedScalarFunctionTest.scala
@@ -25,24 +25,16 @@ import org.apache.flink.table.api.{DataTypes, Types, ValidationException}
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.expressions.utils.{ExpressionTestBase, _}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions._
+import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.{DateFunction, DateTimeFunction, LocalDateFunction, LocalTimeFunction, TimeFunction, TimestampFunction}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil
 import org.apache.flink.types.Row
+
 import org.junit.Test
+
 import java.lang.{Boolean => JBoolean}
 import java.time.ZoneId
 
 class UserDefinedScalarFunctionTest extends ExpressionTestBase {
-
-  @Test
-  def test(): Unit = {
-    val JavaFunc1 = new JavaFunc1()
-
-    testAllApis(
-      JavaFunc1(nullOf(DataTypes.TIME), 15, nullOf(DataTypes.TIMESTAMP(3))),
-      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
-      "JavaFunc1(NULL, 15, NULL)",
-      "null and 15 and null")
-  }
 
   @Test
   def testParameters(): Unit = {
@@ -154,6 +146,13 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func0(Null(INT))",
       "Func0(NULL)",
       "-1")
+
+    val JavaFunc1 = new JavaFunc1()
+    testAllApis(
+      JavaFunc1(nullOf(DataTypes.TIME), 15, nullOf(DataTypes.TIMESTAMP(3))),
+      "JavaFunc1(Null(SQL_TIME), 15, Null(SQL_TIMESTAMP))",
+      "JavaFunc1(NULL, 15, NULL)",
+      "null and 15 and null")
   }
 
   @Test
@@ -255,6 +254,16 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
       "Func26(f6)",
       "Func26(f6)",
       "1990-10-14 12:10:10.000")
+  }
+
+  @Test
+  def testLiteralTemporalParameters(): Unit = {
+    testSqlApi("DateFunction(DATE '2020-03-27')", "2020-03-27")
+    testSqlApi("LocalDateFunction(DATE '2020-03-27')", "2020-03-27")
+    testSqlApi("TimeFunction(TIME '18:30:55')", "18:30:55")
+    testSqlApi("LocalTimeFunction(TIME '18:30:55')", "18:30:55")
+    testSqlApi("DateTimeFunction(TIMESTAMP '2020-03-27 18:30:55')", "2020-03-27T18:30:55")
+    testSqlApi("TimestampFunction(TIMESTAMP '2020-03-27 18:30:55')", "2020-03-27 18:30:55.0")
   }
 
   @Test
@@ -565,7 +574,13 @@ class UserDefinedScalarFunctionTest extends ExpressionTestBase {
     "JavaFunc4" -> new JavaFunc4,
     "RichFunc0" -> new RichFunc0,
     "RichFunc1" -> new RichFunc1,
-    "RichFunc2" -> new RichFunc2
+    "RichFunc2" -> new RichFunc2,
+    "DateFunction" -> DateFunction,
+    "LocalDateFunction" -> LocalDateFunction,
+    "TimeFunction" -> TimeFunction,
+    "LocalTimeFunction" -> LocalTimeFunction,
+    "DateTimeFunction" -> DateTimeFunction,
+    "TimestampFunction" -> TimestampFunction
   )
 }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix cast exception when having time point literal as parameters. For example,  the query `select func(DATE '2020-03-27') as a from source` will throw:

```
java.lang.AssertionError: cannot cast 2020-03-27 as class java.time.LocalDate

	at org.apache.calcite.sql.SqlLiteral.getValueAs(SqlLiteral.java:351)
	at org.apache.calcite.sql.SqlCallBinding.getOperandLiteralValue(SqlCallBinding.java:217)
	at org.apache.flink.table.planner.functions.utils.ScalarSqlFunction$$anon$1$$anonfun$1.apply(ScalarSqlFunction.scala:90)
	at org.apache.flink.table.planner.functions.utils.ScalarSqlFunction$$anon$1$$anonfun$1.apply(ScalarSqlFunction.scala:86)
```

The root cause is the literal parameter extraction in `ScalarSqlFunction#SqlReturnTypeInference`, however the extracted literal parameter is never used... So we can simply remove them. 

## Brief change log

- remove the literal paramter extraction logic

## Verifying this change

- add test in `UserDefinedScalarFunctionTest#testLiteralTemporalParameters`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
