### PR TITLE
[FLINK-16992][table-common] Add all ability interfaces for table sources and sinks

### DIFF
--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.data.RowData;
  * generating watermarks in {@link ScanTableSource}.
  */
 @PublicEvolving
-public final class PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkAssignerProvider {
+public final class PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
 	private final AssignerWithPeriodicWatermarks<RowData> periodicAssigner;
 

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of an {@link AssignerWithPeriodicWatermarks} instance as a runtime implementation for
+ * generating watermarks in {@link ScanTableSource}.
+ */
+@PublicEvolving
+public final class PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkAssignerProvider {
+
+	private final AssignerWithPeriodicWatermarks<RowData> periodicAssigner;
+
+	private PeriodicWatermarkAssignerProvider(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
+		this.periodicAssigner = periodicAssigner;
+	}
+
+	public static PeriodicWatermarkAssignerProvider of(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
+		return new PeriodicWatermarkAssignerProvider(periodicAssigner);
+	}
+
+	public AssignerWithPeriodicWatermarks<RowData> getPeriodicWatermarkAssigner() {
+		return periodicAssigner;
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
@@ -30,12 +30,5 @@ import org.apache.flink.table.data.RowData;
 @PublicEvolving
 public interface PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
-	/**
-	 * Helper method for creating a static provider.
-	 */
-	static PeriodicWatermarkAssignerProvider of(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
-		return () -> periodicAssigner;
-	}
-
 	AssignerWithPeriodicWatermarks<RowData> getPeriodicWatermarkAssigner();
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PeriodicWatermarkAssignerProvider.java
@@ -28,19 +28,14 @@ import org.apache.flink.table.data.RowData;
  * generating watermarks in {@link ScanTableSource}.
  */
 @PublicEvolving
-public final class PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
+public interface PeriodicWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
-	private final AssignerWithPeriodicWatermarks<RowData> periodicAssigner;
-
-	private PeriodicWatermarkAssignerProvider(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
-		this.periodicAssigner = periodicAssigner;
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static PeriodicWatermarkAssignerProvider of(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
+		return () -> periodicAssigner;
 	}
 
-	public static PeriodicWatermarkAssignerProvider of(AssignerWithPeriodicWatermarks<RowData> periodicAssigner) {
-		return new PeriodicWatermarkAssignerProvider(periodicAssigner);
-	}
-
-	public AssignerWithPeriodicWatermarks<RowData> getPeriodicWatermarkAssigner() {
-		return periodicAssigner;
-	}
+	AssignerWithPeriodicWatermarks<RowData> getPeriodicWatermarkAssigner();
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
@@ -30,12 +30,5 @@ import org.apache.flink.table.data.RowData;
 @PublicEvolving
 public interface PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
-	/**
-	 * Helper method for creating a static provider.
-	 */
-	static PunctuatedWatermarkAssignerProvider of(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
-		return () -> punctuatedAssigner;
-	}
-
 	AssignerWithPunctuatedWatermarks<RowData> getPunctuatedWatermarkAssigner();
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.functions.AssignerWithPunctuatedWatermarks;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+
+/**
+ * Provider of an {@link AssignerWithPunctuatedWatermarks} instance as a runtime implementation for
+ * generating watermarks in {@link ScanTableSource}.
+ */
+@PublicEvolving
+public final class PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkAssignerProvider {
+
+	private final AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner;
+
+	private PunctuatedWatermarkAssignerProvider(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
+		this.punctuatedAssigner = punctuatedAssigner;
+	}
+
+	public static PunctuatedWatermarkAssignerProvider of(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
+		return new PunctuatedWatermarkAssignerProvider(punctuatedAssigner);
+	}
+
+	public AssignerWithPunctuatedWatermarks<RowData> getPunctuatedWatermarkAssigner() {
+		return punctuatedAssigner;
+	}
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
@@ -28,19 +28,14 @@ import org.apache.flink.table.data.RowData;
  * generating watermarks in {@link ScanTableSource}.
  */
 @PublicEvolving
-public final class PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
+public interface PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
-	private final AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner;
-
-	private PunctuatedWatermarkAssignerProvider(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
-		this.punctuatedAssigner = punctuatedAssigner;
+	/**
+	 * Helper method for creating a static provider.
+	 */
+	static PunctuatedWatermarkAssignerProvider of(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
+		return () -> punctuatedAssigner;
 	}
 
-	public static PunctuatedWatermarkAssignerProvider of(AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner) {
-		return new PunctuatedWatermarkAssignerProvider(punctuatedAssigner);
-	}
-
-	public AssignerWithPunctuatedWatermarks<RowData> getPunctuatedWatermarkAssigner() {
-		return punctuatedAssigner;
-	}
+	AssignerWithPunctuatedWatermarks<RowData> getPunctuatedWatermarkAssigner();
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/abilities/PunctuatedWatermarkAssignerProvider.java
@@ -28,7 +28,7 @@ import org.apache.flink.table.data.RowData;
  * generating watermarks in {@link ScanTableSource}.
  */
 @PublicEvolving
-public final class PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkAssignerProvider {
+public final class PunctuatedWatermarkAssignerProvider extends SupportsWatermarkPushDown.WatermarkProvider {
 
 	private final AssignerWithPunctuatedWatermarks<RowData> punctuatedAssigner;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/DynamicTableSink.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.connector.sink;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.RuntimeConverter;
+import org.apache.flink.table.connector.sink.abilities.SupportsOverwrite;
+import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -58,7 +60,8 @@ import java.io.Serializable;
  *
  * <p>A {@link DynamicTableSink} can implement the following abilities:
  * <ul>
- *     <li>TBD
+ *     <li>{@link SupportsPartitioning}
+ *     <li>{@link SupportsOverwrite}
  * </ul>
  *
  * <p>In the last step, the planner will call {@link #getSinkRuntimeProvider(Context)} for obtaining a

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsOverwrite.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsOverwrite.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+
+/**
+ * Enables to overwrite existing data in a {@link DynamicTableSink}.
+ *
+ * <p>By default, if this interface is not implemented, existing tables or partitions cannot be overwritten
+ * using e.g. the SQL {@code INSERT OVERWRITE} clause.
+ */
+@PublicEvolving
+public interface SupportsOverwrite {
+
+	/**
+	 * Provides whether existing data should be overwritten or not.
+	 */
+	void applyOverwrite(boolean overwrite);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
@@ -69,6 +69,9 @@ import java.util.Map;
  * {@link #applyStaticPartition(Map)}. The remaining values for partition keys should be obtained from
  * each individual record by the sink during runtime. In the example, the {@code month} field is the dynamic
  * partition key.
+ *
+ * <p>If the {@code PARTITION} clause contains no static assignments or is omitted entirely, all values
+ * for partition keys are obtained dynamically.
  */
 @PublicEvolving
 public interface SupportsPartitioning {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
@@ -56,7 +56,12 @@ import java.util.Map;
  * <p>If all partition keys get a value assigned in the {@code PARTITION} clause, the operation is considered
  * as an "insertion into a static partition". In the above example, the query result should be written
  * into the static partition {@code region='europe', month='2020-01'} which will be passed by the planner
- * into {@link #applyStaticPartition(Map)}.
+ * into {@link #applyStaticPartition(Map)}. The planner is also able to derived static partitions from
+ * literals of a query:
+ *
+ * <pre>{@code
+ *     INSERT INTO t SELECT a, b, c, 'asia' AS region, '2020-01' AS month FROM my_view;
+ * }</pre>
  *
  * <p>Alternatively, we can insert data into <i>dynamic table partitions</i> using the SQL syntax:
  * <pre>{@code
@@ -71,7 +76,7 @@ import java.util.Map;
  * partition key.
  *
  * <p>If the {@code PARTITION} clause contains no static assignments or is omitted entirely, all values
- * for partition keys are obtained dynamically.
+ * for partition keys are either derived from static parts of the query or obtained dynamically.
  */
 @PublicEvolving
 public interface SupportsPartitioning {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/sink/abilities/SupportsPartitioning.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.sink.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+
+import java.util.Map;
+
+/**
+ * Enables to write partitioned data in a {@link DynamicTableSink}.
+ *
+ * <p>Partitions split the data stored in an external system into smaller portions that are identified
+ * by one or more string-based partition keys. A single partition is represented as a {@code Map < String, String >}
+ * which maps each partition key to a partition value. Partition keys and their order are defined by the
+ * catalog table.
+ *
+ * <p>For example, data can be partitioned by region and within a region partitioned by month. The order
+ * of the partition keys (in the example: first by region then by month) is defined by the catalog table. A
+ * list of partitions could be:
+ * <pre>
+ *   List(
+ *     ['region'='europe', 'month'='2020-01'],
+ *     ['region'='europe', 'month'='2020-02'],
+ *     ['region'='asia', 'month'='2020-01'],
+ *     ['region'='asia', 'month'='2020-02']
+ *   )
+ * </pre>
+ *
+ * <p>Given the following partitioned table:
+ * <pre>{@code
+ *   CREATE TABLE t (a INT, b STRING, c DOUBLE, region STRING, month STRING) PARTITION BY (region, month);
+ * }</pre>
+ *
+ * <p>We can insert data into <i>static table partitions</i> using the {@code INSERT INTO ... PARTITION} syntax:
+ * <pre>{@code
+ *     INSERT INTO t PARTITION (region='europe', month='2020-01') SELECT a, b, c FROM my_view;
+ * }</pre>
+ *
+ * <p>If all partition keys get a value assigned in the {@code PARTITION} clause, the operation is considered
+ * as an "insertion into a static partition". In the above example, the query result should be written
+ * into the static partition {@code region='europe', month='2020-01'} which will be passed by the planner
+ * into {@link #applyStaticPartition(Map)}.
+ *
+ * <p>Alternatively, we can insert data into <i>dynamic table partitions</i> using the SQL syntax:
+ * <pre>{@code
+ *     INSERT INTO t PARTITION (region='europe') SELECT a, b, c, month FROM another_view;
+ * }</pre>
+ *
+ * <p>If only a subset of all partition keys (a prefix part) get a value assigned in the {@code PARTITION}
+ * clause, the operation is considered as an "insertion into a dynamic partition". In the above example,
+ * the static partition part is {@code region='europe'} which will be passed by the planner into
+ * {@link #applyStaticPartition(Map)}. The remaining values for partition keys should be obtained from
+ * each individual record by the sink during runtime. In the example, the {@code month} field is the dynamic
+ * partition key.
+ */
+@PublicEvolving
+public interface SupportsPartitioning {
+
+	/**
+	 * Provides the static part of a partition.
+	 *
+	 * <p>A single partition maps each partition key to a partition value. Depending on the user-defined
+	 * statement, the partition might not include all partition keys.
+	 *
+	 * <p>See the documentation of {@link SupportsPartitioning} for more information.
+	 *
+	 * @param partition user-defined (possibly partial) static partition
+	 */
+	void applyStaticPartition(Map<String, String> partition);
+
+	/**
+	 * Returns whether data needs to be grouped by partition before it is consumed by the sink. By default,
+	 * this is not required from the runtime and records arrive in arbitrary partition order.
+	 *
+	 * <p>If this method returns true, the sink can expect that all records will be grouped by the partition
+	 * keys before consumed by the sink. In other words: The sink will receive all elements of one
+	 * partition and then all elements of another partition. Elements of different partitions will not
+	 * be mixed. For some sinks, this can be used to reduce the number of partition writers and improve
+	 * writing performance by writing one partition at a time.
+	 *
+	 * <p>The given argument indicates whether the current execution mode supports grouping or not. For
+	 * example, depending on the execution mode a sorting operation might not be available during runtime.
+	 *
+	 * @param supportsGrouping whether the current execution mode supports grouping
+	 * @return whether data need to be grouped by partition before consumed by the sink. If {@code supportsGrouping}
+	 *         is false, it should never return true, otherwise the planner will fail.
+	 */
+	@SuppressWarnings("unused")
+	default boolean requiresPartitionGrouping(boolean supportsGrouping) {
+		return false;
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/ScanTableSource.java
@@ -20,9 +20,13 @@ package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.abilities.SupportsComputedColumnPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsPartitionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -49,7 +53,10 @@ import java.io.Serializable;
  * during planning:
  * <ul>
  *     <li>{@link SupportsComputedColumnPushDown}
+ *     <li>{@link SupportsWatermarkPushDown}
  *     <li>{@link SupportsFilterPushDown}
+ *     <li>{@link SupportsProjectionPushDown}
+ *     <li>{@link SupportsPartitionPushDown}
  * </ul>
  *
  * <p>In the last step, the planner will call {@link #getScanRuntimeProvider(Context)} for obtaining a
@@ -99,6 +106,8 @@ public interface ScanTableSource extends DynamicTableSource {
 
 		/**
 		 * Creates type information describing the internal data structures of the given {@link DataType}.
+		 *
+		 * @see TableSchema#toPhysicalRowDataType()
 		 */
 		TypeInformation<?> createTypeInformation(DataType producedDataType);
 
@@ -110,6 +119,7 @@ public interface ScanTableSource extends DynamicTableSource {
 		 * nested) POJO can be converted into the internal representation for structured types.
 		 *
 		 * @see LogicalType#supportsInputConversion(Class)
+		 * @see TableSchema#toPhysicalRowDataType()
 		 */
 		DataStructureConverter createDataStructureConverter(DataType producedDataType);
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.RuntimeConverter;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
 
 import java.io.Serializable;
 
@@ -49,8 +50,8 @@ import java.io.Serializable;
  * <p>This interface provides a {@link ComputedColumnConverter} that needs to be applied to every row
  * during runtime.
  *
- * <p>Note: The final data type emitted by a source changes from the produced data type to the full data
- * type of the table's schema. For the example above, this means:
+ * <p>Note: The final output data type emitted by a source changes from the physically produced data
+ * type to the full data type of the table's schema. For the example above, this means:
  *
  * <pre>{@code
  *    ROW<str STRING, i INT>                    // before conversion
@@ -64,10 +65,12 @@ public interface SupportsComputedColumnPushDown {
 	 * Provides a converter that converts the produced {@link RowData} containing the physical
 	 * fields of the external system into a new {@link RowData} with push-downed computed columns.
 	 *
-	 * <p>Note: Use {@link TableSchema#toRowDataType()} instead of {@link TableSchema#toPhysicalRowDataType()}
-	 * for describing the final output data type when creating {@link TypeInformation}.
+	 * <p>Note: Use the passed data type instead of {@link TableSchema#toPhysicalRowDataType()} for
+	 * describing the final output data type when creating {@link TypeInformation}. If the source implements
+	 * {@link SupportsProjectionPushDown}, the projection is already considered in both the converter
+	 * and the given output data type.
 	 */
-	void applyComputedColumn(ComputedColumnConverter converter);
+	void applyComputedColumn(ComputedColumnConverter converter, DataType outputDataType);
 
 	/**
 	 * Generates and adds computed columns to {@link RowData} if necessary.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
@@ -58,11 +58,12 @@ import java.io.Serializable;
  *    ROW<str STRING, ts TIMESTAMP(3), i INT>   // after conversion
  * }</pre>
  *
- * <p>Note: If a source implements {@link SupportsProjectionPushDown}, the projection must be applied
- * to the physical columns only and not to the computed columns. {@link SupportsComputedColumnPushDown}
- * assumes an already applied projection. In the example below, the projections {@code [i, d]} are derived
- * from the DDL ({@code c} requires {@code i}) and query ({@code d} and {@code c} are required). The
- * pushed converter will rely on this order and will process {@code [i, d]} to produce {@code [d, c]}.
+ * <p>Note: If a source implements {@link SupportsProjectionPushDown}, the projection must be applied to
+ * the physical data in the first step. The {@link SupportsComputedColumnPushDown} (already aware of the
+ * projection) will then use the projected physical data and insert computed columns into the result. In
+ * the example below, the projections {@code [i, d]} are derived from the DDL ({@code c} requires {@code i})
+ * and query ({@code d} and {@code c} are required). The pushed converter will rely on this order and
+ * will process {@code [i, d]} to produce {@code [d, c]}.
  * <pre>{@code
  *   CREATE TABLE t (i INT, s STRING, c AS i + 2, d DOUBLE);
  *   SELECT d, c FROM t;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsComputedColumnPushDown.java
@@ -57,6 +57,16 @@ import java.io.Serializable;
  *    ROW<str STRING, i INT>                    // before conversion
  *    ROW<str STRING, ts TIMESTAMP(3), i INT>   // after conversion
  * }</pre>
+ *
+ * <p>Note: If a source implements {@link SupportsProjectionPushDown}, the projection must be applied
+ * to the physical columns only and not to the computed columns. {@link SupportsComputedColumnPushDown}
+ * assumes an already applied projection. In the example below, the projections {@code [i, d]} are derived
+ * from the DDL ({@code c} requires {@code i}) and query ({@code d} and {@code c} are required). The
+ * pushed converter will rely on this order and will process {@code [i, d]} to produce {@code [d, c]}.
+ * <pre>{@code
+ *   CREATE TABLE t (i INT, s STRING, c AS i + 2, d DOUBLE);
+ *   SELECT d, c FROM t;
+ * }</pre>
  */
 @PublicEvolving
 public interface SupportsComputedColumnPushDown {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsFilterPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsFilterPushDown.java
@@ -28,6 +28,14 @@ import java.util.List;
 /**
  * Enables to push down filters into a {@link ScanTableSource}.
  *
+ * <p>Given the following SQL:
+ * <pre>{@code
+ *   SELECT * FROM t WHERE (a = '1' OR a = '2') AND b IS NOT NULL;
+ * }</pre>
+ *
+ * <p>In the example above, {@code [a = '1' OR a = '2']} and {@code [b IS NOT NULL]} are acceptable
+ * filters.
+ *
  * <p>By default, if this interface is not implemented, filters are applied in a subsequent operation
  * after the source.
  *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsLimitPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsLimitPushDown.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+/**
+ * Enables to push down a limit (the expected maximum number of produced records) into a {@link ScanTableSource}.
+ *
+ * <p>It might be beneficial to perform the limiting as early as possible in order to be close to the
+ * actual data generation.
+ *
+ * <p>A source can perform the limiting on a best-effort basis. During runtime, it must not guarantee
+ * that the number of emitted records is less than or equal to the limit.
+ *
+ * <p>Regardless if this interface is implemented or not, a limit is also applied in a subsequent operation
+ * after the source.
+ */
+@PublicEvolving
+public interface SupportsLimitPushDown {
+
+	/**
+	 * Provides the expected maximum number of produced records for limiting on a best-effort basis.
+	 */
+	void applyLimit(long limit);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitionPushDown.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Enables to pass available partitions to the planner and push down partitions into a {@link ScanTableSource}.
+ *
+ * <p>Partitions split the data stored in an external system into smaller portions that are identified
+ * by one or more string-based partition keys. A single partition is represented as a {@code Map < String, String >}
+ * which maps each partition key to a partition value. Partition keys and their order is defined by the
+ * catalog table.
+ *
+ * <p>For example, data can be partitioned by region and within a region partitioned by month. The order
+ * of the partition keys (in the example: first by region then by month) are defined by the catalog table. A
+ * list of partitions could be:
+ * <pre>
+ *   List(
+ *     ['region'='europe', 'month'='2020-01'],
+ *     ['region'='europe', 'month'='2020-02'],
+ *     ['region'='asia', 'month'='2020-01'],
+ *     ['region'='asia', 'month'='2020-02']
+ *   )
+ * </pre>
+ *
+ * <p>By default, if this interface is not implemented, the list of all partitions is queried from the
+ * catalog and the data is read entirely with a subsequent filter operation after the source.
+ *
+ * <p>However, depending on the external system, it might be necessary to query the list of partitions
+ * in a connector-specific way instead of using the catalog information. See {@link #listPartitions()}.
+ *
+ * <p>For efficiency, the planner can pass the number of required partitions and a source must exclude
+ * those partitions from reading (including reading the metadata). See {@link #applyPartitions(List)}.
+ *
+ * <p>Note: After partitions are pushed into the source, the runtime will not perform a subsequent filter
+ * operation for partition keys.
+ */
+@PublicEvolving
+public interface SupportsPartitionPushDown {
+
+	/**
+	 * Returns a list of all partitions that a source can read if available.
+	 *
+	 * <p>A single partition maps each partition key to a partition value.
+	 *
+	 * <p>If {@link Optional#empty()} is returned, the list of partitions is queried from the catalog.
+	 */
+	Optional<List<Map<String, String>>> listPartitions();
+
+	/**
+	 * Provides a list of remaining partitions. After those partitions are applied, a source must not
+	 * read the data of other partitions during runtime.
+	 *
+	 * <p>See the documentation of {@link SupportsPartitionPushDown} for more information.
+	 */
+	void applyPartitions(List<Map<String, String>> remainingPartitions);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsPartitionPushDown.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  * catalog table.
  *
  * <p>For example, data can be partitioned by region and within a region partitioned by month. The order
- * of the partition keys (in the example: first by region then by month) are defined by the catalog table. A
+ * of the partition keys (in the example: first by region then by month) is defined by the catalog table. A
  * list of partitions could be:
  * <pre>
  *   List(
@@ -45,14 +45,15 @@ import java.util.Optional;
  *   )
  * </pre>
  *
- * <p>By default, if this interface is not implemented, the list of all partitions is queried from the
- * catalog and the data is read entirely with a subsequent filter operation after the source.
- *
- * <p>However, depending on the external system, it might be necessary to query the list of partitions
- * in a connector-specific way instead of using the catalog information. See {@link #listPartitions()}.
+ * <p>By default, if this interface is not implemented, the data is read entirely with a subsequent filter
+ * operation after the source.
  *
  * <p>For efficiency, the planner can pass the number of required partitions and a source must exclude
  * those partitions from reading (including reading the metadata). See {@link #applyPartitions(List)}.
+ *
+ * <p>By default, the list of all partitions is queried from the catalog if necessary. However, depending
+ * on the external system, it might be necessary to query the list of partitions in a connector-specific
+ * way instead of using the catalog information. See {@link #listPartitions()}.
  *
  * <p>Note: After partitions are pushed into the source, the runtime will not perform a subsequent filter
  * operation for partition keys.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -42,8 +42,8 @@ import org.apache.flink.table.connector.source.ScanTableSource;
  * the top-level row only or consider nested fields as well (see {@link #supportsNestedProjection()}).
  *
  * <p>Note: If a source implements {@link SupportsComputedColumnPushDown}, the projection must be applied
- * to the physically produced data only. {@link SupportsComputedColumnPushDown} assumes an already applied
- * projection and includes a projection of computed columns.
+ * to the physical data in the first step. The {@link SupportsComputedColumnPushDown} (already aware of the projection)
+ * will then use the projected physical data and insert computed columns into the result.
  */
 @PublicEvolving
 public interface SupportsProjectionPushDown {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -31,14 +31,14 @@ import org.apache.flink.table.connector.source.ScanTableSource;
  * }</pre>
  *
  * <p>In the above example, {@code r.d} and {@code s} are required fields. Other fields can be skipped
- * in a projection.
+ * in a projection. Compared to table's schema, fields are reordered.
  *
  * <p>By default, if this interface is not implemented, a projection is applied in a subsequent operation
  * after the source.
  *
  * <p>For efficiency, a source can push a projection further down in order to be close to the actual
- * data generation. A projection is only selecting fields that are used by a query. It does neither
- * reorder fields nor contain any computation. A projection can either be performed on the fields of
+ * data generation. A projection is only selecting fields that are used by a query (possibly in a different
+ * field order). It does not contain any computation. A projection can either be performed on the fields of
  * the top-level row only or consider nested fields as well (see {@link #supportsNestedProjection()}).
  *
  * <p>Note: If a source implements {@link SupportsComputedColumnPushDown}, the projection must be applied
@@ -59,9 +59,9 @@ public interface SupportsProjectionPushDown {
 	 *
 	 * <p>In the example mentioned in {@link SupportsProjectionPushDown}, this method would receive:
 	 * <ul>
-	 *     <li>{@code [[1], [2]]} for {@code r} and {@code s} if {@link #supportsNestedProjection()}
+	 *     <li>{@code [[2], [1]]} which is equivalent to {@code [["s"], ["r"]]} if {@link #supportsNestedProjection()}
 	 *     returns false.
-	 *     <li>{@code [[1, 0], [2]]} for {@code r.d} and {@code s} if {@link #supportsNestedProjection()}
+	 *     <li>{@code [[2], [1, 0]]} which is equivalent to {@code [["s"], ["r", "d"]]]} if {@link #supportsNestedProjection()}
 	 *     returns true.
 	 * </ul>
 	 *

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsProjectionPushDown.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+/**
+ * Enables to push down a (possibly nested) projection into a {@link ScanTableSource}.
+ *
+ * <p>Given the following SQL:
+ * <pre>{@code
+ *   CREATE TABLE t (i INT, r ROW < d DOUBLE, b BOOLEAN>, s STRING);
+ *   SELECT s, r.d FROM t;
+ * }</pre>
+ *
+ * <p>In the above example, {@code r.d} and {@code s} are required fields. Other fields can be skipped
+ * in a projection.
+ *
+ * <p>By default, if this interface is not implemented, a projection is applied in a subsequent operation
+ * after the source.
+ *
+ * <p>For efficiency, a source can push a projection further down in order to be close to the actual
+ * data generation. A projection is only selecting fields that are used by a query. It does neither
+ * reorder fields nor contain any computation. A projection can either be performed on the fields of
+ * the top-level row only or consider nested fields as well (see {@link #supportsNestedProjection()}).
+ *
+ * <p>Note: If a source implements {@link SupportsComputedColumnPushDown}, the projection must be applied
+ * to the physically produced data only. {@link SupportsComputedColumnPushDown} assumes an already applied
+ * projection and includes a projection of computed columns.
+ */
+@PublicEvolving
+public interface SupportsProjectionPushDown {
+
+	/**
+	 * Returns whether this source supports nested projection.
+	 */
+	boolean supportsNestedProjection();
+
+	/**
+	 * Provides the field index paths that should be used for a projection. The indices are 0-based and
+	 * support fields within (possibly nested) structures if this is enabled via {@link #supportsNestedProjection()}.
+	 *
+	 * <p>In the example mentioned in {@link SupportsProjectionPushDown}, this method would receive:
+	 * <ul>
+	 *     <li>{@code [[1], [2]]} for {@code r} and {@code s} if {@link #supportsNestedProjection()}
+	 *     returns false.
+	 *     <li>{@code [[1, 0], [2]]} for {@code r.d} and {@code s} if {@link #supportsNestedProjection()}
+	 *     returns true.
+	 * </ul>
+	 *
+	 * @param projectedFields field index paths of all fields that must be present in the physically
+	 *                        produced data
+	 */
+	void applyProjection(int[][] projectedFields);
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.abilities;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.ScanTableSource;
+
+/**
+ * Enables to push down watermarks into a {@link ScanTableSource}.
+ *
+ * <p>The concept of watermarks defines when time operations based on an event time attribute will be
+ * triggered. A watermark tells operators that no elements with a timestamp older or equal to the watermark
+ * timestamp should arrive at the operator. Thus, watermarks are a trade-off between latency and completeness.
+ *
+ * <p>Given the following SQL:
+ * <pre>{@code
+ *   CREATE TABLE t (i INT, ts TIMESTAMP(3), WATERMARK FOR ts AS ts - INTERVAL '5' SECOND)  // `ts` becomes a time attribute
+ * }</pre>
+ *
+ * <p>In the above example, generated watermarks are lagging 5 seconds behind the highest seen timestamp.
+ *
+ * <p>By default, if this interface is not implemented, watermarks are generated in a subsequent operation
+ * after the source.
+ *
+ * <p>However, for correctness, it might be necessary to perform the watermark generation as early as
+ * possible in order to be close to the actual data generation within a source's data partition.
+ *
+ * <p>This interface provides a {@link WatermarkAssignerProvider} that needs to be applied to a runtime
+ * implementation. Most built-in Flink sources provide a way of setting the watermark assigner.
+ *
+ * <p>Note: In many cases, watermarks are generated from computed columns. If a source implements this
+ * interface, it is recommended to also implement {@link SupportsComputedColumnPushDown}.
+ */
+@PublicEvolving
+public interface SupportsWatermarkPushDown {
+
+	/**
+	 * Provides actual runtime implementation for generating watermarks.
+	 *
+	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkAssignerProvider}
+	 * serves as the base interface. Concrete {@link WatermarkAssignerProvider} interfaces might be located
+	 * in other Flink modules.
+	 *
+	 * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 */
+	void applyWatermark(WatermarkAssignerProvider assigner);
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Provides actual runtime implementation for generating watermarks.
+	 *
+	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkAssignerProvider}
+	 * serves as the base interface.
+	 */
+	class WatermarkAssignerProvider {
+		// marker interface that will be filled with FLIP-27
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
@@ -41,8 +41,8 @@ import org.apache.flink.table.connector.source.ScanTableSource;
  * <p>However, for correctness, it might be necessary to perform the watermark generation as early as
  * possible in order to be close to the actual data generation within a source's data partition.
  *
- * <p>This interface provides a {@link WatermarkAssignerProvider} that needs to be applied to a runtime
- * implementation. Most built-in Flink sources provide a way of setting the watermark assigner.
+ * <p>This interface provides a {@link WatermarkProvider} that needs to be applied to a runtime
+ * implementation. Most built-in Flink sources provide a way of setting the watermark generator.
  *
  * <p>Note: In many cases, watermarks are generated from computed columns. If a source implements this
  * interface, it is recommended to also implement {@link SupportsComputedColumnPushDown}.
@@ -53,23 +53,27 @@ public interface SupportsWatermarkPushDown {
 	/**
 	 * Provides actual runtime implementation for generating watermarks.
 	 *
-	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkAssignerProvider}
-	 * serves as the base interface. Concrete {@link WatermarkAssignerProvider} interfaces might be located
+	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkProvider}
+	 * serves as the base interface. Concrete {@link WatermarkProvider} interfaces might be located
 	 * in other Flink modules.
 	 *
-	 * <p>See {@code org.apache.flink.table.connector.source.SourceFunctionProvider} in {@code flink-table-api-java-bridge}.
+	 * <p>See {@code org.apache.flink.table.connector.source.abilities} in {@code flink-table-api-java-bridge}.
+	 *
+	 * <p>Implementations need to perform an {@code instanceof} check and fail with an exception if the given
+	 * {@link WatermarkProvider} is unsupported.
 	 */
-	void applyWatermark(WatermarkAssignerProvider assigner);
+	void applyWatermark(WatermarkProvider provider);
 
 	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Provides actual runtime implementation for generating watermarks.
 	 *
-	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkAssignerProvider}
+	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkProvider}
 	 * serves as the base interface.
 	 */
-	class WatermarkAssignerProvider {
-		// marker interface that will be filled with FLIP-27
+	class WatermarkProvider {
+		// marker interface that will be filled after FLIP-126:
+		// WatermarkGenerator<RowData> getWatermarkGenerator();
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/abilities/SupportsWatermarkPushDown.java
@@ -72,7 +72,7 @@ public interface SupportsWatermarkPushDown {
 	 * <p>There exist different interfaces for runtime implementation which is why {@link WatermarkProvider}
 	 * serves as the base interface.
 	 */
-	class WatermarkProvider {
+	interface WatermarkProvider {
 		// marker interface that will be filled after FLIP-126:
 		// WatermarkGenerator<RowData> getWatermarkGenerator();
 	}


### PR DESCRIPTION
## What is the purpose of the change

This adds all ability interfaces that are either supported already or mentioned
in FLIP-95. This commit makes sure that all interfaces follow a common naming scheme
like "SupportsXXX", "applyXXX()" and good documentation with consistent terminology.

## Brief change log

Adds all ability interfaces with good documentation and examples.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
