### PR TITLE
[FLINK-16864][metrics] Add IdleTime metric for task.

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -1441,6 +1441,11 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>idleTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/docs/monitoring/metrics.zh.md
+++ b/docs/monitoring/metrics.zh.md
@@ -1441,6 +1441,11 @@ Certain RocksDB native metrics are available but disabled by default, you can fi
       <td>Gauge</td>
     </tr>
     <tr>
+      <td>idleTimeMsPerSecond</td>
+      <td>The time (in milliseconds) this task is idle (either has no data to process or it is back pressured) per second.</td>
+      <td>Meter</td>
+    </tr>
+    <tr>
       <th rowspan="6"><strong>Task/Operator</strong></th>
       <td>numRecordsIn</td>
       <td>The total number of records this operator/task has received.</td>

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -43,6 +43,7 @@ import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.memory.MemoryManager;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -139,7 +140,7 @@ public class SavepointEnvironment implements Environment {
 
 	@Override
 	public TaskMetricGroup getMetricGroup() {
-		throw new UnsupportedOperationException(ERROR_MSG);
+		return UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/BroadcastRecordWriter.java
@@ -84,7 +84,7 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 		if (bufferBuilder != null) {
 			for (int index = 0; index < numberOfChannels; index++) {
 				if (index != targetChannelIndex) {
-					targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), index);
+					addBufferConsumer(bufferBuilder.createBufferConsumer(), index);
 				}
 			}
 		}
