### PR TITLE
[FLINK-17082][sql] Remove mocking in SQL client 

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableauResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableauResultView.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.client.cli;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
@@ -79,7 +80,7 @@ public class CliTableauResultView implements AutoCloseable {
 		this.sqlExecutor = sqlExecutor;
 		this.sessionId = sessionId;
 		this.resultDescriptor = resultDescriptor;
-		this.displayResultExecutorService = Executors.newSingleThreadExecutor();
+		this.displayResultExecutorService = Executors.newSingleThreadExecutor(new ExecutorThreadFactory("CliTableauResultView"));
 	}
 
 	public void displayStreamResults() throws SqlExecutionException {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -177,19 +177,19 @@ public class CliTableauResultViewTest {
 		view.displayBatchResults();
 		view.close();
 		Assert.assertEquals(
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"|  (NULL) |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|   false |      (NULL) |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|    true |  2147483647 |               (NULL) |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|   false | -2147483648 |  9223372036854775807 |                         (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
-				"|    true |         100 | -9223372036854775808 |                     abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |\n" +
-				"|  (NULL) |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     (NULL) |\n" +
-				"|  (NULL) |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"|  (NULL) |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+\n" +
-				"8 row in set\n",
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| boolean |         int |               bigint |                        varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|  (NULL) |           1 |                    2 |                            abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|   false |      (NULL) |                    0 |                                |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|    true |  2147483647 |               (NULL) |                        abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|   false | -2147483648 |  9223372036854775807 |                         (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"|    true |         100 | -9223372036854775808 |                     abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 |     abcdefghijklmnopqrstuvwxyz |   -12345.06789 |                     (NULL) |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 |                   这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"|  (NULL) |          -1 |                   -1 |  これは日本語をテストするた... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"8 row in set" + System.lineSeparator(),
 				terminalOutput.toString());
 		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
 	}
@@ -241,10 +241,10 @@ public class CliTableauResultViewTest {
 		view.close();
 
 		Assert.assertEquals(
-				"+---------+-----+--------+---------+----------------+-----------+\n" +
-				"| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |\n" +
-				"+---------+-----+--------+---------+----------------+-----------+\n" +
-				"0 row in set\n",
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
+				"| boolean | int | bigint | varchar | decimal(10, 5) | timestamp |" + System.lineSeparator() +
+				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
+				"0 row in set" + System.lineSeparator(),
 				terminalOutput.toString());
 		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
 	}
@@ -291,19 +291,19 @@ public class CliTableauResultViewTest {
 		// width < 2 in IDE by default, every CJK character usually's width is 2, you can open this source file
 		// by vim or just cat the file to check the regular result.
 		Assert.assertEquals(
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
-				"|   + |    true |         100 | -9223372036854775808 |           abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |\n" +
-				"|   - |  (NULL) |          -1 |                   -1 |  abcdefghijklmnop... |   -12345.06789 |                     (NULL) |\n" +
-				"|   + |  (NULL) |          -1 |                   -1 |         这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"|   - |  (NULL) |          -1 |                   -1 |  これは日本語をテ... |   -12345.06789 |      2020-03-04 18:39:14.0 |\n" +
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"Received a total of 8 rows\n",
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"|   + |    true |         100 | -9223372036854775808 |           abcdefg111 |         (NULL) | 2020-03-01 18:39:14.123456 |" + System.lineSeparator() +
+				"|   - |  (NULL) |          -1 |                   -1 |  abcdefghijklmnop... |   -12345.06789 |                     (NULL) |" + System.lineSeparator() +
+				"|   + |  (NULL) |          -1 |                   -1 |         这是一段中文 |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"|   - |  (NULL) |          -1 |                   -1 |  これは日本語をテ... |   -12345.06789 |      2020-03-04 18:39:14.0 |" + System.lineSeparator() +
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"Received a total of 8 rows" + System.lineSeparator(),
 				terminalOutput.toString());
 		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
 	}
@@ -322,10 +322,10 @@ public class CliTableauResultViewTest {
 		view.close();
 
 		Assert.assertEquals(
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"Received a total of 0 rows\n",
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"Received a total of 0 rows" + System.lineSeparator(),
 				terminalOutput.toString());
 		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
 	}
@@ -354,14 +354,14 @@ public class CliTableauResultViewTest {
 		view.close();
 
 		Assert.assertEquals(
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n" +
-				"Query terminated, received a total of 4 rows\n",
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator() +
+				"Query terminated, received a total of 4 rows" + System.lineSeparator(),
 				terminalOutput.toString());
 
 		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
@@ -387,13 +387,13 @@ public class CliTableauResultViewTest {
 		view.close();
 
 		Assert.assertEquals(
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |\n" +
-				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+\n" +
-				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |\n" +
-				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |\n" +
-				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |\n" +
-				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |\n",
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"| +/- | boolean |         int |               bigint |              varchar | decimal(10, 5) |                  timestamp |" + System.lineSeparator() +
+				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
+				"|   + |  (NULL) |           1 |                    2 |                  abc |           1.23 |      2020-03-01 18:39:14.0 |" + System.lineSeparator() +
+				"|   - |   false |      (NULL) |                    0 |                      |              1 |      2020-03-01 18:39:14.1 |" + System.lineSeparator() +
+				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
+				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator(),
 				terminalOutput.toString());
 		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
 	}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -18,11 +18,12 @@
 
 package org.apache.flink.table.client.cli;
 
+import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.client.cli.utils.TerminalUtils;
-import org.apache.flink.table.client.gateway.Executor;
 import org.apache.flink.table.client.gateway.ResultDescriptor;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 import org.apache.flink.table.client.gateway.TypedResult;
@@ -36,23 +37,17 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * Tests for CliTableauResultView.
@@ -164,15 +159,16 @@ public class CliTableauResultViewTest {
 	@Test
 	public void testBatchResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setSnapshotResultSupplier(
+					() -> TypedResult.payload(1),
+					TypedResult::endOfStream)
+			.setResultPageSupplier(() -> data)
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.snapshotResult(anyString(), anyString(), anyInt()))
-				.thenReturn(TypedResult.payload(1))
-				.thenReturn(TypedResult.endOfStream());
-		when(mockExecutor.retrieveResultPage(anyString(), anyInt()))
-				.thenReturn(data);
 
 		view.displayBatchResults();
 		view.close();
@@ -191,35 +187,39 @@ public class CliTableauResultViewTest {
 				"+---------+-------------+----------------------+--------------------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"8 row in set" + System.lineSeparator(),
 				terminalOutput.toString());
-		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(0));
 	}
 
 	@Test
-	public void testCancelBatchResult() throws InterruptedException, ExecutionException, TimeoutException {
+	public void testCancelBatchResult() throws Exception {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setSnapshotResultSupplier(TypedResult::empty)
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.snapshotResult(anyString(), anyString(), anyInt()))
-				.thenReturn(TypedResult.empty());
 
 		// submit result display in another thread
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		Future<?> furture = executorService.submit(view::displayBatchResults);
 
 		// wait until we trying to get batch result
-		verify(mockExecutor, timeout(5000).atLeast(1)).snapshotResult(anyString(), anyString(), anyInt());
+		CommonTestUtils.waitUntilCondition(
+			() -> mockExecutor.getNumSnapshotResultCalls() > 0,
+			Deadline.now().plus(Duration.ofSeconds(5)),
+			50L);
 
 		// send signal to cancel
 		terminal.raise(Terminal.Signal.INT);
 		furture.get(5, TimeUnit.SECONDS);
 
-		Assert.assertEquals("Query terminated\n", terminalOutput.toString());
+		Assert.assertEquals("Query terminated" + System.lineSeparator(), terminalOutput.toString());
 		// didn't have a chance to read page
-		verify(mockExecutor, times(0)).retrieveResultPage(anyString(), anyInt());
+		assertThat(mockExecutor.getNumRetrieveResultPageCalls(), is(0));
 		// tried to cancel query
-		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(1));
 
 		view.close();
 	}
