### PR TITLE
[FLINK-16914][python] Support ArrayType in vectorized Python UDF

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -34,7 +34,7 @@ from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.sdk_worker_main import pipeline_options
 from pyflink.table.types import Row, TinyIntType, SmallIntType, IntType, BigIntType, BooleanType, \
     FloatType, DoubleType, VarCharType, VarBinaryType, DecimalType, DateType, TimeType, \
-    LocalZonedTimestampType, RowType, RowField, to_arrow_type, TimestampType
+    LocalZonedTimestampType, RowType, RowField, to_arrow_type, TimestampType, ArrayType
 
 FLINK_SCALAR_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:scalar_function:v1"
 FLINK_TABLE_FUNCTION_SCHEMA_CODER_URN = "flink:coder:schema:table_function:v1"
@@ -421,44 +421,47 @@ class ArrowCoder(DeterministicCoder):
             return pa.schema([pa.field(n, to_arrow_type(t), t._nullable)
                               for n, t in zip(row_type.field_names(), row_type.field_types())])
 
-        def _to_data_type(field):
-            if field.type.type_name == flink_fn_execution_pb2.Schema.TINYINT:
-                return TinyIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.SMALLINT:
-                return SmallIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.INT:
-                return IntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.BIGINT:
-                return BigIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.BOOLEAN:
-                return BooleanType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.FLOAT:
-                return FloatType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.DOUBLE:
-                return DoubleType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.VARCHAR:
-                return VarCharType(0x7fffffff, field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.VARBINARY:
-                return VarBinaryType(0x7fffffff, field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.DECIMAL:
-                return DecimalType(field.type.decimal_info.precision,
-                                   field.type.decimal_info.scale,
-                                   field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.DATE:
-                return DateType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TIME:
-                return TimeType(field.type.time_info.precision, field.type.nullable)
-            elif field.type.type_name == \
+        def _to_data_type(field_type):
+            if field_type.type_name == flink_fn_execution_pb2.Schema.TINYINT:
+                return TinyIntType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.SMALLINT:
+                return SmallIntType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.INT:
+                return IntType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.BIGINT:
+                return BigIntType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.BOOLEAN:
+                return BooleanType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.FLOAT:
+                return FloatType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.DOUBLE:
+                return DoubleType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.VARCHAR:
+                return VarCharType(0x7fffffff, field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.VARBINARY:
+                return VarBinaryType(0x7fffffff, field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.DECIMAL:
+                return DecimalType(field_type.decimal_info.precision,
+                                   field_type.decimal_info.scale,
+                                   field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.DATE:
+                return DateType(field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.TIME:
+                return TimeType(field_type.time_info.precision, field_type.nullable)
+            elif field_type.type_name == \
                     flink_fn_execution_pb2.Schema.LOCAL_ZONED_TIMESTAMP:
-                return LocalZonedTimestampType(field.type.local_zoned_timestamp_info.precision,
-                                               field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TIMESTAMP:
-                return TimestampType(field.type.timestamp_info.precision, field.type.nullable)
+                return LocalZonedTimestampType(field_type.local_zoned_timestamp_info.precision,
+                                               field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.TIMESTAMP:
+                return TimestampType(field_type.timestamp_info.precision, field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.ARRAY:
+                return ArrayType(_to_data_type(field_type.collection_element_type),
+                                 field_type.nullable)
             else:
-                raise ValueError("field_type %s is not supported." % field.type)
+                raise ValueError("field_type %s is not supported." % field_type)
 
         def _to_row_type(row_schema):
-            return RowType([RowField(f.name, _to_data_type(f)) for f in row_schema.fields])
+            return RowType([RowField(f.name, _to_data_type(f.type)) for f in row_schema.fields])
 
         timezone = pytz.timezone(pipeline_options.view_as(DebugOptions).lookup_experiment(
             "table.exec.timezone"))

--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -153,6 +153,18 @@ class PandasUDFITTests(object):
                                                                       timestamp_value)
             return timestamp_param
 
+        def array_func(array_param):
+            assert isinstance(array_param, pd.Series)
+            assert isinstance(array_param[0], np.ndarray), \
+                'array_param of wrong type %s !' % type(array_param[0])
+            return array_param
+
+        def nested_array_func(nested_array_param):
+            assert isinstance(nested_array_param, pd.Series)
+            assert isinstance(nested_array_param[0], np.ndarray), \
+                'nested_array_param of wrong type %s !' % type(nested_array_param[0])
+            return pd.Series(nested_array_param[0])
+
         self.t_env.register_function(
             "tinyint_func",
             udf(tinyint_func, [DataTypes.TINYINT()], DataTypes.TINYINT(), udf_type="pandas"))
@@ -207,12 +219,36 @@ class PandasUDFITTests(object):
             udf(timestamp_func, [DataTypes.TIMESTAMP(3)], DataTypes.TIMESTAMP(3),
                 udf_type="pandas"))
 
+        self.t_env.register_function(
+            "array_str_func",
+            udf(array_func, [DataTypes.ARRAY(DataTypes.STRING())],
+                DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas"))
+
+        self.t_env.register_function(
+            "array_timestamp_func",
+            udf(array_func, [DataTypes.ARRAY(DataTypes.TIMESTAMP(3))],
+                DataTypes.ARRAY(DataTypes.TIMESTAMP(3)), udf_type="pandas"))
+
+        self.t_env.register_function(
+            "array_int_func",
+            udf(array_func, [DataTypes.ARRAY(DataTypes.INT())],
+                DataTypes.ARRAY(DataTypes.INT()), udf_type="pandas"))
+
+        self.t_env.register_function(
+            "nested_array_func",
+            udf(nested_array_func, [DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING()))],
+                DataTypes.ARRAY(DataTypes.STRING()), udf_type="pandas"))
+
         table_sink = source_sink_utils.TestAppendSink(
-            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p'],
+            ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
+             'r', 's', 't'],
             [DataTypes.TINYINT(), DataTypes.SMALLINT(), DataTypes.INT(), DataTypes.BIGINT(),
              DataTypes.BOOLEAN(), DataTypes.BOOLEAN(), DataTypes.FLOAT(), DataTypes.DOUBLE(),
              DataTypes.STRING(), DataTypes.STRING(), DataTypes.BYTES(), DataTypes.DECIMAL(38, 18),
-             DataTypes.DECIMAL(38, 18), DataTypes.DATE(), DataTypes.TIME(), DataTypes.TIMESTAMP(3)])
+             DataTypes.DECIMAL(38, 18), DataTypes.DATE(), DataTypes.TIME(), DataTypes.TIMESTAMP(3),
+             DataTypes.ARRAY(DataTypes.STRING()), DataTypes.ARRAY(DataTypes.TIMESTAMP(3)),
+             DataTypes.ARRAY(DataTypes.INT()),
+             DataTypes.ARRAY(DataTypes.STRING())])
         self.t_env.register_table_sink("Results", table_sink)
 
         t = self.t_env.from_elements(
@@ -220,7 +256,8 @@ class PandasUDFITTests(object):
               bytearray(b'flink'), decimal.Decimal('1000000000000000000.05'),
               decimal.Decimal('1000000000000000000.05999999999999999899999999999'),
               datetime.date(2014, 9, 13), datetime.time(hour=1, minute=0, second=1),
-              timestamp_value)],
+              timestamp_value, ['hello', '中文', None], [timestamp_value], [1, 2],
+              [['hello', '中文', None]])],
             DataTypes.ROW(
                 [DataTypes.FIELD("a", DataTypes.TINYINT()),
                  DataTypes.FIELD("b", DataTypes.SMALLINT()),
@@ -237,7 +274,11 @@ class PandasUDFITTests(object):
                  DataTypes.FIELD("m", DataTypes.DECIMAL(38, 18)),
                  DataTypes.FIELD("n", DataTypes.DATE()),
                  DataTypes.FIELD("o", DataTypes.TIME()),
-                 DataTypes.FIELD("p", DataTypes.TIMESTAMP(3))]))
+                 DataTypes.FIELD("p", DataTypes.TIMESTAMP(3)),
+                 DataTypes.FIELD("q", DataTypes.ARRAY(DataTypes.STRING())),
+                 DataTypes.FIELD("r", DataTypes.ARRAY(DataTypes.TIMESTAMP(3))),
+                 DataTypes.FIELD("s", DataTypes.ARRAY(DataTypes.INT())),
+                 DataTypes.FIELD("t", DataTypes.ARRAY(DataTypes.ARRAY(DataTypes.STRING())))]))
 
         t.select("tinyint_func(a),"
                  "smallint_func(b),"
@@ -254,7 +295,11 @@ class PandasUDFITTests(object):
                  "decimal_func(m),"
                  "date_func(n),"
                  "time_func(o),"
-                 "timestamp_func(p)") \
+                 "timestamp_func(p),"
+                 "array_str_func(q),"
+                 "array_timestamp_func(r),"
+                 "array_int_func(s),"
+                 "nested_array_func(t)") \
             .insert_into("Results")
         self.t_env.execute("test")
         actual = source_sink_utils.results()
