### PR TITLE
[FLINK-17093][python][table-planner][table-planner-blink] Fix Python UDF to make it work with inputs from composite field

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -31,6 +31,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexFieldAccess;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
@@ -93,22 +94,36 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		RexNode rexNode = tableFunctionScan.getCall();
 		if (rexNode instanceof RexCall) {
 			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode)
-				|| PythonUtil.isNonPythonCall(rexNode) && PythonUtil.containsPythonCall(rexNode, null);
+				|| PythonUtil.isNonPythonCall(rexNode) && PythonUtil.containsPythonCall(rexNode, null)
+				|| (PythonUtil.isPythonCall(rexNode, null) && containsFieldAccessInputs(rexNode));
 		}
 		return false;
+	}
+
+	private boolean containsFieldAccessInputs(RexNode node) {
+		if (node instanceof RexCall) {
+			for (RexNode operand : ((RexCall) node).getOperands()) {
+				if (containsFieldAccessInputs(operand)) {
+					return true;
+				}
+			}
+			return false;
+		} else {
+			return node instanceof RexFieldAccess;
+		}
 	}
 
 	private List<String> createNewFieldNames(
 		RelDataType rowType,
 		RexBuilder rexBuilder,
 		int primitiveFieldCount,
-		ArrayBuffer<RexCall> extractedRexCalls,
+		ArrayBuffer<RexNode> extractedRexNodes,
 		List<RexNode> calcProjects) {
 		for (int i = 0; i < primitiveFieldCount; i++) {
 			calcProjects.add(RexInputRef.of(i, rowType));
 		}
 		// add the fields of the extracted rex calls.
-		Iterator<RexCall> iterator = extractedRexCalls.iterator();
+		Iterator<RexNode> iterator = extractedRexNodes.iterator();
 		while (iterator.hasNext()) {
 			calcProjects.add(iterator.next());
 		}
@@ -117,7 +132,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		for (int i = 0; i < primitiveFieldCount; i++) {
 			nameList.add(rowType.getFieldNames().get(i));
 		}
-		Iterator<Object> indicesIterator = extractedRexCalls.indices().iterator();
+		Iterator<Object> indicesIterator = extractedRexNodes.indices().iterator();
 		while (indicesIterator.hasNext()) {
 			nameList.add("f" + indicesIterator.next());
 		}
@@ -129,7 +144,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 	private FlinkLogicalCalc createNewLeftCalc(
 		RelNode left,
 		RexBuilder rexBuilder,
-		ArrayBuffer<RexCall> extractedRexCalls,
+		ArrayBuffer<RexNode> extractedRexNodes,
 		FlinkLogicalCorrelate correlate) {
 		// add the fields of the primitive left input.
 		List<RexNode> leftCalcProjects = new LinkedList<>();
@@ -138,7 +153,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 			leftRowType,
 			rexBuilder,
 			leftRowType.getFieldCount(),
-			extractedRexCalls,
+			extractedRexNodes,
 			leftCalcProjects);
 
 		// create a new calc
@@ -157,11 +172,11 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 	private FlinkLogicalCalc createTopCalc(
 		int primitiveLeftFieldCount,
 		RexBuilder rexBuilder,
-		ArrayBuffer<RexCall> extractedRexCalls,
+		ArrayBuffer<RexNode> extractedRexNodes,
 		RelDataType calcRowType,
 		FlinkLogicalCorrelate newCorrelate) {
 		RexProgram rexProgram = new RexProgramBuilder(newCorrelate.getRowType(), rexBuilder).getProgram();
-		int offset = extractedRexCalls.size() + primitiveLeftFieldCount;
+		int offset = extractedRexNodes.size() + primitiveLeftFieldCount;
 
 		// extract correlate output RexNode.
 		List<RexNode> newTopCalcProjects = rexProgram
@@ -188,12 +203,20 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 
 	private ScalarFunctionSplitter createScalarFunctionSplitter(
 		int primitiveLeftFieldCount,
-		ArrayBuffer<RexCall> extractedRexCalls,
-		boolean isJavaTableFunction) {
+		ArrayBuffer<RexNode> extractedRexNodes,
+		RexNode tableFunctionNode) {
 		return new ScalarFunctionSplitter(
 			primitiveLeftFieldCount,
-			extractedRexCalls,
-			isJavaTableFunction ? x -> PythonUtil.isPythonCall(x, null) : PythonUtil::isNonPythonCall
+			extractedRexNodes,
+			node -> {
+				if (PythonUtil.isNonPythonCall(tableFunctionNode)) {
+					return PythonUtil.isPythonCall(node, null);
+				} else if (PythonUtil.containsNonPythonCall(node)) {
+					return PythonUtil.isNonPythonCall(node);
+				} else {
+					return node instanceof RexFieldAccess;
+				}
+			}
 		);
 	}
 
@@ -204,7 +227,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		RelNode left = ((HepRelVertex) correlate.getLeft()).getCurrentRel();
 		RelNode right = ((HepRelVertex) correlate.getRight()).getCurrentRel();
 		int primitiveLeftFieldCount = left.getRowType().getFieldCount();
-		ArrayBuffer<RexCall> extractedRexCalls = new ArrayBuffer<>();
+		ArrayBuffer<RexNode> extractedRexNodes = new ArrayBuffer<>();
 
 		RelNode rightNewInput;
 		if (right instanceof FlinkLogicalTableFunctionScan) {
@@ -213,8 +236,8 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 				scan,
 				createScalarFunctionSplitter(
 					primitiveLeftFieldCount,
-					extractedRexCalls,
-					PythonUtil.isNonPythonCall(scan.getCall())));
+					extractedRexNodes,
+					scan.getCall()));
 		} else {
 			FlinkLogicalCalc calc = (FlinkLogicalCalc) right;
 			FlinkLogicalTableFunctionScan scan = StreamExecCorrelateRule.getTableScan(calc);
@@ -222,15 +245,15 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 			FlinkLogicalTableFunctionScan newScan = createNewScan(scan,
 				createScalarFunctionSplitter(
 					primitiveLeftFieldCount,
-					extractedRexCalls,
-					PythonUtil.isNonPythonCall(scan.getCall())));
+					extractedRexNodes,
+					scan.getCall()));
 			rightNewInput = mergedCalc.copy(mergedCalc.getTraitSet(), newScan, mergedCalc.getProgram());
 		}
 
 		FlinkLogicalCalc leftCalc = createNewLeftCalc(
 			left,
 			rexBuilder,
-			extractedRexCalls,
+			extractedRexNodes,
 			correlate);
 
 		FlinkLogicalCorrelate newCorrelate = new FlinkLogicalCorrelate(
@@ -245,7 +268,7 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		FlinkLogicalCalc newTopCalc = createTopCalc(
 			primitiveLeftFieldCount,
 			rexBuilder,
-			extractedRexCalls,
+			extractedRexNodes,
 			correlate.getRowType(),
 			newCorrelate);
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonCorrelate.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.common
 
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexInputRef, RexNode}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
@@ -67,10 +67,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonTableFunctionInfo = createPythonFunctionInfo(pythonRexCall, inputNodes)
     val udtfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect {
-        case inputRef: RexInputRef => inputRef.getIndex
-        case fac: RexFieldAccess => fac.getField.getIndex
-      }
+      .collect { case inputRef: RexInputRef => inputRef.getIndex }
     (udtfInputOffsets, pythonTableFunctionInfo)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -366,6 +366,7 @@ object FlinkBatchRuleSets {
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -352,6 +352,7 @@ object FlinkStreamRuleSets {
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRule.scala
@@ -22,7 +22,7 @@ import java.util.function.Function
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
+import org.apache.calcite.rex.{RexBuilder, RexCall, RexFieldAccess, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.functions.python.PythonFunctionKind
@@ -49,14 +49,14 @@ abstract class PythonCalcSplitRuleBase(description: String)
     val input = calc.getInput
     val rexBuilder = call.builder().getRexBuilder
     val program = calc.getProgram
-    val extractedRexCalls = new mutable.ArrayBuffer[RexCall]()
+    val extractedRexNodes = new mutable.ArrayBuffer[RexNode]()
 
     val extractedFunctionOffset = input.getRowType.getFieldCount
     val splitter = new ScalarFunctionSplitter(
       extractedFunctionOffset,
-      extractedRexCalls,
-      new Function[RexCall, Boolean] {
-        override def apply(rexCall: RexCall): Boolean = needConvertRexCall(program, rexCall)
+      extractedRexNodes,
+      new Function[RexNode, Boolean] {
+        override def apply(node: RexNode): Boolean = needConvert(program, node)
       })
 
     val (bottomCalcCondition, topCalcCondition, topCalcProjects) = split(program, splitter)
@@ -64,10 +64,10 @@ abstract class PythonCalcSplitRuleBase(description: String)
       topCalcProjects, topCalcCondition, extractedFunctionOffset)
 
     val bottomCalcProjects =
-      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexCalls
+      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexNodes
     val bottomCalcFieldNames = SqlValidatorUtil.uniquify(
       accessedFields.map(i => input.getRowType.getFieldNames.get(i)).toSeq ++
-        extractedRexCalls.indices.map("f" + _),
+        extractedRexNodes.indices.map("f" + _),
       rexBuilder.getTypeFactory.getTypeSystem.isSchemaCaseSensitive)
 
     val bottomCalc = new FlinkLogicalCalc(
@@ -81,7 +81,8 @@ abstract class PythonCalcSplitRuleBase(description: String)
         bottomCalcFieldNames,
         rexBuilder))
 
-    val inputRewriter = new ExtractedFunctionInputRewriter(extractedFunctionOffset, accessedFields)
+    val inputRewriter = new ExtractedFunctionInputRewriter(
+      calc.getCluster.getRexBuilder, extractedFunctionOffset, accessedFields)
     val topCalc = new FlinkLogicalCalc(
       calc.getCluster,
       calc.getTraitSet,
@@ -117,9 +118,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
   }
 
   /**
-    * Returns true if need to convert the specified call.
+    * Returns true if need to convert the specified node.
     */
-  def needConvertRexCall(program: RexProgram, call: RexCall): Boolean
+  def needConvert(program: RexProgram, node: RexNode): Boolean
 
   /**
     * Splits the specified [[RexProgram]] using the specified [[ScalarFunctionSplitter]].
@@ -146,7 +147,7 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
       .map(calc.getProgram.expandLocalRef).exists(containsPythonCall(_))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -181,8 +182,8 @@ object PythonCalcSplitProjectionRule extends PythonCalcSplitProjectionRuleBase(
     projects.exists(containsPythonCall(_)) && projects.exists(containsNonPythonCall)
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
-    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = {
+    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(node)
   }
 }
 
@@ -205,9 +206,40 @@ object PythonCalcSplitPandasInProjectionRule extends PythonCalcSplitProjectionRu
       projects.exists(containsPythonCall(_, PythonFunctionKind.PANDAS))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = {
      program.getProjectList.map(program.expandLocalRef).exists(
-       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(call, PythonFunctionKind.PANDAS)
+       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(node, PythonFunctionKind.PANDAS)
+  }
+}
+
+/**
+  * Rule that expands the RexFieldAccess inputs of Python functions contained in
+  * the projection of [[FlinkLogicalCalc]]s.
+  */
+object PythonCalcExpandProjectRule extends PythonCalcSplitRuleBase(
+  "PythonCalcExpandProjectRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
+
+    projects.exists(containsPythonCall(_)) && projects.exists(containsFieldAccessInputs)
+  }
+
+  override def needConvert(program: RexProgram, node: RexNode): Boolean =
+    node.isInstanceOf[RexFieldAccess]
+
+  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
+      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
+    (None, None, program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  }
+
+  private def containsFieldAccessInputs(node: RexNode): Boolean = {
+    node match {
+      case call: RexCall => call.getOperands.exists(containsFieldAccessInputs)
+      case _: RexFieldAccess => true
+      case _ => false
+    }
   }
 }
 
@@ -228,8 +260,7 @@ object PythonCalcPushConditionRule extends PythonCalcSplitRuleBase(
     calc.getProgram.getCondition != null && projects.exists(containsPythonCall(_))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean =
-    isNonPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isNonPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -262,7 +293,7 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
           projects.lastIndexWhere(_.isInstanceOf[RexInputRef]))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -272,25 +303,33 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
 
 private class ScalarFunctionSplitter(
     extractedFunctionOffset: Int,
-    extractedRexCalls: mutable.ArrayBuffer[RexCall],
-    needConvertRexCall: Function[RexCall, Boolean])
+    extractedRexNodes: mutable.ArrayBuffer[RexNode],
+    needConvert: Function[RexNode, Boolean])
   extends RexDefaultVisitor[RexNode] {
 
   override def visitCall(call: RexCall): RexNode = {
-    visit(needConvertRexCall(call), call)
+    if (needConvert(call)) {
+      getExtractedRexNode(call)
+    } else {
+      call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
+    }
+  }
+
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    if (needConvert(fieldAccess)) {
+      getExtractedRexNode(fieldAccess)
+    } else {
+      fieldAccess
+    }
   }
 
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 
-  private def visit(needConvert: Boolean, call: RexCall): RexNode = {
-    if (needConvert) {
-      val newNode = new RexInputRef(
-        extractedFunctionOffset + extractedRexCalls.length, call.getType)
-      extractedRexCalls.append(call)
-      newNode
-    } else {
-      call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
-    }
+  private def getExtractedRexNode(node: RexNode): RexNode = {
+    val newNode = new RexInputRef(
+      extractedFunctionOffset + extractedRexNodes.length, node.getType)
+    extractedRexNodes.append(node)
+    newNode
   }
 }
 
