### PR TITLE
[FLINK-16856][scripts] Manually calculate lines of logging output

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/taskmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/taskmanager.sh
@@ -49,7 +49,9 @@ if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # Startup parameters
 
     java_utils_output=$(runBashJavaUtilsCmd GET_TM_RESOURCE_PARAMS ${FLINK_CONF_DIR})
-    logging_output=$(echo "${java_utils_output}" | head -n -2)
+
+    num_lines=$(echo "${java_utils_output}" | wc -l)
+    logging_output=$(echo "${java_utils_output}" | head -n $((${num_lines} - 2)))
     params_output=$(echo "${java_utils_output}" | tail -n 2)
 
     jvm_params=$(extractExecutionParams "$(echo "$params_output" | head -n 1)")


### PR DESCRIPTION
'head' with a negative '-n' argument isn't standardized, so we now calculate the number of lines to treat as logging output manually.