### PR TITLE
[FLINK-16960][runtime] Add PipelinedRegion interface

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/PipelinedRegionComputeUtil.java
@@ -23,7 +23,7 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.P
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.topology.Result;
-import org.apache.flink.runtime.topology.Topology;
+import org.apache.flink.runtime.topology.BaseTopology;
 import org.apache.flink.runtime.topology.Vertex;
 
 import org.slf4j.Logger;
@@ -60,7 +60,7 @@ public final class PipelinedRegionComputeUtil {
 	}
 
 	public static <V extends Vertex<?, ?, V, R>, R extends Result<?, ?, V, R>> Set<Set<V>> computePipelinedRegions(
-			final Topology<?, ?, V, R> topology) {
+			final BaseTopology<?, ?, V, R> topology) {
 
 		// currently we let a job with co-location constraints fail as one region
 		// putting co-located vertices in the same region with each other can be a future improvement
@@ -115,7 +115,7 @@ public final class PipelinedRegionComputeUtil {
 	}
 
 	private static <V extends Vertex<?, ?, V, ?>> Map<V, Set<V>> buildOneRegionForAllVertices(
-			final Topology<?, ?, V, ?> topology) {
+			final BaseTopology<?, ?, V, ?> topology) {
 
 		LOG.warn("Cannot decompose the topology into individual failover regions due to use of " +
 			"Co-Location constraints (iterations). Job will fail over as one holistic unit.");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalPipelinedRegion.java
@@ -29,11 +29,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * Set of {@link LogicalVertex} that are connected through pipelined {@link LogicalResult}.
  */
-public class LogicalPipelinedRegion {
+public class DefaultLogicalPipelinedRegion {
 
 	private final Set<JobVertexID> vertexIDs;
 
-	public LogicalPipelinedRegion(final Set<? extends LogicalVertex<?, ?>> logicalVertices) {
+	public DefaultLogicalPipelinedRegion(final Set<? extends LogicalVertex<?, ?>> logicalVertices) {
 		checkNotNull(logicalVertices);
 
 		this.vertexIDs = logicalVertices.stream()
@@ -47,7 +47,7 @@ public class LogicalPipelinedRegion {
 
 	@Override
 	public String toString() {
-		return "LogicalPipelinedRegion{" +
+		return "DefaultLogicalPipelinedRegion{" +
 			"vertexIDs=" + vertexIDs +
 			'}';
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopology.java
@@ -102,12 +102,12 @@ public class DefaultLogicalTopology implements LogicalTopology<DefaultLogicalVer
 			.orElseThrow(() -> new IllegalArgumentException("can not find result: " + resultId));
 	}
 
-	public Set<LogicalPipelinedRegion> getLogicalPipelinedRegions() {
+	public Set<DefaultLogicalPipelinedRegion> getLogicalPipelinedRegions() {
 		final Set<Set<DefaultLogicalVertex>> regionsRaw = PipelinedRegionComputeUtil.computePipelinedRegions(this);
 
-		final Set<LogicalPipelinedRegion> regions = new HashSet<>();
+		final Set<DefaultLogicalPipelinedRegion> regions = new HashSet<>();
 		for (Set<DefaultLogicalVertex> regionVertices : regionsRaw) {
-			regions.add(new LogicalPipelinedRegion(regionVertices));
+			regions.add(new DefaultLogicalPipelinedRegion(regionVertices));
 		}
 		return regions;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalPipelinedRegion.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph.topology;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.topology.PipelinedRegion;
+
+/**
+ * Pipelined region on logical level, i.e., {@link JobVertex} level.
+ */
+public interface LogicalPipelinedRegion<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>> extends PipelinedRegion<JobVertexID, IntermediateDataSetID, V, R> {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/topology/LogicalTopology.java
@@ -26,5 +26,5 @@ import org.apache.flink.runtime.topology.Topology;
  * Represents a logical topology, i.e. {@link JobGraph}.
  */
 public interface LogicalTopology<V extends LogicalVertex<V, R>, R extends LogicalResult<V, R>>
-	extends Topology<JobVertexID, IntermediateDataSetID, V, R> {
+	extends Topology<JobVertexID, IntermediateDataSetID, V, R, LogicalPipelinedRegion<V, R>> {
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.topology.PipelinedRegion;
+
+/**
+ * Pipelined region on execution level, i.e., {@link ExecutionGraph} level.
+ */
+public interface SchedulingPipelinedRegion<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>> extends PipelinedRegion<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
@@ -25,7 +25,7 @@ import org.apache.flink.runtime.topology.Topology;
  * Topology of {@link SchedulingExecutionVertex}.
  */
 public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R extends SchedulingResultPartition<V, R>>
-	extends Topology<ExecutionVertexID, IntermediateResultPartitionID, V, R> {
+	extends Topology<ExecutionVertexID, IntermediateResultPartitionID, V, R, SchedulingPipelinedRegion<V, R>> {
 
 	/**
 	 * Looks up the {@link SchedulingExecutionVertex} for the given {@link ExecutionVertexID}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/BaseTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/BaseTopology.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * Base topology for all logical and execution topologies.
+ * A topology consists of {@link Vertex} and {@link Result}.
+ */
+public interface BaseTopology<VID extends VertexID, RID extends ResultID,
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+
+	/**
+	 * Returns an iterable over all vertices, topologically sorted.
+	 *
+	 * @return topologically sorted iterable over all vertices
+	 */
+	Iterable<V> getVertices();
+
+	/**
+	 * Returns whether the topology contains co-location constraints.
+	 * Co-location constraints are currently used for iterations.
+	 *
+	 * @return whether the topology contains co-location constraints
+	 */
+	boolean containsCoLocationConstraints();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/PipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/PipelinedRegion.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.topology;
+
+/**
+ * A pipelined region is a set of vertices connected via pipelined data
+ * exchanges.
+ *
+ * @param <VID> the type of the vertex ids
+ * @param <RID> the type of the result ids
+ * @param <V> the type of the vertices
+ * @param <R> the type of the result
+ */
+public interface PipelinedRegion<VID extends VertexID, RID extends ResultID,
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+
+	/**
+	 * Returns vertices that are in this pipelined region.
+	 *
+	 * @return Iterable over all vertices in this pipelined region
+	 */
+	Iterable<V> getVertices();
+
+	/**
+	 * Returns the vertex with the specified vertex id.
+	 *
+	 * @param vertexId the vertex id used to look up the vertex
+	 * @return the vertex with the specified id
+	 * @throws IllegalArgumentException if there is no vertex in this pipelined
+	 *                                  region with the specified vertex id
+	 */
+	V getVertex(VID vertexId);
+
+	/**
+	 * Returns the results that this pipelined region consumes.
+	 *
+	 * @return Iterable over all consumed results
+	 */
+	Iterable<R> getConsumedResults();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Topology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/topology/Topology.java
@@ -19,24 +19,32 @@
 package org.apache.flink.runtime.topology;
 
 /**
- * Base topology for all logical and execution topologies.
- * A topology consists of {@link Vertex} and {@link Result}.
+ * Extends the {@link BaseTopology} by pipelined regions.
  */
 public interface Topology<VID extends VertexID, RID extends ResultID,
-	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>> {
+	V extends Vertex<VID, RID, V, R>, R extends Result<VID, RID, V, R>,
+	PR extends PipelinedRegion<VID, RID, V, R>>
+	extends BaseTopology<VID, RID, V, R> {
 
 	/**
-	 * Returns an iterable over all vertices, topologically sorted.
+	 * Returns all pipelined regions in this topology.
 	 *
-	 * @return topologically sorted iterable over all vertices
+	 * @return Iterable over pipelined regions in this topology
 	 */
-	Iterable<V> getVertices();
+	default Iterable<PR> getAllPipelinedRegions() {
+		throw new UnsupportedOperationException();
+	}
 
 	/**
-	 * Returns whether the topology contains co-location constraints.
-	 * Co-location constraints are currently used for iterations.
+	 * The pipelined region for a specified vertex.
 	 *
-	 * @return whether the topology contains co-location constraints
+	 * @param vertexId the vertex id identifying the vertex for which the
+	 *                 pipelined region should be returned
+	 * @return the pipelined region of the vertex
+	 * @throws IllegalArgumentException if there is no vertex in this topology
+	 *                                  with the specified vertex id
 	 */
-	boolean containsCoLocationConstraints();
+	default PR getPipelinedRegionOfVertex(VID vertexId) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobgraph/topology/DefaultLogicalTopologyTest.java
@@ -89,7 +89,7 @@ public class DefaultLogicalTopologyTest extends TestLogger {
 
 	@Test
 	public void testGetLogicalPipelinedRegions() {
-		final Set<LogicalPipelinedRegion> regions = logicalTopology.getLogicalPipelinedRegions();
+		final Set<DefaultLogicalPipelinedRegion> regions = logicalTopology.getLogicalPipelinedRegions();
 		assertEquals(2, regions.size());
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -40,8 +40,8 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalPipelinedRegion;
 import org.apache.flink.runtime.jobgraph.topology.DefaultLogicalTopology;
-import org.apache.flink.runtime.jobgraph.topology.LogicalPipelinedRegion;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.operators.util.TaskConfig;
@@ -690,8 +690,8 @@ public class StreamingJobGraphGenerator {
 
 		final boolean allRegionsInSameSlotSharingGroup = streamGraph.isAllVerticesInSameSlotSharingGroupByDefault();
 
-		final Set<LogicalPipelinedRegion> regions = new DefaultLogicalTopology(jobGraph).getLogicalPipelinedRegions();
-		for (LogicalPipelinedRegion region : regions) {
+		final Set<DefaultLogicalPipelinedRegion> regions = new DefaultLogicalTopology(jobGraph).getLogicalPipelinedRegions();
+		for (DefaultLogicalPipelinedRegion region : regions) {
 			final SlotSharingGroup regionSlotSharingGroup;
 			if (allRegionsInSameSlotSharingGroup) {
 				regionSlotSharingGroup = defaultSlotSharingGroup;


### PR DESCRIPTION
## What is the purpose of the change

*This adds the `PipelinedRegion` interface to `org.apache.flink.runtime.topology.Topology`.*

## Brief change log

  - *See commit*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
