### PR TITLE
[FLINK-17131][build] Downgrade javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1735,7 +1735,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.1.1</version><!--$NO-MVN-MAN-VER$-->
+					<version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
 					<configuration>
 						<quiet>true</quiet>
 						<detectOfflineLinks>false</detectOfflineLinks>


### PR DESCRIPTION
Something changed in 3.0.0-M1+ which breaks our builds, so we're reverting back to the last working one.