### PR TITLE
[FLINK-16762][python] Relocate Beam dependency

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -349,6 +349,10 @@ under the License.
 									<pattern>com.google.flatbuffers</pattern>
 									<shadedPattern>org.apache.flink.api.python.shaded.com.google.flatbuffers</shadedPattern>
 								</relocation>
+								<relocation>
+									<pattern>org.apache.beam</pattern>
+									<shadedPattern>org.apache.flink.api.python.shaded.org.apache.beam</shadedPattern>
+								</relocation>
 							</relocations>
 						</configuration>
 					</execution>


### PR DESCRIPTION

## What is the purpose of the change

*This pull request relocates the Beam dependency to avoid the potential conflicts with the existing libraries in the cluster.*

## Brief change log

  - *Relocate org.apache.beam*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
