### PR TITLE
[FLINK-16878][e2e][table] Fix dependency shading of table modules test failure after …

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
+++ b/flink-end-to-end-tests/test-scripts/test_table_shaded_dependencies.sh
@@ -61,6 +61,8 @@ function checkCodeDependencies {
       grep -v "^\s*\-> org.json" |\
       grep -v "^\s*\-> org.apache.tapestry5.json." |\
       grep -v "^\s*\-> org.codehaus.jettison" |\
+      grep -v "^\s*\-> org.apiguardian.api" |\
+      grep -v "^\s*\-> org.apache.commons.io.input" |\
       grep -v "^\s*\-> net.minidev.json" > $CONTENTS_FILE
   if [[ `cat $CONTENTS_FILE | wc -l` -eq '0' ]]; then
       echo "Success: There are no unwanted dependencies in the ${JAR} jar."


### PR DESCRIPTION
…FLINK-14338

After FLINK-14338, the calcite-core dependency has changed, we should update the e2e test for table modules dependency shading.
