### PR TITLE
[FLINK-16983][python] Support RowType in vectorized Python UDF

### DIFF
--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -457,6 +457,10 @@ class ArrowCoder(DeterministicCoder):
             elif field_type.type_name == flink_fn_execution_pb2.Schema.ARRAY:
                 return ArrayType(_to_data_type(field_type.collection_element_type),
                                  field_type.nullable)
+            elif field_type.type_name == flink_fn_execution_pb2.Schema.TypeName.ROW:
+                return RowType(
+                    [RowField(f.name, _to_data_type(f.type), f.description)
+                     for f in field_type.row_schema.fields], field_type.nullable)
             else:
                 raise ValueError("field_type %s is not supported." % field_type)
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -2333,10 +2333,18 @@ def to_arrow_type(data_type):
         else:
             return pa.timestamp('ns')
     elif type(data_type) == ArrayType:
-        if type(data_type.element_type) == LocalZonedTimestampType:
+        if type(data_type.element_type) in [LocalZonedTimestampType, RowType]:
             raise ValueError("%s is not supported to be used as the element type of ArrayType." %
                              data_type.element_type)
         return pa.list_(to_arrow_type(data_type.element_type))
+    elif type(data_type) == RowType:
+        for field in data_type:
+            if type(field.data_type) in [LocalZonedTimestampType, RowType]:
+                raise TypeError("%s is not supported to be used as the field type of RowType" %
+                                field.data_type)
+        fields = [pa.field(field.name, to_arrow_type(field.data_type), field.data_type._nullable)
+                  for field in data_type]
+        return pa.struct(fields)
     else:
         raise ValueError("field_type %s is not supported." % data_type)
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/RowFieldReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/readers/RowFieldReader.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.readers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.complex.StructVector;
+
+/**
+ * {@link ArrowFieldReader} for Row.
+ */
+@Internal
+public final class RowFieldReader extends ArrowFieldReader<Row> {
+
+	private final ArrowFieldReader[] fieldReaders;
+
+	public RowFieldReader(StructVector structVector, ArrowFieldReader[] fieldReaders) {
+		super(structVector);
+		this.fieldReaders = Preconditions.checkNotNull(fieldReaders);
+	}
+
+	@Override
+	public Row read(int index) {
+		if (getValueVector().isNull(index)) {
+			return null;
+		} else {
+			Row row = new Row(fieldReaders.length);
+			for (int i = 0; i < fieldReaders.length; i++) {
+				row.setField(i, fieldReaders[i].read(index));
+			}
+			return row;
+		}
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowRowColumnVector.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/vectors/ArrowRowColumnVector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.vectors;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.dataformat.ColumnarRow;
+import org.apache.flink.table.dataformat.vector.ColumnVector;
+import org.apache.flink.table.dataformat.vector.RowColumnVector;
+import org.apache.flink.table.dataformat.vector.VectorizedColumnBatch;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.vector.complex.StructVector;
+
+/**
+ * Arrow column vector for Row.
+ */
+@Internal
+public final class ArrowRowColumnVector implements RowColumnVector {
+
+	/**
+	 * Container which is used to store the sequence of row values of a column to read.
+	 */
+	private final StructVector structVector;
+	private final ColumnVector[] fieldColumns;
+
+	public ArrowRowColumnVector(StructVector structVector, ColumnVector[] fieldColumns) {
+		this.structVector = Preconditions.checkNotNull(structVector);
+		this.fieldColumns = Preconditions.checkNotNull(fieldColumns);
+	}
+
+	@Override
+	public ColumnarRow getRow(int i) {
+		VectorizedColumnBatch vectorizedColumnBatch = new VectorizedColumnBatch(fieldColumns);
+		return new ColumnarRow(vectorizedColumnBatch, i);
+	}
+
+	@Override
+	public boolean isNullAt(int i) {
+		return structVector.isNull(i);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowRowWriter.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/writers/RowRowWriter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.writers;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.complex.StructVector;
+
+/**
+ * {@link ArrowFieldWriter} for Row.
+ */
+@Internal
+public final class RowRowWriter extends ArrowFieldWriter<Row> {
+
+	private final ArrowFieldWriter<Row>[] fieldsWriters;
+	private final Row nullRow;
+
+	public RowRowWriter(StructVector structVector, ArrowFieldWriter<Row>[] fieldsWriters) {
+		super(structVector);
+		this.fieldsWriters = fieldsWriters;
+		this.nullRow = new Row(fieldsWriters.length);
+	}
+
+	@Override
+	public void doWrite(Row value, int ordinal) {
+		Row row;
+		if (value.getField(ordinal) == null) {
+			row = nullRow;
+			((StructVector) getValueVector()).setNull(getCount());
+		} else {
+			row = (Row) value.getField(ordinal);
+			((StructVector) getValueVector()).setIndexDefined(getCount());
+		}
+		for (int i = 0; i < fieldsWriters.length; i++) {
+			fieldsWriters[i].write(row, i);
+		}
+	}
+
+	@Override
+	public void finish() {
+		super.finish();
+		for (ArrowFieldWriter<?> fieldsWriter : fieldsWriters) {
+			fieldsWriter.finish();
+		}
+	}
+
+	@Override
+	public void reset() {
+		super.reset();
+		for (ArrowFieldWriter<?> fieldsWriter : fieldsWriters) {
+			fieldsWriter.reset();
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/ArrowUtilsTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.runtime.arrow.readers.DoubleFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.FloatFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.IntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.RowArrowReader;
+import org.apache.flink.table.runtime.arrow.readers.RowFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.SmallIntFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TimeFieldReader;
 import org.apache.flink.table.runtime.arrow.readers.TimestampFieldReader;
@@ -45,6 +46,7 @@ import org.apache.flink.table.runtime.arrow.vectors.ArrowDecimalColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowDoubleColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowFloatColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowIntColumnVector;
+import org.apache.flink.table.runtime.arrow.vectors.ArrowRowColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowSmallIntColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTimeColumnVector;
 import org.apache.flink.table.runtime.arrow.vectors.ArrowTimestampColumnVector;
@@ -69,12 +71,14 @@ import org.apache.flink.table.runtime.arrow.writers.RowDecimalWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowDoubleWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowFloatWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowIntWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowRowWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowSmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowTimeWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowTimestampWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowTinyIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowVarBinaryWriter;
 import org.apache.flink.table.runtime.arrow.writers.RowVarCharWriter;
+import org.apache.flink.table.runtime.arrow.writers.RowWriter;
 import org.apache.flink.table.runtime.arrow.writers.SmallIntWriter;
 import org.apache.flink.table.runtime.arrow.writers.TimeWriter;
 import org.apache.flink.table.runtime.arrow.writers.TimestampWriter;
@@ -112,6 +116,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -177,6 +182,17 @@ public class ArrowUtilsTest {
 			RowTimestampWriter.class, TimestampWriter.class, TimestampFieldReader.class, ArrowTimestampColumnVector.class));
 		testFields.add(Tuple7.of("f25", new ArrayType(new VarCharType()), ArrowType.List.INSTANCE,
 			RowArrayWriter.class, ArrayWriter.class, ArrayFieldReader.class, ArrowArrayColumnVector.class));
+
+		RowType rowFieldType = new RowType(Arrays.asList(
+			new RowType.RowField("a", new IntType()),
+			new RowType.RowField("b", new VarCharType()),
+			new RowType.RowField("c", new ArrayType(new VarCharType())),
+			new RowType.RowField("d", new TimestampType(2)),
+			new RowType.RowField("e", new RowType((Arrays.asList(
+				new RowType.RowField("e1", new IntType()),
+				new RowType.RowField("e2", new VarCharType())))))));
+		testFields.add(Tuple7.of("f26", rowFieldType, ArrowType.Struct.INSTANCE,
+			RowRowWriter.class, RowWriter.class, RowFieldReader.class, ArrowRowColumnVector.class));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (Tuple7<String, LogicalType, ArrowType, Class<?>, Class<?>, Class<?>, Class<?>> field : testFields) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/BaseRowArrowReaderWriterTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.dataformat.BinaryRow;
 import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.GenericArray;
+import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.runtime.typeutils.BaseArraySerializer;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
@@ -58,6 +59,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -67,6 +69,7 @@ import java.util.Objects;
 public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<BaseRow> {
 	private static List<LogicalType> fieldTypes = new ArrayList<>();
 	private static RowType rowType;
+	private static RowType rowFieldType;
 	private static BufferAllocator allocator;
 
 	public BaseRowArrowReaderWriterTest() {
@@ -122,6 +125,15 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		fieldTypes.add(new TimestampType(4));
 		fieldTypes.add(new TimestampType(8));
 		fieldTypes.add(new ArrayType(new VarCharType()));
+		rowFieldType = new RowType(Arrays.asList(
+			new RowType.RowField("a", new IntType()),
+			new RowType.RowField("b", new VarCharType()),
+			new RowType.RowField("c", new ArrayType(new VarCharType())),
+			new RowType.RowField("d", new TimestampType(2)),
+			new RowType.RowField("e", new RowType(Arrays.asList(
+				new RowType.RowField("e1", new IntType()),
+				new RowType.RowField("e2", new VarCharType()))))));
+		fieldTypes.add(rowFieldType);
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -152,21 +164,25 @@ public class BaseRowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Base
 		BaseRow row1 = StreamRecordUtils.baserow((byte) 1, (short) 2, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
-			new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3));
+			new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3),
+			GenericRow.of(1, BinaryString.fromString("hello"), new GenericArray(new BinaryString[] {BinaryString.fromString("hello")}, 1), SqlTimestamp.fromEpochMillis(3600000), GenericRow.of(1, BinaryString.fromString("hello"))));
 		BinaryRow row2 = StreamRecordUtils.binaryrow((byte) 1, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
-			Tuple2.of(new GenericArray(new String[] {null, null, null}, 3), new BaseArraySerializer(new VarCharType(), null)));
+			Tuple2.of(new GenericArray(new String[] {null, null, null}, 3), new BaseArraySerializer(new VarCharType(), null)),
+			Tuple2.of(GenericRow.of(1, null, new GenericArray(new BinaryString[] {BinaryString.fromString("hello")}, 1), null, GenericRow.of(1, BinaryString.fromString("hello"))), new BaseRowSerializer(new ExecutionConfig(), rowFieldType)));
 		BaseRow row3 = StreamRecordUtils.baserow(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
 			SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000), SqlTimestamp.fromEpochMillis(3600000, 100000), SqlTimestamp.fromEpochMillis(3600000, 100000),
-			new GenericArray(new String[] {null, null, null}, 3));
+			new GenericArray(new String[] {null, null, null}, 3),
+			GenericRow.of(1, null, new GenericArray(new BinaryString[] {BinaryString.fromString("hello")}, 1), null, null));
 		BinaryRow row4 = StreamRecordUtils.binaryrow((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), Decimal.fromLong(1, 10, 3), 100, 3600000, 3600000, 3600000, 3600000,
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
 			Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 0), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000), 2), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 4), Tuple2.of(SqlTimestamp.fromEpochMillis(3600000, 100000), 8),
