### PR TITLE
[FLINK-15817][k8s] Clean up residual resources when failed to deploy a Flink cluster

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -185,8 +185,13 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 
 			return createClusterClientProvider(clusterId);
 		} catch (Exception e) {
-			client.handleException(e);
-			throw new ClusterDeploymentException("Could not create Kubernetes cluster " + clusterId, e);
+			try {
+				LOG.warn("Failed to create the Kubernetes cluster \"{}\", try to clean up the residual resources.", clusterId);
+				client.stopAndCleanupCluster(clusterId);
+			} catch (Exception e1) {
+				LOG.info("Failed to stop and clean up the Kubernetes cluster \"{}\".", clusterId, e1);
+			}
+			throw new ClusterDeploymentException("Could not create Kubernetes cluster \"" + clusterId + "\".", e);
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Clean up all the residual resources when failed to deploy a new Flink cluster.


## Brief change log

  - Invoke `KubernetesClient#stopAndCleanupCluster` in the exception handling block of `KubernetesClusterDescriptor#deployClusterInternal`.


## Verifying this change

This change is a trivial work on exception handling improvement, it can be manually verified as follows:
Try to deploy a new Flink cluster with the following parameters:
`./bin/kubernetes-session.sh -Dkubernetes.cluster-id=x5rvvn9fltbxi3l2c5piwlwxlyn0yji766afathqokvyttsq5yhtsbsyromrcz -Dkubernetes.container.image=flink:latest -Djobmanager.heap.size=1024m -Dtaskmanager.memory.process.size=1024m -Dkubernetes.jobmanager.service-account=flink`;
as expected, an exception will be thrown since the name of the rest Service has more than 63 characters, one can confirm that all the related k8s resources have been cleaned up after the submission terminates.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