@@ -128,13 +128,13 @@ public final class BroadcastRecordWriter<T extends IOReadableWritable> extends R
 	public BufferBuilder requestNewBufferBuilder(int targetChannel) throws IOException, InterruptedException {
 		checkState(bufferBuilder == null || bufferBuilder.isFinished());
 
-		BufferBuilder builder = targetPartition.getBufferBuilder();
+		BufferBuilder builder = getBufferBuilder();
 		if (randomTriggered) {
-			targetPartition.addBufferConsumer(builder.createBufferConsumer(), targetChannel);
+			addBufferConsumer(builder.createBufferConsumer(), targetChannel);
 		} else {
 			try (BufferConsumer bufferConsumer = builder.createBufferConsumer()) {
 				for (int channel = 0; channel < numberOfChannels; channel++) {
-					targetPartition.addBufferConsumer(bufferConsumer.copy(), channel);
+					addBufferConsumer(bufferConsumer.copy(), channel);
 				}
 			}
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ChannelSelectorRecordWriter.java
@@ -100,8 +100,8 @@ public final class ChannelSelectorRecordWriter<T extends IOReadableWritable> ext
 	public BufferBuilder requestNewBufferBuilder(int targetChannel) throws IOException, InterruptedException {
 		checkState(bufferBuilders[targetChannel] == null || bufferBuilders[targetChannel].isFinished());
 
-		BufferBuilder bufferBuilder = targetPartition.getBufferBuilder();
-		targetPartition.addBufferConsumer(bufferBuilder.createBufferConsumer(), targetChannel);
+		BufferBuilder bufferBuilder = getBufferBuilder();
+		addBufferConsumer(bufferBuilder.createBufferConsumer(), targetChannel);
 		bufferBuilders[targetChannel] = bufferBuilder;
 		return bufferBuilder;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/RecordWriter.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.io.network.api.writer;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.io.IOReadableWritable;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.AvailabilityProvider;
@@ -66,7 +68,7 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 
 	private static final Logger LOG = LoggerFactory.getLogger(RecordWriter.class);
 
-	protected final ResultPartitionWriter targetPartition;
+	private final ResultPartitionWriter targetPartition;
 
 	protected final int numberOfChannels;
 
@@ -77,6 +79,8 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	private Counter numBytesOut = new SimpleCounter();
 
 	private Counter numBuffersOut = new SimpleCounter();
+
+	protected Meter idleTimeMsPerSecond = new MeterView(new SimpleCounter());
 
 	private final boolean flushAlways;
 
@@ -182,6 +186,7 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 	public void setMetricGroup(TaskIOMetricGroup metrics) {
 		numBytesOut = metrics.getNumBytesOutCounter();
 		numBuffersOut = metrics.getNumBuffersOutCounter();
+		idleTimeMsPerSecond = metrics.getIdleTimeMsPerSecond();
 	}
 
 	protected void finishBufferBuilder(BufferBuilder bufferBuilder) {
@@ -274,6 +279,26 @@ public abstract class RecordWriter<T extends IOReadableWritable> implements Avai
 		if (flusherException != null) {
 			throw new IOException("An exception happened while flushing the outputs", flusherException);
 		}
+	}
+
+	protected void addBufferConsumer(BufferConsumer consumer, int targetChannel) throws IOException {
+		targetPartition.addBufferConsumer(consumer, targetChannel);
+	}
+
+	@VisibleForTesting
+	public BufferBuilder getBufferBuilder() throws IOException, InterruptedException {
+		BufferBuilder builder = targetPartition.tryGetBufferBuilder();
+		if (builder == null) {
+			long start = System.currentTimeMillis();
+			builder = targetPartition.getBufferBuilder();
+			idleTimeMsPerSecond.markEvent(System.currentTimeMillis() - start);
+		}
+		return builder;
+	}
+
+	@VisibleForTesting
+	public Meter getIdleTimeMsPerSecond() {
+		return idleTimeMsPerSecond;
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -60,6 +60,14 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
 	 */
 	BufferBuilder getBufferBuilder() throws IOException, InterruptedException;
 
+
+	/**
+	 * Try to request a {@link BufferBuilder} from this partition for writing data.
+	 *
+	 * <p>Returns <code>null</code> if no buffer is available or the buffer provider has been destroyed.
+	 */
+	BufferBuilder tryGetBufferBuilder() throws IOException;
+
 	/**
 	 * Adds the bufferConsumer to the subpartition with the given index.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -40,6 +40,13 @@ public interface BufferProvider extends AvailabilityProvider {
 	/**
 	 * Returns a {@link BufferBuilder} instance from the buffer provider.
 	 *
+	 * <p>Returns <code>null</code> if no buffer is available or the buffer provider has been destroyed.
+	 */
+	BufferBuilder requestBufferBuilder() throws IOException;
+
+	/**
+	 * Returns a {@link BufferBuilder} instance from the buffer provider.
+	 *
 	 * <p>If there is no buffer available, the call will block until one becomes available again or the
 	 * buffer provider has been destroyed.
 	 */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -205,6 +205,11 @@ class LocalBufferPool implements BufferPool {
 	}
 
 	@Override
+	public BufferBuilder requestBufferBuilder() throws IOException {
+		return toBufferBuilder(requestMemorySegment());
+	}
+
+	@Override
 	public BufferBuilder requestBufferBuilderBlocking() throws IOException, InterruptedException {
 		return toBufferBuilder(requestMemorySegmentBlocking());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -208,6 +208,12 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	}
 
 	@Override
+	public BufferBuilder tryGetBufferBuilder() throws IOException {
+		BufferBuilder bufferBuilder = bufferPool.requestBufferBuilder();
+		return bufferBuilder;
+	}
+
+	@Override
 	public boolean addBufferConsumer(BufferConsumer bufferConsumer, int subpartitionIndex) throws IOException {
 		checkNotNull(bufferConsumer);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -71,4 +71,6 @@ public class MetricNames {
 	public static String currentInputWatermarkName(int index) {
 		return String.format(IO_CURRENT_INPUT_WATERMARK_PATERN, index);
 	}
+
+	public static final String TASK_IDLE_TIME = "idleTimeMs" + SUFFIX_RATE;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -45,6 +45,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 	private final Meter numRecordsInRate;
 	private final Meter numRecordsOutRate;
 	private final Meter numBuffersOutRate;
+	private final Meter idleTimePerSecond;
 
 	public TaskIOMetricGroup(TaskMetricGroup parent) {
 		super(parent);
@@ -61,6 +62,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 		this.numBuffersOut = counter(MetricNames.IO_NUM_BUFFERS_OUT);
 		this.numBuffersOutRate = meter(MetricNames.IO_NUM_BUFFERS_OUT_RATE, new MeterView(numBuffersOut));
+
+		this.idleTimePerSecond = meter(MetricNames.TASK_IDLE_TIME, new MeterView(new SimpleCounter()));
 	}
 
 	public IOMetrics createSnapshot() {
@@ -89,6 +92,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
 	public Counter getNumBuffersOutCounter() {
 		return numBuffersOut;
+	}
+
+	public Meter getIdleTimeMsPerSecond() {
+		return idleTimePerSecond;
 	}
 
 	// ============================================================================================

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -70,6 +70,11 @@ public class ConsumableNotifyingResultPartitionWriterDecorator implements Result
 	}
 
 	@Override
+	public BufferBuilder tryGetBufferBuilder() throws IOException {
+		return partitionWriter.tryGetBufferBuilder();
+	}
+
+	@Override
 	public ResultPartitionID getPartitionId() {
 		return partitionWriter.getPartitionId();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/AbstractCollectingResultPartitionWriter.java
@@ -50,6 +50,11 @@ public abstract class AbstractCollectingResultPartitionWriter extends MockResult
 	}
 
 	@Override
+	public BufferBuilder tryGetBufferBuilder() throws IOException {
+		return bufferProvider.requestBufferBuilder();
+	}
+
+	@Override
 	public synchronized boolean addBufferConsumer(BufferConsumer bufferConsumer, int targetChannel) throws IOException {
 		checkState(targetChannel < getNumberOfSubpartitions());
 		bufferConsumers.add(bufferConsumer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -40,6 +40,11 @@ public class NoOpBufferPool implements BufferPool {
 	}
 
 	@Override
+	public BufferBuilder requestBufferBuilder() throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public BufferBuilder requestBufferBuilderBlocking() throws IOException, InterruptedException {
 		throw new UnsupportedOperationException();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -70,6 +70,11 @@ public class MockResultPartitionWriter implements ResultPartitionWriter {
 	}
 
 	@Override
+	public BufferBuilder tryGetBufferBuilder() throws IOException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void flushAll() {
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -66,6 +66,15 @@ public class TestPooledBufferProvider implements BufferProvider {
 		return bufferFactory.create();
 	}
 
+	@Override
+	public BufferBuilder requestBufferBuilder() throws IOException {
+		Buffer buffer = requestBuffer();
+		if (buffer != null) {
+			return new BufferBuilder(buffer.getMemorySegment(), buffer.getRecycler());
+		}
+		return null;
+	}
+
 	private Buffer requestBufferBlocking() throws IOException, InterruptedException {
 		Buffer buffer = buffers.poll();
 		if (buffer != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroupTest.java
@@ -54,6 +54,7 @@ public class TaskIOMetricGroupTest {
 		taskIO.getNumBytesInCounter().inc(100L);
 		taskIO.getNumBytesOutCounter().inc(250L);
 		taskIO.getNumBuffersOutCounter().inc(3L);
+		taskIO.getIdleTimeMsPerSecond().markEvent(2L);
 
 		IOMetrics io = taskIO.createSnapshot();
 		assertEquals(32L, io.getNumRecordsIn());
@@ -61,5 +62,6 @@ public class TaskIOMetricGroupTest {
 		assertEquals(100L, io.getNumBytesIn());
 		assertEquals(250L, io.getNumBytesOut());
 		assertEquals(3L, taskIO.getNumBuffersOutCounter().getCount());
+		assertEquals(2L, taskIO.getIdleTimeMsPerSecond().getCount());
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -267,6 +267,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 		this.recordWriter = createRecordWriterDelegate(configuration, environment);
 		this.actionExecutor = Preconditions.checkNotNull(actionExecutor);
 		this.mailboxProcessor = new MailboxProcessor(this::processInput, mailbox, actionExecutor);
+		this.mailboxProcessor.initMetric(environment.getMetricGroup());
 		this.asyncExceptionHandler = new StreamTaskAsyncExceptionHandler(environment);
 		this.asyncOperationsThreadPool = Executors.newCachedThreadPool(
 			new ExecutorThreadFactory("AsyncOperations", uncaughtExceptionHandler));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/mailbox/MailboxProcessor.java
@@ -19,6 +19,10 @@ package org.apache.flink.streaming.runtime.tasks.mailbox;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
 import org.apache.flink.util.ExceptionUtils;
@@ -82,6 +86,8 @@ public class MailboxProcessor implements Closeable {
 
 	private final StreamTaskActionExecutor actionExecutor;
 
+	private Meter idleTime = new MeterView(new SimpleCounter());
+
 	public MailboxProcessor(MailboxDefaultAction mailboxDefaultAction) {
 		this(mailboxDefaultAction, StreamTaskActionExecutor.IMMEDIATE);
 	}
@@ -126,6 +132,10 @@ public class MailboxProcessor implements Closeable {
 	 */
 	public MailboxExecutor getMailboxExecutor(int priority) {
 		return new MailboxExecutorImpl(mailbox, priority, actionExecutor);
+	}
+
+	public void initMetric(TaskMetricGroup metricGroup) {
+		idleTime = metricGroup.getIOMetricGroup().getIdleTimeMsPerSecond();
 	}
 
 	/**
@@ -269,7 +279,13 @@ public class MailboxProcessor implements Closeable {
 		// If the default action is currently not available, we can run a blocking mailbox execution until the default
 		// action becomes available again.
 		while (isDefaultActionUnavailable() && isMailboxLoopRunning()) {
-			mailbox.take(MIN_PRIORITY).run();
+			maybeMail = mailbox.tryTake(MIN_PRIORITY);
+			if (!maybeMail.isPresent()) {
+				long start = System.currentTimeMillis();
+				maybeMail = Optional.of(mailbox.take(MIN_PRIORITY));
+				idleTime.markEvent(System.currentTimeMillis() - start);
+			}
+			maybeMail.get().run();
 		}
 
 		return isMailboxLoopRunning();
@@ -299,6 +315,11 @@ public class MailboxProcessor implements Closeable {
 	@VisibleForTesting
 	public boolean isMailboxLoopRunning() {
 		return mailboxLoopRunning;
+	}
+
+	@VisibleForTesting
+	public Meter getIdleTime() {
+		return idleTime;
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/mailbox/TaskMailboxProcessorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.streaming.api.operators.MailboxExecutor;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.function.RunnableWithException;
 
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -234,6 +235,53 @@ public class TaskMailboxProcessorTest {
 		MailboxProcessor mailboxProcessor = new MailboxProcessor((ctx) -> {});
 		mailboxProcessor.close();
 		mailboxProcessor.allActionsCompleted();
+	}
+
+	@Test
+	public void testIdleTime() throws InterruptedException {
+		final AtomicReference<MailboxDefaultAction.Suspension> suspendedActionRef = new AtomicReference<>();
+		final int totalSwitches = 10;
+
+		MailboxThread mailboxThread = new MailboxThread() {
+			int count = 0;
+
+			@Override
+			public void runDefaultAction(Controller controller) {
+				// If this is violated, it means that the default action was invoked while we assumed suspension
+				Assert.assertTrue(suspendedActionRef.compareAndSet(null, controller.suspendDefaultAction()));
+				++count;
+				if (count == totalSwitches) {
+					controller.allActionsCompleted();
+				}
+			}
+		};
+		mailboxThread.start();
+		final MailboxProcessor mailboxProcessor = mailboxThread.getMailboxProcessor();
+
+		final Thread asyncUnblocker = new Thread(() -> {
+			while (!Thread.currentThread().isInterrupted()) {
+				final MailboxDefaultAction.Suspension resume =
+					suspendedActionRef.getAndSet(null);
+
+				if (resume != null) {
+					try {
+						Thread.sleep(1);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					mailboxProcessor.getMailboxExecutor(DEFAULT_PRIORITY).execute(resume::resume, "resume");
+				}
+			}
+		});
+
+		asyncUnblocker.start();
+		mailboxThread.signalStart();
+		mailboxThread.join();
+		asyncUnblocker.interrupt();
+		asyncUnblocker.join();
+
+		Assert.assertThat(mailboxProcessor.getIdleTime().getCount(), Matchers.greaterThanOrEqualTo(10L));
+
 	}
 
 	private static MailboxProcessor start(MailboxThread mailboxThread) {


### PR DESCRIPTION
## What is the purpose of the change
This pr adds an IdleTime metric which measures idle time of a task including the time cost for mail processor to wait for new mail and the time cost in record writer to waiting a new buffer.
1. when a job can not catch up with the speed of data generating, the vertex which idle time is near to zero is the bottle neck of the job.
2. when a job is not busy, idle time can be used to guide user how much he can scale down the job.

## Brief change log
A meter metrics named idleTimeMsPerSecond is added in TaskIOMetricGroup:
  - *idleTime contains time waiting mail and time waiting output buffer. *
  - *waiting mail time is collected when mail processor is trying to process a new mail but no mail submitted.*
  - *waiting output buffer time is collected when record writer is trying to request a new buffer from result partition but no buffer available.* 

## Verifying this change

This change is already covered by existing tests, such as 
  - *TaskIOMetricGroupTest*
  - *RecordWriterTest*
  - *TaskMailboxProcessorTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
