### PR TITLE
[FLINK-15347] Add SupervisorActor which monitors the proper termination of AkkaRpcActors

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/concurrent/FutureUtils.java
@@ -1094,12 +1094,30 @@ public class FutureUtils {
 	 * @param <T> type of the value
 	 */
 	public static <T> void forward(CompletableFuture<T> source, CompletableFuture<T> target) {
-		source.whenComplete((value, throwable) -> {
+		source.whenComplete(forwardTo(target));
+	}
+
+	/**
+	 * Forwards the value from the source future to the target future using the provided executor.
+	 *
+	 * @param source future to forward the value from
+	 * @param target future to forward the value to
+	 * @param executor executor to forward the source value to the target future
+	 * @param <T> type of the value
+	 */
+	public static <T> void forwardAsync(CompletableFuture<T> source, CompletableFuture<T> target, Executor executor) {
+		source.whenCompleteAsync(
+			forwardTo(target),
+			executor);
+	}
+
+	private static <T> BiConsumer<T, Throwable> forwardTo(CompletableFuture<T> target) {
+		return (value, throwable) -> {
 			if (throwable != null) {
 				target.completeExceptionally(throwable);
 			} else {
 				target.complete(value);
 			}
-		});
+		};
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/RpcUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.util.AutoCloseableAsync;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,6 +45,8 @@ public class RpcUtils {
 	 * method {@code checkMaxDelay()} in {@link akka.actor.LightArrayRevolverScheduler}.
 	 */
 	public static final Time INF_TIMEOUT = Time.seconds(21474835);
+
+	public static final Duration INF_DURATION = Duration.ofSeconds(21474835);
 
 	/**
 	 * Extracts all {@link RpcGateway} interfaces implemented by the given clazz.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -86,7 +86,7 @@ public class AkkaRpcService implements RpcService {
 
 	private static final Logger LOG = LoggerFactory.getLogger(AkkaRpcService.class);
 
-	static final int VERSION = 1;
+	static final int VERSION = 2;
 
 	private final Object lock = new Object();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceUtils.java
@@ -57,6 +57,8 @@ public class AkkaRpcServiceUtils {
 	private static final String AKKA_TCP = "akka.tcp";
 	private static final String AKKA_SSL_TCP = "akka.ssl.tcp";
 
+	static final String SUPERVISOR_NAME = "rpc";
+
 	private static final String SIMPLE_AKKA_CONFIG_TEMPLATE =
 		"akka {remote {netty.tcp {maximum-frame-size = %s}}}";
 
@@ -166,7 +168,7 @@ public class AkkaRpcServiceUtils {
 
 		final String hostPort = NetUtils.unresolvedHostAndPortToNormalizedString(hostname, port);
 
-		return String.format("%s://flink@%s/user/%s", protocolPrefix, hostPort, endpointName);
+		return String.format("%s://flink@%s/user/%s/%s", protocolPrefix, hostPort, SUPERVISOR_NAME, endpointName);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/SupervisorActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/SupervisorActor.java
@@ -156,7 +156,7 @@ class SupervisorActor extends AbstractActor {
 	}
 
 	public static ActorRef startSupervisorActor(ActorSystem actorSystem) {
-		final Props supervisorProps = Props.create(SupervisorActor.class);
+		final Props supervisorProps = Props.create(SupervisorActor.class).withDispatcher("akka.actor.supervisor-dispatcher");
 		return actorSystem.actorOf(supervisorProps, getActorName());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/SupervisorActor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/SupervisorActor.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.rpc.RpcUtils;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaRpcException;
+import org.apache.flink.runtime.rpc.akka.exceptions.AkkaUnknownMessageException;
+import org.apache.flink.util.Preconditions;
+
+import akka.AkkaException;
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.ChildRestartStats;
+import akka.actor.Props;
+import akka.actor.SupervisorStrategy;
+import akka.japi.pf.DeciderBuilder;
+import akka.pattern.Patterns;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.function.Function;
+
+import scala.PartialFunction;
+import scala.collection.Iterable;
+
+/**
+ * Supervisor actor which is responsible for starting {@link AkkaRpcActor} instances and monitoring
+ * when the actors have terminated.
+ */
+class SupervisorActor extends AbstractActor {
+
+	private static final Logger LOG = LoggerFactory.getLogger(SupervisorActor.class);
+
+	private final Map<ActorRef, AkkaRpcActorRegistration> registeredAkkaRpcActors;
+
+	SupervisorActor() {
+		this.registeredAkkaRpcActors = new HashMap<>();
+	}
+
+	@Override
+	public Receive createReceive() {
+		return receiveBuilder()
+			.match(StartAkkaRpcActor.class, this::createStartAkkaRpcActorMessage)
+			.matchAny(this::handleUnknownMessage)
+			.build();
+	}
+
+	@Override
+	public void postStop() throws Exception {
+		LOG.debug("Stopping supervisor actor.");
+
+		super.postStop();
+
+		for (AkkaRpcActorRegistration actorRegistration : registeredAkkaRpcActors.values()) {
+			terminateAkkaRpcActorOnStop(actorRegistration);
+		}
+
+		registeredAkkaRpcActors.clear();
+	}
+
+	@Override
+	public SupervisorActorSupervisorStrategy supervisorStrategy() {
+		return new SupervisorActorSupervisorStrategy();
+	}
+
+	private void terminateAkkaRpcActorOnStop(AkkaRpcActorRegistration akkaRpcActorRegistration) {
+		akkaRpcActorRegistration.terminateExceptionally(new AkkaRpcException(
+			String.format("Unexpected closing of %s with name %s.", getClass().getSimpleName(), akkaRpcActorRegistration.getEndpointId())));
+	}
+
+	private void createStartAkkaRpcActorMessage(StartAkkaRpcActor startAkkaRpcActor) {
+		final String endpointId = startAkkaRpcActor.getEndpointId();
+		final AkkaRpcActorRegistration akkaRpcActorRegistration = new AkkaRpcActorRegistration(endpointId);
+
+		final Props akkaRpcActorProps = startAkkaRpcActor.getPropsFactory().create(akkaRpcActorRegistration.getInternalTerminationFuture());
+
+		LOG.debug("Starting {} with name {}.", akkaRpcActorProps.actorClass().getSimpleName(), endpointId);
+
+		try {
+			final ActorRef actorRef = getContext().actorOf(akkaRpcActorProps, endpointId);
+
+			registeredAkkaRpcActors.put(actorRef, akkaRpcActorRegistration);
+
+			getSender().tell(StartAkkaRpcActorResponse.success(
+				ActorRegistration.create(
+					actorRef,
+					akkaRpcActorRegistration.getExternalTerminationFuture())),
+				getSelf());
+		} catch (AkkaException akkaException) {
+			getSender().tell(StartAkkaRpcActorResponse.failure(akkaException), getSelf());
+		}
+	}
+
+	private void akkaRpcActorTerminated(ActorRef actorRef) {
+		final AkkaRpcActorRegistration actorRegistration = removeAkkaRpcActor(actorRef);
+
+		LOG.debug("AkkaRpcActor {} has terminated.", actorRef.path());
+		actorRegistration.terminate();
+	}
+
+	private void akkaRpcActorFailed(ActorRef actorRef, Throwable cause) {
+		LOG.warn("AkkaRpcActor {} has failed. Shutting it down now.", actorRef.path(), cause);
+
+		for (Map.Entry<ActorRef, AkkaRpcActorRegistration> registeredAkkaRpcActor : registeredAkkaRpcActors.entrySet()) {
+			final ActorRef otherActorRef = registeredAkkaRpcActor.getKey();
+			if (otherActorRef.equals(actorRef)) {
+				final AkkaRpcException error = new AkkaRpcException(String.format("Stopping actor %s because it failed.", actorRef.path()), cause);
+				registeredAkkaRpcActor.getValue().markFailed(error);
+			} else {
+				final AkkaRpcException siblingException = new AkkaRpcException(String.format("Stopping actor %s because its sibling %s has failed.", otherActorRef.path(), actorRef.path()));
+				registeredAkkaRpcActor.getValue().markFailed(siblingException);
+			}
+		}
+
+		getContext().getSystem().terminate();
+	}
+
+	private AkkaRpcActorRegistration removeAkkaRpcActor(ActorRef actorRef) {
+		return Optional.ofNullable(registeredAkkaRpcActors.remove(actorRef))
+			.orElseThrow(() -> new IllegalStateException(String.format("Could not find actor %s.", actorRef.path())));
+	}
+
+	private void handleUnknownMessage(Object msg) {
+		final AkkaUnknownMessageException cause = new AkkaUnknownMessageException(String.format("Cannot handle unknown message %s.", msg));
+		getSender().tell(new akka.actor.Status.Failure(cause), getSelf());
+		throw cause;
+	}
+
+	public static String getActorName() {
+		return AkkaRpcServiceUtils.SUPERVISOR_NAME;
+	}
+
+	public static ActorRef startSupervisorActor(ActorSystem actorSystem) {
+		final Props supervisorProps = Props.create(SupervisorActor.class);
+		return actorSystem.actorOf(supervisorProps, getActorName());
+	}
+
+	public static StartAkkaRpcActorResponse startAkkaRpcActor(
+			ActorRef supervisor,
+			StartAkkaRpcActor.PropsFactory propsFactory,
+			String endpointId) {
+		return Patterns.ask(
+				supervisor,
+				createStartAkkaRpcActorMessage(
+					propsFactory,
+					endpointId),
+				RpcUtils.INF_DURATION).toCompletableFuture()
+			.thenApply(SupervisorActor.StartAkkaRpcActorResponse.class::cast)
+			.join();
+	}
+
+	public static StartAkkaRpcActor createStartAkkaRpcActorMessage(
+			StartAkkaRpcActor.PropsFactory propsFactory,
+			String endpointId) {
+		return StartAkkaRpcActor.create(propsFactory, endpointId);
+	}
+
+	// -----------------------------------------------------------------------------
+	// Internal classes
+	// -----------------------------------------------------------------------------
+
+	private final class SupervisorActorSupervisorStrategy extends SupervisorStrategy {
+
+		@Override
+		public PartialFunction<Throwable, Directive> decider() {
+			return DeciderBuilder.match(
+				Exception.class, e -> SupervisorStrategy.stop()
+			).build();
+		}
+
+		@Override
+		public boolean loggingEnabled() {
+			return false;
+		}
+
+		@Override
+		public void handleChildTerminated(akka.actor.ActorContext context, ActorRef child, Iterable<ActorRef> children) {
+			akkaRpcActorTerminated(child);
+		}
+
+		@Override
+		public void processFailure(akka.actor.ActorContext context, boolean restart, ActorRef child, Throwable cause, ChildRestartStats stats, Iterable<ChildRestartStats> children) {
+			Preconditions.checkArgument(!restart, "The supervisor strategy should never restart an actor.");
+
+			akkaRpcActorFailed(child, cause);
+		}
+	}
+
+	private static final class AkkaRpcActorRegistration {
+		private final String endpointId;
+
+		private final CompletableFuture<Void> internalTerminationFuture;
+
+		private final CompletableFuture<Void> externalTerminationFuture;
+
+		@Nullable
+		private Throwable errorCause;
+
+		private AkkaRpcActorRegistration(String endpointId) {
+			this.endpointId = endpointId;
+			internalTerminationFuture = new CompletableFuture<>();
+			externalTerminationFuture = new CompletableFuture<>();
+			errorCause = null;
+		}
+
+		private CompletableFuture<Void> getInternalTerminationFuture() {
+			return internalTerminationFuture;
+		}
+
+		private CompletableFuture<Void> getExternalTerminationFuture() {
+			return externalTerminationFuture;
+		}
+
+		private String getEndpointId() {
+			return endpointId;
+		}
+
+		private void terminate() {
+			CompletableFuture<Void> terminationFuture = internalTerminationFuture;
+
+			if (errorCause != null) {
+				if (!internalTerminationFuture.completeExceptionally(errorCause)) {
+					// we have another failure reason -> let's add it
+					terminationFuture = internalTerminationFuture.handle(
+						(ignored, throwable) -> {
+							if (throwable != null) {
+								errorCause.addSuppressed(throwable);
+							}
+
+							throw new CompletionException(errorCause);
+						});
+				}
+			} else {
+				internalTerminationFuture.completeExceptionally(
+					new AkkaRpcException(
+						String.format("RpcEndpoint %s did not complete the internal termination future.", endpointId)));
+			}
+
+			FutureUtils.forward(terminationFuture, externalTerminationFuture);
+		}
+
+		private void terminateExceptionally(Throwable cause) {
+			externalTerminationFuture.completeExceptionally(cause);
+		}
+
+		public void markFailed(Throwable cause) {
+			if (errorCause == null) {
+				errorCause = cause;
+			} else {
+				errorCause.addSuppressed(cause);
+			}
+		}
+	}
+
+	// -----------------------------------------------------------------------------
+	// Messages
+	// -----------------------------------------------------------------------------
+
+	static final class StartAkkaRpcActor {
+		private final PropsFactory propsFactory;
+		private final String endpointId;
+
+		private StartAkkaRpcActor(PropsFactory propsFactory, String endpointId) {
+			this.propsFactory = propsFactory;
+			this.endpointId = endpointId;
+		}
+
+		public String getEndpointId() {
+			return endpointId;
+		}
+
+		public PropsFactory getPropsFactory() {
+			return propsFactory;
+		}
+
+		private static StartAkkaRpcActor create(PropsFactory propsFactory, String endpointId) {
+			return new StartAkkaRpcActor(propsFactory, endpointId);
+		}
+
+		interface PropsFactory {
+			Props create(CompletableFuture<Void> terminationFuture);
+		}
+	}
+
+	static final class ActorRegistration {
+		private final ActorRef actorRef;
+		private final CompletableFuture<Void> terminationFuture;
+
+		private ActorRegistration(ActorRef actorRef, CompletableFuture<Void> terminationFuture) {
+			this.actorRef = actorRef;
+			this.terminationFuture = terminationFuture;
+		}
+
+		public ActorRef getActorRef() {
+			return actorRef;
+		}
+
+		public CompletableFuture<Void> getTerminationFuture() {
+			return terminationFuture;
+		}
+
+		public static ActorRegistration create(ActorRef actorRef, CompletableFuture<Void> terminationFuture) {
+			return new ActorRegistration(actorRef, terminationFuture);
+		}
+	}
+
+	static final class StartAkkaRpcActorResponse {
+		@Nullable
+		private final ActorRegistration actorRegistration;
+
+		@Nullable
+		private final Throwable error;
+
+		private StartAkkaRpcActorResponse(@Nullable ActorRegistration actorRegistration, @Nullable Throwable error) {
+			this.actorRegistration = actorRegistration;
+			this.error = error;
+		}
+
+		public <X extends Throwable> ActorRegistration orElseThrow(Function<? super Throwable, ? extends X> throwableFunction) throws X {
+			if (actorRegistration != null) {
+				return actorRegistration;
+			} else {
+				throw throwableFunction.apply(error);
+			}
+		}
+
+		public static StartAkkaRpcActorResponse success(ActorRegistration actorRegistration) {
+			return new StartAkkaRpcActorResponse(actorRegistration, null);
+		}
+
+		public static StartAkkaRpcActorResponse failure(Throwable error) {
+			return new StartAkkaRpcActorResponse(null, error);
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcRuntimeException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaRpcRuntimeException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka.exceptions;
+
+import org.apache.flink.runtime.rpc.exceptions.RpcRuntimeException;
+
+/**
+ *  Base class for Akka RPC related runtime exceptions.
+ */
+public class AkkaRpcRuntimeException extends RpcRuntimeException {
+	public AkkaRpcRuntimeException(String message) {
+		super(message);
+	}
+
+	public AkkaRpcRuntimeException(Throwable cause) {
+		super(cause);
+	}
+
+	public AkkaRpcRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaUnknownMessageException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/akka/exceptions/AkkaUnknownMessageException.java
@@ -22,7 +22,7 @@ package org.apache.flink.runtime.rpc.akka.exceptions;
  * Exception which indicates that the AkkaRpcActor has received an
  * unknown message type.
  */
-public class AkkaUnknownMessageException extends AkkaRpcException {
+public class AkkaUnknownMessageException extends AkkaRpcRuntimeException {
 
 	private static final long serialVersionUID = 1691338049911020814L;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/RpcRuntimeException.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rpc/exceptions/RpcRuntimeException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.exceptions;
+
+/**
+ * Base class for RPC related runtime exceptions.
+ */
+public class RpcRuntimeException extends RuntimeException {
+
+	public RpcRuntimeException(String message) {
+		super(message);
+	}
+
+	public RpcRuntimeException(Throwable cause) {
+		super(cause);
+	}
+
+	public RpcRuntimeException(String message, Throwable cause) {
+		super(message, cause);
+	}
+}

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -273,7 +273,7 @@ object AkkaUtils {
 
     val logLevel = getLogLevel
 
-    val supervisorStrategy = classOf[StoppingSupervisorWithoutLoggingActorKilledExceptionStrategy]
+    val supervisorStrategy = classOf[EscalatingSupervisorStrategy]
       .getCanonicalName
 
     val config =

--- a/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
+++ b/flink-runtime/src/main/scala/org/apache/flink/runtime/akka/AkkaUtils.scala
@@ -303,6 +303,15 @@ object AkkaUtils {
         |   default-dispatcher {
         |     throughput = $akkaThroughput
         |   }
+        |
+        |   supervisor-dispatcher {
+        |     type = Dispatcher
+        |     executor = "thread-pool-executor"
+        |     thread-pool-executor {
+        |       core-pool-size-min = 1
+        |       core-pool-size-max = 1
+        |     }
+        |   }
         | }
         |}
       """.stripMargin

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/concurrent/FutureUtilsTest.java
@@ -803,6 +803,24 @@ public class FutureUtilsTest extends TestLogger {
 	}
 
 	@Test
+	public void testForwardAsync() throws Exception {
+		final CompletableFuture<String> source = new CompletableFuture<>();
+		final CompletableFuture<String> target = new CompletableFuture<>();
+		final ManuallyTriggeredScheduledExecutor executor = new ManuallyTriggeredScheduledExecutor();
+
+		FutureUtils.forwardAsync(source, target, executor);
+
+		source.complete("foobar");
+
+		assertThat(target.isDone(), is(false));
+
+		// execute the forward action
+		executor.triggerAll();
+
+		assertThat(target.get(), is(equalTo(source.get())));
+	}
+
+	@Test
 	public void testGetWithoutException() {
 		final CompletableFuture<Integer> completableFuture = new CompletableFuture<>();
 		completableFuture.complete(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/FencedRpcEndpointTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.exceptions.FencingTokenException;
-import org.apache.flink.runtime.rpc.exceptions.RpcException;
+import org.apache.flink.runtime.rpc.exceptions.RpcRuntimeException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
@@ -263,7 +263,7 @@ public class FencedRpcEndpointTest extends TestLogger {
 				unfencedGateway.foobar(timeout).get(timeout.toMilliseconds(), TimeUnit.MILLISECONDS);
 				fail("This should have failed because we have an unfenced gateway.");
 			} catch (ExecutionException e) {
-				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof RpcException);
+				assertTrue(ExceptionUtils.stripExecutionException(e) instanceof RpcRuntimeException);
 			}
 
 			try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/ActorSystemResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/ActorSystemResource.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.util.Preconditions;
+
+import akka.actor.ActorSystem;
+import org.junit.rules.ExternalResource;
+
+/**
+ * External resource which starts an {@link akka.actor.ActorSystem}.
+ */
+public class ActorSystemResource extends ExternalResource {
+
+	private final Configuration configuration;
+
+	private ActorSystem actorSystem;
+
+	private ActorSystemResource(Configuration configuration) {
+		this.configuration = configuration;
+	}
+
+	@Override
+	protected void before() throws Throwable {
+		Preconditions.checkState(actorSystem == null, "ActorSystem must not be initialized when calling before.");
+		actorSystem = AkkaUtils.createLocalActorSystem(configuration);
+	}
+
+	@Override
+	protected void after() {
+		Preconditions.checkState(actorSystem != null, "ActorSystem must be initialized when calling after.");
+		AkkaUtils.terminateActorSystem(actorSystem).join();
+	}
+
+	public ActorSystem getActorSystem() {
+		return actorSystem;
+	}
+
+	public static ActorSystemResource defaultConfiguration() {
+		return new ActorSystemResource(new Configuration());
+	}
+
+	public static ActorSystemResource withConfiguration(Configuration configuration) {
+		return new ActorSystemResource(configuration);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaActorSystemTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaActorSystemTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.akka.AkkaUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.Terminated;
+import akka.japi.pf.ReceiveBuilder;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Tests for the {@link akka.actor.ActorSystem} instantiated through {@link AkkaUtils}.
+ */
+public class AkkaActorSystemTest extends TestLogger {
+
+	@Test
+	public void shutsDownOnActorFailure() {
+		final ActorSystem actorSystem = AkkaUtils.createLocalActorSystem(new Configuration());
+
+		try {
+			final CompletableFuture<Terminated> terminationFuture = actorSystem.getWhenTerminated().toCompletableFuture();
+			final ActorRef actorRef = actorSystem.actorOf(Props.create(SimpleActor.class));
+
+			final FlinkException cause = new FlinkException("Flink test exception");
+
+			actorRef.tell(Fail.exceptionally(cause), ActorRef.noSender());
+
+			// make sure that the ActorSystem shuts down
+			terminationFuture.join();
+		} finally {
+			AkkaUtils.terminateActorSystem(actorSystem).join();
+		}
+	}
+
+	private static final class SimpleActor extends AbstractActor {
+
+		@Override
+		public Receive createReceive() {
+			return ReceiveBuilder.create()
+				.match(Fail.class, this::handleFail)
+				.build();
+		}
+
+		private void handleFail(Fail fail) {
+			throw new RuntimeException(fail.getErrorCause());
+		}
+	}
+
+	private static final class Fail {
+		private final Throwable errorCause;
+
+		private Fail(Throwable errorCause) {
+			this.errorCause = errorCause;
+		}
+
+		private Throwable getErrorCause() {
+			return errorCause;
+		}
+
+		private static Fail exceptionally(Throwable errorCause) {
+			return new Fail(errorCause);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcActorTest.java
@@ -450,6 +450,22 @@ public class AkkaRpcActorTest extends TestLogger {
 		}
 	}
 
+	@Test
+	public void terminationFutureDoesNotBlockRpcEndpointCreation() throws Exception {
+		try (final SimpleRpcEndpoint simpleRpcEndpoint = new SimpleRpcEndpoint(akkaRpcService, "foobar")) {
+			final CompletableFuture<Void> terminationFuture = simpleRpcEndpoint.getTerminationFuture();
+
+			// Creating a new RpcEndpoint within the termination future ensures that
+			// completing the termination future won't block the RpcService
+			final CompletableFuture<SimpleRpcEndpoint> foobar2 = terminationFuture.thenApply(ignored -> new SimpleRpcEndpoint(akkaRpcService, "foobar2"));
+
+			simpleRpcEndpoint.closeAsync();
+
+			final SimpleRpcEndpoint simpleRpcEndpoint2 = foobar2.join();
+			simpleRpcEndpoint2.close();
+		}
+	}
+
 	// ------------------------------------------------------------------------
 	//  Test Actors and Interfaces
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/SupervisorActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/SupervisorActorTest.java
@@ -52,7 +52,7 @@ public class SupervisorActorTest extends TestLogger {
 	public void completesTerminationFutureIfActorStops() {
 		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
 
-		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem, actorSystem.getDispatcher());
 
 		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
 
@@ -68,7 +68,7 @@ public class SupervisorActorTest extends TestLogger {
 	public void completesTerminationFutureExceptionallyIfActorStopsExceptionally() throws Exception {
 		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
 
-		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem, actorSystem.getDispatcher());
 
 		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
 
@@ -91,7 +91,7 @@ public class SupervisorActorTest extends TestLogger {
 	public void completesTerminationFutureExceptionallyIfActorStopsWithoutReason() throws InterruptedException {
 		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
 
-		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem, actorSystem.getDispatcher());
 
 		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
 
@@ -110,7 +110,7 @@ public class SupervisorActorTest extends TestLogger {
 	public void completesTerminationFutureExceptionallyIfActorFails() throws Exception {
 		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
 
-		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem, actorSystem.getDispatcher());
 
 		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
 
@@ -138,7 +138,7 @@ public class SupervisorActorTest extends TestLogger {
 	public void completesTerminationFutureOfSiblingsIfActorFails() throws Exception {
 		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
 
-		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem, actorSystem.getDispatcher());
 
 		final SupervisorActor.ActorRegistration actorRegistration1 = startAkkaRpcActor(supervisor, "foobar1");
 		final SupervisorActor.ActorRegistration actorRegistration2 = startAkkaRpcActor(supervisor, "foobar2");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/SupervisorActorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/akka/SupervisorActorTest.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rpc.akka;
+
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.actor.Terminated;
+import akka.japi.pf.ReceiveBuilder;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for the {@link SupervisorActor}.
+ */
+public class SupervisorActorTest extends TestLogger {
+
+	@Rule
+	public final ActorSystemResource actorSystemResource = ActorSystemResource.defaultConfiguration();
+
+	@Test
+	public void completesTerminationFutureIfActorStops() {
+		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+
+		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
+
+		final CompletableFuture<Void> terminationFuture = actorRegistration.getTerminationFuture();
+		assertThat(terminationFuture.isDone(), is(false));
+
+		actorRegistration.getActorRef().tell(TerminateWithFutureCompletion.normal(), ActorRef.noSender());
+
+		terminationFuture.join();
+	}
+
+	@Test
+	public void completesTerminationFutureExceptionallyIfActorStopsExceptionally() throws Exception {
+		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+
+		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
+
+		final CompletableFuture<Void> terminationFuture = actorRegistration.getTerminationFuture();
+		assertThat(terminationFuture.isDone(), is(false));
+
+		final FlinkException cause = new FlinkException("Test cause.");
+		actorRegistration.getActorRef().tell(TerminateWithFutureCompletion.exceptionally(cause), ActorRef.noSender());
+
+		try {
+			terminationFuture.get();
+			fail("Expected the termination future being completed exceptionally");
+		} catch (ExecutionException expected) {
+			ExceptionUtils.findThrowable(expected, e -> e.equals(cause))
+				.orElseThrow(() -> new FlinkException("Unexpected exception", expected));
+		}
+	}
+
+	@Test
+	public void completesTerminationFutureExceptionallyIfActorStopsWithoutReason() throws InterruptedException {
+		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+
+		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
+
+		final CompletableFuture<Void> terminationFuture = actorRegistration.getTerminationFuture();
+		assertThat(terminationFuture.isDone(), is(false));
+
+		actorRegistration.getActorRef().tell(Terminate.INSTANCE, ActorRef.noSender());
+
+		try {
+			terminationFuture.get();
+			fail("Expected the termination future being completed exceptionally");
+		} catch (ExecutionException expected) {}
+	}
+
+	@Test
+	public void completesTerminationFutureExceptionallyIfActorFails() throws Exception {
+		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+
+		final SupervisorActor.ActorRegistration actorRegistration = startAkkaRpcActor(supervisor, "foobar");
+
+		final CompletableFuture<Void> terminationFuture = actorRegistration.getTerminationFuture();
+		assertThat(terminationFuture.isDone(), is(false));
+
+		final CompletableFuture<Terminated> actorSystemTerminationFuture = actorSystem.getWhenTerminated().toCompletableFuture();
+
+		final FlinkException cause = new FlinkException("Test cause.");
+		actorRegistration.getActorRef().tell(Fail.exceptionally(cause), ActorRef.noSender());
+
+		try {
+			terminationFuture.get();
+			fail("Expected the termination future being completed exceptionally");
+		} catch (ExecutionException expected) {
+			ExceptionUtils.findThrowable(expected, e -> e.equals(cause))
+				.orElseThrow(() -> new FlinkException("Unexpected exception", expected));
+		}
+
+		// make sure that the supervisor actor has stopped --> terminating the actor system
+		actorSystemTerminationFuture.join();
+	}
+
+	@Test
+	public void completesTerminationFutureOfSiblingsIfActorFails() throws Exception {
+		final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+
+		final ActorRef supervisor = SupervisorActor.startSupervisorActor(actorSystem);
+
+		final SupervisorActor.ActorRegistration actorRegistration1 = startAkkaRpcActor(supervisor, "foobar1");
+		final SupervisorActor.ActorRegistration actorRegistration2 = startAkkaRpcActor(supervisor, "foobar2");
+
+		final CompletableFuture<Void> terminationFuture = actorRegistration2.getTerminationFuture();
+		assertThat(terminationFuture.isDone(), is(false));
+
+		final FlinkException cause = new FlinkException("Test cause.");
+		actorRegistration1.getActorRef().tell(Fail.exceptionally(cause), ActorRef.noSender());
+
+		try {
+			terminationFuture.get();
+			fail("Expected the termination future being completed exceptionally");
+		} catch (ExecutionException expected) {}
+	}
+
+	private SupervisorActor.ActorRegistration startAkkaRpcActor(ActorRef supervisor, String endpointId) {
+		final SupervisorActor.StartAkkaRpcActorResponse startResponse = SupervisorActor.startAkkaRpcActor(
+			supervisor,
+			terminationFuture -> Props.create(SimpleActor.class, terminationFuture),
+			endpointId);
+
+		return startResponse.orElseThrow(cause -> new AssertionError("Expected the start to succeed.", cause));
+	}
+
+	private static final class SimpleActor extends AbstractActor {
+
+		private final CompletableFuture<Void> terminationFuture;
+
+		private SimpleActor(CompletableFuture<Void> terminationFuture) {
+			this.terminationFuture = terminationFuture;
+		}
+
+		@Override
+		public Receive createReceive() {
+			return ReceiveBuilder.create()
+				.match(Terminate.class, this::terminate)
+				.match(TerminateWithFutureCompletion.class, this::terminateActorWithFutureCompletion)
+				.match(Fail.class, this::fail)
+				.build();
+		}
+
+		private void fail(Fail fail) {
+			throw new RuntimeException(fail.getCause());
+		}
+
+		private void terminate(Terminate terminate) {
+			terminateActor();
+		}
+
+		private void terminateActor() {
+			getContext().stop(getSelf());
+		}
+
+		private void terminateActorWithFutureCompletion(TerminateWithFutureCompletion terminateWithFutureCompletion) {
+			final Throwable terminationError = terminateWithFutureCompletion.getTerminationError();
+			if (terminationError == null) {
+				terminationFuture.complete(null);
+			} else {
+				terminationFuture.completeExceptionally(terminationError);
+			}
+
+			terminateActor();
+		}
+	}
+
+	private static final class Terminate {
+		private static final Terminate INSTANCE = new Terminate();
+	}
+
+	private static final class TerminateWithFutureCompletion {
+		@Nullable
+		private final Throwable terminationError;
+
+		private TerminateWithFutureCompletion(@Nullable Throwable terminationError) {
+			this.terminationError = terminationError;
+		}
+
+		@Nullable
+		private Throwable getTerminationError() {
+			return terminationError;
+		}
+
+		private static TerminateWithFutureCompletion normal() {
+			return new TerminateWithFutureCompletion(null);
+		}
+
+		private static TerminateWithFutureCompletion exceptionally(Throwable cause) {
+			return new TerminateWithFutureCompletion(cause);
+		}
+	}
+
+	private static final class Fail {
+		private final Throwable cause;
+
+		private Fail(Throwable cause) {
+			this.cause = cause;
+		}
+
+		private Throwable getCause() {
+			return cause;
+		}
+
+		private static Fail exceptionally(Throwable cause) {
+			return new Fail(cause);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/retriever/impl/RpcGatewayRetrieverTest.java
@@ -106,8 +106,7 @@ public class RpcGatewayRetrieverTest extends TestLogger {
 			assertEquals(dummyRpcEndpoint2.getAddress(), dummyGateway2.getAddress());
 			assertEquals(expectedValue2, dummyGateway2.foobar(TIMEOUT).get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS));
 		} finally {
-			RpcUtils.terminateRpcEndpoint(dummyRpcEndpoint, TIMEOUT);
-			RpcUtils.terminateRpcEndpoint(dummyRpcEndpoint2, TIMEOUT);
+			RpcUtils.terminateRpcEndpoints(TIMEOUT, dummyRpcEndpoint, dummyRpcEndpoint2);
 		}
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

In order to properly complete the termination future of an RpcEndpoint, we need to monitor
when the underlying AkkaRpcActor has been removed from the ActorSystem. If this is not done,
then it can happen that another RpcEndpoint using the same name cannot be started because
the old RpcEndpoint is still registered.

The way we achieve this monitoring is to introduce a helper actor which is responsible for
starting the AkkaRpcActors for all RpcEndpoints. Since the SupervisorActor is the parent
of all RpcEndpoints, it can tell when they are being removed from the ActorSystem through
the SupervisorStrategy.

A consequence of the new actor is that the akka urls change from akka://flink@actorsystem:port/user/xyz
to akka://flink@actorsystem:port/user/rpc/xyz. The respective method AkkaRpcServiceUtils.getRpcUrl
has been updated to reflect this change. This hierarchy change also warrants the bump of the
AkkaRpcService.VERSION.

The failure behaviour of the underlying ActorSystem has been changed so that it terminates
all running actors if an exception is thrown from the SupervisorActor. The assumption is that
such an exception always indicates a programming error and is unrecoverable.

The same applies to failure originating from an AkkaRpcActor (children of the SupervisorActor).
If such an exception is thrown, then we assume that the system is in an illegal state and shut it
down. The way it works is by recording the failure cause for the respective AkkaRpcActor and
then terminating the ActorSystem.

## Verifying this change

- Added `AkkaActorSystemTest`, `SupervisorActorTest` and `AkkaRpcActorTest.canReuseEndpointNameAfterTermination`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
