### PR TITLE
[FLINK-16632][table-planner-blink] Fix SqlDateTimeUtils#toSqlTimestam…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -118,8 +118,11 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "CAST('1999-9-10 05:20:10.123456' AS TIMESTAMP)",
-      "1999-09-10 05:20:10.123456"
-    )
+      "1999-09-10 05:20:10.123456")
+
+    testSqlApi(
+      "CAST('1999-9-10' AS TIMESTAMP)",
+      "1999-09-10 00:00:00.000000")
   }
 
   @Test
@@ -1121,6 +1124,19 @@ class TemporalTypesTest extends ExpressionTestBase {
       "1970-01-01 00:00:00.12345")
 
     testSqlApi("TO_TIMESTAMP('abc')", "null")
+
+    // TO_TIMESTAMP should complement YEAR/MONTH/DAY/HOUR/MINUTE/SECOND/NANO_OF_SECOND
+    testSqlApi(
+      "TO_TIMESTAMP('2000020210', 'yyyyMMddHH')",
+      "2000-02-02 10:00:00.000")
+
+    testSqlApi(
+      "TO_TIMESTAMP('20000202 59:59.1234567', 'yyyyMMdd mm:ss.SSSSSSS')",
+      "1970-02-02 00:59:59.1234567")
+
+    testSqlApi(
+      "TO_TIMESTAMP('1234567', 'SSSSSSS')",
+      "1970-01-01 00:00:00.1234567")
 
     // CAST between two TIMESTAMPs
     testSqlApi(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -1132,7 +1132,7 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testSqlApi(
       "TO_TIMESTAMP('20000202 59:59.1234567', 'yyyyMMdd mm:ss.SSSSSSS')",
-      "1970-02-02 00:59:59.1234567")
+      "2000-02-02 00:59:59.1234567")
 
     testSqlApi(
       "TO_TIMESTAMP('1234567', 'SSSSSSS')",


### PR DESCRIPTION
…p(String, String) may yield incorrect result


## What is the purpose of the change

`SqlDateTimeUtils#toSqlTimestamp(String, String)` may yield incorrect result. Which cause:

1) cast STRING to TIMESTAMP yields incompatible result. 
The original result comes from `DateTimeUtils#timestampStringToUnixDate` which supports special cases like '1999-9-10 05:20:10' or '1999-9-10'.

2) TO_TIMESTAMP yields incorrect result.
The original result comes from `SqlDateTimeUtils#toTimestamp(String, String, TimeZone)` which follows rules of completion of java.text.SimpleDateFormat

This PR fix that.

## Brief change log
- 11a9a2f Fix SqlDateTimeUtils#toSqlTimestamp(String, String) may yield incorrect result

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
