### PR TITLE
[FLINK-16883] Scan FLINK_CONF directory for available log4j configura…

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -645,3 +645,20 @@ extractExecutionParams() {
 
     echo ${execution_config} | sed "s/$EXECUTION_PREFIX//"
 }
+
+findLog4jConfiguration() {
+    local PATH=$1
+    local LOG4J_CONFIG_FILES=($PATH/log4j-console.*)
+    if [[ ${#LOG4J_CONFIG_FILES[@]} -gt 1 ]]; then
+        echo "[ERROR] Found more than one log4j configuration file: [${LOG4J_CONFIG_FILES[@]}]" 1>&2
+        exit 1
+    fi
+
+    LOG4J_CONFIG=${LOG4J_CONFIG_FILES[0]}
+    if [[ "${LOG4J_CONFIG: -1}" = "*" ]]; then
+        echo "[ERROR] Could not find a valid configuration" 1>&2
+        exit 1
+    fi
+
+    echo "$LOG4J_CONFIG"
+}

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -58,7 +58,9 @@ esac
 
 FLINK_TM_CLASSPATH=`constructFlinkClassPath`
 
-log_setting=("-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlog4j.configurationFile=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback-console.xml")
+log4j_config=`findLog4jConfiguration ${FLINK_CONF_DIR}`
+
+log_setting=("-Dlog4j.configuration=file:${log4j_config}" "-Dlog4j.configurationFile=file:${log4j_config}" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback-console.xml")
 
 JAVA_VERSION=$(${JAVA_RUN} -version 2>&1 | sed 's/.*version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q')
 


### PR DESCRIPTION
…tions

This enables the usage of log4j configurations with different
file endings than properties.

## What is the purpose of the change

This change should allow users who bundle their own Flink distribution to change the default logging behavior with the usage of all configurations types allowed by log4j2.
Before only properties files were supported

## Verifying this change

I verified the changes locally and run the `flink-console.sh` script.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
