### PR TITLE
[FLINK-14162][runtime] SchedulerOperations#allocateSlotsAndDeploy always deploys tasks in a bulk

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -42,7 +42,6 @@ import org.apache.flink.runtime.jobmaster.slotpool.ThrowingSlotProvider;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.BackPressureStatsTracker;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
-import org.apache.flink.runtime.scheduler.strategy.LazyFromSourcesSchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -302,11 +301,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 			deploymentOptionsByVertex,
 			slotExecutionVertexAssignments);
 
-		if (isDeployIndividually()) {
-			deployIndividually(deploymentHandles);
-		} else {
-			waitForAllSlotsAndDeploy(deploymentHandles);
-		}
+		waitForAllSlotsAndDeploy(deploymentHandles);
 	}
 
 	private void validateDeploymentOptions(final Collection<ExecutionVertexDeploymentOption> deploymentOptions) {
@@ -349,25 +344,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 					slotExecutionVertexAssignment);
 			})
 			.collect(Collectors.toList());
-	}
-
-	/**
-	 * <b>HACK:</b> See <a href="https://issues.apache.org/jira/browse/FLINK-14162">FLINK-14162</a>
-	 * for details.
-	 */
-	private boolean isDeployIndividually() {
-		return schedulingStrategy instanceof LazyFromSourcesSchedulingStrategy;
-	}
-
-	private void deployIndividually(final List<DeploymentHandle> deploymentHandles) {
-		for (final DeploymentHandle deploymentHandle : deploymentHandles) {
-			FutureUtils.assertNoException(
-				deploymentHandle
-					.getSlotExecutionVertexAssignment()
-					.getLogicalSlotFuture()
-					.handle(assignResourceOrHandleError(deploymentHandle))
-					.handle(deployOrHandleError(deploymentHandle)));
-		}
 	}
 
 	private void waitForAllSlotsAndDeploy(final List<DeploymentHandle> deploymentHandles) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerOperations.java
@@ -29,6 +29,7 @@ public interface SchedulerOperations {
 
 	/**
 	 * Allocate slots and deploy the vertex when slots are returned.
+	 * Vertices will be deployed only after all of them have been assigned slots.
 	 * The given order will be respected, i.e. tasks with smaller indices will be deployed earlier.
 	 * Only vertices in CREATED state will be accepted. Errors will happen if scheduling Non-CREATED vertices.
 	 *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.IterableUtils;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +144,9 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 				verticesToDeploy,
 				deploymentOptions::get);
 
-		schedulerOperations.allocateSlotsAndDeploy(vertexDeploymentOptions);
+		for (ExecutionVertexDeploymentOption deploymentOption : vertexDeploymentOptions) {
+			schedulerOperations.allocateSlotsAndDeploy(Collections.singletonList(deploymentOption));
+		}
 	}
 
 	private Predicate<SchedulingExecutionVertex<?, ?>> isInputConstraintSatisfied() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
@@ -28,13 +28,16 @@ import org.apache.flink.util.TestLogger;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.InputDependencyConstraint.ALL;
 import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.PIPELINED;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * Unit tests for {@link LazyFromSourcesSchedulingStrategy}.
@@ -351,9 +354,13 @@ public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
 	}
 
 	private void assertLatestScheduledVerticesAreEqualTo(final List<TestingSchedulingExecutionVertex> expected) {
-		assertEquals(
-			idsFromVertices(expected),
-			idsFromDeploymentOptions(testingSchedulerOperation.getLatestScheduledVertices()));
+		final List<List<ExecutionVertexDeploymentOption>> deploymentOptions = testingSchedulerOperation.getScheduledVertices();
+		assertThat(expected.size(), lessThanOrEqualTo(deploymentOptions.size()));
+		for (int i = 0; i < expected.size(); i++) {
+			assertEquals(
+				idsFromVertices(Collections.singletonList(expected.get(expected.size() - i - 1))),
+				idsFromDeploymentOptions(deploymentOptions.get(deploymentOptions.size() - i - 1)));
+		}
 	}
 
 	private static List<ExecutionVertexID> idsFromVertices(final List<TestingSchedulingExecutionVertex> vertices) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulerOperations.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulerOperations.java
@@ -40,8 +40,4 @@ public class TestingSchedulerOperations implements SchedulerOperations {
 	List<List<ExecutionVertexDeploymentOption>> getScheduledVertices() {
 		return Collections.unmodifiableList(scheduledVertices);
 	}
-
-	List<ExecutionVertexDeploymentOption> getLatestScheduledVertices() {
-		return Collections.unmodifiableList(scheduledVertices.get(scheduledVertices.size() - 1));
-	}
 }


### PR DESCRIPTION
## What is the purpose of the change

This is to resolve the hack in DefaultScheduler. It is a prerequisite of pipelined region scheduling.
More details see FLINK-14162.

## Brief change log

  - *SchedulerOperations#allocateSlotsAndDeploy now always deploys tasks in a bulk*
  - *LazyFromSourcesSchedulingStrategy now schedules vertices one by one when invoking SchedulerOperations#allocateSlotsAndDeploy(...)*

## Verifying this change

This change is already covered by existing tests, such as 
 - DefaultSchedulerTest
 - LazyFromSourcesSchedulingStrategyTest (adjusted a bit) 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
