### PR TITLE
[FLINK-17107][checkpointing] Make CheckpointCoordinatorConfiguration#isExactlyOnce() be consistent with StreamConfig#getCheckpointMode()

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -885,7 +885,7 @@ public class StreamingJobGraphGenerator {
 
 		boolean isExactlyOnce;
 		if (mode == CheckpointingMode.EXACTLY_ONCE) {
-			isExactlyOnce = true;
+			isExactlyOnce = cfg.isCheckpointingEnabled();
 		} else if (mode == CheckpointingMode.AT_LEAST_ONCE) {
 			isExactlyOnce = false;
 		} else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -84,6 +84,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import static org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration.MINIMAL_CHECKPOINT_TIME;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -516,14 +517,8 @@ public class StreamingJobGraphGenerator {
 
 		config.setStateBackend(streamGraph.getStateBackend());
 		config.setCheckpointingEnabled(checkpointCfg.isCheckpointingEnabled());
-		if (checkpointCfg.isCheckpointingEnabled()) {
-			config.setCheckpointMode(checkpointCfg.getCheckpointingMode());
-		}
-		else {
-			// the "at-least-once" input handler is slightly cheaper (in the absence of checkpoints),
-			// so we use that one if checkpointing is not enabled
-			config.setCheckpointMode(CheckpointingMode.AT_LEAST_ONCE);
-		}
+		config.setCheckpointMode(getCheckpointingMode(checkpointCfg));
+
 		for (int i = 0; i < vertex.getStatePartitioners().length; i++) {
 			config.setStatePartitioner(i, vertex.getStatePartitioners()[i]);
 		}
@@ -538,6 +533,21 @@ public class StreamingJobGraphGenerator {
 		}
 
 		vertexConfigs.put(vertexID, config);
+	}
+
+	private CheckpointingMode getCheckpointingMode(CheckpointConfig checkpointConfig) {
+		CheckpointingMode checkpointingMode = checkpointConfig.getCheckpointingMode();
+
+		checkArgument(checkpointingMode == CheckpointingMode.EXACTLY_ONCE ||
+			checkpointingMode == CheckpointingMode.AT_LEAST_ONCE, "Unexpected checkpointing mode.");
+
+		if (checkpointConfig.isCheckpointingEnabled()) {
+			return checkpointingMode;
+		} else {
+			// the "at-least-once" input handler is slightly cheaper (in the absence of checkpoints),
+			// so we use that one if checkpointing is not enabled
+			return CheckpointingMode.AT_LEAST_ONCE;
+		}
 	}
 
 	private void connect(Integer headOfChain, StreamEdge edge) {
@@ -881,19 +891,6 @@ public class StreamingJobGraphGenerator {
 			retentionAfterTermination = CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION;
 		}
 
-		CheckpointingMode mode = cfg.getCheckpointingMode();
-
-		boolean isExactlyOnce;
-		if (mode == CheckpointingMode.EXACTLY_ONCE) {
-			isExactlyOnce = cfg.isCheckpointingEnabled();
-		} else if (mode == CheckpointingMode.AT_LEAST_ONCE) {
-			isExactlyOnce = false;
-		} else {
-			throw new IllegalStateException("Unexpected checkpointing mode. " +
-				"Did not expect there to be another checkpointing mode besides " +
-				"exactly-once or at-least-once.");
-		}
-
 		//  --- configure the master-side checkpoint hooks ---
 
 		final ArrayList<MasterTriggerRestoreHook.Factory> hooks = new ArrayList<>();
@@ -951,7 +948,7 @@ public class StreamingJobGraphGenerator {
 				cfg.getMinPauseBetweenCheckpoints(),
 				cfg.getMaxConcurrentCheckpoints(),
 				retentionAfterTermination,
-				isExactlyOnce,
+				getCheckpointingMode(cfg) == CheckpointingMode.EXACTLY_ONCE,
 				cfg.isPreferCheckpointForRecovery(),
 				cfg.getTolerableCheckpointFailureNumber()),
 			serializedStateBackend,


### PR DESCRIPTION
## What is the purpose of the change

CheckpointCoordinatorConfiguration#isExactlyOnce() is inconsistent with StreamConfig#getCheckpointMode() when checkpoint is disabled. CheckpointCoordinatorConfiguration#isExactlyOnce() returns true if checkpoint mode is  EXACTLY_ONCE mode and return false if checkpoint mode is AT_LEAST_ONCE while StreamConfig#getCheckpointMode() will always return AT_LEAST_ONCE which means always not exactly once. This PR tries to fix this inconsistency.


## Brief change log

  - We always use AT_LEAST_ONCE mode to make CheckpointCoordinatorConfiguration#isExactlyOnce() be consistent with StreamConfig#getCheckpointMode()


## Verifying this change

New checks are added to existing test to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
