### PR TITLE
[FLINK-13880][core] Correct the behavior of JobExecutionResult.getAccumulatorResult to match Javadoc

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/JobExecutionResult.java
@@ -98,7 +98,12 @@ public class JobExecutionResult extends JobSubmissionResult {
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> T getAccumulatorResult(String accumulatorName) {
-		return (T) this.accumulatorResults.get(accumulatorName).getUnchecked();
+		OptionalFailure<Object> result = this.accumulatorResults.get(accumulatorName);
+		if (result != null) {
+			return (T) result.getUnchecked();
+		} else {
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the possible NPE in `JobExecutionResult#getAccumulatorResult`. Currently the behavior of this method does not match its Java doc and will throw NPE.

## Brief change log

 - Fix possible NPE in JobExecutionResult#getAccumulatorResult

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
