### PR TITLE
[FLINK-17081][test] Extend some test classes with TestLogger

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/TableUtilsStreamingITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/api/TableUtilsStreamingITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -36,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * IT case for {@link TableUtils} in streaming mode.
  */
-public class TableUtilsStreamingITCase {
+public class TableUtilsStreamingITCase extends TestLogger {
 
 	private StreamExecutionEnvironment env;
 	private StreamTableEnvironment tEnv;

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/utils/BatchAbstractTestBase.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
 
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
@@ -31,7 +32,7 @@ import org.junit.rules.TemporaryFolder;
 /**
  * Batch test base to use {@link ClassRule}.
  */
-public class BatchAbstractTestBase {
+public class BatchAbstractTestBase extends TestLogger {
 
 	public static final int DEFAULT_PARALLELISM = 3;
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -27,12 +27,13 @@ import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => Scala
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.java.StreamTableEnvironment
 import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment, _}
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.TestingAppendSink
 import org.apache.flink.table.planner.utils.TableTestUtil.{readFromResource, replaceStageId}
 import org.apache.flink.table.planner.utils.TestTableSources.getPersonCsvTableSource
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.types.Row
-import org.apache.flink.util.FileUtils
+import org.apache.flink.util.{FileUtils, TestLogger}
 
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
 import org.junit.rules.TemporaryFolder
@@ -42,14 +43,11 @@ import org.junit.{Assert, Before, Rule, Test}
 
 import _root_.java.io.File
 import _root_.java.util
-
-import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
-
 import _root_.scala.collection.mutable
 
 
 @RunWith(classOf[Parameterized])
-class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) {
+class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger {
 
   private val _tempFolder = new TemporaryFolder()
 


### PR DESCRIPTION
## What is the purpose of the change

This PR extend `BatchAbstractTestBase`, `TableEnvironmentITCase` and `TableUtilsStreamingITCase` with `TestLogger` for better debugging.

## Brief change log

 - Extend some test classes with TestLogger

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
