### PR TITLE
[FLINK-17062][python] Fix the conversion from Java row type to Python row type

### DIFF
--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1864,9 +1864,8 @@ def _from_java_type(j_data_type):
         logical_type = java_data_type.getLogicalType()
         field_data_types = java_data_type.getFieldDataTypes()
         if _is_instance_of(logical_type, gateway.jvm.RowType):
-            fields = [DataTypes.FIELD(item,
-                                      _from_java_type(
-                                          field_data_types[item])) for item in field_data_types]
+            fields = [DataTypes.FIELD(name, _from_java_type(field_data_types[name]))
+                      for name in logical_type.getFieldNames()]
             data_type = DataTypes.ROW(fields, logical_type.isNullable())
         else:
             raise TypeError("Unsupported row data type: %s" % j_data_type)


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix the conversion from Java row type to Python row type.*

## Brief change log

  - *Fix the conversion from Java row type to Python row type*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
