### PR TITLE
[FLINK-17052] [client] Introduce PlanGenerator

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1031,14 +1031,6 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Get the registered cached files.
-	 */
-	@Internal
-	public List<Tuple2<String, DistributedCacheEntry>> getCacheFile() {
-		return new ArrayList<>(cacheFile);
-	}
-
-	/**
 	 * Creates the program's {@link Plan}. The plan is a description of all data sources, data sinks,
 	 * and operations and how they interact, as an isolated unit that can be executed with an
 	 * {@link PipelineExecutor}. Obtaining a plan and starting it with an
@@ -1096,8 +1088,14 @@ public class ExecutionEnvironment {
 			}
 		}
 
-		final PlanGenerator generator = new PlanGenerator(sinks, config, cacheFile, jobName);
+		final PlanGenerator generator = new PlanGenerator(sinks, config, jobName);
 		final Plan plan = generator.generate();
+
+		try {
+			registerCachedFilesWithPlan(plan);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
+		}
 
 		// clear all the sinks such that the next execution does not redo everything
 		if (clearSinks) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1074,7 +1074,7 @@ public class ExecutionEnvironment {
 			}
 		}
 
-		final PlanGenerator generator = new PlanGenerator(sinks, config, cacheFile, jobName);
+		final PlanGenerator generator = new PlanGenerator(sinks, config, getParallelism(), cacheFile, jobName);
 		final Plan plan = generator.generate();
 
 		// clear all the sinks such that the next execution does not redo everything

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -1031,7 +1031,7 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Get the registered cached files
+	 * Get the registered cached files.
 	 */
 	@Internal
 	public List<Tuple2<String, DistributedCacheEntry>> getCacheFile() {

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -74,7 +74,6 @@ import com.esotericsoftware.kryo.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1018,19 +1017,6 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Registers all files that were registered at this execution environment's cache registry of the
-	 * given plan's cache registry.
-	 *
-	 * @param p The plan to register files at.
-	 * @throws IOException Thrown if checks for existence and sanity fail.
-	 */
-	protected void registerCachedFilesWithPlan(Plan p) throws IOException {
-		for (Tuple2<String, DistributedCacheEntry> entry : cacheFile) {
-			p.registerCachedFile(entry.f0, entry.f1);
-		}
-	}
-
-	/**
 	 * Creates the program's {@link Plan}. The plan is a description of all data sources, data sinks,
 	 * and operations and how they interact, as an isolated unit that can be executed with an
 	 * {@link PipelineExecutor}. Obtaining a plan and starting it with an
@@ -1088,14 +1074,8 @@ public class ExecutionEnvironment {
 			}
 		}
 
-		final PlanGenerator generator = new PlanGenerator(sinks, config, jobName);
+		final PlanGenerator generator = new PlanGenerator(sinks, config, cacheFile, jobName);
 		final Plan plan = generator.generate();
-
-		try {
-			registerCachedFilesWithPlan(plan);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
-		}
 
 		// clear all the sinks such that the next execution does not redo everything
 		if (clearSinks) {

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.utils;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.cache.DistributedCache;
+import org.apache.flink.api.common.operators.Operator;
+import org.apache.flink.api.common.operators.OperatorInformation;
+import org.apache.flink.api.java.operators.DataSink;
+import org.apache.flink.api.java.operators.OperatorTranslation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
+import org.apache.flink.util.Visitor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A generator that generates a {@link Plan} from a graph of {@link Operator}s.
+ */
+public class PlanGenerator {
+	private static final Logger LOG = LoggerFactory.getLogger(PlanGenerator.class);
+
+	private final List<DataSink<?>> sinks;
+	private final ExecutionConfig config;
+	private final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile;
+	private final String jobName;
+
+	public PlanGenerator(
+			List<DataSink<?>> sinks,
+			ExecutionConfig config,
+			List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile,
+			String jobName) {
+		this.sinks = sinks;
+		this.config = config;
+		this.cacheFile = cacheFile;
+		this.jobName = jobName;
+	}
+
+	public Plan generate() {
+		OperatorTranslation translator = new OperatorTranslation();
+		Plan plan = translator.translateToPlan(sinks, jobName);
+
+		if (config.getParallelism() > 0) {
+			plan.setDefaultParallelism(config.getParallelism());
+		}
+		plan.setExecutionConfig(config);
+
+		// Check plan for GenericTypeInfo's and register the types at the serializers.
+		if (!config.isAutoTypeRegistrationDisabled()) {
+			plan.accept(new Visitor<Operator<?>>() {
+
+				private final Set<Class<?>> registeredTypes = new HashSet<>();
+				private final Set<org.apache.flink.api.common.operators.Operator<?>> visitedOperators = new HashSet<>();
+
+				@Override
+				public boolean preVisit(org.apache.flink.api.common.operators.Operator<?> visitable) {
+					if (!visitedOperators.add(visitable)) {
+						return false;
+					}
+					OperatorInformation<?> opInfo = visitable.getOperatorInfo();
+					Serializers.recursivelyRegisterType(opInfo.getOutputType(), config, registeredTypes);
+					return true;
+				}
+
+				@Override
+				public void postVisit(org.apache.flink.api.common.operators.Operator<?> visitable) {
+				}
+			});
+		}
+
+		try {
+			registerCachedFilesWithPlan(plan);
+		} catch (Exception e) {
+			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
+		}
+
+		// All types are registered now. Print information.
+		int registeredTypes = config.getRegisteredKryoTypes().size() +
+				config.getRegisteredPojoTypes().size() +
+				config.getRegisteredTypesWithKryoSerializerClasses().size() +
+				config.getRegisteredTypesWithKryoSerializers().size();
+		int defaultKryoSerializers = config.getDefaultKryoSerializers().size() +
+				config.getDefaultKryoSerializerClasses().size();
+		LOG.info("The job has {} registered types and {} default Kryo serializers", registeredTypes,
+				defaultKryoSerializers);
+
+		if (config.isForceKryoEnabled() && config.isForceAvroEnabled()) {
+			LOG.warn("In the ExecutionConfig, both Avro and Kryo are enforced. Using Kryo serializer");
+		}
+		if (config.isForceKryoEnabled()) {
+			LOG.info("Using KryoSerializer for serializing POJOs");
+		}
+		if (config.isForceAvroEnabled()) {
+			LOG.info("Using AvroSerializer for serializing POJOs");
+		}
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("Registered Kryo types: {}", config.getRegisteredKryoTypes().toString());
+			LOG.debug("Registered Kryo with Serializers types: {}",
+					config.getRegisteredTypesWithKryoSerializers().entrySet().toString());
+			LOG.debug("Registered Kryo with Serializer Classes types: {}",
+					config.getRegisteredTypesWithKryoSerializerClasses().entrySet().toString());
+			LOG.debug("Registered Kryo default Serializers: {}",
+					config.getDefaultKryoSerializers().entrySet().toString());
+			LOG.debug("Registered Kryo default Serializers Classes {}",
+					config.getDefaultKryoSerializerClasses().entrySet().toString());
+			LOG.debug("Registered POJO types: {}", config.getRegisteredPojoTypes().toString());
+
+			// print information about static code analysis
+			LOG.debug("Static code analysis mode: {}", config.getCodeAnalysisMode());
+		}
+
+		return plan;
+	}
+
+	private void registerCachedFilesWithPlan(Plan p) throws IOException {
+		for (Tuple2<String, DistributedCache.DistributedCacheEntry> entry : cacheFile) {
+			p.registerCachedFile(entry.f0, entry.f1);
+		}
+	}
+}

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
@@ -20,19 +20,16 @@ package org.apache.flink.api.java.utils;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.Plan;
-import org.apache.flink.api.common.cache.DistributedCache;
 import org.apache.flink.api.common.operators.Operator;
 import org.apache.flink.api.common.operators.OperatorInformation;
 import org.apache.flink.api.java.operators.DataSink;
 import org.apache.flink.api.java.operators.OperatorTranslation;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.typeutils.runtime.kryo.Serializers;
 import org.apache.flink.util.Visitor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,17 +42,14 @@ public class PlanGenerator {
 
 	private final List<DataSink<?>> sinks;
 	private final ExecutionConfig config;
-	private final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile;
 	private final String jobName;
 
 	public PlanGenerator(
 			List<DataSink<?>> sinks,
 			ExecutionConfig config,
-			List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile,
 			String jobName) {
 		this.sinks = sinks;
 		this.config = config;
-		this.cacheFile = cacheFile;
 		this.jobName = jobName;
 	}
 
@@ -89,12 +83,6 @@ public class PlanGenerator {
 				public void postVisit(org.apache.flink.api.common.operators.Operator<?> visitable) {
 				}
 			});
