### PR TITLE
[FLINK-16811][jdbc] introduce row converter API to JDBCDialect

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
@@ -294,7 +294,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			if (!hasNext) {
 				return null;
 			}
-			Row row = rowConverter.setRow(resultSet, reuse);
+			Row row = rowConverter.convert(resultSet, reuse);
 			//update hasNext after we've read the record
 			hasNext = resultSet.next();
 			return row;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormat.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.JDBCRowConverter;
 import org.apache.flink.api.java.io.jdbc.split.ParameterValuesProvider;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
@@ -111,6 +112,7 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 	private int resultSetType;
 	private int resultSetConcurrency;
 	private RowTypeInfo rowTypeInfo;
+	private JDBCRowConverter rowConverter;
 
 	private transient Connection dbConn;
 	private transient PreparedStatement statement;
@@ -282,19 +284,17 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 	/**
 	 * Stores the next resultSet row in a tuple.
 	 *
-	 * @param row row to be reused.
+	 * @param reuse row to be reused.
 	 * @return row containing next {@link Row}
 	 * @throws java.io.IOException
 	 */
 	@Override
-	public Row nextRecord(Row row) throws IOException {
+	public Row nextRecord(Row reuse) throws IOException {
 		try {
 			if (!hasNext) {
 				return null;
 			}
-			for (int pos = 0; pos < row.getArity(); pos++) {
-				row.setField(pos, resultSet.getObject(pos + 1));
-			}
+			Row row = rowConverter.setRow(resultSet, reuse);
 			//update hasNext after we've read the record
 			hasNext = resultSet.next();
 			return row;
@@ -403,6 +403,11 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			return this;
 		}
 
+		public JDBCInputFormatBuilder setRowConverter(JDBCRowConverter rowConverter) {
+			format.rowConverter = rowConverter;
+			return this;
+		}
+
 		public JDBCInputFormatBuilder setFetchSize(int fetchSize) {
 			Preconditions.checkArgument(fetchSize == Integer.MIN_VALUE || fetchSize > 0,
 				"Illegal value %s for fetchSize, has to be positive or Integer.MIN_VALUE.", fetchSize);
@@ -433,6 +438,9 @@ public class JDBCInputFormat extends RichInputFormat<Row, InputSplit> implements
 			}
 			if (format.rowTypeInfo == null) {
 				throw new IllegalArgumentException("No " + RowTypeInfo.class.getSimpleName() + " supplied");
+			}
+			if (format.rowConverter == null) {
+				throw new IllegalArgumentException("No row converter supplied");
 			}
 			if (format.parameterValues == null) {
 				LOG.debug("No input splitting configured (data will be read with parallelism 1).");

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCTableSource.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.sources.ProjectableTableSource;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.types.Row;
 
@@ -177,6 +178,7 @@ public class JDBCTableSource implements
 				" BETWEEN ? AND ?";
 		}
 		builder.setQuery(query);
+		builder.setRowConverter(dialect.getRowConverter((RowType) producedDataType.getLogicalType()));
 
 		return builder.finish();
 	}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialect.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.api.java.io.jdbc.dialect;
 
+import org.apache.flink.api.java.io.jdbc.source.row.converter.JDBCRowConverter;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -37,6 +39,13 @@ public interface JDBCDialect extends Serializable {
 	 * @return True if the dialect can be applied on the given jdbc url.
 	 */
 	boolean canHandle(String url);
+
+	/**
+	 * Get a row converter for the database according to the given row type.
+	 * @param rowType the given row type
+	 * @return a row converter for the database
+	 */
+	JDBCRowConverter getRowConverter(RowType rowType);
 
 	/**
 	 * Check if this dialect instance support a specific data type in table schema.

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -18,11 +18,16 @@
 
 package org.apache.flink.api.java.io.jdbc.dialect;
 
+import org.apache.flink.api.java.io.jdbc.source.row.converter.DerbyRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.JDBCRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.MySQLRowConverter;
+import org.apache.flink.api.java.io.jdbc.source.row.converter.PostgresRowConverter;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 
@@ -143,6 +148,11 @@ public final class JDBCDialects {
 		}
 
 		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new DerbyRowConverter(rowType);
+		}
+
+		@Override
 		public Optional<String> defaultDriverName() {
 			return Optional.of("org.apache.derby.jdbc.EmbeddedDriver");
 		}
@@ -223,6 +233,11 @@ public final class JDBCDialects {
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:mysql:");
+		}
+
+		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new MySQLRowConverter(rowType);
 		}
 
 		@Override
@@ -324,6 +339,11 @@ public final class JDBCDialects {
 		@Override
 		public boolean canHandle(String url) {
 			return url.startsWith("jdbc:postgresql:");
+		}
+
+		@Override
+		public JDBCRowConverter getRowConverter(RowType rowType) {
+			return new PostgresRowConverter(rowType);
 		}
 
 		@Override

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.api.java.io.jdbc.source.row.converter;
 
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
@@ -39,7 +38,7 @@ public abstract class AbstractJDBCRowConverter implements JDBCRowConverter {
 	}
 
 	@Override
-	public Row setRow(ResultSet resultSet, Row reuse) throws SQLException {
+	public Row convert(ResultSet resultSet, Row reuse) throws SQLException {
 		for (int pos = 0; pos < rowType.getFieldCount(); pos++) {
 			Object v = resultSet.getObject(pos + 1);
 			reuse.setField(pos, v);

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Base for all row converters.
+ */
+public abstract class AbstractJDBCRowConverter implements JDBCRowConverter {
+
+	protected final RowType rowType;
+
+	public AbstractJDBCRowConverter(RowType rowType) {
+		this.rowType = checkNotNull(rowType);
+	}
+
+	@Override
+	public Row setRow(ResultSet resultSet, Row reuse) throws SQLException {
+		for (int pos = 0; pos < rowType.getFieldCount(); pos++) {
+			Object v = resultSet.getObject(pos + 1);
+			reuse.setField(pos, v);
+		}
+
+		return reuse;
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/DerbyRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/DerbyRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for Derby.
+ */
+public class DerbyRowConverter extends AbstractJDBCRowConverter {
+
+	public DerbyRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.types.Row;
+
+import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Convert row from JDBC result set to a Flink row.
+ */
+public interface JDBCRowConverter extends Serializable {
+
+	/**
+	 * Set {@link Row} with data retrieved from {@link ResultSet}.
+	 *
+	 * @param resultSet ResultSet from JDBC
+	 * @param reuse The row to set
+	 */
+	Row setRow(ResultSet resultSet, Row reuse) throws SQLException;
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
@@ -30,10 +30,10 @@ import java.sql.SQLException;
 public interface JDBCRowConverter extends Serializable {
 
 	/**
-	 * Set {@link Row} with data retrieved from {@link ResultSet}.
+	 * Convert data retrieved from {@link ResultSet} to {@link Row}.
 	 *
 	 * @param resultSet ResultSet from JDBC
 	 * @param reuse The row to set
 	 */
-	Row setRow(ResultSet resultSet, Row reuse) throws SQLException;
+	Row convert(ResultSet resultSet, Row reuse) throws SQLException;
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/MySQLRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/MySQLRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for MySQL.
+ */
+public class MySQLRowConverter extends AbstractJDBCRowConverter {
+
+	public MySQLRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.io.jdbc.source.row.converter;
+
+import org.apache.flink.table.types.logical.RowType;
+
+/**
+ * Row converter for Postgres.
+ */
+public class PostgresRowConverter extends AbstractJDBCRowConverter {
+
+	public PostgresRowConverter(RowType rowType) {
+		super(rowType);
+	}
+}

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCFullTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java.io.jdbc;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.jdbc.JDBCInputFormat.JDBCInputFormatBuilder;
+import org.apache.flink.api.java.io.jdbc.dialect.JDBCDialects;
 import org.apache.flink.api.java.io.jdbc.split.NumericBetweenParametersProvider;
 import org.apache.flink.types.Row;
 
@@ -38,6 +39,7 @@ import java.sql.Statement;
 import java.sql.Types;
 
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.OUTPUT_TABLE;
+import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE_INFO;
 import static org.hamcrest.core.StringContains.containsString;
 
@@ -83,7 +85,8 @@ public class JDBCFullTest extends JDBCDataTestBase {
 				.setDrivername(getDbMetadata().getDriverClass())
 				.setDBUrl(getDbMetadata().getUrl())
 				.setQuery(JdbcTestFixture.SELECT_ALL_BOOKS)
-				.setRowTypeInfo(ROW_TYPE_INFO);
+				.setRowTypeInfo(ROW_TYPE_INFO)
+				.setRowConverter(JDBCDialects.get(getDbMetadata().getUrl()).get().getRowConverter(ROW_TYPE));
 
 		if (exploitParallelism) {
 			final int fetchSize = 1;

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JDBCInputFormatTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.java.io.jdbc.JdbcTestFixture.TestEntry;
+import org.apache.flink.api.java.io.jdbc.dialect.JDBCDialects;
 import org.apache.flink.api.java.io.jdbc.split.GenericParameterValuesProvider;
 import org.apache.flink.api.java.io.jdbc.split.NumericBetweenParametersProvider;
 import org.apache.flink.api.java.io.jdbc.split.ParameterValuesProvider;
@@ -35,6 +36,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.ROW_TYPE_INFO;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.SELECT_ALL_BOOKS;
 import static org.apache.flink.api.java.io.jdbc.JdbcTestFixture.SELECT_EMPTY;
@@ -127,6 +129,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setQuery(SELECT_ALL_BOOKS)
 			.setRowTypeInfo(ROW_TYPE_INFO)
 			.setFetchSize(Integer.MIN_VALUE)
+			.setRowConverter(
+				JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 			.finish();
 	}
 
@@ -137,6 +141,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
 			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowConverter(
+				JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 			.finish();
 		jdbcInputFormat.openInputFormat();
 
@@ -155,6 +161,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setQuery(SELECT_ALL_BOOKS)
 			.setRowTypeInfo(ROW_TYPE_INFO)
 			.setFetchSize(desiredFetchSize)
+			.setRowConverter(
+				JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 			.finish();
 		jdbcInputFormat.openInputFormat();
 		Assert.assertEquals(desiredFetchSize, jdbcInputFormat.getStatement().getFetchSize());
@@ -168,6 +176,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setDBUrl(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl())
 			.setQuery(SELECT_ALL_BOOKS)
 			.setRowTypeInfo(ROW_TYPE_INFO)
+			.setRowConverter(
+				JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 			.finish();
 		jdbcInputFormat.openInputFormat();
 
@@ -188,6 +198,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 			.setQuery(SELECT_ALL_BOOKS)
 			.setRowTypeInfo(ROW_TYPE_INFO)
 			.setAutoCommit(desiredAutoCommit)
+			.setRowConverter(
+				JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 			.finish();
 
 		jdbcInputFormat.openInputFormat();
@@ -203,6 +215,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setQuery(SELECT_ALL_BOOKS)
 				.setRowTypeInfo(ROW_TYPE_INFO)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
+				.setRowConverter(
+					JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 				.finish();
 		//this query does not exploit parallelism
 		Assert.assertEquals(1, jdbcInputFormat.createInputSplits(1).length);
@@ -235,6 +249,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setRowTypeInfo(ROW_TYPE_INFO)
 				.setParametersProvider(pramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
+				.setRowConverter(
+					JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 				.finish();
 
 		jdbcInputFormat.openInputFormat();
@@ -271,6 +287,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setRowTypeInfo(ROW_TYPE_INFO)
 				.setParametersProvider(pramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
+				.setRowConverter(
+					JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 				.finish();
 
 		jdbcInputFormat.openInputFormat();
@@ -307,6 +325,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setRowTypeInfo(ROW_TYPE_INFO)
 				.setParametersProvider(paramProvider)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
+				.setRowConverter(
+					JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 				.finish();
 
 		jdbcInputFormat.openInputFormat();
@@ -346,6 +366,8 @@ public class JDBCInputFormatTest extends JDBCDataTestBase {
 				.setQuery(SELECT_EMPTY)
 				.setRowTypeInfo(ROW_TYPE_INFO)
 				.setResultSetType(ResultSet.TYPE_SCROLL_INSENSITIVE)
+				.setRowConverter(
+					JDBCDialects.get(JdbcTestFixture.DERBY_EBOOKSHOP_DB.getUrl()).get().getRowConverter(ROW_TYPE))
 				.finish();
 		try {
 			jdbcInputFormat.openInputFormat();

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/JdbcTestFixture.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.io.jdbc;
 
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -27,6 +28,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import static org.apache.flink.table.types.utils.TypeConversions.fromLegacyInfoToDataType;
 
 /**
  * Test data and helper objects for JDBC tests.
@@ -102,6 +105,8 @@ public class JdbcTestFixture {
 		BasicTypeInfo.STRING_TYPE_INFO,
 		BasicTypeInfo.DOUBLE_TYPE_INFO,
 		BasicTypeInfo.INT_TYPE_INFO);
+
+	static final RowType ROW_TYPE = (RowType) fromLegacyInfoToDataType(ROW_TYPE_INFO).getLogicalType();
 
 	private static String getCreateQuery(String tableName) {
 		return "CREATE TABLE " + tableName + " (" +

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -142,6 +142,17 @@ public final class StringUtils {
 		if (array instanceof Object[]) {
 			return Arrays.toString((Object[]) array);
 		}
+		// for array of byte array
+		if (array instanceof byte[][]) {
+			byte[][] b = (byte[][]) array;
+			String[] strs = new String[b.length];
+
+			for (int i = 0; i < b.length; i++) {
+				strs[i] = Arrays.toString(b[i]);
+			}
+
+			return Arrays.toString(strs);
+		}
 		if (array instanceof byte[]) {
 			return Arrays.toString((byte[]) array);
 		}


### PR DESCRIPTION
## What is the purpose of the change

commit 1: make StringUtils.arrayToString() convert array of byte array correctly
commit 2: [FLINK-16811][jdbc] introduce row converter API to JDBCDialect

## Brief change log

## Verifying this change
UT and IT added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
