### PR TITLE
[FLINK-17023][scripts] Fix format checking of extractExecutionParams in config.sh

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -644,18 +644,16 @@ extractExecutionParams() {
     local execution_config=$1
     local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
 
-    local line_count=`echo "$execution_config" | grep "" -c`
-    if ! [[ ${line_count} == 1 ]]; then
-        echo "[ERROR] Unexpected result ($line_count lines): $execution_config" 1>&2
+    local num_lines=$(echo "$execution_config" | wc -l)
+    if ! [[ ${num_lines} == 1 ]]; then
+        echo "[ERROR] Unexpected result ($num_lines lines): $execution_config" 1>&2
         echo "[ERROR] extractExecutionParams only accepts exactly one line as the input" 1>&2
-        echo "$output" 1>&2
         exit 1
     fi
 
     if ! [[ ${execution_config} =~ ^${EXECUTION_PREFIX}.* ]]; then
         echo "[ERROR] Unexpected result: $execution_config" 1>&2
         echo "[ERROR] The output of BashJavaUtils is expected to be the execution result, following the prefix '${EXECUTION_PREFIX}'" 1>&2
-        echo "$output" 1>&2
         exit 1
     fi
 

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -644,9 +644,17 @@ extractExecutionParams() {
     local execution_config=$1
     local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
 
-    if ! [[ $execution_config =~ ^${EXECUTION_PREFIX}.* ]]; then
+    local line_count=`echo "$execution_config" | grep "" -c`
+    if ! [[ ${line_count} == 1 ]]; then
+        echo "[ERROR] Unexpected result ($line_count lines): $execution_config" 1>&2
+        echo "[ERROR] extractExecutionParams only accepts exactly one line as the input" 1>&2
+        echo "$output" 1>&2
+        exit 1
+    fi
+
+    if ! [[ ${execution_config} =~ ^${EXECUTION_PREFIX}.* ]]; then
         echo "[ERROR] Unexpected result: $execution_config" 1>&2
-        echo "[ERROR] The last line of the BashJavaUtils outputs is expected to be the execution result, following the prefix '${EXECUTION_PREFIX}'" 1>&2
+        echo "[ERROR] The output of BashJavaUtils is expected to be the execution result, following the prefix '${EXECUTION_PREFIX}'" 1>&2
         echo "$output" 1>&2
         exit 1
     fi


### PR DESCRIPTION
## What is the purpose of the change

In [FLINK-15727](https://issues.apache.org/jira/browse/FLINK-15727) `BashJavaUtils` now returns multiple lines of results to avoid using `BashJavaUtils` twice. But now the format checking for the last line is incorrect.

This PR fixes the format checking for the last line in `extractExecutionParams` in `config.sh`.

## Brief change log

 - Fix format checking of extractExecutionParams in config.sh

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
