### PR TITLE
[FLINK-16346][tests] Use fixed JobIDs

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
@@ -244,7 +244,7 @@ public class BlobsCleanupITCase extends TestLogger {
 		}
 		source.setParallelism(numTasks);
 
-		return new JobGraph("BlobCleanupTest", source);
+		return new JobGraph(new JobID(0, testCase.ordinal()), "BlobCleanupTest", source);
 	}
 
 	/**


### PR DESCRIPTION
I can't reproduce the issue locally (and will close the JIRA accordingly).

The goal of this PR is to slightly ease debugging by clarifying which test run the leaked files belong to; this is currently not clear.
If it occurs again we at least know whether the successful/canceled job leaked them (or maybe even the successful test runs, who knows).