### PR TITLE
[FLINK-17093][python][table-planner][table-planner-blink] Fix Python UDF to make it work with inputs from composite field

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -367,6 +367,7 @@ object FlinkBatchRuleSets {
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -349,6 +349,7 @@ object FlinkStreamRuleSets {
     // Rule that splits python ScalarFunctions from java/scala ScalarFunctions.
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
@@ -20,11 +20,11 @@ package org.apache.flink.table.planner.plan.rules.logical
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
+import org.apache.calcite.rex.{RexBuilder, RexCall, RexFieldAccess, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc
-import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsPythonCall, containsNonPythonCall, isPythonCall, isNonPythonCall}
+import org.apache.flink.table.planner.plan.utils.PythonUtil.{containsNonPythonCall, containsPythonCall, isNonPythonCall, isPythonCall}
 import org.apache.flink.table.planner.plan.utils.{InputRefVisitor, RexDefaultVisitor}
 
 import scala.collection.JavaConverters._
@@ -46,12 +46,12 @@ abstract class PythonCalcSplitRuleBase(description: String)
     val input = calc.getInput
     val rexBuilder = call.builder().getRexBuilder
     val program = calc.getProgram
-    val extractedRexCalls = new mutable.ArrayBuffer[RexCall]()
+    val extractedRexNodes = new mutable.ArrayBuffer[RexNode]()
 
     val extractedFunctionOffset = input.getRowType.getFieldCount
     val splitter = new ScalarFunctionSplitter(
       extractedFunctionOffset,
-      extractedRexCalls,
+      extractedRexNodes,
       isConvertPythonFunction(program))
 
     val (bottomCalcCondition, topCalcCondition, topCalcProjects) = split(program, splitter)
@@ -59,10 +59,10 @@ abstract class PythonCalcSplitRuleBase(description: String)
       topCalcProjects, topCalcCondition, extractedFunctionOffset)
 
     val bottomCalcProjects =
-      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexCalls
+      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexNodes
     val bottomCalcFieldNames = SqlValidatorUtil.uniquify(
       accessedFields.map(i => input.getRowType.getFieldNames.get(i)).toSeq ++
-        extractedRexCalls.indices.map("f" + _),
+        extractedRexNodes.indices.map("f" + _),
       rexBuilder.getTypeFactory.getTypeSystem.isSchemaCaseSensitive)
 
     val bottomCalc = new FlinkLogicalCalc(
@@ -76,7 +76,8 @@ abstract class PythonCalcSplitRuleBase(description: String)
         bottomCalcFieldNames,
         rexBuilder))
 
-    val inputRewriter = new ExtractedFunctionInputRewriter(extractedFunctionOffset, accessedFields)
+    val inputRewriter = new ExtractedFunctionInputRewriter(
+      calc.getCluster.getRexBuilder, extractedFunctionOffset, accessedFields)
     val topCalc = new FlinkLogicalCalc(
       calc.getCluster,
       calc.getTraitSet,
@@ -178,6 +179,37 @@ object PythonCalcSplitProjectionRule extends PythonCalcSplitRuleBase(
 }
 
 /**
+  * Rule that expands the RexFieldAccess inputs of Python functions contained in
+  * the projection of [[FlinkLogicalCalc]]s.
+  */
+object PythonCalcExpandProjectRule extends PythonCalcSplitRuleBase(
+  "PythonCalcExpandProjectRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
+
+    projects.exists(containsPythonCall) &&
+      projects.collect { case call: RexCall => call }.exists(containsFieldAccessInputs)
+  }
+
+  override def isConvertPythonFunction(program: RexProgram): Boolean = false
+
+  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
+  : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
+    (None, None, program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  }
+
+  private def containsFieldAccessInputs(rexCall: RexCall): Boolean = {
+    rexCall.getOperands.exists {
+      case call: RexCall => containsFieldAccessInputs(call)
+      case _: RexFieldAccess => true
+      case _ => false
+    }
+  }
+}
+
+/**
   * Rule that pushes the condition of [[FlinkLogicalCalc]]s before it for the
   * [[FlinkLogicalCalc]]s which contain Python functions in the projection.
   */
