### PR TITLE
[FLINK-17063][table-api] Make null type be a possible result of a type inference.

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/TypeInferenceUtil.java
@@ -99,14 +99,6 @@ public final class TypeInferenceUtil {
 			TypeInference typeInference,
 			CallContext callContext,
 			@Nullable DataType outputType) {
-		return adaptArguments(typeInference, callContext, outputType, false);
-	}
-
-	private static AdaptedCallContext adaptArguments(
-			TypeInference typeInference,
-			CallContext callContext,
-			@Nullable DataType outputType,
-			boolean allowUnknownInputTypes) {
 		final List<DataType> actualTypes = callContext.getArgumentDataTypes();
 
 		typeInference.getTypedArguments()
@@ -123,8 +115,8 @@ public final class TypeInferenceUtil {
 		final AdaptedCallContext adaptedCallContext = inferInputTypes(
 			typeInference,
 			callContext,
-			outputType,
-			allowUnknownInputTypes);
+			outputType
+		);
 
 		// final check if the call is valid after casting
 		final List<DataType> expectedTypes = adaptedCallContext.getArgumentDataTypes();
@@ -274,7 +266,7 @@ public final class TypeInferenceUtil {
 
 			// We might not be able to infer the input types at this moment, if the surrounding function
 			// does not provide an explicit input type strategy. Skip the check for unknown types in input types.
-			final AdaptedCallContext adaptedContext = adaptArguments(typeInference, callContext, null, true);
+			final AdaptedCallContext adaptedContext = adaptArguments(typeInference, callContext, null);
 			return typeInference.getInputTypeStrategy()
 				.inferInputTypes(adaptedContext, false)
 				.map(dataTypes -> dataTypes.get(innerCallPosition));
@@ -448,8 +440,7 @@ public final class TypeInferenceUtil {
 	private static AdaptedCallContext inferInputTypes(
 			TypeInference typeInference,
 			CallContext callContext,
-			@Nullable DataType outputType,
-			boolean allowUnknownInputTypes) {
+			@Nullable DataType outputType) {
 
 		final AdaptedCallContext adaptedCallContext = new AdaptedCallContext(callContext, outputType);
 
@@ -459,11 +450,6 @@ public final class TypeInferenceUtil {
 		final List<DataType> inferredDataTypes = typeInference.getInputTypeStrategy()
 			.inferInputTypes(adaptedCallContext, true)
 			.orElseThrow(() -> new ValidationException("Invalid input arguments."));
-
-		if (!allowUnknownInputTypes && inferredDataTypes.stream().anyMatch(TypeInferenceUtil::isUnknown)) {
-			// input must not contain unknown types at this point
-			throw new ValidationException("Invalid use of untyped NULL in arguments.");
-		}
 
 		adaptedCallContext.setExpectedArguments(inferredDataTypes);
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -334,7 +334,8 @@ public class InputTypeStrategiesTest {
 			TestSpec
 				.forStrategy(WILDCARD)
 				.calledWithArgumentTypes(DataTypes.NULL(), DataTypes.STRING(), DataTypes.NULL())
-				.expectErrorMessage("Invalid use of untyped NULL in arguments."),
+				.expectSignature("f(*)")
+				.expectArgumentTypes(DataTypes.NULL(), DataTypes.STRING(), DataTypes.NULL()),
 
 			// typed arguments help inferring a type
 			TestSpec


### PR DESCRIPTION
## What is the purpose of the change

There are use cases that can benefit from making a null type a valid result of an input and output type inference.
E.g We can use null type in VALUES clause for a temporary placeholder that will be later inferred based on types of other rows.


## Verifying this change

* Updated a test case in `InputTypeStrategiesTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