@@ -227,15 +227,16 @@ public class CliTableauResultViewTest {
 	@Test
 	public void testEmptyBatchResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setSnapshotResultSupplier(
+				() -> TypedResult.payload(1),
+				TypedResult::endOfStream
+			)
+			.setResultPageSupplier(Collections::emptyList)
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.snapshotResult(anyString(), anyString(), anyInt()))
-				.thenReturn(TypedResult.payload(1))
-				.thenReturn(TypedResult.endOfStream());
-		when(mockExecutor.retrieveResultPage(anyString(), anyInt()))
-				.thenReturn(Collections.emptyList());
 
 		view.displayBatchResults();
 		view.close();
@@ -246,21 +247,25 @@ public class CliTableauResultViewTest {
 				"+---------+-----+--------+---------+----------------+-----------+" + System.lineSeparator() +
 				"0 row in set" + System.lineSeparator(),
 				terminalOutput.toString());
-		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(0));
 	}
 
 	@Test
 	public void testFailedBatchResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setSnapshotResultSupplier(
+				() -> TypedResult.payload(1),
+				TypedResult::endOfStream
+			)
+			.setResultPageSupplier(() -> {
+				throw new SqlExecutionException("query failed");
+			})
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.snapshotResult(anyString(), anyString(), anyInt()))
-				.thenReturn(TypedResult.payload(1))
-				.thenReturn(TypedResult.endOfStream());
-		when(mockExecutor.retrieveResultPage(anyString(), anyInt()))
-				.thenThrow(new SqlExecutionException("query failed"));
 
 		try {
 			view.displayBatchResults();
@@ -270,20 +275,26 @@ public class CliTableauResultViewTest {
 		}
 		view.close();
 
-		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(1));
 	}
 
 	@Test
 	public void testStreamingResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setResultChangesSupplier(
+				() -> TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)),
+				() -> TypedResult.payload(streamingData.subList(streamingData.size() / 2, streamingData.size())),
+				TypedResult::endOfStream
+			)
+			.setResultPageSupplier(() -> {
+				throw new SqlExecutionException("query failed");
+			})
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.retrieveResultChanges(anyString(), anyString()))
-				.thenReturn(TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)))
-				.thenReturn(TypedResult.payload(streamingData.subList(streamingData.size() / 2, streamingData.size())))
-				.thenReturn(TypedResult.endOfStream());
 
 		view.displayStreamResults();
 		view.close();
