### PR TITLE
[FLINK-16980][python] Fix Python UDF to work with protobuf 3.6.1

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -322,7 +322,7 @@ def _pickle_from_runner_api_parameter(schema_proto, unused_components, unused_co
     return RowCoder([from_proto(f.type) for f in schema_proto.fields])
 
 
-type_name = flink_fn_execution_pb2.Schema.TypeName
+type_name = flink_fn_execution_pb2.Schema
 _type_name_mappings = {
     type_name.TINYINT: TinyIntCoder(),
     type_name.SMALLINT: SmallIntCoder(),


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Fix PyFlink UDF execution module is not compatible with protobuf 3.6.1*

## Brief change log

  - *Use a compatible way of enum in protobuf*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
