### PR TITLE
[FLINK-9429] run-single-test.sh: fix order of "imports"

### DIFF
--- a/flink-end-to-end-tests/run-single-test.sh
+++ b/flink-end-to-end-tests/run-single-test.sh
@@ -46,8 +46,8 @@ if [ -z "$FLINK_DIR" ] ; then
     exit 1
 fi
 
-source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 source "${END_TO_END_DIR}/../tools/ci/maven-utils.sh"
+source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 
 cleanup_tmp_files
 


### PR DESCRIPTION
Some e2e tests that rely on FLINK_VERSION being set, such as
test_quickstarts.sh, didn't work with run-single-test.sh before.

The reason the tests didn't work locally is that run-single-test.sh has
the order of "imports" wrong. i.e. we have:

 source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 source "${END_TO_END_DIR}/../tools/ci/maven-utils.sh"

while run-nightly-tests.sh has:

 source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 source "${END_TO_END_DIR}/../tools/ci/maven-utils.sh"

This leads to this line failing in test-runner-common.sh because mvn_run
is not available:

  export FLINK_VERSION=$(MVN_RUN_VERBOSE=false run_mvn --file ${END_TO_END_DIR}/pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)

## Brief change log

 - fix order of sourcing

## Verifying this change

 - can be verified locally by running the quickstarts e2e test, for example.

## Does this pull request potentially affect one of the following parts:

  - None

## Documentation

  - Does this pull request introduce a new feature? no

