### PR TITLE
[hotfix][typo] Fix typo in #LocalBufferPool#createBufferPoolFactory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -205,7 +205,7 @@ public class ResultPartitionFactory {
 	 * stuck problem if the minimum pool size is exactly equal to the number of subpartitions, because every subpartition
 	 * might maintain a partial unfilled buffer.
 	 *
-	 * <p>2. Increases one more buffer for every output LocalBufferPool to void performance regression if processing input is
+	 * <p>2. Increases one more buffer for every output LocalBufferPool to avoid performance regression if processing input is
 	 * based on at-least one buffer available on output side.
 	 */
 	@VisibleForTesting


### PR DESCRIPTION
## What is the purpose of the change

void performance regression -> avoid performance regression