@@ -305,18 +316,19 @@ public class CliTableauResultViewTest {
 				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"Received a total of 8 rows" + System.lineSeparator(),
 				terminalOutput.toString());
-		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(0));
 	}
 
 	@Test
 	public void testEmptyStreamingResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setResultChangesSupplier(TypedResult::endOfStream)
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.retrieveResultChanges(anyString(), anyString()))
-				.thenReturn(TypedResult.endOfStream());
 
 		view.displayStreamResults();
 		view.close();
@@ -327,26 +339,31 @@ public class CliTableauResultViewTest {
 				"+-----+---------+-------------+----------------------+----------------------+----------------+----------------------------+" + System.lineSeparator() +
 				"Received a total of 0 rows" + System.lineSeparator(),
 				terminalOutput.toString());
-		verify(mockExecutor, times(0)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(0));
 	}
 
 	@Test
-	public void testCancelStreamingResult() throws InterruptedException, ExecutionException, TimeoutException {
+	public void testCancelStreamingResult() throws Exception {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setResultChangesSupplier(
+				() -> TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)),
+				TypedResult::empty)
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.retrieveResultChanges(anyString(), anyString()))
-				.thenReturn(TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)))
-				.thenReturn(TypedResult.empty());
 
 		// submit result display in another thread
 		ExecutorService executorService = Executors.newSingleThreadExecutor();
 		Future<?> furture = executorService.submit(view::displayStreamResults);
 
 		// wait until we processed first result
-		verify(mockExecutor, timeout(5000).atLeast(2)).retrieveResultChanges(anyString(), anyString());
+		CommonTestUtils.waitUntilCondition(
+			() -> mockExecutor.getNumRetrieveResultChancesCalls() > 1,
+			Deadline.now().plus(Duration.ofSeconds(5)),
+			50L);
 
 		// send signal to cancel
 		terminal.raise(Terminal.Signal.INT);
@@ -364,19 +381,23 @@ public class CliTableauResultViewTest {
 				"Query terminated, received a total of 4 rows" + System.lineSeparator(),
 				terminalOutput.toString());
 
-		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(1));
 	}
 
 	@Test
 	public void testFailedStreamingResult() {
 		ResultDescriptor resultDescriptor = new ResultDescriptor("", schema, true, true);
-		Executor mockExecutor = mock(Executor.class);
+
+		TestingExecutor mockExecutor = new TestingExecutorBuilder()
+			.setResultChangesSupplier(
+				() -> TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)),
+				() -> {
+					throw new SqlExecutionException("query failed");
+				})
+			.build();
+
 		CliTableauResultView view = new CliTableauResultView(
 				terminal, mockExecutor, "session", resultDescriptor);
