### PR TITLE
[FLINK-16576][state backends] Correct the logic of KeyGroupStateHandle#getIntersection

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -460,8 +461,9 @@ public class StateAssignmentOperation {
 	/**
 	 * Extracts certain key group ranges from the given state handles and adds them to the collector.
 	 */
-	private static void extractIntersectingState(
-			Collection<KeyedStateHandle> originalSubtaskStateHandles,
+	@VisibleForTesting
+	public static void extractIntersectingState(
+			Collection<? extends KeyedStateHandle> originalSubtaskStateHandles,
 			KeyGroupRange rangeToExtract,
 			List<KeyedStateHandle> extractedStateCollector) {
 
@@ -618,29 +620,6 @@ public class StateAssignmentOperation {
 			oldParallelism,
 			newParallelism);
 		}
-
-	/**
-	 * Determine the subset of {@link KeyGroupsStateHandle KeyGroupsStateHandles} with correct
-	 * key group index for the given subtask {@link KeyGroupRange}.
-	 *
-	 * <p>This is publicly visible to be used in tests.
-	 */
-	public static List<KeyedStateHandle> getKeyedStateHandles(
-			Collection<? extends KeyedStateHandle> keyedStateHandles,
-			KeyGroupRange subtaskKeyGroupRange) {
-
-		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>(keyedStateHandles.size());
-
-		for (KeyedStateHandle keyedStateHandle : keyedStateHandles) {
-			KeyedStateHandle intersectedKeyedStateHandle = keyedStateHandle.getIntersection(subtaskKeyGroupRange);
-
-			if (intersectedKeyedStateHandle != null) {
-				subtaskKeyedStateHandles.add(intersectedKeyedStateHandle);
-			}
-		}
-
-		return subtaskKeyedStateHandles;
-	}
 
 	static <T extends AbstractChannelStateHandle<?>> OperatorStateRepartitioner<T> channelStateNonRescalingRepartitioner(String logStateName) {
 		return (previousParallelSubtaskStates, oldParallelism, newParallelism) -> {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -83,8 +83,13 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
 	 * @return key-group state over a range that is the intersection between this handle's key-group range and the
 	 *          provided key-group range.
 	 */
+	@Override
 	public KeyGroupsStateHandle getIntersection(KeyGroupRange keyGroupRange) {
-		return new KeyGroupsStateHandle(groupRangeOffsets.getIntersection(keyGroupRange), stateHandle);
+		KeyGroupRangeOffsets offsets = groupRangeOffsets.getIntersection(keyGroupRange);
+		if (offsets.getKeyGroupRange().getNumberOfKeyGroups() <= 0) {
+			return null;
+		}
+		return new KeyGroupsStateHandle(offsets, stateHandle);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import javax.annotation.Nullable;
+
 /**
  * Base for the handles of the checkpointed states in keyed streams. When
  * recovering from failures, the handle will be passed to all tasks whose key
@@ -34,7 +36,9 @@ public interface KeyedStateHandle extends CompositeStateHandle {
 	 * Returns a state over a range that is the intersection between this
 	 * handle's key-group range and the provided key-group range.
 	 *
-	 * @param keyGroupRange The key group range to intersect with
+	 * @param keyGroupRange The key group range to intersect with,
+	 * will return null if the intersection of this handle's key-group and the provided key-group is empty.
 	 */
+	@Nullable
 	KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -103,7 +103,6 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 	@Override
 	public Void restore() throws Exception {
 
-		final Map<Integer, StateMetaInfoSnapshot> kvStatesById = new HashMap<>();
 		registeredKVStates.clear();
 		registeredPQStates.clear();
 
@@ -147,6 +146,8 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 
 				List<StateMetaInfoSnapshot> restoredMetaInfos =
 					serializationProxy.getStateMetaInfoSnapshots();
+
+				final Map<Integer, StateMetaInfoSnapshot> kvStatesById = new HashMap<>();
 
 				createOrCheckStateForMetaInfo(restoredMetaInfos, kvStatesById);
 
@@ -198,9 +199,8 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 						metaInfoSnapshot.getBackendStateType() + ".");
 			}
 
-			if (registeredState == null) {
-				kvStatesById.put(kvStatesById.size(), metaInfoSnapshot);
-			}
+			// always put metaInfo into kvStatesById, because kvStatesById is KeyGroupsStateHandle related
+			kvStatesById.put(kvStatesById.size(), metaInfoSnapshot);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * A test for {@link KeyGroupsStateHandle}
+ */
+public class KeyGroupsStateHandleTest {
+
+	@Test
+	public void testNonEmptyIntersection() {
+		KeyGroupRangeOffsets offsets = new KeyGroupRangeOffsets(0, 7);
+		byte[] dummy = new byte[10];
+		StreamStateHandle streamHandle = new ByteStreamStateHandle("test", dummy);
+		KeyGroupsStateHandle handle = new KeyGroupsStateHandle(offsets, streamHandle);
+
+		KeyGroupRange expectedRange = new KeyGroupRange(0, 3);
+		KeyGroupsStateHandle newHandle = handle.getIntersection(expectedRange);
+		assertNotNull(newHandle);
+		assertEquals(streamHandle, newHandle.getDelegateStateHandle());
+		assertEquals(expectedRange, newHandle.getKeyGroupRange());
+	}
+
+	@Test
+	public void testEmptyIntersection() {
+		KeyGroupRangeOffsets offsets = new KeyGroupRangeOffsets(0, 7);
+		byte[] dummy = new byte[10];
+		StreamStateHandle streamHandle = new ByteStreamStateHandle("test", dummy);
+		KeyGroupsStateHandle handle = new KeyGroupsStateHandle(offsets, streamHandle);
+		// return null if the the keygroup intersection is empty.
+		KeyGroupRange newRange = new KeyGroupRange(8, 11);
+		assertNull(handle.getIntersection(newRange));
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -2991,13 +2991,17 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			backend.snapshot(0, 0, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
 			sharedStateRegistry);
 
-		List<KeyedStateHandle> firstHalfKeyGroupStates = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> firstHalfKeyGroupStates = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 				Collections.singletonList(snapshot),
-				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 0));
+				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 0),
+				firstHalfKeyGroupStates);
 
-		List<KeyedStateHandle> secondHalfKeyGroupStates = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> secondHalfKeyGroupStates = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 				Collections.singletonList(snapshot),
-				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 1));
+				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 1),
+				secondHalfKeyGroupStates);
 
 		backend.dispose();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -115,6 +115,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -2944,102 +2945,149 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 	 * This test verifies that state is correctly assigned to key groups and that restore
 	 * restores the relevant key groups in the backend.
 	 *
