### PR TITLE
[FLINK-16389][kafka] Bump kafka version to 0.10.2.2

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/pom.xml
+++ b/flink-connectors/flink-connector-kafka-0.10/pom.xml
@@ -37,7 +37,7 @@ under the License.
 
 	<!-- Allow users to pass custom connector versions -->
 	<properties>
-		<kafka.version>0.10.2.1</kafka.version>
+		<kafka.version>0.10.2.2</kafka.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kafka-0.10/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.kafka:kafka-clients:0.10.2.1
+- org.apache.kafka:kafka-clients:0.10.2.2


### PR DESCRIPTION
To address [CVE-2018-1288](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1288).