### PR TITLE
[FLINK-16847][python] Support timestamp types in vectorized Python UDF

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl.py
+++ b/flink-python/pyflink/fn_execution/coder_impl.py
@@ -23,11 +23,12 @@ from typing import Any
 from typing import Generator
 from typing import List
 
+import pandas as pd
 import pyarrow as pa
 from apache_beam.coders.coder_impl import StreamCoderImpl, create_InputStream, create_OutputStream
 
 from pyflink.fn_execution.ResettableIO import ResettableIO
-from pyflink.table.types import Row
+from pyflink.table.types import Row, DataType, LocalZonedTimestampType
 
 
 class FlattenRowCoderImpl(StreamCoderImpl):
@@ -420,8 +421,10 @@ class LocalZonedTimestampCoderImpl(TimestampCoderImpl):
 
 class ArrowCoderImpl(StreamCoderImpl):
 
-    def __init__(self, schema):
+    def __init__(self, schema, row_type, timezone):
         self._schema = schema
+        self._field_types = row_type.field_types()
+        self._timezone = timezone
         self._resettable_io = ResettableIO()
         self._batch_reader = ArrowCoderImpl._load_from_stream(self._resettable_io)
         self._batch_writer = pa.RecordBatchStreamWriter(self._resettable_io, self._schema)
@@ -455,14 +458,44 @@ class ArrowCoderImpl(StreamCoderImpl):
                             "pyarrow.Array (%s)."
                 raise RuntimeError(error_msg % (s.dtype, t), e)
 
-        arrays = [create_array(cols[i], self._schema.types[i]) for i in range(0, len(self._schema))]
+        arrays = [create_array(
+            ArrowCoderImpl.tz_convert_to_internal(cols[i], self._field_types[i], self._timezone),
+            self._schema.types[i]) for i in range(0, len(self._schema))]
         return pa.RecordBatch.from_arrays(arrays, self._schema)
 
     def _decode_one_batch_from_stream(self, in_stream: create_InputStream) -> List:
         self._resettable_io.set_input_bytes(in_stream.read_all(True))
         # there is only one arrow batch in the underlying input stream
         table = pa.Table.from_batches([next(self._batch_reader)])
-        return [c.to_pandas(date_as_object=True) for c in table.itercolumns()]
+        return [ArrowCoderImpl.tz_convert_from_internal(
+            c.to_pandas(date_as_object=True), t, self._timezone)
+            for c, t in zip(table.itercolumns(), self._field_types)]
+
+    @staticmethod
+    def tz_convert_from_internal(s: pd.Series, t: DataType, local_tz) -> pd.Series:
+        """
+        Converts the timestamp series from internal according to the specified local timezone.
+
+        Returns the same series if the series is not a timestamp series. Otherwise,
+        returns a converted series.
+        """
+        if type(t) == LocalZonedTimestampType:
+            return s.dt.tz_localize(local_tz)
+        else:
+            return s
+
+    @staticmethod
+    def tz_convert_to_internal(s: pd.Series, t: DataType, local_tz) -> pd.Series:
+        """
+        Converts the timestamp series to internal according to the specified local timezone.
+        """
+        from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
+        if type(t) == LocalZonedTimestampType:
+            if is_datetime64_dtype(s.dtype):
+                return s.dt.tz_localize(None)
+            elif is_datetime64tz_dtype(s.dtype):
+                return s.dt.tz_convert(local_tz).dt.tz_localize(None)
+        return s
 
     def __repr__(self):
         return 'ArrowCoderImpl[%s]' % self._schema

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -34,7 +34,7 @@ from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.sdk_worker_main import pipeline_options
 from pyflink.table.types import Row, TinyIntType, SmallIntType, IntType, BigIntType, BooleanType, \
     FloatType, DoubleType, VarCharType, VarBinaryType, DecimalType, DateType, TimeType, \
-    LocalZonedTimestampType, RowType, RowField, to_arrow_type
+    LocalZonedTimestampType, RowType, RowField, to_arrow_type, TimestampType
 
 FLINK_SCALAR_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:scalar_function:v1"
 FLINK_TABLE_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:table_function:v1"
