### PR TITLE
[FLINK-10203][Connectors/FileSystem] Support truncate method for old Hadoop versions in HadoopRecoverableFsDataOutputStream

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -25,7 +25,7 @@ import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream.Committer;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.util.HadoopUtils;
+import org.apache.flink.runtime.fs.hdfs.truncate.TruncaterFactory;
 
 import org.apache.hadoop.util.VersionInfo;
 import org.slf4j.Logger;
@@ -64,9 +64,9 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 
 		// Part of functionality depends on specific versions. We check these schemes and versions eagerly for
 		// better error messages.
-		if (!HadoopUtils.isMinHadoopVersion(2, 7)) {
+		if (TruncaterFactory.truncateEmulated()) {
 			LOG.warn("WARNING: You are running on hadoop version " + VersionInfo.getVersion() + "." +
-					" If your RollingPolicy does not roll on every checkpoint/savepoint, the StreamingFileSink will throw an exception upon recovery.");
+					" If your RollingPolicy does not roll on every checkpoint/savepoint, the StreamingFileSink will emulate truncate via copying, which can have high performance cost.");
 		}
 	}
 
@@ -129,7 +129,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 
 	@Override
 	public boolean supportsResume() {
-		return true;
+		return !TruncaterFactory.truncateEmulated();
 	}
 
 	@VisibleForTesting

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/LegacyTruncater.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/LegacyTruncater.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs.truncate;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * Concrete implementation of the {@link Truncater} which emulate truncate logic
+ * for Hadoop version lower Hadoop 2.7.
+ * Truncate logic for happy path:
+ * 		1. Create a new file with '.truncated' extension in the same folder and
+ * 		write the content of the file with the required length.
+ * 		2. Remove the original file
+ * 		3. Rename truncated file using the name of the original one.
+ * In case of failure :
+ * 	On the first step of invocation of ‘truncate’ method check if the original file exist:
+ * 		a. If original file exists - start the process from the beginning (point 1).
+ * 		b. If original file not exists but exists the file with '*.truncated' extension.
+ * 	The absence of original file tells us about that truncated file was written fully and source crushed on the
+ * stage of renaming truncated file. We can use it as a resultant file and finish the truncation process.
+ */
+class LegacyTruncater implements Truncater {
+
+	private static final String TRUNCATED_FILE_SUFFIX = ".truncated";
+
+	@VisibleForTesting
+	protected static Path truncatedFile(Path file) {
+		return file.suffix(TRUNCATED_FILE_SUFFIX);
+	}
+
+	@Override
+	public void truncate(FileSystem fs, Path filePath, long length) throws IOException {
+		Path truncatedFilePath = truncatedFile(filePath);
+
+		if (fs.exists(filePath)) {
+			long fileSize = fs.getFileStatus(filePath).getLen();
+
+			// Check the size and if the file should be truncated
+			// to the zero size just recreate an empty file.
+			if (length == 0L) {
+				touch(fs, filePath);
+
+				// Ignore the case of the required size is equal actual file size
+				// Apply truncation logic only for cases when the size is differ
+				// Good question: should we handle the case when file size is smaller
+				// than required truncation length ?
+			} else if (length < fileSize) {
+				copyFileContent(fs, filePath, truncatedFilePath, length);
+				fs.delete(filePath, false);
+				fs.rename(truncatedFilePath, filePath);
+			}
+		} else if (fs.exists(truncatedFilePath)) { // Recovery point for the case when the fail happen after removing of the original file.
+			fs.rename(truncatedFilePath, filePath);
+		} else {
+			throw new IOException("File cannot be truncated. Original file '" + filePath +
+				"' and truncated copy '" + truncatedFilePath + "' does not exist.");
+		}
+	}
+
+	@VisibleForTesting
+	protected void copyFileContent(FileSystem fs, Path src, Path dest, long length) throws IOException {
+		FSDataInputStream srcFile = fs.open(src);
+		FSDataOutputStream destFile = fs.create(dest, true);
+		try {
+			org.apache.hadoop.io.IOUtils.copyBytes(srcFile, destFile, length, true);
+		} catch (IOException e) {
+			if (fs.exists(dest)) {
+				fs.delete(dest, false);
+			}
+			throw e;
+		}
+	}
+
+	@VisibleForTesting
+	protected void touch(FileSystem fs, Path filePath) throws IOException {
+		fs.delete(filePath, false);
+		fs.create(filePath).close();
+	}
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/NativeTruncater.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/NativeTruncater.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs.truncate;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+
+/**
+ * Concrete implementation of the {@link Truncater} which support truncate logic for Hadoop 2.7 and higher.
+ */
+class NativeTruncater implements Truncater {
+
+	private static final long LEASE_TIMEOUT = 100_000L;
+
+	private Method truncateHandle;
+
+	public NativeTruncater() {
+		ensureTruncateInitialized();
+	}
+
+	@Override
+	public void truncate(FileSystem hadoopFs, Path path, long length) throws IOException {
+		waitUntilLeaseIsRevoked(hadoopFs, path);
+
+		// truncate back and append
+		boolean truncated;
+		try {
+			truncated = invokeTruncate(hadoopFs, path, length);
+		} catch (Exception e) {
+			throw new IOException("Problem while truncating file: " + path, e);
+		}
+
+		if (!truncated) {
+			// Truncate did not complete immediately, we must wait for
+			// the operation to complete and release the lease.
+			waitUntilLeaseIsRevoked(hadoopFs, path);
+		}
+	}
+
+	private boolean invokeTruncate(FileSystem hadoopFs, Path file, long length) throws IOException {
+		if (truncateHandle != null) {
+			try {
+				return (Boolean) truncateHandle.invoke(hadoopFs, file, length);
+			} catch (InvocationTargetException e) {
+				ExceptionUtils.rethrowIOException(e.getTargetException());
+			} catch (Throwable t) {
+				throw new IOException(
+					"Truncation of file failed because of access/linking problems with Hadoop's truncate call. " +
+						"This is most likely a dependency conflict or class loading problem.");
+			}
+		} else {
+			throw new IllegalStateException("Truncation handle has not been initialized");
+		}
+		return false;
+	}
+
+	/**
+	 * Called when resuming execution after a failure and waits until the lease
+	 * of the file we are resuming is free.
+	 *
+	 * <p>The lease of the file we are resuming writing/committing to may still
+	 * belong to the process that failed previously and whose state we are
+	 * recovering.
+	 *
+	 * @param path The path to the file we want to resume writing to.
+	 */
+	private static boolean waitUntilLeaseIsRevoked(final FileSystem fs, final Path path) throws IOException {
+		Preconditions.checkState(fs instanceof DistributedFileSystem);
+
+		final DistributedFileSystem dfs = (DistributedFileSystem) fs;
+		dfs.recoverLease(path);
+
+		final Deadline deadline = Deadline.now().plus(Duration.ofMillis(LEASE_TIMEOUT));
+
+		final StopWatch sw = new StopWatch();
+		sw.start();
+
+		boolean isClosed = dfs.isFileClosed(path);
+		while (!isClosed && deadline.hasTimeLeft()) {
+			try {
+				Thread.sleep(500L);
+			} catch (InterruptedException e1) {
+				throw new IOException("Recovering the lease failed: ", e1);
+			}
+			isClosed = dfs.isFileClosed(path);
+		}
+		return isClosed;
+	}
+
+	// ------------------------------------------------------------------------
+	//  Reflection utils for truncation
+	//    These are needed to compile against Hadoop versions before
+	//    Hadoop 2.7, which have no truncation calls for HDFS.
+	// ------------------------------------------------------------------------
+
+	private void ensureTruncateInitialized() throws FlinkRuntimeException {
+		if (truncateHandle == null) {
+			Method truncateMethod;
+			try {
+				truncateMethod = FileSystem.class.getMethod("truncate", Path.class, long.class);
+			} catch (NoSuchMethodException e) {
+				throw new FlinkRuntimeException("Could not find a public truncate method on the Hadoop File System.");
+			}
+
+			if (!Modifier.isPublic(truncateMethod.getModifiers())) {
+				throw new FlinkRuntimeException("Could not find a public truncate method on the Hadoop File System.");
+			}
+
+			truncateHandle = truncateMethod;
+		}
+	}
+
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/Truncater.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/Truncater.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs.truncate;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/**
+ * Interface for encapsulating truncation strategy.
+ */
+public interface Truncater {
+	void truncate(FileSystem hadoopFs, Path filePath, long length) throws IOException;
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/TruncaterFactory.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/truncate/TruncaterFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs.truncate;
+
+import org.apache.flink.runtime.util.HadoopUtils;
+
+/**
+ * Factory for creating appropriate truncater which depends on the Hadoop version.
+ */
+public class TruncaterFactory {
+
+	public static boolean truncateEmulated() {
+		return HadoopUtils.isMinHadoopVersion(2, 7);
+	}
+
+	public static Truncater newInstance() {
+		if (truncateEmulated()) {
+			return new LegacyTruncater();
+		} else {
+			return new NativeTruncater();
+		}
+	}
+}


### PR DESCRIPTION
##  What is the purpose of the change

The new StreamingFileSink ( introduced in 1.6 Flink version ) use HadoopRecoverableFsDataOutputStream wrapper to write data in HDFS.

HadoopRecoverableFsDataOutputStream is a wrapper for FSDataOutputStream to have an ability to restore from the certain point of file after failure and continue to write data. To achieve this recover functionality the HadoopRecoverableFsDataOutputStream use "truncate" method which was introduced only in Hadoop 2.7.

Unfortunately, there are a few official Hadoop distributives which latest version still use Hadoop 2.6 (These distributives: Cloudera, Pivotal HD ). As the result, Flinks Hadoop connector can't work with this distributives.

Flink declares that supported Hadoop from version 2.4.0 upwards (https://ci.apache.org/projects/flink/flink-docs-release-1.6/start/building.html#hadoop-versions)

I guess we should emulate the functionality of "truncate" method for older Hadoop versions.
The fix of this issue is vital for us as Hadoop 2.6 users.

## Brief change log

1. Create a new file with '.truncated' extension in the same folder and write the content of the file with the required length.
2. Remove original file.
3. Rename the truncated file using the name of the original one. 

**In case of failure:**
On the first step of invocation of ‘truncate’ method it checks if the original file exists:

If the original file exists - start the process from the beginning (point 1).

if the original file not exists but exists the file with extension *.truncated .

The absence of the original file tells us that truncated file was written fully and source crushed on the stage of renaming the truncated file. (I want to believe in the guarantee of atomicity of HDFS renaming operation) We can use it as a resultant file and finish the truncation process.

## Brief change log

- Add new abstraction Truncater
- Add Implementation for old Hadoop version ( LegacyTruncater)
- Add Implementation for Hadoop 2.7 and upwards

## Verifying this change

This change contains a test for LegacyTruncater.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
