### PR TITLE
[FLINK-17064][table-planner] Improve literals conversion in ExpressionConverter

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableConfig.java
@@ -145,14 +145,53 @@ public class TableConfig {
 	}
 
 	/**
-	 * Returns the zone id for timestamp with local time zone.
+	 * Returns the current session time zone id. It is used when converting to/from
+	 * {@code TIMESTAMP WITH LOCAL TIME ZONE}. See {@link #setLocalTimeZone(ZoneId)} for more
+	 * details.
+	 *
+	 * @see org.apache.flink.table.types.logical.LocalZonedTimestampType
 	 */
 	public ZoneId getLocalTimeZone() {
 		return localZoneId;
 	}
 
 	/**
-	 * Sets the zone id for timestamp with local time zone.
+	 * Sets the current session time zone id. It is used when converting to/from
+	 * {@code TIMESTAMP WITH LOCAL TIME ZONE}. Internally timestamps with local time zone are
+	 * normalized to {@code UTC}.
+	 *
+	 * <p>Example:
+	 * <pre>{@code
+	 * TableEnvironment tEnv = ...
+	 * TableConfig config = tEnv.getConfig
+	 * config.setLocalTimeZone(ZoneOffset.ofHours(2));
+	 * tEnv("CREATE TABLE testTable (id BIGINT, tmstmp TIMESTAMP WITH LOCAL TIME ZONE)");
+	 * tEnv("INSERT INTO testTable VALUES ((1, '2000-01-01 2:00:00'), (2, TIMESTAMP '2000-01-01 2:00:00'))");
+	 * tEnv("SELECT * FROM testTable"); // query with local time zone set to UTC+2
+	 * }</pre>
+	 * should produce:
+	 * <pre>
+	 * =============================
+	 *    id   |       tmstmp
+	 * =============================
+	 *    1    | 2000-01-01 2:00:00'
+	 *    2    | 2000-01-01 2:00:00'
+	 * </pre>
+	 * If we change the local time zone and query the same table:
+	 * <pre>{@code
+	 * config.setLocalTimeZone(ZoneOffset.ofHours(0));
+	 * tEnv("SELECT * FROM testTable"); // query with local time zone set to UTC+0
+	 * }</pre>
+	 * we should get:
+	 * <pre>
+	 * =============================
+	 *    id   |       tmstmp
+	 * =============================
+	 *    1    | 2000-01-01 0:00:00'
+	 *    2    | 2000-01-01 0:00:00'
+	 * </pre>
+	 *
+	 * @see org.apache.flink.table.types.logical.LocalZonedTimestampType
 	 */
 	public void setLocalTimeZone(ZoneId zoneId) {
 		this.localZoneId = Preconditions.checkNotNull(zoneId);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/expressions/ApiExpressionUtils.java
@@ -284,8 +284,8 @@ public final class ApiExpressionUtils {
 	}
 
 	public static Expression toMonthInterval(Expression e, int multiplier) {
-		return ExpressionUtils.extractValue(e, Integer.class)
-			.map((v) -> intervalOfMonths(v * multiplier))
+		return ExpressionUtils.extractValue(e, BigDecimal.class)
+			.map((v) -> intervalOfMonths(v.intValue() * multiplier))
 			.orElseThrow(() -> new ValidationException("Invalid constant for year-month interval: " + e));
 	}
 
@@ -296,8 +296,8 @@ public final class ApiExpressionUtils {
 	}
 
 	public static Expression toMilliInterval(Expression e, long multiplier) {
-		return ExpressionUtils.extractValue(e, Long.class)
-			.map((v) -> intervalOfMillis(v * multiplier))
+		return ExpressionUtils.extractValue(e, BigDecimal.class)
+			.map((v) -> intervalOfMillis(v.longValue() * multiplier))
 			.orElseThrow(() -> new ValidationException("Invalid constant for day-time interval: " + e));
 	}
 
@@ -308,8 +308,8 @@ public final class ApiExpressionUtils {
 	}
 
 	public static Expression toRowInterval(Expression e) {
-		return ExpressionUtils.extractValue(e, Long.class)
-			.map(ApiExpressionUtils::valueLiteral)
+		return ExpressionUtils.extractValue(e, BigDecimal.class)
+			.map(bd -> ApiExpressionUtils.valueLiteral(bd.longValue()))
 			.orElseThrow(() -> new ValidationException("Invalid constant for row interval: " + e));
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -30,8 +30,17 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
 import java.time.Period;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -76,6 +85,9 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 	/**
 	 * Returns the value (excluding null) as an instance of the given class.
 	 *
+	 * <p>It supports conversions to default conversion classes of {@link LogicalType LogicalTypes}.
+	 * This method should not be called with other classes.
+	 *
 	 * <p>Note to implementers: Whenever we add a new class here, make sure to also update the planner
 	 * for supporting the class via {@link CallContext#getArgumentValue(int, Class)}.
 	 */
@@ -85,90 +97,105 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 			return Optional.empty();
 		}
 
-		final Class<?> valueClass = value.getClass();
-
 		Object convertedValue = null;
 
 		if (clazz.isInstance(value)) {
 			convertedValue = clazz.cast(value);
+		} else if (clazz == Period.class) {
+			convertedValue = convertToPeriod(value);
+		} else if (clazz == Duration.class) {
+			convertedValue = convertToDuration(value);
+		} else if (clazz == LocalDate.class) {
+			convertedValue = convertToLocalDate(value);
+		} else if (clazz == LocalTime.class) {
+			convertedValue = convertToLocalTime(value);
+		} else if (clazz == LocalDateTime.class) {
+			convertedValue = convertToLocalDateTime(value);
+		} else if (clazz == OffsetDateTime.class) {
+			convertedValue = convertToOffsetDateTime(value);
+		} else if (clazz == Instant.class) {
+			convertedValue = convertToInstant(value);
+		} else if (clazz == BigDecimal.class) {
+			convertedValue = convertToBigDecimal(value);
 		}
-
-		else if (valueClass == Duration.class && clazz == Long.class) {
-			final Duration duration = (Duration) value;
-			convertedValue = duration.toMillis();
-		}
-
-		else if (valueClass == Long.class && clazz == Duration.class) {
-			final Long longVal = (Long) value;
-			convertedValue = Duration.ofMillis(longVal);
-		}
-
-		else if (valueClass == Period.class && clazz == Integer.class) {
-			final Period period = (Period) value;
-			convertedValue = (int) period.toTotalMonths();
-		}
-
-		else if (valueClass == Integer.class && clazz == Period.class) {
-			final Integer integer = (Integer) value;
-			convertedValue = Period.ofMonths(integer);
-		}
-
-		else if (valueClass == java.sql.Date.class && clazz == java.time.LocalDate.class) {
-			final java.sql.Date date = (java.sql.Date) value;
-			convertedValue = date.toLocalDate();
-		}
-
-		else if (valueClass == java.sql.Time.class && clazz == java.time.LocalTime.class) {
-			final java.sql.Time time = (java.sql.Time) value;
-			convertedValue = time.toLocalTime();
-		}
-
-		else if (valueClass == java.sql.Timestamp.class && clazz == java.time.LocalDateTime.class) {
-			final java.sql.Timestamp timestamp = (java.sql.Timestamp) value;
-			convertedValue = timestamp.toLocalDateTime();
-		}
-
-		else if (valueClass == java.time.LocalDate.class && clazz == java.sql.Date.class) {
-			final java.time.LocalDate date = (java.time.LocalDate) value;
-			convertedValue = java.sql.Date.valueOf(date);
-		}
-
-		else if (valueClass == java.time.LocalTime.class && clazz == java.sql.Time.class) {
-			final java.time.LocalTime time = (java.time.LocalTime) value;
-			convertedValue = java.sql.Time.valueOf(time);
-		}
-
-		else if (valueClass == java.time.LocalDateTime.class && clazz == java.sql.Timestamp.class) {
-			final java.time.LocalDateTime dateTime = (java.time.LocalDateTime) value;
-			convertedValue = java.sql.Timestamp.valueOf(dateTime);
-		}
-
-		else if (Number.class.isAssignableFrom(valueClass) && Number.class.isAssignableFrom(clazz)) {
-			convertedValue = convertNumeric(clazz);
-		}
-
-		// we can offer more conversions in the future, these conversions must not necessarily
-		// comply with the logical type conversions
 
 		return Optional.ofNullable((T) convertedValue);
 	}
 