@@ -452,6 +452,8 @@ class ArrowCoder(DeterministicCoder):
                     flink_fn_execution_pb2.Schema.TypeName.LOCAL_ZONED_TIMESTAMP:
                 return LocalZonedTimestampType(field.type.local_zoned_timestamp_info.precision,
                                                field.type.nullable)
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.TIMESTAMP:
+                return TimestampType(field.type.timestamp_info.precision, field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2324,7 +2324,7 @@ def to_arrow_type(data_type):
             return pa.time64('us')
         else:
             return pa.time64('ns')
-    elif type(data_type) == LocalZonedTimestampType:
+    elif type(data_type) in [LocalZonedTimestampType, TimestampType]:
         if data_type.precision == 0:
             return pa.timestamp('s')
         elif 1 <= data_type.precision <= 3:

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1179,6 +1179,12 @@ class RowType(DataType):
         """
         return list(self.names)
 
+    def field_types(self):
+        """
+        Returns all field types in a list.
+        """
+        return list([f.data_type for f in self.fields])
+
     def need_conversion(self):
         # We need convert Row()/namedtuple into tuple()
         return True
@@ -2280,6 +2286,55 @@ def _create_type_verifier(data_type, name=None):
             verify_value(obj)
 
     return verify
+
+
+def to_arrow_type(data_type):
+    """
+    Converts the specified Flink data type to pyarrow data type.
+    """
+    import pyarrow as pa
+    if type(data_type) == TinyIntType:
+        return pa.int8()
+    elif type(data_type) == SmallIntType:
+        return pa.int16()
+    elif type(data_type) == IntType:
+        return pa.int32()
+    elif type(data_type) == BigIntType:
+        return pa.int64()
+    elif type(data_type) == BooleanType:
+        return pa.bool_()
+    elif type(data_type) == FloatType:
+        return pa.float32()
+    elif type(data_type) == DoubleType:
+        return pa.float64()
+    elif type(data_type) == VarCharType:
+        return pa.utf8()
+    elif type(data_type) == VarBinaryType:
+        return pa.binary()
+    elif type(data_type) == DecimalType:
+        return pa.decimal128(data_type.precision, data_type.scale)
+    elif type(data_type) == DateType:
+        return pa.date32()
+    elif type(data_type) == TimeType:
+        if data_type.precision == 0:
+            return pa.time32('s')
+        elif 1 <= data_type.precision <= 3:
+            return pa.time32('ms')
+        elif 4 <= data_type.precision <= 6:
+            return pa.time64('us')
+        else:
+            return pa.time64('ns')
+    elif type(data_type) == LocalZonedTimestampType:
+        if data_type.precision == 0:
+            return pa.timestamp('s')
+        elif 1 <= data_type.precision <= 3:
+            return pa.timestamp('ms')
+        elif 4 <= data_type.precision <= 6:
+            return pa.timestamp('us')
+        else:
+            return pa.timestamp('ns')
+    else:
+        raise ValueError("field_type %s is not supported." % data_type)
 
 
 class DataTypes(object):

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/TimestampFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/TimestampFieldReader.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.sql.Timestamp;
+
+/**
+ * {@link ArrowFieldReader} for Timestamp.
+ */
+@Internal
+public final class TimestampFieldReader extends ArrowFieldReader<Timestamp> {
+
+	public TimestampFieldReader(ValueVector valueVector) {
+		super(valueVector);
+		Preconditions.checkState(valueVector instanceof TimeStampVector && ((ArrowType.Timestamp) valueVector.getField().getType()).getTimezone() == null);
+	}
+
+	@Override
+	public Timestamp read(int i) {
+		ValueVector valueVector = getValueVector();
+		if (valueVector.isNull(i)) {
+			return null;
+		} else {
+			long millisecond;
+			if (valueVector instanceof TimeStampSecVector) {
+				millisecond = ((TimeStampSecVector) valueVector).get(i) * 1000;
+			} else if (valueVector instanceof TimeStampMilliVector) {
+				millisecond = ((TimeStampMilliVector) valueVector).get(i);
+			} else if (valueVector instanceof TimeStampMicroVector) {
+				millisecond = ((TimeStampMicroVector) valueVector).get(i) / 1000;
+			} else {
+				millisecond = ((TimeStampNanoVector) valueVector).get(i) / 1_000_000;
+			}
+			return PythonTypeUtils.internalToTimestamp(millisecond);
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTimestampColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowTimestampColumnVector.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.dataformat.vector.TimestampColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+/**
+ * Arrow column vector for Timestamp.
+ */
+@Internal
+public final class ArrowTimestampColumnVector implements TimestampColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of timestamp values of a column to read.
+	 */
+	private final ValueVector valueVector;
+
+	public ArrowTimestampColumnVector(ValueVector valueVector) {
+		this.valueVector = Preconditions.checkNotNull(valueVector);
+		Preconditions.checkState(valueVector instanceof TimeStampVector && ((ArrowType.Timestamp) valueVector.getField().getType()).getTimezone() == null);
+	}
+
+	@Override
+	public SqlTimestamp getTimestamp(int i, int precision) {
+		if (valueVector instanceof TimeStampSecVector) {
+			return SqlTimestamp.fromEpochMillis(((TimeStampSecVector) valueVector).get(i) * 1000);
+		} else if (valueVector instanceof TimeStampMilliVector) {
+			return SqlTimestamp.fromEpochMillis(((TimeStampMilliVector) valueVector).get(i));
+		} else if (valueVector instanceof TimeStampMicroVector) {
+			long micros = ((TimeStampMicroVector) valueVector).get(i);
+			return SqlTimestamp.fromEpochMillis(micros / 1000, (int) (micros % 1000) * 1000);
+		} else {
+			long nanos = ((TimeStampNanoVector) valueVector).get(i);
+			return SqlTimestamp.fromEpochMillis(nanos / 1_000_000, (int) (nanos % 1_000_000));
+		}
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return valueVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowTimestampWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BaseRowTimestampWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+/**
+ * {@link ArrowFieldWriter} for Timestamp.
+ */
+@Internal
+public final class BaseRowTimestampWriter extends ArrowFieldWriter<BaseRow> {
+
+	private final int precision;
+
+	public BaseRowTimestampWriter(ValueVector valueVector, int precision) {
+		super(valueVector);
+		Preconditions.checkState(valueVector instanceof TimeStampVector && ((ArrowType.Timestamp) valueVector.getField().getType()).getTimezone() == null);
+		this.precision = precision;
+	}
+
+	@Override
+	public void doWrite(BaseRow row, int ordinal) {
+		ValueVector valueVector = getValueVector();
+		if (row.isNullAt(ordinal)) {
+			((TimeStampVector) valueVector).setNull(getCount());
+		} else {
+			SqlTimestamp sqlTimestamp = row.getTimestamp(ordinal, precision);
+
+			if (valueVector instanceof TimeStampSecVector) {
+				((TimeStampSecVector) valueVector).setSafe(getCount(), sqlTimestamp.getMillisecond() / 1000);
+			} else if (valueVector instanceof TimeStampMilliVector) {
+				((TimeStampMilliVector) valueVector).setSafe(getCount(), sqlTimestamp.getMillisecond());
+			} else if (valueVector instanceof TimeStampMicroVector) {
+				((TimeStampMicroVector) valueVector).setSafe(getCount(), sqlTimestamp.getMillisecond() * 1000 + sqlTimestamp.getNanoOfMillisecond() / 1000);
+			} else {
+				((TimeStampNanoVector) valueVector).setSafe(getCount(), sqlTimestamp.getMillisecond() * 1_000_000 + sqlTimestamp.getNanoOfMillisecond());
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimestampWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimestampWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import java.sql.Timestamp;
+
+/**
+ * {@link ArrowFieldWriter} for Timestamp.
+ */
+@Internal
+public final class TimestampWriter extends ArrowFieldWriter<Row> {
+
+	public TimestampWriter(ValueVector valueVector) {
+		super(valueVector);
+		Preconditions.checkState(valueVector instanceof TimeStampVector && ((ArrowType.Timestamp) valueVector.getField().getType()).getTimezone() == null);
+	}
+
+	@Override
+	public void doWrite(Row row, int ordinal) {
+		ValueVector valueVector = getValueVector();
+		if (row.getField(ordinal) == null) {
+			((BaseFixedWidthVector) getValueVector()).setNull(getCount());
+		} else {
+			long millisecond = PythonTypeUtils.timestampToInternal((Timestamp) row.getField(ordinal));
+			if (valueVector instanceof TimeStampSecVector) {
+				((TimeStampSecVector) valueVector).setSafe(getCount(), millisecond / 1000);
+			} else if (valueVector instanceof TimeStampMilliVector) {
+				((TimeStampMilliVector) valueVector).setSafe(getCount(), millisecond);
+			} else if (valueVector instanceof TimeStampMicroVector) {
+				((TimeStampMicroVector) valueVector).setSafe(getCount(), millisecond * 1000);
+			} else {
+				((TimeStampNanoVector) valueVector).setSafe(getCount(), millisecond * 1_000_000);
+			}
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/PythonTypeUtils.java
@@ -143,6 +143,26 @@ public final class PythonTypeUtils {
 	}
 
 	/**
+	 * Converts the internal representation of a SQL TIMESTAMP (long) to the Java
+	 * type used for UDF parameters ({@link java.sql.Timestamp}).
+	 *
+	 * <p>Note: The implementation refers to {@link SqlDateTimeUtils#internalToTimestamp}.
+	 */
+	public static java.sql.Timestamp internalToTimestamp(long v) {
+		return new java.sql.Timestamp(v - LOCAL_TZ.getOffset(v));
+	}
+
+	/** Converts the Java type used for UDF parameters of SQL TIMESTAMP type
+	 * ({@link java.sql.Timestamp}) to internal representation (long).
+	 *
+	 * <p>Note: The implementation refers to {@link SqlDateTimeUtils#timestampToInternal}.
+	 */
+	public static long timestampToInternal(java.sql.Timestamp ts) {
+		long time = ts.getTime();
+		return time + LOCAL_TZ.getOffset(time);
+	}
+
+	/**
 	 * Convert LogicalType to conversion class for flink planner.
 	 */
 	public static class LogicalTypeToConversionClassConverter extends LogicalTypeDefaultVisitor<Class> {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TimeFieldReader;
+import org.apache.flink.table.runtime.arrow.readers.TimestampFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
@@ -44,6 +45,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTimeColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowTimestampColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarBinaryColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
@@ -58,6 +60,7 @@ import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTimeWriter;
+import org.apache.flink.table.runtime.arrow.writers.BaseRowTimestampWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
@@ -70,6 +73,7 @@ import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TimeWriter;
+import org.apache.flink.table.runtime.arrow.writers.TimestampWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
@@ -80,6 +84,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
@@ -148,6 +153,14 @@ public class ArrowUtilsTest {
 			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
 		testFields.add(Tuple7.of("f16", new TimeType(8), new ArrowType.Time(TimeUnit.NANOSECOND, 64),
 			TimeWriter.class, BaseRowTimeWriter.class, TimeFieldReader.class, ArrowTimeColumnVector.class));
+		testFields.add(Tuple7.of("f17", new LocalZonedTimestampType(0), new ArrowType.Timestamp(TimeUnit.SECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f18", new LocalZonedTimestampType(2), new ArrowType.Timestamp(TimeUnit.MILLISECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f19", new LocalZonedTimestampType(4), new ArrowType.Timestamp(TimeUnit.MICROSECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f20", new LocalZonedTimestampType(8), new ArrowType.Timestamp(TimeUnit.NANOSECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -89,6 +89,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -160,6 +161,14 @@ public class ArrowUtilsTest {
 		testFields.add(Tuple7.of("f19", new LocalZonedTimestampType(4), new ArrowType.Timestamp(TimeUnit.MICROSECOND, null),
 			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
 		testFields.add(Tuple7.of("f20", new LocalZonedTimestampType(8), new ArrowType.Timestamp(TimeUnit.NANOSECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f21", new TimestampType(0), new ArrowType.Timestamp(TimeUnit.SECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f22", new TimestampType(2), new ArrowType.Timestamp(TimeUnit.MILLISECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f23", new TimestampType(4), new ArrowType.Timestamp(TimeUnit.MICROSECOND, null),
+			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
+		testFields.add(Tuple7.of("f24", new TimestampType(8), new ArrowType.Timestamp(TimeUnit.NANOSECOND, null),
 			TimestampWriter.class, BaseRowTimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -112,6 +113,10 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new LocalZonedTimestampType(2));
 		fieldTypes.add(new LocalZonedTimestampType(4));
 		fieldTypes.add(new LocalZonedTimestampType(8));
+		fieldTypes.add(new TimestampType(0));
+		fieldTypes.add(new TimestampType(2));
+		fieldTypes.add(new TimestampType(4));
+		fieldTypes.add(new TimestampType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -140,15 +145,19 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 	@Override
 	public BaseRow[] getTestData() {
 		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
 		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
 		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
 		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -32,6 +33,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
@@ -106,6 +108,10 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new TimeType(2));
 		fieldTypes.add(new TimeType(4));
 		fieldTypes.add(new TimeType(8));
+		fieldTypes.add(new LocalZonedTimestampType(0));
+		fieldTypes.add(new LocalZonedTimestampType(2));
+		fieldTypes.add(new LocalZonedTimestampType(4));
+		fieldTypes.add(new LocalZonedTimestampType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -133,12 +139,16 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 
 	@Override
 	public BaseRow[] getTestData() {
-		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
-		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
-		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
-		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000);
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
+		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
+		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
+		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -80,6 +81,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new LocalZonedTimestampType(2));
 		fieldTypes.add(new LocalZonedTimestampType(4));
 		fieldTypes.add(new LocalZonedTimestampType(8));
+		fieldTypes.add(new TimestampType(0));
+		fieldTypes.add(new TimestampType(2));
+		fieldTypes.add(new TimestampType(4));
+		fieldTypes.add(new TimestampType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -109,14 +114,17 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 	public Row[] getTestData() {
 		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
 		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
 		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -74,6 +76,10 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new TimeType(2));
 		fieldTypes.add(new TimeType(4));
 		fieldTypes.add(new TimeType(8));
+		fieldTypes.add(new LocalZonedTimestampType(0));
+		fieldTypes.add(new LocalZonedTimestampType(2));
+		fieldTypes.add(new LocalZonedTimestampType(4));
+		fieldTypes.add(new LocalZonedTimestampType(8));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -102,12 +108,15 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 	@Override
 	public Row[] getTestData() {
 		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
-			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
 		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
-			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
 		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
-			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000));
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.util;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
@@ -25,6 +26,7 @@ import org.apache.flink.table.dataformat.BinaryRowWriter;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
@@ -121,6 +123,9 @@ public class StreamRecordUtils {
 			} else if (value instanceof Decimal) {
 				Decimal decimal = (Decimal) value;
 				writer.writeDecimal(j, decimal, decimal.getPrecision());
+			} else if (value instanceof Tuple2 && ((Tuple2) value).f0 instanceof SqlTimestamp) {
+				SqlTimestamp timestamp = (SqlTimestamp) ((Tuple2) value).f0;
+				writer.writeTimestamp(j, timestamp, (int) ((Tuple2) value).f1);
 			} else {
 				throw new RuntimeException("Not support yet!");
 			}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds support of LocalZonedTimestampType and TimestampType in vectorized Python UDF.*

## Brief change log

  - *Add support of LocalZonedTimestampType in vectorized Python UDF*
  - *Add support of TimestampType in vectorized Python UDF*

## Verifying this change

This change added tests and can be verified as follows:

  - *Java tests ArrowUtilsTest, BaseRowArrowReaderWriterTest and RowArrowReaderWriterTest.*
  - *Python tests test_pandas_udf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
