### PR TITLE
[FLINK-16973][tests] Add tooling for collecting jvm crash files

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,8 @@ resources:
   # Container with Maven 3.2.5, SSL to have the same environment everywhere.
   - container: flink-build-container
     image: rmetzger/flink-ci:ubuntu-amd64-3528acd
+    # On AZP provided machines, set this flag to allow writing coredumps in docker
+    options: --privileged
 
 # Define variables:
 # - See tools/azure-pipelines/jobs-template.yml for a short summary of the caching

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/LocalStandaloneKafkaResource.java
@@ -199,7 +199,7 @@ public class LocalStandaloneKafkaResource implements KafkaResource {
 	private static boolean isKafkaRunning(final Path kafkaDir) throws IOException {
 		try {
 			final AtomicBoolean atomicBrokerStarted = new AtomicBoolean(false);
-			queryBrokerStatus(kafkaDir, line -> atomicBrokerStarted.compareAndSet(false, !line.contains("Node does not exist")));
+			queryBrokerStatus(kafkaDir, line -> atomicBrokerStarted.compareAndSet(false, line.contains("dataLength =")));
 			return atomicBrokerStarted.get();
 		} catch (final IOException ioe) {
 			// we get an exception if zookeeper isn't running

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -352,6 +352,7 @@ function check_logs_for_errors {
       | grep -v "Error while loading kafka-version.properties :null" \
       | grep -v "Failed Elasticsearch item request" \
       | grep -v "[Terror] modules" \
+      | grep -v "HeapDumpOnOutOfMemoryError" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files:"

--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -401,12 +401,14 @@ function check_logs_for_exceptions {
 function check_logs_for_non_empty_out_files {
   echo "Checking for non-empty .out files..."
   # exclude reflective access warnings as these are expected (and currently unavoidable) on Java 9
+  # exclude message about JAVA_TOOL_OPTIONS being set (https://bugs.openjdk.java.net/browse/JDK-8039152)
   if grep -ri -v \
     -e "WARNING: An illegal reflective access" \
     -e "WARNING: Illegal reflective access"\
     -e "WARNING: Please consider reporting"\
     -e "WARNING: Use --illegal-access"\
     -e "WARNING: All illegal access"\
+    -e "Picked up JAVA_TOOL_OPTIONS"\
     $FLINK_DIR/log/*.out\
    | grep "." \
    > /dev/null; then

--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -117,6 +117,8 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin:$PATH"
     displayName: "Set to jdk11"
     condition: eq('${{parameters.jdk}}', 'jdk11')  
+  - script: sudo sysctl -w kernel.core_pattern=core.%p
+    displayName: Set coredump pattern
   # Test
   - script: STAGE=test ${{parameters.environment}} ./tools/azure_controller.sh $(module)
     displayName: Test - $(module)

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -72,7 +72,7 @@ function collect_coredumps {
 	local SEARCHDIR=$1
 	local TARGET_DIR=$2
 	echo "Searching for .dump, .dumpstream and related files in '$SEARCHDIR'"
-	for file in `find $SEARCHDIR -type f -regextype posix-extended -iregex '.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
+	for file in `find $SEARCHDIR -type f -regextype posix-extended -iregex '.*\.hprof|.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
 		echo "Moving '$file' to target directory ('$TARGET_DIR')"
 		mv $file $TARGET_DIR/
 	done

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -67,3 +67,13 @@ function setup_maven {
 
 	echo "Installed Maven ${MAVEN_VERSION} to ${M2_HOME}"
 }
+
+function collect_coredumps {
+	local SEARCHDIR=$1
+	local TARGET_DIR=$2
+	echo "Searching for .dump, .dumpstream and related files in '$SEARCHDIR'"
+	for file in `find $SEARCHDIR -type f -regextype posix-extended -iregex '.*\.dump|.*\.dumpstream|.*hs.*\.log|.*/core(.[0-9]+)?$'`; do
+		echo "Moving '$file' to target directory ('$TARGET_DIR')"
+		mv $file $TARGET_DIR/
+	done
+}

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -97,6 +97,10 @@ if [ ! -z "$TF_BUILD" ] ; then
 	ARTIFACTS_FILE=${BUILD_BUILDNUMBER}.tar.gz
 fi
 
+# enable coredumps
+ulimit -c unlimited
+export JAVA_TOOL_OPTIONS="-XX:+HeapDumpOnOutOfMemoryError"
+
 if [ $TEST == $STAGE_PYTHON ]; then
 	CMD=$PYTHON_TEST
 	CMD_PID=$PYTHON_PID
@@ -275,6 +279,8 @@ case $TEST in
 		put_yarn_logs_to_artifacts
 	;;
 esac
+
+collect_coredumps `pwd` $ARTIFACTS_DIR
 
 upload_artifacts_s3
 


### PR DESCRIPTION
## What is the purpose of the change

A lot of tests are failing because of crashed JVMs.
This PR will add some tooling to search the Flink directory for JVM crash files.



## Verifying this change

This change has been tested here: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=7072&view=results
In this test, the "core" profile fails with an artificially induced JVM crash. A coredump + some debugging files are attached.
There was a [previous discussion](https://github.com/apache/flink/pull/11372#discussion_r392367035) about this change. [I tried](https://github.com/rmetzger/flink/commit/cb886dccda18fcb8536ac47dc447d134bb89602c) the proposed approach as well, but files were not properly written into the specified directory.
 

