### PR TITLE
[FLINK-17134] correct logs information in KafkaPartitionDiscoverer

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010PartitionDiscoverer.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/Kafka010PartitionDiscoverer.java
@@ -77,7 +77,7 @@ public class Kafka010PartitionDiscoverer extends AbstractPartitionDiscoverer {
 				final List<PartitionInfo> kafkaPartitions = kafkaConsumer.partitionsFor(topic);
 
 				if (kafkaPartitions == null) {
-					throw new RuntimeException("Could not fetch partitions for %s. Make sure that the topic exists.".format(topic));
+					throw new RuntimeException(String.format("Could not fetch partitions for %s. Make sure that the topic exists.", topic));
 				}
 
 				for (PartitionInfo partitionInfo : kafkaPartitions) {


### PR DESCRIPTION
## What is the purpose of the change

The logging information is not right before because wrong usage of `String.format(xx,xx...)`

## Brief change log

Trival fix. Replace `"Could not fetch partitions for %s. Make sure that the topic exists.".format(topic)` with `String.format("Could not fetch partitions for %s. Make sure that the topic exists.", topic)`.

## Verifying this change

There's no need.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
