### PR TITLE
[docs][typos] Fix build.sh --flink-version interpretation to 1.xx.x releases

### DIFF
--- a/flink-container/docker/README.md
+++ b/flink-container/docker/README.md
@@ -29,7 +29,7 @@ If you want to build the Flink image for a specific version of Flink/Hadoop/Scal
 
     build.sh --from-release --flink-version 1.6.0 --hadoop-version 2.8 --scala-version 2.11 --job-artifacts <COMMA_SEPARATED_PATH_TO_JOB_ARTIFACTS> [--with-python2|--with-python3] --image-name <IMAGE_NAME>
 
-Please note that from Flink-1.8, hadoop version is optional and you could build the Flink image without providing any hadoop version.
+Please note that from Flink 1.8.x, hadoop version is optional and you could build the Flink image without providing any hadoop version.
     
 The script will try to download the released version from the Apache archive.
 

--- a/flink-container/docker/build.sh
+++ b/flink-container/docker/build.sh
@@ -126,9 +126,9 @@ if [ -n "${FROM_RELEASE}" ]; then
 
   FLINK_BASE_URL="$(curl -s https://www.apache.org/dyn/closer.cgi\?preferred\=true)flink/flink-${FLINK_VERSION}/"
 
-  FLINK_MAJOR_VERSION=$(echo "$FLINK_VERSION" | sed -e 's/\.//;s/\(..\).*/\1/')
+  FLINK_MAJOR_VERSION=$(echo "$FLINK_VERSION" | sed -e 's/\.//g')
 
-  if [[ $FLINK_MAJOR_VERSION -ge 18 ]]; then
+  if [[ $FLINK_MAJOR_VERSION -ge 180 ]]; then
 
   # After Flink-1.8 we would let release pre-built package with hadoop
     if [[ -n "${HADOOP_VERSION}" ]]; then

--- a/flink-container/docker/build.sh
+++ b/flink-container/docker/build.sh
@@ -26,7 +26,7 @@ Usage:
   build.sh --help
 
   If the --image-name flag is not used the built image name will be 'flink-job'.
-  Before Flink-1.8, the hadoop-version is required. And from Flink-1.8, the hadoop-version is optional and would download pre-bundled shaded Hadoop jar package if provided.
+  Before Flink 1.8.x, the hadoop-version is required. And from Flink 1.8.x, the hadoop-version is optional and would download pre-bundled shaded Hadoop jar package if provided.
 HERE
   exit 1
 }
@@ -130,9 +130,9 @@ if [ -n "${FROM_RELEASE}" ]; then
 
   if [[ $FLINK_MAJOR_VERSION -ge 180 ]]; then
 
-  # After Flink-1.8 we would let release pre-built package with hadoop
+  # After Flink 1.8.x we would let release pre-built package with hadoop
     if [[ -n "${HADOOP_VERSION}" ]]; then
-        echo "After Flink-1.8, we would download pre-bundle hadoop jar package."
+        echo "After Flink 1.8.x, we would download pre-bundle hadoop jar package."
         # list to get target pre-bundle package
         SHADED_HADOOP_BASE_URL="https://repo.maven.apache.org/maven2/org/apache/flink/flink-shaded-hadoop2-uber/"
         SHADED_HADOOP_VERSION="$(curl -s ${SHADED_HADOOP_BASE_URL} | grep -o "title=\"[0-9.-]*/\"" | sed 's/title=\"//g; s/\/"//g' | grep ${HADOOP_VERSION} | head -1)"


### PR DESCRIPTION
## What is the purpose of the change

* This pull request fixes interpretation of `--flink-version` parameter to 1.xx.x release (e.g 1.10.0 version) in `build.sh` script. The fixes adjusts the `sed` function to consider all digits of version so a `1.10.0` release is now being considered as `110`. Without this fix the `--hadoop-version` is being required because the release `1.10.0` was being considered as `11` that is less than `18` that requires `--hadoop-version` as parameter.
* This PR adjust too a description of flink version in readme to follow the pattern `x.xx.xx` for releases.

## Brief change log
  - *Fix sed replacement causing error in 1.xx.xx release versions causing version 1.10.0 being considered as 11 instead 110 so requering haddop as parameter*
  - *Improves semantic of flink version description to be according the current release format Flink 1.xx.xx instead Flink-1.x*

## Documentation

  - Does this pull request introduce a new feature? (no)
