### PR TITLE
[FLINK-16830][table-api] Let users use Row/List/Map/Seq directly in Expression DSL

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -24,15 +24,26 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.functions.FunctionIdentifier;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.operations.QueryOperation;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Utilities for API-specific {@link Expression}s.
@@ -52,14 +63,151 @@ public final class ApiExpressionUtils {
 		// private
 	}
 
+	/**
+	 * Converts a given object to an expression.
+	 *
+	 * <p>It converts:
+	 * <ul>
+	 *     <li>{@link Row} to a call to a row constructor expression</li>
+	 *     <li>{@link Map} to a call to a map constructor expression</li>
+	 *     <li>{@link List} to a call to an array constructor expression</li>
+	 *     <li>arrays to a call to an array constructor expression</li>
+	 *     <li>Scala's {@code Seq} to an array constructor via reflection</li>
+	 *     <li>Scala's {@code Map} to a map constructor via reflection</li>
+	 *     <li>Scala's {@code BigDecimal} to a DECIMAL literal</li>
+	 *     <li>if none of the above applies, the function tries to convert the object
+	 *          to a value literal with {@link #valueLiteral(Object)}</li>
+	 * </ul>
+	 *
+	 * @param expression An object to convert to an expression
+	 */
 	public static Expression objectToExpression(Object expression) {
 		if (expression instanceof ApiExpression) {
 			return ((ApiExpression) expression).toExpr();
 		} else if (expression instanceof Expression) {
 			return (Expression) expression;
+		} else if (expression instanceof Row) {
+			return convertRow((Row) expression);
+		} else if (expression instanceof Map) {
+			return convertJavaMap((Map<?, ?>) expression);
+		} else if (expression instanceof List) {
+			return convertJavaList((List<?>) expression);
+		} else if (expression.getClass().isArray()) {
+			return convertArray(expression);
 		} else {
-			return valueLiteral(expression);
+			return convertScala(expression).orElseGet(() -> valueLiteral(expression));
 		}
+	}
+
+	private static Expression convertRow(Row expression) {
+		List<Expression> fields = IntStream.range(0, expression.getArity())
+			.mapToObj(expression::getField)
+			.map(ApiExpressionUtils::objectToExpression)
+			.collect(Collectors.toList());
+
+		return unresolvedCall(BuiltInFunctionDefinitions.ROW, fields);
+	}
+
+	private static Expression convertJavaMap(Map<?, ?> expression) {
+		List<Expression> entries = expression.entrySet()
+			.stream()
+			.flatMap(e -> Stream.of(
+				objectToExpression(e.getKey()),
+				objectToExpression(e.getValue())
+			)).collect(Collectors.toList());
+
+		return unresolvedCall(BuiltInFunctionDefinitions.MAP, entries);
+	}
+
+	private static Expression convertJavaList(List<?> expression) {
+		List<Expression> entries = expression
+			.stream()
+			.map(ApiExpressionUtils::objectToExpression)
+			.collect(Collectors.toList());
+
+		return unresolvedCall(BuiltInFunctionDefinitions.ARRAY, entries);
+	}
+
+	private static Expression convertArray(Object expression) {
+		int length = Array.getLength(expression);
+		List<Expression> entries = IntStream.range(0, length)
+			.mapToObj(idx -> Array.get(expression, idx))
+			.map(ApiExpressionUtils::objectToExpression)
+			.collect(Collectors.toList());
+		return unresolvedCall(BuiltInFunctionDefinitions.ARRAY, entries);
+	}
+
+	private static Optional<Expression> convertScala(Object obj) {
+		try {
+			Optional<Expression> array = convertScalaSeq(obj);
+			if (array.isPresent()) {
+				return array;
+			}
+
+			Optional<Expression> bigDecimal = convertScalaBigDecimal(obj);
+			if (bigDecimal.isPresent()) {
+				return bigDecimal;
+			}
+
+			return convertScalaMap(obj);
+		} catch (Exception e) {
+			return Optional.empty();
+		}
+	}
+
+	private static Optional<Expression> convertScalaMap(Object obj)
+			throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+		Class<?> mapClass = Class.forName("scala.collection.Map");
+		if (mapClass.isAssignableFrom(obj.getClass())) {
+			Class<?> seqClass = Class.forName("scala.collection.Seq");
+			Class<?> productClass = Class.forName("scala.Product");
+			Method getElement = productClass.getMethod("productElement", int.class);
+			Method toSeq = mapClass.getMethod("toSeq");
+			Method getMethod = seqClass.getMethod("apply", Object.class);
+			Method lengthMethod = seqClass.getMethod("length");
+
+			Object mapAsSeq = toSeq.invoke(obj);
+			List<Expression> entries = new ArrayList<>();
+			for (int i = 0; i < (Integer) lengthMethod.invoke(mapAsSeq); i++) {
+				Object mapEntry = getMethod.invoke(mapAsSeq, i);
+
+				Object key = getElement.invoke(mapEntry, 0);
+				Object value = getElement.invoke(mapEntry, 1);
+				entries.add(objectToExpression(key));
+				entries.add(objectToExpression(value));
+			}
+
+			return Optional.of(unresolvedCall(BuiltInFunctionDefinitions.MAP, entries));
+		}
+		return Optional.empty();
+	}
+
+	private static Optional<Expression> convertScalaSeq(Object obj)
+			throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+		Class<?> seqClass = Class.forName("scala.collection.Seq");
+		if (seqClass.isAssignableFrom(obj.getClass())) {
+			Method getMethod = seqClass.getMethod("apply", Object.class);
+			Method lengthMethod = seqClass.getMethod("length");
+
+			List<Expression> entries = new ArrayList<>();
+			for (int i = 0; i < (Integer) lengthMethod.invoke(obj); i++) {
+				entries.add(objectToExpression(getMethod.invoke(obj, i)));
+			}
+
+			return Optional.of(unresolvedCall(BuiltInFunctionDefinitions.ARRAY, entries));
+		}
+		return Optional.empty();
+	}
+
+	private static Optional<Expression> convertScalaBigDecimal(Object obj)
+			throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+		Class<?> decimalClass = Class.forName("scala.math.BigDecimal");
+		if (decimalClass.equals(obj.getClass())) {
+			Method toJava = decimalClass.getMethod("bigDecimal");
+			BigDecimal bigDecimal = (BigDecimal) toJava.invoke(obj);
+			return Optional.of(valueLiteral(bigDecimal));
+		}
+		return Optional.empty();
 	}
 
 	public static Expression unwrapFromApi(Expression expression) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ObjectToExpressionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/expressions/ObjectToExpressionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.expressions;
