### PR TITLE
[FLINK-17103][table-planner-blink] Supports dynamic options for Blink…

### DIFF
--- a/docs/_includes/generated/table_config_configuration.html
+++ b/docs/_includes/generated/table_config_configuration.html
@@ -1,0 +1,18 @@
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>table.dynamic-table-options.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable or disable the OPTIONS hint used to specify table optionsdynamically, if disabled, an exception would be thrown if any OPTIONS hint is specified</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -80,7 +80,7 @@ SqlCreate SqlCreateCatalog(Span s, boolean replace) :
 }
 
 /**
-* Parse a "Show Catalogs" metadata query command.
+* Parse a "Show DATABASES" metadata query command.
 */
 SqlShowDatabases SqlShowDatabases() :
 {
@@ -107,7 +107,9 @@ SqlUseDatabase SqlUseDatabase() :
 
 /**
 * Parses a create database statement.
-* CREATE DATABASE database_name [COMMENT database_comment] [WITH (property_name=property_value, ...)];
+* <pre>CREATE DATABASE database_name
+*       [COMMENT database_comment]
+*       [WITH (property_name=property_value, ...)].</pre>
 */
 SqlCreate SqlCreateDatabase(Span s, boolean replace) :
 {
@@ -679,7 +681,7 @@ SqlNode RichSqlInsert() :
         keywordList = new SqlNodeList(keywords, s.addAll(keywords).pos());
         extendedKeywordList = new SqlNodeList(extendedKeywords, s.addAll(extendedKeywords).pos());
     }
-    table = CompoundIdentifier()
+    table = TableRefWithHintsOpt()
     [
         LOOKAHEAD(5)
         [ <EXTEND> ]

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -27,6 +27,7 @@ import org.apache.calcite.sql.SqlInsertKeyword;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlTableRef;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.NlsString;
@@ -40,6 +41,10 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 
 	private final SqlNodeList extendedKeywords;
 
+	private final SqlNode targetTableID;
+
+	private final SqlNodeList tableHints;
+
 	public RichSqlInsert(SqlParserPos pos,
 			SqlNodeList keywords,
 			SqlNodeList extendedKeywords,
@@ -50,6 +55,14 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 		super(pos, keywords, targetTable, source, columnList);
 		this.extendedKeywords = extendedKeywords;
 		this.staticPartitions = staticPartitions;
+		if (targetTable instanceof SqlTableRef) {
+			SqlTableRef tableRef = (SqlTableRef) targetTable;
+			this.targetTableID = tableRef.operand(0);
+			this.tableHints = tableRef.operand(1);
+		} else {
+			this.targetTableID = targetTable;
+			this.tableHints = SqlNodeList.EMPTY;
+		}
 	}
 
 	/**
@@ -82,6 +95,16 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 			ret.put(sqlProperty.getKey().getSimple(), value);
 		}
 		return ret;
+	}
+
+	/** Returns the target table identifier. */
+	public SqlNode getTargetTableID() {
+		return targetTableID;
+	}
+
+	/** Returns the table hints as list of {@code SqlNode} for current insert node. */
+	public SqlNodeList getTableHints() {
+		return this.tableHints;
 	}
 
 	@Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -802,12 +802,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				.ok("DROP TEMPORARY SYSTEM FUNCTION IF EXISTS `CATALOG1`.`DB1`.`FUNCTION1`");
 	}
 
-	@Override
-	public void testTableHintsInInsert() {
-		// Override the superclass tests because Flink insert parse block
-		// is totally customized, and the hints are not supported yet.
-	}
-
 	/** Matcher that invokes the #validate() of the {@link ExtendedSqlNode} instance. **/
 	private static class ValidationMatcher extends BaseMatcher<SqlNode> {
 		private String expectedColumnSql;

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.config;
+
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.configuration.ConfigOption;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * This class holds {@link org.apache.flink.configuration.ConfigOption}s used by
+ * Flink's BLINK table planner.
+ *
+ * <p>NOTE: All option keys in this class must start with "table".
+ */
+public class TableConfigOptions {
+	private TableConfigOptions() {}
+
+	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH_STREAMING)
+	public static final ConfigOption<Boolean> TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED =
+			key("table.dynamic-table-options.enabled")
+					.booleanType()
+					.defaultValue(false)
+					.withDescription("Enable or disable the OPTIONS hint used to specify table options" +
+							"dynamically, if disabled, an exception would be thrown " +
+							"if any OPTIONS hint is specified");
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/TableConfigOptions.java
@@ -25,7 +25,7 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 
 /**
  * This class holds {@link org.apache.flink.configuration.ConfigOption}s used by
- * Flink's BLINK table planner.
+ * table planner.
  *
  * <p>NOTE: All option keys in this class must start with "table".
  */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogTableImpl.java
@@ -82,6 +82,11 @@ public class CatalogTableImpl extends AbstractCatalogTable {
 		return descriptor.asMap();
 	}
 
+	@Override
+	public CatalogTable copy(Map<String, String> options) {
+		return new CatalogTableImpl(getSchema(), getPartitionKeys(), options, getComment());
+	}
+
 	/**
 	 * Construct a {@link CatalogTableImpl} from complete properties that contains table schema.
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -103,6 +103,11 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 	}
 
 	@Override
+	public CatalogTable copy(Map<String, String> options) {
+		throw new UnsupportedOperationException("ConnectorCatalogTable cannot copy with new table options");
+	}
+
+	@Override
 	public CatalogBaseTable copy() {
 		return this;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -37,20 +37,23 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 	private final Map<String, String> staticPartitions;
 	private final QueryOperation child;
 	private final boolean overwrite;
+	private final List<?> tableHints;
 
 	public CatalogSinkModifyOperation(ObjectIdentifier tableIdentifier, QueryOperation child) {
-		this(tableIdentifier, child, new HashMap<>(), false);
+		this(tableIdentifier, child, Collections.emptyMap(), false, Collections.emptyList());
 	}
 
 	public CatalogSinkModifyOperation(
 			ObjectIdentifier tableIdentifier,
 			QueryOperation child,
 			Map<String, String> staticPartitions,
-			boolean overwrite) {
+			boolean overwrite,
+			List<?> tableHints) {
 		this.tableIdentifier = tableIdentifier;
 		this.child = child;
 		this.staticPartitions = staticPartitions;
 		this.overwrite = overwrite;
+		this.tableHints = tableHints;
 	}
 
 	public ObjectIdentifier getTableIdentifier() {
@@ -63,6 +66,10 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 
 	public boolean isOverwrite() {
 		return overwrite;
+	}
+
+	public List<?> getTableHints() {
+		return tableHints;
 	}
 
 	@Override
@@ -81,6 +88,7 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 		params.put("identifier", tableIdentifier);
 		params.put("staticPartitions", staticPartitions);
 		params.put("overwrite", overwrite);
+		params.put("tableHints", tableHints);
 
 		return OperationUtils.formatWithChildren(
 			"CatalogSink",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/CatalogSinkModifyOperation.java
@@ -23,7 +23,6 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -37,10 +36,10 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 	private final Map<String, String> staticPartitions;
 	private final QueryOperation child;
 	private final boolean overwrite;
-	private final List<?> tableHints;
+	private final Map<String, String> dynamicOptions;
 
 	public CatalogSinkModifyOperation(ObjectIdentifier tableIdentifier, QueryOperation child) {
-		this(tableIdentifier, child, Collections.emptyMap(), false, Collections.emptyList());
+		this(tableIdentifier, child, Collections.emptyMap(), false, Collections.emptyMap());
 	}
 
 	public CatalogSinkModifyOperation(
@@ -48,12 +47,12 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 			QueryOperation child,
 			Map<String, String> staticPartitions,
 			boolean overwrite,
-			List<?> tableHints) {
+			Map<String, String> dynamicOptions) {
 		this.tableIdentifier = tableIdentifier;
 		this.child = child;
 		this.staticPartitions = staticPartitions;
 		this.overwrite = overwrite;
-		this.tableHints = tableHints;
+		this.dynamicOptions = dynamicOptions;
 	}
 
 	public ObjectIdentifier getTableIdentifier() {
@@ -68,8 +67,8 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 		return overwrite;
 	}
 
-	public List<?> getTableHints() {
-		return tableHints;
+	public Map<String, String> getDynamicOptions() {
+		return dynamicOptions;
 	}
 
 	@Override
@@ -88,7 +87,7 @@ public class CatalogSinkModifyOperation implements ModifyOperation {
 		params.put("identifier", tableIdentifier);
 		params.put("staticPartitions", staticPartitions);
 		params.put("overwrite", overwrite);
-		params.put("tableHints", tableHints);
+		params.put("dynamicOptions", dynamicOptions);
 
 		return OperationUtils.formatWithChildren(
 			"CatalogSink",

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/CatalogTable.java
@@ -46,4 +46,11 @@ public interface CatalogTable extends CatalogBaseTable {
 	 * @return a map of properties
 	 */
 	Map<String, String> toProperties();
+
+	/**
+	 * Returns a copy of this {@code CatalogTable} with given table options {@code options}.
+	 *
+	 * @return a new copy of this table with replaced table options
+	 */
+	CatalogTable copy(Map<String, String> options);
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
@@ -65,7 +65,7 @@ public interface TableSinkFactory<T> extends TableFactory {
 
 	/**
 	 * Creates and configures a {@link TableSink} based on the given
-	 {@link Context}.
+	 * {@link Context}.
 	 *
 	 * @param context context of this table sink.
 	 * @return the configured table sink.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.planner.calcite.SqlExprToRexConverterImpl;
 import org.apache.flink.table.planner.catalog.FunctionCatalogOperatorTable;
 import org.apache.flink.table.planner.codegen.ExpressionReducer;
 import org.apache.flink.table.planner.functions.sql.FlinkSqlOperatorTable;
+import org.apache.flink.table.planner.hint.FlinkHintStrategies;
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader;
 import org.apache.flink.table.planner.plan.cost.FlinkCostFactory;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
@@ -268,6 +269,7 @@ public class PlannerContext {
 		return JavaScalaConversionUtil.toJava(calciteConfig.getSqlToRelConverterConfig()).orElseGet(
 				() -> SqlToRelConverter.configBuilder()
 						.withTrimUnusedFields(false)
+						.withHintStrategyTable(FlinkHintStrategies.createHintStrategyTable())
 						.withInSubQueryThreshold(Integer.MAX_VALUE)
 						.withExpand(false)
 						.withRelBuilderFactory(FlinkRelFactories.FLINK_REL_BUILDER())

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/hint/FlinkHintStrategies.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.hint;
+
+import org.apache.calcite.rel.hint.HintPredicates;
+import org.apache.calcite.rel.hint.HintStrategy;
+import org.apache.calcite.rel.hint.HintStrategyTable;
+import org.apache.calcite.util.Litmus;
+
+/**
+ * A collection of Flink style {@link HintStrategy}s.
+ */
+public abstract class FlinkHintStrategies {
+
+	/** Customize the {@link HintStrategyTable} which
+	 * contains hint strategies supported by Flink. */
+	public static HintStrategyTable createHintStrategyTable() {
+		return HintStrategyTable.builder()
+				// Configure to always throw when we encounter any hint errors
+				// (either the non-registered hint or the hint format).
+				.errorHandler(Litmus.THROW)
+				.hintStrategy(
+						FlinkHints.HINT_NAME_OPTIONS,
+						HintStrategy.builder(HintPredicates.TABLE_SCAN)
+								.optionChecker((hint, errorHandler) ->
+										errorHandler.check(hint.kvOptions.size() > 0,
+										"Hint [{}] only support non empty key value options",
+										hint.hintName))
+								.build())
+				.build();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/hint/FlinkHints.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.hint;
+
+import org.apache.calcite.rel.hint.RelHint;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Utility class for Flink hints. */
+public abstract class FlinkHints {
+	//~ Static fields/initializers ---------------------------------------------
+
+	public static final String HINT_NAME_OPTIONS = "OPTIONS";
+
+	//~ Tools ------------------------------------------------------------------
+
+	/** Returns the OPTIONS hint options from the
+	 * given list of table hints {@code tableHints}, never null. */
+	public static Map<String, String> getHintedOptions(List<RelHint> tableHints) {
+		return tableHints.stream().filter(hint ->
+				hint.hintName.equalsIgnoreCase(HINT_NAME_OPTIONS))
+				.findFirst()
+				.map(hint -> hint.kvOptions)
+				.orElse(Collections.emptyMap());
+	}
+
+	/**
+	 * Merges the dynamic table options from {@code hints} and static table options
+	 * from table definition {@code props}.
+	 *
+	 * <p>The options in {@code hints} would override the ones in {@code props} if
+	 * they have the same option key.
+	 *
+	 * @param hints Dynamic table options, usually from the OPTIONS hint
+	 * @param props Static table options defined in DDL or connect API
+	 *
+	 * @return New options with merged dynamic table options, or the old {@code props}
+	 * if there is no dynamic table options
+	 */
+	public static Map<String, String> mergeTableOptions(
+			Map<String, String> hints,
+			Map<String, String> props) {
+		if (hints.size() == 0) {
+			return props;
+		}
+		Map<String, String> newProps = new HashMap<>();
+		newProps.putAll(props);
+		newProps.putAll(hints);
+		return Collections.unmodifiableMap(newProps);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -71,6 +71,7 @@ import org.apache.flink.table.operations.ddl.DropTableOperation;
 import org.apache.flink.table.operations.ddl.DropTempSystemFunctionOperation;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.hint.FlinkHints;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.util.StringUtils;
@@ -352,6 +353,7 @@ public class SqlToOperationConverter {
 				.getSqlToRelConverterConfig()
 				.getHintStrategyTable();
 		List<RelHint> tableHints = SqlUtil.getRelHint(hintStrategyTable, insert.getTableHints());
+		Map<String, String> dynamicOptions = FlinkHints.getHintedOptions(tableHints);
 
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(targetTablePath);
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
@@ -368,7 +370,7 @@ public class SqlToOperationConverter {
 			query,
 			insert.getStaticPartitionKVs(),
 			insert.isOverwrite(),
-			tableHints);
+			dynamicOptions);
 	}
 
 	/** Convert use catalog statement. */

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -28,9 +28,11 @@ import org.apache.flink.table.delegation.{Executor, Parser, Planner}
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSinkFactoryContextImpl}
 import org.apache.flink.table.operations.OutputConversionModifyOperation.UpdateMode
 import org.apache.flink.table.operations._
+import org.apache.flink.table.planner.JList
 import org.apache.flink.table.planner.calcite.{CalciteParser, FlinkPlannerImpl, FlinkRelBuilder, FlinkTypeFactory}
 import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema
 import org.apache.flink.table.planner.expressions.PlannerTypeInferenceUtilImpl
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.planner.plan.nodes.calcite.LogicalSink
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
@@ -47,6 +49,7 @@ import org.apache.flink.table.utils.TableSchemaUtils
 import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.plan.{RelTrait, RelTraitDef}
 import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.tools.FrameworkConfig
 
 import java.util
@@ -185,7 +188,8 @@ abstract class PlannerBase(
       case catalogSink: CatalogSinkModifyOperation =>
         val input = getRelBuilder.queryOperation(modifyOperation.getChild).build()
         val identifier = catalogSink.getTableIdentifier
-        getTableSink(identifier).map { case (table, sink) =>
+        val tableHints = catalogSink.getTableHints.asInstanceOf[JList[RelHint]]
+        getTableSink(identifier, tableHints).map { case (table, sink) =>
           // check the logical field type and physical field type are compatible
           val queryLogicalType = FlinkTypeFactory.toLogicalRowType(input.getRowType)
           // validate logical schema and physical schema are compatible
@@ -280,7 +284,7 @@ abstract class PlannerBase(
     */
   protected def translateToPlan(execNodes: util.List[ExecNode[_, _]]): util.List[Transformation[_]]
 
-  private def getTableSink(objectIdentifier: ObjectIdentifier)
+  private def getTableSink(objectIdentifier: ObjectIdentifier, tableHints: JList[RelHint])
     : Option[(CatalogTable, TableSink[_])] = {
     JavaScalaConversionUtil.toScala(catalogManager.getTable(objectIdentifier))
       .map(_.getTable) match {
@@ -294,8 +298,16 @@ abstract class PlannerBase(
       case Some(s) if s.isInstanceOf[CatalogTable] =>
         val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
         val table = s.asInstanceOf[CatalogTable]
+        val dynamicOptions = FlinkHints.getHintedOptions(tableHints)
+        val tableToFind = if (dynamicOptions.nonEmpty) {
+          table.copy(FlinkHints.mergeTableOptions(dynamicOptions, table.getProperties))
+        } else {
+          table
+        }
         val context = new TableSinkFactoryContextImpl(
-          objectIdentifier, table, getTableConfig.getConfiguration)
+          objectIdentifier,
+          tableToFind,
+          getTableConfig.getConfiguration)
         if (catalog.isPresent && catalog.get().getTableFactory.isPresent) {
           val sink = TableFactoryUtil.createTableSinkForCatalogTable(catalog.get(), context)
           if (sink.isPresent) {

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/schema/CatalogSourceTable.scala
@@ -19,11 +19,14 @@
 package org.apache.flink.table.planner.plan.schema
 
 import org.apache.flink.configuration.ReadableConfig
+import org.apache.flink.table.api.config.TableConfigOptions
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.catalog.CatalogTable
 import org.apache.flink.table.factories.{TableFactoryUtil, TableSourceFactory, TableSourceFactoryContextImpl}
+import org.apache.flink.table.planner.JMap
 import org.apache.flink.table.planner.calcite.{FlinkContext, FlinkRelBuilder, FlinkTypeFactory}
 import org.apache.flink.table.planner.catalog.CatalogSchemaTable
+import org.apache.flink.table.planner.hint.FlinkHints
 import org.apache.flink.table.sources.{StreamTableSource, TableSource, TableSourceValidation}
 
 import org.apache.calcite.plan.{RelOptSchema, RelOptTable}
@@ -74,7 +77,19 @@ class CatalogSourceTable[T](
     // erase time indicator types in the rowType
     val erasedRowType = eraseTimeIndicator(rowType, typeFactory)
 
-    val tableSource = findAndCreateTableSource(flinkContext.getTableConfig.getConfiguration)
+    val conf = flinkContext.getTableConfig.getConfiguration
+
+    val hintedOptions = FlinkHints.getHintedOptions(context.getTableHints)
+    if (hintedOptions.nonEmpty
+      && !conf.getBoolean(TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED)) {
+      throw new ValidationException(s"${FlinkHints.HINT_NAME_OPTIONS} hint is allowed only when "
+        + s"${TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED.key} "
+        + s"is set to true")
+    }
+
+    val tableSource = findAndCreateTableSource(
+      hintedOptions,
+      conf)
     val tableSourceTable = new TableSourceTable[T](
       relOptSchema,
       schemaTable.getTableIdentifier,
@@ -82,7 +97,8 @@ class CatalogSourceTable[T](
       statistic,
       tableSource,
       schemaTable.isStreamingMode,
-      catalogTable)
+      catalogTable,
+      hintedOptions)
 
     // 1. push table scan
 
@@ -144,10 +160,22 @@ class CatalogSourceTable[T](
   }
 
   /** Create the table source. */
-  private def findAndCreateTableSource(conf: ReadableConfig): TableSource[T] = {
+  private def findAndCreateTableSource(
+      hintedOptions: JMap[String, String],
+      conf: ReadableConfig): TableSource[T] = {
     val tableFactoryOpt = schemaTable.getTableFactory
+    val tableToFind = if (hintedOptions.nonEmpty) {
+      catalogTable.copy(
+        FlinkHints.mergeTableOptions(
+          hintedOptions,
+          catalogTable.getProperties))
+    } else {
+      catalogTable
+    }
     val context = new TableSourceFactoryContextImpl(
-      schemaTable.getTableIdentifier, catalogTable, conf)
+      schemaTable.getTableIdentifier,
+      tableToFind,
+      conf)
     val tableSource = if (tableFactoryOpt.isPresent) {
       tableFactoryOpt.get() match {
         case tableSourceFactory: TableSourceFactory[_] =>
@@ -160,7 +188,7 @@ class CatalogSourceTable[T](
     }
 
     // validation
-    val tableName = schemaTable.getTableIdentifier.asSummaryString();
+    val tableName = schemaTable.getTableIdentifier.asSummaryString
     tableSource match {
       case ts: StreamTableSource[_] =>
         if (!schemaTable.isStreamingMode && !ts.isBounded) {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -57,12 +57,10 @@ import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.expressions.utils.Func0$;
 import org.apache.flink.table.planner.expressions.utils.Func1$;
 import org.apache.flink.table.planner.expressions.utils.Func8$;
-import org.apache.flink.table.planner.hint.FlinkHints;
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.utils.CatalogManagerMocks;
 
-import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.sql.SqlNode;
 import org.junit.After;
 import org.junit.Before;
@@ -382,15 +380,10 @@ public class SqlToOperationConverterTest {
 		Operation operation = parse(sql, planner, parser);
 		assert operation instanceof CatalogSinkModifyOperation;
 		CatalogSinkModifyOperation sinkModifyOperation = (CatalogSinkModifyOperation) operation;
-		//noinspection unchecked
-		List<RelHint> hints = (List<RelHint>) sinkModifyOperation.getTableHints();
-		assertNotNull(hints);
-		assertThat(hints.size(), is(1));
-		RelHint expected = RelHint.builder(FlinkHints.HINT_NAME_OPTIONS)
-				.hintOption("k1", "v1")
-				.hintOption("k2", "v2")
-				.build();
-		assertThat(hints.get(0), is(expected));
+		Map<String, String> dynamicOptions = sinkModifyOperation.getDynamicOptions();
+		assertNotNull(dynamicOptions);
+		assertThat(dynamicOptions.size(), is(2));
+		assertThat(dynamicOptions.toString(), is("{k1=v1, k2=v2}"));
 	}
 
 	@Test

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -19,3 +19,4 @@ org.apache.flink.table.planner.utils.TestPartitionableSourceFactory
 org.apache.flink.table.planner.utils.TestFilterableTableSourceFactory
 org.apache.flink.table.planner.utils.TestProjectableTableSourceFactory
 org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory
+org.apache.flink.table.planner.utils.TestOptionsTableFactory

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/hint/OptionsHintTest.xml
@@ -1,0 +1,303 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAppendOptions[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendOptions[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintOnTableApiView[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], build=[right])
+:- Calc(select=[a, b, +(a, 1) AS c])
+:  +- Exchange(distribution=[hash[a]])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithAppendedOptions[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[
+select * from
+t1 /*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */
+join
+t2 /*+ OPTIONS(k6='v6', 'd.e.f'='fakeVal') */
+on t1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={d.e.f=fakeVal, k3=v3, k4=v4, k6=v6})], dynamic options: {d.e.f=fakeVal, k6=v6}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], build=[right])
+:- Calc(select=[a, b, +(a, 1) AS c])
+:  +- Exchange(distribution=[hash[a]])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={d.e.f=fakeVal, k3=v3, k4=v4, k6=v6})], dynamic options: {d.e.f=fakeVal, k6=v6}]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithAppendedOptions[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[
+select * from
+t1 /*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */
+join
+t2 /*+ OPTIONS(k6='v6', 'd.e.f'='fakeVal') */
+on t1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={d.e.f=fakeVal, k3=v3, k4=v4, k6=v6})], dynamic options: {d.e.f=fakeVal, k6=v6}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a, b, +(a, 1) AS c])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2, a.b.c=fakeVal, k5=v5})], dynamic options: {a.b.c=fakeVal, k5=v5}]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={d.e.f=fakeVal, k3=v3, k4=v4, k6=v6})], dynamic options: {d.e.f=fakeVal, k6=v6}]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithOverriddenOptions[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[
+select * from
+t1 /*+ OPTIONS(k1='#v1', k2='#v2') */
+join
+t2 /*+ OPTIONS(k3='#v3', k4='#v4') */
+on t1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=#v3, k4=#v4})], dynamic options: {k3=#v3, k4=#v4}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], build=[right])
+:- Calc(select=[a, b, +(a, 1) AS c])
+:  +- Exchange(distribution=[hash[a]])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=#v3, k4=#v4})], dynamic options: {k3=#v3, k4=#v4}]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinWithOverriddenOptions[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[
+select * from
+t1 /*+ OPTIONS(k1='#v1', k2='#v2') */
+join
+t2 /*+ OPTIONS(k3='#v3', k4='#v4') */
+on t1.a = t2.d
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=#v3, k4=#v4})], dynamic options: {k3=#v3, k4=#v4}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a, b, +(a, 1) AS c])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=#v3, k4=#v4})], dynamic options: {k3=#v3, k4=#v4}]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintOnSQLView[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a, b, +(a, 1) AS c])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverrideOptions[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintOnSQLView[0: is-bounded=true]">
+    <Resource name="sql">
+      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], build=[right])
+:- Calc(select=[a, b, +(a, 1) AS c])
+:  +- Exchange(distribution=[hash[a]])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOptionsHintOnTableApiView[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], e=[$4], f=[$5])
++- LogicalJoin(condition=[=($0, $3)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Join(joinType=[InnerJoin], where=[=(a, d)], select=[a, b, c, d, e, f], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[a]])
+:  +- Calc(select=[a, b, +(a, 1) AS c])
+:     +- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=v1, k2=v2})]]], fields=[a, b])
++- Exchange(distribution=[hash[d]])
+   +- TableSourceScan(table=[[default_catalog, default_database, t2, source: [OptionsTableSource(props={k3=v3, k4=v4})]]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverrideOptions[1: is-bounded=false]">
+    <Resource name="sql">
+      <![CDATA[select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[+($0, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[a, b, +(a, 1) AS c])
++- TableSourceScan(table=[[default_catalog, default_database, t1, source: [OptionsTableSource(props={k1=#v1, k2=#v2})], dynamic options: {k1=#v1, k2=#v2}]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -30,7 +30,7 @@ import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTa
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.TestingAppendSink
 import org.apache.flink.table.planner.utils.TableTestUtil.{readFromResource, replaceStageId}
-import org.apache.flink.table.planner.utils.TestTableSources.getPersonCsvTableSource
+import org.apache.flink.table.planner.utils.TestTableSourceSinks.getPersonCsvTableSource
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.types.Row
 import org.apache.flink.util.{FileUtils, TestLogger}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -23,7 +23,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.scala.{StreamTableEnvironment, _}
-import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSources}
+import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
 import org.apache.flink.table.sinks.CsvTableSink
 
 import org.apache.calcite.plan.RelOptUtil
@@ -85,7 +85,7 @@ class TableEnvironmentTest {
     val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
     val tEnv = StreamTableEnvironment.create(execEnv, settings)
 
-    tEnv.registerTableSource("MyTable", TestTableSources.getPersonCsvTableSource)
+    tEnv.registerTableSource("MyTable", TestTableSourceSinks.getPersonCsvTableSource)
     tEnv.registerTableSink("MySink",
       new CsvTableSink("/tmp").configure(Array("first"), Array(STRING)))
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/catalog/CatalogTableITCase.scala
@@ -301,7 +301,7 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
 
     val query =
       """
-        |INSERT INTO T2 /*+ OPTIONS('format.field-delimiter' = ',') */
+        |INSERT INTO T2 /*+ OPTIONS('format.field-delimiter' = '|') */
         |SELECT
         |  TUMBLE_END(ts, INTERVAL '5' SECOND),
         |  MAX(ts6),
@@ -314,8 +314,8 @@ class CatalogTableITCase(isStreamingMode: Boolean) extends AbstractTestBase {
     execJob("testJob")
 
     val expected =
-      "2019-12-12 00:00:05.0,2019-12-12 00:00:04.004001,3,50.00\n" +
-        "2019-12-12 00:00:10.0,2019-12-12 00:00:06.006001,2,5.33\n"
+      "2019-12-12 00:00:05.0|2019-12-12 00:00:04.004001|3|50.00\n" +
+        "2019-12-12 00:00:10.0|2019-12-12 00:00:06.006001|2|5.33\n"
     assertEquals(expected, FileUtils.readFileUtf8(new File(new URI(sinkFilePath))))
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/hint/OptionsHintTest.scala
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.hint
+
+import org.apache.flink.table.api.config.TableConfigOptions
+import org.apache.flink.table.api.{DataTypes, TableSchema, ValidationException}
+import org.apache.flink.table.catalog.{CatalogViewImpl, ObjectPath}
+import org.apache.flink.table.planner.JHashMap
+import org.apache.flink.table.planner.plan.hint.OptionsHintTest.{IS_BOUNDED, Param}
+import org.apache.flink.table.planner.plan.nodes.calcite.LogicalSink
+import org.apache.flink.table.planner.utils.{OptionsTableSink, TableTestBase, TableTestUtil, TestingTableEnvironment}
+
+import org.hamcrest.Matchers._
+import org.junit.Assert.{assertEquals, assertThat}
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import org.junit.{Before, Test}
+
+import scala.collection.JavaConversions._
+
+@RunWith(classOf[Parameterized])
+class OptionsHintTest(param: Param)
+    extends TableTestBase {
+  private val util = param.utilSupplier.apply(this)
+  private val is_bounded = param.isBounded
+
+  @Before
+  def before(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED,
+      true)
+    util.addTable(
+      s"""
+         |create table t1(
+         |  a int,
+         |  b varchar,
+         |  c as a + 1
+         |) with (
+         |  'connector' = 'OPTIONS',
+         |  '$IS_BOUNDED' = '$is_bounded',
+         |  'k1' = 'v1',
+         |  'k2' = 'v2'
+         |)
+       """.stripMargin)
+
+    util.addTable(
+      s"""
+         |create table t2(
+         |  d int,
+         |  e varchar,
+         |  f bigint
+         |) with (
+         |  'connector' = 'OPTIONS',
+         |  '$IS_BOUNDED' = '$is_bounded',
+         |  'k3' = 'v3',
+         |  'k4' = 'v4'
+         |)
+       """.stripMargin)
+  }
+
+  @Test
+  def testOptionsWithGlobalConfDisabled(): Unit = {
+    util.tableEnv.getConfig.getConfiguration.setBoolean(
+      TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED,
+      false)
+    expectedException.expect(isA(classOf[ValidationException]))
+    expectedException.expectMessage(s"OPTIONS hint is allowed only when "
+      + s"${TableConfigOptions.TABLE_DYNAMIC_TABLE_OPTIONS_ENABLED.key} is set to true")
+    util.verifyPlan("select * from t1/*+ OPTIONS(connector='COLLECTION', k2='#v2') */")
+  }
+
+  @Test
+  def testInsertWithDynamicOptions(): Unit = {
+    val sql =
+      s"""
+         |insert into t1 /*+ OPTIONS(k1='#v1', k5='v5') */
+         |select d, e from t2
+         |""".stripMargin
+    util.tableEnv.sqlUpdate(sql)
+    val testTableEnv = util.tableEnv.asInstanceOf[TestingTableEnvironment]
+    val relNodes = testTableEnv.getBufferedOperations.map(util.getPlanner.translateToRel)
+    assertThat(relNodes.length, is(1))
+    assert(relNodes.head.isInstanceOf[LogicalSink])
+    val sink = relNodes.head.asInstanceOf[LogicalSink]
+    assertEquals("{k1=#v1, k2=v2, k5=v5}",
+      sink.sink.asInstanceOf[OptionsTableSink].props.toString)
+  }
+
+  @Test
+  def testAppendOptions(): Unit = {
+    util.verifyPlan("select * from t1/*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */")
+  }
+
+  @Test
+  def testOverrideOptions(): Unit = {
+    util.verifyPlan("select * from t1/*+ OPTIONS(k1='#v1', k2='#v2') */")
+  }
+
+  @Test
+  def testJoinWithAppendedOptions(): Unit = {
+    val sql =
+      s"""
+         |select * from
+         |t1 /*+ OPTIONS(k5='v5', 'a.b.c'='fakeVal') */
+         |join
+         |t2 /*+ OPTIONS(k6='v6', 'd.e.f'='fakeVal') */
+         |on t1.a = t2.d
+         |""".stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testJoinWithOverriddenOptions(): Unit = {
+    val sql =
+      s"""
+         |select * from
+         |t1 /*+ OPTIONS(k1='#v1', k2='#v2') */
+         |join
+         |t2 /*+ OPTIONS(k3='#v3', k4='#v4') */
+         |on t1.a = t2.d
+         |""".stripMargin
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testOptionsHintOnTableApiView(): Unit = {
+    val view1 = util.tableEnv.sqlQuery("select * from t1 join t2 on t1.a = t2.d")
+    util.tableEnv.createTemporaryView("view1", view1)
+    // The table hints on view expect to be ignored.
+    val sql = "select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */"
+    util.verifyPlan(sql)
+  }
+
+  @Test
+  def testOptionsHintOnSQLView(): Unit = {
+    // Equivalent SQL:
+    // select * from t1 join t2 on t1.a = t2.d
+    val props = new JHashMap[String, String]
+    props.put("k1", "v1")
+    props.put("k2", "v2")
+    props.put("k3", "v3")
+    props.put("k4", "v4")
+    val view1 = new CatalogViewImpl(
+      "select * from t1 join t2 on t1.a = t2.d",
+      "select * from t1 join t2 on t1.a = t2.d",
+      TableSchema.builder()
+        .field("a", DataTypes.INT())
+        .field("b", DataTypes.STRING())
+        .field("c", DataTypes.INT())
+        .field("d", DataTypes.INT())
+        .field("e", DataTypes.STRING())
+        .field("f", DataTypes.BIGINT())
+        .build(),
+      props,
+      "a view table"
+    )
+    val catalog = util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
+    catalog.createTable(
+      new ObjectPath(util.tableEnv.getCurrentDatabase, "view1"),
+      view1,
+      false)
+    // The table hints on view expect to be ignored.
+    val sql = "select * from view1/*+ OPTIONS(k1='#v1', k2='#v2', k3='#v3', k4='#v4') */"
+    util.verifyPlan(sql)
+  }
+}
+
+object OptionsHintTest {
+  val IS_BOUNDED = "is-bounded"
+
+  case class Param(utilSupplier: TableTestBase => TableTestUtil, isBounded: Boolean) {
+    override def toString: String = s"$IS_BOUNDED=$isBounded"
+  }
+
+  @Parameters(name = "{index}: {0}")
+  def parameters(): Array[Param] = {
+    Array(
+      Param(_.batchTestUtil(), isBounded = true),
+      Param(_.streamTestUtil(), isBounded = false))
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/TableSourceITCase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchAbstractTestBase.TEMPORARY_FOLDER
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{BatchTestBase, TestData}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSources}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFileInputFormatTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestTableSourceSinks}
 import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter
 import org.apache.flink.types.Row
 import org.junit.{Before, Test}
@@ -184,7 +184,7 @@ class TableSourceITCase extends BatchTestBase {
 
   @Test
   def testCsvTableSource(): Unit = {
-    val csvTable = TestTableSources.getPersonCsvTableSource
+    val csvTable = TestTableSourceSinks.getPersonCsvTableSource
     tEnv.registerTableSource("csvTable", csvTable)
     checkResult(
       "SELECT id, `first`, `last`, score FROM csvTable",
@@ -203,8 +203,8 @@ class TableSourceITCase extends BatchTestBase {
 
   @Test
   def testLookupJoinCsvTemporalTable(): Unit = {
-    val orders = TestTableSources.getOrdersCsvTableSource
-    val rates = TestTableSources.getRatesCsvTableSource
+    val orders = TestTableSourceSinks.getOrdersCsvTableSource
+    val rates = TestTableSourceSinks.getRatesCsvTableSource
     tEnv.registerTableSource("orders", orders)
     tEnv.registerTableSource("rates", rates)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSourceITCase.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.{DataTypes, TableSchema, Types}
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestData, TestingAppendSink}
-import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestStreamTableSource, TestTableSources}
+import org.apache.flink.table.planner.utils.{TestDataTypeTableSource, TestFilterableTableSource, TestInputFormatTableSource, TestNestedProjectableTableSource, TestPartitionableSourceFactory, TestProjectableTableSource, TestStreamTableSource, TestTableSourceSinks}
 import org.apache.flink.types.Row
 
 import org.junit.Assert._
@@ -334,7 +334,7 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testCsvTableSource(): Unit = {
-    val csvTable = TestTableSources.getPersonCsvTableSource
+    val csvTable = TestTableSourceSinks.getPersonCsvTableSource
     tEnv.registerTableSource("persons", csvTable)
 
     val sink = new TestingAppendSink()
@@ -354,8 +354,8 @@ class TableSourceITCase extends StreamingTestBase {
 
   @Test
   def testLookupJoinCsvTemporalTable(): Unit = {
-    val orders = TestTableSources.getOrdersCsvTableSource
-    val rates = TestTableSources.getRatesCsvTableSource
+    val orders = TestTableSourceSinks.getOrdersCsvTableSource
+    val rates = TestTableSourceSinks.getRatesCsvTableSource
     tEnv.registerTableSource("orders", orders)
     tEnv.registerTableSource("rates", rates)
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -78,6 +78,7 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -334,7 +335,8 @@ public class SqlToOperationConverter {
 			identifier,
 			query,
 			insert.getStaticPartitionKVs(),
-			insert.isOverwrite());
+			insert.isOverwrite(),
+			Collections.emptyList());
 	}
 
 	/** Convert use catalog statement. */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -336,7 +336,7 @@ public class SqlToOperationConverter {
 			query,
 			insert.getStaticPartitionKVs(),
 			insert.isOverwrite(),
-			Collections.emptyList());
+			Collections.emptyMap());
 	}
 
 	/** Convert use catalog statement. */


### PR DESCRIPTION
… planner

## What is the purpose of the change

Supports syntax "table /*+ OPTIONS('k1'='v1', 'k2'='v2') */" to specify dynamic options within the scope of the appended table.

## Brief change log

* Implement dynamic options in Blink planner
* Implement CSV connector
* Add plan test OptionsHintTest
* Add a Csv ITCase in CatalogTableITCase

## Verifying this change
See ITCases and UT tests in the patch.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
