### PR TITLE
[FLINK-17133] [Table SQL/API] Support CsvParser Features for CSV form…

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1435,8 +1435,11 @@ CREATE TABLE MyUserTable (
   'format.array-element-delimiter' = '|',     -- optional: the array element delimiter string for separating
                                               -- array and row element values (";" by default)
   'format.escape-character' = '\\',           -- optional: escape character for escaping values (disabled by default)
-  'format.null-literal' = 'n/a'               -- optional: null literal string that is interpreted as a
+  'format.null-literal' = 'n/a',              -- optional: null literal string that is interpreted as a
                                               -- null value (disabled by default)
+  'format.feature.ignore_trailing_unmappable' -- optional: CsvParser Feature that allows ignoring of unmappable "extra" columns;
+                                              -- that is, values for columns that appear after columns for which types are defined.
+                                              -- Support all CsvParser Features list in [Csvparser.Feature]
 )
 {% endhighlight %}
 </div>

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -1435,8 +1435,11 @@ CREATE TABLE MyUserTable (
   'format.array-element-delimiter' = '|',     -- optional: the array element delimiter string for separating
                                               -- array and row element values (";" by default)
   'format.escape-character' = '\\',           -- optional: escape character for escaping values (disabled by default)
-  'format.null-literal' = 'n/a'               -- optional: null literal string that is interpreted as a
+  'format.null-literal' = 'n/a',              -- optional: null literal string that is interpreted as a
                                               -- null value (disabled by default)
+  'format.feature.ignore_trailing_unmappable' -- optional: CsvParser Feature that allows ignoring of unmappable "extra" columns;
+                                              -- that is, values for columns that appear after columns for which types are defined.
+                                              -- Support all CsvParser Features list in [Csvparser.Feature]
 )
 {% endhighlight %}
 </div>

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvRowFormatFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvParser;
 import org.apache.flink.table.descriptors.CsvValidator;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.factories.DeserializationSchemaFactory;
@@ -56,7 +57,10 @@ public final class CsvRowFormatFactory extends TableFormatFactoryBase<Row>
 		properties.add(CsvValidator.FORMAT_ARRAY_ELEMENT_DELIMITER);
 		properties.add(CsvValidator.FORMAT_ESCAPE_CHARACTER);
 		properties.add(CsvValidator.FORMAT_NULL_LITERAL);
-		properties.add(CsvValidator.FORMAT_SCHEMA);
+		for(CsvParser.Feature feature : CsvParser.Feature.values()) {
+			properties.add(CsvValidator.FORMAT_FEATURE_PREFIX + "." + feature.toString().toUpperCase());
+		}
+
 		return properties;
 	}
 
@@ -88,6 +92,9 @@ public final class CsvRowFormatFactory extends TableFormatFactoryBase<Row>
 		descriptorProperties.getOptionalString(CsvValidator.FORMAT_NULL_LITERAL)
 			.ifPresent(schemaBuilder::setNullLiteral);
 
+		descriptorProperties.getPropertiesWithPrefix(CsvValidator.FORMAT_FEATURE_PREFIX)
+			.forEach((k,v) -> schemaBuilder.setFeature(k,Boolean.valueOf(v)));
+
 		return schemaBuilder.build();
 	}
 
@@ -118,6 +125,9 @@ public final class CsvRowFormatFactory extends TableFormatFactoryBase<Row>
 
 		descriptorProperties.getOptionalString(CsvValidator.FORMAT_NULL_LITERAL)
 			.ifPresent(schemaBuilder::setNullLiteral);
+
+		descriptorProperties.getPropertiesWithPrefix(CsvValidator.FORMAT_FEATURE_PREFIX)
+			.forEach((k,v) -> schemaBuilder.setFeature(k,Boolean.valueOf(v)));
 
 		return schemaBuilder.build();
 	}

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/table/descriptors/CsvValidator.java
@@ -40,6 +40,7 @@ public class CsvValidator extends FormatDescriptorValidator {
 	public static final String FORMAT_ESCAPE_CHARACTER = "format.escape-character";
 	public static final String FORMAT_NULL_LITERAL = "format.null-literal";
 	public static final String FORMAT_SCHEMA = "format.schema";
+	public static final String FORMAT_FEATURE_PREFIX = "format.feature";
 
 	@Override
 	public void validate(DescriptorProperties properties) {

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvRowDeSerializationSchemaTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.formats.csv;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvParser;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -152,6 +153,13 @@ public class CsvRowDeSerializationSchemaTest {
 	}
 
 	@Test
+	public void testDeserializeMoreColumnsThanExpectedWithFeature() throws Exception {
+		// one additional string column
+		assertEquals(testDeserialization(true, false, "Test,12,Test,Test"),
+			Row.of("Test", 12, "Test"));
+	}
+
+	@Test
 	public void testDeserializeIgnoreComment() throws Exception {
 		// # is part of the string
 		assertEquals(Row.of("#Test", 12, "Test"), testDeserialization(false, false, "#Test,12,Test"));
@@ -266,6 +274,18 @@ public class CsvRowDeSerializationSchemaTest {
 		final CsvRowDeserializationSchema.Builder deserSchemaBuilder = new CsvRowDeserializationSchema.Builder(rowInfo)
 			.setIgnoreParseErrors(allowParsingErrors)
 			.setAllowComments(allowComments);
+		return deserialize(deserSchemaBuilder, string);
+	}
+
+	private Row testDeserializationWithFeatures(
+		boolean allowParsingErrors,
+		boolean allowComments,
+		String string) throws Exception {
+		final TypeInformation<Row> rowInfo = Types.ROW(Types.STRING, Types.INT, Types.STRING);
+		final CsvRowDeserializationSchema.Builder deserSchemaBuilder = new CsvRowDeserializationSchema.Builder(rowInfo)
+			.setIgnoreParseErrors(allowParsingErrors)
+			.setAllowComments(allowComments)
+			.setFeature(CsvParser.Feature.IGNORE_TRAILING_UNMAPPABLE.toString(),true);
 		return deserialize(deserSchemaBuilder, string);
 	}
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support [CsvParser Features](https://fasterxml.github.io/jackson-dataformats-text/javadoc/csv/2.10/com/fasterxml/jackson/dataformat/csv/CsvParser.Feature.html) for CSV format via SQL DDL.
Such as :
- IGNORE_TRAILING_UNMAPPABLE:
  Feature that allows ignoring of unmappable "extra" columns; that is, values for columns that appear after columns for which types are defined.
- SKIP_EMPTY_LINES
  Feature that allows skipping input lines that are completely empty, instead of being decoded as lines of just a single column with empty String value (or, depending on binding, `null`).
...


## Brief change log

## Verifying this change

This change added tests and can be verified as follows:
  - test Deserialize More Columns Than Expected With Csv Feature IGNORE_TRAILING_UNMAPPABLE is true


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
