### PR TITLE
[FLINK-16943][python] Support set the configuration option "pipeline.jars" in PyFlink.

### DIFF
--- a/docs/dev/table/python/dependency_management.md
+++ b/docs/dev/table/python/dependency_management.md
@@ -22,7 +22,24 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-If third-party dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
+# Java Dependency Management
+
+If third-party Java dependencies are used, you can using following code to add jars for your Python job.
+
+{% highlight python %}
+# Set jar urls in "pipeline.jars". The jars will be uploaded to the cluster.
+# NOTE: Only local file urls (start with "file://") are supported.
+table_env.get_config.set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+
+# Set jar urls in "pipeline.classpaths". The jars will be added to the classpath of the cluster.
+# Users should ensure the urls are accessible on both the local client and the cluster.
+# NOTE: The supported schemes includes: file,ftp,http,https,jar. "hdfs" is not supported by default.
+table_env.get_config.set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+{% endhighlight %}
+
+# Python Dependency Management
+
+If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 
 <table class="table table-bordered">
   <thead>

--- a/docs/dev/table/python/dependency_management.md
+++ b/docs/dev/table/python/dependency_management.md
@@ -22,24 +22,23 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Java Dependency Management
+# Java Dependency
 
-If third-party Java dependencies are used, you can using following code to add jars for your Python job.
+If third-party Java dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 
 {% highlight python %}
-# Set jar urls in "pipeline.jars". The jars will be uploaded to the cluster.
-# NOTE: Only local file urls (start with "file://") are supported.
-table_env.get_config.set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# Specify a list of jar URLs via "pipeline.jars". The jars are separated by ";" and will be uploaded to the cluster.
+# NOTE: Only local file URLs (start with "file://") are supported.
+table_env.get_config().set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
-# Set jar urls in "pipeline.classpaths". The jars will be added to the classpath of the cluster.
-# Users should ensure the urls are accessible on both the local client and the cluster.
-# NOTE: The supported schemes includes: file,ftp,http,https,jar. "hdfs" is not supported by default.
-table_env.get_config.set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# Specify a list of URLs via "pipeline.classpaths". The URLs are separated by ";" and will be added to the classpath of the cluster.
+# NOTE: The Paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
+table_env.get_config().set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-# Python Dependency Management
+# Python Dependency
 
-If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
+If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 
 <table class="table table-bordered">
   <thead>

--- a/docs/dev/table/python/dependency_management.zh.md
+++ b/docs/dev/table/python/dependency_management.zh.md
@@ -22,22 +22,21 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Java Dependency Management
+# Java Dependency
 
-If third-party Java dependencies are used, you can using following code to add jars for your Python job.
+If third-party Java dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 
 {% highlight python %}
-# Set jar urls in "pipeline.jars". The jars will be uploaded to the cluster.
-# NOTE: Only the local file urls (start with "file://") are supported.
-table_env.get_config.set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# Specify a list of jar URLs via "pipeline.jars". The jars are separated by ";" and will be uploaded to the cluster.
+# NOTE: Only local file URLs (start with "file://") are supported.
+table_env.get_config().set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 
-# Set jar urls in "pipeline.classpaths". The jars will be added to the classpath of the cluster.
-# Users should ensure the urls are accessible on both the local client and the cluster.
-# NOTE: The supported schemes includes: file,ftp,http,https,jar. "hdfs" is not supported by default.
-table_env.get_config.set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+# Specify a list of URLs via "pipeline.classpaths". The URLs are separated by ";" and will be added to the classpath of the cluster.
+# NOTE: The Paths must specify a protocol (e.g. file://) and users should ensure that the URLs are accessible on both the client and the cluster.
+table_env.get_config().set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
 {% endhighlight %}
 
-# Python Dependency Management
+# Python Dependency
 
 If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 

