### PR TITLE
[FLINK-16770][e2e] Make the checkpoint resuming e2e case pass by increasing the…

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -39,6 +39,8 @@ fi
 
 set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
 set_config_key "metrics.fetcher.update-interval" "2000"
+# hotfix for FLINK-16770
+set_config_key "state.checkpoints.num-retained" "2"
 setup_flink_slf4j_metric_reporter
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -61,6 +61,8 @@ if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'heap' ]; then
   set_config_key "state.backend.rocksdb.timer-service.factory" "heap"
 fi
 set_config_key "metrics.fetcher.update-interval" "2000"
+# hotfix for FLINK-16770
+set_config_key "state.checkpoints.num-retained" "2"
 
 setup_flink_slf4j_metric_reporter
 


### PR DESCRIPTION
… retained checkpoints number

## What is the purpose of the change

* This is a quick fixing of FLINK-16770
* It could avoid testing failure caused by changing of FLINK-14971
* This hotfix should be reverted when the final solution of FLINK-16770 completes

## Brief change log

* Increase the number of retained checkpoints to avoid all checkpoints are subsumed when a race condition of `CheckpointCoordinator` happens

## Verifying this change

* This change is already covered by existing tests, such as *test_resume_externalized_checkpoints.sh* and *test_resume_savepoint.sh*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