-	 * <p>We have ten key groups. Initially, one backend is responsible for all ten key groups.
-	 * Then we snapshot, split up the state and restore in to backends where each is responsible
-	 * for five key groups. Then we make sure that the state is only available in the correct
-	 * backend.
-	 * @throws Exception
+	 * <p>We have 128 key groups. Initially, four backends with different states are responsible for all the key groups equally.
+	 * Different backends for the same operator may contains different states if we create the state in runtime (such as {@link DeltaTrigger#onElement}
+	 * Then we snapshot, split up the state and restore into 2 backends where each is responsible
+	 * for 64 key groups. Then we make sure that the state is only available in the correct backend.
 	 */
 	@Test
-	public void testKeyGroupSnapshotRestore() throws Exception {
-		final int MAX_PARALLELISM = 10;
+	public void testKeyGroupSnapshotRestoreScaleDown() throws Exception {
+		testKeyGroupSnapshotRestore(4, 2, 128);
+	}
+
+	/**
+	 * This test verifies that state is correctly assigned to key groups and that restore
+	 * restores the relevant key groups in the backend.
+	 *
+	 * <p>We have 128 key groups. Initially, two backends with different states are responsible for all the key groups equally.
+	 * Different backends for the same operator may contains different states if we create the state in runtime (such as {@link DeltaTrigger#onElement}
+	 * Then we snapshot, split up the state and restore into 4 backends where each is responsible
+	 * for 32 key groups. Then we make sure that the state is only available in the correct backend.
+	 */
+	@Test
+	public void testKeyGroupSnapshotRestoreScaleUp() throws Exception {
+		testKeyGroupSnapshotRestore(2, 4, 128);
+	}
+
+	/**
+	 * This test verifies that state is correctly assigned to key groups and that restore
+	 * restores the relevant key groups in the backend.
+	 *
+	 * <p>We have 128 key groups. Initially, two backends with different states are responsible for all the key groups equally.
+	 * Different backends for the same operator may contains different states if we create the state in runtime (such as {@link DeltaTrigger#onElement}
+	 * Then we snapshot, split up the state and restore into 2 backends where each is responsible
+	 * for 64 key groups. Then we make sure that the state is only available in the correct backend.
+	 */
+	@Test
+	public void testKeyGroupsSnapshotRestoreNoRescale() throws Exception {
+		testKeyGroupSnapshotRestore(2, 2, 128);
+	}
+
+	/**
+	 * Similar with testKeyGroupSnapshotRestoreScaleUp, but the KeyGroups were distributed unevenly.
+	 */
+	@Test
+	public void testKeyGroupsSnapshotRestoreScaleUpUnEvenDistribute() throws Exception {
+		testKeyGroupSnapshotRestore(15, 77, 128);
+	}
+
+	/**
+	 * Similar with testKeyGroupSnapshotRestoreScaleDown, but the KeyGroups were distributed unevenly.
+	 */
+	@Test
+	public void testKeyGroupsSnapshotRestoreScaleDownUnEvenDistribute() throws Exception {
+		testKeyGroupSnapshotRestore(77, 15, 128);
+	}
+
+	private void testKeyGroupSnapshotRestore(int sourceParallelism, int targetParallelism, int maxParallelism) throws Exception {
+		checkArgument(sourceParallelism > 0, "parallelism must be positive, current is %s.", sourceParallelism);
+		checkArgument(targetParallelism > 0, "parallelism must be positive, current is %s.", targetParallelism);
+		checkArgument(sourceParallelism <= maxParallelism, "Maximum parallelism must not be smaller than parallelism.");
+		checkArgument(targetParallelism <= maxParallelism, "Maximum parallelism must not be smaller than parallelism.");
+
+		Random random = new Random();
 
 		CheckpointStreamFactory streamFactory = createStreamFactory();
 		SharedStateRegistry sharedStateRegistry = new SharedStateRegistry();
-		final AbstractKeyedStateBackend<Integer> backend = createKeyedBackend(
-				IntSerializer.INSTANCE,
-				MAX_PARALLELISM,
-				new KeyGroupRange(0, MAX_PARALLELISM - 1),
-				env);
-
-		ValueStateDescriptor<String> kvId = new ValueStateDescriptor<>("id", String.class);
-
-		ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
-
-		// keys that fall into the first half/second half of the key groups, respectively
-		int keyInFirstHalf = 17;
-		int keyInSecondHalf = 42;
-		Random rand = new Random(0);
-
-		// for each key, determine into which half of the key-group space they fall
-		int firstKeyHalf = KeyGroupRangeAssignment.assignKeyToParallelOperator(keyInFirstHalf, MAX_PARALLELISM, 2);
-		int secondKeyHalf = KeyGroupRangeAssignment.assignKeyToParallelOperator(keyInFirstHalf, MAX_PARALLELISM, 2);
-
-		while (firstKeyHalf == secondKeyHalf) {
-			keyInSecondHalf = rand.nextInt();
-			secondKeyHalf = KeyGroupRangeAssignment.assignKeyToParallelOperator(keyInSecondHalf, MAX_PARALLELISM, 2);
+		List<KeyGroupRange> keyGroupRanges = new ArrayList<>();
+		List<AbstractKeyedStateBackend<Integer>> stateBackends = new ArrayList<>();
+		for (int i = 0; i < sourceParallelism; ++i) {
+			keyGroupRanges.add(KeyGroupRange.of(maxParallelism * i / sourceParallelism, maxParallelism * (i + 1) / sourceParallelism - 1));
+			stateBackends.add(createKeyedBackend(IntSerializer.INSTANCE, maxParallelism, keyGroupRanges.get(i), env));
 		}
 
-		backend.setCurrentKey(keyInFirstHalf);
-		state.update("ShouldBeInFirstHalf");
+		List<ValueStateDescriptor<String>> stateDescriptors = new ArrayList<>(maxParallelism);
 
-		backend.setCurrentKey(keyInSecondHalf);
-		state.update("ShouldBeInSecondHalf");
+		for (int i = 0; i < maxParallelism; ++i) {
+			// all states have different name to mock that all the parallelisms of one operator have different states.
+			stateDescriptors.add(new ValueStateDescriptor<>("state" + i, String.class));
+		}
 
+		List<Integer> keyInKeyGroups = new ArrayList<>(maxParallelism);
+		List<String> expectedValue = new ArrayList<>(maxParallelism);
+		for (int i = 0; i < sourceParallelism; ++i) {
+			AbstractKeyedStateBackend<Integer> backend = stateBackends.get(i);
+			KeyGroupRange range = keyGroupRanges.get(i);
+			for (int j = range.getStartKeyGroup(); j <= range.getEndKeyGroup(); ++j) {
+				ValueState<String> state = backend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptors.get(j));
+				int keyInKeyGroup = getKeyInKeyGroup(random, maxParallelism, KeyGroupRange.of(j, j));
+				backend.setCurrentKey(keyInKeyGroup);
+				keyInKeyGroups.add(keyInKeyGroup);
+				String updateValue = i + ":" + j;
+				state.update(updateValue);
+				expectedValue.add(updateValue);
+			}
+		}
 
-		KeyedStateHandle snapshot = runSnapshot(
-			backend.snapshot(0, 0, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
-			sharedStateRegistry);
+		// snapshot
+		List<KeyedStateHandle> snapshots = new ArrayList<>(sourceParallelism);
+		for (int i = 0; i < sourceParallelism; ++i) {
+			snapshots.add(
+				runSnapshot(stateBackends.get(i).snapshot(0, 0, streamFactory, CheckpointOptions.forCheckpointWithDefaultLocation()),
+				sharedStateRegistry));
+		}
 
-		List<KeyedStateHandle> firstHalfKeyGroupStates = new ArrayList<>();
-		StateAssignmentOperation.extractIntersectingState(
-				Collections.singletonList(snapshot),
-				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 0),
-				firstHalfKeyGroupStates);
+		for (int i = 0; i < sourceParallelism; ++i) {
+			stateBackends.get(i).dispose();
+		}
 
-		List<KeyedStateHandle> secondHalfKeyGroupStates = new ArrayList<>();
-		StateAssignmentOperation.extractIntersectingState(
-				Collections.singletonList(snapshot),
-				KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(MAX_PARALLELISM, 2, 1),
-				secondHalfKeyGroupStates);
+		// redistribute the stateHandle
+		List<KeyGroupRange> keyGroupRangesRestore = new ArrayList<>();
+		for (int i = 0; i < targetParallelism; ++i) {
+			keyGroupRangesRestore.add(KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(maxParallelism, targetParallelism, i));
+		}
+		List<List<KeyedStateHandle>> keyGroupStatesAfterDistribute = new ArrayList<>(targetParallelism);
+		for (int i = 0; i < targetParallelism; ++i) {
+			List<KeyedStateHandle> keyedStateHandles = new ArrayList<>();
+			StateAssignmentOperation.extractIntersectingState(
+				snapshots,
+				keyGroupRangesRestore.get(i),
+				keyedStateHandles);
+			keyGroupStatesAfterDistribute.add(keyedStateHandles);
+		}
 
-		backend.dispose();
+		// restore and verify
+		List<AbstractKeyedStateBackend<Integer>> targetBackends = new ArrayList<>(targetParallelism);
 
-		// backend for the first half of the key group range
-		final AbstractKeyedStateBackend<Integer> firstHalfBackend = restoreKeyedBackend(
+		for (int i = 0; i < targetParallelism; ++i) {
+			AbstractKeyedStateBackend<Integer> backend = restoreKeyedBackend(
 				IntSerializer.INSTANCE,
-				MAX_PARALLELISM,
-				new KeyGroupRange(0, 4),
-				firstHalfKeyGroupStates,
+				maxParallelism,
+				keyGroupRangesRestore.get(i),
+				keyGroupStatesAfterDistribute.get(i),
 				env);
+			targetBackends.add(backend);
+			KeyGroupRange range = keyGroupRangesRestore.get(i);
+			for (int j = range.getStartKeyGroup(); j <= range.getEndKeyGroup(); ++j) {
+				ValueState<String> state = targetBackends.get(i).getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptors.get(j));
+				backend.setCurrentKey(keyInKeyGroups.get(j));
+				assertEquals(expectedValue.get(j), state.value());
+			}
+		}
 
-		// backend for the second half of the key group range
-		final AbstractKeyedStateBackend<Integer> secondHalfBackend = restoreKeyedBackend(
-				IntSerializer.INSTANCE,
-				MAX_PARALLELISM,
-				new KeyGroupRange(5, 9),
-				secondHalfKeyGroupStates,
-				env);
-
-
-		ValueState<String> firstHalfState = firstHalfBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
-
-		firstHalfBackend.setCurrentKey(keyInFirstHalf);
-		assertTrue(firstHalfState.value().equals("ShouldBeInFirstHalf"));
-
-		firstHalfBackend.setCurrentKey(keyInSecondHalf);
-		assertTrue(firstHalfState.value() == null);
-
-		ValueState<String> secondHalfState = secondHalfBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, kvId);
-
-		secondHalfBackend.setCurrentKey(keyInFirstHalf);
-		assertTrue(secondHalfState.value() == null);
-
-		secondHalfBackend.setCurrentKey(keyInSecondHalf);
-		assertTrue(secondHalfState.value().equals("ShouldBeInSecondHalf"));
-
-		firstHalfBackend.dispose();
-		secondHalfBackend.dispose();
+		for (int i = 0; i < targetParallelism; ++i) {
+			targetBackends.get(i).dispose();
+		}
 	}
 
 	@Test
@@ -4037,6 +4085,19 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
 			return completableFuture;
 		}
 		return CompletableFuture.completedFuture(snapshotRunnableFuture.get());
+	}
+
+	/**
+	 * Returns an Integer key in specified keyGroupRange.
+	 */
+	private int getKeyInKeyGroup(Random random, int maxParallelism, KeyGroupRange keyGroupRange) {
+		int keyInKG = random.nextInt();
+		int kg = KeyGroupRangeAssignment.assignToKeyGroup(keyInKG, maxParallelism);
+		while (!keyGroupRange.contains(kg)) {
+			keyInKG = random.nextInt();
+			kg = KeyGroupRangeAssignment.assignToKeyGroup(keyInKG, maxParallelism);
+		}
+		return keyInKG;
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -417,13 +417,17 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 		KeyGroupRange localKeyGroupRange = keyGroupPartitions.get(subtaskIndex);
 
-		List<KeyedStateHandle> localManagedKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> localManagedKeyGroupState = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 			operatorStateHandles.getManagedKeyedState(),
-			localKeyGroupRange);
+			localKeyGroupRange,
+			localManagedKeyGroupState);
 
-		List<KeyedStateHandle> localRawKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> localRawKeyGroupState = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 			operatorStateHandles.getRawKeyedState(),
-			localKeyGroupRange);
+			localKeyGroupRange,
+			localRawKeyGroupState);
 
 		StateObjectCollection<OperatorStateHandle> managedOperatorStates = operatorStateHandles.getManagedOperatorState();
 		Collection<OperatorStateHandle> localManagedOperatorState;


### PR DESCRIPTION


## What is the purpose of the change

This pr will return null if the handler's key-group does not have any intersection with the given key-group range.


## Verifying this change


This change added tests and can be verified as follows:

- `KeyGroupsStateHandleTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