-			Tuple2.of(new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3), new BaseArraySerializer(new VarCharType(), null)));
-		BaseRow row5 = StreamRecordUtils.baserow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
-		BinaryRow row6 = StreamRecordUtils.binaryrow(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+			Tuple2.of(new GenericArray(new BinaryString[] {BinaryString.fromString("hello"), BinaryString.fromString("中文"), null}, 3), new BaseArraySerializer(new VarCharType(), null)),
+			Tuple2.of(GenericRow.of(1, null, new GenericArray(new BinaryString[] {BinaryString.fromString("hello")}, 1), null, null), new BaseRowSerializer(new ExecutionConfig(), rowFieldType)));
+		BaseRow row5 = StreamRecordUtils.baserow(new Object[fieldTypes.size()]);
+		BinaryRow row6 = StreamRecordUtils.binaryrow(new Object[fieldTypes.size()]);
 		return new BaseRow[]{row1, row2, row3, row4, row5, row6};
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -51,6 +51,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -87,6 +88,14 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 		fieldTypes.add(new TimestampType(4));
 		fieldTypes.add(new TimestampType(8));
 		fieldTypes.add(new ArrayType(new VarCharType()));
+		fieldTypes.add(new RowType(Arrays.asList(
+			new RowType.RowField("a", new IntType()),
+			new RowType.RowField("b", new VarCharType()),
+			new RowType.RowField("c", new ArrayType(new VarCharType())),
+			new RowType.RowField("d", new TimestampType(2)),
+			new RowType.RowField("e", new RowType(Arrays.asList(
+				new RowType.RowField("e1", new IntType()),
+				new RowType.RowField("e2", new VarCharType())))))));
 
 		List<RowType.RowField> rowFields = new ArrayList<>();
 		for (int i = 0; i < fieldTypes.size(); i++) {
@@ -118,18 +127,20 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			new String[] {null, null, null});
+			new String[] {null, null, null},
+			Row.of(1, "hello", new String[] {null, null, null}, new Timestamp(3600000), Row.of(1, "hello")));
 		Row row2 = Row.of(null, (short) 2, 3, 4L, false, 1.0f, 1.0, "中文", "中文".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			new String[] {"hello", "中文", null});
