### PR TITLE
[FLINK-17050][runtime] Remove methods getVertex() and getResultPartition() from SchedulingTopology

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -1547,7 +1547,7 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	ResultPartitionID createResultPartitionId(final IntermediateResultPartitionID resultPartitionId) {
 		final SchedulingResultPartition<?, ?> schedulingResultPartition =
-			getSchedulingTopology().getResultPartitionOrThrow(resultPartitionId);
+			getSchedulingTopology().getResultPartition(resultPartitionId);
 		final SchedulingExecutionVertex<?, ?> producer = schedulingResultPartition.getProducer();
 		final ExecutionVertexID producerId = producer.getId();
 		final JobVertexID jobVertexId = producerId.getJobVertexId();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionReleaseStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/partitionrelease/RegionPartitionReleaseStrategy.java
@@ -88,7 +88,7 @@ public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy 
 		final Set<SchedulingResultPartition<?, ?>> allConsumedPartitionsInRegion = pipelinedRegion
 			.getExecutionVertexIds()
 			.stream()
-			.map(schedulingTopology::getVertexOrThrow)
+			.map(schedulingTopology::getVertex)
 			.flatMap(vertex -> IterableUtils.toStream(vertex.getConsumedResults()))
 			.collect(Collectors.toSet());
 
@@ -157,7 +157,7 @@ public class RegionPartitionReleaseStrategy implements PartitionReleaseStrategy 
 	}
 
 	private boolean areConsumerRegionsFinished(final IntermediateResultPartitionID resultPartitionId) {
-		final SchedulingResultPartition<?, ?> resultPartition = schedulingTopology.getResultPartitionOrThrow(resultPartitionId);
+		final SchedulingResultPartition<?, ?> resultPartition = schedulingTopology.getResultPartition(resultPartitionId);
 		return IterableUtils.toStream(resultPartition.getConsumers())
 			.map(SchedulingExecutionVertex::getId)
 			.allMatch(this::isRegionOfVertexFinished);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -33,7 +33,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -88,13 +87,21 @@ public class DefaultExecutionTopology implements SchedulingTopology<DefaultExecu
 	}
 
 	@Override
-	public Optional<DefaultExecutionVertex> getVertex(ExecutionVertexID executionVertexId) {
-		return Optional.ofNullable(executionVerticesById.get(executionVertexId));
+	public DefaultExecutionVertex getVertexOrThrow(final ExecutionVertexID executionVertexId) {
+		final DefaultExecutionVertex executionVertex = executionVerticesById.get(executionVertexId);
+		if (executionVertex == null) {
+			throw new IllegalArgumentException("can not find vertex: " + executionVertexId);
+		}
+		return executionVertex;
 	}
 
 	@Override
-	public Optional<DefaultResultPartition> getResultPartition(IntermediateResultPartitionID intermediateResultPartitionId) {
-		return Optional.ofNullable(resultPartitionsById.get(intermediateResultPartitionId));
+	public DefaultResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID intermediateResultPartitionId) {
+		final DefaultResultPartition resultPartition = resultPartitionsById.get(intermediateResultPartitionId);
+		if (resultPartition == null) {
+			throw new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId);
+		}
+		return resultPartition;
 	}
 
 	private static List<DefaultResultPartition> generateProducedSchedulingResultPartition(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -87,7 +87,7 @@ public class DefaultExecutionTopology implements SchedulingTopology<DefaultExecu
 	}
 
 	@Override
