### PR TITLE
[FLINK-16980][python] Fix Python UDF to work with protobuf 3.6.1

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -422,37 +422,37 @@ class ArrowCoder(DeterministicCoder):
                               for n, t in zip(row_type.field_names(), row_type.field_types())])
 
         def _to_data_type(field):
-            if field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.TINYINT:
+            if field.type.type_name == flink_fn_execution_pb2.Schema.TINYINT:
                 return TinyIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.SMALLINT:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.SMALLINT:
                 return SmallIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.INT:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.INT:
                 return IntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.BIGINT:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.BIGINT:
                 return BigIntType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.BOOLEAN:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.BOOLEAN:
                 return BooleanType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.FLOAT:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.FLOAT:
                 return FloatType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DOUBLE:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.DOUBLE:
                 return DoubleType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARCHAR:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.VARCHAR:
                 return VarCharType(0x7fffffff, field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.VARBINARY:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.VARBINARY:
                 return VarBinaryType(0x7fffffff, field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DECIMAL:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.DECIMAL:
                 return DecimalType(field.type.decimal_info.precision,
                                    field.type.decimal_info.scale,
                                    field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.DATE:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.DATE:
                 return DateType(field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.TIME:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TIME:
                 return TimeType(field.type.time_info.precision, field.type.nullable)
             elif field.type.type_name == \
-                    flink_fn_execution_pb2.Schema.TypeName.LOCAL_ZONED_TIMESTAMP:
+                    flink_fn_execution_pb2.Schema.LOCAL_ZONED_TIMESTAMP:
                 return LocalZonedTimestampType(field.type.local_zoned_timestamp_info.precision,
                                                field.type.nullable)
-            elif field.type.type_name == flink_fn_execution_pb2.Schema.TypeName.TIMESTAMP:
+            elif field.type.type_name == flink_fn_execution_pb2.Schema.TIMESTAMP:
                 return TimestampType(field.type.timestamp_info.precision, field.type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field.type)
@@ -487,7 +487,7 @@ class PassThroughLengthPrefixCoder(LengthPrefixCoder):
 Coder.register_structured_urn(
     common_urns.coders.LENGTH_PREFIX.urn, PassThroughLengthPrefixCoder)
 
-type_name = flink_fn_execution_pb2.Schema.TypeName
+type_name = flink_fn_execution_pb2.Schema
 _type_name_mappings = {
     type_name.TINYINT: TinyIntCoder(),
     type_name.SMALLINT: SmallIntCoder(),


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Fix PyFlink UDF execution module is not compatible with protobuf 3.6.1*

## Brief change log

  - *Use a compatible way of enum in protobuf*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
