### PR TITLE
[FLINK-16916][serialization] Fix the logic of NullableSerializer#copy

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -218,7 +218,7 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 
 	@Override
 	public void copy(DataInputView source, DataOutputView target) throws IOException {
-		boolean isNull = source.readBoolean();
+		boolean isNull = deserializeNull(source);
 		target.writeBoolean(isNull);
 		if (isNull) {
 			target.write(padding);

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializerTest.java
@@ -71,7 +71,7 @@ public class NullableSerializerTest extends SerializerTestBase<Integer> {
 
 	@Override
 	protected Integer[] getTestData() {
-		return new Integer[] { 5, -1, 0, null };
+		return new Integer[] { 5, -1, null, 5 };
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fix the wrong logic of `NullableSerializer#copy`, 
currently, the logic is such as below:
```
public void copy(DataInputView source, DataOutputView target) throws IOException {
   boolean isNull = source.readBoolean();
   target.writeBoolean(isNull);
   if (isNull) {
      target.write(padding);
   }
   else {
      originalSerializer.copy(source, target);
   }
}
```
we forgot to skip paddings.length bytes when if the padding's length is not 0.

We can correct the logic such as below 
```
public void copy(DataInputView source, DataOutputView target) throws IOException {
   boolean isNull = deserializeNull(source); // this will skip the padding values.
   target.writeBoolean(isNull);
   if (isNull) {
      target.write(padding);
   }
   else {
      originalSerializer.copy(source, target);
   }
}
```


## Verifying this change
Harden the test of `NullalbeSerialierTest#testSerializedCopyAsSequence` by update the test data.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
