### PR TITLE
[FLINK-17128][table] Add isBounded to TableSinkFactory#Context

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -86,7 +86,10 @@ public class HiveTableFactoryTest {
 				ObjectIdentifier.of("mycatalog", "mydb", "mytable"), table, new Configuration()));
 		assertTrue(tableSource instanceof StreamTableSource);
 		TableSink tableSink = tableFactory.createTableSink(new TableSinkFactoryContextImpl(
-				ObjectIdentifier.of("mycatalog", "mydb", "mytable"), table, new Configuration()));
+				ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
+				table,
+				new Configuration(),
+				true));
 		assertTrue(tableSink instanceof StreamTableSink);
 	}
 
@@ -107,7 +110,10 @@ public class HiveTableFactoryTest {
 		assertTrue(opt.isPresent());
 		HiveTableFactory tableFactory = (HiveTableFactory) opt.get();
 		TableSink tableSink = tableFactory.createTableSink(new TableSinkFactoryContextImpl(
-				ObjectIdentifier.of("mycatalog", "mydb", "mytable"), table, new Configuration()));
+				ObjectIdentifier.of("mycatalog", "mydb", "mytable"),
+				table,
+				new Configuration(),
+				true));
 		assertTrue(tableSink instanceof HiveTableSink);
 		TableSource tableSource = tableFactory.createTableSource(new TableSourceFactoryContextImpl(
 				ObjectIdentifier.of("mycatalog", "mydb", "mytable"), table, new Configuration()));

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -378,7 +378,8 @@ public class ExecutionContext<ClusterID> {
 							tableEnv.getCurrentDatabase(),
 							name),
 					CatalogTableImpl.fromProperties(sinkProperties),
