### PR TITLE
Fix typo in RocksDBStateUploader

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploader.java
@@ -81,7 +81,7 @@ public class RocksDBStateUploader extends RocksDBStateDataTransfer {
 			if (throwable instanceof IOException) {
 				throw (IOException) throwable;
 			} else {
-				throw new FlinkRuntimeException("Failed to download data for state handles.", e);
+				throw new FlinkRuntimeException("Failed to upload data for state handles.", e);
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

Fix typo in exception message in RocksDBStateUploader

## Brief change log

Fix typo in exception message in RocksDBStateUploader

## Verifying this change

N/A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
