### PR TITLE
[FLINK-16750][e2e] Always copy and show the logs when yarn e2e tests failed

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_utils.sh
+++ b/flink-end-to-end-tests/test-scripts/common_utils.sh
@@ -22,6 +22,8 @@
 _on_exit_commands=()
 
 function _on_exit_callback {
+  # Export the exit code so that it could be used by the callback commands
+  export TRAPPED_EXIT_CODE=$?
   # Un-register the callback, to avoid multiple invocations: some shells may treat some signals as subset of others.
   trap "" INT EXIT
   # Fast exit, if there is another keyboard interrupt.

--- a/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_yarn_docker.sh
@@ -38,6 +38,9 @@ start_time=$(date +%s)
 
 # make sure we stop our cluster at the end
 function cluster_shutdown {
+  if [ $TRAPPED_EXIT_CODE != 0 ];then
+      debug_copy_and_show_logs
+  fi
   docker-compose -f $END_TO_END_DIR/test-scripts/docker-hadoop-secure-cluster/docker-compose.yml down
   rm $FLINK_TARBALL_DIR/$FLINK_TARBALL
 }

--- a/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/test_yarn_kerberos_docker.sh
@@ -57,14 +57,12 @@ then
     echo "$OUTPUT"
 else
     echo "Running the job failed."
-    debug_copy_and_show_logs
     exit 1
 fi
 
 for expected_result in ${EXPECTED_RESULT_LOG_CONTAINS[@]}; do
     if [[ ! "$OUTPUT" =~ $expected_result ]]; then
         echo "Output does not contain '$expected_result' as required"
-        debug_copy_and_show_logs
         exit 1
     fi
 done


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when the hadoop cluster starts failed in YARN e2e tests, the debug logs will not show up. This will make debugging the failed e2e tests very difficult.

So this PR is to always copy and show the logs when the YARN e2e tests failed.


## Brief change log

* Add `debug_copy_and_show_logs` before `cluster_shutdown`


## Verifying this change

* DO NOT take any behavior change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
