### PR TITLE
[FLINK-16536][network][checkpointing] Implement InputChannel state recovery for unaligned checkpoint

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -250,7 +250,7 @@ public class SavepointEnvironment implements Environment {
 
 	@Override
 	public IndexedInputGate[] getAllInputGates() {
-		throw new UnsupportedOperationException(ERROR_MSG);
+		return new IndexedInputGate[0];
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/reader/AbstractRecordReader.java
@@ -63,6 +63,11 @@ abstract class AbstractRecordReader<T extends IOReadableWritable> extends Abstra
 	}
 
 	protected boolean getNextRecord(T target) throws IOException, InterruptedException {
+		// The action of partition request was removed from InputGate#setup since FLINK-16536, and this is the only
+		// unified way for launching partition request for batch jobs. In order to avoid potential performance concern,
+		// we might consider migrating this action back to the setup based on some condition judgement future.
+		inputGate.requestPartitions();
+
 		if (isFinished) {
 			return false;
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializer.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.consumer.EndOfChannelStateEvent;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -59,6 +60,8 @@ public class EventSerializer {
 
 	private static final int CANCEL_CHECKPOINT_MARKER_EVENT = 4;
 
+	private static final int END_OF_CHANNEL_STATE_EVENT = 5;
+
 	private static final int CHECKPOINT_TYPE_CHECKPOINT = 0;
 
 	private static final int CHECKPOINT_TYPE_SAVEPOINT = 1;
@@ -79,6 +82,9 @@ public class EventSerializer {
 		}
 		else if (eventClass == EndOfSuperstepEvent.class) {
 			return ByteBuffer.wrap(new byte[] { 0, 0, 0, END_OF_SUPERSTEP_EVENT });
+		}
+		else if (eventClass == EndOfChannelStateEvent.class) {
+			return ByteBuffer.wrap(new byte[] { 0, 0, 0, END_OF_CHANNEL_STATE_EVENT });
 		}
 		else if (eventClass == CancelCheckpointMarker.class) {
 			CancelCheckpointMarker marker = (CancelCheckpointMarker) event;
@@ -129,6 +135,8 @@ public class EventSerializer {
 				return type == CHECKPOINT_BARRIER_EVENT;
 			} else if (eventClass.equals(EndOfSuperstepEvent.class)) {
 				return type == END_OF_SUPERSTEP_EVENT;
+			} else if (eventClass.equals(EndOfChannelStateEvent.class)) {
+				return type == END_OF_CHANNEL_STATE_EVENT;
 			} else if (eventClass.equals(CancelCheckpointMarker.class)) {
 				return type == CANCEL_CHECKPOINT_MARKER_EVENT;
 			} else {
@@ -161,6 +169,9 @@ public class EventSerializer {
 			}
 			else if (type == END_OF_SUPERSTEP_EVENT) {
 				return EndOfSuperstepEvent.INSTANCE;
+			}
+			else if (type == END_OF_CHANNEL_STATE_EVENT) {
+				return EndOfChannelStateEvent.INSTANCE;
 			}
 			else if (type == CANCEL_CHECKPOINT_MARKER_EVENT) {
 				long id = buffer.getLong();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -67,7 +67,7 @@ class LocalBufferPool implements BufferPool {
 	 * <p><strong>BEWARE:</strong> Take special care with the interactions between this lock and
 	 * locks acquired before entering this class vs. locks being acquired during calls to external
 	 * code inside this class, e.g. with
-	 * {@link org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel#bufferQueue}
+	 * {@link org.apache.flink.runtime.io.network.partition.consumer.BufferManager#bufferQueue}
 	 * via the {@link #registeredListeners} callback.
 	 */
 	private final ArrayDeque<MemorySegment> availableMemorySegments = new ArrayDeque<MemorySegment>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentProvider;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferListener;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.util.ExceptionUtils;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * The general buffer manager used by {@link InputChannel} to request/recycle
+ * exclusive or floating buffers.
+ */
+public class BufferManager implements BufferListener, BufferRecycler {
+
+	/** The available buffer queue wraps both exclusive and requested floating buffers. */
+	private final AvailableBufferQueue bufferQueue = new AvailableBufferQueue();
+
+	/** The buffer provider for requesting exclusive buffers. */
+	private final MemorySegmentProvider globalPool;
+
+	/** The input channel to own this buffer manager. */
+	private final InputChannel inputChannel;
+
+	/** The tag indicates whether it is waiting for additional floating buffers from the buffer pool. */
+	@GuardedBy("bufferQueue")
+	private boolean isWaitingForFloatingBuffers;
+
+	/** The total number of required buffers for the respective input channel. */
+	@GuardedBy("bufferQueue")
+	private int numRequiredBuffers;
+
+	public BufferManager(
+		MemorySegmentProvider globalPool,
+		InputChannel inputChannel,
+		int numRequiredBuffers) {
+
+		this.globalPool = checkNotNull(globalPool);
+		this.inputChannel = checkNotNull(inputChannel);
+		checkArgument(numRequiredBuffers >= 0);
+		this.numRequiredBuffers = numRequiredBuffers;
+	}
+
+	// ------------------------------------------------------------------------
+	// Buffer request
+	// ------------------------------------------------------------------------
+
+	@Nullable
+	Buffer requestBuffer() {
+		synchronized (bufferQueue) {
+			return bufferQueue.takeBuffer();
+		}
+	}
+
+	/**
+	 * Requests exclusive buffers from the provider and returns the number of requested amount.
+	 */
+	int requestExclusiveBuffers() throws IOException {
+		Collection<MemorySegment> segments = globalPool.requestMemorySegments();
+		checkArgument(!segments.isEmpty(), "The number of exclusive buffers per channel should be larger than 0.");
+
+		synchronized (bufferQueue) {
+			for (MemorySegment segment : segments) {
+				bufferQueue.addExclusiveBuffer(new NetworkBuffer(segment, this), numRequiredBuffers);
+			}
+		}
+		return segments.size();
+	}
+
+	/**
+	 * Requests floating buffers from the buffer pool based on the given required amount, and returns the actual
+	 * requested amount. If the required amount is not fully satisfied, it will register as a listener.
+	 */
+	int requestFloatingBuffers(int numRequired) throws IOException {
+		int numRequestedBuffers = 0;
+		synchronized (bufferQueue) {
+			// Similar to notifyBufferAvailable(), make sure that we never add a buffer after channel
+			// released all buffers via releaseAllResources().
+			if (inputChannel.isReleased()) {
+				return numRequestedBuffers;
+			}
+
+			numRequiredBuffers = numRequired;
+
+			while (bufferQueue.getAvailableBufferSize() < numRequiredBuffers && !isWaitingForFloatingBuffers) {
+				BufferPool bufferPool = inputChannel.inputGate.getBufferPool();
+				Buffer buffer = bufferPool.requestBuffer();
+				if (buffer != null) {
+					bufferQueue.addFloatingBuffer(buffer);
+					numRequestedBuffers++;
+				} else if (bufferPool.addBufferListener(this)) {
+					isWaitingForFloatingBuffers = true;
+					break;
+				}
+			}
+		}
+		return numRequestedBuffers;
+	}
+
+	// ------------------------------------------------------------------------
+	// Buffer recycle
+	// ------------------------------------------------------------------------
+
+	/**
+	 * Exclusive buffer is recycled to this channel manager directly and it may trigger return extra
+	 * floating buffer based on <tt>numRequiredBuffers</tt>.
+	 *
+	 * @param segment The exclusive segment of this channel.
+	 */
+	@Override
+	public void recycle(MemorySegment segment) {
+		int numAddedBuffers = 0;
+		synchronized (bufferQueue) {
+			try {
+				// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+				// after channel released all buffers via releaseAllResources().
+				if (inputChannel.isReleased()) {
+					globalPool.recycleMemorySegments(Collections.singletonList(segment));
+				} else {
+					numAddedBuffers = bufferQueue.addExclusiveBuffer(new NetworkBuffer(segment, this), numRequiredBuffers);
+				}
+			} catch (Throwable t) {
+				ExceptionUtils.rethrow(t);
+			}
+		}
+
+		inputChannel.notifyBufferAvailable(numAddedBuffers);
+	}
+
+	/**
+	 * Recycles all the exclusive and floating buffers from the given buffer queue.
+	 */
+	void releaseAllBuffers(ArrayDeque<Buffer> buffers) throws IOException {
+		// Gather all exclusive buffers and recycle them to global pool in batch, because
+		// we do not want to trigger redistribution of buffers after each recycle.
+		final List<MemorySegment> exclusiveRecyclingSegments = new ArrayList<>();
+
+		Buffer buffer;
+		while ((buffer = buffers.poll()) != null) {
+			if (buffer.getRecycler() == this) {
+				exclusiveRecyclingSegments.add(buffer.getMemorySegment());
+			} else {
+				buffer.recycleBuffer();
+			}
+		}
+		synchronized (bufferQueue) {
+			bufferQueue.releaseAll(exclusiveRecyclingSegments);
+		}
+
+		if (exclusiveRecyclingSegments.size() > 0) {
+			globalPool.recycleMemorySegments(exclusiveRecyclingSegments);
+		}
+	}
+
+	// ------------------------------------------------------------------------
+	// Buffer listener notification
+	// ------------------------------------------------------------------------
+
+	/**
+	 * The buffer pool notifies this listener of an available floating buffer. If the listener is released or
+	 * currently does not need extra buffers, the buffer should be returned to the buffer pool. Otherwise,
+	 * the buffer will be added into the <tt>bufferQueue</tt>.
+	 *
+	 * @param buffer Buffer that becomes available in buffer pool.
+	 * @return NotificationResult indicates whether this channel accepts the buffer and is waiting for
+	 * more floating buffers.
+	 */
+	@Override
+	public BufferListener.NotificationResult notifyBufferAvailable(Buffer buffer) {
+		BufferListener.NotificationResult notificationResult = BufferListener.NotificationResult.BUFFER_NOT_USED;
+		try {
+			synchronized (bufferQueue) {
+				checkState(isWaitingForFloatingBuffers, "This channel should be waiting for floating buffers.");
+
+				// Important: make sure that we never add a buffer after releaseAllResources()
+				// released all buffers. Following scenarios exist:
+				// 1) releaseAllBuffers() already released buffers inside bufferQueue
+				// -> while isReleased is set correctly in InputChannel
+				// 2) releaseAllBuffers() did not yet release buffers from bufferQueue
+				// -> we may or may not have set isReleased yet but will always wait for the
+				// lock on bufferQueue to release buffers
+				if (inputChannel.isReleased() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
+					isWaitingForFloatingBuffers = false;
+					return notificationResult;
+				}
+
+				bufferQueue.addFloatingBuffer(buffer);
+
+				if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
+					isWaitingForFloatingBuffers = false;
+					notificationResult = BufferListener.NotificationResult.BUFFER_USED_NO_NEED_MORE;
+				} else {
+					notificationResult = BufferListener.NotificationResult.BUFFER_USED_NEED_MORE;
+				}
+			}
+
+			if (notificationResult != NotificationResult.BUFFER_NOT_USED) {
+				inputChannel.notifyBufferAvailable(1);
+			}
+		} catch (Throwable t) {
+			inputChannel.setError(t);
+		}
+
+		return notificationResult;
+	}
+
+	@Override
+	public void notifyBufferDestroyed() {
+		// Nothing to do actually.
+	}
+
+	// ------------------------------------------------------------------------
+	// Getter properties
+	// ------------------------------------------------------------------------
+
+	@VisibleForTesting
+	int unsynchronizedGetNumberOfRequiredBuffers() {
+		return numRequiredBuffers;
+	}
+
+	@VisibleForTesting
+	boolean unsynchronizedIsWaitingForFloatingBuffers() {
+		return isWaitingForFloatingBuffers;
+	}
+
+	@VisibleForTesting
+	int getNumberOfAvailableBuffers() {
+		synchronized (bufferQueue) {
+			return bufferQueue.getAvailableBufferSize();
+		}
+	}
+
+	int unsynchronizedGetExclusiveBuffersUsed() {
+		return bufferQueue.exclusiveBuffers.size();
+	}
+
+	int unsynchronizedGetFloatingBuffersAvailable() {
+		return bufferQueue.floatingBuffers.size();
+	}
+
+	/**
+	 * Manages the exclusive and floating buffers of this channel, and handles the
+	 * internal buffer related logic.
+	 */
+	static final class AvailableBufferQueue {
+
+		/**
+		 * The current available floating buffers from the fixed buffer pool.
+		 */
+		final ArrayDeque<Buffer> floatingBuffers;
+
+		/**
+		 * The current available exclusive buffers from the global buffer pool.
+		 */
+		final ArrayDeque<Buffer> exclusiveBuffers;
+
+		AvailableBufferQueue() {
+			this.exclusiveBuffers = new ArrayDeque<>();
+			this.floatingBuffers = new ArrayDeque<>();
+		}
+
+		/**
+		 * Adds an exclusive buffer (back) into the queue and recycles one floating buffer if the
+		 * number of available buffers in queue is more than the required amount.
+		 *
+		 * @param buffer             The exclusive buffer to add
+		 * @param numRequiredBuffers The number of required buffers
+		 * @return How many buffers were added to the queue
+		 */
+		int addExclusiveBuffer(Buffer buffer, int numRequiredBuffers) {
+			exclusiveBuffers.add(buffer);
+			if (getAvailableBufferSize() > numRequiredBuffers) {
+				Buffer floatingBuffer = floatingBuffers.poll();
+				if (floatingBuffer != null) {
+					floatingBuffer.recycleBuffer();
+					return 0;
+				}
+			}
+			return 1;
+		}
+
+		void addFloatingBuffer(Buffer buffer) {
+			floatingBuffers.add(buffer);
+		}
+
+		/**
+		 * Takes the floating buffer first in order to make full use of floating
+		 * buffers reasonably.
+		 *
+		 * @return An available floating or exclusive buffer, may be null
+		 * if the channel is released.
+		 */
+		@Nullable
+		Buffer takeBuffer() {
+			if (floatingBuffers.size() > 0) {
+				return floatingBuffers.poll();
+			} else {
+				return exclusiveBuffers.poll();
+			}
+		}
+
+		/**
+		 * The floating buffer is recycled to local buffer pool directly, and the
+		 * exclusive buffer will be gathered to return to global buffer pool later.
+		 *
+		 * @param exclusiveSegments The list that we will add exclusive segments into.
+		 */
+		void releaseAll(List<MemorySegment> exclusiveSegments) {
+			Buffer buffer;
+			while ((buffer = floatingBuffers.poll()) != null) {
+				buffer.recycleBuffer();
+			}
+			while ((buffer = exclusiveBuffers.poll()) != null) {
+				exclusiveSegments.add(buffer.getMemorySegment());
+			}
+		}
+
+		int getAvailableBufferSize() {
+			return floatingBuffers.size() + exclusiveBuffers.size();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EndOfChannelStateEvent.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/EndOfChannelStateEvent.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.event.RuntimeEvent;
+
+/**
+ * This event marks a {@link RecoveredInputChannel} as fully consumed.
+ */
+public class EndOfChannelStateEvent extends RuntimeEvent {
+
+	/** The singleton instance of this event. */
+	public static final EndOfChannelStateEvent INSTANCE = new EndOfChannelStateEvent();
+
+	// ------------------------------------------------------------------------
+
+	// not instantiable
+	private EndOfChannelStateEvent() {}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public void read(DataInputView in) {
+		// Nothing to do here
+	}
+
+	@Override
+	public void write(DataOutputView out) {
+		// Nothing to do here
+	}
+
+	// ------------------------------------------------------------------------
+
+	@Override
+	public int hashCode() {
+		return 1965146670;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return obj != null && obj.getClass() == EndOfChannelStateEvent.class;
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -154,6 +154,9 @@ public abstract class InputChannel {
 	public void spillInflightBuffers(long checkpointId, ChannelStateWriter channelStateWriter) throws IOException {
 	}
 
+	protected void notifyBufferAvailable(int numAvailableBuffers) {
+	}
+
 	// ------------------------------------------------------------------------
 	// Consume
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -66,10 +66,10 @@ public abstract class InputChannel {
 	// - Partition request backoff --------------------------------------------
 
 	/** The initial backoff (in ms). */
-	private final int initialBackoff;
+	protected final int initialBackoff;
 
 	/** The maximum backoff (in ms). */
-	private final int maxBackoff;
+	protected final int maxBackoff;
 
 	protected final Counter numBytesIn;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGate.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
@@ -25,6 +26,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -133,7 +135,18 @@ public abstract class InputGate implements PullingAsyncDataInput<BufferOrEvent>,
 	/**
 	 * Setup gate, potentially heavy-weight, blocking operation comparing to just creation.
 	 */
-	public abstract void setup() throws IOException, InterruptedException;
+	public abstract void setup() throws IOException;
+
+	/**
+	 * Reads the previous unaligned checkpoint states before requesting partition data.
+	 *
+	 * @param executor the dedicated executor for performing this action for all the internal channels.
+	 * @param reader the dedicated reader for unspilling the respective channel state from snapshots.
+	 * @return the future indicates whether the recovered states have already been drained or not.
+	 */
+	public abstract CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) throws IOException;
+
+	public abstract void requestPartitions() throws IOException;
 
 	public abstract void registerBufferReceivedListener(BufferReceivedListener listener);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -18,13 +18,14 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
-import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -71,10 +72,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		ResultPartitionID partitionId,
 		ResultPartitionManager partitionManager,
 		TaskEventPublisher taskEventPublisher,
-		InputChannelMetrics metrics) {
+		Counter numBytesIn,
+		Counter numBuffersIn) {
 
-		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher,
-			0, 0, metrics);
+		this(inputGate, channelIndex, partitionId, partitionManager, taskEventPublisher, 0, 0, numBytesIn, numBuffersIn);
 	}
 
 	public LocalInputChannel(
@@ -85,9 +86,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		TaskEventPublisher taskEventPublisher,
 		int initialBackoff,
 		int maxBackoff,
-		InputChannelMetrics metrics) {
+		Counter numBytesIn,
+		Counter numBuffersIn) {
 
-		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, metrics.getNumBytesInLocalCounter(), metrics.getNumBuffersInLocalCounter());
+		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, numBytesIn, numBuffersIn);
 
 		this.partitionManager = checkNotNull(partitionManager);
 		this.taskEventPublisher = checkNotNull(taskEventPublisher);
@@ -302,5 +304,14 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 		}
 		// already processed
 		return true;
+	}
+
+	// ------------------------------------------------------------------------
+	// Getter
+	// ------------------------------------------------------------------------
+
+	@VisibleForTesting
+	ResultSubpartitionView getSubpartitionView() {
+		return subpartitionView;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalRecoveredInputChannel.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An input channel reads recovered state from previous unaligned checkpoint snapshots
+ * via {@link ChannelStateReader} and then converts into {@link LocalInputChannel} finally.
+ */
+public class LocalRecoveredInputChannel extends RecoveredInputChannel {
+	private final ResultPartitionManager partitionManager;
+	private final TaskEventPublisher taskEventPublisher;
+
+	LocalRecoveredInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			ResultPartitionManager partitionManager,
+			TaskEventPublisher taskEventPublisher,
+			int initialBackOff,
+			int maxBackoff,
+			InputChannelMetrics metrics) {
+		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInLocalCounter(), metrics.getNumBuffersInLocalCounter());
+
+		this.partitionManager = checkNotNull(partitionManager);
+		this.taskEventPublisher = checkNotNull(taskEventPublisher);
+	}
+
+	@Override
+	public InputChannel toInputChannel() {
+		return new LocalInputChannel(
+			inputGate,
+			getChannelIndex(),
+			partitionId,
+			partitionManager,
+			taskEventPublisher,
+			initialBackoff,
+			maxBackoff,
+			numBytesIn,
+			numBytesIn);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannel.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader.ReadResult;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An input channel reads recovered state from previous unaligned checkpoint snapshots
+ * via {@link ChannelStateReader}.
+ */
+public abstract class RecoveredInputChannel extends InputChannel {
+
+	private static final Logger LOG = LoggerFactory.getLogger(RecoveredInputChannel.class);
+
+	private final ArrayDeque<Buffer> receivedBuffers = new ArrayDeque<>();
+	private final CompletableFuture<?> stateConsumedFuture = new CompletableFuture<>();
+	protected final BufferManager bufferManager;
+
+	@GuardedBy("receivedBuffers")
+	private boolean isReleased;
+
+	RecoveredInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			int initialBackoff,
+			int maxBackoff,
+			Counter numBytesIn,
+			Counter numBuffersIn) {
+		super(inputGate, channelIndex, partitionId, initialBackoff, maxBackoff, numBytesIn, numBuffersIn);
+
+		bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
+	}
+
+	public abstract InputChannel toInputChannel() throws IOException;
+
+	CompletableFuture<?> getStateConsumedFuture() {
+		return stateConsumedFuture;
+	}
+
+	protected void readRecoveredState(ChannelStateReader reader) throws IOException, InterruptedException {
+		ReadResult result = ReadResult.HAS_MORE_DATA;
+		while (result == ReadResult.HAS_MORE_DATA) {
+			Buffer buffer = bufferManager.requestBufferBlocking();
+			result = internalReaderRecoveredState(reader, buffer);
+		}
+		finishReadRecoveredState();
+	}
+
+	private ReadResult internalReaderRecoveredState(ChannelStateReader reader, Buffer buffer) throws IOException {
+		ReadResult result;
+		try {
+			result = reader.readInputData(channelInfo, buffer);
+		} catch (Throwable t) {
+			buffer.recycleBuffer();
+			throw t;
+		}
+		if (buffer.readableBytes() > 0) {
+			onRecoveredStateBuffer(buffer);
+		} else {
+			buffer.recycleBuffer();
+		}
+		return result;
+	}
+
+	private void onRecoveredStateBuffer(Buffer buffer) {
+		boolean recycleBuffer = true;
+		try {
+			final boolean wasEmpty;
+			synchronized (receivedBuffers) {
+				// Similar to notifyBufferAvailable(), make sure that we never add a buffer
+				// after releaseAllResources() released all buffers from receivedBuffers.
+				if (isReleased) {
+					return;
+				}
+
+				wasEmpty = receivedBuffers.isEmpty();
+				receivedBuffers.add(buffer);
+				recycleBuffer = false;
+			}
+
+			if (wasEmpty) {
+				notifyChannelNonEmpty();
+			}
+		} finally {
+			if (recycleBuffer) {
+				buffer.recycleBuffer();
+			}
+		}
+	}
+
+	private void finishReadRecoveredState() throws IOException {
+		onRecoveredStateBuffer(EventSerializer.toBuffer(EndOfChannelStateEvent.INSTANCE));
+		bufferManager.releaseFloatingBuffers();
+		LOG.debug("{}/{} finished recovering input.", inputGate.getOwningTaskName(), channelInfo);
+	}
+
+	@Nullable
+	private BufferAndAvailability getNextRecoveredStateBuffer() throws IOException {
+		final Buffer next;
+		final boolean moreAvailable;
+
+		synchronized (receivedBuffers) {
+			checkState(!isReleased, "Trying to read from released RecoveredInputChannel");
+			next = receivedBuffers.poll();
+			moreAvailable = !receivedBuffers.isEmpty();
+		}
+
+		if (next == null) {
+			return null;
+		} else if (isEndOfChannelStateEvent(next)) {
+			stateConsumedFuture.complete(null);
+			return null;
+		} else {
+			return new BufferAndAvailability(next, moreAvailable, 0);
+		}
+	}
+
+	private boolean isEndOfChannelStateEvent(Buffer buffer) throws IOException {
+		if (buffer.isBuffer()) {
+			return false;
+		}
+
+		AbstractEvent event = EventSerializer.fromBuffer(buffer, getClass().getClassLoader());
+		buffer.setReaderIndex(0);
+		return event.getClass() == EndOfChannelStateEvent.class;
+	}
+
+	@Override
+	Optional<BufferAndAvailability> getNextBuffer() throws IOException {
+		checkError();
+		return Optional.ofNullable(getNextRecoveredStateBuffer());
+	}
+
+	@Override
+	public void resumeConsumption() {
+		throw new UnsupportedOperationException("RecoveredInputChannel should never be blocked.");
+	}
+
+	@Override
+	void requestSubpartition(int subpartitionIndex) {
+		throw new UnsupportedOperationException("RecoveredInputChannel should never request partition.");
+	}
+
+	@Override
+	void sendTaskEvent(TaskEvent event) {
+		throw new UnsupportedOperationException("RecoveredInputChannel should never send any task events.");
+	}
+
+	@Override
+	boolean isReleased() {
+		synchronized (receivedBuffers) {
+			return isReleased;
+		}
+	}
+
+	void releaseAllResources() throws IOException {
+		ArrayDeque<Buffer> releasedBuffers = new ArrayDeque<>();
+		boolean shouldRelease = false;
+
+		synchronized (receivedBuffers) {
+			if (!isReleased) {
+				isReleased = true;
+				shouldRelease = true;
+				releasedBuffers.addAll(receivedBuffers);
+				receivedBuffers.clear();
+			}
+		}
+
+		if (shouldRelease) {
+			bufferManager.releaseAllBuffers(releasedBuffers);
+		}
+	}
+
+	@VisibleForTesting
+	protected int getNumberOfQueuedBuffers() {
+		synchronized (receivedBuffers) {
+			return receivedBuffers.size();
+		}
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -216,7 +216,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 
 		numBytesIn.inc(next.getSize());
 		numBuffersIn.inc();
-		return Optional.of(new BufferAndAvailability(next, moreAvailable, getSenderBacklog()));
+		return Optional.of(new BufferAndAvailability(next, moreAvailable, 0));
 	}
 
 	@Override
@@ -368,6 +368,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return numRequiredBuffers;
 	}
 
+	@VisibleForTesting
 	public int getSenderBacklog() {
 		return numRequiredBuffers - initialCredit;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
@@ -33,7 +32,6 @@ import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -109,15 +107,14 @@ public class RemoteInputChannel extends InputChannel {
 		ConnectionManager connectionManager,
 		int initialBackOff,
 		int maxBackoff,
-		InputChannelMetrics metrics,
-		@Nonnull MemorySegmentProvider memorySegmentProvider) {
+		InputChannelMetrics metrics) {
 
 		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff,
 			metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
-		this.bufferManager = new BufferManager(memorySegmentProvider, this, 0);
+		this.bufferManager = new BufferManager(inputGate.getMemorySegmentProvider(), this, 0);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
@@ -28,7 +29,6 @@ import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
-import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 
@@ -107,10 +107,10 @@ public class RemoteInputChannel extends InputChannel {
 		ConnectionManager connectionManager,
 		int initialBackOff,
 		int maxBackoff,
-		InputChannelMetrics metrics) {
+		Counter numBytesIn,
+		Counter numBuffersIn) {
 
-		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff,
-			metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
+		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, numBytesIn, numBuffersIn);
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
@@ -307,6 +307,11 @@ public class RemoteInputChannel extends InputChannel {
 	@VisibleForTesting
 	BufferManager getBufferManager() {
 		return bufferManager;
+	}
+
+	@VisibleForTesting
+	PartitionRequestClient getPartitionRequestClient() {
+		return partitionRequestClient;
 	}
 
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -28,15 +27,11 @@ import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.BufferListener;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
-import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
-import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
-import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -45,21 +40,18 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * An input channel, which requests a remote partition queue.
  */
-public class RemoteInputChannel extends InputChannel implements BufferRecycler, BufferListener {
+public class RemoteInputChannel extends InputChannel {
 
 	/** ID to distinguish this channel from other channels sharing the same TCP connection. */
 	private final InputChannelID id = new InputChannelID();
@@ -94,23 +86,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	/** The initial number of exclusive buffers assigned to this channel. */
 	private int initialCredit;
 
-	/** The available buffer queue wraps both exclusive and requested floating buffers. */
-	private final AvailableBufferQueue bufferQueue = new AvailableBufferQueue();
-
 	/** The number of available buffers that have not been announced to the producer yet. */
 	private final AtomicInteger unannouncedCredit = new AtomicInteger(0);
-
-	/** The number of required buffers that equals to sender's backlog plus initial credit. */
-	@GuardedBy("bufferQueue")
-	private int numRequiredBuffers;
-
-	/** The tag indicates whether this channel is waiting for additional floating buffers from the buffer pool. */
-	@GuardedBy("bufferQueue")
-	private boolean isWaitingForFloatingBuffers;
-
-	/** Global memory segment provider to request and recycle exclusive buffers (only for credit-based). */
-	@Nonnull
-	private final MemorySegmentProvider memorySegmentProvider;
 
 	/**
 	 * The latest already triggered checkpoint id which would be updated during
@@ -121,6 +98,8 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 
 	/** The current received checkpoint id from the network. */
 	private long receivedCheckpointId = -1;
+
+	private final BufferManager bufferManager;
 
 	public RemoteInputChannel(
 		SingleInputGate inputGate,
@@ -138,7 +117,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 
 		this.connectionId = checkNotNull(connectionId);
 		this.connectionManager = checkNotNull(connectionManager);
-		this.memorySegmentProvider = memorySegmentProvider;
+		this.bufferManager = new BufferManager(memorySegmentProvider, this, 0);
 	}
 
 	/**
@@ -149,17 +128,7 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		checkState(initialCredit == 0, "Bug in input channel setup logic: exclusive buffers have " +
 			"already been set for this input channel.");
 
-		Collection<MemorySegment> segments = checkNotNull(memorySegmentProvider.requestMemorySegments());
-		checkArgument(!segments.isEmpty(), "The number of exclusive buffers per channel should be larger than 0.");
-
-		initialCredit = segments.size();
-		numRequiredBuffers = segments.size();
-
-		synchronized (bufferQueue) {
-			for (MemorySegment segment : segments) {
-				bufferQueue.addExclusiveBuffer(new NetworkBuffer(segment, this), numRequiredBuffers);
-			}
-		}
+		initialCredit = bufferManager.requestExclusiveBuffers();
 	}
 
 	// ------------------------------------------------------------------------
@@ -275,27 +244,11 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	void releaseAllResources() throws IOException {
 		if (isReleased.compareAndSet(false, true)) {
 
-			// Gather all exclusive buffers and recycle them to global pool in batch, because
-			// we do not want to trigger redistribution of buffers after each recycle.
-			final List<MemorySegment> exclusiveRecyclingSegments = new ArrayList<>();
-
+			ArrayDeque<Buffer> releasedBuffers;
 			synchronized (receivedBuffers) {
-				Buffer buffer;
-				while ((buffer = receivedBuffers.poll()) != null) {
-					if (buffer.getRecycler() == this) {
-						exclusiveRecyclingSegments.add(buffer.getMemorySegment());
-					} else {
-						buffer.recycleBuffer();
-					}
-				}
+				releasedBuffers = receivedBuffers;
 			}
-			synchronized (bufferQueue) {
-				bufferQueue.releaseAll(exclusiveRecyclingSegments);
-			}
-
-			if (exclusiveRecyclingSegments.size() > 0) {
-				memorySegmentProvider.recycleMemorySegments(exclusiveRecyclingSegments);
-			}
+			bufferManager.releaseAllBuffers(releasedBuffers);
 
 			// The released flag has to be set before closing the connection to ensure that
 			// buffers received concurrently with closing are properly recycled.
@@ -329,53 +282,24 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		partitionRequestClient.notifyCreditAvailable(this);
 	}
 
-	/**
-	 * Exclusive buffer is recycled to this input channel directly and it may trigger return extra
-	 * floating buffer and notify increased credit to the producer.
-	 *
-	 * @param segment The exclusive segment of this channel.
-	 */
-	@Override
-	public void recycle(MemorySegment segment) {
-		int numAddedBuffers;
-
-		synchronized (bufferQueue) {
-			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
-			// after releaseAllResources() released all buffers (see below for details).
-			if (isReleased.get()) {
-				try {
-					memorySegmentProvider.recycleMemorySegments(Collections.singletonList(segment));
-					return;
-				} catch (Throwable t) {
-					ExceptionUtils.rethrow(t);
-				}
-			}
-			numAddedBuffers = bufferQueue.addExclusiveBuffer(new NetworkBuffer(segment, this), numRequiredBuffers);
-		}
-
-		if (numAddedBuffers > 0 && unannouncedCredit.getAndAdd(numAddedBuffers) == 0) {
-			notifyCreditAvailable();
-		}
-	}
-
+	@VisibleForTesting
 	public int getNumberOfAvailableBuffers() {
-		synchronized (bufferQueue) {
-			return bufferQueue.getAvailableBufferSize();
-		}
+		return bufferManager.getNumberOfAvailableBuffers();
 	}
 
+	@VisibleForTesting
 	public int getNumberOfRequiredBuffers() {
-		return numRequiredBuffers;
+		return bufferManager.unsynchronizedGetNumberOfRequiredBuffers();
 	}
 
 	@VisibleForTesting
 	public int getSenderBacklog() {
-		return numRequiredBuffers - initialCredit;
+		return getNumberOfRequiredBuffers() - initialCredit;
 	}
 
 	@VisibleForTesting
 	boolean isWaitingForFloatingBuffers() {
-		return isWaitingForFloatingBuffers;
+		return bufferManager.unsynchronizedIsWaitingForFloatingBuffers();
 	}
 
 	@VisibleForTesting
@@ -383,58 +307,21 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		return receivedBuffers.poll();
 	}
 
-	/**
-	 * The Buffer pool notifies this channel of an available floating buffer. If the channel is released or
-	 * currently does not need extra buffers, the buffer should be returned to the buffer pool. Otherwise,
-	 * the buffer will be added into the <tt>bufferQueue</tt> and the unannounced credit is increased
-	 * by one.
-	 *
-	 * @param buffer Buffer that becomes available in buffer pool.
-	 * @return NotificationResult indicates whether this channel accepts the buffer and is waiting for
-	 *  	more floating buffers.
-	 */
-	@Override
-	public NotificationResult notifyBufferAvailable(Buffer buffer) {
-		NotificationResult notificationResult = NotificationResult.BUFFER_NOT_USED;
-		try {
-			synchronized (bufferQueue) {
-				checkState(isWaitingForFloatingBuffers,
-					"This channel should be waiting for floating buffers.");
-
-				// Important: make sure that we never add a buffer after releaseAllResources()
-				// released all buffers. Following scenarios exist:
-				// 1) releaseAllResources() already released buffers inside bufferQueue
-				// -> then isReleased is set correctly
-				// 2) releaseAllResources() did not yet release buffers from bufferQueue
-				// -> we may or may not have set isReleased yet but will always wait for the
-				// lock on bufferQueue to release buffers
-				if (isReleased.get() || bufferQueue.getAvailableBufferSize() >= numRequiredBuffers) {
-					isWaitingForFloatingBuffers = false;
-					return notificationResult;
-				}
-
-				bufferQueue.addFloatingBuffer(buffer);
-
-				if (bufferQueue.getAvailableBufferSize() == numRequiredBuffers) {
-					isWaitingForFloatingBuffers = false;
-					notificationResult = NotificationResult.BUFFER_USED_NO_NEED_MORE;
-				} else {
-					notificationResult = NotificationResult.BUFFER_USED_NEED_MORE;
-				}
-			}
-
-			if (unannouncedCredit.getAndAdd(1) == 0) {
-				notifyCreditAvailable();
-			}
-		} catch (Throwable t) {
-			setError(t);
-		}
-		return notificationResult;
+	@VisibleForTesting
+	BufferManager getBufferManager() {
+		return bufferManager;
 	}
 
+
+	/**
+	 * The unannounced credit is increased by the given amount and might notify
+	 * increased credit to the producer.
+	 */
 	@Override
-	public void notifyBufferDestroyed() {
-		// Nothing to do actually.
+	public void notifyBufferAvailable(int numAvailableBuffers) {
+		if (numAvailableBuffers > 0 && unannouncedCredit.getAndAdd(numAvailableBuffers) == 0) {
+			notifyCreditAvailable();
+		}
 	}
 
 	@Override
@@ -486,11 +373,11 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	}
 
 	public int unsynchronizedGetExclusiveBuffersUsed() {
-		return Math.max(0, initialCredit - bufferQueue.exclusiveBuffers.size());
+		return Math.max(0, initialCredit - bufferManager.unsynchronizedGetExclusiveBuffersUsed());
 	}
 
 	public int unsynchronizedGetFloatingBuffersAvailable() {
-		return Math.max(0, bufferQueue.floatingBuffers.size());
+		return Math.max(0, bufferManager.unsynchronizedGetFloatingBuffersAvailable());
 	}
 
 	public InputChannelID getInputChannelId() {
@@ -518,42 +405,18 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 	 */
 	@Nullable
 	public Buffer requestBuffer() {
-		synchronized (bufferQueue) {
-			return bufferQueue.takeBuffer();
-		}
+		return bufferManager.requestBuffer();
 	}
 
 	/**
 	 * Receives the backlog from the producer's buffer response. If the number of available
-	 * buffers is less than backlog + initialCredit, it will request floating buffers from the buffer
-	 * pool, and then notify unannounced credits to the producer.
+	 * buffers is less than backlog + initialCredit, it will request floating buffers from
+	 * the buffer manager, and then notify unannounced credits to the producer.
 	 *
 	 * @param backlog The number of unsent buffers in the producer's sub partition.
 	 */
 	void onSenderBacklog(int backlog) throws IOException {
-		int numRequestedBuffers = 0;
-
-		synchronized (bufferQueue) {
-			// Similar to notifyBufferAvailable(), make sure that we never add a buffer
-			// after releaseAllResources() released all buffers (see above for details).
-			if (isReleased.get()) {
-				return;
-			}
-
-			numRequiredBuffers = backlog + initialCredit;
-			while (bufferQueue.getAvailableBufferSize() < numRequiredBuffers && !isWaitingForFloatingBuffers) {
-				Buffer buffer = inputGate.getBufferPool().requestBuffer();
-				if (buffer != null) {
-					bufferQueue.addFloatingBuffer(buffer);
-					numRequestedBuffers++;
-				} else if (inputGate.getBufferProvider().addBufferListener(this)) {
-					// If the channel has not got enough buffers, register it as listener to wait for more floating buffers.
-					isWaitingForFloatingBuffers = true;
-					break;
-				}
-			}
-		}
-
+		int numRequestedBuffers = bufferManager.requestFloatingBuffers(backlog + initialCredit);
 		if (numRequestedBuffers > 0 && unannouncedCredit.getAndAdd(numRequestedBuffers) == 0) {
 			notifyCreditAvailable();
 		}
@@ -659,84 +522,6 @@ public class RemoteInputChannel extends InputChannel implements BufferRecycler, 
 		public String getMessage() {
 			return String.format("Buffer re-ordering: expected buffer with sequence number %d, but received %d.",
 				expectedSequenceNumber, actualSequenceNumber);
-		}
-	}
-
-	/**
-	 * Manages the exclusive and floating buffers of this channel, and handles the
-	 * internal buffer related logic.
-	 */
-	private static class AvailableBufferQueue {
-
-		/** The current available floating buffers from the fixed buffer pool. */
-		private final ArrayDeque<Buffer> floatingBuffers;
-
-		/** The current available exclusive buffers from the global buffer pool. */
-		private final ArrayDeque<Buffer> exclusiveBuffers;
-
-		AvailableBufferQueue() {
-			this.exclusiveBuffers = new ArrayDeque<>();
-			this.floatingBuffers = new ArrayDeque<>();
-		}
-
-		/**
-		 * Adds an exclusive buffer (back) into the queue and recycles one floating buffer if the
-		 * number of available buffers in queue is more than the required amount.
-		 *
-		 * @param buffer The exclusive buffer to add
-		 * @param numRequiredBuffers The number of required buffers
-		 *
-		 * @return How many buffers were added to the queue
-		 */
-		int addExclusiveBuffer(Buffer buffer, int numRequiredBuffers) {
-			exclusiveBuffers.add(buffer);
-			if (getAvailableBufferSize() > numRequiredBuffers) {
-				Buffer floatingBuffer = floatingBuffers.poll();
-				floatingBuffer.recycleBuffer();
-				return 0;
-			} else {
-				return 1;
-			}
-		}
-
-		void addFloatingBuffer(Buffer buffer) {
-			floatingBuffers.add(buffer);
-		}
-
-		/**
-		 * Takes the floating buffer first in order to make full use of floating
-		 * buffers reasonably.
-		 *
-		 * @return An available floating or exclusive buffer, may be null
-		 * if the channel is released.
-		 */
-		@Nullable
-		Buffer takeBuffer() {
-			if (floatingBuffers.size() > 0) {
-				return floatingBuffers.poll();
-			} else {
-				return exclusiveBuffers.poll();
-			}
-		}
-
-		/**
-		 * The floating buffer is recycled to local buffer pool directly, and the
-		 * exclusive buffer will be gathered to return to global buffer pool later.
-		 *
-		 * @param exclusiveSegments The list that we will add exclusive segments into.
-		 */
-		void releaseAll(List<MemorySegment> exclusiveSegments) {
-			Buffer buffer;
-			while ((buffer = floatingBuffers.poll()) != null) {
-				buffer.recycleBuffer();
-			}
-			while ((buffer = exclusiveBuffers.poll()) != null) {
-				exclusiveSegments.add(buffer.getMemorySegment());
-			}
-		}
-
-		int getAvailableBufferSize() {
-			return floatingBuffers.size() + exclusiveBuffers.size();
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteRecoveredInputChannel.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.io.network.ConnectionID;
+import org.apache.flink.runtime.io.network.ConnectionManager;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An input channel reads recovered state from previous unaligned checkpoint snapshots
+ * via {@link ChannelStateReader} and then converts into {@link RemoteInputChannel} finally.
+ */
+public class RemoteRecoveredInputChannel extends RecoveredInputChannel {
+	private final ConnectionID connectionId;
+	private final ConnectionManager connectionManager;
+
+	private boolean exclusiveBuffersAssigned;
+
+	RemoteRecoveredInputChannel(
+			SingleInputGate inputGate,
+			int channelIndex,
+			ResultPartitionID partitionId,
+			ConnectionID connectionId,
+			ConnectionManager connectionManager,
+			int initialBackOff,
+			int maxBackoff,
+			InputChannelMetrics metrics) {
+		super(inputGate, channelIndex, partitionId, initialBackOff, maxBackoff, metrics.getNumBytesInRemoteCounter(), metrics.getNumBuffersInRemoteCounter());
+
+		this.connectionId = checkNotNull(connectionId);
+		this.connectionManager = checkNotNull(connectionManager);
+	}
+
+	@Override
+	public InputChannel toInputChannel() throws IOException {
+		RemoteInputChannel remoteInputChannel = new RemoteInputChannel(
+			inputGate,
+			getChannelIndex(),
+			partitionId,
+			connectionId,
+			connectionManager,
+			initialBackoff,
+			maxBackoff,
+			numBytesIn,
+			numBuffersIn);
+		remoteInputChannel.assignExclusiveSegments();
+		return remoteInputChannel;
+	}
+
+	void assignExclusiveSegments() throws IOException {
+		checkState(!exclusiveBuffersAssigned, "Exclusive buffers should be assigned only once.");
+
+		bufferManager.requestExclusiveBuffers();
+		exclusiveBuffersAssigned = true;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -184,6 +185,8 @@ public class SingleInputGate extends IndexedInputGate {
 	@Nullable
 	private final BufferDecompressor bufferDecompressor;
 
+	private final MemorySegmentProvider memorySegmentProvider;
+
 	public SingleInputGate(
 		String owningTaskName,
 		int gateIndex,
@@ -193,7 +196,8 @@ public class SingleInputGate extends IndexedInputGate {
 		int numberOfInputChannels,
 		PartitionProducerStateProvider partitionProducerStateProvider,
 		SupplierWithException<BufferPool, IOException> bufferPoolFactory,
-		@Nullable BufferDecompressor bufferDecompressor) {
+		@Nullable BufferDecompressor bufferDecompressor,
+		MemorySegmentProvider memorySegmentProvider) {
 
 		this.owningTaskName = checkNotNull(owningTaskName);
 		Preconditions.checkArgument(0 <= gateIndex, "The gate index must be positive.");
@@ -217,6 +221,7 @@ public class SingleInputGate extends IndexedInputGate {
 		this.partitionProducerStateProvider = checkNotNull(partitionProducerStateProvider);
 
 		this.bufferDecompressor = bufferDecompressor;
+		this.memorySegmentProvider = checkNotNull(memorySegmentProvider);
 
 		this.closeFuture = new CompletableFuture<>();
 	}
@@ -300,6 +305,10 @@ public class SingleInputGate extends IndexedInputGate {
 
 	public BufferPool getBufferPool() {
 		return bufferPool;
+	}
+
+	MemorySegmentProvider getMemorySegmentProvider() {
+		return memorySegmentProvider;
 	}
 
 	public int getNumberOfQueuedBuffers() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -133,7 +133,8 @@ public class SingleInputGateFactory {
 			igdd.getShuffleDescriptors().length,
 			partitionProducerStateProvider,
 			bufferPoolFactory,
-			bufferDecompressor);
+			bufferDecompressor,
+			networkBufferPool);
 
 		createInputChannels(owningTaskName, igdd, inputGate, metrics);
 		return inputGate;
@@ -187,8 +188,7 @@ public class SingleInputGateFactory {
 					connectionManager,
 					partitionRequestInitialBackoff,
 					partitionRequestMaxBackoff,
-					metrics,
-					networkBufferPool);
+					metrics);
 			},
 			nettyShuffleDescriptor ->
 				createKnownInputChannel(
@@ -230,8 +230,7 @@ public class SingleInputGateFactory {
 				connectionManager,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
-				metrics,
-				networkBufferPool);
+				metrics);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -210,7 +210,7 @@ public class SingleInputGateFactory {
 		if (inputChannelDescriptor.isLocalTo(taskExecutorResourceId)) {
 			// Consuming task is deployed to the same TaskManager as the partition => local
 			channelStatistics.numLocalChannels++;
-			return new LocalInputChannel(
+			return new LocalRecoveredInputChannel(
 				inputGate,
 				index,
 				partitionId,
@@ -222,7 +222,7 @@ public class SingleInputGateFactory {
 		} else {
 			// Different instances => remote
 			channelStatistics.numRemoteChannels++;
-			return new RemoteInputChannel(
+			return new RemoteRecoveredInputChannel(
 				inputGate,
 				index,
 				partitionId,
@@ -241,7 +241,8 @@ public class SingleInputGateFactory {
 			int floatingNetworkBuffersPerGate,
 			int size,
 			ResultPartitionType type) {
-		return () -> bufferPoolFactory.createBufferPool(0, floatingNetworkBuffersPerGate);
+		// Note that we should guarantee at-least one floating buffer for local channel state recovery.
+		return () -> bufferPoolFactory.createBufferPool(1, floatingNetworkBuffersPerGate);
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
@@ -31,6 +32,7 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -266,6 +268,18 @@ public class UnionInputGate extends InputGate {
 
 	@Override
 	public void setup() {
+	}
+
+	@Override
+	public CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) {
+		throw new UnsupportedOperationException("This method should never be called.");
+	}
+
+	@Override
+	public void requestPartitions() throws IOException {
+		for (InputGate inputGate : inputGates) {
+			inputGate.requestPartitions();
+		}
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -127,10 +127,20 @@ class UnknownInputChannel extends InputChannel {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			metrics);
+			metrics.getNumBytesInRemoteCounter(),
+			metrics.getNumBuffersInRemoteCounter());
 	}
 
 	public LocalInputChannel toLocalInputChannel() {
-		return new LocalInputChannel(inputGate, getChannelIndex(), partitionId, partitionManager, taskEventPublisher, initialBackoff, maxBackoff, metrics);
+		return new LocalInputChannel(
+			inputGate,
+			getChannelIndex(),
+			partitionId,
+			partitionManager,
+			taskEventPublisher,
+			initialBackoff,
+			maxBackoff,
+			metrics.getNumBytesInRemoteCounter(),
+			metrics.getNumBuffersInRemoteCounter());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnknownInputChannel.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -26,8 +25,6 @@ import org.apache.flink.runtime.io.network.TaskEventPublisher;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
-
-import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -53,9 +50,6 @@ class UnknownInputChannel extends InputChannel {
 
 	private final InputChannelMetrics metrics;
 
-	@Nonnull
-	private final MemorySegmentProvider memorySegmentProvider;
-
 	public UnknownInputChannel(
 			SingleInputGate gate,
 			int channelIndex,
@@ -65,8 +59,7 @@ class UnknownInputChannel extends InputChannel {
 			ConnectionManager connectionManager,
 			int initialBackoff,
 			int maxBackoff,
-			InputChannelMetrics metrics,
-			@Nonnull MemorySegmentProvider memorySegmentProvider) {
+			InputChannelMetrics metrics) {
 
 		super(gate, channelIndex, partitionId, initialBackoff, maxBackoff, null, null);
 
@@ -76,7 +69,6 @@ class UnknownInputChannel extends InputChannel {
 		this.metrics = checkNotNull(metrics);
 		this.initialBackoff = initialBackoff;
 		this.maxBackoff = maxBackoff;
-		this.memorySegmentProvider = memorySegmentProvider;
 	}
 
 	@Override
@@ -127,8 +119,15 @@ class UnknownInputChannel extends InputChannel {
 	// ------------------------------------------------------------------------
 
 	public RemoteInputChannel toRemoteInputChannel(ConnectionID producerAddress) {
-		return new RemoteInputChannel(inputGate, getChannelIndex(), partitionId, checkNotNull(producerAddress),
-			connectionManager, initialBackoff, maxBackoff, metrics, memorySegmentProvider);
+		return new RemoteInputChannel(
+			inputGate,
+			getChannelIndex(),
+			partitionId,
+			checkNotNull(producerAddress),
+			connectionManager,
+			initialBackoff,
+			maxBackoff,
+			metrics);
 	}
 
 	public LocalInputChannel toLocalInputChannel() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/InputGateWithMetrics.java
@@ -19,17 +19,19 @@
 package org.apache.flink.runtime.taskmanager;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
-import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -79,8 +81,18 @@ public class InputGateWithMetrics extends IndexedInputGate {
 	}
 
 	@Override
-	public void setup() throws IOException, InterruptedException {
+	public void setup() throws IOException {
 		inputGate.setup();
+	}
+
+	@Override
+	public CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) throws IOException {
+		return inputGate.readRecoveredState(executor, reader);
+	}
+
+	@Override
+	public void requestPartitions() throws IOException {
+		inputGate.requestPartitions();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -855,7 +855,7 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 
 	@VisibleForTesting
 	public static void setupPartitionsAndGates(
-		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException, InterruptedException {
+		ResultPartitionWriter[] producedPartitions, InputGate[] inputGates) throws IOException {
 
 		for (ResultPartitionWriter partition : producedPartitions) {
 			partition.setup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -39,6 +39,8 @@ public class NettyShuffleEnvironmentBuilder {
 	private static final String[] DEFAULT_TEMP_DIRS = {EnvironmentInformation.getTemporaryFileDirectory()};
 	private static final Duration DEFAULT_REQUEST_SEGMENTS_TIMEOUT = Duration.ofMillis(30000L);
 
+	private int bufferSize = DEFAULT_NETWORK_BUFFER_SIZE;
+
 	private int numNetworkBuffers = DEFAULT_NUM_NETWORK_BUFFERS;
 
 	private int partitionRequestInitialBackoff;
@@ -63,6 +65,11 @@ public class NettyShuffleEnvironmentBuilder {
 
 	public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
 		this.taskManagerLocation = taskManagerLocation;
+		return this;
+	}
+
+	public NettyShuffleEnvironmentBuilder setBufferSize(int bufferSize) {
+		this.bufferSize = bufferSize;
 		return this;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.configuration.NettyShuffleEnvironmentOptions;
-import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
@@ -135,22 +134,22 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 		InputChannel[] ic4 = new InputChannel[rp4Channels];
 		final SingleInputGate[] inputGates = new SingleInputGate[] {ig1, ig2, ig3, ig4};
 
-		ic4[0] = createRemoteInputChannel(ig4, 0, rp1, connManager, network.getNetworkBufferPool());
-		ic4[1] = createRemoteInputChannel(ig4, 0, rp2, connManager, network.getNetworkBufferPool());
-		ic4[2] = createRemoteInputChannel(ig4, 0, rp3, connManager, network.getNetworkBufferPool());
-		ic4[3] = createRemoteInputChannel(ig4, 0, rp4, connManager, network.getNetworkBufferPool());
+		ic4[0] = createRemoteInputChannel(ig4, 0, rp1, connManager);
+		ic4[1] = createRemoteInputChannel(ig4, 0, rp2, connManager);
+		ic4[2] = createRemoteInputChannel(ig4, 0, rp3, connManager);
+		ic4[3] = createRemoteInputChannel(ig4, 0, rp4, connManager);
 		ig4.setInputChannels(ic4);
 
-		ic1[0] = createRemoteInputChannel(ig1, 1, rp1, connManager, network.getNetworkBufferPool());
-		ic1[1] = createRemoteInputChannel(ig1, 1, rp4, connManager, network.getNetworkBufferPool());
+		ic1[0] = createRemoteInputChannel(ig1, 1, rp1, connManager);
+		ic1[1] = createRemoteInputChannel(ig1, 1, rp4, connManager);
 		ig1.setInputChannels(ic1);
 
-		ic2[0] = createRemoteInputChannel(ig2, 1, rp2, connManager, network.getNetworkBufferPool());
-		ic2[1] = createRemoteInputChannel(ig2, 2, rp4, connManager, network.getNetworkBufferPool());
+		ic2[0] = createRemoteInputChannel(ig2, 1, rp2, connManager);
+		ic2[1] = createRemoteInputChannel(ig2, 2, rp4, connManager);
 		ig2.setInputChannels(ic2);
 
-		ic3[0] = createRemoteInputChannel(ig3, 1, rp3, connManager, network.getNetworkBufferPool());
-		ic3[1] = createRemoteInputChannel(ig3, 3, rp4, connManager, network.getNetworkBufferPool());
+		ic3[0] = createRemoteInputChannel(ig3, 1, rp3, connManager);
+		ic3[1] = createRemoteInputChannel(ig3, 3, rp4, connManager);
 		ig3.setInputChannels(ic3);
 
 		Task.setupPartitionsAndGates(resultPartitions, inputGates);
@@ -219,13 +218,11 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 			SingleInputGate inputGate,
 			int channelIndex,
 			ResultPartition resultPartition,
-			ConnectionManager connManager,
-			MemorySegmentProvider memorySegmentProvider) {
+			ConnectionManager connManager) {
 		return InputChannelBuilder.newBuilder()
 			.setChannelIndex(channelIndex)
 			.setPartitionId(resultPartition.getPartitionId())
 			.setConnectionManager(connManager)
-			.setMemorySegmentProvider(memorySegmentProvider)
 			.buildRemoteChannel(inputGate);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -78,9 +78,9 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 	 */
 	@Test
 	public void testRegisterTaskWithLimitedBuffers() throws Exception {
-		// outgoing: 1 buffer per channel (always)
-		// incoming: 2 exclusive buffers per channel
-		final int bufferCount = 14 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue();
+		// outgoing: 1 buffer per channel + 1 extra buffer per ResultPartition
+		// incoming: 2 exclusive buffers per channel + 1 floating buffer per single gate
+		final int bufferCount = 18 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue();
 
 		testRegisterTaskWithLimitedBuffers(bufferCount);
 	}
@@ -91,8 +91,8 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 	 */
 	@Test
 	public void testRegisterTaskWithInsufficientBuffers() throws Exception {
-		// outgoing: 1 buffer per channel (always)
-		// incoming: 2 exclusive buffers per channel
+		// outgoing: 1 buffer per channel + 1 extra buffer per ResultPartition
+		// incoming: 2 exclusive buffers per channel + 1 floating buffer per single gate
 		final int bufferCount = 10 + 10 * NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue() - 1;
 
 		expectedException.expect(IOException.class);
@@ -167,10 +167,10 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 
 		// verify buffer pools for the input gates (NOTE: credit-based uses minimum required buffers
 		// for exclusive buffers not managed by the buffer pool)
-		assertEquals(0, ig1.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(0, ig2.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(0, ig3.getBufferPool().getNumberOfRequiredMemorySegments());
-		assertEquals(0, ig4.getBufferPool().getNumberOfRequiredMemorySegments());
+		assertEquals(1, ig1.getBufferPool().getNumberOfRequiredMemorySegments());
+		assertEquals(1, ig2.getBufferPool().getNumberOfRequiredMemorySegments());
+		assertEquals(1, ig3.getBufferPool().getNumberOfRequiredMemorySegments());
+		assertEquals(1, ig4.getBufferPool().getNumberOfRequiredMemorySegments());
 
 		assertEquals(floatingBuffers, ig1.getBufferPool().getMaxNumberOfMemorySegments());
 		assertEquals(floatingBuffers, ig2.getBufferPool().getMaxNumberOfMemorySegments());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderAndConsumerTest.java
@@ -22,6 +22,8 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 
 import org.junit.Test;
 
+import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
@@ -274,13 +276,15 @@ public class BufferBuilderAndConsumerTest {
 		buffer.recycleBuffer();
 	}
 
-	public static void assertContent(Buffer actualBuffer, BufferRecycler recycler, int... expected) {
+	public static void assertContent(Buffer actualBuffer, @Nullable BufferRecycler recycler, int... expected) {
 		IntBuffer actualIntBuffer = actualBuffer.getNioBufferReadable().asIntBuffer();
 		int[] actual = new int[actualIntBuffer.limit()];
 		actualIntBuffer.get(actual);
 		assertArrayEquals(expected, actual);
 
-		assertEquals(recycler, actualBuffer.getRecycler());
+		if (recycler != null) {
+			assertEquals(recycler, actualBuffer.getRecycler());
+		}
 	}
 
 	private static BufferBuilder createBufferBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -153,10 +153,8 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 	@Test
 	public void testReceiveBuffer() throws Exception {
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
-		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = InputChannelBuilder.newBuilder()
-			.setMemorySegmentProvider(networkBufferPool)
-			.buildRemoteChannel(inputGate);
+		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
+		final RemoteInputChannel inputChannel = InputChannelBuilder.newBuilder().buildRemoteChannel(inputGate);
 		try {
 			inputGate.setInputChannels(inputChannel);
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(8, 8);
@@ -192,8 +190,11 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		BufferCompressor compressor = new BufferCompressor(bufferSize, compressionCodec);
 		BufferDecompressor decompressor = new BufferDecompressor(bufferSize, compressionCodec);
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize, 2);
-		SingleInputGate inputGate = new SingleInputGateBuilder().setBufferDecompressor(decompressor).build();
-		RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, null, networkBufferPool);
+		SingleInputGate inputGate = new SingleInputGateBuilder()
+			.setBufferDecompressor(decompressor)
+			.setSegmentProvider(networkBufferPool)
+			.build();
+		RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, null);
 		inputGate.setInputChannels(inputChannel);
 
 		try {
@@ -311,10 +312,10 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
-		final SingleInputGate inputGate = createSingleInputGate(2);
+		final SingleInputGate inputGate = createSingleInputGate(2, networkBufferPool);
 		final RemoteInputChannel[] inputChannels = new RemoteInputChannel[2];
-		inputChannels[0] = createRemoteInputChannel(inputGate, client, networkBufferPool);
-		inputChannels[1] = createRemoteInputChannel(inputGate, client, networkBufferPool);
+		inputChannels[0] = createRemoteInputChannel(inputGate, client);
+		inputChannels[1] = createRemoteInputChannel(inputGate, client);
 		try {
 			inputGate.setInputChannels(inputChannels);
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
@@ -422,8 +423,8 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 			channel, handler, mock(ConnectionID.class), mock(PartitionRequestClientFactory.class));
 
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
-		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client, networkBufferPool);
+		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 		try {
 			inputGate.setInputChannels(inputChannel);
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);
@@ -492,9 +493,8 @@ public class CreditBasedPartitionRequestClientHandlerTest {
 		int bufferSize = 1024;
 
 		NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize, 2);
-		SingleInputGate inputGate = createSingleInputGate(1);
+		SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = new InputChannelBuilder()
-			.setMemorySegmentProvider(networkBufferPool)
 			.buildRemoteChannel(inputGate);
 		inputGate.setInputChannels(inputChannel);
 		inputGate.assignExclusiveSegments();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientDecoderDelegateTest.java
@@ -86,20 +86,18 @@ public class NettyMessageClientDecoderDelegateTest extends TestLogger {
 			NUMBER_OF_BUFFER_RESPONSES);
 		channel = new EmbeddedChannel(new NettyMessageClientDecoderDelegate(handler));
 
-		inputGate = createSingleInputGate(1);
+		inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = createRemoteInputChannel(
 			inputGate,
-			new TestingPartitionRequestClient(),
-			networkBufferPool);
+			new TestingPartitionRequestClient());
 		inputGate.setInputChannels(inputChannel);
 		inputGate.assignExclusiveSegments();
 		inputChannel.requestSubpartition(0);
 		handler.addInputChannel(inputChannel);
 		inputChannelId = inputChannel.getInputChannelId();
 
-		SingleInputGate releasedInputGate = createSingleInputGate(1);
+		SingleInputGate releasedInputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel releasedInputChannel = new InputChannelBuilder()
-			.setMemorySegmentProvider(networkBufferPool)
 			.buildRemoteChannel(inputGate);
 		releasedInputGate.close();
 		handler.addInputChannel(releasedInputChannel);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -78,11 +78,10 @@ public class NettyMessageClientSideSerializationTest extends TestLogger {
 	@Before
 	public void setup() throws IOException, InterruptedException {
 		networkBufferPool = new NetworkBufferPool(8, BUFFER_SIZE, 8);
-		inputGate = createSingleInputGate(1);
+		inputGate = createSingleInputGate(1, networkBufferPool);
 		RemoteInputChannel inputChannel = createRemoteInputChannel(
 			inputGate,
-			new TestingPartitionRequestClient(),
-			networkBufferPool);
+			new TestingPartitionRequestClient());
 		inputChannel.requestSubpartition(0);
 		inputGate.setInputChannels(inputChannel);
 		inputGate.assignExclusiveSegments();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
@@ -63,12 +63,11 @@ public class NettyPartitionRequestClientTest {
 
 		final int numExclusiveBuffers = 2;
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
-		final SingleInputGate inputGate = createSingleInputGate(1);
+		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
 		final RemoteInputChannel inputChannel = InputChannelBuilder.newBuilder()
 			.setConnectionManager(mockConnectionManagerWithPartitionRequestClient(client))
 			.setInitialBackoff(1)
 			.setMaxBackoff(2)
-			.setMemorySegmentProvider(networkBufferPool)
 			.buildRemoteChannel(inputGate);
 
 		try {
@@ -122,8 +121,8 @@ public class NettyPartitionRequestClientTest {
 
 		final int numExclusiveBuffers = 2;
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, numExclusiveBuffers);
-		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client, networkBufferPool);
+		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 
 		try {
 			inputGate.setInputChannels(inputChannel);
@@ -156,8 +155,8 @@ public class NettyPartitionRequestClientTest {
 		final PartitionRequestClient client = createPartitionRequestClient(channel, handler);
 
 		final NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, 32, 2);
-		final SingleInputGate inputGate = createSingleInputGate(1);
-		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client, networkBufferPool);
+		final SingleInputGate inputGate = createSingleInputGate(1, networkBufferPool);
+		final RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, client);
 
 		try {
 			final BufferPool bufferPool = networkBufferPool.createBufferPool(6, 6);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -76,6 +76,13 @@ public class InputChannelTestUtils {
 		return new SingleInputGateBuilder().setNumberOfChannels(numberOfChannels).build();
 	}
 
+	public static SingleInputGate createSingleInputGate(int numberOfChannels, MemorySegmentProvider segmentProvider) {
+		return new SingleInputGateBuilder()
+			.setNumberOfChannels(numberOfChannels)
+			.setSegmentProvider(segmentProvider)
+			.build();
+	}
+
 	public static ConnectionManager createDummyConnectionManager() throws Exception {
 		final PartitionRequestClient mockClient = mock(PartitionRequestClient.class);
 
@@ -129,12 +136,10 @@ public class InputChannelTestUtils {
 
 	public static RemoteInputChannel createRemoteInputChannel(
 		SingleInputGate inputGate,
-		PartitionRequestClient client,
-		MemorySegmentProvider memorySegmentProvider) {
+		PartitionRequestClient client) {
 
 		return InputChannelBuilder.newBuilder()
 			.setConnectionManager(mockConnectionManagerWithPartitionRequestClient(client))
-			.setMemorySegmentProvider(memorySegmentProvider)
 			.buildRemoteChannel(inputGate);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -96,8 +96,7 @@ public class InputGateFairnessTest {
 			inputChannels[i] = createLocalInputChannel(gate, i, resultPartitionManager);
 		}
 
-		gate.setInputChannels(inputChannels);
-		gate.setup();
+		setupInputGate(gate, inputChannels);
 
 		// read all the buffers and the EOF event
 		for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
@@ -148,8 +147,7 @@ public class InputGateFairnessTest {
 			// seed one initial buffer
 			sources[12].add(bufferConsumer.copy());
 
-			gate.setInputChannels(inputChannels);
-			gate.setup();
+			setupInputGate(gate, inputChannels);
 
 			// read all the buffers and the EOF event
 			for (int i = 0; i < numberOfChannels * buffersPerChannel; i++) {
@@ -202,6 +200,7 @@ public class InputGateFairnessTest {
 
 		gate.setInputChannels(channels);
 		gate.setup();
+		gate.requestPartitions();
 
 		// read all the buffers and the EOF event
 		for (int i = numberOfChannels * (buffersPerChannel + 1); i > 0; --i) {
@@ -246,8 +245,7 @@ public class InputGateFairnessTest {
 		channels[11].onBuffer(mockBuffer, 0, -1);
 		channelSequenceNums[11]++;
 
-		gate.setInputChannels(channels);
-		gate.setup();
+		setupInputGate(gate, channels);
 
 		// read all the buffers and the EOF event
 		for (int i = 0; i < numberOfChannels * buffersPerChannel; i++) {
@@ -394,5 +392,11 @@ public class InputGateFairnessTest {
 			.setChannelIndex(channelIndex)
 			.setConnectionManager(connectionManager)
 			.buildRemoteChannel(inputGate);
+	}
+
+	public static void setupInputGate(SingleInputGate gate, InputChannel... channels) throws IOException {
+		gate.setInputChannels(channels);
+		gate.setup();
+		gate.requestPartitions();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputGateFairnessTest.java
@@ -346,7 +346,8 @@ public class InputGateFairnessTest {
 				numberOfInputChannels,
 				SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
 				STUB_BUFFER_POOL_FACTORY,
-				null);
+				null,
+				new UnpooledMemorySegmentProvider(32 * 1024));
 
 			try {
 				Field f = SingleInputGate.class.getDeclaredField("inputChannelsWithData");
@@ -392,7 +393,6 @@ public class InputGateFairnessTest {
 		return InputChannelBuilder.newBuilder()
 			.setChannelIndex(channelIndex)
 			.setConnectionManager(connectionManager)
-			.setMemorySegmentProvider(new UnpooledMemorySegmentProvider(32 * 1024))
 			.buildRemoteChannel(inputGate);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PartialConsumePipelinedResultTest.java
@@ -141,6 +141,7 @@ public class PartialConsumePipelinedResultTest extends TestLogger {
 		@Override
 		public void invoke() throws Exception {
 			InputGate gate = getEnvironment().getInputGate(0);
+			gate.requestPartitions();
 			Buffer buffer = gate.getNext().orElseThrow(IllegalStateException::new).getBuffer();
 			if (buffer != null) {
 				buffer.recycleBuffer();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -20,10 +20,10 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
-import org.apache.flink.runtime.io.network.LocalConnectionManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
+import org.apache.flink.runtime.io.network.TestingConnectionManager;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
@@ -43,7 +43,7 @@ public class InputChannelBuilder {
 	private ConnectionID connectionID = STUB_CONNECTION_ID;
 	private ResultPartitionManager partitionManager = new ResultPartitionManager();
 	private TaskEventPublisher taskEventPublisher = new TaskEventDispatcher();
-	private ConnectionManager connectionManager = new LocalConnectionManager();
+	private ConnectionManager connectionManager = new TestingConnectionManager();
 	private int initialBackoff = 0;
 	private int maxBackoff = 0;
 	private InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
-import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.LocalConnectionManager;
@@ -48,7 +47,6 @@ public class InputChannelBuilder {
 	private int initialBackoff = 0;
 	private int maxBackoff = 0;
 	private InputChannelMetrics metrics = InputChannelTestUtils.newUnregisteredInputChannelMetrics();
-	private MemorySegmentProvider memorySegmentProvider = InputChannelTestUtils.StubMemorySegmentProvider.getInstance();
 
 	public static InputChannelBuilder newBuilder() {
 		return new InputChannelBuilder();
@@ -94,17 +92,11 @@ public class InputChannelBuilder {
 		return this;
 	}
 
-	public InputChannelBuilder setMemorySegmentProvider(MemorySegmentProvider memorySegmentProvider) {
-		this.memorySegmentProvider = memorySegmentProvider;
-		return this;
-	}
-
 	public InputChannelBuilder setupFromNettyShuffleEnvironment(NettyShuffleEnvironment network) {
 		this.partitionManager = network.getResultPartitionManager();
 		this.connectionManager = network.getConnectionManager();
 		this.initialBackoff = network.getConfiguration().partitionRequestInitialBackoff();
 		this.maxBackoff = network.getConfiguration().partitionRequestMaxBackoff();
-		this.memorySegmentProvider = network.getNetworkBufferPool();
 		return this;
 	}
 
@@ -118,8 +110,7 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			metrics,
-			memorySegmentProvider);
+			metrics);
 	}
 
 	public LocalInputChannel buildLocalChannel(SingleInputGate inputGate) {
@@ -143,7 +134,6 @@ public class InputChannelBuilder {
 			connectionManager,
 			initialBackoff,
 			maxBackoff,
-			metrics,
-			memorySegmentProvider);
+			metrics);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createLocalInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
+import static org.apache.flink.runtime.io.network.partition.InputGateFairnessTest.setupInputGate;
 import static org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.TestingResultPartitionManager;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.junit.Assert.assertFalse;
@@ -549,8 +550,7 @@ public class LocalInputChannelTest {
 					.buildLocalChannel(inputGate);
 			}
 
-			inputGate.setInputChannels(inputChannels);
-			inputGate.setup();
+			setupInputGate(inputGate, inputChannels);
 
 			this.numberOfInputChannels = numberOfInputChannels;
 			this.numberOfExpectedBuffersPerChannel = numberOfExpectedBuffersPerChannel;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RecoveredInputChannelTest.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.execution.CancelTaskException;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferBuilderAndConsumerTest;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionTest;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.runtime.io.network.partition.ResultPartitionTest.ChannelStateReaderWithException;
+import static org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannelTest.cleanup;
+import static org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannelTest.submitTasksAndWaitForResults;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link RecoveredInputChannel}.
+ */
+@RunWith(Parameterized.class)
+public class RecoveredInputChannelTest {
+
+	private final boolean isRemote;
+
+	@Parameterized.Parameters(name = "isRemote = {0}")
+	public static Collection<Object[]> parameters() {
+		return Arrays.asList(new Object[][] {
+			{true},
+			{false},
+		});
+	}
+
+	public RecoveredInputChannelTest(boolean isRemote) {
+		this.isRemote = isRemote;
+	}
+
+	@Test
+	public void testConcurrentReadStateAndProcess() throws Exception {
+		testConcurrentReadStateAndProcess(isRemote);
+	}
+
+	@Test
+	public void testConcurrentReadStateAndRelease() throws Exception {
+		testConcurrentReadStateAndRelease(isRemote);
+	}
+
+	@Test
+	public void testConcurrentReadStateAndProcessAndRelease() throws Exception {
+		testConcurrentReadStateAndProcessAndRelease(isRemote);
+	}
+
+	/**
+	 * Tests that there are no buffers leak while recovering the empty input channel state.
+	 */
+	@Test
+	public void testReadEmptyState() throws Exception {
+		testReadEmptyStateOrThrowException(isRemote, ChannelStateReader.NO_OP);
+	}
+
+	/**
+	 * Tests that there are no buffers leak while throwing exception during state recovery.
+	 */
+	@Test(expected = IOException.class)
+	public void testReadStateWithException() throws Exception {
+		testReadEmptyStateOrThrowException(isRemote, new ChannelStateReaderWithException());
+	}
+
+	private void testReadEmptyStateOrThrowException(boolean isRemote, ChannelStateReader reader) throws Exception {
+		// setup
+		final int totalBuffers = 10;
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final SingleInputGate inputGate = createInputGate(globalPool);
+		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
+
+		try {
+			inputGate.setInputChannels(inputChannel);
+			inputGate.setup();
+
+			// it would throw expected exception for the case of testReadStateWithException.
+			inputChannel.readRecoveredState(reader);
+
+			// the channel only has one EndOfChannelStateEvent in the queue for the case of testReadEmptyState.
+			assertEquals(1, inputChannel.getNumberOfQueuedBuffers());
+			assertFalse(inputChannel.getNextBuffer().isPresent());
+			assertTrue(inputChannel.getStateConsumedFuture().isDone());
+		} finally {
+			// cleanup and verify no buffer leak
+			inputGate.close();
+			globalPool.destroyAllBufferPools();
+			assertEquals(totalBuffers, globalPool.getNumberOfAvailableMemorySegments());
+			globalPool.destroy();
+		}
+	}
+
+	/**
+	 * Tests that the process of reading recovered state executes concurrently with channel
+	 * buffer processing, based on the condition of the total number of states is more that
+	 * the total buffer amount, to confirm that the lifecycle(recycle) of exclusive/floating
+	 * buffers works well.
+	 */
+	private void testConcurrentReadStateAndProcess(boolean isRemote) throws Exception {
+		// setup
+		final int totalBuffers = 10;
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final SingleInputGate inputGate = createInputGate(globalPool);
+		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
+
+		// the number of states is more that the total buffer amount
+		final int totalStates = 15;
+		final int[] states = {1, 2, 3, 4};
+		final ChannelStateReader reader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
+		final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		Throwable thrown = null;
+		try {
+			inputGate.setInputChannels(inputChannel);
+			inputGate.setup();
+
+			final Callable<Void> processTask = processRecoveredBufferTask(inputChannel, totalStates, states);
+			final Callable<Void> readStateTask = readRecoveredStateTask(inputChannel, reader);
+
+			submitTasksAndWaitForResults(executor, new Callable[] {readStateTask, processTask});
+		} catch (Throwable t) {
+			thrown = t;
+		} finally {
+			// cleanup
+			cleanup(globalPool, executor, null, thrown, inputChannel);
+		}
+	}
+
+	private void testConcurrentReadStateAndRelease(boolean isRemote) throws Exception {
+		// setup
+		final int totalBuffers = 10;
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final SingleInputGate inputGate = createInputGate(globalPool);
+		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
+
+		// the number of states is more that the total buffer amount
+		final int totalStates = 15;
+		final int[] states = {1, 2, 3, 4};
+		final ChannelStateReader reader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
+		final ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		Throwable thrown = null;
+		try {
+			inputGate.setInputChannels(inputChannel);
+			inputGate.setup();
+
+			submitTasksAndWaitForResults(
+				executor,
+				new Callable[] {readRecoveredStateTask(inputChannel, reader), releaseChannelTask(inputChannel)});
+		} catch (Throwable t) {
+			thrown = t;
+		} finally {
+			// cleanup
+			cleanup(globalPool, executor, null, thrown, inputChannel);
+		}
+	}
+
+	private void testConcurrentReadStateAndProcessAndRelease(boolean isRemote) throws Exception {
+		// setup
+		final int totalBuffers = 10;
+		final NetworkBufferPool globalPool = new NetworkBufferPool(totalBuffers, 32, 2);
+		final SingleInputGate inputGate = createInputGate(globalPool);
+		final RecoveredInputChannel inputChannel = createRecoveredChannel(isRemote, inputGate);
+
+		// the number of states is more that the total buffer amount
+		final int totalStates = 15;
+		final int[] states = {1, 2, 3, 4};
+		final ChannelStateReader reader = new ResultPartitionTest.FiniteChannelStateReader(totalStates, states);
+		final ExecutorService executor = Executors.newFixedThreadPool(2);
+		Throwable thrown = null;
+		try {
+			inputGate.setInputChannels(inputChannel);
+			inputGate.setup();
+
+			final Callable<Void> processTask = processRecoveredBufferTask(inputChannel, totalStates, states);
+			final Callable<Void> readStateTask = readRecoveredStateTask(inputChannel, reader);
+			final Callable<Void> releaseTask = releaseChannelTask(inputChannel);
+
+			submitTasksAndWaitForResults(executor, new Callable[] {readStateTask, processTask, releaseTask});
+		} catch (Throwable t) {
+			thrown = t;
+		} finally {
+			// cleanup
+			cleanup(globalPool, executor, null, thrown, inputChannel);
+		}
+	}
+
+	private Callable<Void> readRecoveredStateTask(RecoveredInputChannel inputChannel, ChannelStateReader reader) {
+		return () -> {
+			try {
+				inputChannel.readRecoveredState(reader);
+			} catch (CancelTaskException ex) {
+				// within expectation
+			}
+
+			return null;
+		};
+	}
+
+	private Callable<Void> processRecoveredBufferTask(RecoveredInputChannel inputChannel, int totalStates, int[] states) {
+		return () -> {
+			// process all the queued state buffers and verify the data
+			int numProcessedStates = 0;
+			while (numProcessedStates < totalStates) {
+				if (inputChannel.isReleased()) {
+					break;
+				}
+				if (inputChannel.getNumberOfQueuedBuffers() == 0) {
+					Thread.sleep(1);
+					continue;
+				}
+				try {
+					Optional<BufferAndAvailability> bufferAndAvailability = inputChannel.getNextBuffer();
+					if (bufferAndAvailability.isPresent()) {
+						Buffer buffer = bufferAndAvailability.get().buffer();
+						BufferBuilderAndConsumerTest.assertContent(buffer, null, states);
+						buffer.recycleBuffer();
+						numProcessedStates++;
+					}
+				} catch (IllegalStateException e) {
+					assertTrue(e.getMessage().contains("Queried for a buffer after channel has been closed"));
+				}
+			}
+
+			return null;
+		};
+	}
+
+	private Callable<Void> releaseChannelTask(RecoveredInputChannel inputChannel) {
+		return () -> {
+			inputChannel.releaseAllResources();
+			return null;
+		};
+	}
+
+	private RecoveredInputChannel createRecoveredChannel(boolean isRemote, SingleInputGate gate) {
+		if (isRemote) {
+			return new InputChannelBuilder().buildRemoteRecoveredChannel(gate);
+		} else {
+			return new InputChannelBuilder().buildLocalRecoveredChannel(gate);
+		}
+	}
+
+	private SingleInputGate createInputGate(NetworkBufferPool globalPool) throws Exception {
+		return new SingleInputGateBuilder()
+			.setBufferPoolFactory(globalPool.createBufferPool(8, 8))
+			.setSegmentProvider(globalPool)
+			.build();
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -130,7 +130,7 @@ public class RemoteInputChannelTest {
 	@Test
 	public void testConcurrentNotifyBufferAvailableAndRelease() throws Exception {
 		testConcurrentReleaseAndSomething(1024, (inputChannel, buffer, j) ->
-			inputChannel.notifyBufferAvailable(buffer)
+			inputChannel.getBufferManager().notifyBufferAvailable(buffer)
 		);
 	}
 
@@ -377,7 +377,7 @@ public class RemoteInputChannelTest {
 			// The channel requests (backlog + numExclusiveBuffers) floating buffers from local pool.
 			// It does not get enough floating buffers and register as buffer listener
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 13 buffers available in the channel",
 				13, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 16 buffers required in the channel",
@@ -391,7 +391,7 @@ public class RemoteInputChannelTest {
 
 			// The channel is already in the status of waiting for buffers and will not request any more
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 13 buffers available in the channel",
 				13, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
@@ -405,7 +405,7 @@ public class RemoteInputChannelTest {
 
 			// The exclusive buffer is returned to the channel directly
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
@@ -419,7 +419,7 @@ public class RemoteInputChannelTest {
 
 			// Assign the floating buffer to the listener and the channel is still waiting for more floating buffers
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 15 buffers available in the channel",
 				15, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 18 buffers required in the channel",
@@ -433,7 +433,7 @@ public class RemoteInputChannelTest {
 
 			// Only the number of required buffers is changed by (backlog + numExclusiveBuffers)
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 15 buffers available in the channel",
 				15, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 15 buffers required in the channel",
@@ -447,7 +447,7 @@ public class RemoteInputChannelTest {
 
 			// Return the floating buffer to the buffer pool and the channel is not waiting for more floating buffers
 			verify(bufferPool, times(15)).requestBuffer();
-			verify(bufferPool, times(1)).addBufferListener(inputChannel);
+			verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 15 buffers available in the channel",
 				15, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 15 buffers required in the channel",
@@ -461,7 +461,7 @@ public class RemoteInputChannelTest {
 
 			// The floating buffer is requested from the buffer pool and the channel is registered as listener again.
 			verify(bufferPool, times(17)).requestBuffer();
-			verify(bufferPool, times(2)).addBufferListener(inputChannel);
+			verify(bufferPool, times(2)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 16 buffers available in the channel",
 				16, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 17 buffers required in the channel",
@@ -509,7 +509,7 @@ public class RemoteInputChannelTest {
 			// The channel requests (backlog + numExclusiveBuffers) floating buffers from local pool
 			// and gets enough floating buffers
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
@@ -523,7 +523,7 @@ public class RemoteInputChannelTest {
 			// The floating buffer is returned to local buffer directly because the channel is not waiting
 			// for floating buffers
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
@@ -537,7 +537,7 @@ public class RemoteInputChannelTest {
 			// Return one extra floating buffer to the local pool because the number of available buffers
 			// already equals to required buffers
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
@@ -585,7 +585,7 @@ public class RemoteInputChannelTest {
 
 			// The channel gets enough floating buffers from local pool
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 14 buffers required in the channel",
@@ -598,7 +598,7 @@ public class RemoteInputChannelTest {
 
 			// Only the number of required buffers is changed by (backlog + numExclusiveBuffers)
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 12 buffers required in the channel",
@@ -612,7 +612,7 @@ public class RemoteInputChannelTest {
 			// Return one extra floating buffer to the local pool because the number of available buffers
 			// is more than required buffers
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 12 buffers required in the channel",
@@ -626,7 +626,7 @@ public class RemoteInputChannelTest {
 			// The floating buffer is returned to local pool directly because the channel is not waiting for
 			// floating buffers
 			verify(bufferPool, times(14)).requestBuffer();
-			verify(bufferPool, times(0)).addBufferListener(inputChannel);
+			verify(bufferPool, times(0)).addBufferListener(inputChannel.getBufferManager());
 			assertEquals("There should be 14 buffers available in the channel",
 				14, inputChannel.getNumberOfAvailableBuffers());
 			assertEquals("There should be 12 buffers required in the channel",
@@ -678,7 +678,7 @@ public class RemoteInputChannelTest {
 			// and register as listeners as a result
 			for (RemoteInputChannel inputChannel : inputChannels) {
 				inputChannel.onSenderBacklog(8);
-				verify(bufferPool, times(1)).addBufferListener(inputChannel);
+				verify(bufferPool, times(1)).addBufferListener(inputChannel.getBufferManager());
 				assertEquals("There should be " + numExclusiveBuffers + " buffers available in the channel",
 					numExclusiveBuffers, inputChannel.getNumberOfAvailableBuffers());
 			}
@@ -689,8 +689,8 @@ public class RemoteInputChannelTest {
 			}
 
 			for (RemoteInputChannel inputChannel : inputChannels) {
-				verify(inputChannel, times(1)).notifyBufferAvailable(any(Buffer.class));
 				assertEquals("There should be 3 buffers available in the channel", 3, inputChannel.getNumberOfAvailableBuffers());
+				assertEquals("There should be 1 unannounced credits in the channel", 1, inputChannel.getUnannouncedCredit());
 			}
 		} catch (Throwable t) {
 			thrown = t;
@@ -701,8 +701,8 @@ public class RemoteInputChannelTest {
 
 	/**
 	 * Tests that failures are propagated correctly if
-	 * {@link RemoteInputChannel#notifyBufferAvailable(Buffer)} throws an exception. Also tests that
-	 * a second listener will be notified in this case.
+	 * {@link BufferManager#notifyBufferAvailable(Buffer)} throws an exception.
+	 * Also tests that a second listener will be notified in this case.
 	 */
 	@Test
 	public void testFailureInNotifyBufferAvailable() throws Exception {
@@ -974,7 +974,7 @@ public class RemoteInputChannelTest {
 								break;
 							} else {
 								//noinspection ObjectEquality
-								if (buffer.getRecycler() == inputChannel) {
+								if (buffer.getRecycler() == inputChannel.getBufferManager()) {
 									exclusiveBuffers.add(buffer);
 								} else {
 									floatingBuffers.add(buffer);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -649,15 +649,16 @@ public class RemoteInputChannelTest {
 
 		final SingleInputGate inputGate = createSingleInputGate(3, networkBufferPool);
 		final RemoteInputChannel[] inputChannels = new RemoteInputChannel[3];
-		inputChannels[0] = spy(createRemoteInputChannel(inputGate));
-		inputChannels[1] = spy(createRemoteInputChannel(inputGate));
-		inputChannels[2] = spy(createRemoteInputChannel(inputGate));
+		inputChannels[0] = createRemoteInputChannel(inputGate);
+		inputChannels[1] = createRemoteInputChannel(inputGate);
+		inputChannels[2] = createRemoteInputChannel(inputGate);
 		inputGate.setInputChannels(inputChannels);
 		Throwable thrown = null;
 		try {
 			final BufferPool bufferPool = spy(networkBufferPool.createBufferPool(numFloatingBuffers, numFloatingBuffers));
 			inputGate.setBufferPool(bufferPool);
 			inputGate.assignExclusiveSegments();
+			inputGate.requestPartitions();
 			for (RemoteInputChannel inputChannel : inputChannels) {
 				inputChannel.requestSubpartition(0);
 			}
@@ -697,8 +698,8 @@ public class RemoteInputChannelTest {
 
 	/**
 	 * Tests that failures are propagated correctly if
-	 * {@link BufferManager#notifyBufferAvailable(Buffer)} throws an exception.
-	 * Also tests that a second listener will be notified in this case.
+	 * {@link RemoteInputChannel#notifyBufferAvailable(int)} throws an exception. Also tests that
+	 * a second listener will be notified in this case.
 	 */
 	@Test
 	public void testFailureInNotifyBufferAvailable() throws Exception {
@@ -1215,7 +1216,7 @@ public class RemoteInputChannelTest {
 	 * @param executor The executor service for running tasks.
 	 * @param tasks The callable tasks to be submitted and executed.
 	 */
-	private void submitTasksAndWaitForResults(ExecutorService executor, Callable[] tasks) throws Exception {
+	static void submitTasksAndWaitForResults(ExecutorService executor, Callable[] tasks) throws Exception {
 		final List<Future> results = Lists.newArrayListWithCapacity(tasks.length);
 
 		for (Callable task : tasks) {
@@ -1231,7 +1232,7 @@ public class RemoteInputChannelTest {
 	/**
 	 * Helper code to ease cleanup handling with suppressed exceptions.
 	 */
-	private void cleanup(
+	public static void cleanup(
 			NetworkBufferPool networkBufferPool,
 			@Nullable ExecutorService executor,
 			@Nullable Buffer buffer,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -18,9 +18,11 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
@@ -49,6 +51,8 @@ public class SingleInputGateBuilder {
 	private PartitionProducerStateProvider partitionProducerStateProvider = NO_OP_PRODUCER_CHECKER;
 
 	private BufferDecompressor bufferDecompressor = null;
+
+	private MemorySegmentProvider segmentProvider = InputChannelTestUtils.StubMemorySegmentProvider.getInstance();
 
 	private SupplierWithException<BufferPool, IOException> bufferPoolFactory = () -> {
 		throw new UnsupportedOperationException();
@@ -89,6 +93,7 @@ public class SingleInputGateBuilder {
 			config.floatingNetworkBuffersPerGate(),
 			numberOfChannels,
 			partitionType);
+		this.segmentProvider = environment.getNetworkBufferPool();
 		return this;
 	}
 
@@ -102,6 +107,11 @@ public class SingleInputGateBuilder {
 		return this;
 	}
 
+	public SingleInputGateBuilder setSegmentProvider(MemorySegmentProvider segmentProvider) {
+		this.segmentProvider = segmentProvider;
+		return this;
+	}
+
 	public SingleInputGate build() {
 		return new SingleInputGate(
 			"Single Input Gate",
@@ -112,6 +122,7 @@ public class SingleInputGateBuilder {
 			numberOfChannels,
 			partitionProducerStateProvider,
 			bufferPoolFactory,
-			bufferDecompressor);
+			bufferDecompressor,
+			segmentProvider);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.io.network.TaskEventDispatcher;
 import org.apache.flink.runtime.io.network.api.writer.RecordCollectingResultPartitionWriter;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
 import org.apache.flink.runtime.io.network.partition.consumer.IteratorWrappingTestSingleInputGate;
 import org.apache.flink.runtime.io.network.util.TestPooledBufferProvider;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -184,6 +185,10 @@ public class MockEnvironment implements Environment, AutoCloseable {
 		catch (Throwable t) {
 			throw new RuntimeException("Error setting up mock readers: " + t.getMessage(), t);
 		}
+	}
+
+	public void addInputs(List<IndexedInputGate> gates) {
+		inputs.addAll(gates);
 	}
 
 	public void addOutput(final List<Record> outputList) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAlignerMassiveRandomTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
@@ -35,6 +36,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * The test generates two random streams (input channels) which independently
@@ -212,6 +215,15 @@ public class CheckpointBarrierAlignerMassiveRandomTest {
 
 		@Override
 		public void setup() {
+		}
+
+		@Override
+		public CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) {
+			return CompletableFuture.completedFuture(null);
+		}
+
+		@Override
+		public void requestPartitions() {
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
@@ -511,6 +511,7 @@ public class CheckpointBarrierUnalignerTest {
 		sequenceNumbers = new int[numberOfChannels];
 
 		gate.setup();
+		gate.requestPartitions();
 
 		return createCheckpointedInputGate(gate, toNotify);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockIndexedInputGate.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
+import org.apache.flink.runtime.event.TaskEvent;
+import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
+import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
+import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Mock {@link IndexedInputGate}.
+ */
+public class MockIndexedInputGate extends IndexedInputGate {
+
+	public MockIndexedInputGate() {
+	}
+
+	@Override
+	public void setup() {
+	}
+
+	@Override
+	public CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void requestPartitions() {
+	}
+
+	@Override
+	public void resumeConsumption(int channelIndex) {
+	}
+
+	@Override
+	public int getNumberOfInputChannels() {
+		return 1;
+	}
+
+	@Override
+	public InputChannel getChannel(int channelIndex) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return false;
+	}
+
+	@Override
+	public Optional<BufferOrEvent> getNext() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Optional<BufferOrEvent> pollNext() {
+		return getNext();
+	}
+
+	@Override
+	public void sendTaskEvent(TaskEvent event) {
+	}
+
+	@Override
+	public void close() {
+	}
+
+	@Override
+	public void registerBufferReceivedListener(BufferReceivedListener listener) {
+	}
+
+	@Override
+	public int getGateIndex() {
+		return 0;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/MockInputGate.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.runtime.io;
 
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
@@ -30,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Mock {@link InputGate}.
@@ -64,6 +67,15 @@ public class MockInputGate extends InputGate {
 
 	@Override
 	public void setup() {
+	}
+
+	@Override
+	public CompletableFuture<?> readRecoveredState(ExecutorService executor, ChannelStateReader reader) {
+		return CompletableFuture.completedFuture(null);
+	}
+
+	@Override
+	public void requestPartitions() {
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.streaming.runtime.io.benchmark;
 
-import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
@@ -86,8 +85,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				connectionManager,
 				partitionRequestInitialBackoff,
 				partitionRequestMaxBackoff,
-				metrics,
-				networkBufferPool);
+				metrics);
 		}
 	}
 
@@ -150,8 +148,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				ConnectionManager connectionManager,
 				int initialBackOff,
 				int maxBackoff,
-				InputChannelMetrics metrics,
-				MemorySegmentProvider memorySegmentProvider) {
+				InputChannelMetrics metrics) {
 			super(
 				inputGate,
 				channelIndex,
@@ -160,8 +157,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				connectionManager,
 				initialBackOff,
 				maxBackoff,
-				metrics,
-				memorySegmentProvider);
+				metrics);
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -114,7 +114,8 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				taskEventPublisher,
 				initialBackoff,
 				maxBackoff,
-				metrics);
+				metrics.getNumBytesInLocalCounter(),
+				metrics.getNumBuffersInLocalCounter());
 		}
 
 		@Override
@@ -157,7 +158,8 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
 				connectionManager,
 				initialBackOff,
 				maxBackoff,
-				metrics);
+				metrics.getNumBytesInRemoteCounter(),
+				metrics.getNumBuffersInRemoteCounter());
 		}
 
 		@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmarkTest.java
@@ -103,7 +103,7 @@ public class StreamNetworkThroughputBenchmarkTest {
 		int writers = 2;
 		int channels = 2;
 
-		env.setUp(writers, channels, 100, false, writers * channels + writers, writers * channels *
+		env.setUp(writers, channels, 100, false, writers * channels + writers, writers + writers * channels *
 			NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL.defaultValue());
 		env.executeBenchmark(10_000);
 		env.tearDown();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/BackPressureITCase.java
@@ -94,7 +94,7 @@ public class BackPressureITCase extends TestLogger {
 		final Configuration configuration = new Configuration();
 
 		final int memorySegmentSizeKb = 32;
-		final MemorySize networkBuffersMemory = MemorySize.parse(memorySegmentSizeKb * (NUM_TASKS + 2) + "kb");
+		final MemorySize networkBuffersMemory = MemorySize.parse(memorySegmentSizeKb * 6 + "kb");
 
 		configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse(memorySegmentSizeKb + "kb"));
 		configuration.set(TaskManagerOptions.NETWORK_MEMORY_MIN, networkBuffersMemory);


### PR DESCRIPTION
## What is the purpose of the change

During recovery process for unaligned checkpoint, the remote input channel state should also be recovered besides with existing operator states.
    
The remote channel would request buffer and then interact with ChannelStateReader to fill in the state data.  The filled buffer would be inserted into respective data queue for processing in normal way.

It should guarantee that the new data from upstream partition should not overtake the input state data to avoid mis-order issue.

## Brief change log

  - *Delay request partition in `RemoteInputChannel` after finishing reading channel state.*
  - *Add related interfaces method from input channel to handler stacks to notify the read of channel state*
  - *Implement the main process to read channel state via interacting with `ChannelStateReader`*

## Verifying this change

Add some new unit tests to verify the changes

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
