### PR TITLE
[FLINK-16859][table-runtime] Introduce file system table factory

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
@@ -77,7 +77,7 @@ public class TestCsvFileSystemFormatFactory implements FileSystemFormatFactory {
 
 	@Override
 	public Optional<Encoder<BaseRow>> createEncoder(WriterContext context) {
-		LogicalType[] fieldTypes = Arrays.stream(context.getFieldTypes())
+		LogicalType[] fieldTypes = Arrays.stream(context.getFieldTypesWithoutPartKeys())
 				.map(DataType::getLogicalType)
 				.toArray(LogicalType[]::new);
 		DataFormatConverters.DataFormatConverter converter = DataFormatConverters.getConverterForDataType(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.DataFormatConverters;
+import org.apache.flink.table.factories.TableFormatFactoryBase;
+import org.apache.flink.table.filesystem.FileSystemFormatFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_FIELD_DELIMITER;
+import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_LINE_DELIMITER;
+
+/**
+ * Test csv {@link FileSystemFormatFactory}.
+ */
+public class TestCsvFileSystemFormatFactory extends TableFormatFactoryBase<BaseRow> implements FileSystemFormatFactory {
+
+	public TestCsvFileSystemFormatFactory() {
+		super("testcsv", 1, true);
+	}
+
+	@Override
+	public InputFormat<BaseRow, ?> createReader(ReaderContext context) {
+		return new TestRowDataCsvInputFormat(
+				context.getPaths(),
+				context.getSchema(),
+				context.getPartitionKeys(),
+				context.getDefaultPartName(),
+				context.getProjectFields(),
+				context.getPushedDownLimit());
+	}
+
+	@Override
+	public Optional<Encoder<BaseRow>> createEncoder(WriterContext context) {
+		LogicalType[] fieldTypes = Arrays.stream(context.getFieldTypes())
+				.map(DataType::getLogicalType)
+				.toArray(LogicalType[]::new);
+		DataFormatConverters.DataFormatConverter converter = DataFormatConverters.getConverterForDataType(
+				TypeConversions.fromLogicalToDataType(RowType.of(fieldTypes)));
+		return Optional.of((Encoder<BaseRow>) (baseRow, stream) -> {
+			Row row = (Row) converter.toExternal(baseRow);
+			StringBuilder builder = new StringBuilder();
+			Object o;
+			for (int i = 0; i < row.getArity(); i++) {
+				if (i > 0) {
+					builder.append(DEFAULT_FIELD_DELIMITER);
+				}
+				if ((o = row.getField(i)) != null) {
+					builder.append(o);
+				}
+			}
+			String str = builder.toString();
+			stream.write(str.getBytes(StandardCharsets.UTF_8));
+			stream.write(DEFAULT_LINE_DELIMITER.getBytes(StandardCharsets.UTF_8));
+		});
+	}
+
+	@Override
+	public Optional<BulkWriter.Factory<BaseRow>> createBulkWriterFactory(WriterContext context) {
+		return Optional.empty();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestCsvFileSystemFormatFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.api.common.serialization.Encoder;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.DataFormatConverters;
-import org.apache.flink.table.factories.TableFormatFactoryBase;
 import org.apache.flink.table.filesystem.FileSystemFormatFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -33,18 +32,36 @@ import org.apache.flink.types.Row;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_FIELD_DELIMITER;
 import static org.apache.flink.api.java.io.CsvOutputFormat.DEFAULT_LINE_DELIMITER;
+import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 
 /**
  * Test csv {@link FileSystemFormatFactory}.
  */
-public class TestCsvFileSystemFormatFactory extends TableFormatFactoryBase<BaseRow> implements FileSystemFormatFactory {
+public class TestCsvFileSystemFormatFactory implements FileSystemFormatFactory {
 
-	public TestCsvFileSystemFormatFactory() {
-		super("testcsv", 1, true);
+	@Override
+	public boolean supportsSchemaDerivation() {
+		return true;
+	}
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(FORMAT, "testcsv");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestRowDataCsvInputFormat.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestRowDataCsvInputFormat.java
@@ -148,7 +148,7 @@ public class TestRowDataCsvInputFormat extends RichInputFormat<BaseRow, FileInpu
 		} else if (type.equals(Types.STRING)) {
 			return BinaryString.fromString(value);
 		} else {
-			throw new UnsupportedOperationException("Unsupported type: " + type);
+			throw new UnsupportedOperationException("Unsupported partition type: " + type);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestRowDataCsvInputFormat.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/TestRowDataCsvInputFormat.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.io.RowCsvInputFormat;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.dataformat.DataFormatConverters;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.filesystem.PartitionPathUtils;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link InputFormat} that output {@link BaseRow}.
+ */
+public class TestRowDataCsvInputFormat extends RichInputFormat<BaseRow, FileInputSplit> {
+
+	private final List<String> partitionKeys;
+	private final String defaultPartValue;
+	private final int[] selectFields;
+	private final long limit;
+	private final RowCsvInputFormat inputFormat;
+	private final List<TypeInformation> fieldTypes;
+	private final List<String> fieldNames;
+	private final List<DataFormatConverters.DataFormatConverter> csvSelectConverters;
+	private final int[] csvFieldMapping;
+
+	private transient Row csvRow;
+	private transient GenericRow row;
+	private transient long emitted;
+
+	public TestRowDataCsvInputFormat(
+			Path[] paths,
+			TableSchema schema,
+			List<String> partitionKeys,
+			String defaultPartValue,
+			int[] selectFields,
+			long limit) {
+		this.partitionKeys = partitionKeys;
+		this.defaultPartValue = defaultPartValue;
+		this.selectFields = selectFields;
+		this.limit = limit;
+		RowTypeInfo rowType = (RowTypeInfo) schema.toRowType();
+		this.fieldTypes = Arrays.asList(rowType.getFieldTypes());
+		this.fieldNames = Arrays.asList(rowType.getFieldNames());
+
+		List<String> csvFieldNames = fieldNames.stream()
+				.filter(name -> !partitionKeys.contains(name)).collect(Collectors.toList());
+
+		List<String> selectFieldNames = Arrays.stream(selectFields)
+				.mapToObj(fieldNames::get)
+				.collect(Collectors.toList());
+		List<String> csvSelectFieldNames = selectFieldNames.stream()
+				.filter(name -> !partitionKeys.contains(name)).collect(Collectors.toList());
+		List<TypeInformation> csvSelectTypes = csvSelectFieldNames.stream()
+				.map(name -> fieldTypes.get(fieldNames.indexOf(name))).collect(Collectors.toList());
+		this.csvSelectConverters = csvSelectTypes.stream()
+				.map(TypeConversions::fromLegacyInfoToDataType)
+				.map(DataFormatConverters::getConverterForDataType)
+				.collect(Collectors.toList());
+		int[] csvSelectFields = csvSelectFieldNames.stream().mapToInt(csvFieldNames::indexOf).toArray();
+		this.inputFormat = new RowCsvInputFormat(
+				null, csvSelectTypes.toArray(new TypeInformation[0]), csvSelectFields);
+		this.inputFormat.setFilePaths(paths);
+
+		this.csvFieldMapping = csvSelectFieldNames.stream().mapToInt(selectFieldNames::indexOf).toArray();
+		this.emitted = 0;
+	}
+
+	@Override
+	public void configure(Configuration parameters) {
+		inputFormat.configure(parameters);
+	}
+
+	@Override
+	public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+		return inputFormat.getStatistics(cachedStatistics);
+	}
+
+	@Override
+	public FileInputSplit[] createInputSplits(int minNumSplits) throws IOException {
+		return inputFormat.createInputSplits(minNumSplits);
+	}
+
+	@Override
+	public InputSplitAssigner getInputSplitAssigner(FileInputSplit[] inputSplits) {
+		return inputFormat.getInputSplitAssigner(inputSplits);
+	}
+
+	@Override
+	public void open(FileInputSplit split) throws IOException {
+		inputFormat.open(split);
+		Path path = split.getPath();
+		LinkedHashMap<String, String> partSpec = PartitionPathUtils.extractPartitionSpecFromPath(path);
+		this.row = new GenericRow(selectFields.length);
+		for (int i = 0; i < selectFields.length; i++) {
+			int selectField = selectFields[i];
+			String name = fieldNames.get(selectField);
+			if (partitionKeys.contains(name)) {
+				String value = partSpec.get(name);
+				value = defaultPartValue.equals(value) ? null : value;
+				this.row.setField(
+						i, convertStringToInternal(value, fieldTypes.get(selectField)));
+			}
+		}
+		this.csvRow = new Row(csvSelectConverters.size());
+	}
+
+	private Object convertStringToInternal(String value, TypeInformation type) {
+		if (type.equals(Types.INT)) {
+			return Integer.parseInt(value);
+		} else if (type.equals(Types.LONG)) {
+			return Long.parseLong(value);
+		} else if (type.equals(Types.STRING)) {
+			return BinaryString.fromString(value);
+		} else {
+			throw new UnsupportedOperationException("Unsupported type: " + type);
+		}
+	}
+
+	@Override
+	public boolean reachedEnd() {
+		return emitted >= limit || inputFormat.reachedEnd();
+	}
+
+	@Override
+	public BaseRow nextRecord(BaseRow reuse) throws IOException {
+		Row csvRow = inputFormat.nextRecord(this.csvRow);
+		if (csvRow == null) {
+			return null;
+		}
+		for (int i = 0; i < csvSelectConverters.size(); i++) {
+			row.setField(
+					csvFieldMapping[i],
+					csvSelectConverters.get(i).toInternal(csvRow.getField(i)));
+		}
+		emitted++;
+		return row;
+	}
+
+	@Override
+	public void close() throws IOException {
+		inputFormat.close();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -42,7 +42,7 @@ trait FileSystemITCaseBase {
   @Rule
   def fileTempFolder: TemporaryFolder = fileTmpFolder
 
-  def formatProperties(): Seq[String] = Seq()
+  def formatProperties(): Array[String] = Array()
 
   def tableEnv: TableEnvironment
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -65,8 +65,8 @@ trait FileSystemITCaseBase {
          |  a int,
          |  b bigint
          |) partitioned by (a, b) with (
-         |  'connector.type' = 'filesystem',
-         |  'connector.path' = '$resultPath',
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
          |  ${formatProperties().mkString("\n")}
          |)
        """.stripMargin
@@ -79,8 +79,8 @@ trait FileSystemITCaseBase {
          |  a int,
          |  b bigint
          |) with (
-         |  'connector.type' = 'filesystem',
-         |  'connector.path' = '$resultPath',
+         |  'connector' = 'filesystem',
+         |  'path' = '$resultPath',
          |  ${formatProperties().mkString("\n")}
          |)
        """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime
+
+import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.table.api.{SqlDialect, TableEnvironment}
+import org.apache.flink.table.planner.runtime.FileSystemITCaseBase._
+import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
+import org.apache.flink.types.Row
+
+import org.junit.rules.TemporaryFolder
+import org.junit.{Rule, Test}
+
+import scala.collection.Seq
+
+/**
+  * Test File system table factory.
+  */
+trait FileSystemITCaseBase {
+
+  val fileTmpFolder = new TemporaryFolder
+  protected var resultPath: String = _
+
+  @Rule
+  def fileTempFolder: TemporaryFolder = fileTmpFolder
+
+  def formatProperties(): Seq[String] = Seq()
+
+  def tableEnv: TableEnvironment
+
+  def check(sqlQuery: String, expectedResult: Seq[Row]): Unit
+
+  def open(): Unit = {
+    tableEnv.getConfig.setSqlDialect(SqlDialect.HIVE)
+    resultPath = fileTmpFolder.newFolder().toURI.toString
+    BatchTableEnvUtil.registerCollection(
+      tableEnv,
+      "originalT",
+      data_with_partitions,
+      dataType,
+      "x, y, a, b")
+    tableEnv.sqlUpdate(
+      s"""
+         |create table partitionedTable (
+         |  x string,
+         |  y int,
+         |  a int,
+         |  b bigint
+         |) partitioned by (a, b) with (
+         |  'connector.type' = 'filesystem',
+         |  'connector.path' = '$resultPath',
+         |  ${formatProperties().mkString("\n")}
+         |)
+       """.stripMargin
+    )
+    tableEnv.sqlUpdate(
+      s"""
+         |create table nonPartitionedTable (
+         |  x string,
+         |  y int,
+         |  a int,
+         |  b bigint
+         |) with (
+         |  'connector.type' = 'filesystem',
+         |  'connector.path' = '$resultPath',
+         |  ${formatProperties().mkString("\n")}
+         |)
+       """.stripMargin
+    )
+  }
+
+  @Test
+  def testAllStaticPartitions1(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable " +
+        "partition(a='1', b='1') select x, y from originalT where a=1 and b=1")
+    tableEnv.execute("test")
+
+    check(
+      "select x, y from partitionedTable where a=1 and b=1",
+      data_partition_1_1
+    )
+
+    check(
+      "select x, y from partitionedTable",
+      data_partition_1_1
+    )
+  }
+
+  @Test
+  def testAllStaticPartitions2(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable " +
+        "partition(a='2', b='1') select x, y from originalT where a=2 and b=1")
+    tableEnv.execute("test")
+
+    check(
+      "select x, y from partitionedTable where a=2 and b=1",
+      data_partition_2_1
+    )
+
+    check(
+      "select x, y from partitionedTable",
+      data_partition_2_1
+    )
+  }
+
+  @Test
+  def testPartialDynamicPartition(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable " +
+        "partition(a=3) select x, y, b from originalT where a=3")
+    tableEnv.execute("test")
+
+    check(
+      "select x, y from partitionedTable where a=2 and b=1",
+      Seq()
+    )
+
+    check(
+      "select x, y from partitionedTable where a=3 and b=1",
+      Seq(
+        row("x17", 17)
+      )
+    )
+
+    check(
+      "select x, y from partitionedTable where a=3 and b=2",
+      Seq(
+        row("x18", 18)
+      )
+    )
+
+    check(
+      "select x, y from partitionedTable where a=3 and b=3",
+      Seq(
+        row("x19", 19)
+      )
+    )
+
+    check(
+      "select x, y from partitionedTable where a=3",
+      Seq(
+        row("x17", 17),
+        row("x18", 18),
+        row("x19", 19)
+      )
+    )
+  }
+
+  @Test
+  def testDynamicPartition(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable " +
+        "select x, y, a, b from originalT")
+    tableEnv.execute("test")
+
+    check(
+      "select x, y from partitionedTable where a=1 and b=1",
+      data_partition_1_1
+    )
+
+    check(
+      "select x, y from partitionedTable where a=2 and b=1",
+      data_partition_2_1
+    )
+
+    check(
+      "select x, y from partitionedTable",
+      data
+    )
+  }
+
+  @Test
+  def testNonPartition(): Unit = {
+    tableEnv.sqlUpdate("insert into nonPartitionedTable " +
+        "select x, y, a, b from originalT where a=1 and b=1")
+    tableEnv.execute("test")
+
+    check(
+      "select x, y from nonPartitionedTable where a=1 and b=1",
+      data_partition_1_1
+    )
+  }
+}
+
+object FileSystemITCaseBase {
+
+  val fieldNames = Array("x", "y", "a", "b")
+
+  val fieldTypes: Array[TypeInformation[_]] = Array(
+    Types.STRING,
+    Types.INT,
+    Types.INT,
+    Types.LONG)
+  val dataType = new RowTypeInfo(fieldTypes :_*)
+
+  val data_with_partitions: Seq[Row] = Seq(
+    row("x1", 1, 1, 1L),
+    row("x2", 2, 1, 1L),
+    row("x3", 3, 1, 1L),
+    row("x4", 4, 1, 1L),
+    row("x5", 5, 1, 1L),
+    row("x6", 6, 1, 2L),
+    row("x7", 7, 1, 2L),
+    row("x8", 8, 1, 2L),
+    row("x9", 9, 1, 2L),
+    row("x10", 10, 1, 2L),
+    row("x11", 11, 2, 1L),
+    row("x12", 12, 2, 1L),
+    row("x13", 13, 2, 1L),
+    row("x14", 14, 2, 1L),
+    row("x15", 15, 2, 1L),
+    row("x16", 16, 2, 2L),
+    row("x17", 17, 3, 1L),
+    row("x18", 18, 3, 2L),
+    row("x19", 19, 3, 3L),
+    row("x20", 20, 4, 1L),
+    row("x21", 21, 4, 2L),
+    row("x22", 22, 4, 3L),
+    row("x23", 23, 4, 4L),
+    row("x24", 24, 5, 1L),
+    row("x25", 25, 5, 2L),
+    row("x26", 26, 5, 3L),
+    row("x27", 27, 5, 4L)
+  )
+
+  val data: Seq[Row] = data_with_partitions.map(row => Row.of(row.getField(0), row.getField(1)))
+
+  val data_partition_1_1: Seq[Row] = Seq(
+    row("x1", 1),
+    row("x2", 2),
+    row("x3", 3),
+    row("x4", 4),
+    row("x5", 5)
+  )
+
+  val data_partition_2_1: Seq[Row] = Seq(
+    row("x11", 11),
+    row("x12", 12),
+    row("x13", 13),
+    row("x14", 14),
+    row("x15", 15)
+  )
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -67,7 +67,7 @@ trait FileSystemITCaseBase {
          |) partitioned by (a, b) with (
          |  'connector' = 'filesystem',
          |  'path' = '$resultPath',
-         |  ${formatProperties().mkString("\n")}
+         |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
     )
@@ -81,7 +81,7 @@ trait FileSystemITCaseBase {
          |) with (
          |  'connector' = 'filesystem',
          |  'path' = '$resultPath',
-         |  ${formatProperties().mkString("\n")}
+         |  ${formatProperties().mkString(",\n")}
          |)
        """.stripMargin
     )

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/BatchFileSystemITCaseBase.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql
+
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase
+import org.apache.flink.types.Row
+
+import org.junit.Before
+
+import scala.collection.Seq
+
+/**
+  * Batch [[FileSystemITCaseBase]].
+  */
+abstract class BatchFileSystemITCaseBase extends BatchTestBase with FileSystemITCaseBase {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    super.open()
+  }
+
+  override def tableEnv: TableEnvironment = {
+    tEnv
+  }
+
+  override def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
+    checkResult(sqlQuery, expectedResult)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -23,7 +23,7 @@ package org.apache.flink.table.planner.runtime.batch.sql
   */
 class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
 
-  override def formatProperties(): Seq[String] = {
+  override def formatProperties(): Array[String] = {
     super.formatProperties() ++ Seq("'format' = 'testcsv'")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql
+
+/**
+  * Test for file system table factory with testcsv format.
+  */
+class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
+
+  override def formatProperties(): Seq[String] = {
+    super.formatProperties() ++ Seq("'format.type' = 'testcsv'")
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -37,7 +37,7 @@ class FileSystemTestCsvITCase(useBulkWriter: Boolean) extends BatchFileSystemITC
 }
 
 object FileSystemTestCsvITCase {
-  @Parameterized.Parameters(name = "{0}")
+  @Parameterized.Parameters(name = "useBulkWriter-{0}")
   def parameters(): java.util.Collection[Boolean] = {
     java.util.Arrays.asList(true, false)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -18,12 +18,27 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql
 
+import org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory.USE_BULK_WRITER
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
 /**
   * Test for file system table factory with testcsv format.
   */
-class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
+@RunWith(classOf[Parameterized])
+class FileSystemTestCsvITCase(useBulkWriter: Boolean) extends BatchFileSystemITCaseBase {
 
   override def formatProperties(): Array[String] = {
-    super.formatProperties() ++ Seq("'format' = 'testcsv'")
+    super.formatProperties() ++ Seq(
+      "'format' = 'testcsv'",
+      s"'$USE_BULK_WRITER' = '$useBulkWriter'")
+  }
+}
+
+object FileSystemTestCsvITCase {
+  @Parameterized.Parameters(name = "{0}")
+  def parameters(): java.util.Collection[Boolean] = {
+    java.util.Arrays.asList(true, false)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/FileSystemTestCsvITCase.scala
@@ -24,6 +24,6 @@ package org.apache.flink.table.planner.runtime.batch.sql
 class FileSystemTestCsvITCase extends BatchFileSystemITCaseBase {
 
   override def formatProperties(): Seq[String] = {
-    super.formatProperties() ++ Seq("'format.type' = 'testcsv'")
+    super.formatProperties() ++ Seq("'format' = 'testcsv'")
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemITCaseBase.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.api.scala._
+import org.apache.flink.table.api.TableEnvironment
+import org.apache.flink.table.api.scala._
+import org.apache.flink.table.planner.runtime.FileSystemITCaseBase
+import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil, TestingAppendSink}
+import org.apache.flink.types.Row
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+
+import scala.collection.Seq
+
+/**
+  * Streaming [[FileSystemITCaseBase]].
+  */
+abstract class StreamFileSystemITCaseBase extends StreamingTestBase with FileSystemITCaseBase {
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    super.open()
+  }
+
+  override def tableEnv: TableEnvironment = {
+    tEnv
+  }
+
+  override def check(sqlQuery: String, expectedResult: Seq[Row]): Unit = {
+    val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
+    val sink = new TestingAppendSink()
+    result.addSink(sink)
+    env.execute()
+
+    assertEquals(
+      expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
+      sink.getAppendResults.sorted)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
@@ -62,7 +62,7 @@ object TestSinkUtil {
     }
   }
 
-  def rowToString(row: Row, tz: TimeZone): String = {
+  def rowToString(row: Row, tz: TimeZone = TimeZone.getTimeZone("UTC")): String = {
     val sb = StringBuilder.newBuilder
     for (i <- 0 until row.getArity ) {
       if (i > 0) {

--- a/flink-table/flink-table-runtime-blink/pom.xml
+++ b/flink-table/flink-table-runtime-blink/pom.xml
@@ -56,6 +56,12 @@ under the License.
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.TableFormatFactory;
 import org.apache.flink.table.types.DataType;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -110,13 +111,37 @@ public interface FileSystemFormatFactory extends TableFormatFactory<BaseRow> {
 	interface WriterContext {
 
 		/**
+		 * Full schema of the table.
+		 */
+		TableSchema getSchema();
+
+		/**
 		 * Properties of this format.
 		 */
 		Map<String, String> getFormatProperties();
 
 		/**
-		 * Field types without partition fields.
+		 * Partition keys of the table.
 		 */
-		DataType[] getFieldTypes();
+		List<String> getPartitionKeys();
+
+		/**
+		 * Get field names without partition keys.
+		 */
+		default String[] getFieldNamesWithoutPartKeys() {
+			return Arrays.stream(getSchema().getFieldNames())
+					.filter(name -> !getPartitionKeys().contains(name))
+					.toArray(String[]::new);
+		}
+
+		/**
+		 * Get field types without partition keys.
+		 */
+		default DataType[] getFieldTypesWithoutPartKeys() {
+			return Arrays.stream(getSchema().getFieldNames())
+					.filter(name -> !getPartitionKeys().contains(name))
+					.map(name -> getSchema().getFieldDataType(name).get())
+					.toArray(DataType[]::new);
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.factories.TableFormatFactory;
+import org.apache.flink.table.types.DataType;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * File system format factory for creating configured instances of reader and writer.
+ */
+@Internal
+public interface FileSystemFormatFactory extends TableFormatFactory<BaseRow> {
+
+	/**
+	 * Create {@link InputFormat} reader.
+	 */
+	InputFormat<BaseRow, ?> createReader(ReaderContext context);
+
+	/**
+	 * Create {@link Encoder} writer.
+	 */
+	Optional<Encoder<BaseRow>> createEncoder(WriterContext context);
+
+	/**
+	 * Create {@link BulkWriter.Factory} writer.
+	 */
+	Optional<BulkWriter.Factory<BaseRow>> createBulkWriterFactory(WriterContext context);
+
+	/**
+	 * Context of {@link #createReader}.
+	 */
+	interface ReaderContext {
+
+		/**
+		 * Full schema of the table.
+		 */
+		TableSchema getSchema();
+
+		/**
+		 * Partition keys of the table.
+		 */
+		List<String> getPartitionKeys();
+
+		/**
+		 * The default partition name in case the dynamic partition column value is
+		 * null/empty string.
+		 */
+		String getDefaultPartName();
+
+		/**
+		 * Read paths.
+		 */
+		Path[] getPaths();
+
+		/**
+		 * Project the fields of the reader returned.
+		 */
+		int[] getProjectFields();
+
+		/**
+		 * Limiting push-down to reader. Reader only needs to try its best to limit the number
+		 * of output records, but does not need to guarantee that the number must be less than or
+		 * equal to the limit.
+		 */
+		long getPushedDownLimit();
+
+		/**
+		 * Pushed down filters, reader can try its best to filter records.
+		 * The follow up operator will filter the records again.
+		 */
+		List<Expression> getPushedDownFilters();
+	}
+
+	/**
+	 * Context of {@link #createEncoder} and {@link #createBulkWriterFactory}.
+	 */
+	interface WriterContext {
+
+		/**
+		 * Field types without partition fields.
+		 */
+		DataType[] getFieldTypes();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemFormatFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.factories.TableFormatFactory;
 import org.apache.flink.table.types.DataType;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -62,6 +63,11 @@ public interface FileSystemFormatFactory extends TableFormatFactory<BaseRow> {
 		 * Full schema of the table.
 		 */
 		TableSchema getSchema();
+
+		/**
+		 * Properties of this format.
+		 */
+		Map<String, String> getFormatProperties();
 
 		/**
 		 * Partition keys of the table.
@@ -102,6 +108,11 @@ public interface FileSystemFormatFactory extends TableFormatFactory<BaseRow> {
 	 * Context of {@link #createEncoder} and {@link #createBulkWriterFactory}.
 	 */
 	interface WriterContext {
+
+		/**
+		 * Properties of this format.
+		 */
+		Map<String, String> getFormatProperties();
 
 		/**
 		 * Field types without partition fields.

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -35,10 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
-import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
-import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_PATH;
-import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_TYPE_VALUE;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 
@@ -55,6 +52,9 @@ public class FileSystemTableFactory implements
 		TableSourceFactory<BaseRow>,
 		TableSinkFactory<BaseRow> {
 
+	public static final String CONNECTOR_VALUE = "filesystem";
+	public static final String PATH = "path";
+
 	public static final ConfigOption<String> PARTITION_DEFAULT_NAME = key("partition.default-name")
 			.stringType()
 			.defaultValue("__DEFAULT_PARTITION__")
@@ -64,8 +64,7 @@ public class FileSystemTableFactory implements
 	@Override
 	public Map<String, String> requiredContext() {
 		Map<String, String> context = new HashMap<>();
-		context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
-		context.put(CONNECTOR_PROPERTY_VERSION, "1");
+		context.put(CONNECTOR, CONNECTOR_VALUE);
 		return context;
 	}
 
@@ -74,7 +73,7 @@ public class FileSystemTableFactory implements
 		List<String> properties = new ArrayList<>();
 
 		// path
-		properties.add(CONNECTOR_PATH);
+		properties.add(PATH);
 
 		// schema
 		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
@@ -82,7 +81,8 @@ public class FileSystemTableFactory implements
 
 		properties.add(PARTITION_DEFAULT_NAME.key());
 
-		// format wildcard
+		// format
+		properties.add(FORMAT);
 		properties.add(FORMAT + ".*");
 
 		return properties;
@@ -95,7 +95,7 @@ public class FileSystemTableFactory implements
 
 		return new FileSystemTableSource(
 				context.getTable().getSchema(),
-				new Path(properties.getString(CONNECTOR_PATH)),
+				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
 				getFormatFactory(context.getTable().getProperties()));
@@ -108,7 +108,7 @@ public class FileSystemTableFactory implements
 
 		return new FileSystemTableSink(
 				context.getTable().getSchema(),
-				new Path(properties.getString(CONNECTOR_PATH)),
+				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
 				getFormatFactory(context.getTable().getProperties()));

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.TableFactory;
+import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.table.factories.TableSinkFactory;
+import org.apache.flink.table.factories.TableSourceFactory;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.sources.TableSource;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_PATH;
+import static org.apache.flink.table.descriptors.FileSystemValidator.CONNECTOR_TYPE_VALUE;
+import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+
+/**
+ * File system {@link TableFactory}.
+ *
+ * <P>File system support:
+ * 1.The partition information should be in the file system path, whether it's a temporary
+ * table or a catalog table.
+ * 2.Support insert into (append) and insert overwrite.
+ * 3.Support static and dynamic partition inserting.
+ */
+public class FileSystemTableFactory implements
+		TableSourceFactory<BaseRow>,
+		TableSinkFactory<BaseRow> {
+
+	public static final ConfigOption<String> PARTITION_DEFAULT_NAME = key("partition.default-name")
+			.stringType()
+			.defaultValue("__DEFAULT_PARTITION__")
+			.withDescription("The default partition name in case the dynamic partition" +
+					" column value is null/empty string");
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE);
+		context.put(CONNECTOR_PROPERTY_VERSION, "1");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		List<String> properties = new ArrayList<>();
+
+		// path
+		properties.add(CONNECTOR_PATH);
+
+		// schema
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_DATA_TYPE);
+		properties.add(SCHEMA + ".#." + DescriptorProperties.TABLE_SCHEMA_NAME);
+
+		properties.add(PARTITION_DEFAULT_NAME.key());
+
+		// format wildcard
+		properties.add(FORMAT + ".*");
+
+		return properties;
+	}
+
+	@Override
+	public TableSource<BaseRow> createTableSource(TableSourceFactory.Context context) {
+		DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(context.getTable().getProperties());
+
+		return new FileSystemTableSource(
+				context.getTable().getSchema(),
+				new Path(properties.getString(CONNECTOR_PATH)),
+				context.getTable().getPartitionKeys(),
+				getPartitionDefaultName(properties),
+				getFormatFactory(context.getTable().getProperties()));
+	}
+
+	@Override
+	public TableSink<BaseRow> createTableSink(TableSinkFactory.Context context) {
+		DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(context.getTable().getProperties());
+
+		return new FileSystemTableSink(
+				context.getTable().getSchema(),
+				new Path(properties.getString(CONNECTOR_PATH)),
+				context.getTable().getPartitionKeys(),
+				getPartitionDefaultName(properties),
+				getFormatFactory(context.getTable().getProperties()));
+	}
+
+	private String getPartitionDefaultName(DescriptorProperties properties) {
+		return properties
+				.getOptionalString(PARTITION_DEFAULT_NAME.key())
+				.orElse(PARTITION_DEFAULT_NAME.defaultValue());
+	}
+
+	private FileSystemFormatFactory getFormatFactory(Map<String, String> properties) {
+		return TableFactoryService.find(
+				FileSystemFormatFactory.class,
+				properties,
+				this.getClass().getClassLoader());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -108,7 +108,7 @@ public class FileSystemTableFactory implements
 				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
-				getFormatFactory(context.getTable().getProperties()));
+				getFormatProperties(context.getTable().getProperties()));
 	}
 
 	@Override
@@ -121,19 +121,23 @@ public class FileSystemTableFactory implements
 				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
-				getFormatFactory(context.getTable().getProperties()));
+				getFormatProperties(context.getTable().getProperties()));
 	}
 
-	private String getPartitionDefaultName(DescriptorProperties properties) {
+	private static Map<String, String> getFormatProperties(Map<String, String> tableProperties) {
+		return tableProperties;
+	}
+
+	private static String getPartitionDefaultName(DescriptorProperties properties) {
 		return properties
 				.getOptionalString(PARTITION_DEFAULT_NAME.key())
 				.orElse(PARTITION_DEFAULT_NAME.defaultValue());
 	}
 
-	private FileSystemFormatFactory getFormatFactory(Map<String, String> properties) {
+	public static FileSystemFormatFactory createFormatFactory(Map<String, String> properties) {
 		return TableFactoryService.find(
 				FileSystemFormatFactory.class,
 				properties,
-				this.getClass().getClassLoader());
+				FileSystemTableFactory.class.getClassLoader());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -42,19 +42,29 @@ import static org.apache.flink.table.descriptors.Schema.SCHEMA;
 /**
  * File system {@link TableFactory}.
  *
- * <P>File system support:
- * 1.The partition information should be in the file system path, whether it's a temporary
+ * <p>1.The partition information should be in the file system path, whether it's a temporary
  * table or a catalog table.
  * 2.Support insert into (append) and insert overwrite.
  * 3.Support static and dynamic partition inserting.
+ *
+ * <p>Migrate to new source/sink interface after FLIP-95 is ready.
  */
 public class FileSystemTableFactory implements
 		TableSourceFactory<BaseRow>,
 		TableSinkFactory<BaseRow> {
 
 	public static final String CONNECTOR_VALUE = "filesystem";
+
+	/**
+	 * Not use "connector.path" because:
+	 * 1.Using "connector.path" will conflict with current batch csv source and batch csv sink.
+	 * 2.This is compatible with FLIP-122.
+	 */
 	public static final String PATH = "path";
 
+	/**
+	 * Move these properties to validator after FLINK-16904.
+	 */
 	public static final ConfigOption<String> PARTITION_DEFAULT_NAME = key("partition.default-name")
 			.stringType()
 			.defaultValue("__DEFAULT_PARTITION__")

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -150,7 +150,11 @@ public class FileSystemTableSink implements
 		}
 		return encoder
 				.<OutputFormatFactory<BaseRow>>map(en -> path -> createEncoderOutputFormat(en, path))
-				.orElseGet(() -> path -> createBulkWriterOutputFormat(bulk.get(), path));
+				.orElseGet(() -> {
+					// Optional is not serializable.
+					BulkWriter.Factory<BaseRow> bulkWriter = bulk.get();
+					return path -> createBulkWriterOutputFormat(bulkWriter, path);
+				});
 	}
 
 	private static OutputFormat<BaseRow> createBulkWriterOutputFormat(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -39,7 +39,6 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,13 +108,6 @@ public class FileSystemTableSink implements
 				.setParallelism(dataStream.getParallelism());
 	}
 
-	private DataType[] getNonPartitionTypes() {
-		return Arrays.stream(schema.getFieldNames())
-				.filter(name -> !partitionKeys.contains(name))
-				.map(name -> schema.getFieldDataType(name).get())
-				.toArray(DataType[]::new);
-	}
-
 	private Path toStagingPath() {
 		Path stagingDir = new Path(path, ".staging_" + System.currentTimeMillis());
 		try {
@@ -134,13 +126,18 @@ public class FileSystemTableSink implements
 		FileSystemFormatFactory.WriterContext context = new FileSystemFormatFactory.WriterContext() {
 
 			@Override
+			public TableSchema getSchema() {
+				return schema;
+			}
+
+			@Override
 			public Map<String, String> getFormatProperties() {
 				return formatProperties;
 			}
 
 			@Override
-			public DataType[] getFieldTypes() {
-				return getNonPartitionTypes();
+			public List<String> getPartitionKeys() {
+				return partitionKeys;
 			}
 		};
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -152,8 +152,8 @@ public class FileSystemTableSink implements
 				.<OutputFormatFactory<BaseRow>>map(en -> path -> createEncoderOutputFormat(en, path))
 				.orElseGet(() -> {
 					// Optional is not serializable.
-					BulkWriter.Factory<BaseRow> bulkWriter = bulk.get();
-					return path -> createBulkWriterOutputFormat(bulkWriter, path);
+					BulkWriter.Factory<BaseRow> bulkWriterFactory = bulk.get();
+					return path -> createBulkWriterOutputFormat(bulkWriterFactory, path);
 				});
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataOutputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.sinks.AppendStreamTableSink;
+import org.apache.flink.table.sinks.OverwritableTableSink;
+import org.apache.flink.table.sinks.PartitionableTableSink;
+import org.apache.flink.table.sinks.TableSink;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * File system {@link TableSink}.
+ */
+public class FileSystemTableSink implements
+		AppendStreamTableSink<BaseRow>,
+		PartitionableTableSink,
+		OverwritableTableSink {
+
+	private final TableSchema schema;
+	private final List<String> partitionKeys;
+	private final Path path;
+	private final String defaultPartName;
+	private final FileSystemFormatFactory formatFactory;
+
+	private boolean overwrite = false;
+	private boolean dynamicGrouping = false;
+	private LinkedHashMap<String, String> staticPartitions = new LinkedHashMap<>();
+
+	/**
+	 * Construct a file system table sink.
+	 *
+	 * @param schema schema of the table.
+	 * @param path directory path of the file system table.
+	 * @param partitionKeys partition keys of the table.
+	 * @param defaultPartName The default partition name in case the dynamic partition column value
+	 *                        is null/empty string.
+	 * @param formatFactory format factory to create reader.
+	 */
+	public FileSystemTableSink(
+			TableSchema schema,
+			Path path,
+			List<String> partitionKeys,
+			String defaultPartName,
+			FileSystemFormatFactory formatFactory) {
+		this.schema = schema;
+		this.path = path;
+		this.defaultPartName = defaultPartName;
+		this.formatFactory = formatFactory;
+		this.partitionKeys = partitionKeys;
+	}
+
+	@Override
+	public final DataStreamSink<BaseRow> consumeDataStream(DataStream<BaseRow> dataStream) {
+		RowDataPartitionComputer computer = new RowDataPartitionComputer(
+				defaultPartName,
+				schema.getFieldNames(),
+				schema.getFieldDataTypes(),
+				partitionKeys.toArray(new String[0]));
+
+		FileSystemOutputFormat.Builder<BaseRow> builder = new FileSystemOutputFormat.Builder<>();
+		builder.setPartitionComputer(computer);
+		builder.setDynamicGrouped(dynamicGrouping);
+		builder.setPartitionColumns(partitionKeys.toArray(new String[0]));
+		builder.setFormatFactory(createOutputFormatFactory(
+				formatFactory, this::getNonPartitionTypes));
+		builder.setMetaStoreFactory(createTableMetaStoreFactory(path));
+		builder.setOverwrite(overwrite);
+		builder.setStaticPartitions(staticPartitions);
+		builder.setTempPath(toStagingPath());
+		return dataStream.writeUsingOutputFormat(builder.build())
+				.setParallelism(dataStream.getParallelism());
+	}
+
+	private DataType[] getNonPartitionTypes() {
+		return Arrays.stream(schema.getFieldNames())
+				.filter(name -> !partitionKeys.contains(name))
+				.map(name -> schema.getFieldDataType(name).get())
+				.toArray(DataType[]::new);
+	}
+
+	private Path toStagingPath() {
+		Path stagingDir = new Path(path, ".staging_" + System.currentTimeMillis());
+		try {
+			FileSystem fs = stagingDir.getFileSystem();
+			Preconditions.checkState(
+					fs.exists(stagingDir) || fs.mkdirs(stagingDir),
+					"Failed to create staging dir " + stagingDir);
+			return stagingDir;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static OutputFormatFactory<BaseRow> createOutputFormatFactory(
+			FileSystemFormatFactory formatFactory,
+			FileSystemFormatFactory.WriterContext context) {
+		Optional<Encoder<BaseRow>> encoder = formatFactory.createEncoder(context);
+		Optional<BulkWriter.Factory<BaseRow>> bulk = formatFactory.createBulkWriterFactory(context);
+
+		if (!encoder.isPresent() && !bulk.isPresent()) {
+			throw new TableException(
+					formatFactory + " format should implement at least one Encoder or BulkWriter");
+		}
+		return encoder
+				.<OutputFormatFactory<BaseRow>>map(en -> path -> createEncoderOutputFormat(en, path))
+				.orElseGet(() -> path -> createBulkWriterOutputFormat(bulk.get(), path));
+	}
+
+	private static OutputFormat<BaseRow> createBulkWriterOutputFormat(
+			BulkWriter.Factory<BaseRow> factory,
+			Path path) {
+		return new OutputFormat<BaseRow>() {
+
+			private BulkWriter<BaseRow> writer;
+
+			@Override
+			public void configure(Configuration parameters) {
+			}
+
+			@Override
+			public void open(int taskNumber, int numTasks) throws IOException {
+				this.writer = factory.create(path.getFileSystem()
+						.create(path, FileSystem.WriteMode.OVERWRITE));
+			}
+
+			@Override
+			public void writeRecord(BaseRow record) throws IOException {
+				writer.addElement(record);
+			}
+
+			@Override
+			public void close() throws IOException {
+				writer.flush();
+				writer.finish();
+			}
+		};
+	}
+
+	private static OutputFormat<BaseRow> createEncoderOutputFormat(
+			Encoder<BaseRow> encoder,
+			Path path) {
+		return new OutputFormat<BaseRow>() {
+
+			private FSDataOutputStream output;
+
+			@Override
+			public void configure(Configuration parameters) {
+			}
+
+			@Override
+			public void open(int taskNumber, int numTasks) throws IOException {
+				this.output = path.getFileSystem()
+						.create(path, FileSystem.WriteMode.OVERWRITE);
+			}
+
+			@Override
+			public void writeRecord(BaseRow record) throws IOException {
+				encoder.encode(record, output);
+			}
+
+			@Override
+			public void close() throws IOException {
+				this.output.flush();
+				this.output.close();
+			}
+		};
+	}
+
+	private static TableMetaStoreFactory createTableMetaStoreFactory(Path path) {
+		return (TableMetaStoreFactory) () -> new TableMetaStoreFactory.TableMetaStore() {
+
+			@Override
+			public Path getLocationPath() {
+				return path;
+			}
+
+			@Override
+			public Optional<Path> getPartition(LinkedHashMap<String, String> partitionSpec) {
+				return Optional.empty();
+			}
+
+			@Override
+			public void createPartition(
+					LinkedHashMap<String, String> partitionSpec,
+					Path partitionPath) {
+			}
+
+			@Override
+			public void close() {
+			}
+		};
+	}
+
+	@Override
+	public FileSystemTableSink configure(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+		return this;
+	}
+
+	@Override
+	public void setOverwrite(boolean overwrite) {
+		this.overwrite = overwrite;
+	}
+
+	@Override
+	public void setStaticPartition(Map<String, String> partitions) {
+		this.staticPartitions = toPartialLinkedPartSpec(partitions);
+	}
+
+	private LinkedHashMap<String, String> toPartialLinkedPartSpec(Map<String, String> part) {
+		LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
+		for (String partitionKey : partitionKeys) {
+			if (part.containsKey(partitionKey)) {
+				partSpec.put(partitionKey, part.get(partitionKey));
+			}
+		}
+		return partSpec;
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return schema;
+	}
+
+	@Override
+	public DataType getConsumedDataType() {
+		return schema.toRowDataType().bridgedTo(BaseRow.class);
+	}
+
+	@Override
+	public boolean configurePartitionGrouping(boolean supportsGrouping) {
+		this.dynamicGrouping = supportsGrouping;
+		return dynamicGrouping;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -148,7 +148,9 @@ public class FileSystemTableSink implements
 			Path path) {
 		return new OutputFormat<BaseRow>() {
 
-			private BulkWriter<BaseRow> writer;
+			private static final long serialVersionUID = 1L;
+
+			private transient BulkWriter<BaseRow> writer;
 
 			@Override
 			public void configure(Configuration parameters) {
@@ -178,7 +180,9 @@ public class FileSystemTableSink implements
 			Path path) {
 		return new OutputFormat<BaseRow>() {
 
-			private FSDataOutputStream output;
+			private static final long serialVersionUID = 1L;
+
+			private transient FSDataOutputStream output;
 
 			@Override
 			public void configure(Configuration parameters) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.table.filesystem.FileSystemTableFactory.createFormatFactory;
+
 /**
  * File system table source.
  */
@@ -55,7 +57,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 	private final Path path;
 	private final List<String> partitionKeys;
 	private final String defaultPartName;
-	private final FileSystemFormatFactory formatFactory;
+	private final Map<String, String> formatProperties;
 
 	private final int[] selectFields;
 	private final Long limit;
@@ -71,15 +73,15 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 	 * @param partitionKeys partition keys of the table.
 	 * @param defaultPartName The default partition name in case the dynamic partition column value
 	 *                        is null/empty string.
-	 * @param formatFactory format factory to create reader.
+	 * @param formatProperties format properties.
 	 */
 	public FileSystemTableSource(
 			TableSchema schema,
 			Path path,
 			List<String> partitionKeys,
 			String defaultPartName,
-			FileSystemFormatFactory formatFactory) {
-		this(schema, path, partitionKeys, defaultPartName, formatFactory, null, null, null, null);
+			Map<String, String> formatProperties) {
+		this(schema, path, partitionKeys, defaultPartName, formatProperties, null, null, null, null);
 	}
 
 	private FileSystemTableSource(
@@ -87,7 +89,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 			Path path,
 			List<String> partitionKeys,
 			String defaultPartName,
-			FileSystemFormatFactory formatFactory,
+			Map<String, String> formatProperties,
 			List<Map<String, String>> readPartitions,
 			int[] selectFields,
 			Long limit,
@@ -96,7 +98,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 		this.path = path;
 		this.partitionKeys = partitionKeys;
 		this.defaultPartName = defaultPartName;
-		this.formatFactory = formatFactory;
+		this.formatProperties = formatProperties;
 		this.readPartitions = readPartitions;
 		this.selectFields = selectFields;
 		this.limit = limit;
@@ -110,11 +112,17 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 			return new CollectionInputFormat<>(new ArrayList<>(), null);
 		}
 
-		return formatFactory.createReader(new FileSystemFormatFactory.ReaderContext() {
+		return createFormatFactory(formatProperties).createReader(
+				new FileSystemFormatFactory.ReaderContext() {
 
 			@Override
 			public TableSchema getSchema() {
 				return schema;
+			}
+
+			@Override
+			public Map<String, String> getFormatProperties() {
+				return formatProperties;
 			}
 
 			@Override
@@ -202,7 +210,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 				path,
 				partitionKeys,
 				defaultPartName,
-				formatFactory,
+				formatProperties,
 				remainingPartitions,
 				selectFields,
 				limit,
@@ -216,7 +224,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 				path,
 				partitionKeys,
 				defaultPartName,
-				formatFactory,
+				formatProperties,
 				readPartitions,
 				fields,
 				limit,
@@ -230,7 +238,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 				path,
 				partitionKeys,
 				defaultPartName,
-				formatFactory,
+				formatProperties,
 				readPartitions,
 				selectFields,
 				limit,
@@ -249,7 +257,7 @@ public class FileSystemTableSource extends InputFormatTableSource<BaseRow> imple
 				path,
 				partitionKeys,
 				defaultPartName,
-				formatFactory,
+				formatProperties,
 				readPartitions,
 				selectFields,
 				limit,

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSource.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.java.io.CollectionInputFormat;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.sources.FilterableTableSource;
+import org.apache.flink.table.sources.InputFormatTableSource;
+import org.apache.flink.table.sources.LimitableTableSource;
+import org.apache.flink.table.sources.PartitionableTableSource;
+import org.apache.flink.table.sources.ProjectableTableSource;
+import org.apache.flink.table.types.DataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * File system table source.
+ */
+public class FileSystemTableSource extends InputFormatTableSource<BaseRow> implements
+		PartitionableTableSource,
+		ProjectableTableSource<BaseRow>,
+		LimitableTableSource<BaseRow>,
+		FilterableTableSource<BaseRow> {
+
+	private final TableSchema schema;
+	private final Path path;
+	private final List<String> partitionKeys;
+	private final String defaultPartName;
+	private final FileSystemFormatFactory formatFactory;
+
+	private final int[] selectFields;
+	private final Long limit;
+	private final List<Expression> filters;
+
+	private List<Map<String, String>> readPartitions;
+
+	/**
+	 * Construct a file system table source.
+	 *
+	 * @param schema schema of the table.
+	 * @param path directory path of the file system table.
+	 * @param partitionKeys partition keys of the table.
+	 * @param defaultPartName The default partition name in case the dynamic partition column value
+	 *                        is null/empty string.
+	 * @param formatFactory format factory to create reader.
+	 */
+	public FileSystemTableSource(
+			TableSchema schema,
+			Path path,
+			List<String> partitionKeys,
+			String defaultPartName,
+			FileSystemFormatFactory formatFactory) {
+		this(schema, path, partitionKeys, defaultPartName, formatFactory, null, null, null, null);
+	}
+
+	private FileSystemTableSource(
+			TableSchema schema,
+			Path path,
+			List<String> partitionKeys,
+			String defaultPartName,
+			FileSystemFormatFactory formatFactory,
+			List<Map<String, String>> readPartitions,
+			int[] selectFields,
+			Long limit,
+			List<Expression> filters) {
+		this.schema = schema;
+		this.path = path;
+		this.partitionKeys = partitionKeys;
+		this.defaultPartName = defaultPartName;
+		this.formatFactory = formatFactory;
+		this.readPartitions = readPartitions;
+		this.selectFields = selectFields;
+		this.limit = limit;
+		this.filters = filters;
+	}
+
+	@Override
+	public InputFormat<BaseRow, ?> getInputFormat() {
+		// When this table has no partition, just return a empty source.
+		if (!partitionKeys.isEmpty() && getOrFetchPartitions().isEmpty()) {
+			return new CollectionInputFormat<>(new ArrayList<>(), null);
+		}
+
+		return formatFactory.createReader(new FileSystemFormatFactory.ReaderContext() {
+
+			@Override
+			public TableSchema getSchema() {
+				return schema;
+			}
+
+			@Override
+			public List<String> getPartitionKeys() {
+				return partitionKeys;
+			}
+
+			@Override
+			public String getDefaultPartName() {
+				return defaultPartName;
+			}
+
+			@Override
+			public Path[] getPaths() {
+				if (partitionKeys.isEmpty()) {
+					return new Path[] {path};
+				} else {
+					return getOrFetchPartitions().stream()
+							.map(FileSystemTableSource.this::toFullLinkedPartSpec)
+							.map(PartitionPathUtils::generatePartitionPath)
+							.map(n -> new Path(path, n))
+							.toArray(Path[]::new);
+				}
+			}
+
+			@Override
+			public int[] getProjectFields() {
+				return readFields();
+			}
+
+			@Override
+			public long getPushedDownLimit() {
+				return limit == null ? Long.MAX_VALUE : limit;
+			}
+
+			@Override
+			public List<Expression> getPushedDownFilters() {
+				return filters == null ? Collections.emptyList() : filters;
+			}
+		});
+	}
+
+	private List<Map<String, String>> getOrFetchPartitions() {
+		if (readPartitions == null) {
+			readPartitions = getPartitions();
+		}
+		return readPartitions;
+	}
+
+	private LinkedHashMap<String, String> toFullLinkedPartSpec(Map<String, String> part) {
+		LinkedHashMap<String, String> map = new LinkedHashMap<>();
+		for (String k : partitionKeys) {
+			if (!part.containsKey(k)) {
+				throw new TableException("Partition keys are: " + partitionKeys +
+						", incomplete partition spec: " + part);
+			}
+			map.put(k, part.get(k));
+		}
+		return map;
+	}
+
+	@Override
+	public List<Map<String, String>> getPartitions() {
+		try {
+			return PartitionPathUtils
+					.searchPartSpecAndPaths(path.getFileSystem(), path, partitionKeys.size())
+					.stream()
+					.map(tuple2 -> tuple2.f0)
+					.map(spec -> {
+						LinkedHashMap<String, String> ret = new LinkedHashMap<>();
+						spec.forEach((k, v) -> ret.put(k, defaultPartName.equals(v) ? null : v));
+						return ret;
+					})
+					.collect(Collectors.toList());
+		} catch (Exception e) {
+			throw new TableException("Fetch partitions fail.", e);
+		}
+	}
+
+	@Override
+	public FileSystemTableSource applyPartitionPruning(
+			List<Map<String, String>> remainingPartitions) {
+		return new FileSystemTableSource(
+				schema,
+				path,
+				partitionKeys,
+				defaultPartName,
+				formatFactory,
+				remainingPartitions,
+				selectFields,
+				limit,
+				filters);
+	}
+
+	@Override
+	public FileSystemTableSource projectFields(int[] fields) {
+		return new FileSystemTableSource(
+				schema,
+				path,
+				partitionKeys,
+				defaultPartName,
+				formatFactory,
+				readPartitions,
+				fields,
+				limit,
+				filters);
+	}
+
+	@Override
+	public FileSystemTableSource applyLimit(long limit) {
+		return new FileSystemTableSource(
+				schema,
+				path,
+				partitionKeys,
+				defaultPartName,
+				formatFactory,
+				readPartitions,
+				selectFields,
+				limit,
+				filters);
+	}
+
+	@Override
+	public boolean isLimitPushedDown() {
+		return limit != null;
+	}
+
+	@Override
+	public FileSystemTableSource applyPredicate(List<Expression> predicates) {
+		return new FileSystemTableSource(
+				schema,
+				path,
+				partitionKeys,
+				defaultPartName,
+				formatFactory,
+				readPartitions,
+				selectFields,
+				limit,
+				new ArrayList<>(predicates));
+	}
+
+	@Override
+	public boolean isFilterPushedDown() {
+		return this.filters != null;
+	}
+
+	private int[] readFields() {
+		return selectFields == null ?
+				IntStream.range(0, schema.getFieldCount()).toArray() :
+				selectFields;
+	}
+
+	@Override
+	public DataType getProducedDataType() {
+		int[] fields = readFields();
+		String[] schemaFieldNames = schema.getFieldNames();
+		DataType[] schemaTypes = schema.getFieldDataTypes();
+
+		return DataTypes.ROW(Arrays.stream(fields)
+				.mapToObj(i -> DataTypes.FIELD(schemaFieldNames[i], schemaTypes[i]))
+				.toArray(DataTypes.Field[]::new))
+				.bridgedTo(BaseRow.class);
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return schema;
+	}
+
+	@Override
+	public String explainSource() {
+		return super.explainSource() +
+				(readPartitions == null ? "" : ", readPartitions=" + readPartitions) +
+				(selectFields == null ? "" : ", selectFields=" + Arrays.toString(selectFields)) +
+				(limit == null ? "" : ", limit=" + limit) +
+				(filters == null ? "" : ", filters=" + filtersString());
+	}
+
+	private String filtersString() {
+		return filters.stream().map(Expression::asSummaryString).collect(Collectors.joining(","));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/RowDataPartitionComputer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/RowDataPartitionComputer.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.GenericRow;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * {@link PartitionComputer} for {@link BaseRow}.
+ */
+@Internal
+public class RowDataPartitionComputer implements PartitionComputer<BaseRow> {
+
+	private static final long serialVersionUID = 1L;
+
+	protected final String defaultPartValue;
+	protected final String[] partitionColumns;
+	protected final int[] partitionIndexes;
+	protected final LogicalType[] partitionTypes;
+
+	private final int[] nonPartitionIndexes;
+	private final LogicalType[] nonPartitionTypes;
+
+	private transient GenericRow reuseRow;
+
+	public RowDataPartitionComputer(
+			String defaultPartValue,
+			String[] columnNames,
+			DataType[] columnTypes,
+			String[] partitionColumns) {
+		this.defaultPartValue = defaultPartValue;
+		this.partitionColumns = partitionColumns;
+
+		List<String> columnList = Arrays.asList(columnNames);
+		List<LogicalType> columnTypeList = Arrays.stream(columnTypes)
+				.map(DataType::getLogicalType)
+				.collect(Collectors.toList());
+
+		this.partitionIndexes = Arrays.stream(partitionColumns)
+				.mapToInt(columnList::indexOf)
+				.toArray();
+		this.partitionTypes = Arrays.stream(partitionIndexes)
+				.mapToObj(columnTypeList::get)
+				.toArray(LogicalType[]::new);
+
+		List<Integer> partitionIndexList = Arrays.stream(partitionIndexes).boxed().collect(Collectors.toList());
+		this.nonPartitionIndexes = IntStream.range(0, columnNames.length)
+				.filter(c -> !partitionIndexList.contains(c))
+				.toArray();
+		this.nonPartitionTypes = Arrays.stream(nonPartitionIndexes)
+				.mapToObj(columnTypeList::get)
+				.toArray(LogicalType[]::new);
+	}
+
+	@Override
+	public LinkedHashMap<String, String> generatePartValues(BaseRow in) {
+		LinkedHashMap<String, String> partSpec = new LinkedHashMap<>();
+
+		for (int i = 0; i < partitionIndexes.length; i++) {
+			Object field = TypeGetterSetters.get(in, partitionIndexes[i], partitionTypes[i]);
+			String partitionValue = field != null ? field.toString() : null;
+			if (partitionValue == null || "".equals(partitionValue)) {
+				partitionValue = defaultPartValue;
+			}
+			partSpec.put(partitionColumns[i], partitionValue);
+		}
+		return partSpec;
+	}
+
+	@Override
+	public BaseRow projectColumnsToWrite(BaseRow in) {
+		if (partitionIndexes.length == 0) {
+			return in;
+		}
+
+		if (reuseRow == null) {
+			this.reuseRow = new GenericRow(nonPartitionIndexes.length);
+		}
+
+		for (int i = 0; i < nonPartitionIndexes.length; i++) {
+			reuseRow.setField(i, TypeGetterSetters.get(
+					in, nonPartitionIndexes[i], nonPartitionTypes[i]));
+		}
+		return reuseRow;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-runtime-blink/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -13,9 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
-org.apache.flink.table.planner.runtime.batch.sql.TestPartitionableSinkFactory
-org.apache.flink.table.planner.utils.TestPartitionableSourceFactory
-org.apache.flink.table.planner.utils.TestFilterableTableSourceFactory
-org.apache.flink.table.planner.utils.TestProjectableTableSourceFactory
-org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory
+org.apache.flink.table.filesystem.FileSystemTableFactory


### PR DESCRIPTION

## What is the purpose of the change

Introduce FileSystemTableFactory to unify all file system connectors.

More information in https://cwiki.apache.org/confluence/display/FLINK/FLIP-115%3A+Filesystem+connector+in+Table

## Brief change log

- Introduce `FileSystemTableFactory`
- Introduce `FileSystemTableSource`
- Introduce `FileSystemTableSink`
- Introduce `FileSystemFormatFactory` interface to abstract format interface.
- Introduce `RowDataPartitionComputer` to BaseRow handle.

## Verifying this change

- Introduce `FileSystemITCaseBase` to do all format test things.
- `FileSystemTestCsvITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (JavaDocs)
