### PR TITLE
[FLINK-17067][FLINK-17098][table] Refactor some interfaces of CatalogManager

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -491,13 +491,15 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	@Override
 	public boolean dropTemporaryTable(String path) {
 		UnresolvedIdentifier unresolvedIdentifier = parser.parseIdentifier(path);
-		return catalogManager.dropTemporaryTable(unresolvedIdentifier);
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		return catalogManager.dropTemporaryTable(identifier);
 	}
 
 	@Override
 	public boolean dropTemporaryView(String path) {
 		UnresolvedIdentifier unresolvedIdentifier = parser.parseIdentifier(path);
-		return catalogManager.dropTemporaryView(unresolvedIdentifier);
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		return catalogManager.dropTemporaryView(identifier);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -782,7 +782,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 						tableSource,
 						sourceSinkTable.getTableSink().get(),
 						!IS_STREAM_TABLE);
-					catalogManager.createTemporaryTable(sourceAndSink, objectIdentifier, true);
+					catalogManager.dropTemporaryTable(objectIdentifier);
+					catalogManager.createTemporaryTable(sourceAndSink, objectIdentifier, false);
 				}
 			} else {
 				throw new ValidationException(String.format(
@@ -808,7 +809,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 					// wrapper contains only sink (not source)
 					ConnectorCatalogTable sourceAndSink = ConnectorCatalogTable
 						.sourceAndSink(sourceSinkTable.getTableSource().get(), tableSink, !IS_STREAM_TABLE);
-					catalogManager.createTemporaryTable(sourceAndSink, objectIdentifier, true);
+					catalogManager.dropTemporaryTable(objectIdentifier);
+					catalogManager.createTemporaryTable(sourceAndSink, objectIdentifier, false);
 				}
 			} else {
 				throw new ValidationException(String.format(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -529,16 +529,18 @@ public final class CatalogManager {
 	 *
 	 * @param table The table to put in the given path.
 	 * @param objectIdentifier The fully qualified path where to put the table.
-	 * @param replace controls what happens if a table exists in the given path,
-	 *                if true the table is replaced, an exception will be thrown otherwise
+	 * @param ignoreIfExists if false exception will be thrown if a table exists in the given path.
 	 */
 	public void createTemporaryTable(
 			CatalogBaseTable table,
 			ObjectIdentifier objectIdentifier,
-			boolean replace) {
+			boolean ignoreIfExists) {
 		temporaryTables.compute(objectIdentifier, (k, v) -> {
-			if (v != null && !replace) {
-				throw new ValidationException(String.format("Temporary table %s already exists", objectIdentifier));
+			if (v != null) {
+				if (!ignoreIfExists) {
+					throw new ValidationException(String.format("Temporary table %s already exists", objectIdentifier));
+				}
+				return v;
 			} else {
 				return table;
 			}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -546,31 +546,28 @@ public final class CatalogManager {
 	}
 
 	/**
-	 * Qualifies the given {@link UnresolvedIdentifier} with current catalog & database and
-	 * removes a temporary table registered with this path if it exists.
+	 * Drop a temporary table in a given fully qualified path if it exists.
 	 *
-	 * @param identifier potentially unresolved identifier
+	 * @param objectIdentifier The fully qualified path of the table to drop
 	 * @return true if a table with a given identifier existed and was removed, false otherwise
 	 */
-	public boolean dropTemporaryTable(UnresolvedIdentifier identifier) {
-		return dropTemporaryTableInternal(identifier, (table) -> table instanceof CatalogTable);
+	public boolean dropTemporaryTable(ObjectIdentifier objectIdentifier) {
+		return dropTemporaryTableInternal(objectIdentifier, (table) -> table instanceof CatalogTable);
 	}
 
 	/**
-	 * Qualifies the given {@link UnresolvedIdentifier} with current catalog & database and
-	 * removes a temporary view registered with this path if it exists.
+	 * Drop a temporary view in a given fully qualified path if it exists.
 	 *
-	 * @param identifier potentially unresolved identifier
+	 * @param objectIdentifier potentially unresolved identifier
 	 * @return true if a view with a given identifier existed and was removed, false otherwise
 	 */
-	public boolean dropTemporaryView(UnresolvedIdentifier identifier) {
-		return dropTemporaryTableInternal(identifier, (table) -> table instanceof CatalogView);
+	public boolean dropTemporaryView(ObjectIdentifier objectIdentifier) {
+		return dropTemporaryTableInternal(objectIdentifier, (table) -> table instanceof CatalogView);
 	}
 
 	private boolean dropTemporaryTableInternal(
-			UnresolvedIdentifier unresolvedIdentifier,
+			ObjectIdentifier objectIdentifier,
 			Predicate<CatalogBaseTable> filter) {
-		ObjectIdentifier objectIdentifier = qualifyIdentifier(unresolvedIdentifier);
 		CatalogBaseTable catalogBaseTable = temporaryTables.get(objectIdentifier);
 		if (filter.test(catalogBaseTable)) {
 			temporaryTables.remove(objectIdentifier);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -387,10 +387,11 @@ abstract class TableEnvImpl(
             tableSource,
             table.getTableSink.get,
             isBatchTable)
+          catalogManager.dropTemporaryTable(objectIdentifier)
           catalogManager.createTemporaryTable(
             sourceAndSink,
             objectIdentifier,
-            true)
+            false)
         }
 
       // no table is registered
@@ -421,10 +422,11 @@ abstract class TableEnvImpl(
             table.getTableSource.get,
             tableSink,
             isBatchTable)
+          catalogManager.dropTemporaryTable(objectIdentifier)
           catalogManager.createTemporaryTable(
             sourceAndSink,
             objectIdentifier,
-            true)
+            false)
         }
 
       // no table is registered

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -499,13 +499,15 @@ abstract class TableEnvImpl(
   override def dropTemporaryTable(path: String): Boolean = {
     val parser = planningConfigurationBuilder.createCalciteParser()
     val unresolvedIdentifier = UnresolvedIdentifier.of(parser.parseIdentifier(path).names: _*)
-    catalogManager.dropTemporaryTable(unresolvedIdentifier)
+    val identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier)
+    catalogManager.dropTemporaryTable(identifier)
   }
 
   override def dropTemporaryView(path: String): Boolean = {
     val parser = planningConfigurationBuilder.createCalciteParser()
     val unresolvedIdentifier = UnresolvedIdentifier.of(parser.parseIdentifier(path).names: _*)
-    catalogManager.dropTemporaryView(unresolvedIdentifier)
+    val identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier)
+    catalogManager.dropTemporaryView(identifier)
   }
 
   override def listUserDefinedFunctions(): Array[String] = functionCatalog.getUserDefinedFunctions

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -159,7 +159,7 @@ public class CatalogManagerTest extends TestLogger {
 				database(BUILTIN_DEFAULT_DATABASE_NAME, table("test")))
 			.build();
 
-		boolean dropped = manager.dropTemporaryTable(UnresolvedIdentifier.of("test"));
+		boolean dropped = manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")));
 
 		assertThat(dropped, is(false));
 	}
@@ -173,7 +173,7 @@ public class CatalogManagerTest extends TestLogger {
 			.temporaryTable(identifier)
 			.build();
 
-		boolean dropped = manager.dropTemporaryTable(UnresolvedIdentifier.of("test"));
+		boolean dropped = manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")));
 
 		assertThat(dropped, is(true));
 	}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -102,7 +102,7 @@ public class CatalogManagerTest extends TestLogger {
 	}
 
 	@Test
-	public void testReplaceTemporaryTable() throws Exception {
+	public void testIgnoreTemporaryTableExists() throws Exception {
 		ObjectIdentifier tempIdentifier = ObjectIdentifier.of(
 			BUILTIN_CATALOG_NAME,
 			BUILTIN_DEFAULT_DATABASE_NAME,
@@ -110,11 +110,12 @@ public class CatalogManagerTest extends TestLogger {
 		CatalogManager manager = root()
 			.builtin(
 				database(BUILTIN_DEFAULT_DATABASE_NAME))
-			.temporaryTable(tempIdentifier)
 			.build();
 
 		CatalogTest.TestTable table = new CatalogTest.TestTable();
 		manager.createTemporaryTable(table, tempIdentifier, true);
+		CatalogTest.TestTable anotherTable = new CatalogTest.TestTable();
+		manager.createTemporaryTable(anotherTable, tempIdentifier, true);
 		assertThat(manager.getTable(tempIdentifier).get().isTemporary(), equalTo(true));
 		assertThat(manager.getTable(tempIdentifier).get().getTable(), equalTo(table));
 	}


### PR DESCRIPTION

## What is the purpose of the change
This PR refactor some interfaces of CatalogManager:
- CatalogManager#createTemporaryTable should provide [IF NOT EXISTS] semantic. The reason is discussed in FLINK-17067
- CatalogManager#createTable, createTemporaryTable should use ObjectIdentifier as its argument. The reason is discussed in FLINK-17098

## Brief change log

- bdb37a5 changes  CatalogManager#createTemporaryTable with semantic [IF NOT EXISTS] instead of [OR REPLACE]
- 3d10020 changes argument of CatalogManager#createTable and createTemporaryTable by ObjectIdentifier instead of UnresolvedIdentifier


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
