### PR TITLE
[FLINK-17121][build system][python] Adds Pipeline of Building Wheel Packages in Azure CI

### DIFF
--- a/flink-python/dev/build-wheels.sh
+++ b/flink-python/dev/build-wheels.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e -x
+
+## 1. install python env
+dev/lint-python.sh -s py_env
+
+PY_ENV_DIR=`pwd`/dev/.conda/envs
+py_env=("3.5" "3.6" "3.7")
+## 2. install dependency
+for ((i=0;i<${#py_env[@]};i++)) do
+    ${PY_ENV_DIR}/${py_env[i]}/bin/pip install -r dev/dev-requirements.txt
+done
+
+## 3. build wheels
+for ((i=0;i<${#py_env[@]};i++)) do
+    ${PY_ENV_DIR}/${py_env[i]}/bin/python setup.py bdist_wheel
+done
+
+## see the result
+ls -al dist/

--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+setuptools>=18.0
+wheel
+apache-beam==2.19.0
+cython==0.28.1

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -49,6 +49,7 @@ variables:
   SECRET_S3_BUCKET: $[variables.IT_CASE_S3_BUCKET]
   SECRET_S3_ACCESS_KEY: $[variables.IT_CASE_S3_ACCESS_KEY]
   SECRET_S3_SECRET_KEY: $[variables.IT_CASE_S3_SECRET_KEY]
+  VERSION: '1.11-SNAPSHOT'
 
 stages:
   # CI / PR triggered stage:
@@ -126,3 +127,8 @@ stages:
             versionSpec: '= 2.4'
             addToPath: true
         - script: ./tools/travis/docs.sh
+      - template: build-python-wheels.yml
+        parameters:
+          stage_name: build_python_wheels
+          environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
+          container: flink-build-container

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -49,7 +49,6 @@ variables:
   SECRET_S3_BUCKET: $[variables.IT_CASE_S3_BUCKET]
   SECRET_S3_ACCESS_KEY: $[variables.IT_CASE_S3_ACCESS_KEY]
   SECRET_S3_SECRET_KEY: $[variables.IT_CASE_S3_SECRET_KEY]
-  VERSION: '1.11-SNAPSHOT'
 
 stages:
   # CI / PR triggered stage:
@@ -129,6 +128,6 @@ stages:
         - script: ./tools/travis/docs.sh
       - template: build-python-wheels.yml
         parameters:
-          stage_name: build_python_wheels
+          stage_name: cron_python_wheels
           environment: PROFILE="-Dinclude-hadoop -Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.11"
           container: flink-build-container

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  - job: compile_${{parameters.stage_name}}
+    pool:
+      vmImage: 'ubuntu-16.04'
+    container: flink-build-container
+    timeoutInMinutes: 240
+    cancelTimeoutInMinutes: 1
+    workspace:
+      clean: all # this cleans the entire workspace directory before running a new job
+      # It is necessary because the custom build machines are reused for tests.
+      # See also https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#workspace
+
+    steps:
+      # The cache task is persisting the .m2 directory between builds, so that
+      # we do not have to re-download all dependencies from maven central for
+      # each build. The hope is that downloading the cache is faster than
+      # all dependencies individually.
+      # In this configuration, we use a hash over all committed (not generated) .pom files
+      # as a key for the build cache (CACHE_KEY). If we have a cache miss on the hash
+      # (usually because a pom file has changed), we'll fall back to a key without
+      # the pom files (CACHE_FALLBACK_KEY).
+      # Offical documentation of the Cache task: https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
+      - task: Cache@2
+        inputs:
+          key: $(CACHE_KEY)
+          restoreKeys: $(CACHE_FALLBACK_KEY)
+          path: $(MAVEN_CACHE_FOLDER)
+        continueOnError: true # continue the build even if the cache fails.
+        displayName: Cache Maven local repo
+      # Compile
+      - script: STAGE=compile ${{parameters.environment}} ./tools/azure_controller.sh compile
+        displayName: Build
+
+      # upload artifacts for next stage
+      - task: PublishPipelineArtifact@1
+        inputs:
+          path: $(CACHE_FLINK_DIR)
+          artifact: FlinkCompileCacheDir
+
+  - job: BuildWheels
+    dependsOn: compile_${{parameters.stage_name}}
+    strategy:
+      matrix:
+        linux:
+          vm-label: 'ubuntu-16.04'
+        mac:
+          vm-label: 'macOS-10.15'
+    pool:
+      vmImage: $(vm-label)
+    steps:
+      # download artifacts
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: $(CACHE_FLINK_DIR)
+          artifact: FlinkCompileCacheDir
+      - script: |
+          mkdir -p flink-dist/target/flink-$(VERSION)-bin
+          ln -snf $(CACHE_FLINK_DIR)/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION) `pwd`/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION)
+        displayName: Recreate 'flink-dist/target' symlink
+      - script: |
+          cd flink-python
+          bash dev/build-wheels.sh
+        displayName: Build wheels
+      - task: PublishPipelineArtifact@0
+        inputs:
+          artifactName: 'wheel_$(Agent.OS)_$(Agent.JobName)'
+          targetPath: 'flink-python/dist'

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -18,41 +18,25 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     container: flink-build-container
-    timeoutInMinutes: 240
-    cancelTimeoutInMinutes: 1
     workspace:
-      clean: all # this cleans the entire workspace directory before running a new job
-      # It is necessary because the custom build machines are reused for tests.
-      # See also https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#workspace
-
+      clean: all
     steps:
-      # The cache task is persisting the .m2 directory between builds, so that
-      # we do not have to re-download all dependencies from maven central for
-      # each build. The hope is that downloading the cache is faster than
-      # all dependencies individually.
-      # In this configuration, we use a hash over all committed (not generated) .pom files
-      # as a key for the build cache (CACHE_KEY). If we have a cache miss on the hash
-      # (usually because a pom file has changed), we'll fall back to a key without
-      # the pom files (CACHE_FALLBACK_KEY).
-      # Offical documentation of the Cache task: https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops
-      - task: Cache@2
-        inputs:
-          key: $(CACHE_KEY)
-          restoreKeys: $(CACHE_FALLBACK_KEY)
-          path: $(MAVEN_CACHE_FOLDER)
-        continueOnError: true # continue the build even if the cache fails.
-        displayName: Cache Maven local repo
       # Compile
       - script: STAGE=compile ${{parameters.environment}} ./tools/azure_controller.sh compile
         displayName: Build
 
-      # upload artifacts for next stage
+      # upload artifacts for building wheels
       - task: PublishPipelineArtifact@1
         inputs:
           path: $(CACHE_FLINK_DIR)
           artifact: FlinkCompileCacheDir
 
-  - job: BuildWheels
+      - script: |
+          VERSION=$(mvn --file pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "##vso[task.setvariable variable=VERSION;isOutput=true]$VERSION"
+        name: set_version
+
+  - job: build_wheels
     dependsOn: compile_${{parameters.stage_name}}
     strategy:
       matrix:
@@ -62,6 +46,8 @@ jobs:
           vm-label: 'macOS-10.15'
     pool:
       vmImage: $(vm-label)
+    variables:
+      VERSION: $[ dependencies.compile_${{parameters.stage_name}}.outputs['set_version.VERSION'] ]
     steps:
       # download artifacts
       - task: DownloadPipelineArtifact@2

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -29,7 +29,7 @@ jobs:
       - task: PublishPipelineArtifact@1
         inputs:
           path: $(CACHE_FLINK_DIR)
-          artifact: FlinkCompileCacheDir
+          artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
 
       - script: |
           VERSION=$(mvn --file pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
@@ -53,7 +53,7 @@ jobs:
       - task: DownloadPipelineArtifact@2
         inputs:
           path: $(CACHE_FLINK_DIR)
-          artifact: FlinkCompileCacheDir
+          artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
       - script: |
           mkdir -p flink-dist/target/flink-$(VERSION)-bin
           ln -snf $(CACHE_FLINK_DIR)/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION) `pwd`/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add pipeline of building wheel packages in Azure CI*


## Brief change log

  - *Adds template build-python-wheels.yml used to build python wheels*
  - *Includes the build-python-wheels.yml into the nightly builds*

## Verifying this change

This change added tests and can be verified as follows:

  - *Trigger the builds in my free azure count*
  https://dev.azure.com/hxbks2ks/FLINK-TEST/_build/results?buildId=62&view=logs&s=9fca669f-5c5f-59c7-4118-e31c641064f0&j=0e4be578-0a2d-579f-634d-907c09bf7e15

https://dev.azure.com/hxbks2ks/FLINK-TEST/_build/results?buildId=62&view=artifacts&type=publishedArtifacts


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
