### PR TITLE
[FLINK-6258] Deprecate ListCheckpointed interface

### DIFF
--- a/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
+++ b/flink-end-to-end-tests/flink-bucketing-sink-test/src/main/java/org/apache/flink/streaming/tests/BucketingSinkTestProgram.java
@@ -20,15 +20,20 @@ package org.apache.flink.streaming.tests;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.fs.Clock;
@@ -38,8 +43,6 @@ import org.apache.flink.streaming.connectors.fs.bucketing.BucketingSink;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -140,7 +143,7 @@ public class BucketingSinkTestProgram {
 	/**
 	 * Data-generating source function.
 	 */
-	public static class Generator implements SourceFunction<Tuple3<Integer, Long, String>>, ListCheckpointed<Long> {
+	public static class Generator implements SourceFunction<Tuple3<Integer, Long, String>>, CheckpointedFunction {
 
 		private final int numKeys;
 		private final int idlenessMs;
@@ -148,6 +151,8 @@ public class BucketingSinkTestProgram {
 
 		private long ms = 0;
 		private volatile boolean canceled = false;
+
+		private ListState<Long> state = null;
 
 		public Generator(int numKeys, int idlenessMs, int durationSeconds) {
 			this.numKeys = numKeys;
@@ -178,15 +183,19 @@ public class BucketingSinkTestProgram {
 		}
 
 		@Override
-		public List<Long> snapshotState(long checkpointId, long timestamp) {
-			return Collections.singletonList(ms);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(
+					new ListStateDescriptor<Long>("state", LongSerializer.INSTANCE));
+
+			for (Long l : state.get()) {
+				ms += l;
+			}
 		}
 
 		@Override
-		public void restoreState(List<Long> state) {
-			for (Long l : state) {
-				ms += l;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(ms);
 		}
 	}
 }

--- a/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
+++ b/flink-end-to-end-tests/flink-cli-test/src/main/java/org/apache/flink/streaming/tests/PeriodicStreamingJob.java
@@ -18,22 +18,24 @@
 
 package org.apache.flink.streaming.tests;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.tuple.Tuple;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.windowing.time.Time;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * This is a periodic streaming job that runs for CLI testing purposes.
@@ -79,11 +81,13 @@ public class PeriodicStreamingJob {
 	/**
 	 * Data-generating source function.
 	 */
-	public static class PeriodicSourceGenerator implements SourceFunction<Tuple>, ResultTypeQueryable<Tuple>, ListCheckpointed<Long> {
+	public static class PeriodicSourceGenerator implements SourceFunction<Tuple>, ResultTypeQueryable<Tuple>, CheckpointedFunction {
 		private final int sleepMs;
 		private final int durationMs;
 		private final int offsetSeconds;
 		private long ms = 0;
+
+		private ListState<Long> state = null;
 
 		public PeriodicSourceGenerator(float rowsPerSecond, int durationSeconds, int offsetSeconds) {
 			this.durationMs = durationSeconds * 1000;
@@ -115,15 +119,19 @@ public class PeriodicStreamingJob {
 		}
 
 		@Override
-		public List<Long> snapshotState(long checkpointId, long timestamp) {
-			return Collections.singletonList(ms);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(
+					new ListStateDescriptor<Long>("state", LongSerializer.INSTANCE));
+
+			for (Long l : state.get()) {
+				ms += l;
+			}
 		}
 
 		@Override
-		public void restoreState(List<Long> state) {
-			for (Long l : state) {
-				ms += l;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(ms);
 		}
 	}
 }

--- a/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-sql-test/src/main/java/org/apache/flink/sql/tests/StreamSQLTestProgram.java
@@ -21,15 +21,21 @@ package org.apache.flink.sql.tests;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
@@ -255,7 +261,7 @@ public class StreamSQLTestProgram {
 	/**
 	 * Data-generating source function.
 	 */
-	public static class Generator implements SourceFunction<Row>, ResultTypeQueryable<Row>, ListCheckpointed<Long> {
+	public static class Generator implements SourceFunction<Row>, ResultTypeQueryable<Row>, CheckpointedFunction {
 
 		private final int numKeys;
 		private final int offsetSeconds;
@@ -264,6 +270,7 @@ public class StreamSQLTestProgram {
 		private final int durationMs;
 
 		private long ms = 0;
+		private ListState<Long> state = null;
 
 		public Generator(int numKeys, float rowsPerKeyAndSecond, int durationSeconds, int offsetSeconds) {
 			this.numKeys = numKeys;
@@ -297,27 +304,33 @@ public class StreamSQLTestProgram {
 		}
 
 		@Override
-		public List<Long> snapshotState(long checkpointId, long timestamp) {
-			return Collections.singletonList(ms);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(
+					new ListStateDescriptor<Long>("state", LongSerializer.INSTANCE));
+
+			for (Long l : state.get()) {
+				ms += l;
+			}
 		}
 
 		@Override
-		public void restoreState(List<Long> state) {
-			for (Long l : state) {
-				ms += l;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(ms);
 		}
 	}
 
 	/**
 	 * Kills the first execution attempt of an application when it receives the second record.
 	 */
-	public static class KillMapper implements MapFunction<Row, Row>, ListCheckpointed<Integer>, ResultTypeQueryable {
+	public static class KillMapper implements MapFunction<Row, Row>, CheckpointedFunction, ResultTypeQueryable {
 
 		// counts all processed records of all previous execution attempts
 		private int saveRecordCnt = 0;
 		// counts all processed records of this execution attempt
 		private int lostRecordCnt = 0;
+
+		private ListState<Integer> state = null;
 
 		@Override
 		public Row map(Row value) {
@@ -342,15 +355,19 @@ public class StreamSQLTestProgram {
 		}
 
 		@Override
-		public List<Integer> snapshotState(long checkpointId, long timestamp) {
-			return Collections.singletonList(saveRecordCnt);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(
+					new ListStateDescriptor<Integer>("state", IntSerializer.INSTANCE));
+
+			for (Integer i : state.get()) {
+				saveRecordCnt += i;
+			}
 		}
 
 		@Override
-		public void restoreState(List<Integer> state) {
-			for (Integer i : state) {
-				saveRecordCnt += i;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(saveRecordCnt);
 		}
 	}
 }

--- a/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
+++ b/flink-end-to-end-tests/flink-streaming-file-sink-test/src/main/java/StreamingFileSinkProgram.java
@@ -18,12 +18,17 @@
 
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
@@ -32,8 +37,6 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 import java.io.PrintStream;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -99,7 +102,7 @@ public enum StreamingFileSinkProgram {
 	/**
 	 * Data-generating source function.
 	 */
-	public static final class Generator implements SourceFunction<Tuple2<Integer, Integer>>, ListCheckpointed<Integer> {
+	public static final class Generator implements SourceFunction<Tuple2<Integer, Integer>>, CheckpointedFunction {
 
 		private static final long serialVersionUID = -2819385275681175792L;
 
@@ -109,6 +112,8 @@ public enum StreamingFileSinkProgram {
 
 		private volatile int numRecordsEmitted = 0;
 		private volatile boolean canceled = false;
+
+		private ListState<Integer> state = null;
 
 		Generator(final int numKeys, final int idlenessMs, final int durationSeconds) {
 			this.numKeys = numKeys;
@@ -141,15 +146,19 @@ public enum StreamingFileSinkProgram {
 		}
 
 		@Override
-		public List<Integer> snapshotState(final long checkpointId, final long timestamp) {
-			return Collections.singletonList(numRecordsEmitted);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(
+					new ListStateDescriptor<Integer>("state", IntSerializer.INSTANCE));
+
+			for (Integer i : state.get()) {
+				numRecordsEmitted += i;
+			}
 		}
 
 		@Override
-		public void restoreState(final List<Integer> states) {
-			for (final Integer state : states) {
-				numRecordsEmitted += state;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(numRecordsEmitted);
 		}
 	}
 }

--- a/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/async/AsyncIOExample.java
+++ b/flink-examples/flink-examples-streaming/src/main/java/org/apache/flink/streaming/examples/async/AsyncIOExample.java
@@ -18,13 +18,18 @@
 package org.apache.flink.streaming.examples.async;
 
 import org.apache.flink.api.common.functions.FlatMapFunction;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.checkpoint.ListCheckpointed;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -40,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
@@ -61,23 +65,32 @@ public class AsyncIOExample {
 	/**
 	 * A checkpointed source.
 	 */
-	private static class SimpleSource implements SourceFunction<Integer>, ListCheckpointed<Integer> {
+	private static class SimpleSource implements SourceFunction<Integer>, CheckpointedFunction {
 		private static final long serialVersionUID = 1L;
 
 		private volatile boolean isRunning = true;
 		private int counter = 0;
 		private int start = 0;
 
+		private ListState<Integer> state;
+
 		@Override
-		public List<Integer> snapshotState(long checkpointId, long timestamp) throws Exception {
-			return Collections.singletonList(start);
+		public void initializeState(FunctionInitializationContext context) throws Exception {
+			state = context.getOperatorStateStore().getListState(new ListStateDescriptor<>(
+					"state",
+					IntSerializer.INSTANCE));
+
+			// restore any state that we might already have to our fields, initialize state
+			// is also called in case of restore.
+			for (Integer i : state.get()) {
+				start = i;
+			}
 		}
 
 		@Override
-		public void restoreState(List<Integer> state) throws Exception {
-			for (Integer i : state) {
-				this.start = i;
-			}
+		public void snapshotState(FunctionSnapshotContext context) throws Exception {
+			state.clear();
+			state.add(start);
 		}
 
 		public SimpleSource(int maxNum) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/checkpoint/ListCheckpointed.java
@@ -105,9 +105,13 @@ import java.util.List;
  * }
  * }</pre>
  *
+ * @deprecated If you need to do non-keyed state snapshots of your operator, use {@link
+ *        CheckpointedFunction}. This should only be needed in rare cases, though.
+ *
  * @param <T> The type of the operator state.
  */
 @PublicEvolving
+@Deprecated
 public interface ListCheckpointed<T extends Serializable> {
 
 	/**


### PR DESCRIPTION
This also updates the documentation and changes usage in our code to
CheckpointedFunction.

The Google PubSub source unfortunately also uses ListCheckpointed but
here we cannot migrate to CheckpointedFunction because of savepoint
compatibility.
## Brief change log
 
 - add `@deprecated` annotation, pointing to `CheckpointedFunction` as the replacement
 - migrate documentation and examples and internal usage
 - there is one usage left in the GCP PubSub connector, we cannot change that because of savepoint compatibility

## Verifying this change

 - this change some tests to use `CheckpointedFunction` instead of `ListCheckpointed`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: `ListCheckpointed` is `@PublicEvolving`
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

Documentation is updated to remove mentions of ListCheckpointed.

cc @knaufk  @sjwiesman  @alpinegizmo @NicoK (it's probably good for you to be aware of this). Could one of you maybe give me a review?