### PR TITLE
[FLINK-14713][rest]Show All Attempts For Vertex SubTask In Rest Api

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -3339,6 +3339,127 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
 <table class="table table-bordered">
   <tbody>
     <tr>
+      <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns details of all execution attempts of a subtask.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+          <li><code>jobid</code> - 32-character hexadecimal string value that identifies a job.</li>
+          <li><code>vertexid</code> - 32-character hexadecimal string value that identifies a job vertex.</li>
+          <li><code>subtaskindex</code> - Positive integer value that identifies a subtask.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#168850740">Request</button>
+        <div id="168850741" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#-1849883273">Response</button>
+        <div id="-1849883274" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskAllExecutionAttemptsDetailsInfo",
+  "properties" : {
+    "attempts" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
+        "properties" : {
+          "subtask" : {
+            "type" : "integer"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+          },
+          "attempt" : {
+            "type" : "integer"
+          },
+          "host" : {
+            "type" : "string"
+          },
+          "start-time" : {
+            "type" : "integer"
+          },
+          "end-time" : {
+            "type" : "integer"
+          },
+          "duration" : {
+            "type" : "integer"
+          },
+          "metrics" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+            "properties" : {
+              "read-bytes" : {
+                "type" : "integer"
+              },
+              "read-bytes-complete" : {
+                "type" : "boolean"
+              },
+              "write-bytes" : {
+                "type" : "integer"
+              },
+              "write-bytes-complete" : {
+                "type" : "boolean"
+              },
+              "read-records" : {
+                "type" : "integer"
+              },
+              "read-records-complete" : {
+                "type" : "boolean"
+              },
+              "write-records" : {
+                "type" : "integer"
+              },
+              "write-records-complete" : {
+                "type" : "boolean"
+              }
+            }
+          },
+          "taskmanager-id" : {
+            "type" : "string"
+          },
+          "start_time" : {
+            "type" : "integer"
+          }
+        }
+      }
+    }
+  }
+}
+            </code>
+          </pre>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
       <td class="text-left" colspan="2"><h5><strong>/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts/:attempt</strong></h5></td>
     </tr>
     <tr>

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2180,6 +2180,99 @@
       }
     }
   }, {
+    "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts",
+    "method" : "GET",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "vertexid"
+      }, {
+        "key" : "subtaskindex"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "any"
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskAllExecutionAttemptsDetailsInfo",
+      "properties" : {
+        "attempts" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:SubtaskExecutionAttemptDetailsInfo",
+            "properties" : {
+              "subtask" : {
+                "type" : "integer"
+              },
+              "status" : {
+                "type" : "string",
+                "enum" : [ "CREATED", "SCHEDULED", "DEPLOYING", "RUNNING", "FINISHED", "CANCELING", "CANCELED", "FAILED", "RECONCILING" ]
+              },
+              "attempt" : {
+                "type" : "integer"
+              },
+              "host" : {
+                "type" : "string"
+              },
+              "start-time" : {
+                "type" : "integer"
+              },
+              "end-time" : {
+                "type" : "integer"
+              },
+              "duration" : {
+                "type" : "integer"
+              },
+              "metrics" : {
+                "type" : "object",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "properties" : {
+                  "read-bytes" : {
+                    "type" : "integer"
+                  },
+                  "read-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-bytes" : {
+                    "type" : "integer"
+                  },
+                  "write-bytes-complete" : {
+                    "type" : "boolean"
+                  },
+                  "read-records" : {
+                    "type" : "integer"
+                  },
+                  "read-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "write-records" : {
+                    "type" : "integer"
+                  },
+                  "write-records-complete" : {
+                    "type" : "boolean"
+                  }
+                }
+              },
+              "taskmanager-id" : {
+                "type" : "string"
+              },
+              "start_time" : {
+                "type" : "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  }, {
     "url" : "/jobs/:jobid/vertices/:vertexid/subtasks/:subtaskindex/attempts/:attempt",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -90,7 +90,7 @@ public interface AccessExecutionVertex {
 	/**
 	 * Returns prior executions for this execution vertex.
 	 *
-	 * @return prior executions for this execution vertex.
+	 * @return prior executions for this execution vertex
 	 */
 	EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -19,6 +19,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.util.EvictingBoundedList;
 
 import javax.annotation.Nullable;
 
@@ -85,4 +86,11 @@ public interface AccessExecutionVertex {
 	 */
 	@Nullable
 	AccessExecution getPriorExecutionAttempt(int attemptNumber);
+
+	/**
+	 * Returns prior executions for this execution vertex.
+	 *
+	 * @return prior executions for this execution vertex.
+	 */
+	EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/AccessExecutionVertex.java
@@ -19,9 +19,10 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.runtime.util.EvictingBoundedList;
 
 import javax.annotation.Nullable;
+
+import java.util.List;
 
 /**
  * Common interface for the runtime {@link ExecutionVertex} and {@link ArchivedExecutionVertex}.
@@ -92,5 +93,5 @@ public interface AccessExecutionVertex {
 	 *
 	 * @return prior executions for this execution vertex
 	 */
-	EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts();
+	List<AccessExecution> getPriorExecutionAttempts();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -104,4 +104,10 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 			throw new IllegalArgumentException("attempt does not exist");
 		}
 	}
+
+	@Override
+	public EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts() {
+		return priorExecutions;
+	}
+
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -24,6 +24,9 @@ import org.apache.flink.runtime.util.EvictingBoundedList;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializable {
 
@@ -106,7 +109,11 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 	}
 
 	@Override
-	public EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts() {
-		return priorExecutions;
+	public List<AccessExecution> getPriorExecutionAttempts() {
+		List<AccessExecution> accessExecutionList = new ArrayList<>();
+		for (ArchivedExecution archivedExecution: priorExecutions) {
+			accessExecutionList.add(archivedExecution);
+		}
+		return Collections.unmodifiableList(accessExecutionList);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -112,7 +112,9 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 	public List<AccessExecution> getPriorExecutionAttempts() {
 		List<AccessExecution> accessExecutionList = new ArrayList<>();
 		for (ArchivedExecution archivedExecution: priorExecutions) {
-			accessExecutionList.add(archivedExecution);
+			if (priorExecutions != null) {
+				accessExecutionList.add(archivedExecution);
+			}
 		}
 		return Collections.unmodifiableList(accessExecutionList);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionVertex.java
@@ -109,5 +109,4 @@ public class ArchivedExecutionVertex implements AccessExecutionVertex, Serializa
 	public EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts() {
 		return priorExecutions;
 	}
-
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -318,6 +318,11 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 		}
 	}
 
+	@Override
+	public EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts() {
+		return priorExecutions;
+	}
+
 	public ArchivedExecution getLatestPriorExecution() {
 		synchronized (priorExecutions) {
 			final int size = priorExecutions.size();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -322,7 +322,9 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	public List<AccessExecution> getPriorExecutionAttempts() {
 		List<AccessExecution> accessExecutionList = new ArrayList<>();
 		for (ArchivedExecution archivedExecution: priorExecutions) {
-			accessExecutionList.add(archivedExecution);
+			if (priorExecutions != null) {
+				accessExecutionList.add(archivedExecution);
+			}
 		}
 		return Collections.unmodifiableList(accessExecutionList);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -319,8 +319,12 @@ public class ExecutionVertex implements AccessExecutionVertex, Archiveable<Archi
 	}
 
 	@Override
-	public EvictingBoundedList<ArchivedExecution> getPriorExecutionAttempts() {
-		return priorExecutions;
+	public List<AccessExecution> getPriorExecutionAttempts() {
+		List<AccessExecution> accessExecutionList = new ArrayList<>();
+		for (ArchivedExecution archivedExecution: priorExecutions) {
+			accessExecutionList.add(archivedExecution);
+		}
+		return Collections.unmodifiableList(accessExecutionList);
 	}
 
 	public ArchivedExecution getLatestPriorExecution() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.job.SubtaskAllExecutionAttemptsDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskMessageParameters;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.Preconditions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+/**
+ * Handler which returns the details of all execution attempts of a subtask.
+ */
+public class SubtaskAllExecutionAttemptsDetailsHandler extends AbstractSubtaskHandler<SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
+
+	private final MetricFetcher metricFetcher;
+
+	public SubtaskAllExecutionAttemptsDetailsHandler(
+		GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+		Time timeout,
+		Map<String, String> responseHeaders,
+		MessageHeaders<EmptyRequestBody, SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> messageHeaders,
+		ExecutionGraphCache executionGraphCache,
+		Executor executor,
+		MetricFetcher metricFetcher) {
+		super(leaderRetriever, timeout, responseHeaders, messageHeaders, executionGraphCache, executor);
+
+		this.metricFetcher = Preconditions.checkNotNull(metricFetcher);
+	}
+
+	@Override
+	protected SubtaskAllExecutionAttemptsDetailsInfo handleRequest(
+			HandlerRequest<EmptyRequestBody, SubtaskMessageParameters> request,
+			AccessExecutionVertex executionVertex) throws RestHandlerException {
+		final JobID jobID = request.getPathParameter(JobIDPathParameter.class);
+		final JobVertexID jobVertexID = request.getPathParameter(JobVertexIdPathParameter.class);
+
+		return createSubtaskExecutionAttemptsDetailsInfo(executionVertex, jobID, jobVertexID);
+	}
+
+	protected SubtaskAllExecutionAttemptsDetailsInfo createSubtaskExecutionAttemptsDetailsInfo(AccessExecutionVertex executionVertex, JobID jobID, JobVertexID jobVertexID) {
+		List<SubtaskExecutionAttemptDetailsInfo> allAttempts = new ArrayList<>();
+		executionVertex.getPriorExecutionAttempts().forEach(execution -> {
+			if (execution != null) {
+				allAttempts.add(SubtaskExecutionAttemptDetailsInfo.create(execution, metricFetcher, jobID, jobVertexID));
+			}
+		});
+		allAttempts.add(SubtaskExecutionAttemptDetailsInfo.create(executionVertex.getCurrentExecutionAttempt(), metricFetcher, jobID, jobVertexID));
+
+		return new SubtaskAllExecutionAttemptsDetailsInfo(allAttempts);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
@@ -45,7 +45,8 @@ import java.util.concurrent.Executor;
 /**
  * Handler which returns the details of all execution attempts of a subtask.
  */
-public class SubtaskAllExecutionAttemptsDetailsHandler extends AbstractSubtaskHandler<SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
+public class SubtaskAllExecutionAttemptsDetailsHandler
+	extends AbstractSubtaskHandler<SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
 
 	private final MetricFetcher metricFetcher;
 
@@ -72,7 +73,10 @@ public class SubtaskAllExecutionAttemptsDetailsHandler extends AbstractSubtaskHa
 		return createSubtaskExecutionAttemptsDetailsInfo(executionVertex, jobID, jobVertexID);
 	}
 
-	protected SubtaskAllExecutionAttemptsDetailsInfo createSubtaskExecutionAttemptsDetailsInfo(AccessExecutionVertex executionVertex, JobID jobID, JobVertexID jobVertexID) {
+	protected SubtaskAllExecutionAttemptsDetailsInfo createSubtaskExecutionAttemptsDetailsInfo(
+		AccessExecutionVertex executionVertex,
+		JobID jobID,
+		JobVertexID jobVertexID) {
 		List<SubtaskExecutionAttemptDetailsInfo> allAttempts = new ArrayList<>();
 		executionVertex.getPriorExecutionAttempts().forEach(execution -> {
 			if (execution != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandler.java
@@ -78,11 +78,9 @@ public class SubtaskAllExecutionAttemptsDetailsHandler
 		JobID jobID,
 		JobVertexID jobVertexID) {
 		List<SubtaskExecutionAttemptDetailsInfo> allAttempts = new ArrayList<>();
-		executionVertex.getPriorExecutionAttempts().forEach(execution -> {
-			if (execution != null) {
-				allAttempts.add(SubtaskExecutionAttemptDetailsInfo.create(execution, metricFetcher, jobID, jobVertexID));
-			}
-		});
+		executionVertex
+			.getPriorExecutionAttempts()
+			.forEach(execution -> allAttempts.add(SubtaskExecutionAttemptDetailsInfo.create(execution, metricFetcher, jobID, jobVertexID)));
 		allAttempts.add(SubtaskExecutionAttemptDetailsInfo.create(executionVertex.getCurrentExecutionAttempt(), metricFetcher, jobID, jobVertexID));
 
 		return new SubtaskAllExecutionAttemptsDetailsInfo(allAttempts);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptDetailsHeaders.java
@@ -31,7 +31,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * Message headers for the {@link SubtaskAllExecutionAttemptsDetailsHandler}.
  */
-public class SubtaskAllExecutionAttemptDetailsHeaders implements MessageHeaders<EmptyRequestBody, SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
+public class SubtaskAllExecutionAttemptDetailsHeaders
+	implements MessageHeaders<EmptyRequestBody, SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
 
 	private static final SubtaskAllExecutionAttemptDetailsHeaders INSTANCE = new SubtaskAllExecutionAttemptDetailsHeaders();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptDetailsHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptDetailsHeaders.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.SubtaskAllExecutionAttemptsDetailsHandler;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.SubtaskIndexPathParameter;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link SubtaskAllExecutionAttemptsDetailsHandler}.
+ */
+public class SubtaskAllExecutionAttemptDetailsHeaders implements MessageHeaders<EmptyRequestBody, SubtaskAllExecutionAttemptsDetailsInfo, SubtaskMessageParameters> {
+
+	private static final SubtaskAllExecutionAttemptDetailsHeaders INSTANCE = new SubtaskAllExecutionAttemptDetailsHeaders();
+
+	public static final String URL = String.format(
+		"/jobs/:%s/vertices/:%s/subtasks/:%s/attempts",
+		JobIDPathParameter.KEY,
+		JobVertexIdPathParameter.KEY,
+		SubtaskIndexPathParameter.KEY);
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.GET;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	@Override
+	public Class<EmptyRequestBody> getRequestClass() {
+		return EmptyRequestBody.class;
+	}
+
+	@Override
+	public Class<SubtaskAllExecutionAttemptsDetailsInfo> getResponseClass() {
+		return SubtaskAllExecutionAttemptsDetailsInfo.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public SubtaskMessageParameters getUnresolvedMessageParameters() {
+		return new SubtaskMessageParameters();
+	}
+
+	public static SubtaskAllExecutionAttemptDetailsHeaders getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Returns the details of all execution attempts of a subtask.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptsDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskAllExecutionAttemptsDetailsInfo.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * The subtask all execution attempts response.
+ */
+public class SubtaskAllExecutionAttemptsDetailsInfo implements ResponseBody {
+	public static final String FIELD_NAME_ATTEMTPS = "attempts";
+
+	@JsonProperty(FIELD_NAME_ATTEMTPS)
+	private final Collection<SubtaskExecutionAttemptDetailsInfo> attempts;
+
+	@JsonCreator
+	public SubtaskAllExecutionAttemptsDetailsInfo(
+			@JsonProperty(FIELD_NAME_ATTEMTPS) Collection<SubtaskExecutionAttemptDetailsInfo> attempts) {
+		this.attempts = Preconditions.checkNotNull(attempts);
+	}
+
+	@JsonIgnore
+	public Collection<SubtaskExecutionAttemptDetailsInfo> getAttempts() {
+		return attempts;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+
+		final SubtaskAllExecutionAttemptsDetailsInfo that = (SubtaskAllExecutionAttemptsDetailsInfo) o;
+		return Objects.equals(attempts, that.attempts);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(attempts);
+	}
+}
+

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.rest.handler.job.JobVertexBackPressureHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.JobVertexTaskManagersHandler;
 import org.apache.flink.runtime.rest.handler.job.JobsOverviewHandler;
+import org.apache.flink.runtime.rest.handler.job.SubtaskAllExecutionAttemptsDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskCurrentAttemptDetailsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskExecutionAttemptAccumulatorsHandler;
 import org.apache.flink.runtime.rest.handler.job.SubtaskExecutionAttemptDetailsHandler;
@@ -117,6 +118,7 @@ import org.apache.flink.runtime.rest.messages.cluster.JobManagerLogListHeaders;
 import org.apache.flink.runtime.rest.messages.cluster.JobManagerStdoutFileHeader;
 import org.apache.flink.runtime.rest.messages.cluster.ShutdownHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.SubtaskAllExecutionAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskCurrentAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsHeaders;
@@ -492,6 +494,15 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 			executor,
 			metricFetcher);
 
+		final SubtaskAllExecutionAttemptsDetailsHandler subtaskAllExecutionAttemptsDetailsHandler = new  SubtaskAllExecutionAttemptsDetailsHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			SubtaskAllExecutionAttemptDetailsHeaders.getInstance(),
+			executionGraphCache,
+			executor,
+			metricFetcher);
+
 		final RescalingHandlers rescalingHandlers = new RescalingHandlers();
 
 		final RescalingHandlers.RescalingTriggerHandler rescalingTriggerHandler = rescalingHandlers.new RescalingTriggerHandler(
@@ -622,6 +633,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(subtaskExecutionAttemptDetailsHandler.getMessageHeaders(), subtaskExecutionAttemptDetailsHandler));
 		handlers.add(Tuple2.of(subtaskExecutionAttemptAccumulatorsHandler.getMessageHeaders(), subtaskExecutionAttemptAccumulatorsHandler));
 		handlers.add(Tuple2.of(subtaskCurrentAttemptDetailsHandler.getMessageHeaders(), subtaskCurrentAttemptDetailsHandler));
+		handlers.add(Tuple2.of(subtaskAllExecutionAttemptsDetailsHandler.getMessageHeaders(), subtaskAllExecutionAttemptsDetailsHandler));
 		handlers.add(Tuple2.of(jobVertexTaskManagersHandler.getMessageHeaders(), jobVertexTaskManagersHandler));
 		handlers.add(Tuple2.of(jobVertexBackPressureHandler.getMessageHeaders(), jobVertexBackPressureHandler));
 		handlers.add(Tuple2.of(jobCancelTerminationHandler.getMessageHeaders(), jobCancelTerminationHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
@@ -74,7 +74,7 @@ public class SubtaskAllExecutionAttemptsDetailsHandlerTest extends TestLogger {
 
 	@BeforeClass
 	public static void setUpClass() throws HandlerRequestException {
-		HashMap<String, String> receivedPathParameters = new HashMap<>(3);
+		HashMap<String, String> receivedPathParameters = new HashMap<>();
 		receivedPathParameters.put(JobIDPathParameter.KEY, JOBID.toString());
 		receivedPathParameters.put(JobVertexIdPathParameter.KEY, JOB_VERTEXID.toString());
 		receivedPathParameters.put(SubtaskIndexPathParameter.KEY, Integer.toString(SUBTASK_INDEX));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
@@ -36,7 +36,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.handler.HandlerRequest;
 import org.apache.flink.runtime.rest.handler.HandlerRequestException;
 import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
-import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
 import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcherImpl;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
@@ -97,7 +97,7 @@ public class SubtaskAllExecutionAttemptsDetailsHandlerTest extends TestLogger {
 			Time.milliseconds(100),
 			Collections.emptyMap(),
 			SubtaskAllExecutionAttemptDetailsHeaders.getInstance(),
-			new ExecutionGraphCache(
+			new DefaultExecutionGraphCache(
 				restHandlerConfiguration.getTimeout(),
 				Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
 			TestingUtils.defaultExecutor(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskAllExecutionAttemptsDetailsHandlerTest.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rest.handler.legacy.ExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcherImpl;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.SubtaskIndexPathParameter;
+import org.apache.flink.runtime.rest.messages.job.SubtaskAllExecutionAttemptDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.SubtaskAllExecutionAttemptsDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskMessageParameters;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.EvictingBoundedList;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests of {@link SubtaskAllExecutionAttemptsDetailsHandler}.
+ */
+public class SubtaskAllExecutionAttemptsDetailsHandlerTest extends TestLogger {
+
+	private static HandlerRequest<EmptyRequestBody, SubtaskMessageParameters> testRequest;
+	private static SubtaskAllExecutionAttemptsDetailsHandler handler;
+	private static MetricFetcher metricFetcher;
+	private static final JobID JOBID = new JobID();
+	private static final JobVertexID JOB_VERTEXID = new JobVertexID();
+	private static final int SUBTASK_INDEX = 0;
+
+	@BeforeClass
+	public static void setUpClass() throws HandlerRequestException {
+		HashMap<String, String> receivedPathParameters = new HashMap<>(3);
+		receivedPathParameters.put(JobIDPathParameter.KEY, JOBID.toString());
+		receivedPathParameters.put(JobVertexIdPathParameter.KEY, JOB_VERTEXID.toString());
+		receivedPathParameters.put(SubtaskIndexPathParameter.KEY, Integer.toString(SUBTASK_INDEX));
+		testRequest = new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new SubtaskMessageParameters(),
+			receivedPathParameters,
+			Collections.emptyMap());
+
+		metricFetcher = new MetricFetcherImpl<>(
+			() -> null,
+			address -> null,
+			TestingUtils.defaultExecutor(),
+			Time.milliseconds(1000L),
+			MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL.defaultValue());
+
+		RestHandlerConfiguration restHandlerConfiguration = RestHandlerConfiguration.fromConfiguration(new Configuration());
+		handler = new SubtaskAllExecutionAttemptsDetailsHandler(
+			() -> null,
+			Time.milliseconds(100),
+			Collections.emptyMap(),
+			SubtaskAllExecutionAttemptDetailsHeaders.getInstance(),
+			new ExecutionGraphCache(
+				restHandlerConfiguration.getTimeout(),
+				Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+			TestingUtils.defaultExecutor(),
+			metricFetcher);
+	}
+
+	@Test
+	public void testHandleRequest() throws Exception {
+		ArchivedExecutionJobVertex executionJobVertex = createExecutionJobVertex();
+		final SubtaskAllExecutionAttemptsDetailsInfo detailsInfo = handler.handleRequest(testRequest, executionJobVertex);
+		final AccessExecutionVertex[] executionVertices = executionJobVertex.getTaskVertices();
+		SubtaskAllExecutionAttemptsDetailsInfo expectedDetailsInfo = handler.createSubtaskExecutionAttemptsDetailsInfo(executionVertices[SUBTASK_INDEX], JOBID, JOB_VERTEXID);
+		assertEquals(detailsInfo, expectedDetailsInfo);
+	}
+
+	private ArchivedExecutionJobVertex createExecutionJobVertex() {
+		final long bytesIn = 1L;
+		final long bytesOut = 10L;
+		final long recordsIn = 20L;
+		final long recordsOut = 30L;
+
+		final IOMetrics ioMetrics = new IOMetrics(
+			bytesIn,
+			bytesOut,
+			recordsIn,
+			recordsOut);
+
+		final LocalTaskManagerLocation assignedResourceLocation = new LocalTaskManagerLocation();
+
+		final int currentAttemptNum = 2;
+		final long duration = 1024L;
+		EvictingBoundedList<ArchivedExecution> priorExecutionAttempt = new EvictingBoundedList<>(currentAttemptNum);
+		for (int i = 0; i < currentAttemptNum; i++) {
+			long deployTs = System.currentTimeMillis() - (currentAttemptNum + 1 - i) * duration;
+			priorExecutionAttempt.add(createAttempt(ioMetrics, i, ExecutionState.FAILED, assignedResourceLocation, SUBTASK_INDEX, deployTs, duration));
+		}
+		ArchivedExecution currentExecution = createAttempt(ioMetrics, currentAttemptNum, ExecutionState.FINISHED, assignedResourceLocation, SUBTASK_INDEX, System.currentTimeMillis() - duration, duration);
+
+		return new ArchivedExecutionJobVertex(
+			new ArchivedExecutionVertex[]{
+				new ArchivedExecutionVertex(
+					SUBTASK_INDEX,
+					"Test archived execution vertex",
+					currentExecution,
+					priorExecutionAttempt)
+			},
+			JOB_VERTEXID,
+			"test",
+			1,
+			1,
+			ResourceProfile.UNKNOWN,
+			new StringifiedAccumulatorResult[0]);
+	}
+
+	private ArchivedExecution createAttempt(IOMetrics ioMetrics, int attemptNumber, ExecutionState expectedState,
+			TaskManagerLocation assignedResourceLocation, int parallelSubtaskIndex, long deployTs, long duration) {
+		return new ArchivedExecution(
+			new StringifiedAccumulatorResult[0],
+			ioMetrics,
+			new ExecutionAttemptID(),
+			attemptNumber,
+			expectedState,
+			null,
+			assignedResourceLocation,
+			new AllocationID(),
+			parallelSubtaskIndex,
+			createTimes(deployTs, duration, expectedState));
+	}
+
+	private long[] createTimes(long deployingTs, long duration, ExecutionState lastState) {
+		final long[] timestamps = new long[ExecutionState.values().length];
+		timestamps[ExecutionState.DEPLOYING.ordinal()] = deployingTs;
+		timestamps[lastState.ordinal()] = deployingTs + duration;
+		return timestamps;
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
@@ -31,15 +31,15 @@ import java.util.Random;
 /**
  * Tests for (un)marshalling of {@link SubtaskAllExecutionAttemptsDetailsInfo}.
  */
-public class SubtaskAllExecutionAttemptsDetailsInfoTest extends RestResponseMarshallingTestBase {
+public class SubtaskAllExecutionAttemptsDetailsInfoTest extends RestResponseMarshallingTestBase<SubtaskAllExecutionAttemptsDetailsInfo> {
 
 	@Override
-	protected Class getTestResponseClass() {
+	protected Class<SubtaskAllExecutionAttemptsDetailsInfo> getTestResponseClass() {
 		return SubtaskAllExecutionAttemptsDetailsInfo.class;
 	}
 
 	@Override
-	protected ResponseBody getTestResponseInstance() throws Exception {
+	protected SubtaskAllExecutionAttemptsDetailsInfo getTestResponseInstance() throws Exception {
 		final Random random = new Random();
 		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
 			random.nextLong(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.rest.messages.job.SubtaskAllExecutionAttemptsDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Tests for (un)marshalling of {@link SubtaskAllExecutionAttemptsDetailsInfo}.
+ */
+public class SubtaskAllExecutionAttemptsDetailsInfoTest extends RestResponseMarshallingTestBase {
+	@Override
+	protected Class getTestResponseClass() {
+		return SubtaskAllExecutionAttemptsDetailsInfo.class;
+	}
+
+	@Override
+	protected ResponseBody getTestResponseInstance() throws Exception {
+
+		final Random random = new Random();
+		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean(),
+			random.nextLong(),
+			random.nextBoolean());
+		final int subtaskIndex = 1;
+		String host = "local1";
+		long duration = 1024L;
+		String taskmanagerId = "taskmanagerId1";
+		List<SubtaskExecutionAttemptDetailsInfo> subtaskExecutionAttemptDetailsInfoList = new ArrayList<>();
+		subtaskExecutionAttemptDetailsInfoList.add(new SubtaskExecutionAttemptDetailsInfo(
+			subtaskIndex,
+			ExecutionState.FAILED,
+			0,
+			host,
+			System.currentTimeMillis() - duration * 2,
+			System.currentTimeMillis() - duration,
+			duration,
+			jobVertexMetrics,
+			taskmanagerId));
+		subtaskExecutionAttemptDetailsInfoList.add(new SubtaskExecutionAttemptDetailsInfo(
+			subtaskIndex,
+			ExecutionState.RUNNING,
+			1,
+			host,
+			System.currentTimeMillis(),
+			-1L,
+			-1L,
+			jobVertexMetrics,
+			taskmanagerId));
+		return new SubtaskAllExecutionAttemptsDetailsInfo(subtaskExecutionAttemptDetailsInfoList);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/SubtaskAllExecutionAttemptsDetailsInfoTest.java
@@ -32,6 +32,7 @@ import java.util.Random;
  * Tests for (un)marshalling of {@link SubtaskAllExecutionAttemptsDetailsInfo}.
  */
 public class SubtaskAllExecutionAttemptsDetailsInfoTest extends RestResponseMarshallingTestBase {
+
 	@Override
 	protected Class getTestResponseClass() {
 		return SubtaskAllExecutionAttemptsDetailsInfo.class;
@@ -39,7 +40,6 @@ public class SubtaskAllExecutionAttemptsDetailsInfoTest extends RestResponseMars
 
 	@Override
 	protected ResponseBody getTestResponseInstance() throws Exception {
-
 		final Random random = new Random();
 		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
 			random.nextLong(),


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes rest api could get all attempts for a subtask.

## Brief change log

- get all attempts for a subtask


## Verifying this change

This change added tests and can be verified as follows:

- Added SubtaskAllExecutionAttemptsDetailsHandlerTest that verfied SubtaskAllExecutionAttemptsDetailsHandler.
- Added SubtaskAllExecutionAttemptsDetailsInfoTest could verfied SubtaskAllExecutionAttemptsDetailsInfo.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)