### PR TITLE
[FLINK-16949] Enhance AbstractStreamOperatorTestHarness to use customized TtlTimeProvider

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -361,6 +361,11 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		return keyValueStatesByName.size();
 	}
 
+	@VisibleForTesting
+	public TtlTimeProvider getTtlTimeProvider() {
+		return ttlTimeProvider;
+	}
+
 	// TODO remove this once heap-based timers are working with RocksDB incremental snapshots!
 	public boolean requiresLegacySynchronousTimerSnapshots() {
 		return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/AbstractKeyedStateBackend.java
@@ -361,11 +361,6 @@ public abstract class AbstractKeyedStateBackend<K> implements
 		return keyValueStatesByName.size();
 	}
 
-	@VisibleForTesting
-	public TtlTimeProvider getTtlTimeProvider() {
-		return ttlTimeProvider;
-	}
-
 	// TODO remove this once heap-based timers are working with RocksDB incremental snapshots!
 	public boolean requiresLegacySynchronousTimerSnapshots() {
 		return false;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/MockTtlTimeProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/MockTtlTimeProvider.java
@@ -26,4 +26,8 @@ public class MockTtlTimeProvider implements TtlTimeProvider {
 	public long currentTimestamp() {
 		return time;
 	}
+
+	public void setCurrentTimeStamp(long timeStamp) {
+		this.time = timeStamp;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/MockTtlTimeProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/MockTtlTimeProvider.java
@@ -27,7 +27,7 @@ public class MockTtlTimeProvider implements TtlTimeProvider {
 		return time;
 	}
 
-	public void setCurrentTimeStamp(long timeStamp) {
-		this.time = timeStamp;
+	public void setCurrentTimestamp(long timestamp) {
+		this.time = timestamp;
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -85,13 +86,25 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 	/** This object is the factory for everything related to state backends and checkpointing. */
 	private final StateBackend stateBackend;
 
+	private final TtlTimeProvider ttlTimeProvider;
+
 	public StreamTaskStateInitializerImpl(
 		Environment environment,
 		StateBackend stateBackend) {
 
+		this(environment, stateBackend, TtlTimeProvider.DEFAULT);
+	}
+
+	@VisibleForTesting
+	public StreamTaskStateInitializerImpl(
+		Environment environment,
+		StateBackend stateBackend,
+		TtlTimeProvider ttlTimeProvider) {
+
 		this.environment = environment;
 		this.taskStateManager = Preconditions.checkNotNull(environment.getTaskStateManager());
 		this.stateBackend = Preconditions.checkNotNull(stateBackend);
+		this.ttlTimeProvider = ttlTimeProvider;
 	}
 
 	// -----------------------------------------------------------------------------------------------------------------
@@ -258,10 +271,6 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		}
 	}
 
-	protected TtlTimeProvider getTtlTimeProvider() {
-		return TtlTimeProvider.DEFAULT;
-	}
-
 	protected <K> AbstractKeyedStateBackend<K> keyedStatedBackend(
 		TypeSerializer<K> keySerializer,
 		String operatorIdentifierText,
@@ -297,7 +306,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 					taskInfo.getMaxNumberOfParallelSubtasks(),
 					keyGroupRange,
 					environment.getTaskKvStateRegistry(),
-					getTtlTimeProvider(),
+					ttlTimeProvider,
 					metricGroup,
 					stateHandles,
 					cancelStreamRegistryForRestore),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -258,6 +258,10 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 		}
 	}
 
+	protected TtlTimeProvider getTtlTimeProvider() {
+		return TtlTimeProvider.DEFAULT;
+	}
+
 	protected <K> AbstractKeyedStateBackend<K> keyedStatedBackend(
 		TypeSerializer<K> keySerializer,
 		String operatorIdentifierText,
@@ -293,7 +297,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 					taskInfo.getMaxNumberOfParallelSubtasks(),
 					keyGroupRange,
 					environment.getTaskKvStateRegistry(),
-					TtlTimeProvider.DEFAULT,
+					getTtlTimeProvider(),
 					metricGroup,
 					stateHandles,
 					cancelStreamRegistryForRestore),

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -250,7 +250,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 		processingTimeService.setCurrentTime(0);
 
 		ttlTimeProvider = new MockTtlTimeProvider();
-		ttlTimeProvider.setCurrentTimeStamp(0);
+		ttlTimeProvider.setCurrentTimestamp(0);
 
 		this.streamTaskStateInitializer = createStreamTaskStateManager(environment, stateBackend, ttlTimeProvider);
 
@@ -643,7 +643,7 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 	}
 
 	public void setStateTtlProcessingTime(long timeStamp) {
-		ttlTimeProvider.setCurrentTimeStamp(timeStamp);
+		ttlTimeProvider.setCurrentTimestamp(timeStamp);
 	}
 
 	public long getProcessingTime() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarnessTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarnessTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
-import org.apache.flink.runtime.state.ttl.MockTtlTimeProvider;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.util.TestLogger;
 