+			new String[] {"hello", "中文", null},
+			Row.of(1, "hello", new String[] {"hello", "中文", null}, new Timestamp(3600000), Row.of(1, "hello")));
 		Row row3 = Row.of((byte) 1, null, 3, 4L, true, 1.0f, 1.0, "hello", "hello".getBytes(), new BigDecimal(1), SqlDateTimeUtils.internalToDate(100),
 			SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000), SqlDateTimeUtils.internalToTime(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
 			new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000), new Timestamp(3600000),
-			null);
-		Row row4 = Row.of(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+			null, null);
+		Row row4 = new Row(rowType.getFieldCount());
 		return new Row[]{row1, row2, row3, row4};
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
@@ -140,8 +140,7 @@ public final class ColumnarRow implements BaseRow {
 
 	@Override
 	public BaseRow getRow(int ordinal, int numFields) {
-		// TODO
-		throw new UnsupportedOperationException("Row is not supported.");
+		return vectorizedColumnBatch.getRow(rowId, ordinal);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/RowColumnVector.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/RowColumnVector.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.dataformat.vector;
+
+import org.apache.flink.table.dataformat.ColumnarRow;
+
+/**
+ * Row column vector.
+ */
+public interface RowColumnVector extends ColumnVector {
+	ColumnarRow getRow(int i);
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/vector/VectorizedColumnBatch.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.dataformat.vector;
 
 import org.apache.flink.table.dataformat.BaseArray;
+import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataformat.vector.BytesColumnVector.Bytes;
@@ -120,5 +121,9 @@ public class VectorizedColumnBatch implements Serializable {
 
 	public BaseArray getArray(int rowId, int colId) {
 		return ((ArrayColumnVector) columns[colId]).getArray(rowId);
+	}
+
+	public BaseRow getRow(int rowId, int colId) {
+		return ((RowColumnVector) columns[colId]).getRow(rowId);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.SqlTimestamp;
 import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.typeutils.BaseArraySerializer;
+import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
 
@@ -132,6 +133,10 @@ public class StreamRecordUtils {
 				BaseArray array = (BaseArray) ((Tuple2) value).f0;
 				BaseArraySerializer serializer = (BaseArraySerializer) ((Tuple2) value).f1;
 				writer.writeArray(j, array, serializer);
+			} else if (value instanceof Tuple2 && ((Tuple2) value).f0 instanceof BaseRow) {
+				BaseRow baseRow = (BaseRow) ((Tuple2) value).f0;
+				BaseRowSerializer baseRowSerializer = (BaseRowSerializer) ((Tuple2) value).f1;
+				writer.writeRow(j, baseRow, baseRowSerializer);
 			} else {
 				throw new RuntimeException("Not support yet!");
 			}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add support of RowType in vectorized Python UDF.*

## Brief change log

  - *Introduce row column vector in blink*
  - *Introduce ArrowRowColumnVector, RowWriter, etc to support RowType in vectorized Python UDF*


## Verifying this change


This change added tests and can be verified as follows:

  - *Java test cases ArrowUtilsTest, BaseRowArrowReaderWriterTest and RowArrowReaderWriterTest*
  - *Python test case test_pandas_udf.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