@@ -300,10 +339,12 @@ private class ScalarFunctionSplitter(
   *    extracted function.
   * 2) Fields of index less than extractedFunctionOffset refer to the original input field.
   *
+  * @param rexBuilder the RexBuilder
   * @param extractedFunctionOffset the original start offset of the extracted functions
   * @param accessedFields the accessed fields which will be forwarded
   */
 private class ExtractedFunctionInputRewriter(
+    rexBuilder: RexBuilder,
     extractedFunctionOffset: Int,
     accessedFields: Array[Int])
   extends RexDefaultVisitor[RexNode] {
@@ -328,17 +369,25 @@ private class ExtractedFunctionInputRewriter(
     call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
   }
 
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    rexBuilder.makeFieldAccess(
+      fieldAccess.getReferenceExpr.accept(this),
+      fieldAccess.getField.getIndex)
+  }
+
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 }
 
 object PythonCalcSplitRule {
   /**
     * These rules should be applied sequentially in the order of
-    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
+    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, EXPAND_PROJECT, PUSH_CONDITION
+    * and REWRITE_PROJECT.
     */
   val SPLIT_CONDITION: RelOptRule = PythonCalcSplitConditionRule
   val SPLIT_PROJECT: RelOptRule = PythonCalcSplitProjectionRule
   val SPLIT_PANDAS_IN_PROJECT: RelOptRule = PythonCalcSplitPandasInProjectionRule
+  val EXPAND_PROJECT: RelOptRule = PythonCalcExpandProjectRule
   val PUSH_CONDITION: RelOptRule = PythonCalcPushConditionRule
   val REWRITE_PROJECT: RelOptRule = PythonCalcRewriteProjectionRule
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/CalcPythonCorrelateTransposeRuleTest.xml
@@ -31,12 +31,12 @@ LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3], y=[$4])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-FlinkLogicalCalc(select=[a, b, c, f00 AS f0, f1], where=[AND(=(f0, 2), =(+(f1, 1), *(f1, f1)), =(f00, a))])
-+- FlinkLogicalCalc(select=[a, b, c, f00, f1, pyFunc(f00, f00) AS f0])
+FlinkLogicalCalc(select=[a, b, c, f00 AS f0, f10 AS f1], where=[AND(=(f0, 2), =(+(f10, 1), *(f10, f10)), =(f00, a))])
++- FlinkLogicalCalc(select=[a, b, c, f00, f10, pyFunc(f00, f00) AS f0])
    +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
