### PR TITLE
[FLINK-17152]fix wrong Aggfunction resultType and accType in FunctionDefinitionUtil

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/functions/FunctionDefinitionUtil.java
@@ -53,8 +53,8 @@ public class FunctionDefinitionUtil {
 			return new AggregateFunctionDefinition(
 				name,
 				a,
-				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a),
-				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a)
+				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a),
+				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a)
 			);
 		} else if (udf instanceof TableAggregateFunction) {
 			TableAggregateFunction a = (TableAggregateFunction) udf;
@@ -62,8 +62,8 @@ public class FunctionDefinitionUtil {
 			return new TableAggregateFunctionDefinition(
 				name,
 				a,
-				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a),
-				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a)
+				UserDefinedFunctionHelper.getReturnTypeOfAggregateFunction(a),
+				UserDefinedFunctionHelper.getAccumulatorTypeOfAggregateFunction(a)
 			);
 		} else {
 			throw new UnsupportedOperationException(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/functions/FunctionDefinitionUtilTest.java
@@ -19,9 +19,11 @@
 package org.apache.flink.table.functions;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -71,6 +73,8 @@ public class FunctionDefinitionUtilTest {
 
 		assertTrue(((AggregateFunctionDefinition) fd2).getAggregateFunction()
 				instanceof TestAggFunctionWithoutResultType);
+		assertEquals(((AggregateFunctionDefinition) fd2).getResultTypeInfo(), Types.LONG);
+		assertEquals(((AggregateFunctionDefinition) fd2).getAccumulatorTypeInfo(), Types.STRING);
 
 	}
 
@@ -90,6 +94,8 @@ public class FunctionDefinitionUtilTest {
 
 		assertTrue(((TableAggregateFunctionDefinition) fd2).getTableAggregateFunction()
 				instanceof TestTableAggFunctionWithoutResultType);
+		assertEquals(((TableAggregateFunctionDefinition) fd2).getResultTypeInfo(), Types.LONG);
+		assertEquals(((TableAggregateFunctionDefinition) fd2).getAccumulatorTypeInfo(), Types.STRING);
 	}
 
 	/**
@@ -143,14 +149,14 @@ public class FunctionDefinitionUtilTest {
 	/**
 	 * Test function.
 	 */
-	public static class TestAggFunctionWithoutResultType extends AggregateFunction<Long, Long> {
+	public static class TestAggFunctionWithoutResultType extends AggregateFunction<Long, String> {
 		@Override
-		public Long createAccumulator() {
+		public String createAccumulator() {
 			return null;
 		}
 
 		@Override
-		public Long getValue(Long accumulator) {
+		public Long getValue(String accumulator) {
 			return null;
 		}
 	}
@@ -178,9 +184,9 @@ public class FunctionDefinitionUtilTest {
 	/**
 	 * Test function.
 	 */
-	public static class TestTableAggFunctionWithoutResultType extends TableAggregateFunction<Long, Long> {
+	public static class TestTableAggFunctionWithoutResultType extends TableAggregateFunction<Long, String> {
 		@Override
-		public Long createAccumulator() {
+		public String createAccumulator() {
 			return null;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

* In [FLINK-16414](https://github.com/apache/flink/pull/11302), I fixed the problem that using using udaf/udtf which doesn't implement getResultType, but also introduce this problem careless. This pr aims to solve aggregate function can not get correct return type.

## Brief change log

  - #9ed7dbb fix bug and add corresponding unit test.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added more unit tests in FunctionDefinitionUtilTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
