### PR TITLE
[FLINK-15305][tests] Make BoundedDataTestBase#testGetSizeMultipleRegions respect system page size to avoid potential failure

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
@@ -144,7 +144,7 @@ public abstract class BoundedDataTestBase {
 	@Test
 	public void testGetSizeSingleRegion() throws Exception {
 		try (BoundedData bd = createBoundedData()) {
-			testGetSize(bd);
+			testGetSize(bd, 60_787, 76_687);
 		}
 	}
 
@@ -154,14 +154,13 @@ public abstract class BoundedDataTestBase {
 			return;
 		}
 
-		try (BoundedData bd = createBoundedDataWithRegion(100_000)) {
-			testGetSize(bd);
+		int pageSize = PageSizeUtil.getSystemPageSizeOrConservativeMultiple();
+		try (BoundedData bd = createBoundedDataWithRegion(pageSize)) {
+			testGetSize(bd, pageSize / 3, pageSize - BufferReaderWriterUtil.HEADER_LENGTH);
 		}
 	}
 
-	private static void testGetSize(BoundedData bd) throws Exception {
-		final int bufferSize1 = 60_787;
-		final int bufferSize2 = 76_687;
+	private static void testGetSize(BoundedData bd, int bufferSize1, int bufferSize2) throws Exception {
 		final int expectedSize1 = bufferSize1 + BufferReaderWriterUtil.HEADER_LENGTH;
 		final int expectedSizeFinal = bufferSize1 + bufferSize2 + 2 * BufferReaderWriterUtil.HEADER_LENGTH;
 


### PR DESCRIPTION
## What is the purpose of the change

Make BoundedDataTestBase#testGetSizeMultipleRegions respect system page size to avoid potential failure.


## Brief change log

  - Make BoundedDataTestBase#testGetSizeMultipleRegions respect system page size to avoid potential failure

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