@@ -75,8 +74,6 @@ public class AbstractStreamOperatorTestHarnessTest extends TestLogger {
 			result.config.setStateKeySerializer(IntSerializer.INSTANCE);
 
 			Time timeToLive = Time.hours(1);
-			MockTtlTimeProvider mockTtlTimeProvider = new MockTtlTimeProvider();
-			result.setTtlTimeProvider(mockTtlTimeProvider);
 			result.initializeState(new OperatorSubtaskState());
 			result.open();
 
@@ -87,10 +84,10 @@ public class AbstractStreamOperatorTestHarnessTest extends TestLogger {
 
 			int expectedValue = 42;
 			keyedStateBackend.setCurrentKey(1);
-			mockTtlTimeProvider.setCurrentTimeStamp(0L);
+			result.setStateTtlProcessingTime(0L);
 			state.update(expectedValue);
 			Assert.assertEquals(expectedValue, (int) state.value());
-			mockTtlTimeProvider.setCurrentTimeStamp(timeToLive.toMilliseconds() + 1);
+			result.setStateTtlProcessingTime(timeToLive.toMilliseconds() + 1);
 			Assert.assertNull(state.value());
 		}
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarnessTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarnessTest.java
@@ -18,9 +18,16 @@
 
 package org.apache.flink.streaming.util;
 
+import org.apache.flink.api.common.state.StateTtlConfig;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.runtime.state.ttl.MockTtlTimeProvider;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.util.TestLogger;
 
@@ -58,21 +65,33 @@ public class AbstractStreamOperatorTestHarnessTest extends TestLogger {
 
 	@Test
 	public void testSetTtlTimeProvider() throws Exception {
-		AbstractStreamOperatorTestHarness<Integer> result;
-		AbstractStreamOperator operator = new AbstractStreamOperator<Integer>() {};
-		result =
-			new AbstractStreamOperatorTestHarness<>(
+		AbstractStreamOperator<Integer> operator = new AbstractStreamOperator<Integer>() {};
+		try (AbstractStreamOperatorTestHarness<Integer> result = new AbstractStreamOperatorTestHarness<>(
 				operator,
 				1,
 				1,
-				0);
-		result.config.setStateKeySerializer(IntSerializer.INSTANCE);
+				0)) {
 
-		long expectedTimeStamp = 42;
-		result.setTtlTimeProvider(() -> expectedTimeStamp);
-		result.initializeState(new OperatorSubtaskState());
-		result.open();
-		Assert.assertEquals(expectedTimeStamp,
-			((AbstractKeyedStateBackend<?>) operator.getKeyedStateBackend()).getTtlTimeProvider().currentTimestamp());
+			result.config.setStateKeySerializer(IntSerializer.INSTANCE);
+
+			Time timeToLive = Time.hours(1);
+			MockTtlTimeProvider mockTtlTimeProvider = new MockTtlTimeProvider();
+			result.setTtlTimeProvider(mockTtlTimeProvider);
+			result.initializeState(new OperatorSubtaskState());
+			result.open();
+
+			ValueStateDescriptor<Integer> stateDescriptor = new ValueStateDescriptor<>("test", IntSerializer.INSTANCE);
+			stateDescriptor.enableTimeToLive(StateTtlConfig.newBuilder(timeToLive).build());
+			KeyedStateBackend<Integer> keyedStateBackend = operator.getKeyedStateBackend();
+			ValueState<Integer> state = keyedStateBackend.getPartitionedState(VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+			int expectedValue = 42;
+			keyedStateBackend.setCurrentKey(1);
+			mockTtlTimeProvider.setCurrentTimeStamp(0L);
+			state.update(expectedValue);
+			Assert.assertEquals(expectedValue, (int) state.value());
+			mockTtlTimeProvider.setCurrentTimeStamp(timeToLive.toMilliseconds() + 1);
+			Assert.assertNull(state.value());
+		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.state.StatePartitionStreamProvider;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
+import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.InternalTimeServiceManager;
 import org.apache.flink.streaming.api.operators.KeyContext;
@@ -233,7 +234,7 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
 			protected StreamTaskStateInitializer createStreamTaskStateManager(
 				Environment env,
 				StateBackend stateBackend,
-				ProcessingTimeService processingTimeService) {
+				TtlTimeProvider ttlTimeProvider) {
 
 				return new StreamTaskStateInitializerImpl(env, stateBackend) {
 					@Override


### PR DESCRIPTION
## What is the purpose of the change

Enhance specific UTs to use customized `TtlTimeProvider` to simulate changed current time. This would introduce some changes to `AbstractStreamOperatorTestHarness` and add new `StreamTaskStateInitializerTestImpl` for different state backends.

## Brief change log
Introduce some changes to `AbstractStreamOperatorTestHarness` and add new `StreamTaskStateInitializerTestImpl` for different state backends.


## Verifying this change

This change added tests and can be verified as follows:

AbstractStreamOperatorTestHarnessTest#testSetTtlTimeProvider

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
