### PR TITLE
[FLINK-15936] Harden TaskExecutorTest#testSlotAcceptance

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -1802,11 +1802,15 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 					// filter out outdated connections
 					//noinspection ObjectEquality
 					if (resourceManagerConnection == connection) {
-						establishResourceManagerConnection(
-							resourceManagerGateway,
-							resourceManagerId,
-							taskExecutorRegistrationId,
-							clusterInformation);
+						try {
+							establishResourceManagerConnection(
+								resourceManagerGateway,
+								resourceManagerId,
+								taskExecutorRegistrationId,
+								clusterInformation);
+						} catch (Throwable t) {
+							log.error("Establishing Resource Manager connection in Task Executor failed", t);
+						}
 					}
 				});
 		}


### PR DESCRIPTION
## What is the purpose of the change

### Concurrent  `TaskSlotTable` access in the unstable test

The test called `taskSlotTable.allocateSlot` from the test main thread,
concurrently with `taskSlotTable.createSlotReport `while trying to register
RM in the main TM thread. This silently failed the RM registration in `TM.runAsync`.
As a result, RM.notifySlotAvailable was not called in TM.
The taskSlotTable is not thread-safe and must be accessed only from the main RPC thread of TM.

### Failure in `establishResourceManagerConnection`

Failure of `TaskExecutor#establishResourceManagerConnection` is not expected.
It completely breaks the connection mechanism to RM in TM.
As a hotfix, the PR suggests to log it on error level at least.
Alternatively, we can consider calling `TM.onFatalError` as a follow-up.

## Brief change log

The PR refactors the test to wait properly for RM registration
and allocate slots through gateway in TM thread.
The PR also uses proper testing RM/JM instead of mocks.

## Verifying this change

To verify, the test has been looped locally 30k times.