### PR TITLE
[FLINK-16979][hive][build] Exclude jdk.tools

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-1.2.2/pom.xml
@@ -98,6 +98,11 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<!-- This dependency is no longer shipped with the JDK since Java 9.-->
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.2.0/pom.xml
@@ -75,6 +75,11 @@ under the License.
 					<groupId>org.slf4j</groupId>
 					<artifactId>slf4j-log4j12</artifactId>
 				</exclusion>
+				<exclusion>
+					<!-- This dependency is no longer shipped with the JDK since Java 9.-->
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
`jdk.tools` isn't available on Java 9+. As a system dependency explicitly depending on it is usually unnecessary, so it is safe to exclude.