### PR TITLE
[FLINK-16411][AZP] Cache maven artifacts for tests as well

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -105,9 +105,7 @@ jobs:
       path: $(CACHE_FLINK_DIR)
       artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
 
-  # only for the python stage (which runs a full mvn install), download the cache
   - task: Cache@2
-    condition: eq(variables['module'], 'python')
     inputs:
       key: $(CACHE_KEY)
       restoreKeys: $(CACHE_FALLBACK_KEY)


### PR DESCRIPTION
## What is the purpose of the change

Our CI tests are failing very frequently due to connectivity issues. Most likely, the servers have some network problems.
As a temporary mitigation, I'm enabling the maven caches for all jobs. This will add ~10 minutes of build time for each task, reducing our overall throughput. But I want our builds to be greener :) 
In the meantime, I will try to understand the root cause of this.

## Brief change log

- relax the condition for enabling the cache task.


## Verifying this change

In 6 runs, there was only one failure, and that was caused by an unstable e2e test:
<img width="965" alt="Screenshot 2020-03-31 16 39 07" src="https://user-images.githubusercontent.com/89049/78039241-2904d200-736e-11ea-94b3-4caef13590e5.png">

