### PR TITLE
[FLINK-16687][python] Support Python UDF in Java Correlate

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -45,9 +45,9 @@ import scala.collection.Iterator;
 import scala.collection.mutable.ArrayBuffer;
 
 /**
- * Rule will split the Python {@link FlinkLogicalTableFunctionScan} which includes java calls into a
- * {@link FlinkLogicalCalc} which will be the left input of the new {@link FlinkLogicalCorrelate}
- * and a new {@link FlinkLogicalTableFunctionScan} without java calls.
+ * Rule will split the Python {@link FlinkLogicalTableFunctionScan} with Java calls or the Java
+ * {@link FlinkLogicalTableFunctionScan} with Python calls into a {@link FlinkLogicalCalc} which
+ * will be the left input of the new {@link FlinkLogicalCorrelate} and a new {@link FlinkLogicalTableFunctionScan}.
  */
 public class PythonCorrelateSplitRule extends RelOptRule {
 	public static final PythonCorrelateSplitRule INSTANCE = new PythonCorrelateSplitRule();
@@ -60,7 +60,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		FlinkLogicalTableFunctionScan scan,
 		ScalarFunctionSplitter splitter) {
 		RexCall rightRexCall = (RexCall) scan.getCall();
-		// extract java funcs.
+		// extract Java funcs of Python TableFunction or Python funcs of Java TableFunction.
 		List<RexNode> rightCalcProjects = rightRexCall
 			.getOperands()
 			.stream()
@@ -82,17 +82,18 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 	public boolean matches(RelOptRuleCall call) {
 		FlinkLogicalCorrelate correlate = call.rel(0);
 		RelNode right = ((HepRelVertex) correlate.getRight()).getCurrentRel();
-		FlinkLogicalTableFunctionScan pythonTableFuncScan;
+		FlinkLogicalTableFunctionScan tableFunctionScan;
 		if (right instanceof FlinkLogicalTableFunctionScan) {
-			pythonTableFuncScan = (FlinkLogicalTableFunctionScan) right;
+			tableFunctionScan = (FlinkLogicalTableFunctionScan) right;
 		} else if (right instanceof FlinkLogicalCalc) {
-			pythonTableFuncScan = StreamExecCorrelateRule.getTableScan((FlinkLogicalCalc) right);
+			tableFunctionScan = StreamExecCorrelateRule.getTableScan((FlinkLogicalCalc) right);
 		} else {
 			return false;
 		}
-		RexNode rexNode = pythonTableFuncScan.getCall();
+		RexNode rexNode = tableFunctionScan.getCall();
 		if (rexNode instanceof RexCall) {
-			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode);
+			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode)
+				|| PythonUtil.isNonPythonCall(rexNode) && PythonUtil.containsPythonCall(rexNode, null);
 		}
 		return false;
 	}
@@ -101,13 +102,13 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		RelDataType rowType,
 		RexBuilder rexBuilder,
 		int primitiveFieldCount,
-		ArrayBuffer<RexCall> extractedJavaRexCalls,
+		ArrayBuffer<RexCall> extractedRexCalls,
 		List<RexNode> calcProjects) {
 		for (int i = 0; i < primitiveFieldCount; i++) {
 			calcProjects.add(RexInputRef.of(i, rowType));
 		}
-		// add the fields of the extracted java rex calls.
-		Iterator<RexCall> iterator = extractedJavaRexCalls.iterator();
+		// add the fields of the extracted rex calls.
+		Iterator<RexCall> iterator = extractedRexCalls.iterator();
 		while (iterator.hasNext()) {
 			calcProjects.add(iterator.next());
 		}
@@ -116,7 +117,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		for (int i = 0; i < primitiveFieldCount; i++) {
 			nameList.add(rowType.getFieldNames().get(i));
 		}
-		Iterator<Object> indicesIterator = extractedJavaRexCalls.indices().iterator();
+		Iterator<Object> indicesIterator = extractedRexCalls.indices().iterator();
 		while (indicesIterator.hasNext()) {
 			nameList.add("f" + indicesIterator.next());
 		}
@@ -128,7 +129,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 	private FlinkLogicalCalc createNewLeftCalc(
 		RelNode left,
 		RexBuilder rexBuilder,
-		ArrayBuffer<RexCall> extractedJavaRexCalls,
+		ArrayBuffer<RexCall> extractedRexCalls,
 		FlinkLogicalCorrelate correlate) {
 		// add the fields of the primitive left input.
 		List<RexNode> leftCalcProjects = new LinkedList<>();
@@ -137,10 +138,10 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 			leftRowType,
 			rexBuilder,
 			leftRowType.getFieldCount(),
-			extractedJavaRexCalls,
+			extractedRexCalls,
 			leftCalcProjects);
 
-		// create a new java calc
+		// create a new calc
 		return new FlinkLogicalCalc(
 			correlate.getCluster(),
 			correlate.getTraitSet(),
@@ -156,11 +157,11 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 	private FlinkLogicalCalc createTopCalc(
 		int primitiveLeftFieldCount,
 		RexBuilder rexBuilder,
-		ArrayBuffer<RexCall> extractedJavaRexCalls,
+		ArrayBuffer<RexCall> extractedRexCalls,
 		RelDataType calcRowType,
 		FlinkLogicalCorrelate newCorrelate) {
 		RexProgram rexProgram = new RexProgramBuilder(newCorrelate.getRowType(), rexBuilder).getProgram();
-		int offset = extractedJavaRexCalls.size() + primitiveLeftFieldCount;
+		int offset = extractedRexCalls.size() + primitiveLeftFieldCount;
 
 		// extract correlate output RexNode.
 		List<RexNode> newTopCalcProjects = rexProgram
@@ -185,6 +186,25 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 				rexBuilder));
 	}
 
