### PR TITLE
[FLINK-16821][e2e] Use constant minikube version instead of latest

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -36,7 +36,7 @@ function setup_kubernetes_for_linux {
     fi
     # Download minikube.
     if ! [ -x "$(command -v minikube)" ]; then
-        curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && \
+        curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.8.2/minikube-linux-amd64 && \
             chmod +x minikube && sudo mv minikube /usr/local/bin/
     fi
 }


### PR DESCRIPTION
This is a backport of https://github.com/apache/flink/pull/11546 to `release-1.10`.