### PR TITLE
[FLINK-17135][python][tests] Fix the test testPandasFunctionMixedWithGeneralPythonFunction to make it more stable

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -238,18 +238,18 @@ FlinkLogicalCalc(select=[pandasFunc1(a, b) AS EXPR$0])
   </TestCase>
   <TestCase name="testPandasFunctionMixedWithGeneralPythonFunction">
     <Resource name="sql">
-      <![CDATA[SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1 FROM MyTable]]>
+      <![CDATA[SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1, a + 1 FROM MyTable]]>
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
-LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+(pyFunc1($0, $2), 1)])
+LogicalProject(EXPR$0=[pandasFunc1($0, $1)], EXPR$1=[+(pyFunc1($0, $2), 1)], EXPR$2=[+($0, 1)])
 +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
 ]]>
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-FlinkLogicalCalc(select=[f0 AS EXPR$0, +(f1, 1) AS EXPR$1])
-+- FlinkLogicalCalc(select=[f0, pyFunc1(a, c) AS f1])
+FlinkLogicalCalc(select=[f0 AS EXPR$0, +(f1, 1) AS EXPR$1, +(a, 1) AS EXPR$2])
++- FlinkLogicalCalc(select=[a, f0, pyFunc1(a, c) AS f1])
    +- FlinkLogicalCalc(select=[a, c, pandasFunc1(a, b) AS f0])
       +- FlinkLogicalTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
 ]]>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -169,7 +169,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
 
   @Test
   def testPandasFunctionMixedWithGeneralPythonFunction(): Unit = {
-    val sqlQuery = "SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1 FROM MyTable"
+    val sqlQuery = "SELECT pandasFunc1(a, b), pyFunc1(a, c) + 1, a + 1 FROM MyTable"
     util.verifyPlan(sqlQuery)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCalcSplitRuleTest.scala
@@ -440,7 +440,7 @@ class PythonCalcSplitRuleTest extends TableTestBase {
     util.tableEnv.registerFunction("pyFunc1", new PythonScalarFunction("pyFunc1"))
     util.tableEnv.registerFunction("pandasFunc1", new PandasScalarFunction("pandasFunc1"))
 
-    val resultTable = table.select("pandasFunc1(a, b), pyFunc1(a, c) + 1")
+    val resultTable = table.select("pandasFunc1(a, b), pyFunc1(a, c) + 1, a + 1")
 
     val expected = unaryNode(
       "DataStreamCalc",
@@ -451,9 +451,9 @@ class PythonCalcSplitRuleTest extends TableTestBase {
           streamTableNode(table),
           term("select", "a", "c", "pandasFunc1(a, b) AS f0")
         ),
-        term("select", "f0", "pyFunc1(a, c) AS f1")
+        term("select", "a", "f0", "pyFunc1(a, c) AS f1")
       ),
-      term("select",  "f0 AS _c0", "+(f1, 1) AS _c1")
+      term("select",  "f0 AS _c0", "+(f1, 1) AS _c1", "+(a, 1) AS _c2")
     )
 
     util.verifyTable(resultTable, expected)


### PR DESCRIPTION

## What is the purpose of the change

*This pull request changes the test testPandasFunctionMixedWithGeneralPythonFunction a bit to work around the bug introduced in CALCITE-3149.*

## Brief change log

  - *Update the test testPandasFunctionMixedWithGeneralPythonFunction*

## Verifying this change

This change added tests and can be verified as follows:

  - *Updated tests testPandasFunctionMixedWithGeneralPythonFunction*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