@@ -262,7 +307,8 @@ class PandasUDFITTests(object):
                            ["1,32767,-2147483648,1,true,false,1.0,1.0,hello,中文,"
                             "[102, 108, 105, 110, 107],1000000000000000000.050000000000000000,"
                             "1000000000000000000.059999999999999999,2014-09-13,01:00:01,"
-                            "1970-01-01 00:00:00.123"])
+                            "1970-01-01 00:00:00.123,[hello, 中文, null],[1970-01-01 00:00:00.123],"
+                            "[1, 2],[hello, 中文, null]"])
 
 
 class BlinkPandasUDFITTests(object):

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2333,6 +2333,11 @@ def to_arrow_type(data_type):
             return pa.timestamp('us')
         else:
             return pa.timestamp('ns')
+    elif type(data_type) == ArrayType:
+        if type(data_type.element_type) == LocalZonedTimestampType:
+            raise ValueError("%s is not supported to be used as the element type of ArrayType." %
+                             data_type.element_type)
+        return pa.list_(to_arrow_type(data_type.element_type))
     else:
         raise ValueError("field_type %s is not supported." % data_type)
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowUtils.java
@@ -20,7 +20,9 @@ package org.apache.flink.table.runtime.arrow;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.table.runtime.arrow.readers.ArrayFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.ArrowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BigIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.BooleanFieldReader;
@@ -36,6 +38,7 @@ import org.apache.flink.table.runtime.arrow.readers.TimestampFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TinyIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarBinaryFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.VarCharFieldReader;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowArrayColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBigIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowBooleanColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDateColumnVector;
@@ -50,20 +53,8 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowTinyIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarBinaryColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowVarCharColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.BaseRowArrowReader;
+import org.apache.flink.table.runtime.arrow.writers.ArrayWriter;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowBigIntWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowBooleanWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowDateWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowDecimalWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowDoubleWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowFloatWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowIntWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowSmallIntWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowTimeWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowTimestampWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowTinyIntWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowVarBinaryWriter;
-import org.apache.flink.table.runtime.arrow.writers.BaseRowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.BooleanWriter;
 import org.apache.flink.table.runtime.arrow.writers.DateWriter;
@@ -71,12 +62,27 @@ import org.apache.flink.table.runtime.arrow.writers.DecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.DoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.FloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.IntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowArrayWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowBigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowBooleanWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowDateWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowDecimalWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowDoubleWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowFloatWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowSmallIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowTimeWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowTimestampWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowTinyIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowVarBinaryWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowVarCharWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TimeWriter;
 import org.apache.flink.table.runtime.arrow.writers.TimestampWriter;
 import org.apache.flink.table.runtime.arrow.writers.TinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.VarCharWriter;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
