### PR TITLE
[FLINK-16988][table] Add core table source/sink interfaces

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/RowKind.java
+++ b/flink-core/src/main/java/org/apache/flink/types/RowKind.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.types;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Lists all kinds of changes that a row can describe in a changelog.
+ */
+@PublicEvolving
+public enum RowKind {
+
+	/**
+	 * Insertion operation.
+	 */
+	INSERT,
+
+	/**
+	 * Update operation with the previous content of the updated row.
+	 *
+	 * <p>This kind SHOULD occur together with {@link #UPDATE_AFTER} for modelling an update that needs
+	 * to retract the previous row first. It is useful in cases of a non-idempotent update, i.e., an
+	 * update of a row that is not uniquely identifiable by a key.
+	 */
+	UPDATE_BEFORE,
+
+	/**
+	 * Update operation with new content of the updated row.
+	 *
+	 * <p>This kind CAN occur together with {@link #UPDATE_BEFORE} for modelling an update that
+	 * needs to retract the previous row first. OR it describes an idempotent update, i.e., an update
+	 * of a row that is uniquely identifiable by a key.
+	 */
+	UPDATE_AFTER,
+
+	/**
+	 * Deletion operation.
+	 */
+	DELETE
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/sink/SinkFunctionProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of a {@link SinkFunction} instance as a runtime implementation for {@link DynamicTableSink}.
+ */
+@PublicEvolving
+interface SinkFunctionProvider extends DynamicTableSink.SinkRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static SinkFunctionProvider of(SinkFunction<RowData> sinkFunction) {
+		return () -> sinkFunction;
+	}
+
+	/**
+	 * Creates a {@link SinkFunction} instance.
+	 */
+	SinkFunction<RowData> createSinkFunction();
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/SourceFunctionProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/SourceFunctionProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of a {@link SourceFunction} instance as a runtime implementation for {@link ScanTableSource}.
+ */
+@PublicEvolving
+interface SourceFunctionProvider extends ScanTableSource.ScanRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static SourceFunctionProvider of(SourceFunction<RowData> sourceFunction, boolean isBounded) {
+		return new SourceFunctionProvider() {
+			@Override
+			public SourceFunction<RowData> createSourceFunction() {
+				return sourceFunction;
+			}
+
+			@Override
+			public boolean isBounded() {
+				return isBounded;
+			}
+		};
+	}
+
+	/**
+	 * Creates a {@link SourceFunction} instance.
+	 */
+	SourceFunction<RowData> createSourceFunction();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -227,15 +227,34 @@ public class TableSchema {
 	}
 
 	/**
-	 * Converts a table schema into a (nested) data type describing a
-	 * {@link DataTypes#ROW(Field...)}.
+	 * Converts all columns of this schema into a (possibly nested) row data type.
 	 *
-	 * <p>Note that the returned row type contains field types for all the columns, including
-	 * normal columns and computed columns. Be caution with the computed column data types, because
-	 * they are not expected to be included in the row type of TableSource or TableSink.
+	 * <p>Note: The returned row data type contains both physical and computed columns. Be careful when
+	 * using this method in a table source or table sink. In many cases, {@link #toPhysicalRowDataType()}
+	 * might be more appropriate.
+	 *
+	 * @see DataTypes#ROW(Field...)
+	 * @see #toPhysicalRowDataType()
 	 */
 	public DataType toRowDataType() {
 		final Field[] fields = columns.stream()
+			.map(column -> FIELD(column.getName(), column.getType()))
+			.toArray(Field[]::new);
+		return ROW(fields);
+	}
+
+	/**
+	 * Converts all physical columns of this schema into a (possibly nested) row data type.
+	 *
+	 * <p>Note: The returned row data type contains only physical columns. It does not include computed
+	 * columns.
+	 *
+	 * @see DataTypes#ROW(Field...)
+	 * @see #toRowDataType()
+	 */
+	public DataType toPhysicalRowDataType() {
+		final Field[] fields = columns.stream()
+			.filter(column -> !column.isGenerated())
 			.map(column -> FIELD(column.getName(), column.getType()))
 			.toArray(Field[]::new);
 		return ROW(fields);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/ChangelogMode.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The set of changes contained in a changelog.
+ *
+ * @see RowKind
+ */
+@PublicEvolving
+public final class ChangelogMode {
+
+	private static final ChangelogMode INSERT_ONLY = ChangelogMode.newBuilder()
+		.addContainedKind(RowKind.INSERT)
+		.build();
+
+	private final Set<RowKind> kinds;
+
+	private ChangelogMode(Set<RowKind> kinds) {
+		Preconditions.checkArgument(
+			kinds.size() > 0,
+			"At least one kind of row should be contained in a changelog.");
+		this.kinds = Collections.unmodifiableSet(kinds);
+	}
+
+	/**
+	 * Shortcut for a simple {@link RowKind#INSERT}-only changelog.
+	 */
+	public static ChangelogMode insertOnly() {
+		return INSERT_ONLY;
+	}
+
+	/**
+	 * Builder for configuring and creating instances of {@link ChangelogMode}.
+	 */
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public Set<RowKind> getContainedKinds() {
+		return kinds;
+	}
+
+	public boolean contains(RowKind kind) {
+		return kinds.contains(kind);
+	}
+
+	public boolean containsOnly(RowKind kind) {
+		return kinds.size() == 1 && kinds.contains(kind);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		ChangelogMode that = (ChangelogMode) o;
+		return kinds.equals(that.kinds);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(kinds);
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Builder for configuring and creating instances of {@link ChangelogMode}.
+	 */
+	public static class Builder {
+
+		private final Set<RowKind> kinds = EnumSet.noneOf(RowKind.class);
+
+		private Builder() {
+			// default constructor to allow a fluent definition
+		}
+
+		public Builder addContainedKind(RowKind kind) {
+			this.kinds.add(kind);
+			return this;
+		}
+
+		public ChangelogMode build() {
+			return new ChangelogMode(kinds);
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RuntimeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/RuntimeConverter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/**
+ * Base interface for converting data during runtime.
+ *
+ * <p>Instances of this interface are provided by the planner. They are used for converting between data
+ * structures or performing other mapping transformations.
+ *
+ * <p>Because runtime converters are {@link Serializable}, instances can be directly passed into a runtime
+ * implementation, stored in a member variable, and used when it comes to the execution.
+ */
+@PublicEvolving
+public interface RuntimeConverter extends Serializable {
+
+	/**
+	 * Initializes the converter during runtime.
+	 *
+	 * <p>This should be called in the {@code open()} method of a runtime class.
+	 */
+	void open(Context context);
+
+	/**
+	 * Context for conversions during runtime.
+	 *
+	 * <p>Meant for future extensibility. Use {@link Context#empty()} for now.
+	 */
+	interface Context {
+
+		/**
+		 * Empty context.
+		 */
+		static Context empty() {
+			return new Context() {
+				// nothing to do
+			};
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.RuntimeConverter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Sink of a dynamic table to an external storage system.
+ *
+ * <p>Dynamic tables are the core concept of Flink's Table & SQL API for processing both bounded and
+ * unbounded data in a unified fashion. By definition, a dynamic table can change over time.
+ *
+ * <p>When writing a dynamic table, the content can either be considered as a changelog (finite or
+ * infinite) for which all changes are written out continuously until the changelog is exhausted. The
+ * given {@link ChangelogMode} indicates the set of changes that the sink accepts during runtime.
+ *
+ * <p>For regular batch scenarios, the sink can solely accept insert-only rows and write out bounded
+ * streams.
+ *
+ * <p>For regular streaming scenarios, the sink can solely accept insert-only rows and can write out
+ * unbounded streams.
+ *
+ * <p>For change data capture (CDC) scenarios, the sink can write out bounded or unbounded streams with
+ * insert, update, and delete rows. See also {@link RowKind}.
+ *
+ * <p>Instances of {@link DynamicTableSink} can be seen as factories that eventually produce concrete
+ * runtime implementation for writing the actual data.
+ *
+ * <p>Depending on the optionally declared abilities, the planner might apply changes to an instance
+ * and thus mutate the produced runtime implementation.
+ *
+ * <p>A {@link DynamicTableSink} can implement the following abilities:
+ * <ul>
+ *     <li>TBD
+ * </ul>
+ *
+ * <p>In the last step, the planner will call {@link #getSinkRuntimeProvider(Context)} for obtaining a
+ * provider of runtime implementation.
+ */
+@PublicEvolving
+public interface DynamicTableSink {
+
+	/**
+	 * Returns the set of changes that the sink accepts during runtime.
+	 *
+	 * <p>The planner can make suggestions but the sink has the final decision what it requires. If
+	 * the planner does not support this mode, it will throw an error. For example, the sink can
+	 * return that it only supports {@link ChangelogMode#insertOnly()}.
+	 *
+	 * @param requestedMode expected set of changes by the current plan
+	 */
+	ChangelogMode getChangelogMode(ChangelogMode requestedMode);
+
+	/**
+	 * Returns a provider of runtime implementation for writing the data.
+	 *
+	 * <p>There might exist different interfaces for runtime implementation which is why {@link SinkRuntimeProvider}
+	 * serves as the base interface. Concrete {@link SinkRuntimeProvider} interfaces might be located
+	 * in other Flink modules.
+	 *
+	 * <p>Independent of the provider interface, the table runtime expects that a sink implementation
+	 * accepts internal data structures (see {@link org.apache.flink.table.data} for more information).
+	 *
+	 * <p>The given {@link Context} offers utilities by the planner for creating runtime implementation
+	 * with minimal dependencies to internal data structures.
+	 *
+	 * <p>See {@code org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 */
+	SinkRuntimeProvider getSinkRuntimeProvider(Context context);
+
+	/**
+	 * Creates a copy of this instance during planning. The copy should be a deep copy of all mutable
+	 * members.
+	 */
+	DynamicTableSink copy();
+
+	/**
+	 * Returns a string that summarizes this sink for printing to a console or log.
+	 */
+	String asSummaryString();
+
+	// --------------------------------------------------------------------------------------------
+	// Helper interfaces
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Context for creating runtime implementation via a {@link SinkRuntimeProvider}.
+	 *
+	 * <p>It offers utilities by the planner for creating runtime implementation with minimal dependencies
+	 * to internal data structures.
+	 *
+	 * <p>Methods should be called in {@link #getSinkRuntimeProvider(Context)}. The returned instances
+	 * are {@link Serializable} and can be directly passed into the runtime implementation class.
+	 */
+	interface Context {
+
+		/**
+		 * Creates a converter for mapping between Flink's internal data structures and objects specified
+		 * by the given {@link DataType} that can be passed into a runtime implementation.
+		 *
+		 * <p>For example, {@link RowData} and its fields can be converted into a {@link Row}, or the
+		 * internal representation for structured types can be converted back into the original (possibly
+		 * nested) POJO.
+		 *
+		 * @see LogicalType#supportsOutputConversion(Class)
+		 */
+		DataStructureConverter createDataStructureConverter(DataType consumedDataType);
+	}
+
+	/**
+	 * Converter for mapping between Flink's internal data structures and objects specified
+	 * by the given {@link DataType} that can be passed into a runtime implementation.
+	 *
+	 * <p>For example, {@link RowData} and its fields can be converted into a {@link Row}, or the
+	 * internal representation for structured types can be converted back into the original (possibly
+	 * nested) POJO.
+	 *
+	 * @see LogicalType#supportsOutputConversion(Class)
+	 */
+	interface DataStructureConverter extends RuntimeConverter {
+
+		/**
+		 * Converts the given internal structure into an external object.
+		 */
+		@Nullable Object toExternal(@Nullable Object internalStructure);
+	}
+
+	/**
+	 * Provides actual runtime implementation for writing the data.
+	 *
+	 * <p>There might exist different interfaces for runtime implementation which is why {@link SinkRuntimeProvider}
+	 * serves as the base interface. Concrete {@link SinkRuntimeProvider} interfaces might be located
+	 * in other Flink modules.
+	 *
+	 * <p>See {@code org.apache.flink.table.connector.sink.SinkFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 */
+	interface SinkRuntimeProvider {
+		// marker interface
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/OutputFormatProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of an {@link OutputFormat} instance as a runtime implementation for {@link DynamicTableSink}.
+ */
+@PublicEvolving
+interface OutputFormatProvider extends DynamicTableSink.SinkRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static OutputFormatProvider of(OutputFormat<RowData> outputFormat) {
+		return () -> outputFormat;
+	}
+
+	/**
+	 * Creates an {@link OutputFormat} instance.
+	 */
+	OutputFormat<RowData> createOutputFormat();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.functions.AsyncTableFunction;
+
+/**
+ * Provider of an {@link AsyncTableFunction} instance as a runtime implementation for {@link LookupTableSource}.
+ *
+ * <p>The runtime will call the function with values describing the table's lookup keys (in the order
+ * of declaration in {@link LookupTableSource.Context#getKeys()}).
+ */
+@PublicEvolving
+public interface AsyncTableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static <T> AsyncTableFunctionProvider<T> of(AsyncTableFunction<T> asyncTableFunction) {
+		return () -> asyncTableFunction;
+	}
+
+	/**
+	 * Creates a {@link AsyncTableFunction} instance.
+	 */
+	AsyncTableFunction<T> createAsyncTableFunction();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/DynamicTableSource.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.RuntimeConverter;
+import org.apache.flink.table.connector.source.abilities.SupportsComputedColumnPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.Row;
+
+import javax.annotation.Nullable;
+
+/**
+ * Source of a dynamic table from an external storage system.
+ *
+ * <p>Dynamic tables are the core concept of Flink's Table & SQL API for processing both bounded and
+ * unbounded data in a unified fashion. By definition, a dynamic table can change over time.
+ *
+ * <p>When reading a dynamic table, the content can either be considered as:
+ * <ul>
+ *     <li>A changelog (finite or infinite) for which all changes are consumed continuously until the
+ *     changelog is exhausted. See {@link ScanTableSource} for more information.
+ *     <li>A continuously changing or very large external table whose content is usually never read
+ *     entirely but queried for individual values when necessary. See {@link LookupTableSource} for
+ *     more information.
+ * </ul>
+ *
+ * <p>Note: Both interfaces can be implemented at the same time. The planner decides about their usage
+ * depending on the specified query.
+ *
+ * <p>Instances of the above mentioned interfaces can be seen as factories that eventually produce concrete
+ * runtime implementation for reading the actual data.
+ *
+ * <p>Depending on the optionally declared abilities such as {@link SupportsComputedColumnPushDown} or
+ * {@link SupportsFilterPushDown}, the planner might apply changes to an instance and thus mutates
+ * the produced runtime implementation.
+ */
+@PublicEvolving
+public interface DynamicTableSource {
+
+	/**
+	 * Creates a copy of this instance during planning. The copy should be a deep copy of all mutable
+	 * members.
+	 */
+	DynamicTableSource copy();
+
+	/**
+	 * Returns a string that summarizes this source for printing to a console or log.
+	 */
+	String asSummaryString();
+
+	// --------------------------------------------------------------------------------------------
+	// Helper interfaces
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Converter for mapping between objects and Flink's internal data structures during runtime.
+	 *
+	 * <p>On request, the planner will provide a specialized (possibly code generated) converter that
+	 * can be passed into a runtime implementation.
+	 *
+	 * <p>For example, a {@link Row} and its fields can be converted into {@link RowData}, or a (possibly
+	 * nested) POJO can be converted into the internal representation for structured types.
+	 *
+	 * @see LogicalType#supportsInputConversion(Class)
+	 */
+	interface DataStructureConverter extends RuntimeConverter {
+
+		/**
+		 * Converts the given object into an internal data structure.
+		 */
+		@Nullable Object toInternal(@Nullable Object externalStructure);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/InputFormatProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/InputFormatProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of an {@link InputFormat} instance as a runtime implementation for {@link ScanTableSource}.
+ */
+@PublicEvolving
+interface InputFormatProvider extends ScanTableSource.ScanRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static InputFormatProvider of(InputFormat<RowData, ?> inputFormat) {
+		return new InputFormatProvider() {
+			@Override
+			public InputFormat<RowData, ?> createInputFormat() {
+				return inputFormat;
+			}
+
+			@Override
+			public boolean isBounded() {
+				return true;
+			}
+		};
+	}
+
+	/**
+	 * Creates an {@link InputFormat} instance.
+	 */
+	InputFormat<RowData, ?> createInputFormat();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/LookupTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/LookupTableSource.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+import java.io.Serializable;
+
+/**
+ * A {@link DynamicTableSource} that looks up rows of an external storage system by one or more keys
+ * during runtime.
+ *
+ * <p>Compared to {@link ScanTableSource}, the source must not read the entire table and can lazily fetch
+ * individual values from a (possibly continuously changing) external table when necessary.
+ *
+ * <p>Note: Compared to {@link ScanTableSource}, a {@link LookupTableSource} does only support emitting
+ * insert-only changes currently (see also {@link RowKind}). Further abilities are not supported.
+ *
+ * <p>In the last step, the planner will call {@link #getLookupRuntimeProvider(Context)} for obtaining a
+ * provider of runtime implementation. The key fields that are required to perform a lookup are derived
+ * from a query by the planner and will be provided in the given {@link Context#getKeys()}. The values
+ * for those key fields are passed during runtime.
+ */
+@Experimental
+public interface LookupTableSource extends DynamicTableSource {
+
+	/**
+	 * Returns a provider of runtime implementation for reading the data.
+	 *
+	 * <p>There exist different interfaces for runtime implementation which is why {@link LookupRuntimeProvider}
+	 * serves as the base interface.
+	 *
+	 * <p>Independent of the provider interface, a source implementation can work on either arbitrary
+	 * objects or internal data structures (see {@link org.apache.flink.table.data} for more information).
+	 *
+	 * <p>The given {@link Context} offers utilities by the planner for creating runtime implementation
+	 * with minimal dependencies to internal data structures.
+	 *
+	 * @see TableFunctionProvider
+	 * @see AsyncTableFunctionProvider
+	 */
+	LookupRuntimeProvider getLookupRuntimeProvider(Context context);
+
+	// --------------------------------------------------------------------------------------------
+	// Helper interfaces
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Context for creating runtime implementation via a {@link LookupRuntimeProvider}.
+	 *
+	 * <p>It offers utilities by the planner for creating runtime implementation with minimal dependencies
+	 * to internal data structures.
+	 *
+	 * <p>Methods should be called in {@link #getLookupRuntimeProvider(Context)}. Returned instances
+	 * that are {@link Serializable} can be directly passed into the runtime implementation class.
+	 */
+	interface Context {
+
+		/**
+		 * Returns an array of key index paths that should be used during the lookup. The indices are
+		 * 0-based and support composite keys within (possibly nested) structures.
+		 *
+		 * <p>For example, given a table with data type {@code ROW < i INT, s STRING, r ROW < i2 INT, s2 STRING > >},
+		 * this method would return {@code [[0], [2, 1]]} when {@code i} and {@code s2} are used for performing
+		 * a lookup.
+		 *
+		 * @return array of key index paths
+		 */
+		int[][] getKeys();
+
+		/**
+		 * Creates a converter for mapping between objects specified by the given {@link DataType} and
+		 * Flink's internal data structures that can be passed into a runtime implementation.
+		 *
+		 * <p>For example, a {@link Row} and its fields can be converted into {@link RowData} or a (possibly
+		 * nested) POJO can be converted into the internal representation for structured types.
+		 *
+		 * @see LogicalType#supportsInputConversion(Class)
+		 */
+		DataStructureConverter createDataStructureConverter(DataType producedDataType);
+	}
+
+	/**
+	 * Provides actual runtime implementation for reading the data.
+	 *
+	 * <p>There exist different interfaces for runtime implementation which is why {@link LookupRuntimeProvider}
+	 * serves as the base interface.
+	 *
+	 * @see TableFunctionProvider
+	 * @see AsyncTableFunctionProvider
+	 */
+	interface LookupRuntimeProvider {
+		// marker interface
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.abilities.SupportsComputedColumnPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+
+import java.io.Serializable;
+
+/**
+ * A {@link DynamicTableSource} that scans all rows from an external storage system during runtime.
+ *
+ * <p>The scanned rows don't have to contain only insertions but can also contain updates and
+ * deletions. Thus, the table source can be used to read a (finite or infinite) changelog. The given
+ * {@link ChangelogMode} indicates the set of changes that the planner can expect during runtime.
+ *
+ * <p>For regular batch scenarios, the source can emit a bounded stream of insert-only rows.
+ *
+ * <p>For regular streaming scenarios, the source can emit an unbounded stream of insert-only rows.
+ *
+ * <p>For change data capture (CDC) scenarios, the source can emit bounded or unbounded streams with
+ * insert, update, and delete rows. See also {@link RowKind}.
+ *
+ * <p>A {@link ScanTableSource} can implement the following abilities that might mutate an instance
+ * during planning:
+ * <ul>
+ *     <li>{@link SupportsComputedColumnPushDown}
+ *     <li>{@link SupportsFilterPushDown}
+ * </ul>
+ *
+ * <p>In the last step, the planner will call {@link #getScanRuntimeProvider(Context)} for obtaining a
+ * provider of runtime implementation.
+ */
+@PublicEvolving
+public interface ScanTableSource extends DynamicTableSource {
+
+	/**
+	 * Returns the set of changes that the planner can expect during runtime.
+	 *
+	 * @see RowKind
+	 */
+	ChangelogMode getChangelogMode();
+
+	/**
+	 * Returns a provider of runtime implementation for reading the data.
+	 *
+	 * <p>There might exist different interfaces for runtime implementation which is why {@link ScanRuntimeProvider}
+	 * serves as the base interface. Concrete {@link ScanRuntimeProvider} interfaces might be located
+	 * in other Flink modules.
+	 *
+	 * <p>Independent of the provider interface, the table runtime expects that a source implementation
+	 * emits internal data structures (see {@link org.apache.flink.table.data} for more information).
+	 *
+	 * <p>The given {@link Context} offers utilities by the planner for creating runtime implementation
+	 * with minimal dependencies to internal data structures.
+	 *
+	 * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 */
+	ScanRuntimeProvider getScanRuntimeProvider(Context runtimeProviderContext);
+
+	// --------------------------------------------------------------------------------------------
+	// Helper interfaces
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Context for creating runtime implementation via a {@link ScanRuntimeProvider}.
+	 *
+	 * <p>It offers utilities by the planner for creating runtime implementation with minimal dependencies
+	 * to internal data structures.
+	 *
+	 * <p>Methods should be called in {@link #getScanRuntimeProvider(Context)}. The returned instances
+	 * are {@link Serializable} and can be directly passed into the runtime implementation class.
+	 */
+	interface Context {
+
+		/**
+		 * Creates type information describing the internal data structures of the given {@link DataType}.
+		 */
+		TypeInformation<?> createTypeInformation(DataType producedDataType);
+
+		/**
+		 * Creates a converter for mapping between objects specified by the given {@link DataType} and
+		 * Flink's internal data structures that can be passed into a runtime implementation.
+		 *
+		 * <p>For example, a {@link Row} and its fields can be converted into {@link RowData}, or a (possibly
+		 * nested) POJO can be converted into the internal representation for structured types.
+		 *
+		 * @see LogicalType#supportsInputConversion(Class)
+		 */
+		DataStructureConverter createDataStructureConverter(DataType producedDataType);
+	}
+
+	/**
+	 * Provides actual runtime implementation for reading the data.
+	 *
+	 * <p>There might exist different interfaces for runtime implementation which is why {@link ScanRuntimeProvider}
+	 * serves as the base interface. Concrete {@link ScanRuntimeProvider} interfaces might be located
+	 * in other Flink modules.
+	 *
+	 * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 */
+	interface ScanRuntimeProvider {
+
+		/**
+		 * Returns whether the data is bounded or not.
+		 */
+		boolean isBounded();
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/TableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/TableFunctionProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.functions.TableFunction;
+
+/**
+ * Provider of a {@link TableFunction} instance as a runtime implementation for {@link LookupTableSource}.
+ *
+ * <p>The runtime will call the function with values describing the table's lookup keys (in the order
+ * of declaration in {@link LookupTableSource.Context#getKeys()}).
+ */
+@PublicEvolving
+public interface TableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
+
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static <T> TableFunctionProvider<T> of(TableFunction<T> tableFunction) {
+		return () -> tableFunction;
+	}
+
+	/**
+	 * Creates a {@link TableFunction} instance.
+	 */
+	TableFunction<T> createTableFunction();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.RuntimeConverter;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+
+import java.io.Serializable;
+
+/**
+ * Enables to push down computed columns into a {@link ScanTableSource}.
+ *
+ * <p>Computed columns add additional columns to the table's schema. They are defined by logical expressions
+ * that reference other physically existing columns.
+ *
+ * <p>An example in SQL looks like:
+ * <pre>{@code
+ *   CREATE TABLE t (str STRING, ts AS PARSE_TIMESTAMP(str), i INT)   // `ts` is a computed column
+ * }</pre>
+ *
+ * <p>By default, if this interface is not implemented, computed columns are added to the physically produced
+ * row in a subsequent operation after the source.
+ *
+ * <p>However, it might be beneficial to perform the computation as early as possible in order to be
+ * close to the actual data generation. Especially in cases where computed columns are used for generating
+ * watermarks, a source must push down the computation as deep as possible such that the computation
+ * can happen within a source's data partition.
+ *
+ * <p>This interface provides a {@link ComputedColumnConverter} that needs to be applied to every row
+ * during runtime.
+ *
+ * <p>Note: The final data type emitted by a source changes from the produced data type to the full data
+ * type of the table's schema. For the example above, this means:
+ *
+ * <pre>{@code
+ *    ROW<str STRING, i INT>                    // before conversion
+ *    ROW<str STRING, ts TIMESTAMP(3), i INT>   // after conversion
+ * }</pre>
+ */
+@PublicEvolving
+public interface SupportsComputedColumnPushDown {
+
+	/**
+	 * Provides a converter that converts the produced {@link RowData} containing the physical
+	 * fields of the external system into a new {@link RowData} with push-downed computed columns.
+	 *
+	 * <p>Note: Use {@link TableSchema#toRowDataType()} instead of {@link TableSchema#toPhysicalRowDataType()}
+	 * for describing the final output data type when creating {@link TypeInformation}.
+	 */
+	void applyComputedColumn(ComputedColumnConverter converter);
+
+	/**
+	 * Generates and adds computed columns to {@link RowData} if necessary.
+	 *
+	 * <p>Instances of this interface are {@link Serializable} and can be directly passed into the runtime
+	 * implementation class.
+	 */
+	interface ComputedColumnConverter extends RuntimeConverter {
+
+		/**
+		 * Generates and adds computed columns to {@link RowData} if necessary.
+		 *
+		 * @param producedRow physical row read from the external system
+		 * @return row enriched with computed columns
+		 */
+		RowData convert(RowData producedRow);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsFilterPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsFilterPushDown.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.expressions.ExpressionVisitor;
+import org.apache.flink.table.expressions.ResolvedExpression;
+
+import java.util.List;
+
+/**
+ * Enables to push down filters into a {@link ScanTableSource}.
+ *
+ * <p>By default, if this interface is not implemented, filters are applied in a subsequent operation
+ * after the source.
+ *
+ * <p>For efficiency, a source can push filters further down in order to be close to the actual data
+ * generation. The passed filters are translated into conjunctive form. A source can pick filters and
+ * return the accepted and remaining filters.
+ *
+ * <p>Accepted filters are filters that are consumed by the source but may be applied on a best effort
+ * basis. The information about accepted filters helps the planner to adjust the cost estimation for
+ * the current plan. A subsequent filter operation will still take place by the runtime depending on
+ * the remaining filters.
+ *
+ * <p>Remaining filters are filters that cannot be fully applied by the source. The remaining filters
+ * decide if a subsequent filter operation will still take place by the runtime.
+ *
+ * <p>By the above definition, accepted filters and remaining filters must not be disjunctive lists. A
+ * filter can occur in both list. However, all given filters must be present in at least one list.
+ *
+ * <p>Note: A source is not allowed to change the given expressions in the returned {@link Result}.
+ *
+ * <p>Use {@link ExpressionVisitor} to traverse filter expressions.
+ */
+@PublicEvolving
+public interface SupportsFilterPushDown {
+
+	/**
+	 * Provides a list of filters in conjunctive form. A source can pick filters and return the accepted
+	 * and remaining filters.
+	 *
+	 * <p>See the documentation of {@link SupportsFilterPushDown} for more information.
+	 */
+	Result applyFilters(List<ResolvedExpression> filters);
+
+	/**
+	 * Result of a filter push down. It represents the communication of the source to the planner during
+	 * optimization.
+	 */
+	final class Result {
+		private final List<ResolvedExpression> acceptedFilters;
+		private final List<ResolvedExpression> remainingFilters;
+
+		private Result(
+				List<ResolvedExpression> acceptedFilters,
+				List<ResolvedExpression> remainingFilters) {
+			this.acceptedFilters = acceptedFilters;
+			this.remainingFilters = remainingFilters;
+		}
+
+		/**
+		 * Constructs a filter push-down result.
+		 *
+		 * <p>See the documentation of {@link SupportsFilterPushDown} for more information.
+		 *
+		 * @param acceptedFilters filters that are consumed by the source but may be applied on a best
+		 *                        effort basis
+		 * @param remainingFilters filters that a subsequent filter operation still needs to perform
+		 *                         during runtime
+		 */
+		public static Result of(
+				List<ResolvedExpression> acceptedFilters,
+				List<ResolvedExpression> remainingFilters) {
+			return new Result(acceptedFilters, remainingFilters);
+		}
+
+		public List<ResolvedExpression> getAcceptedFilters() {
+			return acceptedFilters;
+		}
+
+		public List<ResolvedExpression> getRemainingFilters() {
+			return remainingFilters;
+		}
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.data;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Reserved until FLIP-95 is entirely implemented.
+ */
+@Internal
+public interface RowData {
+}


### PR DESCRIPTION
## What is the purpose of the change

Adds the core set of interfaces described in FLIP-95. It also add the first ability interfaces to show the big picture.

## Brief change log

New interfaces and JavaDocs for all of them added.

## Verifying this change

No tests necessary yet.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