@@ -237,7 +269,7 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
 
 private class ScalarFunctionSplitter(
     extractedFunctionOffset: Int,
-    extractedRexCalls: mutable.ArrayBuffer[RexCall],
+    extractedRexNodes: mutable.ArrayBuffer[RexNode],
     convertPythonFunction: Boolean)
   extends RexDefaultVisitor[RexNode] {
 
@@ -245,13 +277,25 @@ private class ScalarFunctionSplitter(
     visit(if (isPythonCall(call)) convertPythonFunction else !convertPythonFunction, call)
   }
 
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    if (convertPythonFunction) {
+      fieldAccess
+    } else {
+      // only expand the RexFieldAccess inputs of RexCalls for Python functions
+      val newNode = new RexInputRef(
+        extractedFunctionOffset + extractedRexNodes.length, fieldAccess.getType)
+      extractedRexNodes.append(fieldAccess)
+      newNode
+    }
+  }
+
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 
   private def visit(needConvert: Boolean, call: RexCall): RexNode = {
     if (needConvert) {
       val newNode = new RexInputRef(
-        extractedFunctionOffset + extractedRexCalls.length, call.getType)
-      extractedRexCalls.append(call)
+        extractedFunctionOffset + extractedRexNodes.length, call.getType)
+      extractedRexNodes.append(call)
       newNode
     } else {
       call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
@@ -265,10 +309,12 @@ private class ScalarFunctionSplitter(
   *    extracted function.
   * 2) Fields of index less than extractedFunctionOffset refer to the original input field.
   *
+  * @param rexBuilder the RexBuilder
   * @param extractedFunctionOffset the original start offset of the extracted functions
   * @param accessedFields the accessed fields which will be forwarded
   */
 private class ExtractedFunctionInputRewriter(
+    rexBuilder: RexBuilder,
     extractedFunctionOffset: Int,
     accessedFields: Array[Int])
   extends RexDefaultVisitor[RexNode] {
@@ -293,16 +339,23 @@ private class ExtractedFunctionInputRewriter(
     call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
   }
 
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    rexBuilder.makeFieldAccess(
+      fieldAccess.getReferenceExpr.accept(this),
+      fieldAccess.getField.getIndex)
+  }
+
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 }
 
 object PythonCalcSplitRule {
   /**
     * These rules should be applied sequentially in the order of
-    * SPLIT_CONDITION, SPLIT_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
+    * SPLIT_CONDITION, SPLIT_PROJECT, EXPAND_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
     */
   val SPLIT_CONDITION: RelOptRule = PythonCalcSplitConditionRule
   val SPLIT_PROJECT: RelOptRule = PythonCalcSplitProjectionRule
+  val EXPAND_PROJECT: RelOptRule = PythonCalcExpandProjectRule
   val PUSH_CONDITION: RelOptRule = PythonCalcPushConditionRule
   val REWRITE_PROJECT: RelOptRule = PythonCalcRewriteProjectionRule
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -19,36 +19,49 @@ limitations under the License.
   <TestCase name="testChainingPythonFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc3(pyFunc2(a + pyFunc1(a, c), b), c) FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc3(pyFunc2(+($0, pyFunc1($0, $2)), $1), $2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pyFunc3(pyFunc2(f0, b), c) AS EXPR$0])
 +- FlinkLogicalCalc(select=[b, c, +(a, f0) AS f0])
    +- FlinkLogicalCalc(select=[b, c, a, pyFunc1(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testChainingPythonFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(b, pyFunc1(c, d._1)) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($1, pyFunc1($2, $3._1))])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pyFunc1(b, pyFunc1(c, f0)) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, c, d._1 AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testFieldNameUniquify">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(f1, f2), f0 + 1 FROM MyTable2]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($1, $2)], EXPR$1=[+($0, 1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(f0, f1, f2)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -56,170 +69,128 @@ FlinkLogicalCalc(select=[f00 AS EXPR$0, +(f0, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[f0, pyFunc1(f1, f2) AS f00])
    +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(f0, f1, f2)]]], fields=[f0, f1, f2])
 ]]>
-
-    </Resource>
-  </TestCase>
-  <TestCase name="testPythonFunctionAsInputOfJavaFunction">
-    <Resource name="sql">
-      <![CDATA[SELECT pyFunc1(a, b) + 1 FROM MyTable]]>
-
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[+(pyFunc1($0, $1), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
-+- FlinkLogicalCalc(select=[pyFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testLiteral">
     <Resource name="sql">
       <![CDATA[SELECT a, b, pyFunc1(a, c), 1 FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], EXPR$2=[pyFunc1($0, $2)], EXPR$3=[1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, f0 AS EXPR$2, 1 AS EXPR$3])
 +- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOnePythonFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b) FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testOnlyOnePythonFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT a, b FROM MyTable WHERE pyFunc4(a, c)]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b], where=[f0])
 +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionAsInputOfJavaFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, b) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, $1), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
