### PR TITLE
[hotfix][runtime] Remove unused method ExecutionJobVertex#generateDebugString()

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -447,18 +447,6 @@ public class ExecutionJobVertex implements AccessExecutionJobVertex, Archiveable
 		return getAggregateJobVertexState(num, parallelism);
 	}
 
-	private String generateDebugString() {
-
-		return "ExecutionJobVertex" +
-				"(" + jobVertex.getName() + " | " + jobVertex.getID() + ")" +
-				"{" +
-				"parallelism=" + parallelism +
-				", maxParallelism=" + getMaxParallelism() +
-				", maxParallelismConfigured=" + maxParallelismConfigured +
-				'}';
-	}
-
-
 	//---------------------------------------------------------------------------------------------
 
 	public void connectToPredecessors(Map<IntermediateDataSetID, IntermediateResult> intermediateDataSets) throws JobException {


### PR DESCRIPTION
Remove unused method `ExecutionJobVertex#generateDebugString()`