### PR TITLE
[FLINK-16921][e2e] Make Kubernetes e2e test stable

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -114,4 +114,15 @@ function stop_kubernetes {
     fi
 }
 
+function debug_copy_and_show_logs {
+    echo "Debugging failed Kubernetes test:"
+    echo "Currently existing Kubernetes resources"
+    kubectl get all
+
+    echo "Flink logs:"
+    kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | while read pod;do
+        kubectl logs $pod;
+    done
+}
+
 on_exit cleanup

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -27,6 +27,8 @@ MINIKUBE_START_RETRIES=3
 MINIKUBE_START_BACKOFF=5
 RESULT_HASH="e682ec6622b5e83f2eb614617d5ab2cf"
 
+NON_LINUX_ENV_NOTE="****** Please start/stop minikube manually in non-linux environment. ******"
+
 # If running tests on non-linux os, the kubectl and minikube should be installed manually
 function setup_kubernetes_for_linux {
     # Download kubectl, which is a requirement for using minikube.
@@ -53,32 +55,28 @@ function start_kubernetes_if_not_running {
     if ! check_kubernetes_status; then
         echo "Starting minikube ..."
         # We need sudo permission to set vm-driver to none in linux os.
-        if [[ "${OS_TYPE}" = "linux" ]] ; then
-            # tl;dr: Configure minikube for a low disk space environment
-            #
-            # The VMs provided by azure have ~100GB of disk space, out of which
-            # 85% are allocated, only 15GB are free. That's enough space
-            # for our purposes. However, the kubernetes nodes running during
-            # the k8s tests believe that 85% are not enough free disk space,
-            # so they start garbage collecting their host. During GCing, they
-            # are deleting all docker images currently not in use. 
-            # However, the k8s test is first building a flink image, then launching
-            # stuff on k8s. Sometimes, k8s deletes the new Flink images,
-            # thus it can not find them anymore, letting the test fail /
-            # timeout. That's why we have set the GC threshold to 98% and 99%
-            # here.
-            # Similarly, the kubelets are marking themself as "low disk space",
-            # causing Flink to avoid this node (again, failing the test)
-            sudo CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none \
-                --extra-config=kubelet.image-gc-high-threshold=99 \
-                --extra-config=kubelet.image-gc-low-threshold=98 \
-                --extra-config=kubelet.minimum-container-ttl-duration=120m \
-                --extra-config=kubelet.eviction-hard="memory.available<5Mi,nodefs.available<1Mi,imagefs.available<1Mi" \
-                --extra-config=kubelet.eviction-soft="memory.available<5Mi,nodefs.available<2Mi,imagefs.available<2Mi" \
-                --extra-config=kubelet.eviction-soft-grace-period="memory.available=2h,nodefs.available=2h,imagefs.available=2h"
-        else
-            sudo minikube start
-        fi
+        # tl;dr: Configure minikube for a low disk space environment
+        #
+        # The VMs provided by azure have ~100GB of disk space, out of which
+        # 85% are allocated, only 15GB are free. That's enough space
+        # for our purposes. However, the kubernetes nodes running during
+        # the k8s tests believe that 85% are not enough free disk space,
+        # so they start garbage collecting their host. During GCing, they
+        # are deleting all docker images currently not in use.
+        # However, the k8s test is first building a flink image, then launching
+        # stuff on k8s. Sometimes, k8s deletes the new Flink images,
+        # thus it can not find them anymore, letting the test fail /
+        # timeout. That's why we have set the GC threshold to 98% and 99%
+        # here.
+        # Similarly, the kubelets are marking themself as "low disk space",
+        # causing Flink to avoid this node (again, failing the test)
+        sudo CHANGE_MINIKUBE_NONE_USER=true minikube start --vm-driver=none \
+            --extra-config=kubelet.image-gc-high-threshold=99 \
+            --extra-config=kubelet.image-gc-low-threshold=98 \
+            --extra-config=kubelet.minimum-container-ttl-duration=120m \
+            --extra-config=kubelet.eviction-hard="memory.available<5Mi,nodefs.available<1Mi,imagefs.available<1Mi" \
+            --extra-config=kubelet.eviction-soft="memory.available<5Mi,nodefs.available<2Mi,imagefs.available<2Mi" \
+            --extra-config=kubelet.eviction-soft-grace-period="memory.available=2h,nodefs.available=2h,imagefs.available=2h"
         # Fix the kubectl context, as it's often stale.
         minikube update-context
     fi
@@ -88,21 +86,31 @@ function start_kubernetes_if_not_running {
 }
 
 function start_kubernetes {
-    [[ "${OS_TYPE}" = "linux" ]] && setup_kubernetes_for_linux
-    if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
-        echo "Could not start minikube. Aborting..."
-        exit 1
+    if [[ "${OS_TYPE}" != "linux" ]]; then
+        if ! check_kubernetes_status; then
+            echo "$NON_LINUX_ENV_NOTE"
+            exit 1
+        fi
+    else
+        setup_kubernetes_for_linux
+        if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} start_kubernetes_if_not_running; then
+            echo "Could not start minikube. Aborting..."
+            exit 1
+        fi
     fi
     eval $(minikube docker-env)
 }
 
 function stop_kubernetes {
-    echo "Stopping minikube ..."
-    stop_command="minikube stop"
-    [[ "${OS_TYPE}" = "linux" ]] && stop_command="sudo ${stop_command}"
-    if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} "${stop_command}"; then
-        echo "Could not stop minikube. Aborting..."
-        exit 1
+    if [[ "${OS_TYPE}" != "linux" ]]; then
+        echo "$NON_LINUX_ENV_NOTE"
+    else
+        echo "Stopping minikube ..."
+        stop_command="sudo minikube stop"
+        if ! retry_times ${MINIKUBE_START_RETRIES} ${MINIKUBE_START_BACKOFF} "${stop_command}"; then
+            echo "Could not stop minikube. Aborting..."
+            exit 1
+        fi
     fi
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -49,3 +49,7 @@ kubectl wait --for=condition=complete job/flink-job-cluster --timeout=1h
 kubectl cp `kubectl get pods | awk '/task-manager/ {print $1}'`:/cache/${OUTPUT_FILE} ${OUTPUT_VOLUME}/${OUTPUT_FILE}
 
 check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_FILE} "${RESULT_HASH}"
+
+if [ $? != 0 ];then
+  debug_copy_and_show_logs
+fi


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Use the following optimization to make this K8s e2e test more stable both in azure/travis and local.

* Remove start/stop code for non-linux environment, let the user manually start/stop minikube. Since we will encounter various problem in local environment(e.g. Mac), including disk problem, network problem, docker daemon, driver setup(virtualbox, etc.). 
* Print more debug information so that when the test failed it is easier to investigate
* Explicitly wait for the dispatcher running and then submit the job to the existing cluster


## Brief change log
* Do not start/stop minikube in non-linux environment for k8s e2e tests
* Print more information for debugging when Kubernetes e2e tests failed
* Wait for rest endpoint up and then submit Flink job to existing Kubernetes session


## Verifying this change

* Run in local environment(Mac) more than 10 times, all should pass
* Run in azure more that 3 times, all should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