-		}
-
-		try {
-			registerCachedFilesWithPlan(plan);
-		} catch (Exception e) {
-			throw new RuntimeException("Error while registering cached files: " + e.getMessage(), e);
 		}
 
 		// All types are registered now. Print information.
@@ -134,11 +122,5 @@ public class PlanGenerator {
 		}
 
 		return plan;
-	}
-
-	private void registerCachedFilesWithPlan(Plan p) throws IOException {
-		for (Tuple2<String, DistributedCache.DistributedCacheEntry> entry : cacheFile) {
-			p.registerCachedFile(entry.f0, entry.f1);
-		}
 	}
 }

--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/PlanGenerator.java
@@ -47,16 +47,19 @@ public class PlanGenerator {
 
 	private final List<DataSink<?>> sinks;
 	private final ExecutionConfig config;
+	private final int defaultParallelism;
 	private final List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile;
 	private final String jobName;
 
 	public PlanGenerator(
 			List<DataSink<?>> sinks,
 			ExecutionConfig config,
+			int defaultParallelism,
 			List<Tuple2<String, DistributedCache.DistributedCacheEntry>> cacheFile,
 			String jobName) {
 		this.sinks = checkNotNull(sinks);
 		this.config = checkNotNull(config);
+		this.defaultParallelism = defaultParallelism;
 		this.cacheFile = checkNotNull(cacheFile);
 		this.jobName = checkNotNull(jobName);
 	}
@@ -86,8 +89,8 @@ public class PlanGenerator {
 		OperatorTranslation translator = new OperatorTranslation();
 		Plan plan = translator.translateToPlan(sinks, jobName);
 
-		if (config.getParallelism() > 0) {
-			plan.setDefaultParallelism(config.getParallelism());
+		if (defaultParallelism > 0) {
+			plan.setDefaultParallelism(defaultParallelism);
 		}
 		plan.setExecutionConfig(config);
 		return plan;

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
@@ -45,7 +45,11 @@ public class PlanGeneratorTest {
 				.writeAsText("/tmp/csv");
 
 		PlanGenerator generator = new PlanGenerator(
-				Collections.singletonList(sink), env.getConfig(), Collections.emptyList(), "test");
+				Collections.singletonList(sink),
+				env.getConfig(),
+				env.getParallelism(),
+				Collections.emptyList(),
+				"test");
 		Plan plan = generator.generate();
 		assertEquals(1, plan.getDataSinks().size());
 		assertEquals(10, plan.getDefaultParallelism());

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
@@ -45,7 +45,7 @@ public class PlanGeneratorTest {
 				.writeAsText("/tmp/csv");
 
 		PlanGenerator generator = new PlanGenerator(
-				Collections.singletonList(sink), env.getConfig(), "test");
+				Collections.singletonList(sink), env.getConfig(), Collections.emptyList(), "test");
 		Plan plan = generator.generate();
 		assertEquals(1, plan.getDataSinks().size());
 		assertEquals(10, plan.getDefaultParallelism());

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
@@ -38,7 +38,6 @@ public class PlanGeneratorTest {
 	public void testGenerate() {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
 		env.setParallelism(10);
-		env.registerCachedFile("/tmp/cache", "my_cache");
 
 		DataSink<?> sink = env
 				.fromElements(1, 3, 5)
@@ -46,12 +45,11 @@ public class PlanGeneratorTest {
 				.writeAsText("/tmp/csv");
 
 		PlanGenerator generator = new PlanGenerator(
-				Collections.singletonList(sink), env.getConfig(), env.getCacheFile(), "test");
+				Collections.singletonList(sink), env.getConfig(), "test");
 		Plan plan = generator.generate();
 		assertEquals(1, plan.getDataSinks().size());
 		assertEquals(10, plan.getDefaultParallelism());
 		assertEquals(env.getConfig(), plan.getExecutionConfig());
 		assertEquals("test", plan.getJobName());
-		assertEquals(1, plan.getCachedFiles().size());
 	}
 }

--- a/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
+++ b/flink-java/src/test/java/org/apache/flink/api/java/utils/PlanGeneratorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.java.utils;
+
+import org.apache.flink.api.common.Plan;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.operators.DataSink;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link PlanGenerator}.
+ */
+public class PlanGeneratorTest {
+
+	@Test
+	public void testGenerate() {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(10);
+		env.registerCachedFile("/tmp/cache", "my_cache");
+
+		DataSink<?> sink = env
+				.fromElements(1, 3, 5)
+				.map((MapFunction<Integer, String>) value -> String.valueOf(value + 1))
+				.writeAsText("/tmp/csv");
+
+		PlanGenerator generator = new PlanGenerator(
+				Collections.singletonList(sink), env.getConfig(), env.getCacheFile(), "test");
+		Plan plan = generator.generate();
+		assertEquals(1, plan.getDataSinks().size());
+		assertEquals(10, plan.getDefaultParallelism());
+		assertEquals(env.getConfig(), plan.getExecutionConfig());
+		assertEquals("test", plan.getJobName());
+		assertEquals(1, plan.getCachedFiles().size());
+	}
+}

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
@@ -91,8 +91,6 @@ public final class TestUtils {
 	 * @param expectedParallelism expected operator parallelism
 	 */
 	public static void verifyParallelism(ExecutionEnvironment env, int expectedParallelism) {
-		env.setParallelism(2 * expectedParallelism);
-
 		Optimizer compiler = new Optimizer(null, new DefaultCostEstimator(), new Configuration());
 		OptimizedPlan optimizedPlan = compiler.compile(env.createProgramPlan());
 

--- a/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
+++ b/flink-libraries/flink-gelly/src/test/java/org/apache/flink/graph/generator/TestUtils.java
@@ -91,6 +91,7 @@ public final class TestUtils {
 	 * @param expectedParallelism expected operator parallelism
 	 */
 	public static void verifyParallelism(ExecutionEnvironment env, int expectedParallelism) {
+		env.setParallelism(2 * expectedParallelism);
 		Optimizer compiler = new Optimizer(null, new DefaultCostEstimator(), new Configuration());
 		OptimizedPlan optimizedPlan = compiler.compile(env.createProgramPlan());
 

--- a/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
@@ -51,7 +51,8 @@ class ExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createCollectionsEnvironment', 'readFile', 'readFileOfPrimitives',
                 'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput',
                 'getUserCodeClassLoader', 'getExecutorServiceLoader', 'getConfiguration',
-                'executeAsync', 'registerJobListener', 'clearJobListeners', 'configure'}
+                'executeAsync', 'registerJobListener', 'clearJobListeners', 'configure',
+                'getCacheFile'}
 
 
 if __name__ == '__main__':

--- a/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
+++ b/flink-python/pyflink/dataset/tests/test_execution_environment_completeness.py
@@ -51,8 +51,7 @@ class ExecutionEnvironmentCompletenessTests(PythonAPICompletenessTestCase,
                 'createCollectionsEnvironment', 'readFile', 'readFileOfPrimitives',
                 'generateSequence', 'areExplicitEnvironmentsAllowed', 'createInput',
                 'getUserCodeClassLoader', 'getExecutorServiceLoader', 'getConfiguration',
-                'executeAsync', 'registerJobListener', 'clearJobListeners', 'configure',
-                'getCacheFile'}
+                'executeAsync', 'registerJobListener', 'clearJobListeners', 'configure'}
 
 
 if __name__ == '__main__':

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -17,8 +17,8 @@
  */
 package org.apache.flink.api.scala
 
-import com.esotericsoftware.kryo.Serializer
-import org.apache.flink.annotation.{Public, PublicEvolving}
+import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
+import org.apache.flink.api.common.cache.DistributedCache
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
@@ -34,6 +34,8 @@ import org.apache.flink.core.execution.{JobClient, JobListener, PipelineExecutor
 import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
 import org.apache.flink.util.{NumberSequenceIterator, Preconditions, SplittableIterator}
+
+import com.esotericsoftware.kryo.Serializer
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -479,6 +481,14 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def registerCachedFile(filePath: String, name: String, executable: Boolean = false): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
+  }
+
+  /**
+    * Get the registered cached files.
+    */
+  @Internal
+  def getCacheFile(): List[(String, DistributedCache.DistributedCacheEntry)] = {
+    javaEnv.getCacheFile.asScala.map(f => (f.f0, f.f1)).toList
   }
 
   /**

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -17,8 +17,7 @@
  */
 package org.apache.flink.api.scala
 
-import org.apache.flink.annotation.{Internal, Public, PublicEvolving}
-import org.apache.flink.api.common.cache.DistributedCache
+import org.apache.flink.annotation.{Public, PublicEvolving}
 import org.apache.flink.api.common.io.{FileInputFormat, InputFormat}
 import org.apache.flink.api.common.restartstrategy.RestartStrategies.RestartStrategyConfiguration
 import org.apache.flink.api.common.typeinfo.{BasicTypeInfo, TypeInformation}
@@ -481,14 +480,6 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    */
   def registerCachedFile(filePath: String, name: String, executable: Boolean = false): Unit = {
     javaEnv.registerCachedFile(filePath, name, executable)
-  }
-
-  /**
-    * Get the registered cached files.
-    */
-  @Internal
-  def getCacheFile(): List[(String, DistributedCache.DistributedCacheEntry)] = {
-    javaEnv.getCacheFile.asScala.map(f => (f.f0, f.f1)).toList
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

*As [FLINK-16533](https://issues.apache.org/jira/browse/FLINK-16533) discussed, We move the most part logic of ExecutionEnvironment#createProgramPlan method to PlanGenerator, which can be used by ExecutionEnvironment and flink-table-planner.*


## Brief change log

  - *extract plan generation logic from ExecutionEnvironment#createProgramPlan to PlanGenerator*


## Verifying this change

This change is already covered by existing tests, such as *CollectionExecutionAccumulatorsTest, ExecutorDiscoveryAndJobClientTest*. Added PlanGeneratorTest can also verify the logic.
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