++- FlinkLogicalCalc(select=[pyFunc1(a, b) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b) FROM MyTable WHERE pyFunc4(a, c)]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
 +- FlinkLogicalCalc(select=[a, b], where=[f0])
    +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionMixedWithJavaFunction">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b), c + 1 FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[c, pyFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
-    </Resource>
-  </TestCase>
-  <TestCase name="testReorderPythonCalc">
-    <Resource name="sql">
-      <![CDATA[SELECT a, pyFunc1(a, c), b FROM MyTable]]>
-
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
-+- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPythonFunctionMixedWithJavaFunctionInWhereClause">
     <Resource name="sql">
       <![CDATA[SELECT pyFunc1(a, b), c + 1 FROM MyTable WHERE pyFunc2(a, c) > 0]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
 +- LogicalFilter(condition=[>(pyFunc2($0, $2), 0)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -227,9 +198,44 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[c, pyFunc1(a, b) AS f0])
    +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
       +- FlinkLogicalCalc(select=[a, b, c, pyFunc2(a, c) AS f0])
-         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
-
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(b, d._1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($1, $3._1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pyFunc1(b, f0) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, d._1 AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReorderPythonCalc">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(a, c), b FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
++- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -53,7 +53,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
         .build())
     util.replaceBatchProgram(programs)
 
-    util.addTableSource[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
+    util.addTableSource[(Int, Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c, 'd)
     util.addFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
     util.addFunction("pyFunc2", new PythonScalarFunction("pyFunc2"))
     util.addFunction("pyFunc3", new PythonScalarFunction("pyFunc3"))
@@ -118,6 +118,18 @@ class PythonCalcSplitRuleTest extends TableTestBase {
   @Test
   def testReorderPythonCalc(): Unit = {
     val sqlQuery = "SELECT a, pyFunc1(a, c), b FROM MyTable"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testPythonFunctionWithCompositeInputs(): Unit = {
+    val sqlQuery = "SELECT a, pyFunc1(b, d._1) FROM MyTable"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testChainingPythonFunctionWithCompositeInputs(): Unit = {
+    val sqlQuery = "SELECT a, pyFunc1(b, pyFunc1(c, d._1)) FROM MyTable"
     util.verifyPlan(sqlQuery)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -155,6 +155,7 @@ object FlinkRuleSets {
     CalcMergeRule.INSTANCE,
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.runtime.utils.JavaUserDefinedScalarFunctions.{BooleanPythonScalarFunction, PythonScalarFunction}
 import org.apache.flink.table.utils.TableTestUtil._
 import org.apache.flink.table.utils.TableTestBase
+import org.apache.flink.types.Row
 import org.junit.Test
 
 class PythonCalcSplitRuleTest extends TableTestBase {
@@ -260,6 +261,57 @@ class PythonCalcSplitRuleTest extends TableTestBase {
         "DataStreamPythonCalc",
         streamTableNode(table),
         term("select", "a", "b", "pyFunc1(a, c) AS f0")
+      ),
+      term("select", "a", "f0 AS _c1", "b")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testPythonFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten()).select("a, pyFunc1(a, c$_1), b")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a", "b", "c._1 AS f0")
+        ),
+        term("select", "a", "b", "pyFunc1(a, f0) AS f0")
+      ),
+      term("select", "a", "f0 AS _c1", "b")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testChainingPythonFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten())
+      .select("a, pyFunc1(a, pyFunc1(b, c$_1)), b")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a", "b", "c._1 AS f0")
+        ),
+        term("select", "a", "b", "pyFunc1(a, pyFunc1(b, f0)) AS f0")
       ),
       term("select", "a", "f0 AS _c1", "b")
     )


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fixes Python UDF to make it work with inputs from composite field*

## Brief change log

  - *Add rule PythonCalcExpandProjectRule which expand the input fields which are from composite fields for Python UDF *

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests testPythonFunctionWithCompositeInputs and testChainingPythonFunctionWithCompositeInputs*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
