### PR TITLE
[FLINK-17040][tests] Fix SavepointWriterITCase failure because of UnsupportedOperationException

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -239,7 +239,7 @@ public class SavepointEnvironment implements Environment {
 
 	@Override
 	public ResultPartitionWriter[] getAllWriters() {
-		throw new UnsupportedOperationException(ERROR_MSG);
+		return new ResultPartitionWriter[0];
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

Fix ```SavepointWriterITCase``` failure because of ```UnsupportedOperationException```. As figured out in FLINK-17040, the problem is caused by FLINK-16537.


## Brief change log

  - Implement ```SavepointEnvironment#getAllWriters``` and return ```new ResultPartitionWriter[0]``` instead of throwing ```UnsupportedOperationException```.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
