### PR TITLE
[FLINK-17124][python] Fix The PyFlink Job runs into infinite loop if the UDF file imports job code.

### DIFF
--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -34,6 +34,14 @@ _gateway = None
 _lock = RLock()
 
 
+def is_launch_java_gateway_disabled():
+    if "PYFLINK_GATEWAY_DISABLED" in os.environ \
+            and os.environ["PYFLINK_GATEWAY_DISABLED"].lower() not in ["0", "false", ""]:
+        return True
+    else:
+        return False
+
+
 def get_gateway():
     # type: () -> JavaGateway
     global _gateway
@@ -59,7 +67,10 @@ def launch_gateway():
     """
     launch jvm gateway
     """
-
+    if is_launch_java_gateway_disabled():
+        raise Exception("Launching java gateway is disabled in current environment. "
+                        "This exception is usually caused by the job code is executed "
+                        "unexpectedly in UDF worker.")
     FLINK_HOME = _find_flink_home()
     # TODO windows support
     on_windows = platform.system() == "Windows"

--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -34,7 +34,7 @@ _gateway = None
 _lock = RLock()
 
 
-def is_launch_java_gateway_disabled():
+def is_launch_gateway_disabled():
     if "PYFLINK_GATEWAY_DISABLED" in os.environ \
             and os.environ["PYFLINK_GATEWAY_DISABLED"].lower() not in ["0", "false", ""]:
         return True
@@ -67,10 +67,11 @@ def launch_gateway():
     """
     launch jvm gateway
     """
-    if is_launch_java_gateway_disabled():
-        raise Exception("Launching java gateway is disabled in current environment. "
-                        "This exception is usually caused by the job code is executed "
-                        "unexpectedly in UDF worker.")
+    if is_launch_gateway_disabled():
+        raise Exception("It's launching the PythonGatewayServer during Python UDF execution "
+                        "which is unexpected. It usually occurs in the cases that the job codes are"
+                        "in the top level of the Python script file and are not enclosed in a "
+                        "if name == 'main' statement.")
     FLINK_HOME = _find_flink_home()
     # TODO windows support
     on_windows = platform.system() == "Windows"

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -202,9 +202,8 @@ class BlinkStreamDependencyTests(DependencyTests, PyFlinkBlinkStreamTableTestCas
                 from pyflink.java_gateway import get_gateway
                 get_gateway()
             except Exception as e:
-                assert str(e) == "Launching java gateway is disabled in current environment. " \
-                                 "This exception is usually caused by the job code is executed " \
-                                 "unexpectedly in UDF worker."
+                assert str(e).startswith("It's launching the PythonGatewayServer during Python UDF"
+                                         " execution which is unexpected.")
             else:
                 raise Exception("The gateway server is not disabled!")
             return i

--- a/flink-python/pyflink/table/tests/test_dependency.py
+++ b/flink-python/pyflink/table/tests/test_dependency.py
@@ -178,7 +178,7 @@ class BlinkStreamDependencyTests(DependencyTests, PyFlinkBlinkStreamTableTestCas
         actual = source_sink_utils.results()
         self.assert_equals(actual, ["3,1", "4,2", "5,3"])
 
-    def test_set_python_exec(self):
+    def test_set_environment(self):
         if getattr(os, "symlink", None) is None:
             self.skipTest("Symbolic link is not supported, skip testing 'test_set_python_exec'...")
 
@@ -196,11 +196,28 @@ class BlinkStreamDependencyTests(DependencyTests, PyFlinkBlinkStreamTableTestCas
         self.t_env.register_function("check_python_exec",
                                      udf(check_python_exec, DataTypes.BIGINT(),
                                          DataTypes.BIGINT()))
+
+        def check_pyflink_gateway_disabled(i):
+            try:
+                from pyflink.java_gateway import get_gateway
+                get_gateway()
+            except Exception as e:
+                assert str(e) == "Launching java gateway is disabled in current environment. " \
+                                 "This exception is usually caused by the job code is executed " \
+                                 "unexpectedly in UDF worker."
+            else:
+                raise Exception("The gateway server is not disabled!")
+            return i
+
+        self.t_env.register_function("check_pyflink_gateway_disabled",
+                                     udf(check_pyflink_gateway_disabled, DataTypes.BIGINT(),
+                                         DataTypes.BIGINT()))
+
         table_sink = source_sink_utils.TestAppendSink(
             ['a', 'b'], [DataTypes.BIGINT(), DataTypes.BIGINT()])
         self.t_env.register_table_sink("Results", table_sink)
         t = self.t_env.from_elements([(1, 2), (2, 5), (3, 1)], ['a', 'b'])
-        t.select("check_python_exec(a), a").insert_into("Results")
+        t.select("check_python_exec(a), check_pyflink_gateway_disabled(a)").insert_into("Results")
         self.t_env.execute("test")
 
         actual = source_sink_utils.results()

--- a/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
@@ -194,7 +194,8 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 
 		// disable the launching of gateway server to prevent from this dead loop:
 		// launch UDF worker -> import udf -> import job code
-		//        ^                                    | (If the job code is executed unexpectedly)
+		//        ^                                    | (If the job code is not enclosed in a
+		//        									   |  if name == 'main' statement)
 		//        |                                    V
 		// execute job in local mode <- launch gateway server and submit job to local executor
 		env.put(PYFLINK_GATEWAY_DISABLED, "true");

--- a/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/ProcessPythonEnvironmentManager.java
@@ -61,6 +61,8 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 	private static final Logger LOG = LoggerFactory.getLogger(ProcessPythonEnvironmentManager.class);
 
 	@VisibleForTesting
+	static final String PYFLINK_GATEWAY_DISABLED = "PYFLINK_GATEWAY_DISABLED";
+	@VisibleForTesting
 	public static final String PYTHON_REQUIREMENTS_FILE = "_PYTHON_REQUIREMENTS_FILE";
 	@VisibleForTesting
 	public static final String PYTHON_REQUIREMENTS_CACHE = "_PYTHON_REQUIREMENTS_CACHE";
@@ -189,6 +191,13 @@ public final class ProcessPythonEnvironmentManager implements PythonEnvironmentM
 
 		// set BOOT_LOG_DIR.
 		env.put("BOOT_LOG_DIR", baseDirectory);
+
+		// disable the launching of gateway server to prevent from this dead loop:
+		// launch UDF worker -> import udf -> import job code
+		//        ^                                    | (If the job code is executed unexpectedly)
+		//        |                                    V
+		// execute job in local mode <- launch gateway server and submit job to local executor
+		env.put(PYFLINK_GATEWAY_DISABLED, "true");
 
 		// set the path of python interpreter, it will be used to execute the udf worker.
 		env.put("python", dependencyInfo.getPythonExec());

--- a/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/ProcessPythonEnvironmentManagerTest.java
@@ -42,6 +42,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYFLINK_GATEWAY_DISABLED;
 import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_ARCHIVES_DIR;
 import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_FILES_DIR;
 import static org.apache.flink.python.env.ProcessPythonEnvironmentManager.PYTHON_REQUIREMENTS_CACHE;
@@ -379,6 +380,7 @@ public class ProcessPythonEnvironmentManagerTest {
 		String tmpBase = environmentManager.getBaseDirectory();
 		map.put("python", "python");
 		map.put("BOOT_LOG_DIR", tmpBase);
+		map.put(PYFLINK_GATEWAY_DISABLED, "true");
 		return map;
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

  - *disable the launching of gateway server to prevent from dead loop in ProcessPythonEnvironmentManager*

## Verifying this change

  - *test_set_environment*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
