### PR TITLE
[1.9][FLINK-15812][runtime] Archive jobs asynchronously 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/HistoryServerArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/HistoryServerArchivist.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.webmonitor.WebMonitorUtils;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Writer for an {@link AccessExecutionGraph}.
@@ -41,13 +42,13 @@ public interface HistoryServerArchivist {
 	 */
 	CompletableFuture<Acknowledge> archiveExecutionGraph(AccessExecutionGraph executionGraph);
 
-	static HistoryServerArchivist createHistoryServerArchivist(Configuration configuration, JsonArchivist jsonArchivist) {
+	static HistoryServerArchivist createHistoryServerArchivist(Configuration configuration, JsonArchivist jsonArchivist, Executor ioExecutor) {
 		final String configuredArchivePath = configuration.getString(JobManagerOptions.ARCHIVE_DIR);
 
 		if (configuredArchivePath != null) {
 			final Path archivePath = WebMonitorUtils.validateAndNormalizeUri(new Path(configuredArchivePath).toUri());
 
-			return new JsonResponseHistoryServerArchivist(jsonArchivist, archivePath);
+			return new JsonResponseHistoryServerArchivist(jsonArchivist, archivePath, ioExecutor);
 		} else {
 			return VoidHistoryServerArchivist.INSTANCE;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JsonResponseHistoryServerArchivist.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/JsonResponseHistoryServerArchivist.java
@@ -19,15 +19,15 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.AccessExecutionGraph;
 import org.apache.flink.runtime.history.FsJobArchivist;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.ThrowingRunnable;
 
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * Implementation which archives an {@link AccessExecutionGraph} such that it stores
@@ -39,18 +39,21 @@ class JsonResponseHistoryServerArchivist implements HistoryServerArchivist {
 
 	private final Path archivePath;
 
-	JsonResponseHistoryServerArchivist(JsonArchivist jsonArchivist, Path archivePath) {
+	private final Executor ioExecutor;
+
+	JsonResponseHistoryServerArchivist(JsonArchivist jsonArchivist, Path archivePath, Executor ioExecutor) {
 		this.jsonArchivist = Preconditions.checkNotNull(jsonArchivist);
 		this.archivePath = Preconditions.checkNotNull(archivePath);
+		this.ioExecutor = Preconditions.checkNotNull(ioExecutor);
 	}
 
 	@Override
 	public CompletableFuture<Acknowledge> archiveExecutionGraph(AccessExecutionGraph executionGraph) {
-		try {
-			FsJobArchivist.archiveJob(archivePath, executionGraph.getJobID(), jsonArchivist.archiveJsonWithPath(executionGraph));
-			return CompletableFuture.completedFuture(Acknowledge.get());
-		} catch (IOException e) {
-			return FutureUtils.completedExceptionally(e);
-		}
+		return CompletableFuture
+			.runAsync(
+				ThrowingRunnable.unchecked(() ->
+					FsJobArchivist.archiveJob(archivePath, executionGraph.getJobID(), jsonArchivist.archiveJsonWithPath(executionGraph))),
+				ioExecutor)
+			.thenApply(ignored -> Acknowledge.get());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -209,6 +209,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 
 			clusterComponent = dispatcherResourceManagerComponentFactory.create(
 				configuration,
+				ioExecutor,
 				commonRpcService,
 				haServices,
 				blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
@@ -65,6 +65,7 @@ import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -98,6 +99,7 @@ public abstract class AbstractDispatcherResourceManagerComponentFactory<T extend
 	@Override
 	public DispatcherResourceManagerComponent<T> create(
 			Configuration configuration,
+			Executor ioExecutor,
 			RpcService rpcService,
 			HighAvailabilityServices highAvailabilityServices,
 			BlobServer blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/AbstractDispatcherResourceManagerComponentFactory.java
@@ -181,7 +181,7 @@ public abstract class AbstractDispatcherResourceManagerComponentFactory<T extend
 				webMonitorEndpoint.getRestBaseUrl(),
 				jobManagerMetricGroup);
 
-			final HistoryServerArchivist historyServerArchivist = HistoryServerArchivist.createHistoryServerArchivist(configuration, webMonitorEndpoint);
+			final HistoryServerArchivist historyServerArchivist = HistoryServerArchivist.createHistoryServerArchivist(configuration, webMonitorEndpoint, ioExecutor);
 
 			dispatcher = dispatcherFactory.createDispatcher(
 				configuration,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/component/DispatcherResourceManagerComponentFactory.java
@@ -29,6 +29,8 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
 
+import java.util.concurrent.Executor;
+
 /**
  * Factory for the {@link DispatcherResourceManagerComponent}.
  */
@@ -36,6 +38,7 @@ public interface DispatcherResourceManagerComponentFactory<T extends Dispatcher>
 
 	DispatcherResourceManagerComponent<T> create(
 		Configuration configuration,
+		Executor ioExecutor,
 		RpcService rpcService,
 		HighAvailabilityServices highAvailabilityServices,
 		BlobServer blobServer,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -221,6 +221,10 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		}
 	}
 
+	protected Executor getIOExecutor() {
+		return ioExecutor;
+	}
+
 	@VisibleForTesting
 	@Nonnull
 	protected Collection<DispatcherResourceManagerComponent<?>> getDispatcherResourceManagerComponents() {
@@ -377,6 +381,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 		return Collections.singleton(
 			dispatcherResourceManagerComponentFactory.create(
 				configuration,
+				ioExecutor,
 				rpcServiceFactory.createRpcService(),
 				haServices,
 				blobServer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/TestingMiniCluster.java
@@ -114,6 +114,7 @@ public class TestingMiniCluster extends MiniCluster {
 			result.add(
 				dispatcherResourceManagerComponentFactory.create(
 					configuration,
+					getIOExecutor(),
 					rpcServiceFactory.createRpcService(),
 					haServices,
 					blobServer,

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/ProcessFailureCancelingITCase.java
@@ -74,6 +74,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.testutils.CommonTestUtils.getJavaCommandPath;
@@ -126,9 +127,10 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 			StandaloneResourceManagerFactory.INSTANCE);
 		DispatcherResourceManagerComponent<?> dispatcherResourceManagerComponent = null;
 
+		final ScheduledExecutorService ioExecutor = TestingUtils.defaultExecutor();
 		final HighAvailabilityServices haServices = HighAvailabilityServicesUtils.createHighAvailabilityServices(
 			config,
-			TestingUtils.defaultExecutor(),
+			ioExecutor,
 			HighAvailabilityServicesUtils.AddressResolution.NO_ADDRESS_RESOLUTION);
 
 		try {
@@ -142,6 +144,7 @@ public class ProcessFailureCancelingITCase extends TestLogger {
 
 			dispatcherResourceManagerComponent = resourceManagerComponentFactory.create(
 				config,
+				ioExecutor,
 				rpcService,
 				haServices,
 				blobServerResource.getBlobServer(),


### PR DESCRIPTION
Backport of #11649.

Additionally required FLINK-14278 to have access to an Executor.