### PR TITLE
[FLINK-16667][python][client] Support new Python dependency configuration options in flink-client.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -128,7 +128,7 @@ public class CliFrontendParser {
 		"Python script with the program entry point. " +
 			"The dependent resources can be configured with the `--pyFiles` option.");
 
-	static final Option PYFILES_OPTION = new Option("pyfs", "pyFiles", true,
+	public static final Option PYFILES_OPTION = new Option("pyfs", "pyFiles", true,
 		"Attach custom python files for job. " +
 			"These files will be added to the PYTHONPATH of both the local client and the remote python UDF worker. " +
 			"The standard python resource file suffixes such as .py/.egg/.zip or directory are all supported. " +
@@ -139,14 +139,14 @@ public class CliFrontendParser {
 		"Python module with the program entry point. " +
 			"This option must be used in conjunction with `--pyFiles`.");
 
-	static final Option PYREQUIREMENTS_OPTION = new Option("pyreq", "pyRequirements", true,
+	public static final Option PYREQUIREMENTS_OPTION = new Option("pyreq", "pyRequirements", true,
 		"Specify a requirements.txt file which defines the third-party dependencies. " +
 			"These dependencies will be installed and added to the PYTHONPATH of the python UDF worker. " +
 			"A directory which contains the installation packages of these dependencies could be specified " +
 			"optionally. Use '#' as the separator if the optional parameter exists " +
 			"(e.g.: --pyRequirements file:///tmp/requirements.txt#file:///tmp/cached_dir).");
 
-	static final Option PYARCHIVE_OPTION = new Option("pyarch", "pyArchives", true,
+	public static final Option PYARCHIVE_OPTION = new Option("pyarch", "pyArchives", true,
 		"Add python archive files for job. The archive files will be extracted to the working directory " +
 			"of python UDF worker. Currently only zip-format is supported. For each archive file, a target directory " +
 			"be specified. If the target directory name is specified, the archive file will be extracted to a " +
@@ -159,7 +159,7 @@ public class CliFrontendParser {
 			"py37.zip/py37/bin/python). The data files could be accessed in Python UDF, e.g.: " +
 			"f = open('data/data.txt', 'r').");
 
-	static final Option PYEXEC_OPTION = new Option("pyexec", "pyExecutable", true,
+	public static final Option PYEXEC_OPTION = new Option("pyexec", "pyExecutable", true,
 		"Specify the path of the python interpreter used to execute the python UDF worker " +
 			"(e.g.: --pyExecutable /usr/local/bin/python3). " +
 			"The python UDF worker depends on Python 3.5+, Apache Beam (version == 2.19.0), " +

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -19,7 +19,6 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
@@ -62,17 +61,8 @@ public class ExecutionConfigAccessor {
 
 		final Configuration configuration = new Configuration();
 
-		if (options.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT) {
-			configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, options.getParallelism());
-		}
-
-		configuration.setBoolean(DeploymentOptions.ATTACHED, !options.getDetachedMode());
-		configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, options.isShutdownOnAttachedExit());
-
-		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, options.getClasspaths(), URL::toString);
+		options.applyToConfiguration(configuration);
 		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jobJars, URL::toString);
-
-		SavepointRestoreSettings.toConfiguration(options.getSavepointRestoreSettings(), configuration);
 
 		return new ExecutionConfigAccessor(configuration);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -19,18 +19,20 @@
 package org.apache.flink.client.cli;
 
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.ConfigUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Option;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.apache.flink.client.cli.CliFrontendParser.ARGS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.CLASSPATH_OPTION;
@@ -38,23 +40,20 @@ import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.DETACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.JAR_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.PARALLELISM_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
-import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.SHUTDOWN_IF_ATTACHED_OPTION;
 import static org.apache.flink.client.cli.CliFrontendParser.YARN_DETACHED_OPTION;
+import static org.apache.flink.client.cli.ProgramOptionsUtils.containsPythonDependencyOptions;
+import static org.apache.flink.client.cli.ProgramOptionsUtils.createPythonProgramOptions;
+import static org.apache.flink.client.cli.ProgramOptionsUtils.isPythonEntryPoint;
 
 /**
  * Base class for command line options that refer to a JAR file program.
  */
 public class ProgramOptions extends CommandLineOptions {
 
-	private final String jarFilePath;
+	private String jarFilePath;
 
-	private final String entryPointClass;
+	protected String entryPointClass;
 
 	private final List<URL> classpaths;
 
@@ -68,55 +67,16 @@ public class ProgramOptions extends CommandLineOptions {
 
 	private final SavepointRestoreSettings savepointSettings;
 
-	/**
-	 * Flag indicating whether the job is a Python job.
-	 */
-	private final boolean isPython;
-
-	public ProgramOptions(CommandLine line) throws CliArgsException {
+	ProgramOptions(CommandLine line) throws CliArgsException {
 		super(line);
-
-		String[] args = line.hasOption(ARGS_OPTION.getOpt()) ?
-			line.getOptionValues(ARGS_OPTION.getOpt()) :
-			line.getArgs();
 
 		this.entryPointClass = line.hasOption(CLASS_OPTION.getOpt()) ?
 			line.getOptionValue(CLASS_OPTION.getOpt()) : null;
 
-		isPython = line.hasOption(PY_OPTION.getOpt()) | line.hasOption(PYMODULE_OPTION.getOpt())
-			| "org.apache.flink.client.python.PythonGatewayServer".equals(entryPointClass);
-		if (isPython) {
-			// copy python related parameters to program args and place them in front of user parameters
-			List<String> pyArgList = new ArrayList<>();
-			Set<Option> pyOptions = new HashSet<>();
-			pyOptions.add(PY_OPTION);
-			pyOptions.add(PYMODULE_OPTION);
-			pyOptions.add(PYFILES_OPTION);
-			pyOptions.add(PYREQUIREMENTS_OPTION);
-			pyOptions.add(PYARCHIVE_OPTION);
-			pyOptions.add(PYEXEC_OPTION);
-			for (Option option: line.getOptions()) {
-				if (pyOptions.contains(option)) {
-					pyArgList.add("--" + option.getLongOpt());
-					pyArgList.add(option.getValue());
-				}
-			}
-			String[] newArgs = pyArgList.toArray(new String[args.length + pyArgList.size()]);
-			System.arraycopy(args, 0, newArgs, pyArgList.size(), args.length);
-			args = newArgs;
-		}
+		this.jarFilePath = line.hasOption(JAR_OPTION.getOpt()) ?
+			line.getOptionValue(JAR_OPTION.getOpt()) : null;
 
-		if (line.hasOption(JAR_OPTION.getOpt())) {
-			this.jarFilePath = line.getOptionValue(JAR_OPTION.getOpt());
-		} else if (!isPython && args.length > 0) {
-			jarFilePath = args[0];
-			args = Arrays.copyOfRange(args, 1, args.length);
-		}
-		else {
-			jarFilePath = null;
-		}
-
-		this.programArgs = args;
+		this.programArgs = extractProgramArgs(line);
 
 		List<URL> classpaths = new ArrayList<URL>();
 		if (line.hasOption(CLASSPATH_OPTION.getOpt())) {
@@ -152,6 +112,26 @@ public class ProgramOptions extends CommandLineOptions {
 		this.savepointSettings = CliFrontendParser.createSavepointRestoreSettings(line);
 	}
 
+	protected String[] extractProgramArgs(CommandLine line) {
+		String[] args = line.hasOption(ARGS_OPTION.getOpt()) ?
+			line.getOptionValues(ARGS_OPTION.getOpt()) :
+			line.getArgs();
+
+		if (args.length > 0 && !line.hasOption(JAR_OPTION.getOpt())) {
+			jarFilePath = args[0];
+			args = Arrays.copyOfRange(args, 1, args.length);
+		}
+
+		return args;
+	}
+
+	public void validate() throws CliArgsException {
+		// Java program should be specified a JAR file
+		if (getJarFilePath() == null) {
+			throw new CliArgsException("Java program should be specified a JAR file.");
+		}
+	}
+
 	public String getJarFilePath() {
 		return jarFilePath;
 	}
@@ -184,10 +164,22 @@ public class ProgramOptions extends CommandLineOptions {
 		return savepointSettings;
 	}
 
-	/**
-	 * Indicates whether the job is a Python job.
-	 */
-	public boolean isPython() {
-		return isPython;
+	public void applyToConfiguration(Configuration configuration) {
+		if (getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT) {
+			configuration.setInteger(CoreOptions.DEFAULT_PARALLELISM, getParallelism());
+		}
+
+		configuration.setBoolean(DeploymentOptions.ATTACHED, !getDetachedMode());
+		configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, isShutdownOnAttachedExit());
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, getClasspaths(), URL::toString);
+		SavepointRestoreSettings.toConfiguration(getSavepointRestoreSettings(), configuration);
+	}
+
+	public static ProgramOptions create(CommandLine line) throws CliArgsException {
+		if (isPythonEntryPoint(line) || containsPythonDependencyOptions(line)) {
+			return createPythonProgramOptions(line);
+		} else {
+			return new ProgramOptions(line);
+		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.client.program.PackagedProgramUtils;
+
+import org.apache.commons.cli.CommandLine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.apache.flink.client.cli.CliFrontendParser.CLASS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
+
+/**
+ * Utility class for {@link ProgramOptions}.
+ */
+enum ProgramOptionsUtils {
+	;
+
+	private static final Logger LOG = LoggerFactory.getLogger(ProgramOptionsUtils.class);
+
+	/**
+	 * @return True if the commandline contains "-py" or "-pym" options or comes from PyFlink shell, false otherwise.
+	 */
+	static boolean isPythonEntryPoint(CommandLine line) {
+		return line.hasOption(PY_OPTION.getOpt()) ||
+			line.hasOption(PYMODULE_OPTION.getOpt()) ||
+			"org.apache.flink.client.python.PythonGatewayServer".equals(line.getOptionValue(CLASS_OPTION.getOpt()));
+	}
+
+	/**
+	 * @return True if the commandline contains "-pyfs", "-pyarch", "-pyreq", "-pyexec" options, false otherwise.
+	 */
+	static boolean containsPythonDependencyOptions(CommandLine line) {
+		return line.hasOption(PYFILES_OPTION.getOpt()) ||
+			line.hasOption(PYREQUIREMENTS_OPTION.getOpt()) ||
+			line.hasOption(PYARCHIVE_OPTION.getOpt()) ||
+			line.hasOption(PYEXEC_OPTION.getOpt());
+	}
+
+	static ProgramOptions createPythonProgramOptions(CommandLine line) throws CliArgsException {
+		try {
+			ClassLoader classLoader;
+			try {
+				classLoader = new URLClassLoader(
+					new URL[]{PackagedProgramUtils.getPythonJar()},
+					Thread.currentThread().getContextClassLoader());
+			} catch (RuntimeException e) {
+				LOG.warn(
+					"An attempt to load the flink-python jar from the \"opt\" directory failed, " +
+						"fall back to use the context class loader.", e);
+				classLoader = Thread.currentThread().getContextClassLoader();
+			}
+			Class<?> pythonProgramOptionsClazz = Class.forName(
+				"org.apache.flink.client.cli.PythonProgramOptions",
+				false,
+				classLoader);
+			Constructor<?> constructor = pythonProgramOptionsClazz.getConstructor(CommandLine.class);
+			return (ProgramOptions) constructor.newInstance(line);
+		} catch (InstantiationException |
+			InvocationTargetException |
+			NoSuchMethodException |
+			IllegalAccessException |
+			ClassNotFoundException e) {
+			throw new CliArgsException(
+				"Python command line option detected but the flink-python module seems to be missing " +
+					"or not working as expected.", e);
+		}
+	}
+}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgram.java
@@ -20,7 +20,6 @@ package org.apache.flink.client.program;
 
 import org.apache.flink.api.common.ProgramDescription;
 import org.apache.flink.client.ClientUtils;
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.util.InstantiationUtil;
@@ -40,12 +39,6 @@ import java.lang.reflect.Modifier;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -241,33 +234,7 @@ public class PackagedProgram {
 		}
 
 		if (isPython) {
-			String flinkOptPath = System.getenv(ConfigConstants.ENV_FLINK_OPT_DIR);
-			final List<Path> pythonJarPath = new ArrayList<>();
-			try {
-				Files.walkFileTree(FileSystems.getDefault().getPath(flinkOptPath), new SimpleFileVisitor<Path>() {
-					@Override
-					public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-						FileVisitResult result = super.visitFile(file, attrs);
-						if (file.getFileName().toString().startsWith("flink-python")) {
-							pythonJarPath.add(file);
-						}
-						return result;
-					}
-				});
-			} catch (IOException e) {
-				throw new RuntimeException(
-					"Exception encountered during finding the flink-python jar. This should not happen.", e);
-			}
-
-			if (pythonJarPath.size() != 1) {
-				throw new RuntimeException("Found " + pythonJarPath.size() + " flink-python jar.");
-			}
-
-			try {
-				libs.add(pythonJarPath.get(0).toUri().toURL());
-			} catch (MalformedURLException e) {
-				throw new RuntimeException("URL is invalid. This should not happen.", e);
-			}
+			libs.add(PackagedProgramUtils.getPythonJar());
 		}
 
 		return libs;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.client.program;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.client.FlinkPipelineTranslationUtil;
+import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.optimizer.CompilerException;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -28,7 +29,18 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -167,6 +179,36 @@ public enum PackagedProgramUtils {
 	public static Boolean isPython(String entryPointClassName) {
 		return (entryPointClassName != null) &&
 			(entryPointClassName.equals(PYTHON_DRIVER_CLASS_NAME) || entryPointClassName.equals(PYTHON_GATEWAY_CLASS_NAME));
+	}
+
+	public static URL getPythonJar() {
+		String flinkOptPath = System.getenv(ConfigConstants.ENV_FLINK_OPT_DIR);
+		final List<Path> pythonJarPath = new ArrayList<>();
+		try {
+			Files.walkFileTree(FileSystems.getDefault().getPath(flinkOptPath), new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					FileVisitResult result = super.visitFile(file, attrs);
+					if (file.getFileName().toString().startsWith("flink-python")) {
+						pythonJarPath.add(file);
+					}
+					return result;
+				}
+			});
+		} catch (IOException e) {
+			throw new RuntimeException(
+				"Exception encountered during finding the flink-python jar. This should not happen.", e);
+		}
+
+		if (pythonJarPath.size() != 1) {
+			throw new RuntimeException("Found " + pythonJarPath.size() + " flink-python jar.");
+		}
+
+		try {
+			return pythonJarPath.get(0).toUri().toURL();
+		} catch (MalformedURLException e) {
+			throw new RuntimeException("URL is invalid. This should not happen.", e);
+		}
 	}
 
 	private static ProgramInvocationException generateException(

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -118,7 +118,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-		ProgramOptions programOptions = new ProgramOptions(commandLine);
+		ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
 		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
@@ -141,7 +141,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-		ProgramOptions programOptions = new ProgramOptions(commandLine);
+		ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
 		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
@@ -164,7 +164,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-		ProgramOptions programOptions = new ProgramOptions(commandLine);
+		ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 		assertEquals(getTestJarPath(), programOptions.getJarFilePath());
 		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
@@ -192,7 +192,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-		ProgramOptions programOptions = new ProgramOptions(commandLine);
+		ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 		assertEquals(arguments[4], programOptions.getJarFilePath());
 		assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
@@ -212,7 +212,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 		String[] arguments = {"/some/none/existing/path"};
 
 		CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-		ProgramOptions programOptions = new ProgramOptions(commandLine);
+		ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 		assertEquals(arguments[0], programOptions.getJarFilePath());
 		assertArrayEquals(new String[0], programOptions.getProgramArgs());
@@ -272,7 +272,7 @@ public class CliFrontendPackageProgramTest extends TestLogger {
 			String[] reducedArguments = { "true", "arg1", "arg2" };
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
-			ProgramOptions programOptions = new ProgramOptions(commandLine);
+			ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 			assertEquals(getTestJarPath(), programOptions.getJarFilePath());
 			assertArrayEquals(classpath, programOptions.getClasspaths().toArray());

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendRunTest.java
@@ -89,7 +89,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 			String[] parameters = {"-s", "expectedSavepointPath", getTestJarPath()};
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-			ProgramOptions programOptions = new ProgramOptions(commandLine);
+			ProgramOptions programOptions = ProgramOptions.create(commandLine);
 			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
 
 			SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
@@ -103,7 +103,7 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 			String[] parameters = {"-s", "expectedSavepointPath", "-n", getTestJarPath()};
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-			ProgramOptions programOptions = new ProgramOptions(commandLine);
+			ProgramOptions programOptions = ProgramOptions.create(commandLine);
 			ExecutionConfigAccessor executionOptions = ExecutionConfigAccessor.fromProgramOptions(programOptions, Collections.emptyList());
 
 			SavepointRestoreSettings savepointSettings = executionOptions.getSavepointRestoreSettings();
@@ -118,34 +118,13 @@ public class CliFrontendRunTest extends CliFrontendTestBase {
 				{ getTestJarPath(), "-arg1", "value1", "justavalue", "--arg2", "value2"};
 
 			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-			ProgramOptions programOptions = new ProgramOptions(commandLine);
+			ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
 			assertEquals("-arg1", programOptions.getProgramArgs()[0]);
 			assertEquals("value1", programOptions.getProgramArgs()[1]);
 			assertEquals("justavalue", programOptions.getProgramArgs()[2]);
 			assertEquals("--arg2", programOptions.getProgramArgs()[3]);
 			assertEquals("value2", programOptions.getProgramArgs()[4]);
-		}
-
-		// test python arguments
-		{
-			String[] parameters =
-				{
-					"-py", "test.py", "-pyfs", "test1.py,test2.zip,test3.egg,test4_dir", "-pyreq", "a.txt#b_dir",
-					"-pyarch", "c.zip#venv,d.zip", "-pyexec", "bin/python"
-				};
-			CommandLine commandLine = CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, parameters, true);
-			ProgramOptions programOptions = new ProgramOptions(commandLine);
-			assertEquals("--python", programOptions.getProgramArgs()[0]);
-			assertEquals("test.py", programOptions.getProgramArgs()[1]);
-			assertEquals("--pyFiles", programOptions.getProgramArgs()[2]);
-			assertEquals("test1.py,test2.zip,test3.egg,test4_dir", programOptions.getProgramArgs()[3]);
-			assertEquals("--pyRequirements", programOptions.getProgramArgs()[4]);
-			assertEquals("a.txt#b_dir", programOptions.getProgramArgs()[5]);
-			assertEquals("--pyArchives", programOptions.getProgramArgs()[6]);
-			assertEquals("c.zip#venv,d.zip", programOptions.getProgramArgs()[7]);
-			assertEquals("--pyExecutable", programOptions.getProgramArgs()[8]);
-			assertEquals("bin/python", programOptions.getProgramArgs()[9]);
 		}
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.util.PythonDependencyUtils;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.client.cli.CliFrontendParser.ARGS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
+import static org.apache.flink.client.cli.ProgramOptionsUtils.isPythonEntryPoint;
+
+/**
+ * The class for command line options that refer to a Python program or JAR program with Python command line options.
+ */
+public class PythonProgramOptions extends ProgramOptions {
+
+	private final Configuration pythonConfiguration;
+
+	private final boolean isPythonEntryPoint;
+
+	public PythonProgramOptions(CommandLine line) throws CliArgsException {
+		super(line);
+		isPythonEntryPoint = isPythonEntryPoint(line);
+		pythonConfiguration = PythonDependencyUtils.parsePythonDependencyConfiguration(line);
+		// If the job is Python Shell job, the entry point class name is PythonGateWayServer.
+		// Otherwise, the entry point class of python job is PythonDriver
+		if (entryPointClass == null) {
+			entryPointClass = "org.apache.flink.client.python.PythonDriver";
+		}
+	}
+
+	@Override
+	protected String[] extractProgramArgs(CommandLine line) {
+		String[] args;
+		if (isPythonEntryPoint(line)) {
+			String[] rawArgs = line.hasOption(ARGS_OPTION.getOpt()) ?
+				line.getOptionValues(ARGS_OPTION.getOpt()) :
+				line.getArgs();
+			// copy python related parameters to program args and place them in front of user parameters
+			List<String> pyArgList = new ArrayList<>();
+			Set<Option> pyOptions = new HashSet<>();
+			pyOptions.add(PY_OPTION);
+			pyOptions.add(PYMODULE_OPTION);
+			for (Option option : line.getOptions()) {
+				if (pyOptions.contains(option)) {
+					pyArgList.add("--" + option.getLongOpt());
+					pyArgList.add(option.getValue());
+				}
+			}
+			String[] newArgs = pyArgList.toArray(new String[rawArgs.length + pyArgList.size()]);
+			System.arraycopy(rawArgs, 0, newArgs, pyArgList.size(), rawArgs.length);
+			args = newArgs;
+		} else {
+			args = super.extractProgramArgs(line);
+		}
+
+		return args;
+	}
+
+	@Override
+	public void validate() throws CliArgsException {
+		if (!isPythonEntryPoint) {
+			super.validate();
+		}
+	}
+
+	@Override
+	public void applyToConfiguration(Configuration configuration) {
+		super.applyToConfiguration(configuration);
+		configuration.addAll(pythonConfiguration);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonDependencyUtils.java
@@ -27,6 +27,8 @@ import org.apache.flink.python.PythonOptions;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 
+import org.apache.commons.cli.CommandLine;
+
 import javax.annotation.Nullable;
 
 import java.io.File;
@@ -38,6 +40,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
 import static org.apache.flink.python.PythonOptions.PYTHON_CLIENT_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 
@@ -75,6 +81,23 @@ public class PythonDependencyUtils {
 			Configuration config) {
 		PythonDependencyManager pythonDependencyManager = new PythonDependencyManager(cachedFiles, config);
 		return pythonDependencyManager.getConfigWithPythonDependencyOptions();
+	}
+
+	public static Configuration parsePythonDependencyConfiguration(CommandLine commandLine) {
+		Configuration config = new Configuration();
+		if (commandLine.hasOption(PYFILES_OPTION.getOpt())) {
+			config.set(PythonOptions.PYTHON_FILES, commandLine.getOptionValue(PYFILES_OPTION.getOpt()));
+		}
+		if (commandLine.hasOption(PYREQUIREMENTS_OPTION.getOpt())) {
+			config.set(PythonOptions.PYTHON_REQUIREMENTS, commandLine.getOptionValue(PYREQUIREMENTS_OPTION.getOpt()));
+		}
+		if (commandLine.hasOption(PYARCHIVE_OPTION.getOpt())) {
+			config.set(PythonOptions.PYTHON_ARCHIVES, commandLine.getOptionValue(PYARCHIVE_OPTION.getOpt()));
+		}
+		if (commandLine.hasOption(PYEXEC_OPTION.getOpt())) {
+			config.set(PythonOptions.PYTHON_EXECUTABLE, commandLine.getOptionValue(PYEXEC_OPTION.getOpt()));
+		}
+		return config;
 	}
 
 	/**

--- a/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/cli/PythonProgramOptionsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.client.cli;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.PythonOptions;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.flink.client.cli.CliFrontendParser.PYARCHIVE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYEXEC_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYFILES_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYMODULE_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PYREQUIREMENTS_OPTION;
+import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
+import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
+import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link PythonProgramOptions}.
+ */
+public class PythonProgramOptionsTest {
+
+	private Options options;
+
+	@Before
+	public void setUp() {
+		options = new Options();
+		options.addOption(PY_OPTION);
+		options.addOption(PYFILES_OPTION);
+		options.addOption(PYMODULE_OPTION);
+		options.addOption(PYREQUIREMENTS_OPTION);
+		options.addOption(PYARCHIVE_OPTION);
+		options.addOption(PYEXEC_OPTION);
+	}
+
+	@Test
+	public void testCreateProgramOptionsWithPythonCommandLine() throws CliArgsException {
+		String[] parameters = {
+			"-py", "test.py",
+			"-pym", "test",
+			"-pyfs", "test1.py,test2.zip,test3.egg,test4_dir",
+			"-pyreq", "a.txt#b_dir",
+			"-pyarch", "c.zip#venv,d.zip",
+			"-pyexec", "bin/python",
+			"userarg1", "userarg2"
+		};
+
+		CommandLine line = CliFrontendParser.parse(options, parameters, false);
+		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
+		Configuration config = new Configuration();
+		programOptions.applyToConfiguration(config);
+		assertEquals("test1.py,test2.zip,test3.egg,test4_dir", config.get(PythonOptions.PYTHON_FILES));
+		assertEquals("a.txt#b_dir", config.get(PYTHON_REQUIREMENTS));
+		assertEquals("c.zip#venv,d.zip", config.get(PythonOptions.PYTHON_ARCHIVES));
+		assertEquals("bin/python", config.get(PYTHON_EXECUTABLE));
+		assertArrayEquals(
+			new String[] {"--python", "test.py", "--pyModule", "test", "userarg1", "userarg2"},
+			programOptions.getProgramArgs());
+	}
+
+	@Test
+	public void testCreateProgramOptionsWithLongOptions() throws CliArgsException {
+		String[] args = {
+			"--python", "xxx.py",
+			"--pyModule", "xxx",
+			"--pyFiles", "/absolute/a.py,relative/b.py,relative/c.py",
+			"--pyRequirements", "d.txt#e_dir",
+			"--pyExecutable", "/usr/bin/python",
+			"--pyArchives", "g.zip,h.zip#data,h.zip#data2",
+			"userarg1", "userarg2"
+		};
+
+		CommandLine line = CliFrontendParser.parse(options, args, false);
+		PythonProgramOptions programOptions = (PythonProgramOptions) ProgramOptions.create(line);
+		Configuration config = new Configuration();
+		programOptions.applyToConfiguration(config);
+		assertEquals("/absolute/a.py,relative/b.py,relative/c.py", config.get(PythonOptions.PYTHON_FILES));
+		assertEquals("d.txt#e_dir", config.get(PYTHON_REQUIREMENTS));
+		assertEquals("g.zip,h.zip#data,h.zip#data2", config.get(PythonOptions.PYTHON_ARCHIVES));
+		assertEquals("/usr/bin/python", config.get(PYTHON_EXECUTABLE));
+		assertArrayEquals(
+			new String[] {"--python", "xxx.py", "--pyModule", "xxx", "userarg1", "userarg2"},
+			programOptions.getProgramArgs());
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/PythonDependencyUtilsTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,6 +41,7 @@ import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_ARCHIVES
 import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_FILES;
 import static org.apache.flink.python.util.PythonDependencyUtils.PYTHON_REQUIREMENTS_FILE;
 import static org.apache.flink.python.util.PythonDependencyUtils.configurePythonDependencies;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Tests for PythonDependencyUtils.
@@ -190,7 +190,7 @@ public class PythonDependencyUtilsTest {
 				t -> t.f0,
 				t -> t.f1.filePath));
 
-		Assert.assertEquals(expected, actual);
+		assertEquals(expected, actual);
 	}
 
 	private void verifyConfiguration(Configuration expected, Configuration actual) {
@@ -198,6 +198,6 @@ public class PythonDependencyUtilsTest {
 		actual.addAllToProperties(actualProperties);
 		Properties expectedProperties = new Properties();
 		expected.addAllToProperties(expectedProperties);
-		Assert.assertEquals(expectedProperties, actualProperties);
+		assertEquals(expectedProperties, actualProperties);
 	}
 }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -315,7 +315,7 @@ public class ExecutionContext<ClusterID> {
 				commandLine);
 
 		try {
-			final ProgramOptions programOptions = new ProgramOptions(commandLine);
+			final ProgramOptions programOptions = ProgramOptions.create(commandLine);
 			final ExecutionConfigAccessor executionConfigAccessor = ExecutionConfigAccessor.fromProgramOptions(programOptions, dependencies);
 			executionConfigAccessor.applyToConfiguration(executionConfig);
 		} catch (CliArgsException e) {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces new Python dependency configuration options in flink-client.*


## Brief change log

  - *Add logic to the constructor of `ProgramOptions` to parse the python command line arguments to configurations.*
  - *Write the python configurations to `ExecutionConfigAccessor` when constructing it from `ProgramOptions`.*


## Verifying this change

This change is already covered by existing tests, such as *PythonDependencyUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
