### PR TITLE
[FLINK-16812][jdbc] support array types in PostgresRowConverter

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/AbstractJDBCRowConverter.java
@@ -54,7 +54,10 @@ public abstract class AbstractJDBCRowConverter implements JDBCRowConverter {
 		return reuse;
 	}
 
-	private JDBCFieldConverter createConverter(LogicalType type) {
+	/**
+	 * Create a runtime JDBC field converter from given {@link LogicalType}.
+	 */
+	public JDBCFieldConverter createConverter(LogicalType type) {
 		LogicalTypeRoot root = type.getTypeRoot();
 
 		if (root == LogicalTypeRoot.SMALLINT) {

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/JDBCRowConverter.java
@@ -43,6 +43,6 @@ public interface JDBCRowConverter extends Serializable {
 	 */
 	@FunctionalInterface
 	interface JDBCFieldConverter extends Serializable {
-		Object convert(Object value);
+		Object convert(Object value) throws SQLException;
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
@@ -20,8 +20,10 @@ package org.apache.flink.api.java.io.jdbc.source.row.converter;
 
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
 
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGobject;
@@ -41,9 +43,9 @@ public class PostgresRowConverter extends AbstractJDBCRowConverter {
 
 		if (root == LogicalTypeRoot.ARRAY) {
 			ArrayType arrayType = (ArrayType) type;
-			LogicalTypeRoot elemType = arrayType.getElementType().getTypeRoot();
 
-			if (elemType == LogicalTypeRoot.VARBINARY) {
+			// PG's bytea[] is wrapped in PGobject, rather than primitive byte arrays
+			if (LogicalTypeChecks.hasFamily(arrayType.getElementType(), LogicalTypeFamily.BINARY_STRING)) {
 
 				return v -> {
 					PgArray pgArray = (PgArray) v;

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/source/row/converter/PostgresRowConverter.java
@@ -18,7 +18,13 @@
 
 package org.apache.flink.api.java.io.jdbc.source.row.converter;
 
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
+
+import org.postgresql.jdbc.PgArray;
+import org.postgresql.util.PGobject;
 
 /**
  * Row converter for Postgres.
@@ -28,4 +34,39 @@ public class PostgresRowConverter extends AbstractJDBCRowConverter {
 	public PostgresRowConverter(RowType rowType) {
 		super(rowType);
 	}
+
+	@Override
+	public JDBCFieldConverter createConverter(LogicalType type) {
+		LogicalTypeRoot root = type.getTypeRoot();
+
+		if (root == LogicalTypeRoot.ARRAY) {
+			ArrayType arrayType = (ArrayType) type;
+			LogicalTypeRoot elemType = arrayType.getElementType().getTypeRoot();
+
+			if (elemType == LogicalTypeRoot.VARBINARY) {
+
+				return v -> {
+					PgArray pgArray = (PgArray) v;
+					Object[] in = (Object[]) pgArray.getArray();
+
+					Object[] out = new Object[in.length];
+					for (int i = 0; i < in.length; i++) {
+						out[i] = ((PGobject) in[i]).getValue().getBytes();
+					}
+
+					return out;
+				};
+			} else {
+				return v -> ((PgArray) v).getArray();
+			}
+		} else {
+			return createPrimitiveConverter(type);
+		}
+	}
+
+	// Have its own method so that Postgres can support primitives that super class doesn't support in the future
+	private JDBCFieldConverter createPrimitiveConverter(LogicalType type) {
+		return super.createConverter(type);
+	}
+
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -88,6 +88,32 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03]", results.toString());
 	}
 
+	@Test
+	public void testArrayTypes() throws Exception {
+		TableEnvironment tEnv = getTableEnvWithPgCatalog();
+
+		List<Row> results = TableUtils.collectToList(
+			tEnv.sqlQuery(String.format("select * from %s", TABLE_ARRAY_TYPE)));
+
+		assertEquals("[" +
+				"[1, 2, 3]," +
+				"[[92, 120, 51, 50], [92, 120, 51, 51], [92, 120, 51, 52]]," +
+				"[3, 4, 5]," +
+				"[4, 5, 6]," +
+				"[5.5, 6.6, 7.7]," +
+				"[6.6, 7.7, 8.8]," +
+				"[7.70000, 8.80000, 9.90000]," +
+				"[true, false, true]," +
+				"[a, b, c]," +
+				"[b, c, d]," +
+				"[b  , c  , d  ]," +
+				"[b, c, d]," +
+				"[2016-06-22T19:10:25, 2019-06-22T19:10:25]," +
+				"[2015-01-01, 2020-01-01]," +
+				"[00:51:03, 00:59:03]]",
+			results.toString());
+	}
+
 	private TableEnvironment getTableEnvWithPgCatalog() {
 		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
 		TableEnvironment tableEnv = TableEnvironment.create(settings);

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTest.java
@@ -71,7 +71,7 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 	public void testListTables() throws DatabaseNotExistException {
 		List<String> actual = catalog.listTables(DEFAULT_DATABASE);
 
-		assertEquals(Arrays.asList("public.dt", "public.t1", "public.t4", "public.t5"), actual);
+		assertEquals(Arrays.asList("public.dt", "public.dt2", "public.t1", "public.t4", "public.t5"), actual);
 
 		actual = catalog.listTables(TEST_DB);
 
@@ -145,5 +145,12 @@ public class PostgresCatalogTest extends PostgresCatalogTestBase {
 		CatalogBaseTable table = catalog.getTable(new ObjectPath(DEFAULT_DATABASE, TABLE_PRIMITIVE_TYPE));
 
 		assertEquals(getPrimitiveTable().schema, table.getSchema());
+	}
+
+	@Test
+	public void tesArrayDataTypes() throws TableNotExistException {
+		CatalogBaseTable table = catalog.getTable(new ObjectPath(DEFAULT_DATABASE, TABLE_ARRAY_TYPE));
+
+		assertEquals(getArrayTable().schema, table.getSchema());
 	}
 }

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -57,6 +57,7 @@ public class PostgresCatalogTestBase {
 	protected static final String TABLE4 = "t4";
 	protected static final String TABLE5 = "t5";
 	protected static final String TABLE_PRIMITIVE_TYPE = "dt";
+	protected static final String TABLE_ARRAY_TYPE = "dt2";
 
 	protected static String baseUrl;
 	protected static PostgresCatalog catalog;
@@ -85,12 +86,15 @@ public class PostgresCatalogTestBase {
 		// table: test.public.t2
 		// table: test.test_schema.t3
 		// table: postgres.public.dt
+		// table: postgres.public.dt2
 		createTable(TEST_DB, PostgresTablePath.fromFlinkTableName(TABLE2), getSimpleTable().pgSchemaSql);
 		createTable(TEST_DB, new PostgresTablePath(TEST_SCHEMA, TABLE3), getSimpleTable().pgSchemaSql);
 		createTable(PostgresTablePath.fromFlinkTableName(TABLE_PRIMITIVE_TYPE), getPrimitiveTable().pgSchemaSql);
+		createTable(PostgresTablePath.fromFlinkTableName(TABLE_ARRAY_TYPE), getArrayTable().pgSchemaSql);
 
 		executeSQL(DEFAULT_DATABASE, String.format("insert into public.%s values (%s);", TABLE1, getSimpleTable().values));
 		executeSQL(DEFAULT_DATABASE, String.format("insert into %s values (%s);", TABLE_PRIMITIVE_TYPE, getPrimitiveTable().values));
+		executeSQL(DEFAULT_DATABASE, String.format("insert into %s values (%s);", TABLE_ARRAY_TYPE, getArrayTable().values));
 	}
 
 	public static void createTable(PostgresTablePath tablePath, String tableSchemaSql) throws SQLException {
@@ -204,6 +208,64 @@ public class PostgresCatalogTestBase {
 				"'2015-01-01'," +
 				"'00:51:02.746572'"
 		);
+	}
+
+	// TODO: add back timestamptz once blink planner supports timestamp with timezone
+	public static TestTable getArrayTable() {
+		return new TestTable(
+			TableSchema.builder()
+				.field("int_arr", DataTypes.ARRAY(DataTypes.INT()))
+				.field("bytea_arr", DataTypes.ARRAY(DataTypes.BYTES()))
+				.field("short_arr", DataTypes.ARRAY(DataTypes.SMALLINT()))
+				.field("long_arr", DataTypes.ARRAY(DataTypes.BIGINT()))
+				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
+				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
+				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
+				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
+				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
+				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
+				.field("character_arr", DataTypes.ARRAY(DataTypes.CHAR(3)))
+				.field("character_varying_arr", DataTypes.ARRAY(DataTypes.VARCHAR(20)))
+				.field("timestamp_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP(5)))
+//				.field("timestamptz_arr", DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4)))
+				.field("date_arr", DataTypes.ARRAY(DataTypes.DATE()))
+				.field("time_arr", DataTypes.ARRAY(DataTypes.TIME(0)))
+				.build(),
+
+			"int_arr integer[], " +
+				"bytea_arr bytea[], " +
+				"short_arr smallint[], " +
+				"long_arr bigint[], " +
+				"real_arr real[], " +
+				"double_precision_arr double precision[], " +
+				"numeric_arr numeric(10, 5)[], " +
+				"boolean_arr boolean[], " +
+				"text_arr text[], " +
+				"char_arr char[], " +
+				"character_arr character(3)[], " +
+				"character_varying_arr character varying(20)[], " +
+				"timestamp_arr timestamp(5)[], " +
+//				"timestamptz_arr timestamptz(4)[], " +
+				"date_arr date[], " +
+				"time_arr time(0)[]",
+
+			String.format("'{1,2,3}'," +
+					"'{2,3,4}'," +
+					"'{3,4,5}'," +
+					"'{4,5,6}'," +
+					"'{5.5,6.6,7.7}'," +
+					"'{6.6,7.7,8.8}'," +
+					"'{7.7,8.8,9.9}'," +
+					"'{true,false,true}'," +
+					"'{a,b,c}'," +
+					"'{b,c,d}'," +
+					"'{b,c,d}'," +
+					"'{b,c,d}'," +
+					"'{\"2016-06-22 19:10:25\", \"2019-06-22 19:10:25\"}'," +
+//				"'{\"2006-06-22 19:10:25\", \"2009-06-22 19:10:25\"}'," +
+					"'{\"2015-01-01\", \"2020-01-01\"}'," +
+					"'{\"00:51:02.746572\", \"00:59:02.746572\"}'"
+			));
 	}
 
 }

--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -139,9 +139,6 @@ public final class StringUtils {
 		if (array instanceof long[]) {
 			return Arrays.toString((long[]) array);
 		}
-		if (array instanceof Object[]) {
-			return Arrays.toString((Object[]) array);
-		}
 		// for array of byte array
 		if (array instanceof byte[][]) {
 			byte[][] b = (byte[][]) array;
@@ -170,6 +167,9 @@ public final class StringUtils {
 		}
 		if (array instanceof short[]) {
 			return Arrays.toString((short[]) array);
+		}
+		if (array instanceof Object[]) {
+			return Arrays.toString((Object[]) array);
 		}
 
 		if (array.getClass().isArray()) {

--- a/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
@@ -39,6 +39,17 @@ public class StringUtilsTest extends TestLogger {
 	}
 
 	@Test
+	public void testArrayOfBytesArray() {
+		byte[][] expectedArray = new byte[][]{
+			{1, -97, 49, 74 },
+			{2, -92, 48, 73 }
+		};
+
+		String controlString = StringUtils.arrayToString(expectedArray);
+		assertEquals("[[1, -97, 49, 74], [2, -92, 48, 73]]", controlString);
+	}
+
+	@Test
 	public void testArrayToString() {
 		double[] array = {1.0};
 		String controlString = StringUtils.arrayToString(array);


### PR DESCRIPTION
## What is the purpose of the change

commit 1: fix bug that StringUtils.arrayToString() should consider Object[] lastly, otherwise it will take byte[][] as Object[] and produce wrong string
commit 2: support array types in PostgresRowConverter

## Brief change log

## Verifying this change

with UTs added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

docs will added later