### PR TITLE
[FLINK-14234][runtime] Notifies all kinds of consumable partitions to SchedulingStrategy

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -269,8 +269,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
 	}
 
 	@Override
-	protected void scheduleOrUpdateConsumersInternal(final IntermediateResultPartitionID partitionId) {
-		schedulingStrategy.onPartitionConsumable(partitionId);
+	protected void notifyPartitionConsumable(final Set<IntermediateResultPartitionID> resultPartitionIds) {
+		if (resultPartitionIds.size() > 0) {
+			schedulingStrategy.onPartitionConsumable(resultPartitionIds);
+		}
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -107,6 +107,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -615,10 +616,10 @@ public abstract class SchedulerBase implements SchedulerNG {
 			throw new RuntimeException(e);
 		}
 
-		scheduleOrUpdateConsumersInternal(partitionId.getPartitionId());
+		notifyPartitionConsumable(Collections.singleton(partitionId.getPartitionId()));
 	}
 
-	protected void scheduleOrUpdateConsumersInternal(IntermediateResultPartitionID resultPartitionId) {
+	protected void notifyPartitionConsumable(Set<IntermediateResultPartitionID> resultPartitionIds) {
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/EagerSchedulingStrategy.java
@@ -63,7 +63,7 @@ public class EagerSchedulingStrategy implements SchedulingStrategy {
 	}
 
 	@Override
-	public void onPartitionConsumable(IntermediateResultPartitionID resultPartitionId) {
+	public void onPartitionConsumable(Set<IntermediateResultPartitionID> resultPartitionIds) {
 		// Will not react to these notifications.
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputDependencyConstraintChecker.java
@@ -19,28 +19,13 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.api.common.InputDependencyConstraint;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSet;
-import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
-import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.apache.flink.runtime.io.network.partition.ResultPartitionType.BLOCKING;
 
 /**
  * A wrapper class for {@link InputDependencyConstraint} checker.
  */
 public class InputDependencyConstraintChecker {
-	private final SchedulingIntermediateDataSetManager intermediateDataSetManager =
-		new SchedulingIntermediateDataSetManager();
 
 	public boolean check(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
 		if (Iterables.isEmpty(schedulingExecutionVertex.getConsumedResults())) {
@@ -56,18 +41,6 @@ public class InputDependencyConstraintChecker {
 			default:
 				throw new IllegalStateException("Unknown InputDependencyConstraint " + inputConstraint);
 		}
-	}
-
-	List<SchedulingResultPartition<?, ?>> markSchedulingResultPartitionFinished(SchedulingResultPartition<?, ?> srp) {
-		return intermediateDataSetManager.markSchedulingResultPartitionFinished(srp);
-	}
-
-	void resetSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
-		intermediateDataSetManager.resetSchedulingResultPartition(srp);
-	}
-
-	void addSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
-		intermediateDataSetManager.addSchedulingResultPartition(srp);
 	}
 
 	private boolean checkAll(final SchedulingExecutionVertex<?, ?> schedulingExecutionVertex) {
@@ -89,101 +62,7 @@ public class InputDependencyConstraintChecker {
 	}
 
 	private boolean partitionConsumable(SchedulingResultPartition<?, ?> partition) {
-		if (BLOCKING.equals(partition.getResultType())) {
-			return intermediateDataSetManager.allPartitionsFinished(partition);
-		} else {
-			final ResultPartitionState state = partition.getState();
-			return ResultPartitionState.CONSUMABLE.equals(state);
-		}
-	}
-
-	private static class SchedulingIntermediateDataSetManager {
-
-		private final Map<IntermediateDataSetID, SchedulingIntermediateDataSet> intermediateDataSets = new HashMap<>();
-
-		List<SchedulingResultPartition<?, ?>> markSchedulingResultPartitionFinished(SchedulingResultPartition<?, ?> srp) {
-			SchedulingIntermediateDataSet intermediateDataSet = getSchedulingIntermediateDataSet(srp.getResultId());
-			if (intermediateDataSet.markPartitionFinished(srp.getId())) {
-				return intermediateDataSet.getSchedulingResultPartitions();
-			}
-			return Collections.emptyList();
-		}
-
-		void resetSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
-			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
-			sid.resetPartition(srp.getId());
-		}
-
-		void addSchedulingResultPartition(SchedulingResultPartition<?, ?> srp) {
-			SchedulingIntermediateDataSet sid = getOrCreateSchedulingIntermediateDataSetIfAbsent(srp.getResultId());
-			sid.addSchedulingResultPartition(srp);
-		}
-
-		boolean allPartitionsFinished(SchedulingResultPartition<?, ?> srp) {
-			SchedulingIntermediateDataSet sid = getSchedulingIntermediateDataSet(srp.getResultId());
-			return sid.allPartitionsFinished();
-		}
-
-		private SchedulingIntermediateDataSet getSchedulingIntermediateDataSet(
-				final IntermediateDataSetID intermediateDataSetId) {
-			return getSchedulingIntermediateDataSetInternal(intermediateDataSetId, false);
-		}
-
-		private SchedulingIntermediateDataSet getOrCreateSchedulingIntermediateDataSetIfAbsent(
-				final IntermediateDataSetID intermediateDataSetId) {
-			return getSchedulingIntermediateDataSetInternal(intermediateDataSetId, true);
-		}
-
-		private SchedulingIntermediateDataSet getSchedulingIntermediateDataSetInternal(
-				final IntermediateDataSetID intermediateDataSetId,
-				boolean createIfAbsent) {
-
-			return intermediateDataSets.computeIfAbsent(
-				intermediateDataSetId,
-				(key) -> {
-					if (createIfAbsent) {
-						return new SchedulingIntermediateDataSet();
-					} else {
-						throw new IllegalArgumentException("can not find data set for " + intermediateDataSetId);
-					}
-				});
-		}
-	}
-
-	/**
-	 * Representation of {@link IntermediateDataSet}.
-	 */
-	private static class SchedulingIntermediateDataSet {
-
-		private final List<SchedulingResultPartition<?, ?>> partitions;
-
-		private final Set<IntermediateResultPartitionID> producingPartitionIds;
-
-		SchedulingIntermediateDataSet() {
-			partitions = new ArrayList<>();
-			producingPartitionIds = new HashSet<>();
-		}
-
-		boolean markPartitionFinished(IntermediateResultPartitionID partitionId) {
-			producingPartitionIds.remove(partitionId);
-			return producingPartitionIds.isEmpty();
-		}
-
-		void resetPartition(IntermediateResultPartitionID partitionId) {
-			producingPartitionIds.add(partitionId);
-		}
-
-		boolean allPartitionsFinished() {
-			return producingPartitionIds.isEmpty();
-		}
-
-		void addSchedulingResultPartition(SchedulingResultPartition<?, ?> partition) {
-			partitions.add(partition);
-			producingPartitionIds.add(partition.getId());
-		}
-
-		List<SchedulingResultPartition<?, ?>> getSchedulingResultPartitions() {
-			return Collections.unmodifiableList(partitions);
-		}
+		final ResultPartitionState state = partition.getState();
+		return ResultPartitionState.CONSUMABLE.equals(state);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategy.java
@@ -53,9 +53,9 @@ public interface SchedulingStrategy {
 	void onExecutionStateChange(ExecutionVertexID executionVertexId, ExecutionState executionState);
 
 	/**
-	 * Called whenever an {@link IntermediateResultPartition} becomes consumable.
+	 * Called whenever any {@link IntermediateResultPartition} becomes consumable.
 	 *
-	 * @param resultPartitionId The id of the result partition
+	 * @param resultPartitionIds The ids of the result partitions that become consumable
 	 */
-	void onPartitionConsumable(IntermediateResultPartitionID resultPartitionId);
+	void onPartitionConsumable(Set<IntermediateResultPartitionID> resultPartitionIds);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/LazyFromSourcesSchedulingStrategyTest.java
@@ -251,7 +251,7 @@ public class LazyFromSourcesSchedulingStrategyTest extends TestLogger {
 		final TestingSchedulingResultPartition partition1 = producer1.getProducedResults().iterator().next();
 
 		schedulingStrategy.onExecutionStateChange(producer1.getId(), ExecutionState.RUNNING);
-		schedulingStrategy.onPartitionConsumable(partition1.getId());
+		schedulingStrategy.onPartitionConsumable(Collections.singleton(partition1.getId()));
 
 		assertLatestScheduledVerticesAreEqualTo(consumers);
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
@@ -43,6 +43,8 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 
 	private Set<ExecutionVertexID> receivedVerticesToRestart;
 
+	private Set<IntermediateResultPartitionID> receivedConsumablePartitions;
+
 	public TestSchedulingStrategy(
 			final SchedulerOperations schedulerOperations,
 			final SchedulingTopology<?, ?> schedulingTopology) {
@@ -66,6 +68,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 
 	@Override
 	public void onPartitionConsumable(final Set<IntermediateResultPartitionID> resultPartitionIds) {
+		this.receivedConsumablePartitions = resultPartitionIds;
 	}
 
 	public void schedule(final List<ExecutionVertexID> verticesToSchedule) {
@@ -78,6 +81,10 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 
 	public Set<ExecutionVertexID> getReceivedVerticesToRestart() {
 		return receivedVerticesToRestart;
+	}
+
+	public Set<IntermediateResultPartitionID> getReceivedConsumablePartitions() {
+		return receivedConsumablePartitions;
 	}
 
 	private void allocateSlotsAndDeploy(final List<ExecutionVertexID> verticesToSchedule) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestSchedulingStrategy.java
@@ -65,7 +65,7 @@ public class TestSchedulingStrategy implements SchedulingStrategy {
 	}
 
 	@Override
-	public void onPartitionConsumable(final IntermediateResultPartitionID resultPartitionId) {
+	public void onPartitionConsumable(final Set<IntermediateResultPartitionID> resultPartitionIds) {
 	}
 
 	public void schedule(final List<ExecutionVertexID> verticesToSchedule) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -91,6 +91,10 @@ public class TestingSchedulingResultPartition
 		this.producer = checkNotNull(producer);
 	}
 
+	void setState(final ResultPartitionState state) {
+		this.state = state;
+	}
+
 	/**
 	 * Builder for {@link TestingSchedulingResultPartition}.
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -159,7 +159,7 @@ public class TestingSchedulingTopology
 
 		protected ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
 
-		protected ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
+		protected ResultPartitionState resultPartitionState = ResultPartitionState.CREATED;
 
 		protected ProducerConsumerConnectionBuilder(
 			final List<TestingSchedulingExecutionVertex> producers,


### PR DESCRIPTION
## What is the purpose of the change

This PR notifies all kinds of consumable partitions to SchedulingStrategy. In this way, the LazyFromSourcesSchedulingStrategy can be simplified a lot since it does not need to maintain result status by itself and does not need to be aware of result partition types.

## Brief change log

  - *Notified all kinds of consumable partitions to SchedulingStrategy*
  - *Simplified LazyFromSourcesSchedulingStrategy and InputDependencyConstraintChecker*


## Verifying this change

  - *Added unit tests for consumable partition notification*
  - *Updated tests of LazyFromSourcesSchedulingStrategy and InputDependencyConstraintChecker*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
