### PR TITLE
[FLINK-16877][table-runtime] SingleDirectoryWriter should not produce file when no input record

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SingleDirectoryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SingleDirectoryWriter.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.filesystem;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.OutputFormat;
 
+import java.io.IOException;
 import java.util.LinkedHashMap;
 
 import static org.apache.flink.table.filesystem.PartitionPathUtils.generatePartitionPath;
@@ -33,15 +34,25 @@ import static org.apache.flink.table.filesystem.PartitionPathUtils.generateParti
 @Internal
 public class SingleDirectoryWriter<T> implements PartitionWriter<T> {
 
+	private final Context<T> context;
+	private final PartitionTempFileManager manager;
 	private final PartitionComputer<T> computer;
-	private final OutputFormat<T> format;
+	private final LinkedHashMap<String, String> staticPartitions;
+
+	private OutputFormat<T> format;
 
 	public SingleDirectoryWriter(
 			Context<T> context,
 			PartitionTempFileManager manager,
 			PartitionComputer<T> computer,
-			LinkedHashMap<String, String> staticPartitions) throws Exception {
+			LinkedHashMap<String, String> staticPartitions) {
+		this.context = context;
+		this.manager = manager;
 		this.computer = computer;
+		this.staticPartitions = staticPartitions;
+	}
+
+	private void createFormat() throws IOException {
 		this.format = context.createNewOutputFormat(staticPartitions.size() == 0 ?
 				manager.createPartitionDir() :
 				manager.createPartitionDir(generatePartitionPath(staticPartitions)));
@@ -49,11 +60,17 @@ public class SingleDirectoryWriter<T> implements PartitionWriter<T> {
 
 	@Override
 	public void write(T in) throws Exception {
+		if (format == null) {
+			createFormat();
+		}
 		format.writeRecord(computer.projectColumnsToWrite(in));
 	}
 
 	@Override
 	public void close() throws Exception {
-		format.close();
+		if (format != null) {
+			format.close();
+			format = null;
+		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

SingleDirectoryWriter should not produce file when no input record.
Now it will produce an empty file, we should avoid this.

## Brief change log

Modify `SingleDirectoryWriter` to lazy creating OutputFormat.

## Verifying this change

`PartitionWriterTest.testEmptySingleDirectoryWriter`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)