+
+import org.apache.flink.types.Row;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.apache.flink.table.api.Expressions.array;
+import static org.apache.flink.table.api.Expressions.map;
+import static org.apache.flink.table.api.Expressions.row;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.objectToExpression;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unwrapFromApi;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for converting an object to a {@link Expression} via {@link ApiExpressionUtils#objectToExpression(Object)}.
+ */
+public class ObjectToExpressionTest {
+
+	@Test
+	public void testListConversion() {
+		Expression expr = objectToExpression(asList(1, 2));
+
+		assertThatEquals(expr, array(1, 2));
+	}
+
+	@Test
+	public void testNestedListConversion() {
+		Expression expr = objectToExpression(asList(singletonList(1), singletonList(2)));
+
+		assertThatEquals(expr, array(array(1), array(2)));
+	}
+
+	@Test
+	public void testMapConversion() {
+		Map<String, List<Integer>> map = new HashMap<>();
+		map.put("key1", singletonList(2));
+		map.put("key2", asList(1, 2));
+
+		Expression expr = objectToExpression(map);
+		assertThatEquals(
+			expr,
+			map(
+				"key1", array(2),
+				"key2", array(1, 2)
+			)
+		);
+	}
+
+	@Test
+	public void testRowConversion() {
+		Expression expr = objectToExpression(Row.of(1, "ABC", new int[]{1, 2, 3}));
+
+		assertThatEquals(expr, row(1, "ABC", array(1, 2, 3)));
+	}
+
+	private static void assertThatEquals(Expression actual, Expression expected) {
+		assertThat(unwrapFromApi(actual), equalTo(unwrapFromApi(expected)));
+	}
+
+}

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ExpressionsConsistencyCheckTest.scala
@@ -90,7 +90,7 @@ class ExpressionsConsistencyCheckTest {
     //  Scala implicit conversions to ImplicitExpressionOperations
     //-----------------------------------------------------------------------------------
     "WithOperations",
-    "apiExpressionToExpression",
+    "AnyWithOperations",
     "LiteralScalaDecimalExpression",
     "LiteralJavaDecimalExpression",
     "LiteralShortExpression",
@@ -127,6 +127,11 @@ class ExpressionsConsistencyCheckTest {
     "localDate2Literal",
     "float2Literal",
     "array2ArrayConstructor",
+    "seq2ArrayConstructor",
+    "javaList2ArrayConstructor",
+    "map2MapConstructor",
+    "javaMap2MapConstructor",
+    "row2RowConstructor",
     "tableSymbolToExpression",
 
     //-----------------------------------------------------------------------------------

--- a/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ImplicitConversionsTest.scala
+++ b/flink-table/flink-table-api-scala/src/test/scala/org/apache/flink/table/api/ImplicitConversionsTest.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api
+
+import org.apache.flink.table.expressions.ApiExpressionUtils.unwrapFromApi
+import org.apache.flink.table.expressions.Expression
+import org.apache.flink.types.Row
+
+import org.hamcrest.CoreMatchers.equalTo
+import org.junit.Assert.assertThat
+import org.junit.Test
+
+/**
+ * Tests for conversion between objects and [[Expression]]s used in Expression DSL.
+ */
+class ImplicitConversionsTest extends ImplicitExpressionConversions {
+  @Test
+  def testSeqConversion(): Unit = {
+    val expr = Seq(1, 2).toExpr
+
+    assertThatEquals(expr, array(1, 2))
+  }
+
+  @Test
+  def testSeqOfExpressionsConversion(): Unit = {
+    val expr = Seq(row(1, "ABC"), row(3, "DEF")).toExpr
+
+    assertThatEquals(expr, array(row(1, "ABC"), row(3, "DEF")))
+  }
+
+  @Test
+  def testListConversion(): Unit = {
+    val expr = List(1, 2).toExpr
+
+    assertThatEquals(expr, array(1, 2))
+  }
+
+  @Test
+  def testMapConversion(): Unit = {
+    val expr = Map("key1" -> List(2), "key2" -> List(1, 2)).toExpr
+
+    assertThatEquals(
+      expr,
+        map(
+          "key1", array(2),
+          "key2", array(1, 2)
+        )
+    )
+  }
+
+  @Test
+  def testNestedListConversion(): Unit = {
+    val expr = List(List(1), List(2)).toExpr
+
+    assertThatEquals(expr, array(array(1), array(2)))
+  }
+
+  @Test
+  def testRowConversion(): Unit = {
+    val expr = Row.of(Int.box(1), "ABC").toExpr
+
+    assertThatEquals(expr, row(1, "ABC"))
+  }
+
+  @Test
+  def testRowConversionWithScalaTypes(): Unit = {
+    val expr = Row.of(Int.box(1), Seq("ABC", "DEF"), BigDecimal(1234)).toExpr
+
+    assertThatEquals(expr, row(1, array("ABC", "DEF"), BigDecimal(1234)))
+  }
+
+  private def assertThatEquals(actual: Expression, expected: Expression): Unit = {
+    assertThat(unwrapFromApi(actual), equalTo(unwrapFromApi(expected)))
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR implements conversion logic from Row/List/Map/Seq to a corresponding Expression. From now on users can use those types in the Expression DSL without the need to converting those types manually.

It is also a prerequisite to use those type directly in TableEnvironment#fromValues.

## Verifying this change
- ObjectToExpressionTest for when the conversion is used from Java's DSL
- ImplicitConversionsTest for when the conversion is used from Scala's DSL

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