-      :- FlinkLogicalCalc(select=[a, b, c, *($cor0.a, $cor0.a) AS f0])
+      :- FlinkLogicalCalc(select=[a, b, c, *($cor0.a, $cor0.a) AS f0, $cor0.b AS f1])
       :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-      +- FlinkLogicalTableFunctionScan(invocation=[func($3, $cor0.b)], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+      +- FlinkLogicalTableFunctionScan(invocation=[func($3, $4)], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -23,7 +23,7 @@ limitations under the License.
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pandasFunc3(pandasFunc2(+($0, pandasFunc1($0, $2)), $1), $2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -31,7 +31,7 @@ LogicalProject(EXPR$0=[pandasFunc3(pandasFunc2(+($0, pandasFunc1($0, $2)), $1), 
 FlinkLogicalCalc(select=[pandasFunc3(pandasFunc2(f0, b), c) AS EXPR$0])
 +- FlinkLogicalCalc(select=[b, c, +(a, f0) AS f0])
    +- FlinkLogicalCalc(select=[b, c, a, pandasFunc1(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -42,7 +42,7 @@ FlinkLogicalCalc(select=[pandasFunc3(pandasFunc2(f0, b), c) AS EXPR$0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc3(pyFunc2(+($0, pyFunc1($0, $2)), $1), $2)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -50,7 +50,25 @@ LogicalProject(EXPR$0=[pyFunc3(pyFunc2(+($0, pyFunc1($0, $2)), $1), $2)])
 FlinkLogicalCalc(select=[pyFunc3(pyFunc2(f0, b), c) AS EXPR$0])
 +- FlinkLogicalCalc(select=[b, c, +(a, f0) AS f0])
    +- FlinkLogicalCalc(select=[b, c, a, pyFunc1(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testChainingPythonFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(b, pyFunc1(c, d._1)) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($1, pyFunc1($2, $3._1))])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pyFunc1(b, pyFunc1(c, f0)) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, c, d._1 AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -79,14 +97,14 @@ FlinkLogicalCalc(select=[f00 AS EXPR$0, +(f0, 1) AS EXPR$1])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], b=[$1], EXPR$2=[pyFunc1($0, $2)], EXPR$3=[1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b, f0 AS EXPR$2, 1 AS EXPR$3])
 +- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -97,13 +115,13 @@ FlinkLogicalCalc(select=[a, b, f0 AS EXPR$2, 1 AS EXPR$3])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pandasFunc1($0, $1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -115,14 +133,14 @@ FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[pandasFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b], where=[f0])
 +- FlinkLogicalCalc(select=[a, b, pandasFunc4(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -133,13 +151,13 @@ FlinkLogicalCalc(select=[a, b], where=[f0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
-+- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -151,14 +169,14 @@ FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
       <![CDATA[
 LogicalProject(a=[$0], b=[$1])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, b], where=[f0])
 +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -169,14 +187,14 @@ FlinkLogicalCalc(select=[a, b], where=[f0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[+(pyFunc1($0, $1), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
 +- FlinkLogicalCalc(select=[pyFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -187,91 +205,14 @@ FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[+(pandasFunc1($0, $1), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
 +- FlinkLogicalCalc(select=[pandasFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPandasFunctionMixedWithGeneralPythonFunction">
-    <Resource name="sql">
-      <![CDATA[SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1 FROM MyTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+(pyFunc1($0, $2), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[f0 AS EXPR$0, +(f1, 1) AS EXPR$1])
-+- FlinkLogicalCalc(select=[f0, pyFunc1(a, c) AS f1])
-   +- FlinkLogicalCalc(select=[a, c, pandasFunc1(a, b) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPandasFunctionMixedWithJavaFunction">
-    <Resource name="sql">
-      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
-+- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPandasFunctionMixedWithJavaFunctionInWhereClause">
-    <Resource name="sql">
-      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable WHERE pandasFunc2(a, c) > 0]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
-+- LogicalFilter(condition=[>(pandasFunc2($0, $2), 0)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
-+- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
-   +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
-      +- FlinkLogicalCalc(select=[a, b, c, pandasFunc2(a, c) AS f0])
-         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testPandasFunctionNotChainingWithGeneralPythonFunction">
-    <Resource name="sql">
-      <![CDATA[SELECT pyFunc1(a, pandasFunc1(a, b)) + 1 FROM MyTable]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[+(pyFunc1($0, pandasFunc1($0, $1)), 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
-+- FlinkLogicalCalc(select=[pyFunc1(a, f0) AS f0])
-   +- FlinkLogicalCalc(select=[a, pandasFunc1(a, b) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -283,7 +224,7 @@ FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
       <![CDATA[
 LogicalProject(EXPR$0=[pandasFunc1($0, $1)])
 +- LogicalFilter(condition=[pandasFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -291,7 +232,120 @@ LogicalProject(EXPR$0=[pandasFunc1($0, $1)])
 FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
 +- FlinkLogicalCalc(select=[a, b], where=[f0])
    +- FlinkLogicalCalc(select=[a, b, pandasFunc4(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithGeneralPythonFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+(pyFunc1($0, $2), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(f1, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[f0, pyFunc1(a, c) AS f1])
+   +- FlinkLogicalCalc(select=[a, c, pandasFunc1(a, b) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithJavaFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionMixedWithJavaFunctionInWhereClause">
+    <Resource name="sql">
+      <![CDATA[SELECT pandasFunc1(a, b), c + 1 FROM MyTable WHERE pandasFunc2(a, c) > 0]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+($2, 1)])
++- LogicalFilter(condition=[>(pandasFunc2($0, $2), 0)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
++- FlinkLogicalCalc(select=[c, pandasFunc1(a, b) AS f0])
+   +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
+      +- FlinkLogicalCalc(select=[a, b, c, pandasFunc2(a, c) AS f0])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pandasFunc1(b, d._1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pandasFunc1($1, $3._1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pandasFunc1(b, f0) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, d._1 AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, pyFunc1(b, d._1) FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], EXPR$1=[pyFunc1($1, $3._1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, pyFunc1(b, f0) AS EXPR$1])
++- FlinkLogicalCalc(select=[a, b, d._1 AS f0])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPandasFunctionNotChainingWithGeneralPythonFunction">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, pandasFunc1(a, b)) + 1 FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[+(pyFunc1($0, pandasFunc1($0, $1)), 1)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[+(f0, 1) AS EXPR$0])
++- FlinkLogicalCalc(select=[pyFunc1(a, f0) AS f0])
+   +- FlinkLogicalCalc(select=[a, pandasFunc1(a, b) AS f0])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -303,7 +357,7 @@ FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)])
 +- LogicalFilter(condition=[pyFunc4($0, $2)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -311,7 +365,7 @@ LogicalProject(EXPR$0=[pyFunc1($0, $1)])
 FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
 +- FlinkLogicalCalc(select=[a, b], where=[f0])
    +- FlinkLogicalCalc(select=[a, b, pyFunc4(a, c) AS f0])
-      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+      +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -322,14 +376,14 @@ FlinkLogicalCalc(select=[pyFunc1(a, b) AS EXPR$0])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[c, pyFunc1(a, b) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -340,14 +394,14 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
     <Resource name="planBefore">
       <![CDATA[
 LogicalProject(a=[$0], EXPR$1=[pyFunc1($0, $2)], b=[$1])
-+- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
 +- FlinkLogicalCalc(select=[a, b, pyFunc1(a, c) AS f0])
-   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>
@@ -359,7 +413,7 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
       <![CDATA[
 LogicalProject(EXPR$0=[pyFunc1($0, $1)], EXPR$1=[+($2, 1)])
 +- LogicalFilter(condition=[>(pyFunc2($0, $2), 0)])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
@@ -368,7 +422,7 @@ FlinkLogicalCalc(select=[f0 AS EXPR$0, +(c, 1) AS EXPR$1])
 +- FlinkLogicalCalc(select=[c, pyFunc1(a, b) AS f0])
    +- FlinkLogicalCalc(select=[c, a, b], where=[>(f0, 0)])
       +- FlinkLogicalCalc(select=[a, b, c, pyFunc2(a, c) AS f0])
-         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+         +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
@@ -16,6 +16,29 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testJavaTableFunctionWithPythonCalc">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, x FROM MyTable, LATERAL TABLE(javaFunc(pyFunc(c))) AS T(x)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+   +- LogicalTableFunctionScan(invocation=[javaFunc(pyFunc($cor0.c))], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f00 AS f0])
++- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+   :- FlinkLogicalCalc(select=[a, b, c, pyFunc(f0) AS f0])
+   :  +- FlinkLogicalCalc(select=[a, b, c, $cor0.c AS f0])
+   :     +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- FlinkLogicalTableFunctionScan(invocation=[javaFunc($3)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testPythonTableFunctionWithJavaFunc">
     <Resource name="sql">
       <![CDATA[SELECT a, b, c, x, y FROM MyTable, LATERAL TABLE(func(a * a, pyFunc(b, c))) AS T(x, y)]]>
@@ -30,34 +53,57 @@ LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3], y=[$4])
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-FlinkLogicalCalc(select=[a, b, c, f00 AS f0, f1])
+FlinkLogicalCalc(select=[a, b, c, f00 AS f0, f10 AS f1])
 +- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 2}])
-   :- FlinkLogicalCalc(select=[a, b, c, *($cor0.a, $cor0.a) AS f0])
+   :- FlinkLogicalCalc(select=[a, b, c, *($cor0.a, $cor0.a) AS f0, $cor0.b AS f1, $cor0.c AS f2])
    :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-   +- FlinkLogicalTableFunctionScan(invocation=[func($3, pyFunc($cor0.b, $cor0.c))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+   +- FlinkLogicalTableFunctionScan(invocation=[func($3, pyFunc($4, $5))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJavaTableFunctionWithPythonCalc">
-	<Resource name="sql">
-		<![CDATA[SELECT a, b, c, x FROM MyTable, LATERAL TABLE(javaFunc(pyFunc(c))) AS T(x)]]>
-	</Resource>
-	<Resource name="planBefore">
-	  <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], x=[$3])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
-   +- LogicalTableFunctionScan(invocation=[javaFunc(pyFunc($cor0.c))], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+  <TestCase name="testJavaTableFunctionWithPythonCalcCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, x FROM MyTable, LATERAL TABLE(javaFunc(pyFunc(d._1))) AS T(x)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], x=[$4])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+   +- LogicalTableFunctionScan(invocation=[javaFunc(pyFunc($cor0.d._1))], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
 ]]>
-	</Resource>
-	<Resource name="planAfter">
-	  <![CDATA[
-FlinkLogicalCalc(select=[a, b, c, f00 AS f0])
-+- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
-   :- FlinkLogicalCalc(select=[a, b, c, pyFunc($cor0.c) AS f0])
-   :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
-   +- FlinkLogicalTableFunctionScan(invocation=[javaFunc($3)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f00 AS x])
++- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{3}])
+   :- FlinkLogicalCalc(select=[a, b, c, d, pyFunc(f0) AS f0])
+   :  +- FlinkLogicalCalc(select=[a, b, c, d, $cor0.d._1 AS f0])
+   :     +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+   +- FlinkLogicalTableFunctionScan(invocation=[javaFunc($4)], rowType=[RecordType(VARCHAR(2147483647) f0)], elementType=[class [Ljava.lang.Object;])
 ]]>
-	</Resource>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPythonTableFunctionWithCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, x, y FROM MyTable, LATERAL TABLE(func(d._1 * a, pyFunc(d._2, c))) AS T(x, y)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], x=[$4], y=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+   +- LogicalTableFunctionScan(invocation=[func(*($cor0.d._1, $cor0.a), pyFunc($cor0.d._2, $cor0.c))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f00 AS x, f10 AS y])
++- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- FlinkLogicalCalc(select=[a, b, c, d, *($cor0.d._1, $cor0.a) AS f0, $cor0.d._2 AS f1, $cor0.c AS f2])
+   :  +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+   +- FlinkLogicalTableFunctionScan(invocation=[func($4, pyFunc($5, $6))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -53,7 +53,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
         .build())
     util.replaceBatchProgram(programs)
 
-    util.addTableSource[(Int, Int, Int)]("MyTable", 'a, 'b, 'c)
+    util.addTableSource[(Int, Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c, 'd)
     util.addFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
     util.addFunction("pyFunc2", new PythonScalarFunction("pyFunc2"))
     util.addFunction("pyFunc3", new PythonScalarFunction("pyFunc3"))
@@ -176,6 +176,24 @@ class PythonCalcSplitRuleTest extends TableTestBase {
   @Test
   def testPandasFunctionNotChainingWithGeneralPythonFunction(): Unit = {
     val sqlQuery = "SELECT pyFunc1(a, pandasFunc1(a, b)) + 1 FROM MyTable"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testPythonFunctionWithCompositeInputs(): Unit = {
+    val sqlQuery = "SELECT a, pyFunc1(b, d._1) FROM MyTable"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testChainingPythonFunctionWithCompositeInputs(): Unit = {
+    val sqlQuery = "SELECT a, pyFunc1(b, pyFunc1(c, d._1)) FROM MyTable"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testPandasFunctionWithCompositeInputs(): Unit = {
+    val sqlQuery = "SELECT a, pandasFunc1(b, d._1) FROM MyTable"
     util.verifyPlan(sqlQuery)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
@@ -71,4 +71,20 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
       "LATERAL TABLE(javaFunc(pyFunc(c))) AS T(x)"
     util.verifyPlan(sqlQuery)
   }
+
+  @Test
+  def testPythonTableFunctionWithCompositeInputs(): Unit = {
+    util.addTableSource[(Int, Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c, 'd)
+    val sqlQuery = "SELECT a, b, c, x, y FROM MyTable, " +
+      "LATERAL TABLE(func(d._1 * a, pyFunc(d._2, c))) AS T(x, y)"
+    util.verifyPlan(sqlQuery)
+  }
+
+  @Test
+  def testJavaTableFunctionWithPythonCalcCompositeInputs(): Unit = {
+    util.addTableSource[(Int, Int, String, (String, String))]("MyTable", 'a, 'b, 'c, 'd)
+    val sqlQuery = "SELECT a, b, c, x FROM MyTable, " +
+      "LATERAL TABLE(javaFunc(pyFunc(d._1))) AS T(x)"
+    util.verifyPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/plan/rules/logical/PythonCorrelateSplitRule.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexProgram;
 import org.apache.calcite.rex.RexProgramBuilder;
+import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 
 import java.util.LinkedList;
@@ -102,22 +103,9 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 		if (rexNode instanceof RexCall) {
 			return PythonUtil.isPythonCall(rexNode, null) && PythonUtil.containsNonPythonCall(rexNode)
 				|| PythonUtil.isNonPythonCall(rexNode) && PythonUtil.containsPythonCall(rexNode, null)
-				|| (PythonUtil.isPythonCall(rexNode, null) && containsFieldAccessInputs(rexNode));
+				|| (PythonUtil.isPythonCall(rexNode, null) && RexUtil.containsFieldAccess(rexNode));
 		}
 		return false;
-	}
-
-	private boolean containsFieldAccessInputs(RexNode node) {
-		if (node instanceof RexCall) {
-			for (RexNode operand : ((RexCall) node).getOperands()) {
-				if (containsFieldAccessInputs(operand)) {
-					return true;
-				}
-			}
-			return false;
-		} else {
-			return node instanceof RexFieldAccess;
-		}
 	}
 
 	private List<String> createNewFieldNames(
@@ -217,10 +205,13 @@ public class PythonCorrelateSplitRule extends RelOptRule {
 			extractedRexNodes,
 			node -> {
 				if (PythonUtil.isNonPythonCall(tableFunctionNode)) {
+					// splits the RexCalls which contain Python functions into separate node
 					return PythonUtil.isPythonCall(node, null);
 				} else if (PythonUtil.containsNonPythonCall(node)) {
+					// splits the RexCalls which contain non-Python functions into separate node
 					return PythonUtil.isNonPythonCall(node);
 				} else {
+					// splits the RexFieldAccesses which contain non-Python functions into separate node
 					return node instanceof RexFieldAccess;
 				}
 			}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonCorrelate.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.plan.nodes
 
 import org.apache.calcite.rel.core.JoinRelType
-import org.apache.calcite.rex.{RexCall, RexFieldAccess, RexInputRef, RexNode}
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator
 import org.apache.flink.table.functions.python.PythonFunctionInfo
@@ -60,10 +60,7 @@ trait CommonPythonCorrelate extends CommonPythonBase {
     val pythonTableFunctionInfo = createPythonFunctionInfo(pythonRexCall, inputNodes)
     val udtfInputOffsets = inputNodes.toArray
       .map(_._1)
-      .collect {
-        case inputRef: RexInputRef => inputRef.getIndex
-        case fac: RexFieldAccess => fac.getField.getIndex
-      }
+      .collect { case inputRef: RexInputRef => inputRef.getIndex }
     (udtfInputOffsets, pythonTableFunctionInfo)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -165,6 +165,7 @@ object FlinkRuleSets {
     PythonCalcSplitRule.SPLIT_CONDITION,
     PythonCalcSplitRule.SPLIT_PROJECT,
     PythonCalcSplitRule.SPLIT_PANDAS_IN_PROJECT,
+    PythonCalcSplitRule.EXPAND_PROJECT,
     PythonCalcSplitRule.PUSH_CONDITION,
     PythonCalcSplitRule.REWRITE_PROJECT
   )

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/logical/PythonCalcSplitRule.scala
@@ -22,7 +22,7 @@ import java.util.function.Function
 
 import org.apache.calcite.plan.RelOptRule.{any, operand}
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
-import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode, RexProgram}
+import org.apache.calcite.rex.{RexBuilder, RexCall, RexFieldAccess, RexInputRef, RexNode, RexProgram}
 import org.apache.calcite.sql.validate.SqlValidatorUtil
 import org.apache.flink.table.functions.ScalarFunction
 import org.apache.flink.table.functions.python.PythonFunctionKind
@@ -49,14 +49,14 @@ abstract class PythonCalcSplitRuleBase(description: String)
     val input = calc.getInput
     val rexBuilder = call.builder().getRexBuilder
     val program = calc.getProgram
-    val extractedRexCalls = new mutable.ArrayBuffer[RexCall]()
+    val extractedRexNodes = new mutable.ArrayBuffer[RexNode]()
 
     val extractedFunctionOffset = input.getRowType.getFieldCount
     val splitter = new ScalarFunctionSplitter(
       extractedFunctionOffset,
-      extractedRexCalls,
-      new Function[RexCall, Boolean] {
-        override def apply(rexCall: RexCall): Boolean = needConvertRexCall(program, rexCall)
+      extractedRexNodes,
+      new Function[RexNode, Boolean] {
+        override def apply(node: RexNode): Boolean = needConvert(program, node)
       })
 
     val (bottomCalcCondition, topCalcCondition, topCalcProjects) = split(program, splitter)
@@ -64,10 +64,10 @@ abstract class PythonCalcSplitRuleBase(description: String)
       topCalcProjects, topCalcCondition, extractedFunctionOffset)
 
     val bottomCalcProjects =
-      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexCalls
+      accessedFields.map(RexInputRef.of(_, input.getRowType)) ++ extractedRexNodes
     val bottomCalcFieldNames = SqlValidatorUtil.uniquify(
       accessedFields.map(i => input.getRowType.getFieldNames.get(i)).toSeq ++
-        extractedRexCalls.indices.map("f" + _),
+        extractedRexNodes.indices.map("f" + _),
       rexBuilder.getTypeFactory.getTypeSystem.isSchemaCaseSensitive)
 
     val bottomCalc = new FlinkLogicalCalc(
@@ -81,7 +81,8 @@ abstract class PythonCalcSplitRuleBase(description: String)
         bottomCalcFieldNames,
         rexBuilder))
 
-    val inputRewriter = new ExtractedFunctionInputRewriter(extractedFunctionOffset, accessedFields)
+    val inputRewriter = new ExtractedFunctionInputRewriter(
+      calc.getCluster.getRexBuilder, extractedFunctionOffset, accessedFields)
     val topCalc = new FlinkLogicalCalc(
       calc.getCluster,
       calc.getTraitSet,
@@ -117,9 +118,9 @@ abstract class PythonCalcSplitRuleBase(description: String)
   }
 
   /**
-    * Returns true if need to convert the specified call.
+    * Returns true if need to convert the specified node.
     */
-  def needConvertRexCall(program: RexProgram, call: RexCall): Boolean
+  def needConvert(program: RexProgram, node: RexNode): Boolean
 
   /**
     * Splits the specified [[RexProgram]] using the specified [[ScalarFunctionSplitter]].
@@ -146,7 +147,7 @@ object PythonCalcSplitConditionRule extends PythonCalcSplitRuleBase(
       .map(calc.getProgram.expandLocalRef).exists(containsPythonCall(_))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -181,8 +182,8 @@ object PythonCalcSplitProjectionRule extends PythonCalcSplitProjectionRuleBase(
     projects.exists(containsPythonCall(_)) && projects.exists(containsNonPythonCall)
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
-    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = {
+    program.getProjectList.map(program.expandLocalRef).exists(isNonPythonCall) == isPythonCall(node)
   }
 }
 
@@ -205,9 +206,40 @@ object PythonCalcSplitPandasInProjectionRule extends PythonCalcSplitProjectionRu
       projects.exists(containsPythonCall(_, PythonFunctionKind.PANDAS))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = {
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = {
      program.getProjectList.map(program.expandLocalRef).exists(
-       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(call, PythonFunctionKind.PANDAS)
+       isPythonCall(_, PythonFunctionKind.GENERAL)) == isPythonCall(node, PythonFunctionKind.PANDAS)
+  }
+}
+
+/**
+  * Rule that expands the RexFieldAccess inputs of Python functions contained in
+  * the projection of [[FlinkLogicalCalc]]s.
+  */
+object PythonCalcExpandProjectRule extends PythonCalcSplitRuleBase(
+  "PythonCalcExpandProjectRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val calc: FlinkLogicalCalc = call.rel(0).asInstanceOf[FlinkLogicalCalc]
+    val projects = calc.getProgram.getProjectList.map(calc.getProgram.expandLocalRef)
+
+    projects.exists(containsPythonCall(_)) && projects.exists(containsFieldAccessInputs)
+  }
+
+  override def needConvert(program: RexProgram, node: RexNode): Boolean =
+    node.isInstanceOf[RexFieldAccess]
+
+  override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
+      : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
+    (None, None, program.getProjectList.map(program.expandLocalRef(_).accept(splitter)))
+  }
+
+  private def containsFieldAccessInputs(node: RexNode): Boolean = {
+    node match {
+      case call: RexCall => call.getOperands.exists(containsFieldAccessInputs)
+      case _: RexFieldAccess => true
+      case _ => false
+    }
   }
 }
 
@@ -228,8 +260,7 @@ object PythonCalcPushConditionRule extends PythonCalcSplitRuleBase(
     calc.getProgram.getCondition != null && projects.exists(containsPythonCall(_))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean =
-    isNonPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isNonPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -262,7 +293,7 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
           projects.lastIndexWhere(_.isInstanceOf[RexInputRef]))
   }
 
-  override def needConvertRexCall(program: RexProgram, call: RexCall): Boolean = isPythonCall(call)
+  override def needConvert(program: RexProgram, node: RexNode): Boolean = isPythonCall(node)
 
   override def split(program: RexProgram, splitter: ScalarFunctionSplitter)
       : (Option[RexNode], Option[RexNode], Seq[RexNode]) = {
@@ -272,25 +303,33 @@ object PythonCalcRewriteProjectionRule extends PythonCalcSplitRuleBase(
 
 private class ScalarFunctionSplitter(
     extractedFunctionOffset: Int,
-    extractedRexCalls: mutable.ArrayBuffer[RexCall],
-    needConvertRexCall: Function[RexCall, Boolean])
+    extractedRexNodes: mutable.ArrayBuffer[RexNode],
+    needConvert: Function[RexNode, Boolean])
   extends RexDefaultVisitor[RexNode] {
 
   override def visitCall(call: RexCall): RexNode = {
-    visit(needConvertRexCall(call), call)
+    if (needConvert(call)) {
+      getExtractedRexNode(call)
+    } else {
+      call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
+    }
+  }
+
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    if (needConvert(fieldAccess)) {
+      getExtractedRexNode(fieldAccess)
+    } else {
+      fieldAccess
+    }
   }
 
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 
-  private def visit(needConvert: Boolean, call: RexCall): RexNode = {
-    if (needConvert) {
-      val newNode = new RexInputRef(
-        extractedFunctionOffset + extractedRexCalls.length, call.getType)
-      extractedRexCalls.append(call)
-      newNode
-    } else {
-      call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
-    }
+  private def getExtractedRexNode(node: RexNode): RexNode = {
+    val newNode = new RexInputRef(
+      extractedFunctionOffset + extractedRexNodes.length, node.getType)
+    extractedRexNodes.append(node)
+    newNode
   }
 }
 
@@ -300,10 +339,12 @@ private class ScalarFunctionSplitter(
   *    extracted function.
   * 2) Fields of index less than extractedFunctionOffset refer to the original input field.
   *
+  * @param rexBuilder the RexBuilder
   * @param extractedFunctionOffset the original start offset of the extracted functions
   * @param accessedFields the accessed fields which will be forwarded
   */
 private class ExtractedFunctionInputRewriter(
+    rexBuilder: RexBuilder,
     extractedFunctionOffset: Int,
     accessedFields: Array[Int])
   extends RexDefaultVisitor[RexNode] {
@@ -328,17 +369,25 @@ private class ExtractedFunctionInputRewriter(
     call.clone(call.getType, call.getOperands.asScala.map(_.accept(this)))
   }
 
+  override def visitFieldAccess(fieldAccess: RexFieldAccess): RexNode = {
+    rexBuilder.makeFieldAccess(
+      fieldAccess.getReferenceExpr.accept(this),
+      fieldAccess.getField.getIndex)
+  }
+
   override def visitNode(rexNode: RexNode): RexNode = rexNode
 }
 
 object PythonCalcSplitRule {
   /**
     * These rules should be applied sequentially in the order of
-    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, PUSH_CONDITION and REWRITE_PROJECT.
+    * SPLIT_CONDITION, SPLIT_PROJECT, SPLIT_PANDAS_IN_PROJECT, EXPAND_PROJECT, PUSH_CONDITION
+    * and REWRITE_PROJECT.
     */
   val SPLIT_CONDITION: RelOptRule = PythonCalcSplitConditionRule
   val SPLIT_PROJECT: RelOptRule = PythonCalcSplitProjectionRule
   val SPLIT_PANDAS_IN_PROJECT: RelOptRule = PythonCalcSplitPandasInProjectionRule
+  val EXPAND_PROJECT: RelOptRule = PythonCalcExpandProjectRule
   val PUSH_CONDITION: RelOptRule = PythonCalcPushConditionRule
   val REWRITE_PROJECT: RelOptRule = PythonCalcRewriteProjectionRule
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -484,4 +484,77 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
     util.verifyTable(resultTable, expected)
   }
+
+  @Test
+  def testPythonFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten()).select("a, pyFunc1(a, c$_1), b")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a", "b", "c._1 AS f0")
+        ),
+        term("select", "a", "b", "pyFunc1(a, f0) AS f0")
+      ),
+      term("select", "a", "f0 AS _c1", "b")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testChainingPythonFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten())
+      .select("a, pyFunc1(a, pyFunc1(b, c$_1)), b")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCalc",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a", "b", "c._1 AS f0")
+        ),
+        term("select", "a", "b", "pyFunc1(a, pyFunc1(b, f0)) AS f0")
+      ),
+      term("select", "a", "f0 AS _c1", "b")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testPandasFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c)
+    util.tableEnv.registerFunction("pandasFunc1", new PandasScalarFunction("pandasFunc1"))
+
+    val resultTable = table.select('a, 'b, 'c.flatten())
+      .select("pandasFunc1(a, c$_1)")
+
+    val expected = unaryNode(
+      "DataStreamPythonCalc",
+      unaryNode(
+        "DataStreamCalc",
+        streamTableNode(table),
+        term("select", "a", "c._1 AS f0")
+      ),
+      term("select", "pandasFunc1(a, f0) AS _c0")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCorrelateSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCorrelateSplitRuleTest.scala
@@ -91,4 +91,79 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
 
     util.verifyTable(result, expected)
   }
+
+  @Test
+  def testPythonTableFunctionWithCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, Int, (Int, Int))]("MyTable", 'a, 'b, 'c, 'd)
+    val tableFunc = new MockPythonTableFunction
+    util.addFunction("tableFunc", tableFunc)
+
+    val pyFunc = new PythonScalarFunction("pyFunc")
+    util.addFunction("pyFunc", pyFunc)
+    val resultTable = table.select('a, 'b, 'c, 'd.flatten())
+      .joinLateral("tableFunc(a * d$_1, pyFunc(d$_2, c))")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamPythonCorrelate",
+        unaryNode(
+          "DataStreamCalc",
+          streamTableNode(table),
+          term("select", "a", "b", "c", "d._1 AS d$_1", "d._2 AS d$_2", "*(a, d._1) AS f0")
+        ),
+        term("invocation",
+          s"${tableFunc.functionIdentifier()}($$5, " +
+            s"${pyFunc.functionIdentifier()}($$4, $$2))"),
+        term("correlate", s"table(${tableFunc.getClass.getSimpleName}(f0, " +
+          s"pyFunc(d$$_2, c)))"),
+        term("select", "a, b, c, d$_1, d$_2, f0, f00, f1"),
+        term("rowType","RecordType(INTEGER a, INTEGER b, INTEGER c, INTEGER d$_1, " +
+          "INTEGER d$_2, INTEGER f0, INTEGER f00, INTEGER f1)"),
+        term("joinType", "INNER")
+      ),
+      term("select", "a", "b", "c", "d$_1", "d$_2", "f00 AS f0", "f1")
+    )
+
+    util.verifyTable(resultTable, expected)
+  }
+
+  @Test
+  def testJavaTableFunctionWithPythonCalcCompositeInputs(): Unit = {
+    val util = streamTestUtil()
+    val table = util.addTable[(Int, Int, String, (String, String))]("MyTable", 'a, 'b, 'c, 'd)
+    val tableFunc = new TableFunc1
+    util.addFunction("tableFunc", tableFunc)
+
+    val pyFunc = new PythonScalarFunction("pyFunc")
+    util.addFunction("pyFunc", pyFunc)
+    val result = table.select('a, 'b, 'c, 'd.flatten())
+      .joinLateral("tableFunc(pyFunc(d$_1))")
+
+    val expected = unaryNode(
+      "DataStreamCalc",
+      unaryNode(
+        "DataStreamCorrelate",
+        unaryNode(
+          "DataStreamPythonCalc",
+          unaryNode(
+            "DataStreamCalc",
+            streamTableNode(table),
+            term("select", "a", "b", "c", "d._1 AS f0", "d._2 AS f1", "d._1 AS f2")),
+          term("select", "a", "b", "c", "f0 AS d$_1", "f1 AS d$_2", "pyFunc(f2) AS f0")),
+        term("invocation",
+          s"${tableFunc.functionIdentifier}($$5)"),
+        term("correlate", s"table(TableFunc1(f0))"),
+        term("select", "a", "b", "c", "d$_1", "d$_2", "f0", "f00"),
+        term("rowType",
+          "RecordType(INTEGER a, INTEGER b, VARCHAR(65536) c, VARCHAR(65536) d$_1, " +
+            "VARCHAR(65536) d$_2, VARCHAR(65536) f0, VARCHAR(65536) f00)"),
+        term("joinType", "INNER")
+      ),
+      term("select", "a", "b", "c", "d$_1", "d$_2", "f00 AS f0")
+    )
+
+    util.verifyTable(result, expected)
+  }
 }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request fix Python UDF to make it work with inputs from composite field*


## Brief change log

  - *Add PythonCalcExpandProjectRule to fix the Python UDFs contained in the Calc*
  - *Updates PythonCorrelateSplitRule to fix the Python UDFs contained in the Correlate*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests testPythonFunctionWithCompositeInputs, testChainingPythonFunctionWithCompositeInputs and testPandasFunctionWithCompositeInputs in PythonCalcSplitRuleTest*
  - *Added tests in testPythonTableFunctionWithCompositeInputs and testJavaTableFunctionWithPythonCalcCompositeInputs in PythonCorrelateSplitRuleTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
