### PR TITLE
[FLINK-16906][e2e][hotfix] Disable TPC-DS end-to-end test (Blink)

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -201,7 +201,9 @@ run_test "SQL Client end-to-end test (Blink planner) Elasticsearch (v6.3.1)" "$E
 run_test "SQL Client end-to-end test (Blink planner) Elasticsearch (v7.5.1)" "$END_TO_END_DIR/test-scripts/test_sql_client.sh blink 7"
 
 run_test "TPC-H end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpch.sh"
-run_test "TPC-DS end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"
+
+# Test disabled until FLINK-16906 is resolved
+# run_test "TPC-DS end-to-end test (Blink planner)" "$END_TO_END_DIR/test-scripts/test_tpcds.sh"
 
 run_test "Heavy deployment end-to-end test" "$END_TO_END_DIR/test-scripts/test_heavy_deployment.sh" "skip_check_exceptions"
 


### PR DESCRIPTION
Currently, all e2e tests are failing because of this test. I propose to disable them for now.

I would like to wait until CI has passed for this PR. We don't know if other e2e tests are broken as well, as the issue seems to be deeper in the stack.