### PR TITLE
[FLINK-17080] Fix possible NPE in Utils.CollectHelper

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
@@ -138,6 +138,12 @@ public final class Utils {
 
 		@Override
 		public void close() {
+			// when the sink is up but not initialized and the job fails due to other operators,
+			// it is possible that close() is called when open() is not called,
+			// so we have to do this null check
+			if (accumulator == null) {
+				accumulator = new SerializedListAccumulator<>();
+			}
 			// Important: should only be added in close method to minimize traffic of accumulators
 			getRuntimeContext().addAccumulator(id, accumulator);
 		}

--- a/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/Utils.java
@@ -141,11 +141,10 @@ public final class Utils {
 			// when the sink is up but not initialized and the job fails due to other operators,
 			// it is possible that close() is called when open() is not called,
 			// so we have to do this null check
-			if (accumulator == null) {
-				accumulator = new SerializedListAccumulator<>();
+			if (accumulator != null) {
+				// Important: should only be added in close method to minimize traffic of accumulators
+				getRuntimeContext().addAccumulator(id, accumulator);
 			}
-			// Important: should only be added in close method to minimize traffic of accumulators
-			getRuntimeContext().addAccumulator(id, accumulator);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/TableUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/api/TableUtils.java
@@ -84,7 +84,11 @@ public class TableUtils {
 			tEnv.insertInto(sinkName, table);
 			JobExecutionResult executionResult = tEnv.execute(jobName);
 			ArrayList<byte[]> accResult = executionResult.getAccumulatorResult(id);
-			deserializedList = SerializedListAccumulator.deserializeList(accResult, serializer);
+			if (accResult != null) {
+				deserializedList = SerializedListAccumulator.deserializeList(accResult, serializer);
+			} else {
+				throw new RuntimeException("Could not retrieve table result. It is very likely that the job fails.");
+			}
 		} finally {
 			tEnv.dropTemporaryTable(sinkName);
 		}


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the possible NPE when closing `Utils.CollectHelper`. When the sink is up but not initialized and the job fails due to other operators, it is possible that `close()` is called when `open()` is not called. Currently `Utils.CollectHelper` does not deal with this case.

See [here](https://issues.apache.org/jira/browse/FLINK-16636?focusedCommentId=17079109&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17079109) for more detailed discussion.

## Brief change log

- Fix possible NPE in Utils.CollectHelper


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
