### PR TITLE
[FLINK-14652] Refactor notifyCheckpointComplete to SubtaskCheckpointCoordinator

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestTaskStateManager.java
@@ -46,6 +46,7 @@ import java.util.Map;
 public class TestTaskStateManager implements TaskStateManager {
 
 	private long reportedCheckpointId;
+	private long notifiedCompletedCheckpointId;
 
 	private JobID jobId;
 	private ExecutionAttemptID executionAttemptID;
@@ -86,6 +87,7 @@ public class TestTaskStateManager implements TaskStateManager {
 		this.jobManagerTaskStateSnapshotsByCheckpointId = new HashMap<>();
 		this.taskManagerTaskStateSnapshotsByCheckpointId = new HashMap<>();
 		this.reportedCheckpointId = -1L;
+		this.notifiedCompletedCheckpointId = -1L;
 	}
 
 	@Override
@@ -170,7 +172,7 @@ public class TestTaskStateManager implements TaskStateManager {
 
 	@Override
 	public void notifyCheckpointComplete(long checkpointId) throws Exception {
-
+		this.notifiedCompletedCheckpointId = checkpointId;
 	}
 
 	public JobID getJobId() {
@@ -219,6 +221,10 @@ public class TestTaskStateManager implements TaskStateManager {
 
 	public long getReportedCheckpointId() {
 		return reportedCheckpointId;
+	}
+
+	public long getNotifiedCompletedCheckpointId() {
+		return notifiedCompletedCheckpointId;
 	}
 
 	public void setReportedCheckpointId(long reportedCheckpointId) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -868,7 +868,6 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 	private void notifyCheckpointComplete(long checkpointId) {
 		try {
 			subtaskCheckpointCoordinator.notifyCheckpointComplete(checkpointId, operatorChain, this::isRunning);
-			getEnvironment().getTaskStateManager().notifyCheckpointComplete(checkpointId);
 			if (isRunning && isSynchronousSavepointId(checkpointId)) {
 				finishTask();
 				// Reset to "notify" the internal synchronous savepoint mailbox loop.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -867,18 +867,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 	private void notifyCheckpointComplete(long checkpointId) {
 		try {
-			boolean isRunning = this.isRunning;
-			if (isRunning) {
-				LOG.debug("Notification of complete checkpoint for task {}", getName());
-
-				for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
-					operatorWrapper.getStreamOperator().notifyCheckpointComplete(checkpointId);
-				}
-			} else {
-				LOG.debug("Ignoring notification of complete checkpoint for not-running task {}", getName());
-			}
-
-			subtaskCheckpointCoordinator.getChannelStateWriter().notifyCheckpointComplete(checkpointId);
+			subtaskCheckpointCoordinator.notifyCheckpointComplete(checkpointId, operatorChain, this::isRunning);
 			getEnvironment().getTaskStateManager().notifyCheckpointComplete(checkpointId);
 			if (isRunning && isSynchronousSavepointId(checkpointId)) {
 				finishTask();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinator.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
  * <ol>
  * <li>build a snapshot (invokable)</li>
  * <li>report snapshot to the JobManager</li>
+ * <li>action upon checkpoint notification</li>
  * <li>maintain storage locations</li>
  * </ol>
  */
@@ -52,4 +53,16 @@ interface SubtaskCheckpointCoordinator extends Closeable {
 		CheckpointMetrics checkpointMetrics,
 		OperatorChain<?, ?> operatorChain,
 		Supplier<Boolean> isCanceled) throws Exception;
+
+	/**
+	 * Notified on the task side once a distributed checkpoint has been completed.
+	 *
+	 * @param checkpointId The checkpoint id to notify as been completed.
+	 * @param operatorChain The chain of operators executed by the task.
+	 * @param isRunning Whether the task is running.
+	 */
+	void notifyCheckpointComplete(
+		long checkpointId,
+		OperatorChain<?, ?> operatorChain,
+		Supplier<Boolean> isRunning) throws Exception;
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -179,6 +179,7 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 		} else {
 			LOG.debug("Ignoring notification of complete checkpoint for not-running task {}", taskName);
 		}
+		channelStateWriter.notifyCheckpointComplete(checkpointId);
 		env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorImpl.java
@@ -168,6 +168,20 @@ class SubtaskCheckpointCoordinatorImpl implements SubtaskCheckpointCoordinator {
 		}
 	}
 
+	@Override
+	public void notifyCheckpointComplete(long checkpointId, OperatorChain<?, ?> operatorChain, Supplier<Boolean> isRunning) throws Exception {
+		if (isRunning.get()) {
+			LOG.debug("Notification of complete checkpoint for task {}", taskName);
+
+			for (StreamOperatorWrapper<?, ?> operatorWrapper : operatorChain.getAllOperators(true)) {
+				operatorWrapper.getStreamOperator().notifyCheckpointComplete(checkpointId);
+			}
+		} else {
+			LOG.debug("Ignoring notification of complete checkpoint for not-running task {}", taskName);
+		}
+		env.getTaskStateManager().notifyCheckpointComplete(checkpointId);
+	}
+
 	private void cleanup(
 			Map<OperatorID, OperatorSnapshotFutures> operatorSnapshotsInProgress,
 			CheckpointMetaData metadata,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.core.fs.CloseableRegistry;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
+import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorage;
+import org.apache.flink.util.function.BiFunctionWithException;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor.IMMEDIATE;
+
+/**
+ * A mock builder to build {@link SubtaskCheckpointCoordinator}.
+ */
+public class MockSubtaskCheckpointCoordinatorBuilder {
+	private String taskName = "mock-task";
+	private CheckpointStorageWorkerView checkpointStorage;
+	private Environment environment;
+	private AsyncExceptionHandler asyncExceptionHandler;
+	private StreamTaskActionExecutor actionExecutor = IMMEDIATE;
+	private CloseableRegistry closeableRegistry = new CloseableRegistry();
+	private ExecutorService executorService = Executors.newDirectExecutorService();
+	private BiFunctionWithException<ChannelStateWriter, Long, CompletableFuture<Void>, IOException> prepareInputSnapshot = (channelStateWriter, aLong) -> FutureUtils.completedVoidFuture();
+
+	public MockSubtaskCheckpointCoordinatorBuilder setEnvironment(Environment environment) {
+		this.environment = environment;
+		return this;
+	}
+
+	SubtaskCheckpointCoordinator build() throws IOException {
+		if (environment == null) {
+			this.environment = MockEnvironment.builder().build();
+		}
+		if (checkpointStorage == null) {
+			this.checkpointStorage = new MemoryBackendCheckpointStorage(environment.getJobID(), null, null, 1024);
+		}
+		if (asyncExceptionHandler == null) {
+			this.asyncExceptionHandler = new NonHandleAsyncException();
+		}
+
+		return new SubtaskCheckpointCoordinatorImpl(
+			checkpointStorage,
+			taskName,
+			actionExecutor,
+			closeableRegistry,
+			executorService,
+			environment,
+			asyncExceptionHandler,
+			false,
+			prepareInputSnapshot);
+	}
+
+	private static class NonHandleAsyncException implements AsyncExceptionHandler {
+
+		@Override
+		public void handleAsyncException(String message, Throwable exception) {
+			// do nothing.
+		}
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link SubtaskCheckpointCoordinator}.
+ */
+public class SubtaskCheckpointCoordinatorTest {
+
+	@Test
+	public void testNotifyCheckpointComplete() throws Exception {
+		TestTaskStateManager stateManager = new TestTaskStateManager();
+		MockEnvironment mockEnvironment = MockEnvironment.builder().setTaskStateManager(stateManager).build();
+		SubtaskCheckpointCoordinator subtaskCheckpointCoordinator = new MockSubtaskCheckpointCoordinatorBuilder()
+			.setEnvironment(mockEnvironment)
+			.build();
+
+		long checkpointId = 42L;
+		{
+			subtaskCheckpointCoordinator.notifyCheckpointComplete(checkpointId, mock(OperatorChain.class), () -> true);
+			assertEquals(checkpointId, stateManager.getNotifiedCompletedCheckpointId());
+		}
+
+		long newCheckpointId = checkpointId + 1;
+		{
+			subtaskCheckpointCoordinator.notifyCheckpointComplete(newCheckpointId, mock(OperatorChain.class), () -> false);
+			// even task is not running, state manager could still receive the notification.
+			assertEquals(newCheckpointId, stateManager.getNotifiedCompletedCheckpointId());
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

FLINK-14652 planed to focus on refactoring checkpoint related code into one place on task side  The `SubtaskCheckpointCoordinator` which introduced recently in FLINK-16744 actually already implement most of this work. This PR would introduce `notifyCheckpointComplete` to `SubtaskCheckpointCoordinator` to let that coordinator could coordinate more work on task side before we introduce `notifyCheckpointAborted`. 

## Brief change log

Introduce `notifyCheckpointComplete` to `SubtaskCheckpointCoordinator`.

## Verifying this change
This change added tests and can be verified as follows:

  - `SubtaskCheckpointCoordinatorTest#testNotifyCheckpointComplete` would verify the logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
