### PR TITLE
[FLINK-16598][k8s] Respect the rest-port exposed by the external Service when retrieving Endpoint

### DIFF
--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClientTestBase.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes;
+
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+
+import io.fabric8.kubernetes.api.model.LoadBalancerIngress;
+import io.fabric8.kubernetes.api.model.LoadBalancerStatus;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceStatus;
+import io.fabric8.kubernetes.api.model.ServiceStatusBuilder;
+import org.junit.Before;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+
+/**
+ * Base class for {@link KubernetesClusterDescriptorTest} and
+ * {@link org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClientTest}.
+ */
+public class KubernetesClientTestBase extends KubernetesTestBase {
+
+	protected static final int REST_PORT = 9021;
+	protected static final int NODE_PORT = 31234;
+
+	@Before
+	public void setup() throws Exception {
+		super.setup();
+	}
+
+	protected void mockExpectedServiceFromServerSide(Service expectedService) {
+		final String serviceName = expectedService.getMetadata().getName();
+		final String path = String.format("/api/v1/namespaces/%s/services/%s", NAMESPACE, serviceName);
+		server.expect()
+			.get()
+			.withPath(path)
+			.andReturn(200, expectedService)
+			.always();
+	}
+
+	protected Service buildExternalServiceWithLoadBalancer(@Nullable String hostname, @Nullable String ip) {
+		final ServicePort servicePort = new ServicePortBuilder()
+			.withName(Constants.REST_PORT_NAME)
+			.withPort(REST_PORT)
+			.withNewTargetPort(REST_PORT)
+			.build();
+		final ServiceStatus serviceStatus = new ServiceStatusBuilder()
+			.withLoadBalancer(new LoadBalancerStatus(Collections.singletonList(new LoadBalancerIngress(hostname, ip))))
+			.build();
+
+		return buildExternalService(
+			KubernetesConfigOptions.ServiceExposedType.LoadBalancer,
+			servicePort,
+			serviceStatus);
+	}
+
+	protected Service buildExternalServiceWithNodePort() {
+		final ServicePort servicePort = new ServicePortBuilder()
+			.withName(Constants.REST_PORT_NAME)
+			.withPort(REST_PORT)
+			.withNodePort(NODE_PORT)
+			.withNewTargetPort(REST_PORT)
+			.build();
+
+		final ServiceStatus serviceStatus = new ServiceStatusBuilder()
+			.withLoadBalancer(new LoadBalancerStatus(Collections.emptyList()))
+			.build();
+
+		return buildExternalService(
+			KubernetesConfigOptions.ServiceExposedType.NodePort,
+			servicePort,
+			serviceStatus);
+	}
+
+	protected Service buildExternalServiceWithClusterIP() {
+		final ServicePort servicePort = new ServicePortBuilder()
+			.withName(Constants.REST_PORT_NAME)
+			.withPort(REST_PORT)
+			.withNewTargetPort(REST_PORT)
+			.build();
+
+		return buildExternalService(
+			KubernetesConfigOptions.ServiceExposedType.ClusterIP,
+			servicePort,
+			null);
+	}
+
+	private Service buildExternalService(
+			KubernetesConfigOptions.ServiceExposedType serviceExposedType,
+			ServicePort servicePort,
+			@Nullable ServiceStatus serviceStatus) {
+		final ServiceBuilder serviceBuilder = new ServiceBuilder()
+			.editOrNewMetadata()
+				.withName(KubernetesUtils.getRestServiceName(CLUSTER_ID))
+				.endMetadata()
+			.editOrNewSpec()
+				.withType(serviceExposedType.name())
+				.addNewPortLike(servicePort)
+					.endPort()
+				.endSpec();
+
+		if (serviceStatus != null) {
+			serviceBuilder.withStatus(serviceStatus);
+		}
+
+		return serviceBuilder.build();
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, we parse the `rest.port` from the Flink `Configuration` when a user submits his jobs to an existing native Kubernetes session cluster, this is definitely wrong since we do not respect the real port exposed by the external Service created when deploying the session cluster. This PR will fix this problem.


## Brief change log

  - *Refactor the logic on retrieving the rest-port/service-exposed-type in the method of `Fabric8FlinkKubeClient#getRestEndpoint`*
  - *Introduce a new test class `KubernetesClientTestBase` which provides some tools for the Service*


## Verifying this change

The following unit tests cover the test branch:
- *Fabric8FlinkKubeClientTest#testServiceLoadBalancerWithNoIP*
- *Fabric8FlinkKubeClientTest#testClusterIPService*

, and can be manually verified as follows:

  - *Start a native Kubernetes session cluster, by default, the rest port exposed by the rest Service is 8081*
  - *Then submit a job to the session cluster, but specify a different rest port via -Drest.port=8082*
  - *As expected, the job is successfully submitted to the session cluster*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
