### PR TITLE
[FLINK-16605] Add max limitation to the total number of slots

### DIFF
--- a/docs/_includes/generated/expert_scheduling_section.html
+++ b/docs/_includes/generated/expert_scheduling_section.html
@@ -15,6 +15,12 @@
             <td>Enable the slot spread out allocation strategy. This strategy tries to spread out the slots evenly across all available <span markdown="span">`TaskExecutors`</span>.</td>
         </tr>
         <tr>
+            <td><h5>slotmanager.max-number-of-slots</h5></td>
+            <td style="word-wrap: break-word;">2147483647</td>
+            <td>Integer</td>
+            <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
+        </tr>
+        <tr>
             <td><h5>slot.idle.timeout</h5></td>
             <td style="word-wrap: break-word;">50000</td>
             <td>Long</td>

--- a/docs/_includes/generated/resource_manager_configuration.html
+++ b/docs/_includes/generated/resource_manager_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>slotmanager.max-number-of-slots</h5></td>
+            <td style="word-wrap: break-word;">2147483647</td>
+            <td>Integer</td>
+            <td>Defines the maximum number of slots that the Flink cluster allocates. This configuration option is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take effect for standalone clusters, where how many slots are allocated is not controlled by Flink.</td>
+        </tr>
+        <tr>
             <td><h5>resourcemanager.job.timeout</h5></td>
             <td style="word-wrap: break-word;">"5 minutes"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -19,6 +19,7 @@
 package org.apache.flink.configuration;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.description.Description;
 
 /**
@@ -55,6 +56,16 @@ public class ResourceManagerOptions {
 		.withDescription("Defines the network port to connect to for communication with the resource manager. By" +
 			" default, the port of the JobManager, because the same ActorSystem is used." +
 			" Its not possible to use this configuration key to define port ranges.");
+
+	@Documentation.Section(Documentation.Sections.EXPERT_SCHEDULING)
+	public static final ConfigOption<Integer> MAX_SLOT_NUM = ConfigOptions
+		.key("slotmanager.max-number-of-slots")
+		.intType()
+		.defaultValue(Integer.MAX_VALUE)
+		.withDescription("Defines the maximum number of slots that the Flink cluster allocates. This configuration option " +
+			"is meant for limiting the resource consumption for batch workloads. It is not recommended to configure this option " +
+			"for streaming workloads, which may fail if there are not enough slots. Note that this configuration option does not take " +
+			"effect for standalone clusters, where how many slots are allocated is not controlled by Flink.");
 
 	/**
 	 * The timeout for a slot request to be discarded, in milliseconds.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -47,6 +47,7 @@ public class SlotManagerConfiguration {
 	private final SlotMatchingStrategy slotMatchingStrategy;
 	private final WorkerResourceSpec defaultWorkerResourceSpec;
 	private final int numSlotsPerWorker;
+	private final int maxSlotNum;
 
 	public SlotManagerConfiguration(
 			Time taskManagerRequestTimeout,
@@ -55,7 +56,8 @@ public class SlotManagerConfiguration {
 			boolean waitResultConsumedBeforeRelease,
 			SlotMatchingStrategy slotMatchingStrategy,
 			WorkerResourceSpec defaultWorkerResourceSpec,
-			int numSlotsPerWorker) {
+			int numSlotsPerWorker,
+			int maxSlotNum) {
 
 		this.taskManagerRequestTimeout = Preconditions.checkNotNull(taskManagerRequestTimeout);
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
@@ -64,7 +66,9 @@ public class SlotManagerConfiguration {
 		this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
 		this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
 		Preconditions.checkState(numSlotsPerWorker > 0);
+		Preconditions.checkState(maxSlotNum > 0);
 		this.numSlotsPerWorker = numSlotsPerWorker;
+		this.maxSlotNum = maxSlotNum;
 	}
 
 	public Time getTaskManagerRequestTimeout() {
@@ -95,6 +99,10 @@ public class SlotManagerConfiguration {
 		return numSlotsPerWorker;
 	}
 
+	public int getMaxSlotNum() {
+		return maxSlotNum;
+	}
+
 	public static SlotManagerConfiguration fromConfiguration(
 			Configuration configuration,
 			WorkerResourceSpec defaultWorkerResourceSpec) throws ConfigurationException {
@@ -120,6 +128,8 @@ public class SlotManagerConfiguration {
 
 		int numSlotsPerWorker = configuration.getInteger(TaskManagerOptions.NUM_TASK_SLOTS);
 
+		int maxSlotNum = configuration.getInteger(ResourceManagerOptions.MAX_SLOT_NUM);
+
 		return new SlotManagerConfiguration(
 			rpcTimeout,
 			slotRequestTimeout,
@@ -127,7 +137,8 @@ public class SlotManagerConfiguration {
 			waitResultConsumedBeforeRelease,
 			slotMatchingStrategy,
 			defaultWorkerResourceSpec,
-			numSlotsPerWorker);
+			numSlotsPerWorker,
+			maxSlotNum);
 	}
 
 	private static Time getSlotRequestTimeout(final Configuration configuration) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -61,8 +61,9 @@ public class SlotManagerConfiguration {
 		this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
 		this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
 		this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
-		this.slotMatchingStrategy = slotMatchingStrategy;
-		this.defaultWorkerResourceSpec = defaultWorkerResourceSpec;
+		this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
+		this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
+		Preconditions.checkState(numSlotsPerWorker > 0);
 		this.numSlotsPerWorker = numSlotsPerWorker;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerImpl.java
@@ -122,6 +122,9 @@ public class SlotManagerImpl implements SlotManager {
 	/** Release task executor only when each produced result partition is either consumed or failed. */
 	private final boolean waitResultConsumedBeforeRelease;
 
