### PR TITLE
[FLINK-16018] Increase default value of web.timeout to 10 minutes

### DIFF
--- a/docs/_includes/generated/web_configuration.html
+++ b/docs/_includes/generated/web_configuration.html
@@ -70,7 +70,7 @@
         </tr>
         <tr>
             <td><h5>web.timeout</h5></td>
-            <td style="word-wrap: break-word;">10000</td>
+            <td style="word-wrap: break-word;">600000</td>
             <td>Long</td>
             <td>Timeout for asynchronous operations by the web monitor in milliseconds.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/WebOptions.java
@@ -178,7 +178,7 @@ public class WebOptions {
 	 */
 	public static final ConfigOption<Long> TIMEOUT =
 		key("web.timeout")
-		.defaultValue(10L * 1000L)
+		.defaultValue(10L * 60L * 1000L)
 		.withDescription("Timeout for asynchronous operations by the web monitor in milliseconds.");
 
 	// ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

In order to not fail the job submission with a TimeoutException if
it takes longer than 10 s, this commit increases the web.timeout to
10 minutes.

## Verifying this change

- Tried it out manually

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
