### PR TITLE
[FLINK-16673][python] Support metrics for Python UDTF

### DIFF
--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import unittest
 from pyflink.table import DataTypes
 from pyflink.table.udf import TableFunction, udtf, ScalarFunction, udf
 from pyflink.testing import source_sink_utils
@@ -61,8 +62,17 @@ class PyFlinkBlinkStreamUserDefinedFunctionTests(UserDefinedTableFunctionTests,
     pass
 
 
-class MultiEmit(TableFunction):
+class MultiEmit(TableFunction, unittest.TestCase):
+
+    def open(self, function_context):
+        mg = function_context.get_metric_group()
+        self.counter = mg.add_group("key", "value").counter("my_counter")
+        self.counter_sum = 0
+
     def eval(self, x, y):
+        self.counter.inc(y)
+        self.counter_sum += y
+        self.assertEqual(self.counter_sum, self.counter.get_count())
         for i in range(y):
             yield x, i
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/AbstractPythonTableFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/table/AbstractPythonTableFunctionRunner.java
@@ -81,6 +81,7 @@ public abstract class AbstractPythonTableFunctionRunner<IN> extends AbstractPyth
 	public FlinkFnApi.UserDefinedFunctions getUserDefinedFunctionsProto() {
 		FlinkFnApi.UserDefinedFunctions.Builder builder = FlinkFnApi.UserDefinedFunctions.newBuilder();
 		builder.addUdfs(getUserDefinedFunctionProto(tableFunction));
+		builder.setMetricEnabled(flinkMetricContainer != null);
 		return builder.build();
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

This pull request adds metric support for Python UDTF. Note: Most parts of the code had already been added in the PR of adding support for Python UDF(FLINK-16672) since these code can be reused. 


## Brief change log

  - Add test for metric registrations for Python UDTF.
  - Enable python metric for Python UDTF.


## Verifying this change

This change added tests and can be verified as follows:

  - Add tests in test_udtf.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (PythonDocs)