--- a/docs/dev/table/python/dependency_management.zh.md
+++ b/docs/dev/table/python/dependency_management.zh.md
@@ -22,7 +22,24 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-If third-party dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
+# Java Dependency Management
+
+If third-party Java dependencies are used, you can using following code to add jars for your Python job.
+
+{% highlight python %}
+# Set jar urls in "pipeline.jars". The jars will be uploaded to the cluster.
+# NOTE: Only the local file urls (start with "file://") are supported.
+table_env.get_config.set_configuration("pipeline.jars", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+
+# Set jar urls in "pipeline.classpaths". The jars will be added to the classpath of the cluster.
+# Users should ensure the urls are accessible on both the local client and the cluster.
+# NOTE: The supported schemes includes: file,ftp,http,https,jar. "hdfs" is not supported by default.
+table_env.get_config.set_configuration("pipeline.classpaths", "file:///my/jar/path/connector.jar;file:///my/jar/path/udf.jar")
+{% endhighlight %}
+
+# Python Dependency Management
+
+If third-party Python dependencies are used, you can specify the dependencies with the following Python Table APIs or through <a href="{{ site.baseurl }}/zh/ops/cli.html#usage">command line arguments</a> directly when submitting the job.
 
 <table class="table table-bordered">
   <thead>

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/executors/LocalExecutor.java
@@ -21,7 +21,6 @@ package org.apache.flink.client.deployment.executors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.Plan;
 import org.apache.flink.api.dag.Pipeline;
-import org.apache.flink.client.FlinkPipelineTranslationUtil;
 import org.apache.flink.client.program.PerJobMiniClusterFactory;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
@@ -95,6 +94,6 @@ public class LocalExecutor implements PipelineExecutor {
 			plan.setDefaultParallelism(slotsPerTaskManager * numTaskManagers);
 		}
 
-		return FlinkPipelineTranslationUtil.getJobGraph(pipeline, configuration, 1);
+		return PipelineExecutorUtils.getJobGraph(pipeline, configuration);
 	}
 }

--- a/flink-python/bin/pyflink-gateway-server.sh
+++ b/flink-python/bin/pyflink-gateway-server.sh
@@ -69,6 +69,9 @@ if [[ -n "$FLINK_TESTING" ]]; then
   fi
 
   FIND_EXPRESSION=""
+  FIND_EXPRESSION="$FIND_EXPRESSION -path ${FLINK_SOURCE_ROOT_DIR}/flink-table/flink-table-planner/target/flink-table-planner*-tests.jar"
+  FIND_EXPRESSION="$FIND_EXPRESSION -o -path ${FLINK_SOURCE_ROOT_DIR}/flink-runtime/target/flink-runtime*tests.jar"
+  FIND_EXPRESSION="$FIND_EXPRESSION -o -path ${FLINK_SOURCE_ROOT_DIR}/flink-streaming-java/target/flink-streaming-java*tests.jar"
   FIND_EXPRESSION="$FIND_EXPRESSION -o -path ${FLINK_SOURCE_ROOT_DIR}/flink-formats/flink-csv/target/flink-csv*.jar"
   FIND_EXPRESSION="$FIND_EXPRESSION -o -path ${FLINK_SOURCE_ROOT_DIR}/flink-formats/flink-avro/target/flink-avro*.jar"
   FIND_EXPRESSION="$FIND_EXPRESSION -o -path ${FLINK_SOURCE_ROOT_DIR}/flink-formats/flink-avro/target/avro*.jar"
@@ -86,7 +89,7 @@ if [[ -n "$FLINK_TESTING" ]]; then
     else
       FLINK_TEST_CLASSPATH="$FLINK_TEST_CLASSPATH":"$testJarFile"
     fi
-  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( -name 'flink-*-tests.jar'${FIND_EXPRESSION} \) -print0 | sort -z)
+  done < <(find "$FLINK_SOURCE_ROOT_DIR" ! -type d \( ${FIND_EXPRESSION} \) -print0 | sort -z)
   set +f
 
   cd $CURRENT_DIR

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -411,6 +411,35 @@ under the License.
 				<artifactId>maven-jar-plugin</artifactId>
 				<executions>
 					<execution>
+						<id>testUDF1</id>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/TestScalarFunction1.class</include>
+							</includes>
+							<outputDirectory>
+								${project.build.directory}/func1
+							</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>testUDF2</id>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+						<configuration>
+							<includes>
+								<include>**/TestScalarFunction2.class</include>
+							</includes>
+							<outputDirectory>
+								${project.build.directory}/func2
+							</outputDirectory>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-jar</id>
 						<goals>
 							<goal>test-jar</goal>
 						</goals>

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -406,6 +406,17 @@ under the License.
 					<argLine>-Xms256m -Xmx2048m -Dmvn.forkNumber=${surefire.forkNumber} -Dio.netty.tryReflectionSetAccessible=true -XX:+UseG1GC</argLine>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-python/pyflink/common/configuration.py