-	public DefaultExecutionVertex getVertexOrThrow(final ExecutionVertexID executionVertexId) {
+	public DefaultExecutionVertex getVertex(final ExecutionVertexID executionVertexId) {
 		final DefaultExecutionVertex executionVertex = executionVerticesById.get(executionVertexId);
 		if (executionVertex == null) {
 			throw new IllegalArgumentException("can not find vertex: " + executionVertexId);
@@ -96,7 +96,7 @@ public class DefaultExecutionTopology implements SchedulingTopology<DefaultExecu
 	}
 
 	@Override
-	public DefaultResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID intermediateResultPartitionId) {
+	public DefaultResultPartition getResultPartition(final IntermediateResultPartitionID intermediateResultPartitionId) {
 		final DefaultResultPartition resultPartition = resultPartitionsById.get(intermediateResultPartitionId);
 		if (resultPartition == null) {
 			throw new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategy.java
@@ -86,7 +86,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 		// increase counter of the dataset first
 		verticesToRestart
 			.stream()
-			.map(schedulingTopology::getVertexOrThrow)
+			.map(schedulingTopology::getVertex)
 			.flatMap(vertex -> IterableUtils.toStream(vertex.getProducedResults()))
 			.forEach(inputConstraintChecker::resetSchedulingResultPartition);
 
@@ -101,7 +101,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 		}
 
 		final Set<SchedulingExecutionVertex<?, ?>> verticesToSchedule = IterableUtils
-			.toStream(schedulingTopology.getVertexOrThrow(executionVertexId).getProducedResults())
+			.toStream(schedulingTopology.getVertex(executionVertexId).getProducedResults())
 			.filter(partition -> partition.getResultType().isBlocking())
 			.flatMap(partition -> inputConstraintChecker.markSchedulingResultPartitionFinished(partition).stream())
 			.flatMap(partition -> IterableUtils.toStream(partition.getConsumers()))
@@ -113,7 +113,7 @@ public class LazyFromSourcesSchedulingStrategy implements SchedulingStrategy {
 	@Override
 	public void onPartitionConsumable(IntermediateResultPartitionID resultPartitionId) {
 		final SchedulingResultPartition<?, ?> resultPartition = schedulingTopology
-			.getResultPartitionOrThrow(resultPartitionId);
+			.getResultPartition(resultPartitionId);
 
 		if (!resultPartition.getResultType().isPipelined()) {
 			return;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -43,7 +43,7 @@ class SchedulingStrategyUtils {
 			final Set<ExecutionVertexID> vertexIds) {
 
 		return vertexIds.stream()
-			.map(topology::getVertexOrThrow)
+			.map(topology::getVertex)
 			.collect(Collectors.toSet());
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.topology.Topology;
 
-import java.util.Optional;
-
 /**
  * Topology of {@link SchedulingExecutionVertex}.
  */
@@ -33,29 +31,10 @@ public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R
 	 * Looks up the {@link SchedulingExecutionVertex} for the given {@link ExecutionVertexID}.
 	 *
 	 * @param executionVertexId identifying the respective scheduling vertex
-	 * @return Optional containing the respective scheduling vertex or none if the vertex does not exist
-	 */
-	Optional<V> getVertex(ExecutionVertexID executionVertexId);
-
-	/**
-	 * Looks up the {@link SchedulingExecutionVertex} for the given {@link ExecutionVertexID}.
-	 *
-	 * @param executionVertexId identifying the respective scheduling vertex
 	 * @return The respective scheduling vertex
 	 * @throws IllegalArgumentException If the vertex does not exist
 	 */
-	default V getVertexOrThrow(ExecutionVertexID executionVertexId) {
-		return getVertex(executionVertexId).orElseThrow(
-				() -> new IllegalArgumentException("can not find vertex: " + executionVertexId));
-	}
-
-	/**
-	 * Looks up the {@link SchedulingResultPartition} for the given {@link IntermediateResultPartitionID}.
-	 *
-	 * @param intermediateResultPartitionId identifying the respective scheduling result partition
-	 * @return Optional containing the respective scheduling result partition or none if the partition does not exist
-	 */
-	Optional<R> getResultPartition(IntermediateResultPartitionID intermediateResultPartitionId);
+	V getVertexOrThrow(ExecutionVertexID executionVertexId);
 
 	/**
 	 * Looks up the {@link SchedulingResultPartition} for the given {@link IntermediateResultPartitionID}.
@@ -64,8 +43,5 @@ public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R
 	 * @return The respective scheduling result partition
 	 * @throws IllegalArgumentException If the partition does not exist
 	 */
-	default R getResultPartitionOrThrow(IntermediateResultPartitionID intermediateResultPartitionId) {
-		return getResultPartition(intermediateResultPartitionId).orElseThrow(
-				() -> new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId));
-	}
+	R getResultPartitionOrThrow(IntermediateResultPartitionID intermediateResultPartitionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingTopology.java
@@ -34,7 +34,7 @@ public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R
 	 * @return The respective scheduling vertex
 	 * @throws IllegalArgumentException If the vertex does not exist
 	 */
-	V getVertexOrThrow(ExecutionVertexID executionVertexId);
+	V getVertex(ExecutionVertexID executionVertexId);
 
 	/**
 	 * Looks up the {@link SchedulingResultPartition} for the given {@link IntermediateResultPartitionID}.
@@ -43,5 +43,5 @@ public interface SchedulingTopology<V extends SchedulingExecutionVertex<V, R>, R
 	 * @return The respective scheduling result partition
 	 * @throws IllegalArgumentException If the partition does not exist
 	 */
-	R getResultPartitionOrThrow(IntermediateResultPartitionID intermediateResultPartitionId);
+	R getResultPartition(IntermediateResultPartitionID intermediateResultPartitionId);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -654,7 +654,7 @@ public class DefaultSchedulerTest extends TestLogger {
 
 		scheduler.updateTaskExecutionState(new TaskExecutionState(jobid, attemptId1, ExecutionState.FAILED, new RuntimeException("expected")));
 		scheduler.cancel();
-		final ExecutionState vertex2StateAfterCancel = topology.getVertexOrThrow(executionVertex2).getState();
+		final ExecutionState vertex2StateAfterCancel = topology.getVertex(executionVertex2).getState();
 		final JobStatus statusAfterCancelWhileRestarting = scheduler.requestJobStatus();
 		scheduler.updateTaskExecutionState(new TaskExecutionState(jobid, attemptId2, ExecutionState.CANCELED, new RuntimeException("expected")));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -98,7 +98,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
 			for (Map.Entry<IntermediateResultPartitionID, IntermediateResultPartition> entry : vertex.getProducedPartitions().entrySet()) {
 				IntermediateResultPartition partition = entry.getValue();
-				DefaultResultPartition schedulingResultPartition = adapter.getResultPartitionOrThrow(entry.getKey());
+				DefaultResultPartition schedulingResultPartition = adapter.getResultPartition(entry.getKey());
 
 				assertPartitionEquals(partition, schedulingResultPartition);
 			}
@@ -114,7 +114,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 			.get();
 
 		final DefaultResultPartition schedulingResultPartition = adapter
-			.getResultPartitionOrThrow(intermediateResultPartition.getPartitionId());
+			.getResultPartition(intermediateResultPartition.getPartitionId());
 
 		assertEquals(ResultPartitionState.CREATED, schedulingResultPartition.getState());
 
@@ -125,7 +125,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 	@Test
 	public void testGetVertexOrThrow() {
 		try {
-			adapter.getVertexOrThrow(new ExecutionVertexID(new JobVertexID(), 0));
+			adapter.getVertex(new ExecutionVertexID(new JobVertexID(), 0));
 			fail("get not exist vertex");
 		} catch (IllegalArgumentException exception) {
 			// expected
@@ -135,7 +135,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 	@Test
 	public void testResultPartitionOrThrow() {
 		try {
-			adapter.getResultPartitionOrThrow(new IntermediateResultPartitionID());
+			adapter.getResultPartition(new IntermediateResultPartitionID());
 			fail("get not exist result partition");
 		} catch (IllegalArgumentException exception) {
 			// expected

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -98,8 +98,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 		for (ExecutionVertex vertex : executionGraph.getAllExecutionVertices()) {
 			for (Map.Entry<IntermediateResultPartitionID, IntermediateResultPartition> entry : vertex.getProducedPartitions().entrySet()) {
 				IntermediateResultPartition partition = entry.getValue();
-				DefaultResultPartition schedulingResultPartition = adapter.getResultPartition(entry.getKey())
-					.orElseThrow(() -> new IllegalArgumentException("can not find partition " + entry.getKey()));
+				DefaultResultPartition schedulingResultPartition = adapter.getResultPartitionOrThrow(entry.getKey());
 
 				assertPartitionEquals(partition, schedulingResultPartition);
 			}
@@ -115,8 +114,7 @@ public class DefaultExecutionTopologyTest extends TestLogger {
 			.get();
 
 		final DefaultResultPartition schedulingResultPartition = adapter
-			.getResultPartition(intermediateResultPartition.getPartitionId())
-			.get();
+			.getResultPartitionOrThrow(intermediateResultPartition.getPartitionId());
 
 		assertEquals(ResultPartitionState.CREATED, schedulingResultPartition.getState());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -62,7 +62,7 @@ public class TestingSchedulingTopology
 	}
 
 	@Override
-	public TestingSchedulingExecutionVertex getVertexOrThrow(final ExecutionVertexID executionVertexId) {
+	public TestingSchedulingExecutionVertex getVertex(final ExecutionVertexID executionVertexId) {
 		final TestingSchedulingExecutionVertex executionVertex = schedulingExecutionVertices.get(executionVertexId);
 		if (executionVertex == null) {
 			throw new IllegalArgumentException("can not find vertex: " + executionVertexId);
@@ -71,7 +71,7 @@ public class TestingSchedulingTopology
 	}
 
 	@Override
-	public TestingSchedulingResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID intermediateResultPartitionId) {
+	public TestingSchedulingResultPartition getResultPartition(final IntermediateResultPartitionID intermediateResultPartitionId) {
 		final TestingSchedulingResultPartition resultPartition = schedulingResultPartitions.get(intermediateResultPartitionId);
 		if (resultPartition == null) {
 			throw new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -63,14 +62,21 @@ public class TestingSchedulingTopology
 	}
 
 	@Override
-	public Optional<TestingSchedulingExecutionVertex> getVertex(ExecutionVertexID executionVertexId)  {
-		return Optional.ofNullable(schedulingExecutionVertices.get(executionVertexId));
+	public TestingSchedulingExecutionVertex getVertexOrThrow(final ExecutionVertexID executionVertexId) {
+		final TestingSchedulingExecutionVertex executionVertex = schedulingExecutionVertices.get(executionVertexId);
+		if (executionVertex == null) {
+			throw new IllegalArgumentException("can not find vertex: " + executionVertexId);
+		}
+		return executionVertex;
 	}
 
 	@Override
-	public Optional<TestingSchedulingResultPartition> getResultPartition(
-			IntermediateResultPartitionID intermediateResultPartitionId) {
-		return Optional.of(schedulingResultPartitions.get(intermediateResultPartitionId));
+	public TestingSchedulingResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID intermediateResultPartitionId) {
+		final TestingSchedulingResultPartition resultPartition = schedulingResultPartitions.get(intermediateResultPartitionId);
+		if (resultPartition == null) {
+			throw new IllegalArgumentException("can not find partition: " + intermediateResultPartitionId);
+		}
+		return resultPartition;
 	}
 
 	void addSchedulingExecutionVertex(TestingSchedulingExecutionVertex schedulingExecutionVertex) {


### PR DESCRIPTION
## What is the purpose of the change

*This removes unused methods `getVertex()` and `getResultPartition()` from `SchedulingTopology`*


## Brief change log

  - *See commits*

## Verifying this change

This change is already covered by existing tests, such as *`DefaultExecutionTopologyTest`*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
