### PR TITLE
[FLINK-17088] [runtime][web] Search TaskManager log content based on keywords function

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/task-manager.ts
@@ -75,3 +75,8 @@ interface GarbageCollectorsItem {
   count: number;
   time: number;
 }
+
+export interface TaskManagerLogSearchInterface {
+  word: string;
+  lines: string;
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.html
@@ -26,11 +26,12 @@
     </nz-breadcrumb-item>
   </nz-breadcrumb>
   <flink-refresh-download
-    [isLoading]="isLoading"
-    [downloadHref]="downloadUrl"
-    [downloadName]="logName"
-    (reload)="reloadLog()"
-    (fullScreen)="toggleFullScreen($event)">
+      [searchAble]="true"
+      [isLoading]="isLoading"
+      [downloadHref]="downloadUrl"
+      [downloadName]="logName"
+      (reload)="reloadLog($event)"
+      (fullScreen)="toggleFullScreen($event)">
   </flink-refresh-download>
 </div>
 <flink-monaco-editor [value]="logs"></flink-monaco-editor>

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.less
@@ -51,4 +51,6 @@ flink-refresh-download {
   right: 12px;
   top: 0;
   line-height: 47px;
+  display: flex;
+  align-items: center;
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/task-manager/log-detail/task-manager-log-detail.component.ts
@@ -16,7 +16,7 @@
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { TaskManagerDetailInterface } from 'interfaces';
+import { TaskManagerDetailInterface, TaskManagerLogSearchInterface } from 'interfaces';
 import { TaskManagerService } from 'services';
 import { first } from 'rxjs/operators';
 import { MonacoEditorComponent } from 'share/common/monaco-editor/monaco-editor.component';
@@ -36,6 +36,7 @@ export class TaskManagerLogDetailComponent implements OnInit {
   downloadUrl = '';
   isLoading = false;
   taskManagerDetail: TaskManagerDetailInterface;
+  taskManagerLogSearch: TaskManagerLogSearchInterface;
   isFullScreen = false;
   hasLogName = false;
   @ViewChild(MonacoEditorComponent) monacoEditorComponent: MonacoEditorComponent;
@@ -46,10 +47,10 @@ export class TaskManagerLogDetailComponent implements OnInit {
     private activatedRoute: ActivatedRoute
   ) {}
 
-  reloadLog() {
-    this.isLoading = true;
-    this.cdr.markForCheck();
-    this.taskManagerService.loadLog(this.taskManagerDetail.id, this.logName, this.hasLogName).subscribe(
+  reloadLog(taskManagerLogSearch: TaskManagerLogSearchInterface = {word: '', lines: ''}) {
+      this.isLoading = true;
+      this.cdr.markForCheck();
+      this.taskManagerService.loadLog(this.taskManagerDetail.id, this.logName, this.hasLogName, taskManagerLogSearch.word, taskManagerLogSearch.lines).subscribe(
       data => {
         this.logs = data.data;
         this.downloadUrl = data.url;

--- a/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/task-manager.service.ts
@@ -64,11 +64,20 @@ export class TaskManagerService {
    * @param taskManagerId
    * @param logName
    * @param hasLogName
+   * @param word
+   * @param lines
    */
-  loadLog(taskManagerId: string, logName: string, hasLogName: boolean) {
+  loadLog(taskManagerId: string, logName: string, hasLogName: boolean, word: string, lines: String) {
     let url = '';
     if (hasLogName) {
       url = `${BASE_URL}/taskmanagers/${taskManagerId}/logs/${logName}`;
+      if(word) {
+        if(lines) {
+          url = `${url}/${word}/${lines}`
+        } else {
+           url = `${url}/${word}/0`
+        }
+      }
     } else {
       url = `${BASE_URL}/taskmanagers/${taskManagerId}/log`;
     }

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/refresh-download/refresh-download.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/refresh-download/refresh-download.component.html
@@ -23,10 +23,18 @@
 </nz-button-group>
 
 <ng-template #defaultTemplate>
-  <span *ngIf="isLoading; else reloadTpl;">Loading...</span>
-  <ng-template #reloadTpl>
-    <a (click)="reload.emit()"><i nz-icon class="operate-icon" nzType="sync" nzTheme="outline"></i> Reload</a>
-  </ng-template>
+  <div *ngIf="searchAble" style="width:250px; display: flex; align-items: center;">
+    <input style="margin-right: 2px; width:120px;" nzSize="small" type="text" nz-input [(ngModel)]="search.word" placeholder="search word" />
+    <input style="margin-right: 2px; width:60px;" nzSize="small" type="text" nz-input [(ngModel)]="search.lines" placeholder="lines" />
+    <button (click)="toggleReload()" nz-button nzType="primary" nzSize="small" nzSearch>Search</button>
+  </div>
+  <nz-divider nzType="vertical"></nz-divider>
+  <div style="width: 80px; text-align: center;">
+    <span *ngIf="isLoading; else reloadTpl;">Loading...</span>
+    <ng-template #reloadTpl>
+      <a (click)="toggleReload()"><i nz-icon class="operate-icon" nzType="sync" nzTheme="outline"></i> Reload</a>
+    </ng-template>
+  </div>
   <nz-divider nzType="vertical"></nz-divider>
   <a [attr.download]="downloadName" [attr.href]="downloadHref"><i nz-icon class="operate-icon" nzType="download" nzTheme="outline"></i> Download</a>
   <nz-divider nzType="vertical"></nz-divider>

--- a/flink-runtime-web/web-dashboard/src/app/share/customize/refresh-download/refresh-download.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/customize/refresh-download/refresh-download.component.ts
@@ -17,6 +17,7 @@
  */
 
 import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from '@angular/core';
+import { TaskManagerLogSearchInterface } from 'interfaces';
 
 @Component({
   selector: 'flink-refresh-download',
@@ -24,15 +25,24 @@ import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter } from 
   styleUrls: ['./refresh-download.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
+
 export class RefreshDownloadComponent {
   @Input() downloadName: string;
   @Input() downloadHref: string;
   @Input() isLoading = false;
   @Input() compactMode = false;
-  @Output() reload = new EventEmitter<void>();
+  @Input() searchAble: boolean;
+  @Output() reload = new EventEmitter<any>();
   @Output() fullScreen = new EventEmitter<boolean>();
   isFullScreen = false;
+  search = {
+      word: '',
+      lines: '',
+    } as TaskManagerLogSearchInterface;
 
+  toggleReload() {
+    this.reload.emit(this.search);
+  }
   toggleFullScreen() {
     this.isFullScreen = !this.isFullScreen;
     this.fullScreen.emit(this.isFullScreen);

--- a/flink-runtime-web/web-dashboard/src/app/share/share.module.ts
+++ b/flink-runtime-web/web-dashboard/src/app/share/share.module.ts
@@ -17,6 +17,7 @@
  */
 
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { NgZorroAntdModule } from 'ng-zorro-antd';
 import { ResizeComponent } from 'share/common/resize/resize.component';
@@ -34,7 +35,7 @@ import { RefreshDownloadComponent } from 'share/customize/refresh-download/refre
 import { BackpressureBadgeComponent } from './customize/backpressure-badge/backpressure-badge.component';
 
 @NgModule({
-  imports: [CommonModule, NgZorroAntdModule, PipeModule, DagreModule],
+  imports: [CommonModule, NgZorroAntdModule, PipeModule, DagreModule, FormsModule],
   declarations: [
     JobBadgeComponent,
     TaskBadgeComponent,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogSearchInfoHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogSearchInfoHandler.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,24 +26,21 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.exceptions.UnknownTaskExecutorException;
 import org.apache.flink.runtime.rest.NotFoundException;
-import org.apache.flink.runtime.rest.handler.AbstractHandler;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.RestHandlerException;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogFileNamePathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogSearchInfoParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogSearchLineParameter;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
-import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerMessageParameters;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogSearchInfoParameters;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
-import org.apache.flink.shaded.guava18.com.google.common.cache.CacheLoader;
-import org.apache.flink.shaded.guava18.com.google.common.cache.LoadingCache;
-import org.apache.flink.shaded.guava18.com.google.common.cache.RemovalNotification;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFutureListener;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
@@ -53,25 +50,25 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpChunkedInp
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRequest;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponse;
-import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.LastHttpContent;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslHandler;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedFile;
 import org.apache.flink.shaded.netty4.io.netty.util.concurrent.Future;
 import org.apache.flink.shaded.netty4.io.netty.util.concurrent.GenericFutureListener;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.LineIterator;
+
 import javax.annotation.Nonnull;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
@@ -79,70 +76,57 @@ import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpRes
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
 /**
- * Base class for serving files from the {@link TaskExecutor}.
+ * Rest handler which serves the search file of the {@link TaskExecutor}.
  */
-public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessageParameters> extends AbstractHandler<RestfulGateway, EmptyRequestBody, M> {
+public class TaskManagerLogSearchInfoHandler extends AbstractTaskManagerFileHandler<TaskManagerLogSearchInfoParameters> {
+	private final String readWrite = "rw";
+	private final String searchLogPrefix = "result";
+	private final String searchLogSuffix = ".tmp";
+	private final String lineSeparator = System.getProperty("line.separator", "\n");
 
-	private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
-	protected final TransientBlobService transientBlobService;
+	public TaskManagerLogSearchInfoHandler(
+		@Nonnull GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+		@Nonnull Time timeout,
+		@Nonnull Map<String, String> responseHeaders,
+		@Nonnull UntypedResponseMessageHeaders<EmptyRequestBody, TaskManagerLogSearchInfoParameters> untypedResponseMessageHeaders,
+		@Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
+		@Nonnull TransientBlobService transientBlobService,
+		@Nonnull Time cacheEntryDuration) {
+		super(leaderRetriever, timeout, responseHeaders, untypedResponseMessageHeaders, resourceManagerGatewayRetriever, transientBlobService, cacheEntryDuration);
 
-	protected final LoadingCache<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>> fileBlobKeys;
-
-	protected AbstractTaskManagerFileHandler(
-			@Nonnull GatewayRetriever<? extends RestfulGateway> leaderRetriever,
-			@Nonnull Time timeout,
-			@Nonnull Map<String, String> responseHeaders,
-			@Nonnull UntypedResponseMessageHeaders<EmptyRequestBody, M> untypedResponseMessageHeaders,
-			@Nonnull GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-			@Nonnull TransientBlobService transientBlobService,
-			@Nonnull Time cacheEntryDuration) {
-		super(leaderRetriever, timeout, responseHeaders, untypedResponseMessageHeaders);
-
-		this.resourceManagerGatewayRetriever = Preconditions.checkNotNull(resourceManagerGatewayRetriever);
-
-		this.transientBlobService = Preconditions.checkNotNull(transientBlobService);
-
-		this.fileBlobKeys = CacheBuilder
-			.newBuilder()
-			.expireAfterWrite(cacheEntryDuration.toMilliseconds(), TimeUnit.MILLISECONDS)
-			.removalListener(this::removeBlob)
-			.build(
-				new CacheLoader<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>>() {
-					@Override
-					public CompletableFuture<TransientBlobKey> load(Tuple2<ResourceID, String> taskManagerIdAndFileName) throws Exception {
-						return loadTaskManagerFile(taskManagerIdAndFileName);
-					}
-			});
 	}
 
 	@Override
-	protected CompletableFuture<Void> respondToRequest(ChannelHandlerContext ctx, HttpRequest httpRequest, HandlerRequest<EmptyRequestBody, M> handlerRequest, RestfulGateway gateway) throws RestHandlerException {
+	protected CompletableFuture<Void> respondToRequest(
+		ChannelHandlerContext ctx,
+		HttpRequest httpRequest,
+		HandlerRequest<EmptyRequestBody, TaskManagerLogSearchInfoParameters> handlerRequest,
+		RestfulGateway gateway) throws RestHandlerException {
+
 		final ResourceID taskManagerId = handlerRequest.getPathParameter(TaskManagerIdPathParameter.class);
-
-		String filename = getFileName(handlerRequest);
+		final String filename = handlerRequest.getPathParameter(LogFileNamePathParameter.class);
+		final String searchWord = handlerRequest.getPathParameter(LogSearchInfoParameter.class);
+		final String lines = handlerRequest.getPathParameter(LogSearchLineParameter.class);
 		final Tuple2<ResourceID, String> taskManagerIdAndFileName = new Tuple2<>(taskManagerId, filename);
-		final CompletableFuture<TransientBlobKey> blobKeyFuture;
-		try {
-			blobKeyFuture = fileBlobKeys.get(taskManagerIdAndFileName);
-		} catch (ExecutionException e) {
-			final Throwable cause = ExceptionUtils.stripExecutionException(e);
-			throw new RestHandlerException("Could not retrieve file blob key future.", HttpResponseStatus.INTERNAL_SERVER_ERROR, cause);
-		}
 
+		final CompletableFuture<TransientBlobKey> blobKeyFuture = loadTaskManagerFile(taskManagerIdAndFileName);
 		final CompletableFuture<Void> resultFuture = blobKeyFuture.thenAcceptAsync(
 			(TransientBlobKey blobKey) -> {
 				final File file;
 				try {
-					file = transientBlobService.getFile(blobKey);
+					file = super.transientBlobService.getFile(blobKey);
 				} catch (IOException e) {
 					throw new CompletionException(new FlinkException("Could not retrieve file from transient blob store.", e));
 				}
 
 				try {
-					transferFile(
+					searchLogFile(
 						ctx,
 						file,
-						httpRequest);
+						httpRequest,
+						searchWord,
+						lines
+					);
 				} catch (FlinkException e) {
 					throw new CompletionException(new FlinkException("Could not transfer file to client.", e));
 				}
@@ -153,65 +137,71 @@ public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessag
 			(Void ignored, Throwable throwable) -> {
 				if (throwable != null) {
 					log.error("Failed to transfer file from TaskExecutor {}.", taskManagerId, throwable);
-					fileBlobKeys.invalidate(taskManagerId);
 
 					final Throwable strippedThrowable = ExceptionUtils.stripCompletionException(throwable);
 
 					if (strippedThrowable instanceof UnknownTaskExecutorException) {
 						throw new CompletionException(
 							new NotFoundException(
-								String.format("Failed to transfer file from TaskExecutor %s because it was unknown.", taskManagerId),
+								String.format("Failed to search log file from TaskExecutor %s because it was unknown.", taskManagerId),
 								strippedThrowable));
 					} else {
 						throw new CompletionException(
 							new FlinkException(
-								String.format("Failed to transfer file from TaskExecutor %s.", taskManagerId),
+								String.format("Failed to search log file from TaskExecutor %s.", taskManagerId),
 								strippedThrowable));
 					}
 				}
 			});
 	}
 
-	protected CompletableFuture<TransientBlobKey> loadTaskManagerFile(Tuple2<ResourceID, String> taskManagerIdAndFileName) throws RestHandlerException {
-		log.debug("Load file from TaskManager {}.", taskManagerIdAndFileName.f0);
-
-		final ResourceManagerGateway resourceManagerGateway = resourceManagerGatewayRetriever
-			.getNow()
-			.orElseThrow(() -> {
-				log.debug("Could not connect to ResourceManager right now.");
-				return new RestHandlerException(
-					"Cannot connect to ResourceManager right now. Please try to refresh.",
-					HttpResponseStatus.NOT_FOUND);
-			});
-
-		return requestFileUpload(resourceManagerGateway, taskManagerIdAndFileName);
-	}
-
-	protected abstract CompletableFuture<TransientBlobKey> requestFileUpload(ResourceManagerGateway resourceManagerGateway, Tuple2<ResourceID, String> taskManagerIdAndFileName);
-
-	private void removeBlob(RemovalNotification<Tuple2<ResourceID, String>, CompletableFuture<TransientBlobKey>> removalNotification) {
-		log.debug("Remove cached file for TaskExecutor {}.", removalNotification.getKey());
-
-		final CompletableFuture<TransientBlobKey> value = removalNotification.getValue();
-
-		if (value != null) {
-			value.thenAccept(transientBlobService::deleteFromCache);
-		}
-	}
-
-	private void transferFile(ChannelHandlerContext ctx, File file, HttpRequest httpRequest) throws FlinkException {
-		final RandomAccessFile randomAccessFile;
+	private void searchLogFile(ChannelHandlerContext ctx, File file, HttpRequest httpRequest, String searchWord, String lines) throws FlinkException {
+		final LineIterator lineIterator;
+		final RandomAccessFile resultAccessFile;
+		final File resultFile;
 
 		try {
-			randomAccessFile = new RandomAccessFile(file, "r");
-		} catch (FileNotFoundException e) {
+			resultFile = File.createTempFile(searchLogPrefix, searchLogSuffix, new File(file.getParent()));
+			lineIterator = FileUtils.lineIterator(file, StandardCharsets.UTF_8.name());
+			resultAccessFile = new RandomAccessFile(resultFile, readWrite);
+		} catch (IOException e) {
 			throw new FlinkException("Can not find file " + file + ".", e);
 		}
 
+		int num;
 		try {
+			num = Integer.parseInt(lines);
+		} catch (NumberFormatException e) {
+			num = 0;
+		}
 
-			final long fileLength = randomAccessFile.length();
-			final FileChannel fileChannel = randomAccessFile.getChannel();
+		try {
+			boolean flag = false;
+			int count = 0;
+			while (lineIterator.hasNext()) {
+				String line = lineIterator.nextLine();
+				if (line.toLowerCase().contains(searchWord.toLowerCase())) {
+					resultAccessFile.writeBytes(line);
+					resultAccessFile.writeBytes(lineSeparator);
+					flag = true;
+					continue;
+				}
+				if (flag && (count < num)) {
+					resultAccessFile.writeBytes(line);
+					resultAccessFile.writeBytes(lineSeparator);
+					count++;
+				} else {
+					flag = false;
+					count = 0;
+				}
+			}
+
+			if (!(resultAccessFile.length() > 0)) {
+				resultAccessFile.writeBytes("No content matching the search keywords");
+			}
+
+			final long fileLength = resultAccessFile.length();
+			final FileChannel fileChannel = resultAccessFile.getChannel();
 
 			try {
 				HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
@@ -229,7 +219,8 @@ public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessag
 				final ChannelFuture lastContentFuture;
 				final GenericFutureListener<Future<? super Void>> completionListener = future -> {
 					fileChannel.close();
-					randomAccessFile.close();
+					resultAccessFile.close();
+					lineIterator.close();
 				};
 
 				if (ctx.pipeline().get(SslHandler.class) == null) {
@@ -237,37 +228,44 @@ public abstract class AbstractTaskManagerFileHandler<M extends TaskManagerMessag
 						new DefaultFileRegion(fileChannel, 0, fileLength), ctx.newProgressivePromise())
 						.addListener(completionListener);
 					lastContentFuture = ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT);
-
 				} else {
 					lastContentFuture = ctx
 						.writeAndFlush(
-							new HttpChunkedInput(new ChunkedFile(randomAccessFile, 0, fileLength, 8192)),
+							new HttpChunkedInput(new ChunkedFile(resultAccessFile, 0, fileLength, 8192)),
 							ctx.newProgressivePromise())
 						.addListener(completionListener);
-
-					// HttpChunkedInput will write the end marker (LastHttpContent) for us.
 				}
 
 				// close the connection, if no keep-alive is needed
 				if (!HttpHeaders.isKeepAlive(httpRequest)) {
 					lastContentFuture.addListener(ChannelFutureListener.CLOSE);
 				}
+
+				//rm result log file
+				resultFile.deleteOnExit();
 			} catch (IOException ex) {
 				fileChannel.close();
 				throw ex;
 			}
 		} catch (IOException ioe) {
 			try {
-				randomAccessFile.close();
+				resultAccessFile.close();
+				lineIterator.close();
 			} catch (IOException e) {
-				throw new FlinkException("Close file or channel error.", e);
+				throw new FlinkException("Close file error.", e);
 			}
 
-			throw new FlinkException("Could not transfer file " + file + " to the client.", ioe);
+			throw new FlinkException("Could not search log file " + file + " to the client.", ioe);
 		}
 	}
 
-	protected String getFileName(HandlerRequest<EmptyRequestBody, M> handlerRequest) {
-		return null;
+	@Override
+	protected CompletableFuture<TransientBlobKey> requestFileUpload(ResourceManagerGateway resourceManagerGateway, Tuple2<ResourceID, String> taskManagerIdAndFileName) {
+		return resourceManagerGateway.requestTaskManagerFileUploadByName(taskManagerIdAndFileName.f0, taskManagerIdAndFileName.f1, timeout);
+	}
+
+	@Override
+	protected String getFileName(HandlerRequest<EmptyRequestBody, TaskManagerLogSearchInfoParameters> handlerRequest) {
+		return handlerRequest.getPathParameter(LogFileNamePathParameter.class);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LogSearchInfoParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LogSearchInfoParameter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogSearchInfoHandler;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+
+/**
+ * Parameters for {@link TaskManagerLogSearchInfoHandler}.
+ */
+public class LogSearchInfoParameter extends MessagePathParameter<String> {
+	public static final String KEY = "word";
+
+	public LogSearchInfoParameter() {
+		super(KEY);
+	}
+
+	@Override
+	protected String convertFromString(String value) {
+		return value;
+	}
+
+	@Override
+	protected String convertToString(String value) {
+		return value;
+	}
+
+	@Override
+	public String getDescription() {
+		return "String value that identifies the log search word from which to read.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LogSearchLineParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/LogSearchLineParameter.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogSearchInfoHandler;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+
+/**
+ * Parameters for {@link TaskManagerLogSearchInfoHandler}.
+ */
+public class LogSearchLineParameter extends MessagePathParameter<String> {
+	public static final String KEY = "lines";
+
+	public LogSearchLineParameter() {
+		super(KEY);
+	}
+
+	@Override
+	protected String convertFromString(String value) {
+		return value;
+	}
+
+	@Override
+	protected String convertToString(String value) {
+		return value;
+	}
+
+	@Override
+	public String getDescription() {
+		return "String value that identifies the log search word from which to read.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerLogSearchInfoHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerLogSearchInfoHeaders.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogSearchInfoHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+
+/**
+ * Headers for the {@link TaskManagerLogSearchInfoHandler}.
+ */
+public class TaskManagerLogSearchInfoHeaders implements
+	UntypedResponseMessageHeaders<EmptyRequestBody, TaskManagerLogSearchInfoParameters> {
+
+	private static final TaskManagerLogSearchInfoHeaders INSTANCE = new TaskManagerLogSearchInfoHeaders();
+
+	private static final String URL = String.format("/taskmanagers/:%s/logs/:%s/:%s/:%s", TaskManagerIdPathParameter.KEY, LogFileNamePathParameter.KEY, LogSearchInfoParameter.KEY, LogSearchLineParameter.KEY);
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public TaskManagerLogSearchInfoParameters getUnresolvedMessageParameters() {
+		return new TaskManagerLogSearchInfoParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static TaskManagerLogSearchInfoHeaders getInstance() {
+		return INSTANCE;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerLogSearchInfoParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/taskmanager/TaskManagerLogSearchInfoParameters.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.taskmanager;
+
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogSearchInfoHandler;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Parameters for {@link TaskManagerLogSearchInfoHandler}.
+ */
+public class TaskManagerLogSearchInfoParameters extends TaskManagerFileMessageParameters {
+
+	public final LogSearchInfoParameter infoParameter = new LogSearchInfoParameter();
+	public final LogSearchLineParameter lineParameter = new LogSearchLineParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Collections.unmodifiableCollection(Arrays.asList(
+			infoParameter,
+			lineParameter,
+			logFileNamePathParameter,
+			taskManagerIdParameter
+		));
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -82,6 +82,7 @@ import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerCustomLogHan
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerDetailsHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogFileHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogListHandler;
+import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerLogSearchInfoHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagerStdoutFileHandler;
 import org.apache.flink.runtime.rest.handler.taskmanager.TaskManagersHandler;
 import org.apache.flink.runtime.rest.messages.ClusterConfigurationInfoHeaders;
@@ -115,6 +116,7 @@ import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetails
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerCustomLogHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogFileHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogSearchInfoHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerStdoutFileHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
@@ -662,10 +664,21 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			resourceManagerRetriever
 		);
 
+		final TaskManagerLogSearchInfoHandler taskManagerLogSearchInfoHandler = new TaskManagerLogSearchInfoHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			TaskManagerLogSearchInfoHeaders.getInstance(),
+			resourceManagerRetriever,
+			transientBlobService,
+			cacheEntryDuration
+		);
+
 		handlers.add(Tuple2.of(TaskManagerLogFileHeaders.getInstance(), taskManagerLogFileHandler));
 		handlers.add(Tuple2.of(TaskManagerStdoutFileHeaders.getInstance(), taskManagerStdoutFileHandler));
 		handlers.add(Tuple2.of(TaskManagerCustomLogHeaders.getInstance(), taskManagerCustomLogHandler));
 		handlers.add(Tuple2.of(TaskManagerLogsHeaders.getInstance(), taskManagerLogListHandler));
+		handlers.add(Tuple2.of(TaskManagerLogSearchInfoHeaders.getInstance(), taskManagerLogSearchInfoHandler));
 
 		handlers.stream()
 			.map(tuple -> tuple.f1)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/AbstractTaskManagerFileHandlerTest.java
@@ -300,11 +300,11 @@ public class AbstractTaskManagerFileHandlerTest extends TestLogger {
 	/**
 	 * Testing implementation of {@link ChannelHandlerContext}.
 	 */
-	private static final class TestingChannelHandlerContext implements ChannelHandlerContext {
+	protected static final class TestingChannelHandlerContext implements ChannelHandlerContext {
 
 		final File outputFile;
 
-		private TestingChannelHandlerContext(File outputFile) {
+		TestingChannelHandlerContext(File outputFile) {
 			this.outputFile = Preconditions.checkNotNull(outputFile);
 		}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogSearchInfoHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/taskmanager/TaskManagerLogSearchInfoHandlerTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.taskmanager;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
+import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.taskmanager.AbstractTaskManagerFileHandlerTest.TestingChannelHandlerContext;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.UntypedResponseMessageHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogFileNamePathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogSearchInfoParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.LogSearchLineParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerIdPathParameter;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogSearchInfoHeaders;
+import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogSearchInfoParameters;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultFullHttpRequest;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVersion;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ * Test for the {@link TaskManagerLogSearchInfoHandler}.
+ */
+public class TaskManagerLogSearchInfoHandlerTest extends TestLogger {
+	private static final ResourceID EXPECTED_TASK_MANAGER_ID = ResourceID.generate();
+
+	private static final DefaultFullHttpRequest HTTP_REQUEST = new DefaultFullHttpRequest(
+		HttpVersion.HTTP_1_1, HttpMethod.GET, TestTaskManagerLogSearchInfoHeaders.URL);
+
+	private static HandlerRequest<EmptyRequestBody, TaskManagerLogSearchInfoParameters> handlerRequest;
+
+	@ClassRule
+	public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+	private static BlobServer blobServer;
+
+	private static final String SEARCH_LINES = "0";
+	private static final String SEARCH_WORD = "word";
+	private static final String LOG_NAME = "search.log";
+	private static final String RESULT_NAME = "result.log";
+
+	private  File file1;
+	private  File file2;
+	private String fileContent1;
+	private String fileContent2;
+	private TransientBlobKey transientBlobKey;
+
+	@BeforeClass
+	public static void setup() throws IOException, HandlerRequestException {
+		final Configuration configuration = new Configuration();
+		configuration.setString(BlobServerOptions.STORAGE_DIRECTORY, temporaryFolder.newFolder().getAbsolutePath());
+
+		blobServer = new BlobServer(configuration, new VoidBlobStore());
+
+		handlerRequest = createRequest(EXPECTED_TASK_MANAGER_ID, LOG_NAME, SEARCH_WORD, SEARCH_LINES);
+	}
+
+	@Before
+	public void setupTest() throws IOException {
+		fileContent1 = "search word\n"
+			+ "search";
+		file1 = createFileWithContent(fileContent1, LOG_NAME);
+
+		transientBlobKey = storeFileInBlobServer(file1);
+
+		fileContent2 = "search word\n";
+		file2 = createFileWithContent(fileContent2, RESULT_NAME);
+	}
+
+	@After
+	public void delFileTest() {
+		file1.deleteOnExit();
+		file2.deleteOnExit();
+	}
+
+	@AfterClass
+	public static void teardown() throws IOException {
+		if (blobServer != null) {
+			blobServer.close();
+			blobServer = null;
+		}
+	}
+
+	/**
+	 * Tests that the {@link AbstractTaskManagerFileHandler} serves the requested file.
+	 */
+	@Test
+	public void testFileSearching() throws Exception {
+		final Time cacheEntryDuration = Time.milliseconds(1000L);
+
+		final Queue<CompletableFuture<TransientBlobKey>> requestFileUploads = new ArrayDeque<>(1);
+
+		requestFileUploads.add(CompletableFuture.completedFuture(transientBlobKey));
+
+		final ResourceManagerGateway resourceManagerGateway = new TestingResourceManagerGateway();
+
+		final TaskManagerLogSearchInfoHandler taskManagerLogSearchInfoHandler = new TaskManagerLogSearchInfoHandler(
+			() -> CompletableFuture.completedFuture(null),
+			TestingUtils.infiniteTime(),
+			Collections.emptyMap(),
+			new TestTaskManagerLogSearchInfoHeaders(),
+			() -> CompletableFuture.completedFuture(resourceManagerGateway),
+			blobServer,
+			cacheEntryDuration
+		) {
+			@Override
+			protected CompletableFuture<TransientBlobKey> requestFileUpload(ResourceManagerGateway resourceManagerGateway, Tuple2<ResourceID, String> taskManagerIdAndFileName) {
+				final CompletableFuture<TransientBlobKey> transientBlobKeyFuture = requestFileUploads.poll();
+
+				if (transientBlobKeyFuture != null) {
+					return transientBlobKeyFuture;
+				} else {
+					return FutureUtils.completedExceptionally(new FlinkException("Could not upload file."));
+				}
+			}
+		};
+
+		final File outputFile = temporaryFolder.newFile();
+		final TestingChannelHandlerContext testingContext = new AbstractTaskManagerFileHandlerTest.TestingChannelHandlerContext(outputFile);
+
+		taskManagerLogSearchInfoHandler.respondToRequest(
+			testingContext,
+			HTTP_REQUEST,
+			handlerRequest,
+			null);
+
+		assertThat(outputFile.length(), is(greaterThan(0L)));
+		assertThat(FileUtils.readFileUtf8(outputFile), is(equalTo(fileContent2)));
+	}
+
+	private static TransientBlobKey storeFileInBlobServer(File fileToStore) throws IOException {
+		// store the requested file in the BlobServer
+		try (FileInputStream fileInputStream = new FileInputStream(fileToStore)) {
+			return blobServer.getTransientBlobService().putTransient(fileInputStream);
+		}
+	}
+
+	private static File createFileWithContent(String fileContent, String fileName) throws IOException {
+		final File file = temporaryFolder.newFile(fileName);
+
+		// write random content into the file
+		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+			fileOutputStream.write(fileContent.getBytes("UTF-8"));
+		}
+
+		return file;
+	}
+
+	private static HandlerRequest<EmptyRequestBody, TaskManagerLogSearchInfoParameters> createRequest(ResourceID taskManagerId, String fileName, String word, String lines) throws HandlerRequestException {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put(TaskManagerIdPathParameter.KEY, taskManagerId.toString());
+		parameters.put(LogFileNamePathParameter.KEY, fileName);
+		parameters.put(LogSearchInfoParameter.KEY, word);
+		parameters.put(LogSearchLineParameter.KEY, lines);
+		Map<String, List<String>> queryParameters = Collections.emptyMap();
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new TaskManagerLogSearchInfoParameters(),
+			parameters,
+			queryParameters);
+	}
+
+
+	/**
+	 * Testing {@link TaskManagerLogSearchInfoHeaders}.
+	 */
+	private static final class TestTaskManagerLogSearchInfoHeaders implements
+		UntypedResponseMessageHeaders<EmptyRequestBody, TaskManagerLogSearchInfoParameters> {
+
+		private static final String URL = "/taskmanagers/:%s/logs/:%s/:%s/:%s";
+
+		@Override
+		public Class<EmptyRequestBody> getRequestClass() {
+			return EmptyRequestBody.class;
+		}
+
+		@Override
+		public TaskManagerLogSearchInfoParameters getUnresolvedMessageParameters() {
+			return new TaskManagerLogSearchInfoParameters();
+		}
+
+		@Override
+		public HttpMethodWrapper getHttpMethod() {
+			return HttpMethodWrapper.GET;
+		}
+
+		@Override
+		public String getTargetRestEndpointURL() {
+			return URL;
+		}
+	}
+
+}


### PR DESCRIPTION
##  What is the purpose of the change
Usually the taskmanager log file has a lot of content. There are several ways to search for content keywords:
The first one: in browser ctrl + f
The second type: use shell command operations on the server ip, such as grep -A
The third kind: Log files are connected to Elasticsearch through Logstash / Filebeat

These all increase the user's operation, which brings inconvenience, so the search function is developed to query the log content.

## Brief change log
  - *flink-runtime module add TaskManagerLogSearchInfoHandler class*
  - *web-dashboard change*

## Verifying this change

1. Added tests in `TaskManagerLogSearchInfoHandlerTest`
2. $ cd web-dashboard 
    $ npm run proxy 
![image](https://user-images.githubusercontent.com/20353043/79012388-c1822a00-7b98-11ea-82a6-a0bbffe7c6b4.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