-					tableEnv.getConfig().getConfiguration()));
+					tableEnv.getConfig().getConfiguration(),
+					!environment.getExecution().inStreamingMode()));
 		} else if (environment.getExecution().isBatchPlanner()) {
 			final BatchTableSinkFactory<?> factory = (BatchTableSinkFactory<?>)
 				TableFactoryService.find(BatchTableSinkFactory.class, sinkProperties, classLoader);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
@@ -98,6 +98,11 @@ public interface TableSinkFactory<T> extends TableFactory {
 		 * {@code TableEnvironment} session configurations.
 		 */
 		ReadableConfig getConfiguration();
+
+		/**
+		 * @return true if input of the sink is bounded, otherwise it is a unbounded input.
+		 */
+		boolean isBounded();
 	}
 
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.factories;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -100,7 +101,10 @@ public interface TableSinkFactory<T> extends TableFactory {
 		ReadableConfig getConfiguration();
 
 		/**
-		 * @return true if input of the sink is bounded, otherwise it is a unbounded input.
+		 * It depends on whether the {@code TableEnvironment} execution mode is batch.
+		 *
+		 * <p>In the future, the new sink interface will infer from input to source.
+		 * See {@link Source#getBoundedness}.
 		 */
 		boolean isBounded();
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactoryContextImpl.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableSinkFactoryContextImpl.java
@@ -34,14 +34,17 @@ public class TableSinkFactoryContextImpl implements TableSinkFactory.Context {
 	private final ObjectIdentifier identifier;
 	private final CatalogTable table;
 	private final ReadableConfig config;
+	private final boolean isBounded;
 
 	public TableSinkFactoryContextImpl(
 			ObjectIdentifier identifier,
 			CatalogTable table,
-			ReadableConfig config) {
+			ReadableConfig config,
+			boolean isBounded) {
 		this.identifier = checkNotNull(identifier);
 		this.table = checkNotNull(table);
 		this.config = checkNotNull(config);
+		this.isBounded = isBounded;
 	}
 
 	@Override
@@ -57,5 +60,10 @@ public class TableSinkFactoryContextImpl implements TableSinkFactory.Context {
 	@Override
 	public ReadableConfig getConfiguration() {
 		return config;
+	}
+
+	@Override
+	public boolean isBounded() {
+		return isBounded;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -307,7 +307,8 @@ abstract class PlannerBase(
         val context = new TableSinkFactoryContextImpl(
           objectIdentifier,
           tableToFind,
-          getTableConfig.getConfiguration)
+          getTableConfig.getConfiguration,
+          !isStreamingMode)
         if (catalog.isPresent && catalog.get().getTableFactory.isPresent) {
           val sink = TableFactoryUtil.createTableSinkForCatalogTable(catalog.get(), context)
           if (sink.isPresent) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/TableFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/common/TableFactoryTest.scala
@@ -38,7 +38,8 @@ class TableFactoryTest(isBatch: Boolean) extends TableTestBase {
   def testTableSourceSinkFactory(): Unit = {
     val factory = new TestContextTableFactory(
       ObjectIdentifier.of("cat", "default", "t1"),
-      ObjectIdentifier.of("cat", "default", "t2"))
+      ObjectIdentifier.of("cat", "default", "t2"),
+      isBatch)
     util.tableEnv.getConfig.getConfiguration.setBoolean(TestContextTableFactory.REQUIRED_KEY, true)
     util.tableEnv.registerCatalog("cat", new GenericInMemoryCatalog("default") {
       override def getTableFactory: Optional[TableFactory] = Optional.of(factory)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/TestContextTableFactory.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/utils/TestContextTableFactory.scala
@@ -34,7 +34,8 @@ import java.{lang, util}
   */
 class TestContextTableFactory[T](
     sourceIdentifier: ObjectIdentifier,
-    sinkIdentifier: ObjectIdentifier)
+    sinkIdentifier: ObjectIdentifier,
+    isBatch: Boolean)
     extends TableSourceFactory[T] with TableSinkFactory[T] {
 
   var hasInvokedSource = false
@@ -57,6 +58,7 @@ class TestContextTableFactory[T](
 
   override def createTableSink(context: TableSinkFactory.Context): TableSink[T] = {
     Assert.assertTrue(context.getConfiguration.get(REQUIRED_KEY))
+    Assert.assertEquals(isBatch, context.isBounded)
     Assert.assertEquals(sinkIdentifier, context.getObjectIdentifier)
     hasInvokedSink = true
     TableFactoryUtil.findAndCreateTableSink(context)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -750,7 +750,7 @@ abstract class TableEnvImpl(
         val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
         val catalogTable = s.asInstanceOf[CatalogTable]
         val context = new TableSinkFactoryContextImpl(
-          objectIdentifier, catalogTable, config.getConfiguration)
+          objectIdentifier, catalogTable, config.getConfiguration, true)
         if (catalog.isPresent && catalog.get().getTableFactory.isPresent) {
           val sink = TableFactoryUtil.createTableSinkForCatalogTable(catalog.get(), context)
           if (sink.isPresent) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -418,7 +418,7 @@ class StreamPlanner(
         val catalog = catalogManager.getCatalog(objectIdentifier.getCatalogName)
         val catalogTable = s.asInstanceOf[CatalogTable]
         val context = new TableSinkFactoryContextImpl(
-          objectIdentifier, catalogTable, config.getConfiguration)
+          objectIdentifier, catalogTable, config.getConfiguration, false)
         if (catalog.isPresent && catalog.get().getTableFactory.isPresent) {
           val sink = TableFactoryUtil.createTableSinkForCatalogTable(catalog.get(), context)
           if (sink.isPresent) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TestContextTableFactory.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TestContextTableFactory.scala
@@ -57,6 +57,7 @@ class TestContextTableFactory[T](
 
   override def createTableSink(context: TableSinkFactory.Context): TableSink[T] = {
     Assert.assertTrue(context.getConfiguration.get(REQUIRED_KEY))
+    Assert.assertFalse(context.isBounded)
     Assert.assertEquals(sinkIdentifier, context.getObjectIdentifier)
     hasInvokedSink = true
     TableFactoryUtil.findAndCreateTableSink(context)


### PR DESCRIPTION

## What is the purpose of the change

For current table environment, the difference between batch and streaming is very clear.
Add isBounded to TableSinkFactory#Context. And we can use this bool to distinguish batch and streaming.

## Brief change log

- Add isBounded to TableSinkFactory#Context
- Modify blink planner
- Modify flink planner

## Verifying this change

`TableFactoryTest` in blink and flink planner

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