+	/** Defines the max limitation of the total number of slots. */
+	private final int maxSlotNum;
+
 	/**
 	 * If true, fail unfulfillable slot requests immediately. Otherwise, allow unfulfillable request to pend.
 	 * A slot request is considered unfulfillable if it cannot be fulfilled by neither a slot that is already registered
@@ -157,6 +160,7 @@ public class SlotManagerImpl implements SlotManager {
 		this.numSlotsPerWorker = slotManagerConfiguration.getNumSlotsPerWorker();
 		this.defaultSlotResourceProfile = generateDefaultSlotResourceProfile(defaultWorkerResourceSpec, numSlotsPerWorker);
 		this.slotManagerMetricGroup = Preconditions.checkNotNull(slotManagerMetricGroup);
+		this.maxSlotNum = slotManagerConfiguration.getMaxSlotNum();
 
 		slots = new HashMap<>(16);
 		freeSlots = new LinkedHashMap<>(16);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/SlotReport.java
@@ -49,6 +49,10 @@ public class SlotReport implements Serializable, Iterable<SlotStatus> {
 		this.slotsStatus = checkNotNull(slotsStatus);
 	}
 
+	public int getNumSlotStatus() {
+		return slotsStatus.size();
+	}
+
 	@Override
 	public Iterator<SlotStatus> iterator() {
 		return slotsStatus.iterator();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerHATest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.TestingHeartbeatServices;
@@ -74,7 +75,8 @@ public class ResourceManagerHATest extends TestLogger {
 				true,
 				AnyMatchingSlotMatchingStrategy.INSTANCE,
 				WorkerResourceSpec.ZERO,
-				1));
+				1,
+				ResourceManagerOptions.MAX_SLOT_NUM.defaultValue()));
 		ResourceManagerRuntimeServices resourceManagerRuntimeServices = ResourceManagerRuntimeServices.fromConfiguration(
 			resourceManagerRuntimeServicesConfiguration,
 			highAvailabilityServices,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -20,9 +20,11 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.testingUtils.TestingUtils;
 
@@ -121,5 +123,11 @@ public class SlotManagerBuilder {
 			scheduledExecutor,
 			slotManagerConfiguration,
 			slotManagerMetricGroup);
+	}
+
+	public SlotManagerImpl buildAndStartWithDirectExec(ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
+		final SlotManagerImpl slotManager = build();
+		slotManager.start(resourceManagerId, Executors.directExecutor(), resourceManagerActions);
+		return slotManager;
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
@@ -36,6 +37,7 @@ public class SlotManagerBuilder {
 	private WorkerResourceSpec defaultWorkerResourceSpec;
 	private int numSlotsPerWorker;
 	private SlotManagerMetricGroup slotManagerMetricGroup;
+	private int maxSlotNum;
 
 	private SlotManagerBuilder() {
 		this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -47,6 +49,7 @@ public class SlotManagerBuilder {
 		this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
 		this.numSlotsPerWorker = 1;
 		this.slotManagerMetricGroup = UnregisteredMetricGroups.createUnregisteredSlotManagerMetricGroup();
+		this.maxSlotNum = ResourceManagerOptions.MAX_SLOT_NUM.defaultValue();
 	}
 
 	public static SlotManagerBuilder newBuilder() {
@@ -98,6 +101,11 @@ public class SlotManagerBuilder {
 		return this;
 	}
 
+	public SlotManagerBuilder setMaxSlotNum(int maxSlotNum) {
+		this.maxSlotNum = maxSlotNum;
+		return this;
+	}
+
 	public SlotManagerImpl build() {
 		final SlotManagerConfiguration slotManagerConfiguration = new SlotManagerConfiguration(
 			taskManagerRequestTimeout,
@@ -106,7 +114,8 @@ public class SlotManagerBuilder {
 			waitResultConsumedBeforeRelease,
 			slotMatchingStrategy,
 			defaultWorkerResourceSpec,
-			numSlotsPerWorker);
+			numSlotsPerWorker,
+			maxSlotNum);
 
 		return new SlotManagerImpl(
 			scheduledExecutor,


### PR DESCRIPTION

## What is the purpose of the change

Add max limitation to the total number of slots.

## Brief change log

- Introduce "cluster.number-of-slots.max" configuration option with default value MAX_INT
- Make the SlotManager respect the max number of slots, when exceeded, it would not allocate resource anymore.


## Verifying this change

- SlotManagerImplTest#testRespectMaxLimitBeforeAllocateResource
- SlotManagerImplTest#testReleaseResourceWhenExceedMaxLimit

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
