### PR TITLE
[BP-1.10][16576][state backends] Fix the problem of wrong mapping between stateId and metaInfo in HeapRestoreOperation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/StateAssignmentOperation.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
@@ -459,10 +460,11 @@ public class StateAssignmentOperation {
 	/**
 	 * Extracts certain key group ranges from the given state handles and adds them to the collector.
 	 */
-	private static void extractIntersectingState(
-		Collection<KeyedStateHandle> originalSubtaskStateHandles,
-		KeyGroupRange rangeToExtract,
-		List<KeyedStateHandle> extractedStateCollector) {
+	@VisibleForTesting
+	public static void extractIntersectingState(
+			Collection<? extends KeyedStateHandle> originalSubtaskStateHandles,
+			KeyGroupRange rangeToExtract,
+			List<KeyedStateHandle> extractedStateCollector) {
 
 		for (KeyedStateHandle keyedStateHandle : originalSubtaskStateHandles) {
 
@@ -618,26 +620,4 @@ public class StateAssignmentOperation {
 			newParallelism);
 		}
 
-	/**
-	 * Determine the subset of {@link KeyGroupsStateHandle KeyGroupsStateHandles} with correct
-	 * key group index for the given subtask {@link KeyGroupRange}.
-	 *
-	 * <p>This is publicly visible to be used in tests.
-	 */
-	public static List<KeyedStateHandle> getKeyedStateHandles(
-		Collection<? extends KeyedStateHandle> keyedStateHandles,
-		KeyGroupRange subtaskKeyGroupRange) {
-
-		List<KeyedStateHandle> subtaskKeyedStateHandles = new ArrayList<>(keyedStateHandles.size());
-
-		for (KeyedStateHandle keyedStateHandle : keyedStateHandles) {
-			KeyedStateHandle intersectedKeyedStateHandle = keyedStateHandle.getIntersection(subtaskKeyGroupRange);
-
-			if (intersectedKeyedStateHandle != null) {
-				subtaskKeyedStateHandles.add(intersectedKeyedStateHandle);
-			}
-		}
-
-		return subtaskKeyedStateHandles;
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupsStateHandle.java
@@ -83,8 +83,13 @@ public class KeyGroupsStateHandle implements StreamStateHandle, KeyedStateHandle
 	 * @return key-group state over a range that is the intersection between this handle's key-group range and the
 	 *          provided key-group range.
 	 */
+	@Override
 	public KeyGroupsStateHandle getIntersection(KeyGroupRange keyGroupRange) {
-		return new KeyGroupsStateHandle(groupRangeOffsets.getIntersection(keyGroupRange), stateHandle);
+		KeyGroupRangeOffsets offsets = groupRangeOffsets.getIntersection(keyGroupRange);
+		if (offsets.getKeyGroupRange().getNumberOfKeyGroups() <= 0) {
+			return null;
+		}
+		return new KeyGroupsStateHandle(offsets, stateHandle);
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyedStateHandle.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.state;
 
+import javax.annotation.Nullable;
+
 /**
  * Base for the handles of the checkpointed states in keyed streams. When
  * recovering from failures, the handle will be passed to all tasks whose key
@@ -34,7 +36,9 @@ public interface KeyedStateHandle extends CompositeStateHandle {
 	 * Returns a state over a range that is the intersection between this
 	 * handle's key-group range and the provided key-group range.
 	 *
-	 * @param keyGroupRange The key group range to intersect with
+	 * @param keyGroupRange The key group range to intersect with,
+	 * will return null if the intersection of this handle's key-group and the provided key-group is empty.
 	 */
+	@Nullable
 	KeyedStateHandle getIntersection(KeyGroupRange keyGroupRange);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapRestoreOperation.java
@@ -103,7 +103,6 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 	@Override
 	public Void restore() throws Exception {
 
-		final Map<Integer, StateMetaInfoSnapshot> kvStatesById = new HashMap<>();
 		registeredKVStates.clear();
 		registeredPQStates.clear();
 
@@ -147,6 +146,8 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 
 				List<StateMetaInfoSnapshot> restoredMetaInfos =
 					serializationProxy.getStateMetaInfoSnapshots();
+
+				final Map<Integer, StateMetaInfoSnapshot> kvStatesById = new HashMap<>();
 
 				createOrCheckStateForMetaInfo(restoredMetaInfos, kvStatesById);
 
@@ -198,9 +199,8 @@ public class HeapRestoreOperation<K> implements RestoreOperation<Void> {
 						metaInfoSnapshot.getBackendStateType() + ".");
 			}
 
-			if (registeredState == null) {
-				kvStatesById.put(kvStatesById.size(), metaInfoSnapshot);
-			}
+			// always put metaInfo into kvStatesById, because kvStatesById is KeyGroupsStateHandle related
+			kvStatesById.put(kvStatesById.size(), metaInfoSnapshot);
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/KeyGroupsStateHandleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.state;
+
+import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * A test for {@link KeyGroupsStateHandle}
+ */
+public class KeyGroupsStateHandleTest {
+
+	@Test
+	public void testNonEmptyIntersection() {
+		KeyGroupRangeOffsets offsets = new KeyGroupRangeOffsets(0, 7);
+		byte[] dummy = new byte[10];
+		StreamStateHandle streamHandle = new ByteStreamStateHandle("test", dummy);
+		KeyGroupsStateHandle handle = new KeyGroupsStateHandle(offsets, streamHandle);
+
+		KeyGroupRange expectedRange = new KeyGroupRange(0, 3);
+		KeyGroupsStateHandle newHandle = handle.getIntersection(expectedRange);
+		assertNotNull(newHandle);
+		assertEquals(streamHandle, newHandle.getDelegateStateHandle());
+		assertEquals(expectedRange, newHandle.getKeyGroupRange());
+	}
+
+	@Test
+	public void testEmptyIntersection() {
+		KeyGroupRangeOffsets offsets = new KeyGroupRangeOffsets(0, 7);
+		byte[] dummy = new byte[10];
+		StreamStateHandle streamHandle = new ByteStreamStateHandle("test", dummy);
+		KeyGroupsStateHandle handle = new KeyGroupsStateHandle(offsets, streamHandle);
+		// return null if the the keygroup intersection is empty.
+		KeyGroupRange newRange = new KeyGroupRange(8, 11);
+		assertNull(handle.getIntersection(newRange));
+	}
+}
+

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -398,13 +398,17 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
 
 		KeyGroupRange localKeyGroupRange = keyGroupPartitions.get(subtaskIndex);
 
-		List<KeyedStateHandle> localManagedKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> localManagedKeyGroupState = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 			operatorStateHandles.getManagedKeyedState(),
-			localKeyGroupRange);
+			localKeyGroupRange,
+			localManagedKeyGroupState);
 
-		List<KeyedStateHandle> localRawKeyGroupState = StateAssignmentOperation.getKeyedStateHandles(
+		List<KeyedStateHandle> localRawKeyGroupState = new ArrayList<>();
+		StateAssignmentOperation.extractIntersectingState(
 			operatorStateHandles.getRawKeyedState(),
-			localKeyGroupRange);
+			localKeyGroupRange,
+			localRawKeyGroupState);
 
 		StateObjectCollection<OperatorStateHandle> managedOperatorStates = operatorStateHandles.getManagedOperatorState();
 		Collection<OperatorStateHandle> localManagedOperatorState;


### PR DESCRIPTION

## What is the purpose of the change

cherry-pick FLINK-16576 to release-1.10

## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