@@ -116,6 +122,7 @@ import org.apache.arrow.vector.TinyIntVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.TimeUnit;
@@ -127,6 +134,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -143,17 +151,22 @@ public final class ArrowUtils {
 	 */
 	public static Schema toArrowSchema(RowType rowType) {
 		Collection<Field> fields = rowType.getFields().stream()
-			.map(ArrowUtils::toArrowField)
+			.map(f -> ArrowUtils.toArrowField(f.getName(), f.getType()))
 			.collect(Collectors.toCollection(ArrayList::new));
 		return new Schema(fields);
 	}
 
-	private static Field toArrowField(RowType.RowField rowField) {
+	private static Field toArrowField(String fieldName, LogicalType logicalType) {
 		FieldType fieldType = new FieldType(
-			rowField.getType().isNullable(),
-			rowField.getType().accept(LogicalTypeToArrowTypeConverter.INSTANCE),
+			logicalType.isNullable(),
+			logicalType.accept(LogicalTypeToArrowTypeConverter.INSTANCE),
 			null);
-		return new Field(rowField.getName(), fieldType, null);
+		List<Field> children = null;
+		if (logicalType instanceof ArrayType) {
+			children = Collections.singletonList(toArrowField(
+				"element", ((ArrayType) logicalType).getElementType()));
+		}
+		return new Field(fieldName, fieldType, children);
 	}
 
 	/**
@@ -173,33 +186,37 @@ public final class ArrowUtils {
 
 	private static ArrowFieldWriter<Row> createRowArrowFieldWriter(FieldVector vector, LogicalType fieldType) {
 		if (vector instanceof TinyIntVector) {
-			return new TinyIntWriter((TinyIntVector) vector);
+			return new RowTinyIntWriter((TinyIntVector) vector);
 		} else if (vector instanceof SmallIntVector) {
-			return new SmallIntWriter((SmallIntVector) vector);
+			return new RowSmallIntWriter((SmallIntVector) vector);
 		} else if (vector instanceof IntVector) {
-			return new IntWriter((IntVector) vector);
+			return new RowIntWriter((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
-			return new BigIntWriter((BigIntVector) vector);
+			return new RowBigIntWriter((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
-			return new BooleanWriter((BitVector) vector);
+			return new RowBooleanWriter((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
-			return new FloatWriter((Float4Vector) vector);
+			return new RowFloatWriter((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
-			return new DoubleWriter((Float8Vector) vector);
+			return new RowDoubleWriter((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
-			return new VarCharWriter((VarCharVector) vector);
+			return new RowVarCharWriter((VarCharVector) vector);
 		} else if (vector instanceof VarBinaryVector) {
-			return new VarBinaryWriter((VarBinaryVector) vector);
+			return new RowVarBinaryWriter((VarBinaryVector) vector);
 		} else if (vector instanceof DecimalVector) {
 			DecimalVector decimalVector = (DecimalVector) vector;
-			return new DecimalWriter(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
+			return new RowDecimalWriter(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
 		} else if (vector instanceof DateDayVector) {
-			return new DateWriter((DateDayVector) vector);
+			return new RowDateWriter((DateDayVector) vector);
 		} else if (vector instanceof TimeSecVector || vector instanceof TimeMilliVector ||
 			vector instanceof TimeMicroVector || vector instanceof TimeNanoVector) {
-			return new TimeWriter(vector);
+			return new RowTimeWriter(vector);
 		} else if (vector instanceof TimeStampVector && ((ArrowType.Timestamp) vector.getField().getType()).getTimezone() == null) {
-			return new TimestampWriter(vector);
+			return new RowTimestampWriter(vector);
+		} else if (vector instanceof ListVector) {
+			ListVector listVector = (ListVector) vector;
+			LogicalType elementType = ((ArrayType) fieldType).getElementType();
+			return new RowArrayWriter(listVector, createRowArrowFieldWriter(listVector.getDataVector(), elementType));
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -215,39 +232,39 @@ public final class ArrowUtils {
 		for (int i = 0; i < vectors.size(); i++) {
 			FieldVector vector = vectors.get(i);
 			vector.allocateNew();
-			fieldWriters[i] = createBaseRowArrowFieldWriter(vector, rowType.getTypeAt(i));
+			fieldWriters[i] = createArrowFieldWriter(vector, rowType.getTypeAt(i));
 		}
 
 		return new ArrowWriter<>(root, fieldWriters);
 	}
 
-	private static ArrowFieldWriter<BaseRow> createBaseRowArrowFieldWriter(FieldVector vector, LogicalType fieldType) {
+	private static <T extends TypeGetterSetters> ArrowFieldWriter<T> createArrowFieldWriter(FieldVector vector, LogicalType fieldType) {
 		if (vector instanceof TinyIntVector) {
-			return new BaseRowTinyIntWriter((TinyIntVector) vector);
+			return new TinyIntWriter<>((TinyIntVector) vector);
 		} else if (vector instanceof SmallIntVector) {
-			return new BaseRowSmallIntWriter((SmallIntVector) vector);
+			return new SmallIntWriter<>((SmallIntVector) vector);
 		} else if (vector instanceof IntVector) {
-			return new BaseRowIntWriter((IntVector) vector);
+			return new IntWriter<>((IntVector) vector);
 		} else if (vector instanceof BigIntVector) {
-			return new BaseRowBigIntWriter((BigIntVector) vector);
+			return new BigIntWriter<>((BigIntVector) vector);
 		} else if (vector instanceof BitVector) {
-			return new BaseRowBooleanWriter((BitVector) vector);
+			return new BooleanWriter<>((BitVector) vector);
 		} else if (vector instanceof Float4Vector) {
-			return new BaseRowFloatWriter((Float4Vector) vector);
+			return new FloatWriter<>((Float4Vector) vector);
 		} else if (vector instanceof Float8Vector) {
-			return new BaseRowDoubleWriter((Float8Vector) vector);
+			return new DoubleWriter<>((Float8Vector) vector);
 		} else if (vector instanceof VarCharVector) {
-			return new BaseRowVarCharWriter((VarCharVector) vector);
+			return new VarCharWriter<>((VarCharVector) vector);
 		} else if (vector instanceof VarBinaryVector) {
-			return new BaseRowVarBinaryWriter((VarBinaryVector) vector);
+			return new VarBinaryWriter<>((VarBinaryVector) vector);
 		} else if (vector instanceof DecimalVector) {
 			DecimalVector decimalVector = (DecimalVector) vector;
-			return new BaseRowDecimalWriter(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
+			return new DecimalWriter<>(decimalVector, getPrecision(decimalVector), decimalVector.getScale());
 		} else if (vector instanceof DateDayVector) {
-			return new BaseRowDateWriter((DateDayVector) vector);
+			return new DateWriter<>((DateDayVector) vector);
 		} else if (vector instanceof TimeSecVector || vector instanceof TimeMilliVector ||
 			vector instanceof TimeMicroVector || vector instanceof TimeNanoVector) {
-			return new BaseRowTimeWriter(vector);
+			return new TimeWriter<>(vector);
 		} else if (vector instanceof TimeStampVector && ((ArrowType.Timestamp) vector.getField().getType()).getTimezone() == null) {
 			int precision;
 			if (fieldType instanceof LocalZonedTimestampType) {
@@ -255,7 +272,11 @@ public final class ArrowUtils {
 			} else {
 				precision = ((TimestampType) fieldType).getPrecision();
 			}
-			return new BaseRowTimestampWriter(vector, precision);
+			return new TimestampWriter<>(vector, precision);
+		} else if (vector instanceof ListVector) {
+			ListVector listVector = (ListVector) vector;
+			LogicalType elementType = ((ArrayType) fieldType).getElementType();
+			return new ArrayWriter<>(listVector, createArrowFieldWriter(listVector.getDataVector(), elementType));
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -275,7 +296,7 @@ public final class ArrowUtils {
 		return new RowArrowReader(fieldReaders.toArray(new ArrowFieldReader[0]));
 	}
 
-	private static ArrowFieldReader createRowArrowFieldReader(FieldVector vector, LogicalType fieldType) {
+	public static ArrowFieldReader createRowArrowFieldReader(FieldVector vector, LogicalType fieldType) {
 		if (vector instanceof TinyIntVector) {
 			return new TinyIntFieldReader((TinyIntVector) vector);
 		} else if (vector instanceof SmallIntVector) {
@@ -303,6 +324,12 @@ public final class ArrowUtils {
 			return new TimeFieldReader(vector);
 		} else if (vector instanceof TimeStampVector && ((ArrowType.Timestamp) vector.getField().getType()).getTimezone() == null) {
 			return new TimestampFieldReader(vector);
+		} else if (vector instanceof ListVector) {
+			ListVector listVector = (ListVector) vector;
+			LogicalType elementType = ((ArrayType) fieldType).getElementType();
+			return new ArrayFieldReader(listVector,
+				createRowArrowFieldReader(listVector.getDataVector(), elementType),
+				elementType);
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -322,7 +349,7 @@ public final class ArrowUtils {
 		return new BaseRowArrowReader(columnVectors.toArray(new ColumnVector[0]));
 	}
 
-	private static ColumnVector createColumnVector(FieldVector vector, LogicalType fieldType) {
+	public static ColumnVector createColumnVector(FieldVector vector, LogicalType fieldType) {
 		if (vector instanceof TinyIntVector) {
 			return new ArrowTinyIntColumnVector((TinyIntVector) vector);
 		} else if (vector instanceof SmallIntVector) {
@@ -350,6 +377,10 @@ public final class ArrowUtils {
 			return new ArrowTimeColumnVector(vector);
 		} else if (vector instanceof TimeStampVector && ((ArrowType.Timestamp) vector.getField().getType()).getTimezone() == null) {
 			return new ArrowTimestampColumnVector(vector);
+		} else if (vector instanceof ListVector) {
+			ListVector listVector = (ListVector) vector;
+			return new ArrowArrayColumnVector(listVector,
+				createColumnVector(listVector.getDataVector(), ((ArrayType) fieldType).getElementType()));
 		} else {
 			throw new UnsupportedOperationException(String.format(
 				"Unsupported type %s.", fieldType));
@@ -452,6 +483,11 @@ public final class ArrowUtils {
 			} else {
 				return new ArrowType.Timestamp(TimeUnit.NANOSECOND, null);
 			}
+		}
+
+		@Override
+		public ArrowType visit(ArrayType arrayType) {
+			return ArrowType.List.INSTANCE;
 		}
 
 		@Override

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/ArrayFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/ArrayFieldReader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.complex.ListVector;
+
+import java.lang.reflect.Array;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+
+/**
+ * {@link ArrowFieldReader} for Array.
+ */
+@Internal
+public final class ArrayFieldReader extends ArrowFieldReader<Object[]> {
+
+	private final ArrowFieldReader arrayData;
+	private final Class<?> elementClass;
+
+	public ArrayFieldReader(ListVector listVector, ArrowFieldReader arrayData, LogicalType elementType) {
+		super(listVector);
+		this.arrayData = Preconditions.checkNotNull(arrayData);
+		this.elementClass = getElementClass(elementType);
+	}
+
+	@Override
+	public Object[] read(int index) {
+		if (getValueVector().isNull(index)) {
+			return null;
+		} else {
+			int startIndex = index * ListVector.OFFSET_WIDTH;
+			int start = getValueVector().getOffsetBuffer().getInt(startIndex);
+			int end = getValueVector().getOffsetBuffer().getInt(startIndex + ListVector.OFFSET_WIDTH);
+			Object[] result = (Object[]) Array.newInstance(elementClass, end - start);
+			for (int i = 0; i < result.length; i++) {
+				result[i] = arrayData.read(start + i);
+			}
+			return result;
+		}
+	}
+
+	private Class<?> getElementClass(LogicalType elementType) {
+		DataType dataType = TypeConversions.fromLogicalToDataType(elementType);
+		if (elementType instanceof TimestampType) {
+			// the default conversion class is java.time.LocalDateTime
+			dataType = dataType.bridgedTo(Timestamp.class);
+		} else if (elementType instanceof DateType) {
+			// the default conversion class is java.time.LocalDate
+			dataType = dataType.bridgedTo(Date.class);
+		} else if (elementType instanceof TimeType) {
+			// the default conversion class is java.time.LocalTime
+			dataType = dataType.bridgedTo(Time.class);
+		}
+		return dataType.getConversionClass();
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowArrayColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowArrayColumnVector.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseArray;
+import org.apache.flink.table.dataformat.ColumnarArray;
+import org.apache.flink.table.dataformat.vector.ArrayColumnVector;
+import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.complex.ListVector;
+
+/**
+ * Arrow column vector for Array.
+ */
+@Internal
+public final class ArrowArrayColumnVector implements ArrayColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of array values of a column to read.
+	 */
+	private final ListVector listVector;
+	private final ColumnVector elementVector;
+
+	public ArrowArrayColumnVector(ListVector listVector, ColumnVector elementVector) {
+		this.listVector = Preconditions.checkNotNull(listVector);
+		this.elementVector = Preconditions.checkNotNull(elementVector);
+	}
+
+	@Override
+	public BaseArray getArray(int i) {
+		int index = i * ListVector.OFFSET_WIDTH;
+		int start = listVector.getOffsetBuffer().getInt(index);
+		int end = listVector.getOffsetBuffer().getInt(index + ListVector.OFFSET_WIDTH);
+		return new ColumnarArray(elementVector, start, end - start);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return listVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/ArrayWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/ArrayWriter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.BaseArray;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.complex.ListVector;
+
+/**
+ * {@link ArrowFieldWriter} for Array.
+ */
+@Internal
+public final class ArrayWriter<T1 extends TypeGetterSetters, T2 extends TypeGetterSetters> extends ArrowFieldWriter<T1> {
+
+	private final ArrowFieldWriter<T2> elementWriter;
+
+	public ArrayWriter(ListVector listVector, ArrowFieldWriter<T2> elementWriter) {
+		super(listVector);
+		this.elementWriter = Preconditions.checkNotNull(elementWriter);
+	}
+
+	@Override
+	public void doWrite(T1 row, int ordinal) {
+		if (!row.isNullAt(ordinal)) {
+			((ListVector) getValueVector()).startNewValue(getCount());
+			BaseArray array = row.getArray(ordinal);
+			for (int i = 0; i < array.numElements(); i++) {
+				elementWriter.write((T2) array, i);
+			}
+			((ListVector) getValueVector()).endValue(getCount(), array.numElements());
+		}
+	}
+
+	@Override
+	public void finish() {
+		super.finish();
+		elementWriter.finish();
+	}
+
+	@Override
+	public void reset() {
+		super.reset();
+		elementWriter.reset();
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BigIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BigIntWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.BigIntVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.BigIntVector;
  * {@link ArrowFieldWriter} for BigInt.
  */
 @Internal
-public final class BigIntWriter extends ArrowFieldWriter<Row> {
+public final class BigIntWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public BigIntWriter(BigIntVector bigIntVector) {
 		super(bigIntVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((BigIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((BigIntVector) getValueVector()).setSafe(getCount(), (long) value.getField(ordinal));
+			((BigIntVector) getValueVector()).setSafe(getCount(), row.getLong(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BooleanWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/BooleanWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.BitVector;
 
@@ -27,17 +27,17 @@ import org.apache.arrow.vector.BitVector;
  * {@link ArrowFieldWriter} for Boolean.
  */
 @Internal
-public final class BooleanWriter extends ArrowFieldWriter<Row> {
+public final class BooleanWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public BooleanWriter(BitVector bitVector) {
 		super(bitVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((BitVector) getValueVector()).setNull(getCount());
-		} else if ((boolean) value.getField(ordinal)) {
+		} else if (row.getBoolean(ordinal)) {
 			((BitVector) getValueVector()).setSafe(getCount(), 1);
 		} else {
 			((BitVector) getValueVector()).setSafe(getCount(), 0);

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DateWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DateWriter.java
@@ -19,30 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.DateDayVector;
-
-import java.sql.Date;
 
 /**
  * {@link ArrowFieldWriter} for Date.
  */
 @Internal
-public final class DateWriter extends ArrowFieldWriter<Row> {
+public final class DateWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public DateWriter(DateDayVector dateDayVector) {
 		super(dateDayVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((DateDayVector) getValueVector()).setNull(getCount());
 		} else {
-			((DateDayVector) getValueVector()).setSafe(
-				getCount(), PythonTypeUtils.dateToInternal(((Date) value.getField(ordinal))));
+			((DateDayVector) getValueVector()).setSafe(getCount(), row.getInt(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DecimalWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/DecimalWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.DecimalVector;
 
@@ -31,7 +31,7 @@ import static org.apache.flink.table.runtime.typeutils.PythonTypeUtils.fromBigDe
  * {@link ArrowFieldWriter} for Decimal.
  */
 @Internal
-public final class DecimalWriter extends ArrowFieldWriter<Row> {
+public final class DecimalWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	private final int precision;
 	private final int scale;
@@ -43,11 +43,11 @@ public final class DecimalWriter extends ArrowFieldWriter<Row> {
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((DecimalVector) getValueVector()).setNull(getCount());
 		} else {
-			BigDecimal bigDecimal = (BigDecimal) value.getField(ordinal);
+			BigDecimal bigDecimal = row.getDecimal(ordinal, precision, scale).toBigDecimal();
 			bigDecimal = fromBigDecimal(bigDecimal, precision, scale);
 			if (bigDecimal == null) {
 				((DecimalVector) getValueVector()).setNull(getCount());

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/FloatWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/FloatWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.Float4Vector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.Float4Vector;
  * {@link ArrowFieldWriter} for Float.
  */
 @Internal
-public final class FloatWriter extends ArrowFieldWriter<Row> {
+public final class FloatWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public FloatWriter(Float4Vector floatVector) {
 		super(floatVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((Float4Vector) getValueVector()).setNull(getCount());
 		} else {
-			((Float4Vector) getValueVector()).setSafe(getCount(), (float) value.getField(ordinal));
+			((Float4Vector) getValueVector()).setSafe(getCount(), row.getFloat(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/IntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/IntWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.IntVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.IntVector;
  * {@link ArrowFieldWriter} for Int.
  */
 @Internal
-public final class IntWriter extends ArrowFieldWriter<Row> {
+public final class IntWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public IntWriter(IntVector intVector) {
 		super(intVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((IntVector) getValueVector()).setNull(getCount());
 		} else {
-			((IntVector) getValueVector()).setSafe(getCount(), (int) value.getField(ordinal));
+			((IntVector) getValueVector()).setSafe(getCount(), row.getInt(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowBigIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowBigIntWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
 import org.apache.arrow.vector.BigIntVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.BigIntVector;
  * {@link ArrowFieldWriter} for BigInt.
  */
 @Internal
-public final class BaseRowBigIntWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowBigIntWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowBigIntWriter(BigIntVector bigIntVector) {
+	public RowBigIntWriter(BigIntVector bigIntVector) {
 		super(bigIntVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
 			((BigIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((BigIntVector) getValueVector()).setSafe(getCount(), row.getLong(ordinal));
+			((BigIntVector) getValueVector()).setSafe(getCount(), (long) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowBooleanWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowBooleanWriter.java
@@ -19,26 +19,28 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.BitVector;
 
 /**
- * {@link ArrowFieldWriter} for Int.
+ * {@link ArrowFieldWriter} for Boolean.
  */
 @Internal
-public final class BaseRowIntWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowBooleanWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowIntWriter(IntVector intVector) {
-		super(intVector);
+	public RowBooleanWriter(BitVector bitVector) {
+		super(bitVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((IntVector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((BitVector) getValueVector()).setNull(getCount());
+		} else if ((boolean) value.getField(ordinal)) {
+			((BitVector) getValueVector()).setSafe(getCount(), 1);
 		} else {
-			((IntVector) getValueVector()).setSafe(getCount(), row.getInt(ordinal));
+			((BitVector) getValueVector()).setSafe(getCount(), 0);
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDateWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDateWriter.java
@@ -19,26 +19,30 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.DateDayVector;
+
+import java.sql.Date;
 
 /**
- * {@link ArrowFieldWriter} for SmallInt.
+ * {@link ArrowFieldWriter} for Date.
  */
 @Internal
-public final class BaseRowSmallIntWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowDateWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowSmallIntWriter(SmallIntVector smallIntVector) {
-		super(smallIntVector);
+	public RowDateWriter(DateDayVector dateDayVector) {
+		super(dateDayVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((SmallIntVector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((DateDayVector) getValueVector()).setNull(getCount());
 		} else {
-			((SmallIntVector) getValueVector()).setSafe(getCount(), row.getShort(ordinal));
+			((DateDayVector) getValueVector()).setSafe(
+				getCount(), PythonTypeUtils.dateToInternal(((Date) value.getField(ordinal))));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDecimalWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDecimalWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
 import org.apache.arrow.vector.DecimalVector;
 
@@ -31,23 +31,23 @@ import static org.apache.flink.table.runtime.typeutils.PythonTypeUtils.fromBigDe
  * {@link ArrowFieldWriter} for Decimal.
  */
 @Internal
-public final class BaseRowDecimalWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowDecimalWriter extends ArrowFieldWriter<Row> {
 
 	private final int precision;
 	private final int scale;
 
-	public BaseRowDecimalWriter(DecimalVector decimalVector, int precision, int scale) {
+	public RowDecimalWriter(DecimalVector decimalVector, int precision, int scale) {
 		super(decimalVector);
 		this.precision = precision;
 		this.scale = scale;
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
 			((DecimalVector) getValueVector()).setNull(getCount());
 		} else {
-			BigDecimal bigDecimal = row.getDecimal(ordinal, precision, scale).toBigDecimal();
+			BigDecimal bigDecimal = (BigDecimal) value.getField(ordinal);
 			bigDecimal = fromBigDecimal(bigDecimal, precision, scale);
 			if (bigDecimal == null) {
 				((DecimalVector) getValueVector()).setNull(getCount());

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDoubleWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowDoubleWriter.java
@@ -19,26 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.Float8Vector;
 
 /**
- * {@link ArrowFieldWriter} for TinyInt.
+ * {@link ArrowFieldWriter} for Double.
  */
 @Internal
-public final class BaseRowTinyIntWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowDoubleWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowTinyIntWriter(TinyIntVector tinyIntVector) {
-		super(tinyIntVector);
+	public RowDoubleWriter(Float8Vector doubleVector) {
+		super(doubleVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((TinyIntVector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((Float8Vector) getValueVector()).setNull(getCount());
 		} else {
-			((TinyIntVector) getValueVector()).setSafe(getCount(), row.getByte(ordinal));
+			((Float8Vector) getValueVector()).setSafe(getCount(), (double) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowFloatWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowFloatWriter.java
@@ -19,28 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.Float4Vector;
 
 /**
- * {@link ArrowFieldWriter} for Boolean.
+ * {@link ArrowFieldWriter} for Float.
  */
 @Internal
-public final class BaseRowBooleanWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowFloatWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowBooleanWriter(BitVector bitVector) {
-		super(bitVector);
+	public RowFloatWriter(Float4Vector floatVector) {
+		super(floatVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((BitVector) getValueVector()).setNull(getCount());
-		} else if (row.getBoolean(ordinal)) {
-			((BitVector) getValueVector()).setSafe(getCount(), 1);
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((Float4Vector) getValueVector()).setNull(getCount());
 		} else {
-			((BitVector) getValueVector()).setSafe(getCount(), 0);
+			((Float4Vector) getValueVector()).setSafe(getCount(), (float) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowIntWriter.java
@@ -19,26 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.IntVector;
 
 /**
- * {@link ArrowFieldWriter} for Date.
+ * {@link ArrowFieldWriter} for Int.
  */
 @Internal
-public final class BaseRowDateWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowIntWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowDateWriter(DateDayVector dateDayVector) {
-		super(dateDayVector);
+	public RowIntWriter(IntVector intVector) {
+		super(intVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((DateDayVector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((IntVector) getValueVector()).setNull(getCount());
 		} else {
-			((DateDayVector) getValueVector()).setSafe(getCount(), row.getInt(ordinal));
+			((IntVector) getValueVector()).setSafe(getCount(), (int) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowSmallIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowSmallIntWriter.java
@@ -19,26 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.SmallIntVector;
 
 /**
- * {@link ArrowFieldWriter} for VarChar.
+ * {@link ArrowFieldWriter} for SmallInt.
  */
 @Internal
-public final class BaseRowVarCharWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowSmallIntWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowVarCharWriter(VarCharVector varCharVector) {
-		super(varCharVector);
+	public RowSmallIntWriter(SmallIntVector smallIntVector) {
+		super(smallIntVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((VarCharVector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((SmallIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((VarCharVector) getValueVector()).setSafe(getCount(), row.getString(ordinal).getBytes());
+			((SmallIntVector) getValueVector()).setSafe(getCount(), (short) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowTimeWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowTimeWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -29,13 +29,21 @@ import org.apache.arrow.vector.TimeNanoVector;
 import org.apache.arrow.vector.TimeSecVector;
 import org.apache.arrow.vector.ValueVector;
 
+import java.sql.Time;
+import java.util.TimeZone;
+
 /**
  * {@link ArrowFieldWriter} for Time.
  */
 @Internal
-public final class BaseRowTimeWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowTimeWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowTimeWriter(ValueVector valueVector) {
+	// The local time zone.
+	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
+
+	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+
+	public RowTimeWriter(ValueVector valueVector) {
 		super(valueVector);
 		Preconditions.checkState(
 			valueVector instanceof TimeSecVector ||
@@ -45,18 +53,24 @@ public final class BaseRowTimeWriter extends ArrowFieldWriter<BaseRow> {
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
+	public void doWrite(Row row, int ordinal) {
 		ValueVector valueVector = getValueVector();
-		if (row.isNullAt(ordinal)) {
-			((BaseFixedWidthVector) valueVector).setNull(getCount());
-		} else if (valueVector instanceof TimeSecVector) {
-			((TimeSecVector) valueVector).setSafe(getCount(), row.getInt(ordinal) / 1000);
-		} else if (valueVector instanceof TimeMilliVector) {
-			((TimeMilliVector) valueVector).setSafe(getCount(), row.getInt(ordinal));
-		} else if (valueVector instanceof TimeMicroVector) {
-			((TimeMicroVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000L);
+		if (row.getField(ordinal) == null) {
+			((BaseFixedWidthVector) getValueVector()).setNull(getCount());
 		} else {
-			((TimeNanoVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000000L);
+			Time time = (Time) row.getField(ordinal);
+			long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
+			int timeMilli = (int) (ts % MILLIS_PER_DAY);
+
+			if (valueVector instanceof TimeSecVector) {
+				((TimeSecVector) valueVector).setSafe(getCount(), timeMilli / 1000);
+			} else if (valueVector instanceof TimeMilliVector) {
+				((TimeMilliVector) valueVector).setSafe(getCount(), timeMilli);
+			} else if (valueVector instanceof TimeMicroVector) {
+				((TimeMicroVector) valueVector).setSafe(getCount(), timeMilli * 1000L);
+			} else {
+				((TimeNanoVector) valueVector).setSafe(getCount(), timeMilli * 1000000L);
+			}
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowTinyIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowTinyIntWriter.java
@@ -19,26 +19,26 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.TinyIntVector;
 
 /**
- * {@link ArrowFieldWriter} for Float.
+ * {@link ArrowFieldWriter} for TinyInt.
  */
 @Internal
-public final class BaseRowFloatWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowTinyIntWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowFloatWriter(Float4Vector floatVector) {
-		super(floatVector);
+	public RowTinyIntWriter(TinyIntVector tinyIntVector) {
+		super(tinyIntVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((Float4Vector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((TinyIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((Float4Vector) getValueVector()).setSafe(getCount(), row.getFloat(ordinal));
+			((TinyIntVector) getValueVector()).setSafe(getCount(), (byte) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowVarBinaryWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowVarBinaryWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.types.Row;
 
 import org.apache.arrow.vector.VarBinaryVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.VarBinaryVector;
  * {@link ArrowFieldWriter} for VarBinary.
  */
 @Internal
-public final class BaseRowVarBinaryWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowVarBinaryWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowVarBinaryWriter(VarBinaryVector varBinaryVector) {
+	public RowVarBinaryWriter(VarBinaryVector varBinaryVector) {
 		super(varBinaryVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
 			((VarBinaryVector) getValueVector()).setNull(getCount());
 		} else {
-			((VarBinaryVector) getValueVector()).setSafe(getCount(), row.getBinary(ordinal));
+			((VarBinaryVector) getValueVector()).setSafe(getCount(), (byte[]) value.getField(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowVarCharWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowVarCharWriter.java
@@ -19,26 +19,28 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.dataformat.BaseRow;
+import org.apache.flink.table.runtime.util.StringUtf8Utils;
+import org.apache.flink.types.Row;
 
-import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.VarCharVector;
 
 /**
- * {@link ArrowFieldWriter} for Double.
+ * {@link ArrowFieldWriter} for VarChar.
  */
 @Internal
-public final class BaseRowDoubleWriter extends ArrowFieldWriter<BaseRow> {
+public final class RowVarCharWriter extends ArrowFieldWriter<Row> {
 
-	public BaseRowDoubleWriter(Float8Vector doubleVector) {
-		super(doubleVector);
+	public RowVarCharWriter(VarCharVector varCharVector) {
+		super(varCharVector);
 	}
 
 	@Override
-	public void doWrite(BaseRow row, int ordinal) {
-		if (row.isNullAt(ordinal)) {
-			((Float8Vector) getValueVector()).setNull(getCount());
+	public void doWrite(Row value, int ordinal) {
+		if (value.getField(ordinal) == null) {
+			((VarCharVector) getValueVector()).setNull(getCount());
 		} else {
-			((Float8Vector) getValueVector()).setSafe(getCount(), row.getDouble(ordinal));
+			((VarCharVector) getValueVector()).setSafe(
+				getCount(), StringUtf8Utils.encodeUTF8(((String) value.getField(ordinal))));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/SmallIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/SmallIntWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.SmallIntVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.SmallIntVector;
  * {@link ArrowFieldWriter} for SmallInt.
  */
 @Internal
-public final class SmallIntWriter extends ArrowFieldWriter<Row> {
+public final class SmallIntWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public SmallIntWriter(SmallIntVector smallIntVector) {
 		super(smallIntVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((SmallIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((SmallIntVector) getValueVector()).setSafe(getCount(), (short) value.getField(ordinal));
+			((SmallIntVector) getValueVector()).setSafe(getCount(), row.getShort(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimeWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TimeWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -29,19 +29,11 @@ import org.apache.arrow.vector.TimeNanoVector;
 import org.apache.arrow.vector.TimeSecVector;
 import org.apache.arrow.vector.ValueVector;
 
-import java.sql.Time;
-import java.util.TimeZone;
-
 /**
  * {@link ArrowFieldWriter} for Time.
  */
 @Internal
-public final class TimeWriter extends ArrowFieldWriter<Row> {
-
-	// The local time zone.
-	private static final TimeZone LOCAL_TZ = TimeZone.getDefault();
-
-	private static final long MILLIS_PER_DAY = 86400000L; // = 24 * 60 * 60 * 1000
+public final class TimeWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public TimeWriter(ValueVector valueVector) {
 		super(valueVector);
@@ -53,24 +45,18 @@ public final class TimeWriter extends ArrowFieldWriter<Row> {
 	}
 
 	@Override
-	public void doWrite(Row row, int ordinal) {
+	public void doWrite(T row, int ordinal) {
 		ValueVector valueVector = getValueVector();
-		if (row.getField(ordinal) == null) {
-			((BaseFixedWidthVector) getValueVector()).setNull(getCount());
+		if (row.isNullAt(ordinal)) {
+			((BaseFixedWidthVector) valueVector).setNull(getCount());
+		} else if (valueVector instanceof TimeSecVector) {
+			((TimeSecVector) valueVector).setSafe(getCount(), row.getInt(ordinal) / 1000);
+		} else if (valueVector instanceof TimeMilliVector) {
+			((TimeMilliVector) valueVector).setSafe(getCount(), row.getInt(ordinal));
+		} else if (valueVector instanceof TimeMicroVector) {
+			((TimeMicroVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000L);
 		} else {
-			Time time = (Time) row.getField(ordinal);
-			long ts = time.getTime() + LOCAL_TZ.getOffset(time.getTime());
-			int timeMilli = (int) (ts % MILLIS_PER_DAY);
-
-			if (valueVector instanceof TimeSecVector) {
-				((TimeSecVector) valueVector).setSafe(getCount(), timeMilli / 1000);
-			} else if (valueVector instanceof TimeMilliVector) {
-				((TimeMilliVector) valueVector).setSafe(getCount(), timeMilli);
-			} else if (valueVector instanceof TimeMicroVector) {
-				((TimeMicroVector) valueVector).setSafe(getCount(), timeMilli * 1000L);
-			} else {
-				((TimeNanoVector) valueVector).setSafe(getCount(), timeMilli * 1000000L);
-			}
+			((TimeNanoVector) valueVector).setSafe(getCount(), row.getInt(ordinal) * 1000000L);
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TinyIntWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/TinyIntWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.TinyIntVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.TinyIntVector;
  * {@link ArrowFieldWriter} for TinyInt.
  */
 @Internal
-public final class TinyIntWriter extends ArrowFieldWriter<Row> {
+public final class TinyIntWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public TinyIntWriter(TinyIntVector tinyIntVector) {
 		super(tinyIntVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((TinyIntVector) getValueVector()).setNull(getCount());
 		} else {
-			((TinyIntVector) getValueVector()).setSafe(getCount(), (byte) value.getField(ordinal));
+			((TinyIntVector) getValueVector()).setSafe(getCount(), row.getByte(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarBinaryWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarBinaryWriter.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.VarBinaryVector;
 
@@ -27,18 +27,18 @@ import org.apache.arrow.vector.VarBinaryVector;
  * {@link ArrowFieldWriter} for VarBinary.
  */
 @Internal
-public final class VarBinaryWriter extends ArrowFieldWriter<Row> {
+public final class VarBinaryWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public VarBinaryWriter(VarBinaryVector varBinaryVector) {
 		super(varBinaryVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((VarBinaryVector) getValueVector()).setNull(getCount());
 		} else {
-			((VarBinaryVector) getValueVector()).setSafe(getCount(), (byte[]) value.getField(ordinal));
+			((VarBinaryVector) getValueVector()).setSafe(getCount(), row.getBinary(ordinal));
 		}
 	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarCharWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/VarCharWriter.java
@@ -19,8 +19,7 @@
 package org.apache.flink.table.runtime.arrow.writers;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.table.runtime.util.StringUtf8Utils;
-import org.apache.flink.types.Row;
+import org.apache.flink.table.dataformat.TypeGetterSetters;
 
 import org.apache.arrow.vector.VarCharVector;
 
@@ -28,19 +27,18 @@ import org.apache.arrow.vector.VarCharVector;
  * {@link ArrowFieldWriter} for VarChar.
  */
 @Internal
-public final class VarCharWriter extends ArrowFieldWriter<Row> {
+public final class VarCharWriter<T extends TypeGetterSetters> extends ArrowFieldWriter<T> {
 
 	public VarCharWriter(VarCharVector varCharVector) {
 		super(varCharVector);
 	}
 
 	@Override
-	public void doWrite(Row value, int ordinal) {
-		if (value.getField(ordinal) == null) {
+	public void doWrite(T row, int ordinal) {
+		if (row.isNullAt(ordinal)) {
 			((VarCharVector) getValueVector()).setNull(getCount());
 		} else {
-			((VarCharVector) getValueVector()).setSafe(
-				getCount(), StringUtf8Utils.encodeUTF8(((String) value.getField(ordinal))));
+			((VarCharVector) getValueVector()).setSafe(getCount(), row.getString(ordinal).getBytes());
 		}
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -22,10 +22,14 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
+import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
+import org.apache.flink.table.dataformat.GenericArray;
 import org.apache.flink.table.dataformat.SqlTimestamp;
+import org.apache.flink.table.runtime.typeutils.BaseArraySerializer;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.util.StreamRecordUtils;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
@@ -117,6 +121,7 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new TimestampType(2));
 		fieldTypes.add(new TimestampType(4));
 		fieldTypes.add(new TimestampType(8));
+		fieldTypes.add(new ArrayType(new VarCharType()));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -146,18 +151,22 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 	public BaseRow[] getTestData() {
 		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
-			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
+			new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3));
 		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
-			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
+			Tuple2.of(new GenericArray(new String[] {null, null, null}, 3), new BaseArraySerializer(new VarCharType(), null)));
 		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
-			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000));
+			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
+			new GenericArray(new String[] {null, null, null}, 3));
 		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
-			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8));
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
+			Tuple2.of(new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3), new BaseArraySerializer(new VarCharType(), null)));
+		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.arrow;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.table.runtime.functions.SqlDateTimeUtils;
+import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BooleanType;
 import org.apache.flink.table.types.logical.DateType;
@@ -85,6 +86,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new TimestampType(2));
 		fieldTypes.add(new TimestampType(4));
 		fieldTypes.add(new TimestampType(8));
+		fieldTypes.add(new ArrayType(new VarCharType()));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -115,16 +117,19 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		Row row1 = Row.of((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
+			new String[] {null, null, null});
 		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
+			new String[] {"hello", "中文", null});
 		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000));
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
+			null);
+		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/ArrowPythonScalarFunctionRunnerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.arrow.ArrowUtils;
 import org.apache.flink.table.runtime.arrow.ArrowWriter;
 import org.apache.flink.table.runtime.arrow.writers.ArrowFieldWriter;
-import org.apache.flink.table.runtime.arrow.writers.BigIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowBigIntWriter;
 import org.apache.flink.table.runtime.runners.python.scalar.AbstractPythonScalarFunctionRunnerTest;
 import org.apache.flink.table.runtime.utils.PassThroughArrowPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
@@ -64,7 +64,7 @@ public class ArrowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFun
 
 		ArrowFieldWriter<Row>[] fieldWriters = runner.arrowWriter.getFieldWriters();
 		assertEquals(1, fieldWriters.length);
-		assertTrue(fieldWriters[0] instanceof BigIntWriter);
+		assertTrue(fieldWriters[0] instanceof RowBigIntWriter);
 	}
 
 	@Test
@@ -74,9 +74,9 @@ public class ArrowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFun
 
 		ArrowFieldWriter<Row>[] fieldWriters = runner.arrowWriter.getFieldWriters();
 		assertEquals(3, fieldWriters.length);
-		assertTrue(fieldWriters[0] instanceof BigIntWriter);
-		assertTrue(fieldWriters[1] instanceof BigIntWriter);
-		assertTrue(fieldWriters[2] instanceof BigIntWriter);
+		assertTrue(fieldWriters[0] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[1] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[2] instanceof RowBigIntWriter);
 	}
 
 	@Test
@@ -86,11 +86,11 @@ public class ArrowPythonScalarFunctionRunnerTest extends AbstractPythonScalarFun
 
 		ArrowFieldWriter<Row>[] fieldWriters = runner.arrowWriter.getFieldWriters();
 		assertEquals(5, fieldWriters.length);
-		assertTrue(fieldWriters[0] instanceof BigIntWriter);
-		assertTrue(fieldWriters[1] instanceof BigIntWriter);
-		assertTrue(fieldWriters[2] instanceof BigIntWriter);
-		assertTrue(fieldWriters[3] instanceof BigIntWriter);
-		assertTrue(fieldWriters[4] instanceof BigIntWriter);
+		assertTrue(fieldWriters[0] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[1] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[2] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[3] instanceof RowBigIntWriter);
+		assertTrue(fieldWriters[4] instanceof RowBigIntWriter);
 	}
 
 	@Test

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarArray.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarArray.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat;
+
+import org.apache.flink.table.dataformat.vector.ArrayColumnVector;
+import org.apache.flink.table.dataformat.vector.BooleanColumnVector;
+import org.apache.flink.table.dataformat.vector.ByteColumnVector;
+import org.apache.flink.table.dataformat.vector.BytesColumnVector;
+import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.table.dataformat.vector.DecimalColumnVector;
+import org.apache.flink.table.dataformat.vector.DoubleColumnVector;
+import org.apache.flink.table.dataformat.vector.FloatColumnVector;
+import org.apache.flink.table.dataformat.vector.IntColumnVector;
+import org.apache.flink.table.dataformat.vector.LongColumnVector;
+import org.apache.flink.table.dataformat.vector.ShortColumnVector;
+import org.apache.flink.table.dataformat.vector.TimestampColumnVector;
+
+import java.util.Arrays;
+
+/**
+ * Columnar array to support access to vector column data.
+ */
+public final class ColumnarArray implements BaseArray {
+
+	private final ColumnVector data;
+	private final int offset;
+	private final int numElements;
+
+	public ColumnarArray(ColumnVector data, int offset, int numElements) {
+		this.data = data;
+		this.offset = offset;
+		this.numElements = numElements;
+	}
+
+	@Override
+	public int numElements() {
+		return numElements;
+	}
+
+	@Override
+	public boolean isNullAt(int pos) {
+		return data.isNullAt(offset + pos);
+	}
+
+	@Override
+	public void setNullAt(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public boolean getBoolean(int ordinal) {
+		return ((BooleanColumnVector) data).getBoolean(offset + ordinal);
+	}
+
+	@Override
+	public byte getByte(int ordinal) {
+		return ((ByteColumnVector) data).getByte(offset + ordinal);
+	}
+
+	@Override
+	public short getShort(int ordinal) {
+		return ((ShortColumnVector) data).getShort(offset + ordinal);
+	}
+
+	@Override
+	public int getInt(int ordinal) {
+		return ((IntColumnVector) data).getInt(offset + ordinal);
+	}
+
+	@Override
+	public long getLong(int ordinal) {
+		return ((LongColumnVector) data).getLong(offset + ordinal);
+	}
+
+	@Override
+	public float getFloat(int ordinal) {
+		return ((FloatColumnVector) data).getFloat(offset + ordinal);
+	}
+
+	@Override
+	public double getDouble(int ordinal) {
+		return ((DoubleColumnVector) data).getDouble(offset + ordinal);
+	}
+
+	@Override
+	public BinaryString getString(int ordinal) {
+		BytesColumnVector.Bytes byteArray = getByteArray(ordinal);
+		return BinaryString.fromBytes(byteArray.data, byteArray.offset, byteArray.len);
+	}
+
+	@Override
+	public Decimal getDecimal(int ordinal, int precision, int scale) {
+		return ((DecimalColumnVector) data).getDecimal(offset + ordinal, precision, scale);
+	}
+
+	@Override
+	public SqlTimestamp getTimestamp(int ordinal, int precision) {
+		return ((TimestampColumnVector) data).getTimestamp(offset + ordinal, precision);
+	}
+
+	@Override
+	public <T> BinaryGeneric<T> getGeneric(int ordinal) {
+		throw new UnsupportedOperationException("GenericType is not supported.");
+	}
+
+	@Override
+	public byte[] getBinary(int ordinal) {
+		BytesColumnVector.Bytes byteArray = getByteArray(ordinal);
+		if (byteArray.len == byteArray.data.length) {
+			return byteArray.data;
+		} else {
+			return Arrays.copyOfRange(byteArray.data, byteArray.offset, byteArray.len);
+		}
+	}
+
+	@Override
+	public BaseArray getArray(int ordinal) {
+		return ((ArrayColumnVector) data).getArray(offset + ordinal);
+	}
+
+	@Override
+	public BaseMap getMap(int ordinal) {
+		throw new UnsupportedOperationException("Map is not supported.");
+	}
+
+	@Override
+	public BaseRow getRow(int ordinal, int numFields) {
+		throw new UnsupportedOperationException("Row is not supported.");
+	}
+
+	@Override
+	public void setBoolean(int ordinal, boolean value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setByte(int ordinal, byte value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setShort(int ordinal, short value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setInt(int ordinal, int value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setLong(int ordinal, long value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setFloat(int ordinal, float value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setDouble(int ordinal, double value) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setDecimal(int i, Decimal value, int precision) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setTimestamp(int ordinal, SqlTimestamp value, int precision) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNotNullAt(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullLong(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullInt(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullBoolean(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullByte(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullShort(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullFloat(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public void setNullDouble(int pos) {
+		throw new UnsupportedOperationException("Not support the operation!");
+	}
+
+	@Override
+	public boolean[] toBooleanArray() {
+		boolean[] res = new boolean[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getBoolean(i);
+		}
+		return res;
+	}
+
+	@Override
+	public byte[] toByteArray() {
+		byte[] res = new byte[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getByte(i);
+		}
+		return res;
+	}
+
+	@Override
+	public short[] toShortArray() {
+		short[] res = new short[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getShort(i);
+		}
+		return res;
+	}
+
+	@Override
+	public int[] toIntArray() {
+		int[] res = new int[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getInt(i);
+		}
+		return res;
+	}
+
+	@Override
+	public long[] toLongArray() {
+		long[] res = new long[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getLong(i);
+		}
+		return res;
+	}
+
+	@Override
+	public float[] toFloatArray() {
+		float[] res = new float[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getFloat(i);
+		}
+		return res;
+	}
+
+	@Override
+	public double[] toDoubleArray() {
+		double[] res = new double[numElements];
+		for (int i = 0; i < numElements; i++) {
+			res[i] = getDouble(i);
+		}
+		return res;
+	}
+
+	private BytesColumnVector.Bytes getByteArray(int ordinal) {
+		return ((BytesColumnVector) data).getBytes(offset + ordinal);
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
@@ -146,8 +146,7 @@ public final class ColumnarRow implements BaseRow {
 
 	@Override
 	public BaseArray getArray(int ordinal) {
-		// TODO
-		throw new UnsupportedOperationException("Array is not supported.");
+		return vectorizedColumnBatch.getArray(rowId, ordinal);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/DataFormatConverters.java
@@ -1118,7 +1118,7 @@ public class DataFormatConverters {
 		T[] toExternalImpl(BaseArray value) {
 			return (isEleIndentity && value instanceof GenericArray) ?
 					genericArrayToJavaArray((GenericArray) value, elementType) :
-					binaryArrayToJavaArray((BinaryArray) value, elementType, componentClass, elementConverter);
+					baseArrayToJavaArray(value, elementType, componentClass, elementConverter);
 		}
 
 		@Override
@@ -1153,7 +1153,7 @@ public class DataFormatConverters {
 		}
 	}
 
-	private static <T> T[] binaryArrayToJavaArray(BinaryArray value, LogicalType elementType,
+	private static <T> T[] baseArrayToJavaArray(BaseArray value, LogicalType elementType,
 			Class<T> componentClass, DataFormatConverter<Object, T> elementConverter) {
 		int size = value.numElements();
 		T[] values = (T[]) Array.newInstance(componentClass, size);
@@ -1259,8 +1259,8 @@ public class DataFormatConverters {
 
 		private Map binaryMapToMap(BinaryMap value) {
 			Map<Object, Object> map = new HashMap<>();
-			Object[] keys = binaryArrayToJavaArray(value.keyArray(), keyType, keyComponentClass, keyConverter);
-			Object[] values = binaryArrayToJavaArray(value.valueArray(), valueType, valueComponentClass, valueConverter);
+			Object[] keys = baseArrayToJavaArray(value.keyArray(), keyType, keyComponentClass, keyConverter);
+			Object[] values = baseArrayToJavaArray(value.valueArray(), valueType, valueComponentClass, valueConverter);
 			for (int i = 0; i < value.numElements(); i++) {
 				map.put(keys[i], values[i]);
 			}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/ArrayColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/ArrayColumnVector.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector;
+
+import org.apache.flink.table.dataformat.BaseArray;
+
+/**
+ * Array column vector.
+ */
+public interface ArrayColumnVector extends ColumnVector {
+	BaseArray getArray(int i);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.dataformat.vector;
 
+import org.apache.flink.table.dataformat.BaseArray;
 import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataformat.vector.BytesColumnVector.Bytes;
@@ -115,5 +116,9 @@ public class VectorizedColumnBatch implements Serializable {
 
 	public SqlTimestamp getTimestamp(int rowId, int colId, int precision) {
 		return ((TimestampColumnVector) (columns[colId])).getTimestamp(rowId, precision);
+	}
+
+	public BaseArray getArray(int rowId, int colId) {
+		return ((ArrayColumnVector) columns[colId]).getArray(rowId);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializerTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/typeutils/BaseArraySerializerTest.java
@@ -31,13 +31,16 @@ import org.apache.flink.table.dataformat.BinaryArray;
 import org.apache.flink.table.dataformat.BinaryArrayWriter;
 import org.apache.flink.table.dataformat.BinaryGeneric;
 import org.apache.flink.table.dataformat.BinaryString;
+import org.apache.flink.table.dataformat.ColumnarArray;
 import org.apache.flink.table.dataformat.GenericArray;
+import org.apache.flink.table.dataformat.vector.heap.HeapBytesVector;
 import org.apache.flink.testutils.DeeplyEqualsChecker;
 
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObj;
 import static org.apache.flink.table.runtime.typeutils.SerializerTestUtil.MyObjSerializer;
@@ -138,6 +141,7 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 				createArray("11", "haa", "ke"),
 				createArray("11", "haa", "ke"),
 				createArray("11", "lele", "haa", "ke"),
+				createColumnarArray("11", "lele", "haa", "ke"),
 		};
 	}
 
@@ -149,5 +153,13 @@ public class BaseArraySerializerTest extends SerializerTestBase<BaseArray> {
 		}
 		writer.complete();
 		return array;
+	}
+
+	private static ColumnarArray createColumnarArray(String... vs) {
+		HeapBytesVector vector = new HeapBytesVector(vs.length);
+		for (String v : vs) {
+			vector.fill(v.getBytes(StandardCharsets.UTF_8));
+		}
+		return new ColumnarArray(vector, 0, vs.length);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.runtime.util;
 
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.dataformat.BaseArray;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryRowWriter;
@@ -28,6 +29,7 @@ import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.table.runtime.typeutils.BaseArraySerializer;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
 
@@ -126,6 +128,10 @@ public class StreamRecordUtils {
 			} else if (value instanceof Tuple2 && ((Tuple2) value).f0 instanceof SqlTimestamp) {
 				SqlTimestamp timestamp = (SqlTimestamp) ((Tuple2) value).f0;
 				writer.writeTimestamp(j, timestamp, (int) ((Tuple2) value).f1);
+			} else if (value instanceof Tuple2 && ((Tuple2) value).f0 instanceof BaseArray) {
+				BaseArray array = (BaseArray) ((Tuple2) value).f0;
+				BaseArraySerializer serializer = (BaseArraySerializer) ((Tuple2) value).f1;
+				writer.writeArray(j, array, serializer);
 			} else {
 				throw new RuntimeException("Not support yet!");
 			}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request adds the support of ArrayType in vectorized Python UDF.*

## Brief change log

  - *Introduces ArrowArrayColumnVector and BaseRowArrayWriter in flink-python module and introduces ColumnarArray and ArrayColumnVector in flink-table-runtime-blink module to support ArrayType in the blink planner for vectorized Python UDF*
  - *Introduces ArrayFieldReader and ArrayWriter in flink-python module to support ArrayType in the old planner for vectorized Python UDF*

## Verifying this change
This change added tests and can be verified as follows:

  - *Java tests ArrowUtilsTest, RowArrowReaderWriterTest and BaseRowArrowReaderWriterTest*
  - *Python tests: test_pandas_udf.test_all_data_types*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
