### PR TITLE
[FLINK-16820][jdbc] support reading timestamp, data, and time in JDBCTableSource

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcTypeUtil.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcTypeUtil.java
@@ -24,11 +24,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ObjectArrayTypeInfo;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.inference.TypeTransformations;
+import org.apache.flink.table.types.utils.DataTypeUtils;
 
-import java.sql.Date;
-import java.sql.Time;
-import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.HashMap;
@@ -117,17 +115,7 @@ class JdbcTypeUtil {
 		schema.getTableColumns()
 			.forEach(c -> {
 				if (!c.isGenerated()) {
-					LogicalTypeRoot root = c.getType().getLogicalType().getTypeRoot();
-					final DataType type;
-					if (root == LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE) {
-						type = c.getType().bridgedTo(Timestamp.class);
-					} else if (root == LogicalTypeRoot.DATE) {
-						type = c.getType().bridgedTo(Date.class);
-					} else if (root == LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE) {
-						type = c.getType().bridgedTo(Time.class);
-					} else {
-						type = c.getType();
-					}
+					final DataType type = DataTypeUtils.transform(c.getType(), TypeTransformations.timeToSqlTypes());
 					physicalSchemaBuilder.field(c.getName(), type);
 				}
 			});

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/dialect/JDBCDialects.java
@@ -407,7 +407,6 @@ public final class JDBCDialects {
 			//  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in LegacyTypeInfoDataTypeConverter.
 			return Arrays.asList(
 					LogicalTypeRoot.BINARY,
-					LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
 					LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE,
 					LogicalTypeRoot.INTERVAL_YEAR_MONTH,
 					LogicalTypeRoot.INTERVAL_DAY_TIME,

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
@@ -27,6 +27,7 @@ import java.sql.SQLException;
 /**
  * Convert row from JDBC result set to a Flink row.
  */
+@FunctionalInterface
 public interface JDBCRowConverter extends Serializable {
 
 	/**
@@ -36,4 +37,12 @@ public interface JDBCRowConverter extends Serializable {
 	 * @param reuse The row to set
 	 */
 	Row convert(ResultSet resultSet, Row reuse) throws SQLException;
+
+	/**
+	 * Runtime converter to convert JDBC field to Java objects.
+	 */
+	@FunctionalInterface
+	interface JDBCFieldConverter extends Serializable {
+		Object convert(Object value);
+	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -78,6 +78,16 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		assertEquals("[1]", results.toString());
 	}
 
+	@Test
+	public void testPrimitiveTypes() throws Exception {
+		TableEnvironment tEnv = getTableEnvWithPgCatalog();
+
+		List<Row> results = TableUtils.collectToList(
+			tEnv.sqlQuery(String.format("select * from %s", TABLE_PRIMITIVE_TYPE)));
+
+		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03]", results.toString());
+	}
+
 	private TableEnvironment getTableEnvWithPgCatalog() {
 		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
 		TableEnvironment tableEnv = TableEnvironment.create(settings);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.apache.flink.api.java.io.jdbc.catalog.PostgresCatalog.DEFAULT_DATABASE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -61,20 +62,20 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	public void testDbExists() throws Exception {
 		assertFalse(catalog.databaseExists("nonexistent"));
 
-		assertTrue(catalog.databaseExists(PostgresCatalog.DEFAULT_DATABASE));
+		assertTrue(catalog.databaseExists(DEFAULT_DATABASE));
 	}
 
 	// ------ tables ------
 
 	@Test
 	public void testListTables() throws DatabaseNotExistException {
-		List<String> actual = catalog.listTables(PostgresCatalog.DEFAULT_DATABASE);
+		List<String> actual = catalog.listTables(DEFAULT_DATABASE);
 
-		assertEquals(Arrays.asList("public.t1", "public.t4", "public.t5"), actual);
+		assertEquals(Arrays.asList("public.dt", "public.t1", "public.t4", "public.t5"), actual);
 
 		actual = catalog.listTables(TEST_DB);
 
-		assertEquals(Arrays.asList("public.datatypes", "public.t2", "test_schema.t3"), actual);
+		assertEquals(Arrays.asList("public.t2", "test_schema.t3"), actual);
 	}
 
 	@Test
@@ -87,7 +88,7 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	public void testTableExists() {
 		assertFalse(catalog.tableExists(new ObjectPath(TEST_DB, "nonexist")));
 
-		assertTrue(catalog.tableExists(new ObjectPath(PostgresCatalog.DEFAULT_DATABASE, TABLE1)));
+		assertTrue(catalog.tableExists(new ObjectPath(DEFAULT_DATABASE, TABLE1)));
 		assertTrue(catalog.tableExists(new ObjectPath(TEST_DB, TABLE2)));
 		assertTrue(catalog.tableExists(new ObjectPath(TEST_DB, "test_schema.t3")));
 	}
@@ -140,9 +141,9 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	}
 
 	@Test
-	public void testDataTypes() throws TableNotExistException {
-		CatalogBaseTable table = catalog.getTable(new ObjectPath(TEST_DB, "datatypes"));
+	public void testPrimitiveDataTypes() throws TableNotExistException {
+		CatalogBaseTable table = catalog.getTable(new ObjectPath(DEFAULT_DATABASE, TABLE_PRIMITIVE_TYPE));
 
-		assertEquals(getDataTypesTable().schema, table.getSchema());
+		assertEquals(getPrimitiveTable().schema, table.getSchema());
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

commit 1: fix bug that JDBCInputFormat doesn't correctly map Short, by introducing field converters
commit2:  support reading timestamp, data, and time in JDBCTableSource
commit3:  add e2e tests for reading primitive data types from postgres with JDBCTableSource and PostgresCatalog

## Brief change log


## Verifying this change

see tests added

## Does this pull request potentially affect one of the following parts:

N/A

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

docs will be added later