### PR TITLE
[FLINK-16942][es] Allow users to override http/transport type

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
+++ b/flink-connectors/flink-connector-elasticsearch5/src/main/java/org/apache/flink/streaming/connectors/elasticsearch5/Elasticsearch5ApiCallBridge.java
@@ -67,9 +67,10 @@ public class Elasticsearch5ApiCallBridge implements ElasticsearchApiCallBridge<T
 
 	@Override
 	public TransportClient createClient(Map<String, String> clientConfig) {
-		Settings settings = Settings.builder().put(clientConfig)
+		Settings settings = Settings.builder()
 			.put(NetworkModule.HTTP_TYPE_KEY, Netty3Plugin.NETTY_HTTP_TRANSPORT_NAME)
 			.put(NetworkModule.TRANSPORT_TYPE_KEY, Netty3Plugin.NETTY_TRANSPORT_NAME)
+			.put(clientConfig)
 			.build();
 
 		TransportClient transportClient = new PreBuiltTransportClient(settings);


### PR DESCRIPTION
Inverts the order in which the `Settings` are assembled so that users can override the http/transport type.
This should allow users to use the netty4 transport client if they wish to do so.