### PR TITLE
[FLINK-16696][rest] Properly document async responses 

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -2256,7 +2256,13 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
   "properties" : {
     "operation" : {
-      "type" : "any"
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationInfo",
+      "properties" : {
+        "failure-cause" : {
+          "type" : "any"
+        }
+      }
     },
     "status" : {
       "type" : "object",
@@ -2387,7 +2393,16 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
   "properties" : {
     "operation" : {
-      "type" : "any"
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:savepoints:SavepointInfo",
+      "properties" : {
+        "failure-cause" : {
+          "type" : "any"
+        },
+        "location" : {
+          "type" : "string"
+        }
+      }
     },
     "status" : {
       "type" : "object",
@@ -3760,7 +3775,13 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
   "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationResult",
   "properties" : {
     "operation" : {
-      "type" : "any"
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:handler:async:AsynchronousOperationInfo",
+      "properties" : {
+        "failure-cause" : {
+          "type" : "any"
+        }
+      }
     },
     "status" : {
       "type" : "object",

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RestAPIDocGenerator.java
@@ -19,6 +19,8 @@
 package org.apache.flink.docs.rest;
 
 import org.apache.flink.runtime.rest.RestServerEndpoint;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationResult;
+import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationStatusMessageHeaders;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
@@ -39,6 +41,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.module.jsonSchema.
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -129,11 +133,17 @@ public class RestAPIDocGenerator {
 	}
 
 	private static String createHtmlEntry(MessageHeaders<?, ?, ?> spec) {
+		Class<?> nestedAsyncOperationResultClass = null;
+		if (spec instanceof AsynchronousOperationStatusMessageHeaders) {
+			nestedAsyncOperationResultClass = ((AsynchronousOperationStatusMessageHeaders<?, ?>) spec).getValueClass();
+		}
 		String requestEntry = createMessageHtmlEntry(
 			spec.getRequestClass(),
+			null,
 			EmptyRequestBody.class);
 		String responseEntry = createMessageHtmlEntry(
 			spec.getResponseClass(),
+			nestedAsyncOperationResultClass,
 			EmptyResponseBody.class);
 
 		String pathParameterList = createPathParameterHtmlList(spec.getUnresolvedMessageParameters().getPathParameters());
@@ -237,13 +247,12 @@ public class RestAPIDocGenerator {
 		return queryParameterList.toString();
 	}
 
-	private static String createMessageHtmlEntry(Class<?> messageClass, Class<?> emptyMessageClass) {
-		JsonSchema schema;
-		try {
-			schema = schemaGen.generateSchema(messageClass);
-		} catch (JsonProcessingException e) {
-			LOG.error("Failed to generate message schema for class {}.", messageClass, e);
-			throw new RuntimeException("Failed to generate message schema for class " + messageClass.getCanonicalName() + ".", e);
+	private static String createMessageHtmlEntry(Class<?> messageClass, @Nullable Class<?> nestedAsyncOperationResultClass, Class<?> emptyMessageClass) {
+		JsonSchema schema = generateSchema(messageClass);
+
+		if (nestedAsyncOperationResultClass != null) {
+			JsonSchema innerSchema = generateSchema(nestedAsyncOperationResultClass);
+			schema.asObjectSchema().getProperties().put(AsynchronousOperationResult.FIELD_NAME_OPERATION, innerSchema);
 		}
 
 		String json;
@@ -260,6 +269,15 @@ public class RestAPIDocGenerator {
 		}
 
 		return json;
+	}
+
+	private static JsonSchema generateSchema(Class<?> messageClass) {
+		try {
+			return schemaGen.generateSchema(messageClass);
+		} catch (JsonProcessingException e) {
+			LOG.error("Failed to generate message schema for class {}.", messageClass, e);
+			throw new RuntimeException("Failed to generate message schema for class " + messageClass.getCanonicalName() + ".", e);
+		}
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationResult.java
@@ -36,7 +36,7 @@ public class AsynchronousOperationResult<V> implements AsynchronouslyCreatedReso
 
 	private static final String FIELD_NAME_STATUS = "status";
 
-	private static final String FIELD_NAME_OPERATION = "operation";
+	public static final String FIELD_NAME_OPERATION = "operation";
 
 	@JsonProperty(FIELD_NAME_STATUS)
 	private final QueueStatus queueStatus;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationStatusMessageHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/async/AsynchronousOperationStatusMessageHeaders.java
@@ -38,7 +38,7 @@ public abstract class AsynchronousOperationStatusMessageHeaders<V, M extends Mes
 	 *
 	 * @return value class
 	 */
-	protected abstract Class<V> getValueClass();
+	public abstract Class<V> getValueClass();
 
 	@Override
 	public Class<AsynchronousOperationResult<V>> getResponseClass() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/rescaling/RescalingStatusHeaders.java
@@ -43,7 +43,7 @@ public class RescalingStatusHeaders extends
 	private RescalingStatusHeaders() {}
 
 	@Override
-	protected Class<AsynchronousOperationInfo> getValueClass() {
+	public Class<AsynchronousOperationInfo> getValueClass() {
 		return AsynchronousOperationInfo.class;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/savepoints/SavepointHandlers.java
@@ -91,7 +91,7 @@ import java.util.concurrent.CompletableFuture;
  *     "status": {
  *         "id": "COMPLETED"
  *     },
- *     "savepoint": {
+ *     "operation": {
  *         "location": "/tmp/savepoint-d9813b-8a68e674325b"
  *     }
  * }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointDisposalStatusHeaders.java
@@ -69,7 +69,7 @@ public class SavepointDisposalStatusHeaders extends AsynchronousOperationStatusM
 	}
 
 	@Override
-	protected Class<AsynchronousOperationInfo> getValueClass() {
+	public Class<AsynchronousOperationInfo> getValueClass() {
 		return AsynchronousOperationInfo.class;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/savepoints/SavepointStatusHeaders.java
@@ -72,7 +72,7 @@ public class SavepointStatusHeaders
 	}
 
 	@Override
-	protected Class<SavepointInfo> getValueClass() {
+	public Class<SavepointInfo> getValueClass() {
 		return SavepointInfo.class;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/async/AbstractAsynchronousOperationHandlersTest.java
@@ -297,7 +297,7 @@ public class AbstractAsynchronousOperationHandlersTest extends TestLogger {
 		private TestingStatusMessageHeaders() {}
 
 		@Override
-		protected Class<OperationResult> getValueClass() {
+		public Class<OperationResult> getValueClass() {
 			return OperationResult.class;
 		}
 


### PR DESCRIPTION
Fixes an issue where the REST API status response for asynchronous operations wasn't documented properly.

The async operation result has a generic parameter, which obviously doesn't work with the REST API generation since it relies on classes. As a result the generator always considered the inner (generic) result as an `Object`, basically not documenting anything.

This PR provides a stop-gap solution by hard-coding additional logic for `AsynchronousOperationStatusMessageHeaders`.
I exposed the inner class by making `AsynchronousOperationStatusMessageHeaders#getValueClass` public, generate a separate schema for it, and overwrite the corresponding property entry of the outer schema.