-	private @Nullable <T> Object convertNumeric(Class<T> toClazz) {
-		BigDecimal bigDecimal = new BigDecimal(String.valueOf(value));
-		if (toClazz == Byte.class) {
-			return bigDecimal.byteValue();
-		} else if (toClazz == Short.class) {
-			return bigDecimal.shortValue();
-		} else if (toClazz == Integer.class) {
-			return bigDecimal.intValue();
-		} else if (toClazz == Long.class) {
-			return bigDecimal.longValue();
-		} else if (toClazz == Float.class) {
-			return bigDecimal.floatValue();
-		} else if (toClazz == Double.class) {
-			return bigDecimal.doubleValue();
-		} else if (toClazz == BigDecimal.class) {
-			return bigDecimal;
+	private @Nullable LocalDate convertToLocalDate(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == java.sql.Date.class) {
+			return ((Date) value).toLocalDate();
+		} else if (valueClass == Integer.class) {
+			return LocalDate.ofEpochDay((int) value);
+		}
+		return null;
+	}
+
+	private @Nullable LocalTime convertToLocalTime(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == java.sql.Time.class) {
+			return ((Time) value).toLocalTime();
+		} else if (valueClass == Integer.class) {
+			return LocalTime.ofNanoOfDay((int) value * 1_000_000L);
+		} else if (valueClass == Long.class) {
+			return LocalTime.ofNanoOfDay((long) value);
+		}
+		return null;
+	}
+
+	private @Nullable LocalDateTime convertToLocalDateTime(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == java.sql.Timestamp.class) {
+			return ((Timestamp) value).toLocalDateTime();
+		}
+
+		return null;
+	}
+
+	private @Nullable OffsetDateTime convertToOffsetDateTime(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == ZonedDateTime.class) {
+			return ((ZonedDateTime) value).toOffsetDateTime();
+		}
+
+		return null;
+	}
+
+	private @Nullable Instant convertToInstant(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == Integer.class) {
+			return Instant.ofEpochSecond((int) value);
+		} else if (valueClass == Long.class) {
+			return Instant.ofEpochMilli((long) value);
+		}
+
+		return null;
+	}
+
+	private @Nullable Duration convertToDuration(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == Long.class) {
+			final Long longValue = (Long) value;
+			return Duration.ofMillis(longValue);
+		}
+
+		return null;
+	}
+
+	private @Nullable Period convertToPeriod(Object value) {
+		Class<?> valueClass = value.getClass();
+		if (valueClass == Integer.class) {
+			final Integer integer = (Integer) value;
+			return Period.ofMonths(integer);
+		}
+
+		return null;
+	}
+
+	private @Nullable BigDecimal convertToBigDecimal(Object value) {
+		if (Number.class.isAssignableFrom(value.getClass())) {
+			return new BigDecimal(String.valueOf(value));
 		}
 
 		return null;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/CallContext.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.List;
 import java.util.Optional;
@@ -60,6 +61,9 @@ public interface CallContext {
 	/**
 	 * Returns the literal value of the argument at the given position, given that the argument is a
 	 * literal, is not null, and can be expressed as an instance of the provided class.
+	 *
+	 * <p>It supports conversions to default conversion classes of {@link LogicalType LogicalTypes}.
+	 * This method should not be called with other classes.
 	 *
 	 * <p>Use {@link #isArgumentLiteral(int)} before to check if the argument is actually a literal.
 	 */

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -56,11 +56,11 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.runtime.types.LogicalTypeDataTypeConverter.fromDataTypeToLogicalType;
@@ -161,13 +161,9 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
 				value = fromLocalDateTime(datetime);
 				break;
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-				TimeZone timeZone = TimeZone.getTimeZone(
-					ShortcutUtils.unwrapContext(this.relBuilder)
-						.getTableConfig()
-						.getLocalTimeZone()
-				);
+				// normalize to UTC
 				Instant instant = extractValue(valueLiteral, Instant.class);
-				value = fromLocalDateTime(LocalDateTime.ofInstant(instant, timeZone.toZoneId()));
+				value = fromLocalDateTime(instant.atOffset(ZoneOffset.UTC).toLocalDateTime());
 				break;
 			default:
 				value = extractValue(valueLiteral, Object.class);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
@@ -30,6 +30,7 @@ import org.apache.calcite.util.TimestampString;
 
 import java.time.Duration;
 import java.time.Period;
+import java.time.ZoneOffset;
 
 /**
  * A {@link CallContext} backed by {@link SqlOperatorBinding}.
@@ -108,6 +109,14 @@ public abstract class AbstractSqlCallContext implements CallContext {
 		else if (clazz == java.time.LocalDateTime.class) {
 			final TimestampString timestampString = accessor.getValueAs(TimestampString.class);
 			convertedValue = java.time.LocalDateTime.parse(timestampString.toString().replace(' ', 'T'));
+		}
+
+		else if (clazz == java.time.Instant.class) {
+			// timestamp string is in UTC, convert back to an instant
+			final TimestampString timestampString = accessor.getValueAs(TimestampString.class);
+			convertedValue = java.time.LocalDateTime.parse(timestampString.toString().replace(' ', 'T'))
+				.atOffset(ZoneOffset.UTC)
+				.toInstant();
 		}
 
 		if (convertedValue != null) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/functions/inference/AbstractSqlCallContext.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.inference.CallContext;
 
-import org.apache.calcite.sql.SqlIntervalLiteral;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.util.DateString;
 import org.apache.calcite.util.TimeString;
@@ -82,9 +81,6 @@ public abstract class AbstractSqlCallContext implements CallContext {
 	 */
 	@SuppressWarnings("unchecked")
 	protected static <T> T getLiteralValueAs(LiteralValueAccessor accessor, Class<T> clazz) {
-		final Object value = accessor.getValueAs(Object.class);
-		final Class<?> valueClass = value.getClass();
-
 		Object convertedValue = null;
 
 		if (clazz == Duration.class) {
@@ -99,36 +95,14 @@ public abstract class AbstractSqlCallContext implements CallContext {
 			}
 		}
 
-		else if (valueClass == SqlIntervalLiteral.IntervalValue.class && clazz == Integer.class) {
-			final long longVal = accessor.getValueAs(Long.class);
-			if (longVal <= Integer.MAX_VALUE && longVal >= Integer.MIN_VALUE) {
-				convertedValue = (int) longVal;
-			}
-		}
-
-		else if (clazz == java.sql.Date.class) {
-			final DateString dateString = accessor.getValueAs(DateString.class);
-			convertedValue = java.sql.Date.valueOf(dateString.toString());
-		}
-
 		else if (clazz == java.time.LocalDate.class) {
 			final DateString dateString = accessor.getValueAs(DateString.class);
 			convertedValue = java.time.LocalDate.parse(dateString.toString());
 		}
 
-		else if (clazz == java.sql.Time.class) {
-			final TimeString timeString = accessor.getValueAs(TimeString.class);
-			convertedValue = java.sql.Time.valueOf(timeString.toString());
-		}
-
 		else if (clazz == java.time.LocalTime.class) {
 			final TimeString timeString = accessor.getValueAs(TimeString.class);
 			convertedValue = java.time.LocalTime.parse(timeString.toString());
-		}
-
-		else if (clazz == java.sql.Timestamp.class) {
-			final TimestampString timestampString = accessor.getValueAs(TimestampString.class);
-			convertedValue = java.sql.Timestamp.valueOf(timestampString.toString());
 		}
 
 		else if (clazz == java.time.LocalDateTime.class) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ShortcutUtils.java
@@ -28,6 +28,7 @@ import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.tools.RelBuilder;
 
 /**
  * Utilities for quick access of commonly used instances (like {@link FlinkTypeFactory}) without
@@ -50,6 +51,10 @@ public final class ShortcutUtils {
 
 	public static FlinkTypeFactory unwrapTypeFactory(RelDataTypeFactory typeFactory) {
 		return (FlinkTypeFactory) typeFactory;
+	}
+
+	public static FlinkContext unwrapContext(RelBuilder relBuilder) {
+		return unwrapContext(relBuilder.getCluster());
 	}
 
 	public static FlinkContext unwrapContext(RelNode relNode) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactory.scala
@@ -123,6 +123,9 @@ class FlinkTypeFactory(typeSystem: RelDataTypeSystem) extends JavaTypeFactoryImp
           true,
           getTypeSystem)
 
+      case LogicalTypeRoot.SYMBOL =>
+        createSqlType(SqlTypeName.SYMBOL)
+
       case _@t =>
         throw new TableException(s"Type is not supported: $t")
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -537,7 +537,7 @@ class CodeGeneratorContext(val tableConfig: TableConfig) {
   /**
     * Adds a reusable TimeZone to the member area of the generated class.
     */
-  def addReusableTimeZone(): String = {
+  def addReusableSessionTimeZone(): String = {
     val zoneID = TimeZone.getTimeZone(tableConfig.getLocalTimeZone).getID
     val stmt =
       s"""private static final java.util.TimeZone $DEFAULT_TIMEZONE_TERM =

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -30,12 +30,12 @@ import org.apache.flink.table.planner.codegen.FunctionCodeGenerator.generateFunc
 import org.apache.flink.table.planner.plan.utils.PythonUtil.containsPythonCall
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.table.util.TimestampStringUtils.fromLocalDateTime
+
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.rex.{RexBuilder, RexExecutor, RexNode}
 import org.apache.calcite.sql.`type`.SqlTypeName
-import org.apache.commons.lang3.StringEscapeUtils
+
 import java.io.File
-import java.time.LocalDateTime
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -154,8 +154,7 @@ class ExpressionReducer(
           case SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
             val reducedValue = reduced.getField(reducedIdx)
             val value = if (reducedValue != null) {
-              val ins = reducedValue.asInstanceOf[SqlTimestamp].toInstant
-              val dt = LocalDateTime.ofInstant(ins, config.getLocalTimeZone)
+              val dt = reducedValue.asInstanceOf[SqlTimestamp].toLocalDateTime
               fromLocalDateTime(dt)
             } else {
               reducedValue

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -30,12 +30,15 @@ import org.apache.flink.table.runtime.types.PlannerTypeUtils
 import org.apache.flink.table.runtime.typeutils.TypeCheckUtils.{isCharacterString, isReference, isTemporal}
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
+
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.util.TimestampString
 import org.apache.commons.lang3.StringEscapeUtils
-import java.math.{BigDecimal => JBigDecimal}
 
+import java.math.{BigDecimal => JBigDecimal}
 import org.apache.flink.table.util.TimestampStringUtils.toLocalDateTime
+
+import java.time.ZoneOffset
 
 import scala.collection.mutable
 
@@ -381,7 +384,8 @@ object GenerateUtils {
         val fieldTerm = newName("timestampWithLocalZone")
         val ins =
           toLocalDateTime(literalValue.asInstanceOf[TimestampString])
-          .atZone(ctx.tableConfig.getLocalTimeZone).toInstant
+            .atOffset(ZoneOffset.UTC)
+            .toInstant
         val ts = SqlTimestamp.fromInstant(ins)
         val fieldTimestampWithLocalZone =
           s"""

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/FloorCeilCallGen.scala
@@ -69,7 +69,7 @@ class FloorCeilCallGen(
             case YEAR | QUARTER | MONTH | DAY | HOUR
               if terms.length + 1 == method.getParameterCount &&
                 method.getParameterTypes()(terms.length) == classOf[TimeZone] =>
-              val timeZone = ctx.addReusableTimeZone()
+              val timeZone = ctx.addReusableSessionTimeZone()
               val longTerm = s"${terms.head}.getMillisecond()"
               s"""
                  |$SQL_TIMESTAMP.fromEpochMillis(

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/MethodCallGen.scala
@@ -46,7 +46,7 @@ class MethodCallGen(method: Method) extends CallGenerator {
         val call = if (terms.length + 1 == method.getParameterCount &&
           method.getParameterTypes()(terms.length) == classOf[TimeZone]) {
           // insert the zoneID parameters for timestamp functions
-          val timeZone = ctx.addReusableTimeZone()
+          val timeZone = ctx.addReusableSessionTimeZone()
           s"""
              |${qualifyMethod(method)}(${terms.mkString(", ")}, $timeZone)
            """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/ScalarOperatorGens.scala
@@ -881,14 +881,14 @@ object ScalarOperatorGens {
       if (fromType.getPrecision < toType.getPrecision) {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
           operandTerm =>
-            val timeZone = ctx.addReusableTimeZone()
+            val timeZone = ctx.addReusableSessionTimeZone()
             s"$method($operandTerm, $timeZone)"
         }
       } else {
         val truncate_method = qualifyMethod(BuiltInMethods.TRUNCATE_SQL_TIMESTAMP)
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
           operandTerm =>
-            val timeZone = ctx.addReusableTimeZone()
+            val timeZone = ctx.addReusableSessionTimeZone()
             s"$truncate_method($method($operandTerm, $timeZone), ${toType.getPrecision})"
         }
       }
@@ -900,14 +900,14 @@ object ScalarOperatorGens {
       if (fromType.getPrecision < toType.getPrecision) {
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
           operandTerm =>
-            val zone = ctx.addReusableTimeZone()
+            val zone = ctx.addReusableSessionTimeZone()
             s"$method($operandTerm, $zone)"
         }
       } else {
         val truncate_method = qualifyMethod(BuiltInMethods.TRUNCATE_SQL_TIMESTAMP)
         generateUnaryOperatorIfNotNull(ctx, targetType, operand) {
           operandTerm =>
-            val zone = ctx.addReusableTimeZone()
+            val zone = ctx.addReusableSessionTimeZone()
             s"$truncate_method($method($operandTerm, $zone), ${toType.getPrecision})"
         }
       }
@@ -1064,7 +1064,7 @@ object ScalarOperatorGens {
     case (VARCHAR | CHAR, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
       generateUnaryOperatorIfNotNull(
         ctx, targetType, operand, resultNullable = true) { operandTerm =>
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val method = qualifyMethod(BuiltInMethods.STRING_TO_TIMESTAMP_TIME_ZONE)
         s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm.toString(), $zone))"
       }
@@ -1157,7 +1157,7 @@ object ScalarOperatorGens {
     // Date -> Timestamp with local time zone
     case (DATE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val method = qualifyMethod(BuiltInMethods.DATE_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
         s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm, $zone))"
       }
@@ -1165,7 +1165,7 @@ object ScalarOperatorGens {
     // Timestamp with local time zone -> Date
     case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, DATE) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_DATE)
         s"$method($operandTerm.getMillisecond(), $zone)"
       }
@@ -1173,7 +1173,7 @@ object ScalarOperatorGens {
     // Time -> Timestamp with local time zone
     case (TIME_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIME_TO_TIMESTAMP_WITH_LOCAL_TIME_ZONE)
         s"$SQL_TIMESTAMP.fromEpochMillis($method($operandTerm, $zone))"
       }
@@ -1181,7 +1181,7 @@ object ScalarOperatorGens {
     // Timestamp with local time zone -> Time
     case (TIMESTAMP_WITH_LOCAL_TIME_ZONE, TIME_WITHOUT_TIME_ZONE) =>
       generateUnaryOperatorIfNotNull(ctx, targetType, operand) { operandTerm =>
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_WITH_LOCAL_TIME_ZONE_TO_TIME)
         s"$method($operandTerm.getMillisecond(), $zone)"
       }
@@ -2329,7 +2329,7 @@ object ScalarOperatorGens {
         s"${qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING)}($operandTerm, $precision)"
       case TIMESTAMP_WITH_LOCAL_TIME_ZONE =>
         val method = qualifyMethod(BuiltInMethods.TIMESTAMP_TO_STRING_TIME_ZONE)
-        val zone = ctx.addReusableTimeZone()
+        val zone = ctx.addReusableSessionTimeZone()
         val precision = fromType.asInstanceOf[LocalZonedTimestampType].getPrecision
         s"$method($operandTerm, $zone, $precision)"
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/TypeConversionsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/TypeConversionsTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.expressions;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.planner.expressions.utils.ScalarOperatorsTestBase;
+
+import org.junit.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+
+import static org.apache.flink.table.api.Expressions.lit;
+
+/**
+ * Tests for {@code CAST} expression.
+ */
+public class TypeConversionsTest extends ScalarOperatorsTestBase {
+	@Test
+	public void testTimestampWithLocalTimeZoneToString() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(2));
+		testTableApi(
+			lit(Instant.EPOCH).cast(DataTypes.STRING()),
+			"1970-01-01 02:00:00"
+		);
+	}
+
+	@Test
+	public void testTimestampWithLocalTimeZoneToDate() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(4));
+		testTableApi(
+			lit(Instant.EPOCH).cast(DataTypes.DATE()),
+			"1970-01-01"
+		);
+	}
+
+	@Test
+	public void testTimestampWithLocalTimeZoneToTime() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(4));
+		testTableApi(
+			lit(Instant.EPOCH).cast(DataTypes.TIME(0)),
+			"04:00:00"
+		);
+	}
+
+	@Test
+	public void testTimestampWithLocalTimeZoneToTimestamp() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(3));
+		testTableApi(
+			lit(Instant.EPOCH).cast(DataTypes.TIMESTAMP(0)),
+			"1970-01-01 03:00:00"
+		);
+	}
+
+	@Test
+	public void testStringToTimestampWithLocalTimeZone() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(2));
+		testTableApi(
+			lit("1970-01-01 00:00:00").cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
+			"1970-01-01 00:00:00"
+		);
+
+		testSqlApi(
+			"cast('1970-01-01 00:00:00' AS TIMESTAMP(0) WITH LOCAL TIME ZONE)",
+			"1970-01-01 00:00:00"
+		);
+	}
+
+	@Test
+	public void testTimestampToTimestampWithLocalTimeZone() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(2));
+		testTableApi(
+			lit(LocalDateTime.parse("1970-01-01T00:00:00")).cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
+			"1970-01-01 00:00:00"
+		);
+
+		testSqlApi(
+			"cast(TIMESTAMP '1970-01-01 00:00:00' AS TIMESTAMP(0) WITH LOCAL TIME ZONE)",
+			"1970-01-01 00:00:00"
+		);
+	}
+
+	@Test
+	public void testTimeToTimestampWithLocalTimeZone() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(2));
+		testTableApi(
+			lit(LocalTime.parse("12:00:00")).cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
+			"1970-01-01 12:00:00"
+		);
+
+		testSqlApi(
+			"cast(TIME '12:00:00' AS TIMESTAMP(0) WITH LOCAL TIME ZONE)",
+			"1970-01-01 12:00:00"
+		);
+	}
+
+	@Test
+	public void testDateToTimestampWithLocalTimeZone() {
+		config().setLocalTimeZone(ZoneOffset.ofHours(2));
+		testTableApi(
+			lit(LocalDate.parse("1970-02-01")).cast(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(0)),
+			"1970-02-01 00:00:00"
+		);
+
+		testSqlApi(
+			"cast(DATE '1970-02-01' AS TIMESTAMP(0) WITH LOCAL TIME ZONE)",
+			"1970-02-01 00:00:00"
+		);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -22,23 +22,37 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.plan.metadata.MetadataTestUtil;
 import org.apache.flink.table.planner.plan.trait.FlinkRelDistributionTraitDef;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.plan.ConventionTraitDef;
 import org.apache.calcite.rel.RelCollationTraitDef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.TimeString;
+import org.apache.calcite.util.TimestampString;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Period;
 import java.util.Arrays;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.valueLiteral;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 /**
  * Test for {@link ExpressionConverter}.
@@ -65,16 +79,117 @@ public class ExpressionConverterTest {
 
 	@Test
 	public void testLiteral() {
-		RexNode rex = converter.visit(new ValueLiteralExpression((byte) 1, DataTypes.TINYINT()));
+		RexNode rex = converter.visit(valueLiteral((byte) 1));
 		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
 		Assert.assertEquals(SqlTypeName.TINYINT, rex.getType().getSqlTypeName());
 
-		rex = converter.visit(new ValueLiteralExpression((short) 1, DataTypes.SMALLINT()));
+		rex = converter.visit(valueLiteral((short) 1));
 		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
 		Assert.assertEquals(SqlTypeName.SMALLINT, rex.getType().getSqlTypeName());
 
-		rex = converter.visit(new ValueLiteralExpression(1, DataTypes.INT()));
+		rex = converter.visit(valueLiteral(1));
 		Assert.assertEquals(1, (int) ((RexLiteral) rex).getValueAs(Integer.class));
 		Assert.assertEquals(SqlTypeName.INTEGER, rex.getType().getSqlTypeName());
+	}
+
+	@Test
+	public void testCharLiteral() {
+		RexNode rex = converter.visit(valueLiteral("ABC", DataTypes.CHAR(4).notNull()));
+		assertThat(((RexLiteral) rex).getValueAs(String.class), equalTo("ABC "));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.CHAR));
+		assertThat(rex.getType().getPrecision(), equalTo(4));
+	}
+
+	@Test
+	public void testVarCharLiteral() {
+		RexNode rex = converter.visit(valueLiteral("ABC", DataTypes.STRING().notNull()));
+		assertThat(((RexLiteral) rex).getValueAs(String.class), equalTo("ABC"));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.VARCHAR));
+		assertThat(rex.getType().getPrecision(), equalTo(Integer.MAX_VALUE));
+	}
+
+	@Test
+	public void testBinaryLiteral() {
+		RexNode rex = converter.visit(valueLiteral(new byte[]{1, 2, 3}, DataTypes.BINARY(4).notNull()));
+		assertThat(((RexLiteral) rex).getValueAs(byte[].class), equalTo(new byte[] {1, 2, 3, 0}));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.BINARY));
+		assertThat(rex.getType().getPrecision(), equalTo(4));
+	}
+
+	@Test
+	public void testTimestampLiteral() {
+		RexNode rex = converter.visit(valueLiteral(
+			LocalDateTime.parse("2012-12-12T12:12:12.12345"),
+			DataTypes.TIMESTAMP(3).notNull()));
+		assertThat(
+			((RexLiteral) rex).getValueAs(TimestampString.class),
+			equalTo(new TimestampString("2012-12-12 12:12:12.123")));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.TIMESTAMP));
+		assertThat(rex.getType().getPrecision(), equalTo(3));
+	}
+
+	@Test
+	public void testTimeLiteral() {
+		RexNode rex = converter.visit(valueLiteral(
+			LocalTime.parse("12:12:12.12345"),
+			DataTypes.TIME(3).notNull()));
+		assertThat(
+			((RexLiteral) rex).getValueAs(TimeString.class),
+			equalTo(new TimeString("12:12:12.123")));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.TIME));
+		assertThat(rex.getType().getPrecision(), equalTo(3));
+	}
+
+	@Test
+	public void testDateLiteral() {
+		RexNode rex = converter.visit(valueLiteral(
+			LocalDate.parse("2012-12-12"),
+			DataTypes.DATE().notNull()));
+		assertThat(
+			((RexLiteral) rex).getValueAs(DateString.class),
+			equalTo(new DateString("2012-12-12")));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.DATE));
+	}
+
+	@Test
+	public void testIntervalDayTime() {
+		Duration value = Duration.ofDays(3).plusMillis(21);
+		RexNode rex = converter.visit(valueLiteral(value));
+		assertThat(
+			((RexLiteral) rex).getValueAs(BigDecimal.class),
+			equalTo(BigDecimal.valueOf(value.toMillis())));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.INTERVAL_DAY_SECOND));
+		// TODO planner ignores the precision
+		assertThat(rex.getType().getPrecision(), equalTo(2)); // day precision, should actually be 1
+		assertThat(rex.getType().getScale(), equalTo(6));     // fractional precision, should actually be 3
+	}
+
+	@Test
+	public void testIntervalYearMonth() {
+		Period value = Period.of(999, 3, 1);
+		RexNode rex = converter.visit(valueLiteral(value));
+		assertThat(
+			((RexLiteral) rex).getValueAs(BigDecimal.class),
+			equalTo(BigDecimal.valueOf(value.toTotalMonths())));
+		// TODO planner ignores the precision
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.INTERVAL_YEAR_MONTH));
+		assertThat(rex.getType().getPrecision(), equalTo(2)); // year precision, should actually be 3
+	}
+
+	@Test
+	public void testDecimalLiteral() {
+		BigDecimal value = new BigDecimal("12345678.999");
+		RexNode rex = converter.visit(valueLiteral(value));
+		assertThat(((RexLiteral) rex).getValueAs(BigDecimal.class), equalTo(value));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.DECIMAL));
+		assertThat(rex.getType().getPrecision(), equalTo(11));
+		assertThat(rex.getType().getScale(), equalTo(3));
+	}
+
+	@Test
+	public void testSymbolLiteral() {
+		RexNode rex = converter.visit(valueLiteral(TimePointUnit.MICROSECOND));
+		assertThat(((RexLiteral) rex).getValueAs(TimeUnit.class), equalTo(TimeUnit.MICROSECOND));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.SYMBOL));
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -125,6 +126,18 @@ public class ExpressionConverterTest {
 			((RexLiteral) rex).getValueAs(TimestampString.class),
 			equalTo(new TimestampString("2012-12-12 12:12:12.123")));
 		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.TIMESTAMP));
+		assertThat(rex.getType().getPrecision(), equalTo(3));
+	}
+
+	@Test
+	public void testTimestampWithLocalZoneLiteral() {
+		RexNode rex = converter.visit(valueLiteral(
+			Instant.ofEpochMilli(100),
+			DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull()));
+		assertThat(
+			((RexLiteral) rex).getValueAs(TimestampString.class),
+			equalTo(TimestampString.fromMillisSinceEpoch(100)));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE));
 		assertThat(rex.getType().getPrecision(), equalTo(3));
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverterTest.java
@@ -132,7 +132,20 @@ public class ExpressionConverterTest {
 	public void testTimeLiteral() {
 		RexNode rex = converter.visit(valueLiteral(
 			LocalTime.parse("12:12:12.12345"),
-			DataTypes.TIME(3).notNull()));
+			DataTypes.TIME(2).notNull()));
+		assertThat(
+			((RexLiteral) rex).getValueAs(TimeString.class),
+			equalTo(new TimeString("12:12:12.12")));
+		assertThat(rex.getType().getSqlTypeName(), equalTo(SqlTypeName.TIME));
+		assertThat(rex.getType().getPrecision(), equalTo(2));
+	}
+
+	@Test
+	public void testTimeLiteralBiggerPrecision() {
+		RexNode rex = converter.visit(valueLiteral(
+			LocalTime.parse("12:12:12.12345"),
+			DataTypes.TIME(5).notNull()));
+		// TODO planner supports up to TIME(3)
 		assertThat(
 			((RexLiteral) rex).getValueAs(TimeString.class),
 			equalTo(new TimeString("12:12:12.123")));


### PR DESCRIPTION
## What is the purpose of the change

It simplifies conversion of literals in ExpressionConverter. It also fixes certain mappings from Flink's type system to Calcite's which were losing precision.

## Verifying this change

Extended ExpressionConverterTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
