### PR TITLE
[FLINK-5763][state backends] Make savepoints self-contained and relocatable

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -90,7 +90,7 @@ public class EntropyInjector {
 	// ------------------------------------------------------------------------
 
 	@Nullable
-	private static EntropyInjectingFileSystem getEntropyFs(FileSystem fs) {
+	public static EntropyInjectingFileSystem getEntropyFs(FileSystem fs) {
 		if (fs instanceof EntropyInjectingFileSystem) {
 			return (EntropyInjectingFileSystem) fs;
 		}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointLoader.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointLoader.java
@@ -50,7 +50,7 @@ public final class SavepointLoader {
 			.resolveCheckpointPointer(savepointPath);
 
 		try (DataInputStream stream = new DataInputStream(location.getMetadataHandle().openInputStream())) {
-			return Checkpoints.loadCheckpointMetadata(stream, Thread.currentThread().getContextClassLoader());
+			return Checkpoints.loadCheckpointMetadata(stream, Thread.currentThread().getContextClassLoader(), savepointPath);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -93,7 +93,7 @@ public class Checkpoints {
 	//  Reading and validating checkpoint metadata
 	// ------------------------------------------------------------------------
 
-	public static CheckpointMetadata loadCheckpointMetadata(DataInputStream in, ClassLoader classLoader) throws IOException {
+	public static CheckpointMetadata loadCheckpointMetadata(DataInputStream in, ClassLoader classLoader, String externalPointer) throws IOException {
 		checkNotNull(in, "input stream");
 		checkNotNull(classLoader, "classLoader");
 
@@ -102,7 +102,7 @@ public class Checkpoints {
 		if (magicNumber == HEADER_MAGIC_NUMBER) {
 			final int version = in.readInt();
 			final MetadataSerializer serializer = MetadataSerializers.getSerializer(version);
-			return serializer.deserialize(in, classLoader);
+			return serializer.deserialize(in, classLoader, externalPointer);
 		}
 		else {
 			throw new IOException("Unexpected magic number. This can have multiple reasons: " +
@@ -131,7 +131,7 @@ public class Checkpoints {
 		final CheckpointMetadata checkpointMetadata;
 		try (InputStream in = metadataHandle.openInputStream()) {
 			DataInputStream dis = new DataInputStream(in);
-			checkpointMetadata = loadCheckpointMetadata(dis, classLoader);
+			checkpointMetadata = loadCheckpointMetadata(dis, classLoader, checkpointPointer);
 		}
 
 		// generate mapping from operator to task
@@ -234,7 +234,7 @@ public class Checkpoints {
 		try (InputStream in = metadataHandle.openInputStream();
 			DataInputStream dis = new DataInputStream(in)) {
 
-			metadata = loadCheckpointMetadata(dis, classLoader);
+			metadata = loadCheckpointMetadata(dis, classLoader, pointer);
 		}
 
 		Exception exception = null;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/ChannelStateHandleSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/ChannelStateHandleSerializer.java
@@ -88,6 +88,6 @@ class ChannelStateHandleSerializer {
 		for (int i = 0; i < offsetsSize; i++) {
 			offsets.add(dis.readLong());
 		}
-		return handleBuilder.apply(deserializeStreamStateHandle(dis), offsets, info);
+		return handleBuilder.apply(deserializeStreamStateHandle(dis, null), offsets, info);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataSerializer.java
@@ -36,8 +36,9 @@ public interface MetadataSerializer extends Versioned {
 	 *
 	 * @param dis Input stream to deserialize savepoint from
 	 * @param  userCodeClassLoader the user code class loader
+	 * @param externalPointer the external pointer of the given checkpoint
 	 * @return The deserialized savepoint
 	 * @throws IOException Serialization failures are forwarded
 	 */
-	CheckpointMetadata deserialize(DataInputStream dis, ClassLoader userCodeClassLoader) throws IOException;
+	CheckpointMetadata deserialize(DataInputStream dis, ClassLoader userCodeClassLoader, String externalPointer) throws IOException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV1Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV1Serializer.java
@@ -44,7 +44,7 @@ public class MetadataV1Serializer implements MetadataSerializer {
 	}
 
 	@Override
-	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader cl) throws IOException {
+	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader cl, String externalPointer) throws IOException {
 		throw new IOException("This savepoint / checkpoint version (Flink 1.1 / 1.2) is no longer supported.");
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV2Serializer.java
@@ -56,8 +56,8 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 	// ------------------------------------------------------------------------
 
 	@Override
-	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader) throws IOException {
-		return deserializeMetadata(dis);
+	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader, String externalPointer) throws IOException {
+		return deserializeMetadata(dis, externalPointer);
 	}
 
 	// ------------------------------------------------------------------------
@@ -89,7 +89,7 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 	}
 
 	@Override
-	protected OperatorState deserializeOperatorState(DataInputStream dis) throws IOException {
+	protected OperatorState deserializeOperatorState(DataInputStream dis, String externalPointer) throws IOException {
 		final OperatorID jobVertexId = new OperatorID(dis.readLong(), dis.readLong());
 		final int parallelism = dis.readInt();
 		final int maxParallelism = dis.readInt();
@@ -106,7 +106,7 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 
 		for (int j = 0; j < numSubTaskStates; j++) {
 			final int subtaskIndex = dis.readInt();
-			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis);
+			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis, externalPointer);
 			taskState.putState(subtaskIndex, subtaskState);
 		}
 
@@ -125,7 +125,7 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 	}
 
 	@Override
-	protected OperatorSubtaskState deserializeSubtaskState(DataInputStream dis) throws IOException {
+	protected OperatorSubtaskState deserializeSubtaskState(DataInputStream dis, String externalPointer) throws IOException {
 		// read two unused fields for compatibility:
 		//   - "duration"
 		//   - number of legacy states
@@ -138,6 +138,6 @@ public class MetadataV2Serializer extends MetadataV2V3SerializerBase implements 
 					"no longer supported.");
 		}
 
-		return super.deserializeSubtaskState(dis);
+		return super.deserializeSubtaskState(dis, externalPointer);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3Serializer.java
@@ -71,8 +71,8 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 	}
 
 	@Override
-	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader) throws IOException {
-		return deserializeMetadata(dis);
+	public CheckpointMetadata deserialize(DataInputStream dis, ClassLoader classLoader, String externalPointer) throws IOException {
+		return deserializeMetadata(dis, externalPointer);
 	}
 
 	// ------------------------------------------------------------------------
@@ -109,7 +109,7 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 	}
 
 	@Override
-	protected OperatorState deserializeOperatorState(DataInputStream dis) throws IOException {
+	protected OperatorState deserializeOperatorState(DataInputStream dis, String externalPointer) throws IOException {
 		final OperatorID jobVertexId = new OperatorID(dis.readLong(), dis.readLong());
 		final int parallelism = dis.readInt();
 		final int maxParallelism = dis.readInt();
@@ -117,14 +117,14 @@ public class MetadataV3Serializer extends MetadataV2V3SerializerBase implements 
 		final OperatorState operatorState = new OperatorState(jobVertexId, parallelism, maxParallelism);
 
 		// Coordinator state
-		operatorState.setCoordinatorState(deserializeStreamStateHandle(dis));
+		operatorState.setCoordinatorState(deserializeStreamStateHandle(dis, externalPointer));
 
 		// Sub task states
 		final int numSubTaskStates = dis.readInt();
 
 		for (int j = 0; j < numSubTaskStates; j++) {
 			final int subtaskIndex = dis.readInt();
-			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis);
+			final OperatorSubtaskState subtaskState = deserializeSubtaskState(dis, externalPointer);
 			operatorState.putState(subtaskIndex, subtaskState);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCheckpointStorage.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
 import org.apache.flink.runtime.state.CheckpointStreamFactory.CheckpointStateOutputStream;
+import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStreamFactory.FsCheckpointStateOutputStream;
 
 import javax.annotation.Nullable;
@@ -169,11 +170,14 @@ public class FsCheckpointStorage extends AbstractFsCheckpointStorage {
 
 	@Override
 	public CheckpointStateOutputStream createTaskOwnedStateStream() {
+		// as the comment of CheckpointStorageWorkerView#createTaskOwnedStateStream said we may change into shared state,
+		// so we use CheckpointedStateScope.SHARED here.
 		return new FsCheckpointStateOutputStream(
 				taskOwnedStateDirectory,
 				fileSystem,
 				writeBufferSize,
-				fileSizeThreshold);
+				fileSizeThreshold,
+				CheckpointedStateScope.SHARED);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsCompletedCheckpointStorageLocation.java
@@ -57,6 +57,10 @@ public class FsCompletedCheckpointStorageLocation implements CompletedCheckpoint
 		return externalPointer;
 	}
 
+	public Path getExclusiveCheckpointDir() {
+		return exclusiveCheckpointDir;
+	}
+
 	@Override
 	public FileStateHandle getMetadataHandle() {
 		return metadataFileHandle;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RelativeFileStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/RelativeFileStateHandle.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state.filesystem;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StreamStateHandle;
+
+import java.io.IOException;
+
+
+/**
+ * {@link StreamStateHandle} for state that was written to a file stream.
+ * The differences between {@link FileStateHandle} and {@link RelativeFileStateHandle} is that, {@link RelativeFileStateHandle}
+ * contains relativePath for the given handle.
+ */
+public class RelativeFileStateHandle extends FileStateHandle {
+	private static final long serialVersionUID = 1L;
+
+	private final String relativePath;
+
+	public RelativeFileStateHandle(
+		Path path,
+		String relativePath,
+		long stateSize) {
+		super(path, stateSize);
+		this.relativePath = relativePath;
+	}
+
+	@Override
+	public FSDataInputStream openInputStream() throws IOException {
+		try {
+			return super.openInputStream();
+		} catch (IOException e) {
+			System.out.println(e.getMessage());
+			throw e;
+		}
+	}
+
+	@Override
+	public void discardState() throws Exception {
+		super.discardState();
+	}
+
+	public String getRelativePath() {
+		return relativePath;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("RelativeFileStateHandle State: %s, %s [%d bytes]", getFilePath(), relativePath, getStateSize());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (o == this) {
+			return true;
+		}
+
+		if (! (o instanceof RelativeFileStateHandle)) {
+			return false;
+		}
+
+		RelativeFileStateHandle other = (RelativeFileStateHandle) o;
+		return getFilePath().equals(other.getFilePath()) && relativePath.equals(other.relativePath);
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapSnapshotStrategy.java
@@ -140,7 +140,7 @@ class HeapSnapshotStrategy<K>
 
 		final SupplierWithException<CheckpointStreamWithResultProvider, Exception> checkpointStreamSupplier =
 
-			localRecoveryConfig.isLocalRecoveryEnabled() ?
+			localRecoveryConfig.isLocalRecoveryEnabled() && !checkpointOptions.getCheckpointType().isSavepoint() ?
 
 				() -> CheckpointStreamWithResultProvider.createDuplicatingStream(
 					checkpointId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointMetadataTest.java
@@ -45,7 +45,7 @@ public class CheckpointMetadataTest {
 		final int numMasterStates = 7;
 
 		Collection<OperatorState> taskStates =
-				CheckpointTestUtils.createOperatorStates(rnd, numTaskStates, numSubtaskStates);
+				CheckpointTestUtils.createOperatorStates(rnd, null, numTaskStates, numSubtaskStates);
 
 		Collection<MasterState> masterStates =
 				CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/CheckpointTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint.metadata;
 
 import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -35,8 +36,11 @@ import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.StateHandleID;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.filesystem.RelativeFileStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 import org.apache.flink.util.StringUtils;
+
+import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,9 +65,14 @@ public class CheckpointTestUtils {
 
 	/**
 	 * Creates a random collection of OperatorState objects containing various types of state handles.
+	 *
+	 * @param basePath The basePath for savepoint, will be null for checkpoint.
+	 * @param numTaskStates Number of tasks.
+	 * @param numSubtasksPerTask Number of subtask for each task.
 	 */
 	public static Collection<OperatorState> createOperatorStates(
 			Random random,
+			@Nullable String basePath,
 			int numTaskStates,
 			int numSubtasksPerTask) {
 
@@ -75,7 +84,7 @@ public class CheckpointTestUtils {
 
 			final boolean hasCoordinatorState = random.nextBoolean();
 			if (hasCoordinatorState) {
-				final StreamStateHandle stateHandle = createDummyStreamStateHandle(random);
+				final StreamStateHandle stateHandle = createDummyStreamStateHandle(random, basePath);
 				taskState.setCoordinatorState(stateHandle);
 			}
 
@@ -113,22 +122,22 @@ public class CheckpointTestUtils {
 				KeyedStateHandle keyedStateStream = null;
 
 				if (hasKeyedBackend) {
-					if (isIncremental) {
+					if (isIncremental && !isSavepoint(basePath)) {
 						keyedStateBackend = createDummyIncrementalKeyedStateHandle(random);
 					} else {
-						keyedStateBackend = createDummyKeyGroupStateHandle(random);
+						keyedStateBackend = createDummyKeyGroupStateHandle(random, basePath);
 					}
 				}
 
 				if (hasKeyedStream) {
-					keyedStateStream = createDummyKeyGroupStateHandle(random);
+					keyedStateStream = createDummyKeyGroupStateHandle(random, basePath);
 				}
 
 				StateObjectCollection<InputChannelStateHandle> inputChannelStateHandles =
-					random.nextBoolean() ? singleton(createNewInputChannelStateHandle(random.nextInt(5), random)) : empty();
+					(random.nextBoolean() && !isSavepoint(basePath)) ? singleton(createNewInputChannelStateHandle(random.nextInt(5), random)) : empty();
 
 				StateObjectCollection<ResultSubpartitionStateHandle> resultSubpartitionStateHandles =
-					random.nextBoolean() ? singleton(createNewResultSubpartitionStateHandle(random.nextInt(5), random)) : empty();
+					(random.nextBoolean() && !isSavepoint(basePath)) ? singleton(createNewResultSubpartitionStateHandle(random.nextInt(5), random)) : empty();
 
 				taskState.putState(subtaskIdx, new OperatorSubtaskState(
 						operatorStateHandleBackend,
@@ -143,6 +152,10 @@ public class CheckpointTestUtils {
 		}
 
 		return taskStates;
+	}
+
+	private static boolean isSavepoint(String basePath) {
+		return basePath != null;
 	}
 
 	/**
@@ -188,7 +201,7 @@ public class CheckpointTestUtils {
 			42L,
 			createRandomStateHandleMap(rnd),
 			createRandomStateHandleMap(rnd),
-			createDummyStreamStateHandle(rnd));
+			createDummyStreamStateHandle(rnd, null));
 	}
 
 	public static Map<StateHandleID, StreamStateHandle> createRandomStateHandleMap(Random rnd) {
@@ -196,23 +209,33 @@ public class CheckpointTestUtils {
 		Map<StateHandleID, StreamStateHandle> result = new HashMap<>(size);
 		for (int i = 0; i < size; ++i) {
 			StateHandleID randomId = new StateHandleID(createRandomUUID(rnd).toString());
-			StreamStateHandle stateHandle = createDummyStreamStateHandle(rnd);
+			StreamStateHandle stateHandle = createDummyStreamStateHandle(rnd, null);
 			result.put(randomId, stateHandle);
 		}
 
 		return result;
 	}
 
-	public static KeyGroupsStateHandle createDummyKeyGroupStateHandle(Random rnd) {
+	public static KeyGroupsStateHandle createDummyKeyGroupStateHandle(Random rnd, String basePath) {
 		return new KeyGroupsStateHandle(
 			new KeyGroupRangeOffsets(1, 1, new long[]{rnd.nextInt(1024)}),
-			createDummyStreamStateHandle(rnd));
+			createDummyStreamStateHandle(rnd, basePath));
 	}
 
-	public static StreamStateHandle createDummyStreamStateHandle(Random rnd) {
-		return new ByteStreamStateHandle(
-			String.valueOf(createRandomUUID(rnd)),
-			String.valueOf(createRandomUUID(rnd)).getBytes(ConfigConstants.DEFAULT_CHARSET));
+	public static StreamStateHandle createDummyStreamStateHandle(Random rnd, String basePath) {
+		if (!isSavepoint(basePath)) {
+			return new ByteStreamStateHandle(
+				String.valueOf(createRandomUUID(rnd)),
+				String.valueOf(createRandomUUID(rnd)).getBytes(ConfigConstants.DEFAULT_CHARSET));
+		} else {
+			long stateSize = rnd.nextLong();
+			if (stateSize <= 0) {
+				stateSize = -stateSize;
+			}
+			String relativePath = String.valueOf(createRandomUUID(rnd));
+			Path statePath = new Path(basePath, relativePath);
+			return new RelativeFileStateHandle(statePath, relativePath, stateSize);
+		}
 	}
 
 	private static UUID createRandomUUID(Random rnd) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/metadata/MetadataV3SerializerTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.checkpoint.metadata;
 
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ByteArrayInputStreamWithPos;
 import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -25,7 +27,11 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.checkpoint.MasterState;
 import org.apache.flink.runtime.checkpoint.OperatorState;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import javax.annotation.Nullable;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -42,6 +48,9 @@ import static org.junit.Assert.assertEquals;
  */
 public class MetadataV3SerializerTest {
 
+	@Rule
+	public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
 	@Test
 	public void testCheckpointWithNoState() throws Exception {
 		final Random rnd = new Random();
@@ -51,7 +60,7 @@ public class MetadataV3SerializerTest {
 			final Collection<OperatorState> taskStates = Collections.emptyList();
 			final Collection<MasterState> masterStates = Collections.emptyList();
 
-			testCheckpointSerialization(checkpointId, taskStates, masterStates);
+			testCheckpointSerialization(checkpointId, taskStates, masterStates, null);
 		}
 	}
 
@@ -69,12 +78,20 @@ public class MetadataV3SerializerTest {
 			final Collection<MasterState> masterStates =
 					CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);
 
-			testCheckpointSerialization(checkpointId, operatorStates, masterStates);
+			testCheckpointSerialization(checkpointId, operatorStates, masterStates, null);
 		}
 	}
 
 	@Test
-	public void testCheckpointWithOnlyTaskState() throws Exception {
+	public void testCheckpointWithOnlyTaskStateForCheckpoint() throws Exception {
+		testCheckpointWithOnlyTaskState(null);
+	}
+	@Test
+	public void testCheckpointWithOnlyTaskStateForSavepoint() throws Exception {
+		testCheckpointWithOnlyTaskState(temporaryFolder.newFolder().toURI().toString());
+	}
+
+	private void testCheckpointWithOnlyTaskState(String basePath) throws Exception {
 		final Random rnd = new Random();
 		final int maxTaskStates = 20;
 		final int maxNumSubtasks = 20;
@@ -85,16 +102,25 @@ public class MetadataV3SerializerTest {
 			final int numTasks = rnd.nextInt(maxTaskStates) + 1;
 			final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
 			final Collection<OperatorState> taskStates =
-					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks);
+					CheckpointTestUtils.createOperatorStates(rnd, basePath, numTasks, numSubtasks);
 
 			final Collection<MasterState> masterStates = Collections.emptyList();
 
-			testCheckpointSerialization(checkpointId, taskStates, masterStates);
+			testCheckpointSerialization(checkpointId, taskStates, masterStates, basePath);
 		}
 	}
 
 	@Test
-	public void testCheckpointWithMasterAndTaskState() throws Exception {
+	public void testCheckpointWithMasterAndTaskStateForCheckpoint() throws Exception {
+		testCheckpointWithMasterAndTaskState(null);
+	}
+
+	@Test
+	public void testCheckpointWithMasterAndTaskStateForSavepoint() throws Exception {
+		testCheckpointWithMasterAndTaskState(temporaryFolder.newFolder().toURI().toString());
+	}
+
+	private void testCheckpointWithMasterAndTaskState(String basePath) throws Exception {
 		final Random rnd = new Random();
 
 		final int maxNumMasterStates = 5;
@@ -107,34 +133,48 @@ public class MetadataV3SerializerTest {
 			final int numTasks = rnd.nextInt(maxTaskStates) + 1;
 			final int numSubtasks = rnd.nextInt(maxNumSubtasks) + 1;
 			final Collection<OperatorState> taskStates =
-					CheckpointTestUtils.createOperatorStates(rnd, numTasks, numSubtasks);
+					CheckpointTestUtils.createOperatorStates(rnd, basePath, numTasks, numSubtasks);
 
 			final int numMasterStates = rnd.nextInt(maxNumMasterStates) + 1;
 			final Collection<MasterState> masterStates =
 					CheckpointTestUtils.createRandomMasterStates(rnd, numMasterStates);
 
-			testCheckpointSerialization(checkpointId, taskStates, masterStates);
+			testCheckpointSerialization(checkpointId, taskStates, masterStates, basePath);
 		}
 	}
 
+	/**
+	 * Test checkpoint metadata (de)serialization.
+	 *
+	 * @param checkpointId The given checkpointId will write into the metadata.
+	 * @param operatorStates the given states for all the operators.
+	 * @param masterStates the masterStates of the given checkpoint/savepoint.
+	 */
 	private void testCheckpointSerialization(
 			long checkpointId,
 			Collection<OperatorState> operatorStates,
-			Collection<MasterState> masterStates) throws IOException {
+			Collection<MasterState> masterStates,
+			@Nullable String basePath) throws IOException {
 
 		MetadataV3Serializer serializer = MetadataV3Serializer.INSTANCE;
 
 		ByteArrayOutputStreamWithPos baos = new ByteArrayOutputStreamWithPos();
 		DataOutputStream out = new DataOutputViewStreamWrapper(baos);
 
-		MetadataV3Serializer.serialize(new CheckpointMetadata(checkpointId, operatorStates, masterStates), out);
+		CheckpointMetadata metadata = new CheckpointMetadata(checkpointId, operatorStates, masterStates);
+		MetadataV3Serializer.serialize(metadata, out);
+		Path metaPath = null;
+		// add this because we need to resolve the checkpoint pointer in MetadataV2V3SerializerBase.
+		if (basePath != null) {
+			metaPath = new Path(basePath, "_metadata");
+			metaPath.getFileSystem().create(metaPath, FileSystem.WriteMode.OVERWRITE);
+		}
 		out.close();
 
 		byte[] bytes = baos.toByteArray();
 
 		DataInputStream in = new DataInputViewStreamWrapper(new ByteArrayInputStreamWithPos(bytes));
-		CheckpointMetadata deserialized = serializer.deserialize(in, getClass().getClassLoader());
-
+		CheckpointMetadata deserialized = serializer.deserialize(in, getClass().getClassLoader(), basePath);
 		assertEquals(checkpointId, deserialized.getCheckpointId());
 		assertEquals(operatorStates, deserialized.getOperatorStates());
 
@@ -142,6 +182,9 @@ public class MetadataV3SerializerTest {
 		for (Iterator<MasterState> a = masterStates.iterator(), b = deserialized.getMasterStates().iterator();
 				a.hasNext();) {
 			CheckpointTestUtils.assertMasterStateEquality(a.next(), b.next());
+		}
+		if (metaPath != null) {
+			metaPath.getFileSystem().delete(metaPath, true);
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/IncrementalRemoteKeyedStateHandleTest.java
@@ -264,7 +264,7 @@ public class IncrementalRemoteKeyedStateHandleTest {
 			1L,
 			placeSpies(CheckpointTestUtils.createRandomStateHandleMap(rnd)),
 			placeSpies(CheckpointTestUtils.createRandomStateHandleMap(rnd)),
-			spy(CheckpointTestUtils.createDummyStreamStateHandle(rnd)));
+			spy(CheckpointTestUtils.createDummyStreamStateHandle(rnd, null)));
 	}
 
 	private static Map<StateHandleID, StreamStateHandle> placeSpies(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -178,16 +178,16 @@ public class StreamTaskStateInitializerImplTest {
 					new OperatorStateHandle.StateMetaInfo(
 						new long[]{0, 10},
 						OperatorStateHandle.Mode.SPLIT_DISTRIBUTE)),
-				CheckpointTestUtils.createDummyStreamStateHandle(random)),
+				CheckpointTestUtils.createDummyStreamStateHandle(random, null)),
 			new OperatorStreamStateHandle(
 				Collections.singletonMap(
 					"_default_",
 					new OperatorStateHandle.StateMetaInfo(
 						new long[]{0, 20, 30},
 						OperatorStateHandle.Mode.SPLIT_DISTRIBUTE)),
-				CheckpointTestUtils.createDummyStreamStateHandle(random)),
-			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
-			CheckpointTestUtils.createDummyKeyGroupStateHandle(random),
+				CheckpointTestUtils.createDummyStreamStateHandle(random, null)),
+			CheckpointTestUtils.createDummyKeyGroupStateHandle(random, null),
+			CheckpointTestUtils.createDummyKeyGroupStateHandle(random, null),
 			singleton(createNewInputChannelStateHandle(10, random)),
 			singleton(createNewResultSubpartitionStateHandle(10, random)));
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/OperatorSnapshotUtil.java
@@ -127,7 +127,7 @@ public class OperatorSnapshotUtil {
 			final int v = dis.readInt();
 
 			// still required for compatibility to consume the bytes.
-			MetadataV3Serializer.deserializeStreamStateHandle(dis);
+			MetadataV3Serializer.deserializeStreamStateHandle(dis, null);
 
 			List<OperatorStateHandle> rawOperatorState = null;
 			int numRawOperatorStates = dis.readInt();
@@ -135,7 +135,7 @@ public class OperatorSnapshotUtil {
 				rawOperatorState = new ArrayList<>();
 				for (int i = 0; i < numRawOperatorStates; i++) {
 					OperatorStateHandle operatorState = MetadataV3Serializer.deserializeOperatorStateHandle(
-						dis);
+						dis, null);
 					rawOperatorState.add(operatorState);
 				}
 			}
@@ -146,7 +146,7 @@ public class OperatorSnapshotUtil {
 				managedOperatorState = new ArrayList<>();
 				for (int i = 0; i < numManagedOperatorStates; i++) {
 					OperatorStateHandle operatorState = MetadataV3Serializer.deserializeOperatorStateHandle(
-						dis);
+						dis, null);
 					managedOperatorState.add(operatorState);
 				}
 			}
@@ -157,7 +157,7 @@ public class OperatorSnapshotUtil {
 				rawKeyedState = new ArrayList<>();
 				for (int i = 0; i < numRawKeyedStates; i++) {
 					KeyedStateHandle keyedState = MetadataV3Serializer.deserializeKeyedStateHandle(
-						dis);
+						dis, null);
 					rawKeyedState.add(keyedState);
 				}
 			}
@@ -168,7 +168,7 @@ public class OperatorSnapshotUtil {
 				managedKeyedState = new ArrayList<>();
 				for (int i = 0; i < numManagedKeyedStates; i++) {
 					KeyedStateHandle keyedState = MetadataV3Serializer.deserializeKeyedStateHandle(
-						dis);
+						dis, null);
 					managedKeyedState.add(keyedState);
 				}
 			}


### PR DESCRIPTION
## What is the purpose of the change

This pr wants to make savepoint self-contained and relocatable.

## Brief change log

 - Add `RelativeStateHandle` extends `FileStateHandle`, `RelativeStateHandle` contains a property named with `relativepath`
- Will return a `RelativeStateHandle` in `FsCheckpointStateOutputStream#closeAndGetHandle` if is savepoint and not in `EntropyFileSystem`.
- Just serialize relative path for `RelativeStateHandle` when serialize meta data of savepoint.
- Will construct the full path using the deserialized relative path and the base path got from the `FsCompletedCheckpointStorageLocation#getExclusiveCheckpointDir`
- Add a ITCase to cover the savepoint relocated case.


## Verifying this change

- SavepointITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
