### PR TITLE
[FLINK-16954] Don't use JDK11 APIs in ClassRelocator

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -120,6 +120,16 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- We use a version property here and don't use dependency management because this is
+		 the only place where we use asm-7 in the Flink 1.9.x line. We need this for the
+		 ClassRelocator -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-shaded-asm-7</artifactId>
+            <version>7.1-10.0</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>


### PR DESCRIPTION
We instead use asm-7, which is normally not available in the Flink 1.9.x
line, as a test dependency.

cc @zentol 