+	private ScalarFunctionSplitter createScalarFunctionSplitter(
+		int primitiveLeftFieldCount,
+		ArrayBuffer<RexCall> extractedRexCalls,
+		boolean isJavaTableFunction) {
+		if (isJavaTableFunction) {
+			return new ScalarFunctionSplitter(
+				primitiveLeftFieldCount,
+				extractedRexCalls,
+				x -> PythonUtil.isPythonCall(x, null)
+			);
+		} else {
+			return new ScalarFunctionSplitter(
+				primitiveLeftFieldCount,
+				extractedRexCalls,
+				PythonUtil::isNonPythonCall
+			);
+		}
+	}
+
 	@Override
 	public void onMatch(RelOptRuleCall call) {
 		FlinkLogicalCorrelate correlate = call.rel(0);
@@ -192,29 +212,33 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		RelNode left = ((HepRelVertex) correlate.getLeft()).getCurrentRel();
 		RelNode right = ((HepRelVertex) correlate.getRight()).getCurrentRel();
 		int primitiveLeftFieldCount = left.getRowType().getFieldCount();
-		ArrayBuffer<RexCall> extractedJavaRexCalls = new ArrayBuffer<>();
-		ScalarFunctionSplitter splitter = new ScalarFunctionSplitter(
-			primitiveLeftFieldCount,
-			extractedJavaRexCalls,
-			PythonUtil::isNonPythonCall
-		);
+		ArrayBuffer<RexCall> extractedRexCalls = new ArrayBuffer<>();
 
 		RelNode rightNewInput;
 		if (right instanceof FlinkLogicalTableFunctionScan) {
 			FlinkLogicalTableFunctionScan scan = (FlinkLogicalTableFunctionScan) right;
-			rightNewInput = createNewScan(scan, splitter);
+			rightNewInput = createNewScan(
+				scan,
+				createScalarFunctionSplitter(
+					primitiveLeftFieldCount,
+					extractedRexCalls,
+					PythonUtil.isNonPythonCall(scan.getCall())));
 		} else {
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
 			FlinkLogicalTableFunctionScan scan = StreamExecCorrelateRule.getTableScan(calc);
 			FlinkLogicalCalc mergedCalc = StreamExecCorrelateRule.getMergedCalc(calc);
-			FlinkLogicalTableFunctionScan newScan = createNewScan(scan, splitter);
+			FlinkLogicalTableFunctionScan newScan = createNewScan(scan,
+				createScalarFunctionSplitter(
+					primitiveLeftFieldCount,
+					extractedRexCalls,
+					PythonUtil.isNonPythonCall(scan.getCall())));
 			rightNewInput = mergedCalc.copy(mergedCalc.getTraitSet(), newScan, mergedCalc.getProgram());
 		}
 
 		FlinkLogicalCalc leftCalc = createNewLeftCalc(
 			left,
 			rexBuilder,
-			extractedJavaRexCalls,
+			extractedRexCalls,
 			correlate);
 
 		FlinkLogicalCorrelate newCorrelate = new FlinkLogicalCorrelate(
@@ -229,7 +253,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		FlinkLogicalCalc newTopCalc = createTopCalc(
 			primitiveLeftFieldCount,
 			rexBuilder,
-			extractedJavaRexCalls,
+			extractedRexCalls,
 			correlate.getRowType(),
 			newCorrelate);
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -60,7 +60,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		FlinkLogicalTableFunctionScan scan,
 		ScalarFunctionSplitter splitter) {
 		RexCall rightRexCall = (RexCall) scan.getCall();
-		// extract Java funcs of Python TableFunction or Python funcs of Java TableFunction.
+		// extract Java funcs from Python TableFunction or Python funcs from Java TableFunction.
 		List<RexNode> rightCalcProjects = rightRexCall
 			.getOperands()
 			.stream()
@@ -98,7 +98,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		return false;
 	}
 
-	private List<String> createNewFiledNames(
+	private List<String> createNewFieldNames(
 		RelDataType rowType,
 		RexBuilder rexBuilder,
 		int primitiveFieldCount,
@@ -134,7 +134,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		// add the fields of the primitive left input.
 		List<RexNode> leftCalcProjects = new LinkedList<>();
 		RelDataType leftRowType = left.getRowType();
-		List<String> leftCalcCalcFieldNames = createNewFiledNames(
+		List<String> leftCalcCalcFieldNames = createNewFieldNames(
 			leftRowType,
 			rexBuilder,
 			leftRowType.getFieldCount(),
@@ -190,19 +190,11 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		int primitiveLeftFieldCount,
 		ArrayBuffer<RexCall> extractedRexCalls,
 		boolean isJavaTableFunction) {
-		if (isJavaTableFunction) {
-			return new ScalarFunctionSplitter(
-				primitiveLeftFieldCount,
-				extractedRexCalls,
-				x -> PythonUtil.isPythonCall(x, null)
-			);
-		} else {
-			return new ScalarFunctionSplitter(
-				primitiveLeftFieldCount,
-				extractedRexCalls,
-				PythonUtil::isNonPythonCall
-			);
-		}
+		return new ScalarFunctionSplitter(
+			primitiveLeftFieldCount,
+			extractedRexCalls,
+			isJavaTableFunction ? x -> PythonUtil.isPythonCall(x, null) : PythonUtil::isNonPythonCall
+		);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCalc.scala
@@ -46,7 +46,10 @@ trait CommonPythonCalc extends CommonPythonBase {
 
     val udfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect { case inputRef: RexInputRef => inputRef.getIndex }
+      .collect {
+        case inputRef: RexInputRef => inputRef.getIndex
+        case fac: RexFieldAccess => fac.getField.getIndex
+      }
     (udfInputOffsets, pythonFunctionInfos)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -219,9 +219,8 @@ public class JavaUserDefinedScalarFunctions {
 			return i + j;
 		}
 
-		@Override
-		public TypeInformation<?> getResultType(Class<?>[] signature) {
-			return BasicTypeInfo.INT_TYPE_INFO;
+		public String eval(String a) {
+			return a;
 		}
 
 		@Override

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
@@ -38,4 +38,26 @@ FlinkLogicalCalc(select=[a, b, c, f00 AS f0, f1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJavaTableFunctionWithPythonCalc">
+	<Resource name="sql">
+		<![CDATA[SELECT a, b, c, x FROM MyTable, LATERAL TABLE(javaFunc(pyFunc(c))) AS T(x)]]>
+	</Resource>
+	<Resource name="planBefore">
+	  <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableFunctionScan(invocation=[javaFunc(pyFunc($cor0.c))], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+]]>
+	</Resource>
+	<Resource name="planAfter">
+	  <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f00 AS f0])
++- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+   :- FlinkLogicalCalc(select=[a, b, c, pyFunc($cor0.c) AS f0])
+   :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableFunctionScan(invocation=[javaFunc($3)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+]]>
+	</Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.optimize.program._
 import org.apache.flink.table.planner.plan.rules.FlinkStreamRuleSets
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.PythonScalarFunction
-import org.apache.flink.table.planner.utils.{MockPythonTableFunction, TableTestBase}
+import org.apache.flink.table.planner.utils.{MockPythonTableFunction, TableFunc1, TableTestBase}
 import org.junit.{Before, Test}
 
 class PythonCorrelateSplitRuleTest extends TableTestBase {
@@ -51,16 +51,24 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
         .build())
     util.replaceStreamProgram(programs)
 
-    util.addTableSource[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
     util.addFunction("func", new MockPythonTableFunction)
+    util.addFunction("javaFunc", new TableFunc1)
     util.addFunction("pyFunc", new PythonScalarFunction("pyFunc"))
   }
 
   @Test
   def testPythonTableFunctionWithJavaFunc(): Unit = {
+    util.addTableSource[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
     val sqlQuery = "SELECT a, b, c, x, y FROM MyTable, " +
       "LATERAL TABLE(func(a * a, pyFunc(b, c))) AS T(x, y)"
     util.verifyPlan(sqlQuery)
   }
 
+  @Test
+  def testJavaTableFunctionWithPythonCalc(): Unit = {
+    util.addTableSource[(Int, Int, String)]("MyTable", 'a, 'b, 'c)
+    val sqlQuery = "SELECT a, b, c, x FROM MyTable, " +
+      "LATERAL TABLE(javaFunc(pyFunc(c))) AS T(x)"
+    util.verifyPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -62,7 +62,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		FlinkLogicalTableFunctionScan scan,
 		ScalarFunctionSplitter splitter) {
 		RexCall rightRexCall = (RexCall) scan.getCall();
-		// extract Java funcs of Python TableFunction or Python funcs of Java TableFunction.
+		// extract Java funcs from Python TableFunction or Python funcs from Java TableFunction.
 		List<RexNode> rightCalcProjects = rightRexCall
 			.getOperands()
 			.stream()
@@ -105,7 +105,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		return false;
 	}
 
-	private List<String> createNewFiledNames(
+	private List<String> createNewFieldNames(
 		RelDataType rowType,
 		RexBuilder rexBuilder,
 		int primitiveFieldCount,
@@ -141,7 +141,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		// add the fields of the primitive left input.
 		List<RexNode> leftCalcProjects = new LinkedList<>();
 		RelDataType leftRowType = left.getRowType();
-		List<String> leftCalcCalcFieldNames = createNewFiledNames(
+		List<String> leftCalcCalcFieldNames = createNewFieldNames(
 			leftRowType,
 			rexBuilder,
 			leftRowType.getFieldCount(),
@@ -197,19 +197,11 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		int primitiveLeftFieldCount,
 		ArrayBuffer<RexCall> extractedRexCalls,
 		boolean isJavaTableFunction) {
-		if (isJavaTableFunction) {
-			return new ScalarFunctionSplitter(
-				primitiveLeftFieldCount,
-				extractedRexCalls,
-				x -> PythonUtil.isPythonCall(x, null)
-			);
-		} else {
-			return new ScalarFunctionSplitter(
-				primitiveLeftFieldCount,
-				extractedRexCalls,
-				PythonUtil::isNonPythonCall
-			);
-		}
+		return new ScalarFunctionSplitter(
+			primitiveLeftFieldCount,
+			extractedRexCalls,
+			isJavaTableFunction ? x -> PythonUtil.isPythonCall(x, null) : PythonUtil::isNonPythonCall
+		);
 	}
 
 	@Override

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCalc.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.plan.nodes
 
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
+import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexInputRef, RexNode, RexProgram}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
@@ -40,7 +40,10 @@ trait CommonPythonCalc extends CommonPythonBase {
 
     val udfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect { case inputRef: RexInputRef => inputRef.getIndex }
+      .collect {
+        case inputRef: RexInputRef => inputRef.getIndex
+        case fac: RexFieldAccess => fac.getField.getIndex
+      }
     (udfInputOffsets, pythonFunctionInfos)
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -99,9 +99,8 @@ public class JavaUserDefinedScalarFunctions {
 			return i + j;
 		}
 
-		@Override
-		public TypeInformation<?> getResultType(Class<?>[] signature) {
-			return BasicTypeInfo.INT_TYPE_INFO;
+		public String eval(String s) {
+			return s;
 		}
 
 		@Override


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support Python UDF in Java Correlate*


## Brief change log

  - *Add the logic of extracting Python UDF in PythonCorrelateSplitRule *


## Verifying this change

This change added tests and can be verified as follows:

  - *Added unit test of testJavaTableFunctionWithPythonCalc in PythonCorrelateSplitRuleTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
