### PR TITLE
[FLINK-14504][rest] Add Cluster DataSet REST API

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -102,6 +102,187 @@
 <table class="table table-bordered">
   <tbody>
     <tr>
+      <td class="text-left" colspan="2"><h5><strong>/datasets</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns all cluster data sets.</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-2127843514">Request</button>
+        <div id="-2127843514" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#2178839">Response</button>
+        <div id="2178839" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:dataset:ClusterDataSetListResponseBody",
+  "properties" : {
+    "dataSets" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:dataset:ClusterDataSetEntry",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "isComplete" : {
+            "type" : "boolean"
+          }
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><h5><strong>/datasets/delete/:triggerid</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns the status for the delete operation of a cluster data set.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>triggerid</code> - 32-character hexadecimal string that identifies an asynchronous operation trigger ID. The ID was returned then the operation was triggered.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-2131471052">Request</button>
+        <div id="-2131471052" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#330413108">Response</button>
+        <div id="330413108" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
+  "properties" : {
+    "operation" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationInfo",
+      "properties" : {
+        "failure-cause" : {
+          "type" : "any"
+        }
+      }
+    },
+    "status" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+      "properties" : {
+        "id" : {
+          "type" : "string",
+          "required" : true,
+          "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+        }
+      }
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><h5><strong>/datasets/:datasetid</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>DELETE</code></td>
+      <td class="text-left">Response code: <code>202 Accepted</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Triggers the deletion of a cluster data set. This async operation would return a 'triggerid' for further query identifier.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>datasetid</code> - 32-character hexadecimal string value that identifies a cluster data set.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1341404463">Request</button>
+        <div id="1341404463" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#711384652">Response</button>
+        <div id="711384652" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:TriggerResponse",
+  "properties" : {
+    "request-id" : {
+      "type" : "any"
+    }
+  }
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
       <td class="text-left" colspan="2"><h5><strong>/jars</strong></h5></td>
     </tr>
     <tr>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -61,6 +61,102 @@
       }
     }
   }, {
+    "url" : "/datasets",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:dataset:ClusterDataSetListResponseBody",
+      "properties" : {
+        "dataSets" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:dataset:ClusterDataSetEntry",
+            "properties" : {
+              "id" : {
+                "type" : "string"
+              },
+              "isComplete" : {
+                "type" : "boolean"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
+    "url" : "/datasets/delete/:triggerid",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "triggerid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
+      "properties" : {
+        "status" : {
+          "type" : "object",
+          "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:queue:QueueStatus",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "required" : true,
+              "enum" : [ "IN_PROGRESS", "COMPLETED" ]
+            }
+          }
+        },
+        "operation" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
+    "url" : "/datasets/:datasetid",
+    "method" : "DELETE",
+    "status-code" : "202 Accepted",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "datasetid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:TriggerResponse",
+      "properties" : {
+        "request-id" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
     "url" : "/jars",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ClusterPartitionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ClusterPartitionManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Interface for components that manage cluster partitions.
+ */
+public interface ClusterPartitionManager {
+
+	/**
+	 * Returns all datasets for which partitions are being tracked.
+	 *
+	 * @return tracked datasets
+	 */
+	CompletableFuture<Map<IntermediateDataSetID, DataSetMetaInfo>> listDataSets();
+
+	/**
+	 * Releases all partitions associated with the given dataset.
+	 *
+	 * @param dataSetToRelease dataset for which all associated partitions should be released
+	 * @return future that is completed once all partitions have been released
+	 */
+	CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetToRelease);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
@@ -17,18 +17,40 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.util.Preconditions;
+
+import java.util.Optional;
+
 /**
  * Container for meta-data of a data set.
  */
 public final class DataSetMetaInfo {
+	private static final int UNKNOWN = -1;
 
+	private final int numRegisteredPartitions;
 	private final int numTotalPartitions;
 
-	public DataSetMetaInfo(int numTotalPartitions) {
+	public DataSetMetaInfo(int numRegisteredPartitions, int numTotalPartitions) {
+		this.numRegisteredPartitions = numRegisteredPartitions;
 		this.numTotalPartitions = numTotalPartitions;
+	}
+
+	public Optional<Integer> getNumRegisteredPartitions() {
+		return numRegisteredPartitions == UNKNOWN
+			? Optional.empty()
+			: Optional.of(numRegisteredPartitions);
 	}
 
 	public int getNumTotalPartitions() {
 		return numTotalPartitions;
+	}
+
+	static DataSetMetaInfo withoutNumRegisteredPartitions(int numTotalPartitions) {
+		return new DataSetMetaInfo(UNKNOWN, numTotalPartitions);
+	}
+
+	static DataSetMetaInfo withNumRegisteredPartitions(int numRegisteredPartitions, int numTotalPartitions) {
+		Preconditions.checkArgument(numRegisteredPartitions > 0);
+		return new DataSetMetaInfo(numRegisteredPartitions, numTotalPartitions);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataSetMetaInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.runtime.io.network.partition;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Optional;
@@ -30,7 +31,7 @@ public final class DataSetMetaInfo {
 	private final int numRegisteredPartitions;
 	private final int numTotalPartitions;
 
-	public DataSetMetaInfo(int numRegisteredPartitions, int numTotalPartitions) {
+	private DataSetMetaInfo(int numRegisteredPartitions, int numTotalPartitions) {
 		this.numRegisteredPartitions = numRegisteredPartitions;
 		this.numTotalPartitions = numTotalPartitions;
 	}
@@ -49,7 +50,8 @@ public final class DataSetMetaInfo {
 		return new DataSetMetaInfo(UNKNOWN, numTotalPartitions);
 	}
 
-	static DataSetMetaInfo withNumRegisteredPartitions(int numRegisteredPartitions, int numTotalPartitions) {
+	@VisibleForTesting
+	public static DataSetMetaInfo withNumRegisteredPartitions(int numRegisteredPartitions, int numTotalPartitions) {
 		Preconditions.checkArgument(numRegisteredPartitions > 0);
 		return new DataSetMetaInfo(numRegisteredPartitions, numTotalPartitions);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResourceManagerPartitionTracker.java
@@ -59,9 +59,9 @@ public interface ResourceManagerPartitionTracker {
 	CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetId);
 
 	/**
-	 * Returns all data sets for which all partitions are being tracked.
+	 * Returns all data sets for which partitions are being tracked.
 	 *
-	 * @return completely tracked datasets
+	 * @return tracked datasets
 	 */
 	Map<IntermediateDataSetID, DataSetMetaInfo> listDataSets();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -38,8 +38,10 @@ import org.apache.flink.runtime.heartbeat.HeartbeatTarget;
 import org.apache.flink.runtime.heartbeat.NoOpHeartbeatManager;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.partition.DataSetMetaInfo;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterGateway;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
@@ -635,6 +637,16 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
 		} else {
 			return taskExecutor.getTaskExecutorGateway().requestLogList(timeout);
 		}
+	}
+
+	@Override
+	public CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetId) {
+		return clusterPartitionTracker.releaseClusterPartitions(dataSetId);
+	}
+
+	@Override
+	public CompletableFuture<Map<IntermediateDataSetID, DataSetMetaInfo>> listDataSets() {
+		return CompletableFuture.completedFuture(clusterPartitionTracker.listDataSets());
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.partition.ClusterPartitionManager;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -50,7 +51,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * The {@link ResourceManager}'s RPC gateway interface.
  */
-public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManagerId> {
+public interface ResourceManagerGateway extends FencedRpcGateway<ResourceManagerId>, ClusterPartitionManager {
 
 	/**
 	 * Register a {@link JobMaster} at the resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetDeleteHandlers.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.dataset;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.async.AbstractAsynchronousOperationHandlers;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
+import org.apache.flink.runtime.rest.handler.async.OperationKey;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetDeleteStatusHeaders;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetDeleteStatusMessageParameters;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetDeleteTriggerHeaders;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetDeleteTriggerMessageParameters;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetIdPathParameter;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.SerializedThrowable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handler for {@link ClusterDataSetDeleteTriggerHeaders}.
+ */
+public class ClusterDataSetDeleteHandlers extends AbstractAsynchronousOperationHandlers<OperationKey, Void> {
+
+	/**
+	 * {@link TriggerHandler} implementation for the cluster data set delete operation.
+	 */
+	public class ClusterDataSetDeleteTriggerHandler extends TriggerHandler<RestfulGateway, EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters> {
+
+		private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
+
+		public ClusterDataSetDeleteTriggerHandler(
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+			super(
+				leaderRetriever,
+				timeout,
+				responseHeaders,
+				ClusterDataSetDeleteTriggerHeaders.INSTANCE);
+			this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
+		}
+
+		@Override
+		protected CompletableFuture<Void> triggerOperation(HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters> request, RestfulGateway gateway) throws RestHandlerException {
+			final IntermediateDataSetID clusterPartitionId = request.getPathParameter(ClusterDataSetIdPathParameter.class);
+			ResourceManagerGateway resourceManagerGateway = AbstractResourceManagerHandler.getResourceManagerGateway(resourceManagerGatewayRetriever);
+			return resourceManagerGateway.releaseClusterPartitions(clusterPartitionId);
+		}
+
+		@Override
+		protected OperationKey createOperationKey(HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters> request) {
+			return new OperationKey(new TriggerId());
+		}
+	}
+
+	/**
+	 * {@link StatusHandler} implementation for the cluster data set delete operation.
+	 */
+	public class ClusterDataSetDeleteStatusHandler extends StatusHandler<RestfulGateway, AsynchronousOperationInfo, ClusterDataSetDeleteStatusMessageParameters> {
+
+		public ClusterDataSetDeleteStatusHandler(
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders) {
+			super(
+				leaderRetriever,
+				timeout,
+				responseHeaders,
+				ClusterDataSetDeleteStatusHeaders.INSTANCE);
+		}
+
+		@Override
+		protected OperationKey getOperationKey(HandlerRequest<EmptyRequestBody, ClusterDataSetDeleteStatusMessageParameters> request) {
+			final TriggerId triggerId = request.getPathParameter(TriggerIdPathParameter.class);
+			return new OperationKey(triggerId);
+		}
+
+		@Override
+		protected AsynchronousOperationInfo exceptionalOperationResultResponse(Throwable throwable) {
+			return AsynchronousOperationInfo.completeExceptional(new SerializedThrowable(throwable));
+		}
+
+		@Override
+		protected AsynchronousOperationInfo operationResultResponse(Void ignored) {
+			return AsynchronousOperationInfo.complete();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/dataset/ClusterDataSetListHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.dataset;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetListHeaders;
+import org.apache.flink.runtime.rest.messages.dataset.ClusterDataSetListResponseBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import javax.annotation.Nonnull;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handler for {@link ClusterDataSetListHeaders}.
+ */
+public class ClusterDataSetListHandler extends AbstractResourceManagerHandler<RestfulGateway, EmptyRequestBody, ClusterDataSetListResponseBody, EmptyMessageParameters> {
+	public ClusterDataSetListHandler(
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) {
+		super(leaderRetriever, timeout, responseHeaders, ClusterDataSetListHeaders.INSTANCE, resourceManagerGatewayRetriever);
+	}
+
+	@Override
+	protected CompletableFuture<ClusterDataSetListResponseBody> handleRequest(@Nonnull HandlerRequest<EmptyRequestBody, EmptyMessageParameters> request, @Nonnull ResourceManagerGateway gateway) throws RestHandlerException {
+		return gateway.listDataSets().thenApply(ClusterDataSetListResponseBody::from);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/resourcemanager/AbstractResourceManagerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/resourcemanager/AbstractResourceManagerHandler.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.rest.handler.taskmanager;
+package org.apache.flink.runtime.rest.handler.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.resourcemanager.ResourceManager;
@@ -40,18 +40,18 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Base class for TaskManager related REST handler which need access to the {@link ResourceManager}.
+ * Base class for REST handlers which need access to the {@link ResourceManager}.
  *
  * @param <T> type of the {@link RestfulGateway}
  * @param <R> request type
  * @param <P> response type
  * @param <M> message parameters type
  */
-abstract class AbstractTaskManagerHandler<T extends RestfulGateway, R extends RequestBody, P extends ResponseBody, M extends MessageParameters> extends AbstractRestHandler<T, R, P, M> {
+public abstract class AbstractResourceManagerHandler<T extends RestfulGateway, R extends RequestBody, P extends ResponseBody, M extends MessageParameters> extends AbstractRestHandler<T, R, P, M> {
 
 	private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
 
-	protected AbstractTaskManagerHandler(
+	protected AbstractResourceManagerHandler(
 			GatewayRetriever<? extends T> leaderRetriever,
 			Time timeout,
 			Map<String, String> responseHeaders,
@@ -71,7 +71,7 @@ abstract class AbstractTaskManagerHandler<T extends RestfulGateway, R extends Re
 
 	protected abstract CompletableFuture<P> handleRequest(@Nonnull HandlerRequest<R, M> request, @Nonnull ResourceManagerGateway gateway) throws RestHandlerException;
 
-	protected ResourceManagerGateway getResourceManagerGateway(GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) throws RestHandlerException {
+	public static ResourceManagerGateway getResourceManagerGateway(GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever) throws RestHandlerException {
 		return resourceManagerGatewayRetriever
 			.getNow()
 			.orElseThrow(() -> new RestHandlerException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerDetailsHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsInfo;
@@ -51,7 +52,7 @@ import java.util.concurrent.CompletionException;
 /**
  * Handler which serves detailed TaskManager information.
  */
-public class TaskManagerDetailsHandler extends AbstractTaskManagerHandler<RestfulGateway, EmptyRequestBody, TaskManagerDetailsInfo, TaskManagerMessageParameters> {
+public class TaskManagerDetailsHandler extends AbstractResourceManagerHandler<RestfulGateway, EmptyRequestBody, TaskManagerDetailsInfo, TaskManagerMessageParameters> {
 
 	private final MetricFetcher metricFetcher;
 	private final MetricStore metricStore;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogListHandler.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.LogInfo;
 import org.apache.flink.runtime.rest.messages.LogListInfo;
@@ -47,7 +48,7 @@ import java.util.concurrent.CompletionException;
 /**
  * Handler which serves detailed TaskManager log list information.
  */
-public class TaskManagerLogListHandler extends AbstractTaskManagerHandler<RestfulGateway, EmptyRequestBody, LogListInfo, TaskManagerMessageParameters> {
+public class TaskManagerLogListHandler extends AbstractResourceManagerHandler<RestfulGateway, EmptyRequestBody, LogListInfo, TaskManagerMessageParameters> {
 
 	private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagersHandler.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.resourcemanager.AbstractResourceManagerHandler;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
@@ -37,7 +38,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Returns an overview over all registered TaskManagers of the cluster.
  */
-public class TaskManagersHandler extends AbstractTaskManagerHandler<RestfulGateway, EmptyRequestBody, TaskManagersInfo, EmptyMessageParameters> {
+public class TaskManagersHandler extends AbstractResourceManagerHandler<RestfulGateway, EmptyRequestBody, TaskManagersInfo, EmptyMessageParameters> {
 
 	public TaskManagersHandler(
 			GatewayRetriever<? extends RestfulGateway> leaderRetriever,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteStatusHeaders.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationStatusMessageHeaders;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Specification for retrieving the status for the delete operation of a cluster data set.
+ *
+ * @see ClusterDataSetDeleteStatusHeaders
+ */
+public class ClusterDataSetDeleteStatusHeaders extends AsynchronousOperationStatusMessageHeaders<AsynchronousOperationInfo, ClusterDataSetDeleteStatusMessageParameters> {
+
+	public static final ClusterDataSetDeleteStatusHeaders INSTANCE = new ClusterDataSetDeleteStatusHeaders();
+
+	private static final String URL = ClusterDataSetListHeaders.URL + "/delete/:" + TriggerIdPathParameter.KEY;
+
+	private ClusterDataSetDeleteStatusHeaders() {
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Returns the status for the delete operation of a cluster data set.";
+	}
+
+	@Override
+	public Class<AsynchronousOperationInfo> getValueClass() {
+		return AsynchronousOperationInfo.class;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public ClusterDataSetDeleteStatusMessageParameters getUnresolvedMessageParameters() {
+		return new ClusterDataSetDeleteStatusMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteStatusMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteStatusMessageParameters.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.TriggerIdPathParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for the {@link ClusterDataSetDeleteStatusHeaders}.
+ */
+public class ClusterDataSetDeleteStatusMessageParameters extends MessageParameters {
+
+	public final TriggerIdPathParameter triggerIdPathParameter = new TriggerIdPathParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(triggerIdPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerHeaders.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationTriggerMessageHeaders;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Specification for triggering the deletion of a cluster data set.
+ *
+ * @see ClusterDataSetDeleteStatusHeaders
+ */
+public class ClusterDataSetDeleteTriggerHeaders extends AsynchronousOperationTriggerMessageHeaders<EmptyRequestBody, ClusterDataSetDeleteTriggerMessageParameters> {
+
+	public static final ClusterDataSetDeleteTriggerHeaders INSTANCE = new ClusterDataSetDeleteTriggerHeaders();
+
+	private static final String URL = ClusterDataSetListHeaders.URL + "/:" + ClusterDataSetIdPathParameter.KEY;
+
+	private ClusterDataSetDeleteTriggerHeaders() {
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.ACCEPTED;
+	}
+
+	@Override
+	protected String getAsyncOperationDescription() {
+		return "Triggers the deletion of a cluster data set.";
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public ClusterDataSetDeleteTriggerMessageParameters getUnresolvedMessageParameters() {
+		return new ClusterDataSetDeleteTriggerMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.DELETE;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetDeleteTriggerMessageParameters.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for the {@link ClusterDataSetDeleteTriggerHeaders}.
+ */
+public class ClusterDataSetDeleteTriggerMessageParameters extends MessageParameters {
+
+	public final ClusterDataSetIdPathParameter clusterDataSetIdPathParameter = new ClusterDataSetIdPathParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.singleton(clusterDataSetIdPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetEntry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The entry for a single cluster data set.
+ *
+ * @see ClusterDataSetListResponseBody
+ */
+class ClusterDataSetEntry {
+	private static final String FIELD_NAME_DATA_SET_ID = "id";
+	private static final String FIELD_NAME_COMPLETE = "isComplete";
+
+	@JsonProperty(FIELD_NAME_DATA_SET_ID)
+	private final String dataSetId;
+
+	@JsonProperty(FIELD_NAME_COMPLETE)
+	private final boolean isComplete;
+
+	ClusterDataSetEntry(IntermediateDataSetID dataSetId, boolean isComplete) {
+		this(dataSetId.toHexString(), isComplete);
+	}
+
+	@JsonCreator
+	private ClusterDataSetEntry(
+		@JsonProperty(FIELD_NAME_DATA_SET_ID) String dataSetId,
+		@JsonProperty(FIELD_NAME_COMPLETE) boolean isComplete) {
+		this.dataSetId = dataSetId;
+		this.isComplete = isComplete;
+	}
+
+	@JsonIgnore
+	public String getDataSetId() {
+		return dataSetId;
+	}
+
+	@JsonIgnore
+	public boolean isComplete() {
+		return isComplete;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetIdPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetIdPathParameter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
+
+/**
+ * Path parameter identifying cluster data sets.
+ */
+public class ClusterDataSetIdPathParameter extends MessagePathParameter<IntermediateDataSetID> {
+
+	public static final String KEY = "datasetid";
+
+	public ClusterDataSetIdPathParameter() {
+		super(KEY);
+	}
+
+	@Override
+	protected IntermediateDataSetID convertFromString(String value) {
+		return new IntermediateDataSetID(new AbstractID(StringUtils.hexStringToByte(value)));
+	}
+
+	@Override
+	protected String convertToString(IntermediateDataSetID value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "32-character hexadecimal string value that identifies a cluster data set.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListHeaders.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Specification for retrieving an overview over all available cluster partitions.
+ */
+public class ClusterDataSetListHeaders implements MessageHeaders<EmptyRequestBody, ClusterDataSetListResponseBody, EmptyMessageParameters> {
+
+	public static final ClusterDataSetListHeaders INSTANCE = new ClusterDataSetListHeaders();
+
+	static final String URL = "/datasets";
+
+	private ClusterDataSetListHeaders() {
+	}
+
+	@Override
+	public Class<ClusterDataSetListResponseBody> getResponseClass() {
+		return ClusterDataSetListResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Returns all cluster data sets.";
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public EmptyMessageParameters getUnresolvedMessageParameters() {
+		return EmptyMessageParameters.getInstance();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListResponseBody.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.io.network.partition.DataSetMetaInfo;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@link ResponseBody} for {@link ClusterDataSetListHeaders}.
+ */
+public class ClusterDataSetListResponseBody implements ResponseBody {
+	private static final String FIELD_NAME_PARTITIONS = "dataSets";
+
+	@JsonProperty(FIELD_NAME_PARTITIONS)
+	private final List<ClusterDataSetEntry> dataSets;
+
+	@JsonCreator
+	private ClusterDataSetListResponseBody(@JsonProperty(FIELD_NAME_PARTITIONS) List<ClusterDataSetEntry> dataSets) {
+		this.dataSets = dataSets;
+	}
+
+	public static ClusterDataSetListResponseBody from(Map<IntermediateDataSetID, DataSetMetaInfo> dataSets) {
+		final List<ClusterDataSetEntry> convertedInfo = dataSets.entrySet().stream()
+			.map(entry -> {
+				DataSetMetaInfo metaInfo = entry.getValue();
+				int numRegisteredPartitions = metaInfo.getNumRegisteredPartitions().orElse(0);
+				int numTotalPartition = metaInfo.getNumTotalPartitions();
+				return new ClusterDataSetEntry(entry.getKey(), numRegisteredPartitions == numTotalPartition);
+			})
+			.collect(Collectors.toList());
+		return new ClusterDataSetListResponseBody(convertedInfo);
+	}
+
+	@JsonIgnore
+	public List<ClusterDataSetEntry> getDataSets() {
+		return dataSets;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -39,6 +39,8 @@ import org.apache.flink.runtime.rest.handler.cluster.JobManagerCustomLogHandler;
 import org.apache.flink.runtime.rest.handler.cluster.JobManagerLogFileHandler;
 import org.apache.flink.runtime.rest.handler.cluster.JobManagerLogListHandler;
 import org.apache.flink.runtime.rest.handler.cluster.ShutdownHandler;
+import org.apache.flink.runtime.rest.handler.dataset.ClusterDataSetDeleteHandlers;
+import org.apache.flink.runtime.rest.handler.dataset.ClusterDataSetListHandler;
 import org.apache.flink.runtime.rest.handler.job.JobAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobCancellationHandler;
 import org.apache.flink.runtime.rest.handler.job.JobConfigHandler;
@@ -543,6 +545,13 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			timeout,
 			responseHeaders);
 
+		final ClusterDataSetListHandler clusterDataSetListHandler = new ClusterDataSetListHandler(leaderRetriever, timeout, responseHeaders, resourceManagerRetriever);
+		final ClusterDataSetDeleteHandlers clusterDataSetDeleteHandlers = new ClusterDataSetDeleteHandlers();
+		final ClusterDataSetDeleteHandlers.ClusterDataSetDeleteTriggerHandler clusterDataSetDeleteTriggerHandler =
+			clusterDataSetDeleteHandlers.new ClusterDataSetDeleteTriggerHandler(leaderRetriever, timeout, responseHeaders, resourceManagerRetriever);
+		final ClusterDataSetDeleteHandlers.ClusterDataSetDeleteStatusHandler clusterDataSetDeleteStatusHandler =
+			clusterDataSetDeleteHandlers.new ClusterDataSetDeleteStatusHandler(leaderRetriever, timeout, responseHeaders);
+
 		final ShutdownHandler shutdownHandler = new ShutdownHandler(
 			leaderRetriever,
 			timeout,
@@ -606,6 +615,9 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(rescalingStatusHandler.getMessageHeaders(), rescalingStatusHandler));
 		handlers.add(Tuple2.of(savepointDisposalTriggerHandler.getMessageHeaders(), savepointDisposalTriggerHandler));
 		handlers.add(Tuple2.of(savepointDisposalStatusHandler.getMessageHeaders(), savepointDisposalStatusHandler));
+		handlers.add(Tuple2.of(clusterDataSetListHandler.getMessageHeaders(), clusterDataSetListHandler));
+		handlers.add(Tuple2.of(clusterDataSetDeleteTriggerHandler.getMessageHeaders(), clusterDataSetDeleteTriggerHandler));
+		handlers.add(Tuple2.of(clusterDataSetDeleteStatusHandler.getMessageHeaders(), clusterDataSetDeleteStatusHandler));
 
 		// TODO: Remove once the Yarn proxy can forward all REST verbs
 		handlers.add(Tuple2.of(YarnCancelJobTerminationHeaders.getInstance(), yarnJobCancelTerminationHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.io.network.partition.DataSetMetaInfo;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobmaster.JobMasterId;
 import org.apache.flink.runtime.jobmaster.JobMasterRegistrationSuccess;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -51,6 +53,7 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -357,5 +360,15 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
 	@Override
 	public String getHostname() {
 		return hostname;
+	}
+
+	@Override
+	public CompletableFuture<Map<IntermediateDataSetID, DataSetMetaInfo>> listDataSets() {
+		return CompletableFuture.completedFuture(Collections.emptyMap());
+	}
+
+	@Override
+	public CompletableFuture<Void> releaseClusterPartitions(IntermediateDataSetID dataSetToRelease) {
+		return CompletableFuture.completedFuture(null);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListResponseBodyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/dataset/ClusterDataSetListResponseBodyTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.dataset;
+
+import org.apache.flink.runtime.io.network.partition.DataSetMetaInfo;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.StringUtils;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link ClusterDataSetListResponseBody}.
+ */
+public class ClusterDataSetListResponseBodyTest extends RestResponseMarshallingTestBase<ClusterDataSetListResponseBody> {
+
+	@Test
+	public void testFrom() {
+		final Map<IntermediateDataSetID, DataSetMetaInfo> originalDataSets = new HashMap<>();
+		originalDataSets.put(new IntermediateDataSetID(), DataSetMetaInfo.withNumRegisteredPartitions(1, 2));
+		originalDataSets.put(new IntermediateDataSetID(), DataSetMetaInfo.withNumRegisteredPartitions(2, 2));
+
+		List<ClusterDataSetEntry> convertedDataSets = ClusterDataSetListResponseBody.from(originalDataSets).getDataSets();
+		assertThat(convertedDataSets, hasSize(2));
+		for (ClusterDataSetEntry convertedDataSet : convertedDataSets) {
+			IntermediateDataSetID id = new IntermediateDataSetID(new AbstractID(StringUtils.hexStringToByte(convertedDataSet.getDataSetId())));
+
+			DataSetMetaInfo dataSetMetaInfo = originalDataSets.get(id);
+
+			assertThat(convertedDataSet.isComplete(), is(dataSetMetaInfo.getNumRegisteredPartitions().orElse(0) == dataSetMetaInfo.getNumTotalPartitions()));
+		}
+	}
+
+	@Override
+	protected Class<ClusterDataSetListResponseBody> getTestResponseClass() {
+		return ClusterDataSetListResponseBody.class;
+	}
+
+	@Override
+	protected ClusterDataSetListResponseBody getTestResponseInstance() throws Exception {
+		final Map<IntermediateDataSetID, DataSetMetaInfo> dataSets = new HashMap<>();
+		dataSets.put(new IntermediateDataSetID(), DataSetMetaInfo.withNumRegisteredPartitions(1, 2));
+		return ClusterDataSetListResponseBody.from(dataSets);
+	}
+
+	@Override
+	protected void assertOriginalEqualsToUnmarshalled(ClusterDataSetListResponseBody expected, ClusterDataSetListResponseBody actual) {
+		final List<ClusterDataSetEntry> expectedDataSets = expected.getDataSets();
+		final List<ClusterDataSetEntry> actualDataSets = actual.getDataSets();
+
+		assertThat(actualDataSets, hasSize(expectedDataSets.size()));
+		for (int i = 0; i < expectedDataSets.size(); i++) {
+			ClusterDataSetEntry expectedDataSet = expectedDataSets.get(i);
+			ClusterDataSetEntry actualDataSet = actualDataSets.get(i);
+
+			assertThat(actualDataSet.getDataSetId(), is(expectedDataSet.getDataSetId()));
+			assertThat(actualDataSet.isComplete(), is(expectedDataSet.isComplete()));
+		}
+
+	}
+}


### PR DESCRIPTION
Adds the REST API for managing cluster partitions. The collection of all cluster partitions belonging to a single data set is referred to as a "Cluster DataSet".

The API allows the user to list and delete partitions. The handlers are relatively straight-forward and pretty much just forward calls to the RM (which forwards them to the Tracker), at most converting some data-structures.

As a prerequisite we no longer filter incomplete data sets in `PartitionTracker#listDataSets`.
We don't have a mechanism to ensure that either all partitions of a data set are registered or the remaining partitions are released at some point.
In these cases the user has to step in, but without being able to list incomplete partitions there's nothing that can be done.
To differentiate between complete/incomplete partitions we expose the number of currently registered partitions.
This count is only determined when the listing is requested for performance and complexity reasons.