+++ b/flink-python/pyflink/common/configuration.py
@@ -69,7 +69,9 @@ class Configuration:
         :type value: str
         """
         jvm = get_gateway().jvm
-        if key == jvm.org.apache.flink.configuration.PipelineOptions.JARS.key():
+        jars_key = jvm.org.apache.flink.configuration.PipelineOptions.JARS.key()
+        classpaths_key = jvm.org.apache.flink.configuration.PipelineOptions.CLASSPATHS.key()
+        if key in [jars_key, classpaths_key]:
             add_jars_to_context_class_loader(value.split(";"))
         self._j_configuration.setString(key, value)
 

--- a/flink-python/pyflink/common/configuration.py
+++ b/flink-python/pyflink/common/configuration.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.java_gateway import get_gateway
+from pyflink.util.utils import add_jars_to_context_class_loader
 
 
 class Configuration:
@@ -67,6 +68,9 @@ class Configuration:
         :param value: The value of the key/value pair to be added.
         :type value: str
         """
+        jvm = get_gateway().jvm
+        if key == jvm.org.apache.flink.configuration.PipelineOptions.JARS.key():
+            add_jars_to_context_class_loader(value.split(";"))
         self._j_configuration.setString(key, value)
 
     def get_integer(self, key, default_value):

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -947,7 +947,7 @@ class TableEnvironment(object):
         :type job_name: str
         :return: The result of the job execution, containing elapsed time and accumulators.
         """
-        self._write_pipeline_jars_to_j_env()
+        self._add_pipeline_jars_to_j_env_config()
         return JobExecutionResult(self._j_tenv.execute(job_name))
 
     def from_elements(self, elements, schema=None, verify_schema=True):
@@ -1096,7 +1096,7 @@ class TableEnvironment(object):
                 and is_local_deployment(j_config):
             j_config.setString(jvm.PythonOptions.PYTHON_EXECUTABLE.key(), sys.executable)
 
-    def _write_pipeline_jars_to_j_env(self):
+    def _add_pipeline_jars_to_j_env_config(self):
         jvm = get_gateway().jvm
         jars_key = jvm.org.apache.flink.configuration.PipelineOptions.JARS.key()
         jar_urls = self.get_config().get_configuration().get_string(jars_key, None)

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1725,7 +1725,10 @@ def _to_java_type(data_type):
     elif isinstance(data_type, UserDefinedType):
         if data_type.java_udt():
             return gateway.jvm.org.apache.flink.util.InstantiationUtil.instantiate(
-                gateway.jvm.Class.forName(data_type.java_udt()))
+                gateway.jvm.Class.forName(
+                    data_type.java_udt(),
+                    True,
+                    gateway.jvm.Thread.currentThread().getContextClassLoader()))
         else:
             return _to_java_type(data_type.sql_type())
 

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -113,13 +113,13 @@ def add_jars_to_context_class_loader(jar_urls):
     # validate and normalize
     jar_urls = [gateway.jvm.java.net.URL(url).toString() for url in jar_urls]
     context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
-    existed_urls = []
+    existing_urls = []
     if context_classloader.getClass().getName() == "java.net.URLClassLoader":
-        existed_urls = set([url.toString() for url in context_classloader.getURLs()])
-    if all([url in existed_urls for url in jar_urls]):
+        existing_urls = set([url.toString() for url in context_classloader.getURLs()])
+    if all([url in existing_urls for url in jar_urls]):
         # if urls all existed, no need to create new class loader.
         return
-    jar_urls.extend(existed_urls)
+    jar_urls.extend(existing_urls)
     # remove duplicates and create Java objects.
     j_urls = [gateway.jvm.java.net.URL(url) for url in set(jar_urls)]
     new_classloader = gateway.jvm.java.net.URLClassLoader(

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -98,3 +98,30 @@ def is_local_deployment(j_configuration):
     JDeploymentOptions = jvm.org.apache.flink.configuration.DeploymentOptions
     return j_configuration.containsKey(JDeploymentOptions.TARGET.key()) \
         and j_configuration.getString(JDeploymentOptions.TARGET.key(), None) == "local"
+
+
+def add_jars_to_context_class_loader(jar_urls):
+    """
+    Add jars to Python gateway server for local compilation and local execution (i.e. minicluster).
+    There are many component in Flink which won't be added to classpath by default. e.g. Kafka
+    connector, JDBC connector, CSV format etc. This utility function can be used to hot load the
+    jars.
+
+    :param jar_urls: The list of jar urls.
+    """
+    gateway = get_gateway()
+    # validate and normalize
+    jar_urls = [gateway.jvm.java.net.URL(url).toString() for url in jar_urls]
+    context_classloader = gateway.jvm.Thread.currentThread().getContextClassLoader()
+    existed_urls = []
+    if context_classloader.getClass().getName() == "java.net.URLClassLoader":
+        existed_urls = set([url.toString() for url in context_classloader.getURLs()])
+    if all([url in existed_urls for url in jar_urls]):
+        # if urls all existed, no need to create new class loader.
+        return
+    jar_urls.extend(existed_urls)
+    # remove duplicates and create Java objects.
+    j_urls = [gateway.jvm.java.net.URL(url) for url in set(jar_urls)]
+    new_classloader = gateway.jvm.java.net.URLClassLoader(
+        to_jarray(gateway.jvm.java.net.URL, j_urls), context_classloader)
+    gateway.jvm.Thread.currentThread().setContextClassLoader(new_classloader)

--- a/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.util;
+
+import org.apache.flink.table.functions.ScalarFunction;
+
+/**
+ * Just a simple scalar function for testing add jars from python side.
+ */
+public class TestScalarFunction extends ScalarFunction {
+
+	public String eval(int a, String b) {
+		return a + " or " + b;
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction1.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction1.java
@@ -23,9 +23,9 @@ import org.apache.flink.table.functions.ScalarFunction;
 /**
  * Just a simple scalar function for testing add jars from python side.
  */
-public class TestScalarFunction extends ScalarFunction {
+public class TestScalarFunction1 extends ScalarFunction {
 
-	public String eval(int a, String b) {
-		return a + " or " + b;
+	public String eval(long a, String b) {
+		return a + " and " + b;
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction2.java
+++ b/flink-python/src/test/java/org/apache/flink/python/util/TestScalarFunction2.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.util;
+
+import org.apache.flink.table.functions.ScalarFunction;
+
+/**
+ * Just a simple scalar function for testing add jars from python side.
+ */
+public class TestScalarFunction2 extends ScalarFunction {
+
+	public String eval(long a, String b) {
+		return a + " or " + b;
+	}
+}

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -148,8 +148,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-python/target/flink-python*-tests.jar" \
-            ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner-blink/target/flink-table-planner-blink*-tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-python/target/func1/flink-python*-tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-python/target/func2/flink-python*-tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
     
             # .git directory

--- a/tools/travis_controller.sh
+++ b/tools/travis_controller.sh
@@ -148,6 +148,8 @@ if [ $STAGE == "$STAGE_COMPILE" ]; then
             ! -path "$CACHE_FLINK_DIR/flink-dist/target/flink-*-bin/flink-*/opt/flink-python*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-elasticsearch-base/target/flink-*.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-connectors/flink-connector-kafka-base/target/flink-*.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-python/target/flink-python*-tests.jar" \
+            ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner-blink/target/flink-table-planner-blink*-tests.jar" \
             ! -path "$CACHE_FLINK_DIR/flink-table/flink-table-planner/target/flink-table-planner*tests.jar" | xargs rm -rf
     
             # .git directory


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports set the configuration option "pipeline.jars" in PyFlink, which could be used to add user jars during the job code execution.*


## Brief change log

  - *When the "pipeline.jars" is set to the python configuration object, load the jars to context class loader.*
  - *When the PyFlink `TableEnvironment#execute()` method is called, pass the "pipeline.jars" configuration in `TableConfig` to `ExecutionEnviornment#configuration`*

## Verifying this change

This change is already covered by existing tests, such as *test_table_environment_api.py*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
