### PR TITLE
[FLINK-17036] Datadog EU site parameter

### DIFF
--- a/docs/monitoring/metrics.md
+++ b/docs/monitoring/metrics.md
@@ -767,6 +767,7 @@ Parameters:
 - `tags` - (optional) the global tags that will be applied to metrics when sending to Datadog. Tags should be separated by comma only
 - `proxyHost` - (optional) The proxy host to use when sending to Datadog.
 - `proxyPort` - (optional) The proxy port to use when sending to Datadog, defaults to 8080.
+- `dataCenter` - (optional) The data center (`EU`/`US`) to connect to, defaults to `US`.
 
 Example configuration:
 
@@ -777,6 +778,7 @@ metrics.reporter.dghttp.apikey: xxx
 metrics.reporter.dghttp.tags: myflinkapp,prod
 metrics.reporter.dghttp.proxyHost: my.web.proxy.com
 metrics.reporter.dghttp.proxyPort: 8080
+metrics.reporter.dhhttp.dataCenter: US
 
 {% endhighlight %}
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DataCenter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DataCenter.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.datadog;
+
+/**
+ * The data center to connect to.
+ */
+enum DataCenter {
+	US("com"),
+	EU("eu");
+
+	private final String domain;
+
+	DataCenter(String domain) {
+		this.domain = domain;
+	}
+
+	public String getDomain() {
+		return domain;
+	}
+}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -123,7 +123,7 @@ public class DatadogHttpClient {
 	}
 
 	/**
-	 * A handler for OkHttpClient callback. In case of error or failure it logs the error at warning level.
+	 * A handler for OkHttpClient callback.  In case of error or failure it logs the error at warning level.
 	 */
 	protected static class EmptyCallback implements Callback {
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -56,8 +56,7 @@ public class DatadogHttpClient {
 	private final String proxyHost;
 	private final int proxyPort;
 
-	public DatadogHttpClient(String dgApiKey, String dgProxyHost, int dgProxyPort, DataCenter dataCenter,
-			boolean validateApiKey) {
+	public DatadogHttpClient(String dgApiKey, String dgProxyHost, int dgProxyPort, DataCenter dataCenter, boolean validateApiKey) {
 		if (dgApiKey == null || dgApiKey.isEmpty()) {
 			throw new IllegalArgumentException("Invalid API key:" + dgApiKey);
 		}

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -67,8 +67,11 @@ public class DatadogHttpClient {
 
 		Proxy proxy = getProxy();
 
-		client = new OkHttpClient.Builder().connectTimeout(TIMEOUT, TimeUnit.SECONDS)
-				.writeTimeout(TIMEOUT, TimeUnit.SECONDS).readTimeout(TIMEOUT, TimeUnit.SECONDS).proxy(proxy).build();
+		client = new OkHttpClient.Builder()
+			.connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+			.writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+			.readTimeout(TIMEOUT, TimeUnit.SECONDS)
+			.proxy(proxy).build();
 
 		seriesUrl = String.format(SERIES_URL_FORMAT, dataCenter.getDomain(), apiKey);
 		validateUrl = String.format(VALIDATE_URL_FORMAT, dataCenter.getDomain(), apiKey);
@@ -91,7 +94,8 @@ public class DatadogHttpClient {
 
 		try (Response response = client.newCall(r).execute()) {
 			if (!response.isSuccessful()) {
-				throw new IllegalArgumentException(String.format("API key: %s is invalid", apiKey));
+				throw new IllegalArgumentException(
+					String.format("API key: %s is invalid", apiKey));
 			}
 		} catch (IOException e) {
 			throw new IllegalStateException("Failed contacting Datadog to validate API key", e);
@@ -101,7 +105,10 @@ public class DatadogHttpClient {
 	public void send(DSeries request) throws Exception {
 		String postBody = serialize(request);
 
-		Request r = new Request.Builder().url(seriesUrl).post(RequestBody.create(MEDIA_TYPE, postBody)).build();
+		Request r = new Request.Builder()
+			.url(seriesUrl)
+			.post(RequestBody.create(MEDIA_TYPE, postBody))
+			.build();
 
 		client.newCall(r).enqueue(EmptyCallback.getEmptyCallback());
 	}
@@ -116,8 +123,7 @@ public class DatadogHttpClient {
 	}
 
 	/**
-	 * A handler for OkHttpClient callback. In case of error or failure it logs the
-	 * error at warning level.
+	 * A handler for OkHttpClient callback. In case of error or failure it logs the error at warning level.
 	 */
 	protected static class EmptyCallback implements Callback {
 

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -70,7 +70,8 @@ public class DatadogHttpClient {
 			.connectTimeout(TIMEOUT, TimeUnit.SECONDS)
 			.writeTimeout(TIMEOUT, TimeUnit.SECONDS)
 			.readTimeout(TIMEOUT, TimeUnit.SECONDS)
-			.proxy(proxy).build();
+			.proxy(proxy)
+			.build();
 
 		seriesUrl = String.format(SERIES_URL_FORMAT, dataCenter.getDomain(), apiKey);
 		validateUrl = String.format(VALIDATE_URL_FORMAT, dataCenter.getDomain(), apiKey);

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpClient.java
@@ -42,10 +42,8 @@ import java.util.concurrent.TimeUnit;
 public class DatadogHttpClient {
 	private static final Logger LOGGER = LoggerFactory.getLogger(DatadogHttpClient.class);
 
-	private static final String SERIES_URL_FORMAT_US = "https://app.datadoghq.com/api/v1/series?api_key=%s";
-	private static final String VALIDATE_URL_FORMAT_US = "https://app.datadoghq.com/api/v1/validate?api_key=%s";
-	private static final String SERIES_URL_FORMAT_EU = "https://app.datadoghq.eu/api/v1/series?api_key=%s";
-	private static final String VALIDATE_URL_FORMAT_EU = "https://app.datadoghq.eu/api/v1/validate?api_key=%s";
+	private static final String SERIES_URL_FORMAT = "https://app.datadoghq.%s/api/v1/series?api_key=%s";
+	private static final String VALIDATE_URL_FORMAT = "https://app.datadoghq.%s/api/v1/validate?api_key=%s";
 	private static final MediaType MEDIA_TYPE = MediaType.parse("application/json; charset=utf-8");
 	private static final int TIMEOUT = 3;
 	private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -57,9 +55,8 @@ public class DatadogHttpClient {
 
 	private final String proxyHost;
 	private final int proxyPort;
-	private final String dataCenter;
 
-	public DatadogHttpClient(String dgApiKey, String dgProxyHost, int dgProxyPort, String dgDataCenter,
+	public DatadogHttpClient(String dgApiKey, String dgProxyHost, int dgProxyPort, DataCenter dataCenter,
 			boolean validateApiKey) {
 		if (dgApiKey == null || dgApiKey.isEmpty()) {
 			throw new IllegalArgumentException("Invalid API key:" + dgApiKey);
@@ -67,20 +64,14 @@ public class DatadogHttpClient {
 		apiKey = dgApiKey;
 		proxyHost = dgProxyHost;
 		proxyPort = dgProxyPort;
-		dataCenter = dgDataCenter;
 
 		Proxy proxy = getProxy();
 
 		client = new OkHttpClient.Builder().connectTimeout(TIMEOUT, TimeUnit.SECONDS)
 				.writeTimeout(TIMEOUT, TimeUnit.SECONDS).readTimeout(TIMEOUT, TimeUnit.SECONDS).proxy(proxy).build();
-		if (dataCenter.equals("US")){
-			seriesUrl = String.format(SERIES_URL_FORMAT_US, apiKey);
-			validateUrl = String.format(VALIDATE_URL_FORMAT_US, apiKey);
-		}
-		else {
-			seriesUrl = String.format(SERIES_URL_FORMAT_EU, apiKey);
-			validateUrl = String.format(VALIDATE_URL_FORMAT_EU, apiKey);
-		}
+
+		seriesUrl = String.format(SERIES_URL_FORMAT, dataCenter.getDomain(), apiKey);
+		validateUrl = String.format(VALIDATE_URL_FORMAT, dataCenter.getDomain(), apiKey);
 
 		if (validateApiKey) {
 			validateApiKey();

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -60,7 +60,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	public static final String API_KEY = "apikey";
 	public static final String PROXY_HOST = "proxyHost";
 	public static final String PROXY_PORT = "proxyPort";
-	public static final String DATACENTER = "dataCenter";
+	public static final String DATA_CENTER = "dataCenter";
 	public static final String TAGS = "tags";
 
 	@Override
@@ -110,14 +110,15 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 		String apiKey = config.getString(API_KEY, null);
 		String proxyHost = config.getString(PROXY_HOST, null);
 		Integer proxyPort = config.getInteger(PROXY_PORT, 8080);
-		String dataCenter = config.getString(DATACENTER, null);
+		String rawDataCenter = config.getString(DATA_CENTER, "US");
+		DataCenter dataCenter = DataCenter.valueOf(rawDataCenter);
 		String tags = config.getString(TAGS, "");
 
 		client = new DatadogHttpClient(apiKey, proxyHost, proxyPort, dataCenter, true);
 
 		configTags = getTagsFromConfig(tags);
 
-		LOGGER.info("Configured DatadogHttpReporter with {tags={}, proxyHost={}, proxyPort={}}", tags, proxyHost, proxyPort);
+		LOGGER.info("Configured DatadogHttpReporter with {tags={}, proxyHost={}, proxyPort={}, dataCenter={}", tags, proxyHost, proxyPort, dataCenter);
 	}
 
 	@Override

--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -60,6 +60,7 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 	public static final String API_KEY = "apikey";
 	public static final String PROXY_HOST = "proxyHost";
 	public static final String PROXY_PORT = "proxyPort";
+	public static final String DATACENTER = "dataCenter";
 	public static final String TAGS = "tags";
 
 	@Override
@@ -109,9 +110,10 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
 		String apiKey = config.getString(API_KEY, null);
 		String proxyHost = config.getString(PROXY_HOST, null);
 		Integer proxyPort = config.getInteger(PROXY_PORT, 8080);
+		String dataCenter = config.getString(DATACENTER, null);
 		String tags = config.getString(TAGS, "");
 
-		client = new DatadogHttpClient(apiKey, proxyHost, proxyPort, true);
+		client = new DatadogHttpClient(apiKey, proxyHost, proxyPort, dataCenter, true);
 
 		configTags = getTagsFromConfig(tags);
 

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -45,7 +45,7 @@ public class DatadogHttpClientTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithEmptyKey() {
-		new DatadogHttpClient("", null, 123, DataCenter.US,  false);
+		new DatadogHttpClient("", null, 123, DataCenter.US, false);
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -45,23 +45,23 @@ public class DatadogHttpClientTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithEmptyKey() {
-		new DatadogHttpClient("", null, 123, null,  false);
+		new DatadogHttpClient("", null, 123, DataCenter.US,  false);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithNullKey() {
-		new DatadogHttpClient(null, null, 123, null, false);
+		new DatadogHttpClient(null, null, 123, DataCenter.US, false);
 	}
 
 	@Test
 	public void testGetProxyWithNullProxyHost() {
-		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123, null, false);
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123, DataCenter.US, false);
 		assert(client.getProxy() == Proxy.NO_PROXY);
 	}
 
 	@Test
 	public void testGetProxy() {
-		DatadogHttpClient client = new DatadogHttpClient("anApiKey", "localhost", 123, null, false);
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", "localhost", 123, DataCenter.US, false);
 
 		assertTrue(client.getProxy().address() instanceof InetSocketAddress);
 

--- a/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
+++ b/flink-metrics/flink-metrics-datadog/src/test/java/org/apache/flink/metrics/datadog/DatadogHttpClientTest.java
@@ -45,23 +45,23 @@ public class DatadogHttpClientTest {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithEmptyKey() {
-		new DatadogHttpClient("", null, 123, false);
+		new DatadogHttpClient("", null, 123, null,  false);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testClientWithNullKey() {
-		new DatadogHttpClient(null, null, 123, false);
+		new DatadogHttpClient(null, null, 123, null, false);
 	}
 
 	@Test
 	public void testGetProxyWithNullProxyHost() {
-		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123, false);
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", null, 123, null, false);
 		assert(client.getProxy() == Proxy.NO_PROXY);
 	}
 
 	@Test
 	public void testGetProxy() {
-		DatadogHttpClient client = new DatadogHttpClient("anApiKey", "localhost", 123, false);
+		DatadogHttpClient client = new DatadogHttpClient("anApiKey", "localhost", 123, null, false);
 
 		assertTrue(client.getProxy().address() instanceof InetSocketAddress);
 


### PR DESCRIPTION
Please note I am a current Datadog employee.

## What is the purpose of the change
This pull request adds the option to specify the EU site param for Datadog.

## Brief change log
  - Adds an additional param for this

## Verifying this change
This change is already covered by existing tests, such as *DatadogHttpClientTest.java*.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

No to all.

## Documentation

  - Does this pull request introduce a new feature? Yes, Datadog docs and also Apache docs need updated and if this goes through will need to be done.
  - If yes, how is the feature documented? not documented yet.
