### PR TITLE
[FLINK-16737][k8s] Remove KubernetesUtils#getContentFromFile

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubeClientFactory.java
@@ -20,7 +20,7 @@ package org.apache.flink.kubernetes.kubeclient;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
-import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.util.FileUtils;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
@@ -29,6 +29,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 
 /**
@@ -55,7 +56,7 @@ public class KubeClientFactory {
 				// Note: the third parameter kubeconfigPath is optional and is set to null. It is only used to rewrite
 				// relative tls asset paths inside kubeconfig when a file is passed, and in the case that the kubeconfig
 				// references some assets via relative paths.
-				config = Config.fromKubeconfig(kubeContext, KubernetesUtils.getContentFromFile(kubeConfigFile), null);
+				config = Config.fromKubeconfig(kubeContext, FileUtils.readFileUtf8(new File(kubeConfigFile)), null);
 			} catch (IOException e) {
 				throw new KubernetesClientException("Load kubernetes config failed.", e);
 			}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -33,12 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -51,29 +45,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class KubernetesUtils {
 
 	private static final Logger LOG = LoggerFactory.getLogger(KubernetesUtils.class);
-
-	/**
-	 * Read file content to string.
-	 *
-	 * @param filePath file path
-	 * @return content
-	 */
-	public static String getContentFromFile(String filePath) throws FileNotFoundException {
-		File file = new File(filePath);
-		if (file.exists()) {
-			StringBuilder content = new StringBuilder();
-			String line;
-			try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file)))){
-				while ((line = reader.readLine()) != null) {
-					content.append(line).append(System.lineSeparator());
-				}
-			} catch (IOException e) {
-				throw new RuntimeException("Error read file content.", e);
-			}
-			return content.toString();
-		}
-		throw new FileNotFoundException("File " + filePath + " not exists.");
-	}
 
 	/**
 	 * Check whether the port config option is a fixed port. If not, the fallback port will be set to configuration.


### PR DESCRIPTION
## What is the purpose of the change

Since `org.apache.flink.util.FileUtils` has already provided some utilities such as readFile or readFileUtf8 for reading file contents, we can remove the `KubernetesUtils#getContentFromFile`and use the `FileUtils` tool instead.


## Verifying this change

This change is trivial code cleanup.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
