### PR TITLE
[FLINK-16766][python]Support create StreamTableEnvironment without pa…

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1107,8 +1107,11 @@ class StreamTableEnvironment(TableEnvironment):
         super(StreamTableEnvironment, self).__init__(j_tenv)
 
     def _get_j_env(self):
-        if self._is_blink_planner:
-            return self._j_tenv.getPlanner().getExecEnv()
+        if "getPlanner" in dir(self._j_tenv):
+            if self._is_blink_planner:
+                return self._j_tenv.getPlanner().getExecEnv()
+            else:
+                return self._j_tenv.getPlanner().getExecutionEnvironment()
         else:
             return self._j_tenv.execEnv()
 

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1107,13 +1107,10 @@ class StreamTableEnvironment(TableEnvironment):
         super(StreamTableEnvironment, self).__init__(j_tenv)
 
     def _get_j_env(self):
-        if "getPlanner" in dir(self._j_tenv):
-            if self._is_blink_planner:
-                return self._j_tenv.getPlanner().getExecEnv()
-            else:
-                return self._j_tenv.getPlanner().getExecutionEnvironment()
+        if self._is_blink_planner:
+            return self._j_tenv.getPlanner().getExecEnv()
         else:
-            return self._j_tenv.execEnv()
+            return self._j_tenv.getPlanner().getExecutionEnvironment()
 
     def get_config(self):
         """

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -296,6 +296,15 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
             planner.getClass().getName(),
             "org.apache.flink.table.planner.delegation.StreamPlanner")
 
+        t_env = StreamTableEnvironment.create(
+            environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
+
+        planner = t_env._j_tenv.getPlanner()
+
+        self.assertEqual(
+            planner.getClass().getName(),
+            "org.apache.flink.table.planner.delegation.StreamPlanner")
+
     def test_table_environment_with_blink_planner(self):
         self.env.set_parallelism(1)
         t_env = StreamTableEnvironment.create(

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -297,6 +297,15 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
             "org.apache.flink.table.planner.delegation.StreamPlanner")
 
         t_env = StreamTableEnvironment.create(
+            environment_settings=EnvironmentSettings.new_instance().build())
+
+        planner = t_env._j_tenv.getPlanner()
+
+        self.assertEqual(
+            planner.getClass().getName(),
+            "org.apache.flink.table.planner.StreamPlanner")
+
+        t_env = StreamTableEnvironment.create(
             environment_settings=EnvironmentSettings.new_instance().use_blink_planner().build())
 
         planner = t_env._j_tenv.getPlanner()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will create `StreamTableEnvironment` without passing `StreamExecutionEnvironment` parameter.*


## Brief change log

  - *Modify `StreamExecutionEnvironment` parameter to optional, support create `StreamTableEnvironment` without passing `StreamExecutionEnvironment` parameter through method `create` of `TableTableEnvironment`.*


## Verifying this change

  - *Modify `test_create_table_environment_with_blink_planner` method to add create `StreamTableEnvironment` without passing `StreamExecutionEnvironment` test case.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
