### PR TITLE
[FLINK-16761][python]Return JobExecutionResult for Python ExecutionEnvironment and TableEnvironment

### DIFF
--- a/flink-python/pyflink/common/__init__.py
+++ b/flink-python/pyflink/common/__init__.py
@@ -26,6 +26,7 @@ from pyflink.common.configuration import Configuration
 from pyflink.common.execution_config import ExecutionConfig
 from pyflink.common.execution_mode import ExecutionMode
 from pyflink.common.input_dependency_constraint import InputDependencyConstraint
+from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies, RestartStrategyConfiguration
 
 __all__ = [
@@ -33,6 +34,7 @@ __all__ = [
     'ExecutionConfig',
     'ExecutionMode',
     'InputDependencyConstraint',
+    'JobExecutionResult',
     'RestartStrategies',
     'RestartStrategyConfiguration',
 ]

--- a/flink-python/pyflink/common/job_execution_result.py
+++ b/flink-python/pyflink/common/job_execution_result.py
@@ -1,0 +1,96 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['JobExecutionResult']
+
+
+class JobExecutionResult(object):
+    """
+    The result of a job execution. Gives access to the execution time of the job,
+    and to all accumulators created by this job.
+    """
+
+    def __init__(self, j_job_execution_result):
+        self._j_job_execution_result = j_job_execution_result
+
+    def get_job_id(self):
+        """
+        Returns the JobID assigned to the job by the Flink runtime.
+
+        :return: JobID, or null if the job has been executed on a runtime without JobIDs
+                 or if the execution failed.
+        """
+        return self._j_job_execution_result.getJobID()
+
+    def is_job_execution_result(self):
+        """
+        Checks if this JobSubmissionResult is also a JobExecutionResult.
+
+        .. seealso:: :func:`get_job_execution_result` to retrieve the JobExecutionResult.
+
+        :return: ``True`` if this is a JobExecutionResult, ``False`` otherwise.
+        """
+        return self._j_job_execution_result.isJobExecutionResult()
+
+    def get_job_execution_result(self):
+        """
+        Returns the JobExecutionResult if available.
+
+        :throws: Exception if this is not a JobExecutionResult.
+        :return: The JobExecutionResult.
+        """
+        return self
+
+    def get_net_runtime(self):
+        """
+        Gets the net execution time of the job, i.e., the execution time in the parallel system,
+        without the pre-flight steps like the optimizer.
+
+        :return: The net execution time in milliseconds.
+        """
+        return self._j_job_execution_result.getNetRuntime()
+
+    def get_accumulator_result(self, accumulator_name):
+        """
+        Gets the accumulator with the given name. Returns None, if no accumulator with
+        that name was produced.
+
+        :param accumulator_name: The name of the accumulator.
+        :return: The value of the accumulator with the given name.
+        """
+        return self.get_all_accumulator_results().get(accumulator_name)
+
+    def get_all_accumulator_results(self):
+        """
+        Gets all accumulators produced by the job. The map contains the accumulators as
+        mappings from the accumulator name to the accumulator value.
+
+        :return: The dict which the keys are names of the accumulator and the values
+                 are values of the accumulator produced by the job.
+        """
+        j_result_map = self._j_job_execution_result.getAllAccumulatorResults()
+        accumulators = {}
+        for key in j_result_map:
+            accumulators[key] = j_result_map[key]
+        return accumulators
+
+    def to_string(self):
+        """
+        Convert JobExecutionResult to a string, if possible.
+        """
+        return self._j_job_execution_result.toString()

--- a/flink-python/pyflink/dataset/execution_environment.py
+++ b/flink-python/pyflink/dataset/execution_environment.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.common.execution_config import ExecutionConfig
+from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies
 from pyflink.java_gateway import get_gateway
 from pyflink.util.utils import load_java_class
@@ -159,11 +160,12 @@ class ExecutionEnvironment(object):
         The program execution will be logged and displayed with the given job name.
 
         :param job_name: Desired name of the job, optional.
+        :return: The result of the job execution, containing elapsed time and accumulators.
         """
         if job_name is None:
-            self._j_execution_environment.execute()
+            return JobExecutionResult(self._j_execution_environment.execute())
         else:
-            self._j_execution_environment.execute(job_name)
+            return JobExecutionResult(self._j_execution_environment.execute(job_name))
 
     def get_execution_plan(self):
         """

--- a/flink-python/pyflink/dataset/tests/test_execution_environment.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment.py
@@ -18,9 +18,10 @@
 import json
 import os
 import tempfile
+import time
 
-from pyflink.dataset import ExecutionEnvironment
 from pyflink.common import ExecutionConfig, RestartStrategies
+from pyflink.dataset import ExecutionEnvironment
 from pyflink.table import DataTypes, BatchTableEnvironment, CsvTableSource, CsvTableSink
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
@@ -113,3 +114,22 @@ class ExecutionEnvironmentTests(PyFlinkTestCase):
         plan = self.env.get_execution_plan()
 
         json.loads(plan)
+
+    def test_execute(self):
+        tmp_dir = tempfile.gettempdir()
+        field_names = ['a', 'b', 'c']
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env = BatchTableEnvironment.create(self.env)
+        t_env.register_table_sink(
+            'Results',
+            CsvTableSink(field_names, field_types,
+                         os.path.join('{}/{}.csv'.format(tmp_dir, round(time.time())))))
+        t_env.insert_into('Results', t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c']))
+        execution_result = self.env.execute('test_batch_execute')
+        self.assertIsNotNone(execution_result.get_job_id())
+        self.assertTrue(execution_result.is_job_execution_result())
+        self.assertIsNotNone(execution_result.get_job_execution_result().get_job_id())
+        self.assertIsNotNone(execution_result.get_net_runtime())
+        self.assertEqual(len(execution_result.get_all_accumulator_results()), 0)
+        self.assertIsNone(execution_result.get_accumulator_result('accumulator'))
+        self.assertIsNotNone(execution_result.to_string())

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.common.execution_config import ExecutionConfig
+from pyflink.common.job_execution_result import JobExecutionResult
 from pyflink.common.restart_strategy import RestartStrategies
 from pyflink.datastream.checkpoint_config import CheckpointConfig
 from pyflink.datastream.checkpointing_mode import CheckpointingMode
@@ -402,11 +403,12 @@ class StreamExecutionEnvironment(object):
         The program execution will be logged and displayed with the provided name
 
         :param job_name: Desired name of the job, optional.
+        :return: The result of the job execution, containing elapsed time and accumulators.
         """
         if job_name is None:
-            self._j_stream_execution_environment.execute()
+            return JobExecutionResult(self._j_stream_execution_environment.execute())
         else:
-            self._j_stream_execution_environment.execute(job_name)
+            return JobExecutionResult(self._j_stream_execution_environment.execute(job_name))
 
     def get_execution_plan(self):
         """

--- a/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/tests/test_stream_execution_environment.py
@@ -18,6 +18,7 @@
 import os
 import tempfile
 import json
+import time
 
 import unittest
 
@@ -193,3 +194,22 @@ class StreamExecutionEnvironmentTests(PyFlinkTestCase):
         plan = self.env.get_execution_plan()
 
         json.loads(plan)
+
+    def test_execute(self):
+        tmp_dir = tempfile.gettempdir()
+        field_names = ['a', 'b', 'c']
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env = StreamTableEnvironment.create(self.env)
+        t_env.register_table_sink(
+            'Results',
+            CsvTableSink(field_names, field_types,
+                         os.path.join('{}/{}.csv'.format(tmp_dir, round(time.time())))))
+        t_env.insert_into('Results', t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c']))
+        execution_result = t_env.execute('test_stream_execute')
+        self.assertIsNotNone(execution_result.get_job_id())
+        self.assertTrue(execution_result.is_job_execution_result())
+        self.assertIsNotNone(execution_result.get_job_execution_result().get_job_id())
+        self.assertIsNotNone(execution_result.get_net_runtime())
+        self.assertEqual(len(execution_result.get_all_accumulator_results()), 0)
+        self.assertIsNone(execution_result.get_accumulator_result('accumulator'))
+        self.assertIsNotNone(execution_result.to_string())

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -22,6 +22,7 @@ from abc import ABCMeta, abstractmethod
 
 from py4j.java_gateway import get_java_class, get_method
 
+from pyflink.common import JobExecutionResult
 from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table.catalog import Catalog
 from pyflink.table.table_config import TableConfig
@@ -938,8 +939,9 @@ class TableEnvironment(object):
 
         :param job_name: Desired name of the job.
         :type job_name: str
+        :return: The result of the job execution, containing elapsed time and accumulators.
         """
-        self._j_tenv.execute(job_name)
+        return JobExecutionResult(self._j_tenv.execute(job_name))
 
     def from_elements(self, elements, schema=None, verify_schema=True):
         """


### PR DESCRIPTION
## What is the purpose of the change

 *This pull request will return `JobExecutionResult` for Python `ExecutionEnvironment` and `TableEnvironment`.*

## Brief change log

 - *Add `JobExecutionResult` for return result of method `execute` in Python `ExecutionEnvironment` and `TableEnvironment`.*

## Verifying this change

  - *Added `test_execute` method to verify `JobExecutionResult` for return result of `execute` in Python `ExecutionEnvironment`.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
