### PR TITLE
[FLINK-14311] Relax restart checker to harden StreaminFileSink e2e test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -731,7 +731,8 @@ function wait_for_restart_to_complete {
     local expected_num_restarts=$((current_num_restarts + 1))
 
     echo "Waiting for restart to happen"
-    while ! [[ ${current_num_restarts} -eq ${expected_num_restarts} ]]; do
+    while [[ ${current_num_restarts} -le ${expected_num_restarts} ]]; do
+        echo "Still waiting for restarts. Expected: $expected_num_restarts Current: $current_num_restarts"
         sleep 5
         current_num_restarts=$(get_job_metric ${jobid} "fullRestarts")
         if [[ -z ${current_num_restarts} ]]; then


### PR DESCRIPTION
Before, we were checking for an exact number of restarts, this is too
strict, because we could have more than the expected number of restarts.
Now we check whether we have gte the number of expected restarts.

@GJL could you maybe look at this? Or @zentol ?