-
-		when(mockExecutor.retrieveResultChanges(anyString(), anyString()))
-				.thenReturn(TypedResult.payload(streamingData.subList(0, streamingData.size() / 2)))
-				.thenThrow(new SqlExecutionException("query failed"));
 
 		try {
 			view.displayStreamResults();
@@ -395,6 +416,6 @@ public class CliTableauResultViewTest {
 				"|   + |    true |  2147483647 |               (NULL) |              abcdefg |     1234567890 |     2020-03-01 18:39:14.12 |" + System.lineSeparator() +
 				"|   - |   false | -2147483648 |  9223372036854775807 |               (NULL) |    12345.06789 |    2020-03-01 18:39:14.123 |" + System.lineSeparator(),
 				terminalOutput.toString());
-		verify(mockExecutor, times(1)).cancelQuery(anyString(), anyString());
+		assertThat(mockExecutor.getNumCancelCalls(), is(1));
 	}
 }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.client.config.entries.ViewEntry;
+import org.apache.flink.table.client.gateway.Executor;
+import org.apache.flink.table.client.gateway.ProgramTargetDescriptor;
+import org.apache.flink.table.client.gateway.ResultDescriptor;
+import org.apache.flink.table.client.gateway.SessionContext;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A customizable {@link Executor} for testing purposes.
+ */
+class TestingExecutor implements Executor {
+
+	private int numCancelCalls = 0;
+
+	private int numRetrieveResultChancesCalls = 0;
+	private final List<SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException>> resultChanges;
+
+	private int numSnapshotResultCalls = 0;
+	private final List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResults;
+
+	private int numRetrieveResultPageCalls = 0;
+	private final List<SupplierWithException<List<Row>, SqlExecutionException>> resultPages;
+
+	private int numUseCatalogCalls = 0;
+	private final BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer;
+
+	private int numUseDatabaseCalls = 0;
+	private BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer;
+
+	TestingExecutor(
+			List<SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException>> resultChanges,
+			List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResults,
+			List<SupplierWithException<List<Row>, SqlExecutionException>> resultPages,
+			BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer,
+			BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer) {
+		this.resultChanges = resultChanges;
+		this.snapshotResults = snapshotResults;
+		this.resultPages = resultPages;
+		this.useCatalogConsumer = useCatalogConsumer;
+		this.useDatabaseConsumer = useDatabaseConsumer;
+	}
+
+	@Override
+	public void cancelQuery(String sessionId, String resultId) throws SqlExecutionException {
+		numCancelCalls++;
+	}
+
+	@Override
+	public TypedResult<List<Tuple2<Boolean, Row>>> retrieveResultChanges(String sessionId, String resultId) throws SqlExecutionException {
+		return resultChanges.get(Math.min(numRetrieveResultChancesCalls++, resultChanges.size() - 1)).get();
+	}
+
+	@Override
+	public List<Row> retrieveResultPage(String resultId, int page) throws SqlExecutionException {
+		return resultPages.get(Math.min(numRetrieveResultPageCalls++, resultPages.size() - 1)).get();
+	}
+
+	@Override
+	public TypedResult<Integer> snapshotResult(String sessionId, String resultId, int pageSize) throws SqlExecutionException {
+		return snapshotResults.get(Math.min(numSnapshotResultCalls++, snapshotResults.size() - 1)).get();
+	}
+
+	@Override
+	public void useCatalog(String sessionId, String catalogName) throws SqlExecutionException {
+		numUseCatalogCalls++;
+		useCatalogConsumer.accept(sessionId, catalogName);
+	}
+
+	@Override
+	public void useDatabase(String sessionId, String databaseName) throws SqlExecutionException {
+		numUseDatabaseCalls++;
+		useDatabaseConsumer.accept(sessionId, databaseName);
+	}
+
+	@Override
+	public void start() throws SqlExecutionException {
+	}
+
+	@Override
+	public String openSession(SessionContext session) throws SqlExecutionException {
+		return session.getSessionId();
+	}
+
+	@Override
+	public void closeSession(String sessionId) throws SqlExecutionException {
+	}
+
+	@Override
+	public Map<String, String> getSessionProperties(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public void resetSessionProperties(String sessionId) throws SqlExecutionException {
+	}
+
+	@Override
+	public void setSessionProperty(String sessionId, String key, String value) throws SqlExecutionException {
+	}
+
+	@Override
+	public void addView(String sessionId, String name, String query) throws SqlExecutionException {
+	}
+
+	@Override
+	public void removeView(String sessionId, String name) throws SqlExecutionException {
+	}
+
+	@Override
+	public Map<String, ViewEntry> listViews(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> listCatalogs(String sessionid) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> listDatabases(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public void createTable(String sessionId, String ddl) throws SqlExecutionException {
+	}
+
+	@Override
+	public void dropTable(String sessionId, String ddl) throws SqlExecutionException {
+	}
+
+	@Override
+	public List<String> listTables(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> listUserDefinedFunctions(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> listFunctions(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> listModules(String sessionId) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public TableSchema getTableSchema(String sessionId, String name) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public String explainStatement(String sessionId, String statement) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public List<String> completeStatement(String sessionId, String statement, int position) {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public ResultDescriptor executeQuery(String sessionId, String query) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	@Override
+	public ProgramTargetDescriptor executeUpdate(String sessionId, String statement) throws SqlExecutionException {
+		throw new UnsupportedOperationException("Not implemented.");
+	}
+
+	public int getNumCancelCalls() {
+		return numCancelCalls;
+	}
+
+	public int getNumRetrieveResultChancesCalls() {
+		return numRetrieveResultChancesCalls;
+	}
+
+	public int getNumSnapshotResultCalls() {
+		return numSnapshotResultCalls;
+	}
+
+	public int getNumRetrieveResultPageCalls() {
+		return numRetrieveResultPageCalls;
+	}
+
+	public int getNumUseCatalogCalls() {
+		return numUseCatalogCalls;
+	}
+
+	public int getNumUseDatabaseCalls() {
+		return numUseDatabaseCalls;
+	}
+}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutorBuilder.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.client.cli;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.client.gateway.SqlExecutionException;
+import org.apache.flink.table.client.gateway.TypedResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.SupplierWithException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builder for {@link TestingExecutor}.
+ */
+class TestingExecutorBuilder {
+
+	private List<SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException>> resultChangesSupplier = Collections.emptyList();
+	private List<SupplierWithException<TypedResult<Integer>, SqlExecutionException>> snapshotResultsSupplier = Collections.emptyList();
+	private List<SupplierWithException<List<Row>, SqlExecutionException>> resultPagesSupplier = Collections.emptyList();
+	private BiConsumerWithException<String, String, SqlExecutionException> setUseCatalogConsumer = (ignoredA, ignoredB) -> {};
+	private BiConsumerWithException<String, String, SqlExecutionException> setUseDatabaseConsumer = (ignoredA, ignoredB) -> {};
+
+	@SafeVarargs
+	public final TestingExecutorBuilder setResultChangesSupplier(SupplierWithException<TypedResult<List<Tuple2<Boolean, Row>>>, SqlExecutionException> ... resultChangesSupplier) {
+		this.resultChangesSupplier = Arrays.asList(resultChangesSupplier);
+		return this;
+	}
+
+	@SafeVarargs
+	public final TestingExecutorBuilder setSnapshotResultSupplier(SupplierWithException<TypedResult<Integer>, SqlExecutionException> ... snapshotResultsSupplier) {
+		this.snapshotResultsSupplier = Arrays.asList(snapshotResultsSupplier);
+		return this;
+	}
+
+	@SafeVarargs
+	public final TestingExecutorBuilder setResultPageSupplier(SupplierWithException<List<Row>, SqlExecutionException> ... resultPageSupplier) {
+		resultPagesSupplier = Arrays.asList(resultPageSupplier);
+		return this;
+	}
+
+	public final TestingExecutorBuilder setUseCatalogConsumer(BiConsumerWithException<String, String, SqlExecutionException> useCatalogConsumer) {
+		this.setUseCatalogConsumer = useCatalogConsumer;
+		return this;
+	}
+
+	public final TestingExecutorBuilder setUseDatabaseConsumer(BiConsumerWithException<String, String, SqlExecutionException> useDatabaseConsumer) {
+		this.setUseDatabaseConsumer = useDatabaseConsumer;
+		return this;
+	}
+
+	public TestingExecutor build() {
+		return new TestingExecutor(
+			resultChangesSupplier,
+			snapshotResultsSupplier,
+			resultPagesSupplier,
+			setUseCatalogConsumer,
+			setUseDatabaseConsumer);
+	}
+}


### PR DESCRIPTION
Removes `Executor` mocks in the SQL client tests on the suspicion of using massive amounts of memory.  (see FLINK-16973)

Introduces a customizable `TestingExecutor` that provides the same functionality as the mock:
- tracking number of calls
- returning a result depending of the call count

Additionally, the executor for the CliTableauView now has a name, and the CliTableauViewTest can now pass on Windows (line-endings).