### PR TITLE
[FLINK-16981][tests] Add global PowerMock exclusions

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBAsyncSnapshotTest.java
@@ -76,7 +76,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.annotation.Nullable;
@@ -107,7 +106,6 @@ import static org.mockito.Mockito.verify;
  * Tests for asynchronous RocksDB Key/Value state checkpoints.
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.management.*", "com.sun.jndi.*", "org.apache.log4j.*"})
 @SuppressWarnings("serial")
 public class RocksDBAsyncSnapshotTest extends TestLogger {
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/resources/org/powermock/extensions/configuration.properties
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/resources/org/powermock/extensions/configuration.properties
@@ -1,0 +1,19 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+powermock.global-ignore=javax.management.*,com.sun.jndi.*,org.apache.log4j.*,org.apache.logging.log4j.*


### PR DESCRIPTION
Potential fix for _all_ PowerMock LinkageError issues.
It is well known that certain classes should be explicitly ignored, but specifying them on each test is tedious, easily forgotten and led to inconsistent configurations.

This PR makes use of project-wide exclude through a configuration file in `flink-test-utils-junit`. All of our modules depend on it, and by bundling the configuration file in the main jar it is thus on the classpath for all tests.

The effectiveness can be easily checked by running `RocksDBAsyncSnapshotTest`; with the configuration file no error will be logged, without it a LinkageError will appear.