### PR TITLE
[FLINK-17065][python][doc] Add documentation about the Python versions supported for PyFlink

### DIFF
--- a/docs/dev/table/python/installation.md
+++ b/docs/dev/table/python/installation.md
@@ -26,11 +26,11 @@ under the License.
 {:toc}
 
 ## Environment Requirements
-<span class="label label-info">Note</span> Python 3.5+ is required for PyFlink. Please run the following command to make sure that it meets the requirements:
+<span class="label label-info">Note</span> Python version (3.5, 3.6 or 3.7) is required for PyFlink. Please run the following command to make sure that it meets the requirements:
 
 {% highlight bash %}
 $ python --version
-# the version printed here must be 3.5+
+# the version printed here must be 3.5, 3.6 or 3.7
 {% endhighlight %}
 
 ## Installation of PyFlink

--- a/docs/dev/table/python/installation.zh.md
+++ b/docs/dev/table/python/installation.zh.md
@@ -26,11 +26,11 @@ under the License.
 {:toc}
 
 ## Environment Requirements
-<span class="label label-info">Note</span> Python 3.5+ is required for PyFlink. Please run the following command to make sure that it meets the requirements:
+<span class="label label-info">Note</span> Python version (3.5, 3.6 or 3.7) is required for PyFlink. Please run the following command to make sure that it meets the requirements:
 
 {% highlight bash %}
 $ python --version
-# the version printed here must be 3.5+
+# the version printed here must be 3.5, 3.6 or 3.7
 {% endhighlight %}
 
 ## Installation of PyFlink

--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -65,7 +65,7 @@ Then go to the root directory of flink source code and run this command to build
 cd flink-python; python setup.py sdist bdist_wheel
 {% endhighlight %}
 
-<span class="label label-info">Note</span> Python 3.5 or higher is required to build PyFlink.
+<span class="label label-info">Note</span> Python version (3.5, 3.6 or 3.7) is required to build PyFlink.
 
 The sdist and wheel package will be found under `./flink-python/dist/`. Either of them could be used for pip installation, such as:
 

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -65,7 +65,7 @@ mvn clean install -DskipTests -Dfast
 cd flink-python; python setup.py sdist bdist_wheel
 {% endhighlight %}
 
-<span class="label label-info">注意事项</span> 构建PyFlink需要Python3.5及以上的版本.
+<span class="label label-info">注意事项</span> 构建PyFlink需要Python的版本为3.5, 3.6 或者 3.7.
 
 构建好的源码发布包和wheel包位于`./flink-python/dist/`目录下。它们均可使用pip安装,比如:
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -122,11 +122,11 @@ These examples about how to submit a job in CLI.
 
 <div data-lang="python" markdown="1">
 
-<span class="label label-info">Note</span> When submitting Python job via `flink run`, Flink will run the command “python”. Please run the following command to confirm that the command “python” in current environment points to Python 3.5+:
+<span class="label label-info">Note</span> When submitting Python job via `flink run`, Flink will run the command “python”. Please run the following command to confirm that the command “python” in current environment points to a specified Python version 3.5, 3.6 or 3.7:
 
 {% highlight bash %}
 $ python --version
-# the version printed here must be 3.5+
+# the version printed here must be 3.5, 3.6 or 3.7
 {% endhighlight %}
 
 -   Run Python Table program:
@@ -377,12 +377,12 @@ Action "run" compiles and runs a program.
                                           interpreter used to execute the python
                                           UDF worker (e.g.: --pyExecutable
                                           /usr/local/bin/python3). The python
-                                          UDF worker depends on Python 3.5+,
-                                          Apache Beam (version == 2.15.0), Pip
-                                          (version >= 7.1.0) and SetupTools
-                                          (version >= 37.0.0). Please ensure
-                                          that the specified environment meets
-                                          the above requirements.
+                                          UDF worker depends on a specified Python
+                                          version 3.5, 3.6 or 3.7, Apache Beam
+                                          (version == 2.15.0), Pip (version >= 7.1.0)
+                                          and SetupTools (version >= 37.0.0).
+                                          Please ensure that the specified environment
+                                          meets the above requirements.
      -pyfs,--pyFiles <pythonFiles>        Attach custom python files for job.
                                           These files will be added to the
                                           PYTHONPATH of both the local client

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -122,11 +122,11 @@ option.
 
 <div data-lang="python" markdown="1">
 
-<span class="label label-info">注意</span> 通过`flink run`提交Python任务时Flink会调用“python”命令。请执行以下命令以确认当前环境下的指令“python”指向Python 3.5及以上版本：
+<span class="label label-info">注意</span> 通过`flink run`提交Python任务时Flink会调用“python”命令。请执行以下命令以确认当前环境下的指令“python”指向Python的版本为3.5, 3.6 或者 3.7中的一个：
 
 {% highlight bash %}
 $ python --version
-# the version printed here must be 3.5+
+# # the version printed here must be 3.5, 3.6 or 3.7
 {% endhighlight %}
 
 -   提交一个Python Table的作业:
@@ -376,12 +376,12 @@ Action "run" compiles and runs a program.
                                           interpreter used to execute the python
                                           UDF worker (e.g.: --pyExecutable
                                           /usr/local/bin/python3). The python
-                                          UDF worker depends on Python 3.5+,
-                                          Apache Beam (version == 2.15.0), Pip
-                                          (version >= 7.1.0) and SetupTools
-                                          (version >= 37.0.0). Please ensure
-                                          that the specified environment meets
-                                          the above requirements.
+                                          UDF worker depends on a specified Python
+                                          version 3.5, 3.6 or 3.7, Apache Beam
+                                          (version == 2.15.0), Pip (version >= 7.1.0)
+                                          and SetupTools (version >= 37.0.0).
+                                          Please ensure that the specified environment
+                                          meets the above requirements.
      -pyfs,--pyFiles <pythonFiles>        Attach custom python files for job.
                                           These files will be added to the
                                           PYTHONPATH of both the local client

--- a/docs/ops/cli.zh.md
+++ b/docs/ops/cli.zh.md
@@ -126,7 +126,7 @@ option.
 
 {% highlight bash %}
 $ python --version
-# # the version printed here must be 3.5, 3.6 or 3.7
+# the version printed here must be 3.5, 3.6 or 3.7
 {% endhighlight %}
 
 -   提交一个Python Table的作业:


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add documentation about the Python versions supported for PyFlink*

## Brief change log

  - *Add Python versions supported for PyFlink in installation.md and installation.zh.md*
  - *Add Python versions supported for PyFlink in building.md and building.zh.md*
  - *Add Python versions supported for PyFlink in cli.md and cli.zh.md*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
