### PR TITLE
[FLINK-16770][checkpointing] Revert commits of FLINK-16945 and FLINK-14971

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_externalized_checkpoints.sh
@@ -39,8 +39,6 @@ fi
 
 set_config_key "taskmanager.numberOfTaskSlots" "${NUM_SLOTS}"
 set_config_key "metrics.fetcher.update-interval" "2000"
-# hotfix for FLINK-16770
-set_config_key "state.checkpoints.num-retained" "2"
 setup_flink_slf4j_metric_reporter
 start_cluster
 

--- a/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
+++ b/flink-end-to-end-tests/test-scripts/test_resume_savepoint.sh
@@ -61,8 +61,6 @@ if [ $STATE_BACKEND_ROCKS_TIMER_SERVICE_TYPE == 'heap' ]; then
   set_config_key "state.backend.rocksdb.timer-service.factory" "heap"
 fi
 set_config_key "metrics.fetcher.update-interval" "2000"
-# hotfix for FLINK-16770
-set_config_key "state.checkpoints.num-retained" "2"
 
 setup_flink_slf4j_metric_reporter
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1370,7 +1370,6 @@ public class CheckpointCoordinator {
 		return this.pendingCheckpoints.size();
 	}
 
-	@VisibleForTesting
 	public int getNumberOfRetainedSuccessfulCheckpoints() {
 		synchronized (lock) {
 			return completedCheckpointStore.getNumberOfRetainedCheckpoints();
@@ -1383,7 +1382,6 @@ public class CheckpointCoordinator {
 		}
 	}
 
-	@VisibleForTesting
 	public List<CompletedCheckpoint> getSuccessfulCheckpoints() throws Exception {
 		synchronized (lock) {
 			return completedCheckpointStore.getAllCheckpoints();
@@ -1394,7 +1392,6 @@ public class CheckpointCoordinator {
 		return checkpointStorage;
 	}
 
-	@VisibleForTesting
 	public CompletedCheckpointStore getCheckpointStore() {
 		return completedCheckpointStore;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -23,16 +23,12 @@ import org.apache.flink.api.common.JobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import java.util.List;
 import java.util.ListIterator;
 
 /**
  * A bounded LIFO-queue of {@link CompletedCheckpoint} instances.
- * Note that it might be visited by multiple threads. So implementation should keep it thread-safe.
  */
-@ThreadSafe
 public interface CompletedCheckpointStore {
 
 	Logger LOG = LoggerFactory.getLogger(CompletedCheckpointStore.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
-import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -29,6 +28,7 @@ import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.StateUtil;
 import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 
@@ -111,11 +111,6 @@ public class PendingCheckpoint {
 	/** The executor for potentially blocking I/O operations, like state disposal. */
 	private final Executor executor;
 
-	/** The executor for non-blocking operations. */
-	private final Executor mainThreadExecutor;
-
-	private final CompletedCheckpointStore completedCheckpointStore;
-
 	private int numAcknowledgedTasks;
 
 	private boolean discarded;
@@ -140,9 +135,7 @@ public class PendingCheckpoint {
 			CheckpointProperties props,
 			CheckpointStorageLocation targetLocation,
 			Executor executor,
-			Executor mainThreadExecutor,
-			CompletableFuture<CompletedCheckpoint> onCompletionPromise,
-			CompletedCheckpointStore completedCheckpointStore) {
+			CompletableFuture<CompletedCheckpoint> onCompletionPromise) {
 
 		checkArgument(verticesToConfirm.size() > 0,
 				"Checkpoint needs at least one vertex that commits the checkpoint");
@@ -154,8 +147,6 @@ public class PendingCheckpoint {
 		this.props = checkNotNull(props);
 		this.targetLocation = checkNotNull(targetLocation);
 		this.executor = Preconditions.checkNotNull(executor);
-		this.mainThreadExecutor = Preconditions.checkNotNull(mainThreadExecutor);
-		this.completedCheckpointStore = Preconditions.checkNotNull(completedCheckpointStore);
 
 		this.operatorStates = new HashMap<>();
 		this.masterStates = new ArrayList<>(masterStateIdentifiers.size());
@@ -298,37 +289,24 @@ public class PendingCheckpoint {
 		return onCompletionPromise;
 	}
 
-	public CompletableFuture<CompletedCheckpoint> finalizeCheckpoint() {
+	public CompletedCheckpoint finalizeCheckpoint() throws IOException {
 
 		synchronized (lock) {
-			if (isDiscarded()) {
-				return FutureUtils.completedExceptionally(new IllegalStateException(
-					"checkpoint is discarded"));
-			}
-			if (!isFullyAcknowledged()) {
-				return FutureUtils.completedExceptionally(new IllegalStateException(
-					"Pending checkpoint has not been fully acknowledged yet"));
-			}
-
-			// now we stop the canceller before finalization
-			// it simplifies the concurrent conflict issue here
-			cancelCanceller();
+			checkState(!isDiscarded(), "checkpoint is discarded");
+			checkState(isFullyAcknowledged(), "Pending checkpoint has not been fully acknowledged yet");
 
 			// make sure we fulfill the promise with an exception if something fails
-			final CompletableFuture<CompletedCheckpoint> finalizingFuture =
-				CompletableFuture.supplyAsync(() -> {
-				try {
-					checkState(!isDiscarded(), "The checkpoint has been discarded");
-					// write out the metadata
-					final CheckpointMetadata savepoint = new CheckpointMetadata(checkpointId, operatorStates.values(), masterStates);
-					final CompletedCheckpointStorageLocation finalizedLocation;
+			try {
+				// write out the metadata
+				final CheckpointMetadata savepoint = new CheckpointMetadata(checkpointId, operatorStates.values(), masterStates);
+				final CompletedCheckpointStorageLocation finalizedLocation;
 
-					try (CheckpointMetadataOutputStream out = targetLocation.createMetadataOutputStream()) {
-						Checkpoints.storeCheckpointMetadata(savepoint, out);
-						finalizedLocation = out.closeAndFinalizeCheckpoint();
-					}
+				try (CheckpointMetadataOutputStream out = targetLocation.createMetadataOutputStream()) {
+					Checkpoints.storeCheckpointMetadata(savepoint, out);
+					finalizedLocation = out.closeAndFinalizeCheckpoint();
+				}
 
-					CompletedCheckpoint completed = new CompletedCheckpoint(
+				CompletedCheckpoint completed = new CompletedCheckpoint(
 						jobId,
 						checkpointId,
 						checkpointTimestamp,
@@ -338,25 +316,6 @@ public class PendingCheckpoint {
 						props,
 						finalizedLocation);
 
-					try {
-						completedCheckpointStore.addCheckpoint(completed);
-					} catch (Throwable t) {
-						completed.discardOnFailedStoring();
-					}
-					return completed;
-				} catch (Throwable t) {
-					LOG.warn("Could not finalize checkpoint {}.", checkpointId, t);
-					onCompletionPromise.completeExceptionally(t);
-					throw new CompletionException(t);
-				}
-			}, executor);
-
-			return finalizingFuture.thenApplyAsync((completed) -> {
-
-				// since canceller has been already cancelled, discarding means the coordinator must be shut down
-				// all the resources should be released properly when it's shutting down the coordinator
-				checkState(!isDiscarded(), "The checkpoint has been discarded");
-
 				onCompletionPromise.complete(completed);
 
 				// to prevent null-pointers from concurrent modification, copy reference onto stack
@@ -365,7 +324,7 @@ public class PendingCheckpoint {
 					// Finalize the statsCallback and give the completed checkpoint a
 					// callback for discards.
 					CompletedCheckpointStats.DiscardCallback discardCallback =
-						statsCallback.reportCompletedCheckpoint(completed.getExternalPointer());
+							statsCallback.reportCompletedCheckpoint(finalizedLocation.getExternalPointer());
 					completed.setDiscardCallback(discardCallback);
 				}
 
@@ -373,7 +332,12 @@ public class PendingCheckpoint {
 				dispose(false);
 
 				return completed;
-			}, mainThreadExecutor);
+			}
+			catch (Throwable t) {
+				onCompletionPromise.completeExceptionally(t);
+				ExceptionUtils.rethrowIOException(t);
+				return null; // silence the compiler
+			}
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/PendingCheckpoint.java
@@ -78,6 +78,8 @@ public class PendingCheckpoint {
 	/** The PendingCheckpoint logs to the same logger as the CheckpointCoordinator. */
 	private static final Logger LOG = LoggerFactory.getLogger(CheckpointCoordinator.class);
 
+	private final Object lock = new Object();
+
 	private final JobID jobId;
 
 	private final long checkpointId;
@@ -113,9 +115,6 @@ public class PendingCheckpoint {
 	private final Executor mainThreadExecutor;
 
 	private final CompletedCheckpointStore completedCheckpointStore;
-
-	/** The lock for avoiding conflict between I/O operations. */
-	private final Object operationLock = new Object();
 
 	private int numAcknowledgedTasks;
 
@@ -267,16 +266,18 @@ public class PendingCheckpoint {
 	 * @return true, if the handle was set, false, if the checkpoint is already disposed;
 	 */
 	public boolean setCancellerHandle(ScheduledFuture<?> cancellerHandle) {
-		if (this.cancellerHandle == null) {
-			if (!discarded) {
-				this.cancellerHandle = cancellerHandle;
-				return true;
-			} else {
-				return false;
+		synchronized (lock) {
+			if (this.cancellerHandle == null) {
+				if (!discarded) {
+					this.cancellerHandle = cancellerHandle;
+					return true;
+				} else {
+					return false;
+				}
 			}
-		}
-		else {
-			throw new IllegalStateException("A canceller handle was already set");
+			else {
+				throw new IllegalStateException("A canceller handle was already set");
+			}
 		}
 	}
 
@@ -299,24 +300,24 @@ public class PendingCheckpoint {
 
 	public CompletableFuture<CompletedCheckpoint> finalizeCheckpoint() {
 
-		if (isDiscarded()) {
-			return FutureUtils.completedExceptionally(new IllegalStateException(
-				"checkpoint is discarded"));
-		}
-		if (!isFullyAcknowledged()) {
-			return FutureUtils.completedExceptionally(new IllegalStateException(
-				"Pending checkpoint has not been fully acknowledged yet"));
-		}
+		synchronized (lock) {
+			if (isDiscarded()) {
+				return FutureUtils.completedExceptionally(new IllegalStateException(
+					"checkpoint is discarded"));
+			}
+			if (!isFullyAcknowledged()) {
+				return FutureUtils.completedExceptionally(new IllegalStateException(
+					"Pending checkpoint has not been fully acknowledged yet"));
+			}
 
-		// now we stop the canceller before finalization
-		// it simplifies the concurrent conflict issue here
-		cancelCanceller();
+			// now we stop the canceller before finalization
+			// it simplifies the concurrent conflict issue here
+			cancelCanceller();
 
-		// make sure we fulfill the promise with an exception if something fails
-		final CompletableFuture<CompletedCheckpoint> finalizingFuture =
-			CompletableFuture.supplyAsync(() -> {
-			try {
-				synchronized (operationLock) {
+			// make sure we fulfill the promise with an exception if something fails
+			final CompletableFuture<CompletedCheckpoint> finalizingFuture =
+				CompletableFuture.supplyAsync(() -> {
+				try {
 					checkState(!isDiscarded(), "The checkpoint has been discarded");
 					// write out the metadata
 					final CheckpointMetadata savepoint = new CheckpointMetadata(checkpointId, operatorStates.values(), masterStates);
@@ -343,38 +344,37 @@ public class PendingCheckpoint {
 						completed.discardOnFailedStoring();
 					}
 					return completed;
+				} catch (Throwable t) {
+					LOG.warn("Could not finalize checkpoint {}.", checkpointId, t);
+					onCompletionPromise.completeExceptionally(t);
+					throw new CompletionException(t);
 				}
-			} catch (Throwable t) {
-				LOG.warn("Could not finalize checkpoint {}.", checkpointId, t);
-				onCompletionPromise.completeExceptionally(t);
-				throw new CompletionException(t);
-			}
-		}, executor);
+			}, executor);
 
-		return finalizingFuture.thenApplyAsync((completed) -> {
+			return finalizingFuture.thenApplyAsync((completed) -> {
 
-			// since canceller has been already cancelled, discarding means the coordinator must be shut down
-			// all the resources should be released properly when it's shutting down the coordinator
-			checkState(!isDiscarded(), "The checkpoint has been discarded");
+				// since canceller has been already cancelled, discarding means the coordinator must be shut down
+				// all the resources should be released properly when it's shutting down the coordinator
+				checkState(!isDiscarded(), "The checkpoint has been discarded");
 
-			onCompletionPromise.complete(completed);
+				onCompletionPromise.complete(completed);
 
-			// to prevent null-pointers from concurrent modification, copy reference onto stack
-			PendingCheckpointStats statsCallback = this.statsCallback;
-			if (statsCallback != null) {
-				// Finalize the statsCallback and give the completed checkpoint a
-				// callback for discards.
-				CompletedCheckpointStats.DiscardCallback discardCallback =
-					statsCallback.reportCompletedCheckpoint(completed.getExternalPointer());
-				completed.setDiscardCallback(discardCallback);
+				// to prevent null-pointers from concurrent modification, copy reference onto stack
+				PendingCheckpointStats statsCallback = this.statsCallback;
+				if (statsCallback != null) {
+					// Finalize the statsCallback and give the completed checkpoint a
+					// callback for discards.
+					CompletedCheckpointStats.DiscardCallback discardCallback =
+						statsCallback.reportCompletedCheckpoint(completed.getExternalPointer());
+					completed.setDiscardCallback(discardCallback);
+				}
 
-			}
+				// mark this pending checkpoint as disposed, but do NOT drop the state
+				dispose(false);
 
-			// mark this pending checkpoint as disposed, but do NOT drop the state
-			dispose(false);
-
-			return completed;
-		}, mainThreadExecutor);
+				return completed;
+			}, mainThreadExecutor);
+		}
 	}
 
 	/**
@@ -390,108 +390,112 @@ public class PendingCheckpoint {
 			TaskStateSnapshot operatorSubtaskStates,
 			CheckpointMetrics metrics) {
 
-		if (discarded) {
-			return TaskAcknowledgeResult.DISCARDED;
-		}
+		synchronized (lock) {
+			if (discarded) {
+				return TaskAcknowledgeResult.DISCARDED;
+			}
 
-		final ExecutionVertex vertex = notYetAcknowledgedTasks.remove(executionAttemptId);
+			final ExecutionVertex vertex = notYetAcknowledgedTasks.remove(executionAttemptId);
 
-		if (vertex == null) {
-			if (acknowledgedTasks.contains(executionAttemptId)) {
-				return TaskAcknowledgeResult.DUPLICATE;
+			if (vertex == null) {
+				if (acknowledgedTasks.contains(executionAttemptId)) {
+					return TaskAcknowledgeResult.DUPLICATE;
+				} else {
+					return TaskAcknowledgeResult.UNKNOWN;
+				}
 			} else {
-				return TaskAcknowledgeResult.UNKNOWN;
+				acknowledgedTasks.add(executionAttemptId);
 			}
-		} else {
-			acknowledgedTasks.add(executionAttemptId);
-		}
 
-		List<OperatorID> operatorIDs = vertex.getJobVertex().getOperatorIDs();
-		int subtaskIndex = vertex.getParallelSubtaskIndex();
-		long ackTimestamp = System.currentTimeMillis();
+			List<OperatorID> operatorIDs = vertex.getJobVertex().getOperatorIDs();
+			int subtaskIndex = vertex.getParallelSubtaskIndex();
+			long ackTimestamp = System.currentTimeMillis();
 
-		long stateSize = 0L;
+			long stateSize = 0L;
 
-		if (operatorSubtaskStates != null) {
-			for (OperatorID operatorID : operatorIDs) {
+			if (operatorSubtaskStates != null) {
+				for (OperatorID operatorID : operatorIDs) {
 
-				OperatorSubtaskState operatorSubtaskState =
-					operatorSubtaskStates.getSubtaskStateByOperatorID(operatorID);
+					OperatorSubtaskState operatorSubtaskState =
+						operatorSubtaskStates.getSubtaskStateByOperatorID(operatorID);
 
-				// if no real operatorSubtaskState was reported, we insert an empty state
-				if (operatorSubtaskState == null) {
-					operatorSubtaskState = new OperatorSubtaskState();
+					// if no real operatorSubtaskState was reported, we insert an empty state
+					if (operatorSubtaskState == null) {
+						operatorSubtaskState = new OperatorSubtaskState();
+					}
+
+					OperatorState operatorState = operatorStates.get(operatorID);
+
+					if (operatorState == null) {
+						operatorState = new OperatorState(
+							operatorID,
+							vertex.getTotalNumberOfParallelSubtasks(),
+							vertex.getMaxParallelism());
+						operatorStates.put(operatorID, operatorState);
+					}
+
+					operatorState.putState(subtaskIndex, operatorSubtaskState);
+					stateSize += operatorSubtaskState.getStateSize();
 				}
-
-				OperatorState operatorState = operatorStates.get(operatorID);
-
-				if (operatorState == null) {
-					operatorState = new OperatorState(
-						operatorID,
-						vertex.getTotalNumberOfParallelSubtasks(),
-						vertex.getMaxParallelism());
-					operatorStates.put(operatorID, operatorState);
-				}
-
-				operatorState.putState(subtaskIndex, operatorSubtaskState);
-				stateSize += operatorSubtaskState.getStateSize();
 			}
+
+			++numAcknowledgedTasks;
+
+			// publish the checkpoint statistics
+			// to prevent null-pointers from concurrent modification, copy reference onto stack
+			final PendingCheckpointStats statsCallback = this.statsCallback;
+			if (statsCallback != null) {
+				// Do this in millis because the web frontend works with them
+				long alignmentDurationMillis = metrics.getAlignmentDurationNanos() / 1_000_000;
+				long checkpointStartDelayMillis = metrics.getCheckpointStartDelayNanos() / 1_000_000;
+
+				SubtaskStateStats subtaskStateStats = new SubtaskStateStats(
+					subtaskIndex,
+					ackTimestamp,
+					stateSize,
+					metrics.getSyncDurationMillis(),
+					metrics.getAsyncDurationMillis(),
+					metrics.getBytesBufferedInAlignment(),
+					alignmentDurationMillis,
+					checkpointStartDelayMillis);
+
+				statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
+			}
+
+			return TaskAcknowledgeResult.SUCCESS;
 		}
-
-		++numAcknowledgedTasks;
-
-		// publish the checkpoint statistics
-		// to prevent null-pointers from concurrent modification, copy reference onto stack
-		final PendingCheckpointStats statsCallback = this.statsCallback;
-		if (statsCallback != null) {
-			// Do this in millis because the web frontend works with them
-			long alignmentDurationMillis = metrics.getAlignmentDurationNanos() / 1_000_000;
-			long checkpointStartDelayMillis = metrics.getCheckpointStartDelayNanos() / 1_000_000;
-
-			SubtaskStateStats subtaskStateStats = new SubtaskStateStats(
-				subtaskIndex,
-				ackTimestamp,
-				stateSize,
-				metrics.getSyncDurationMillis(),
-				metrics.getAsyncDurationMillis(),
-				metrics.getBytesBufferedInAlignment(),
-				alignmentDurationMillis,
-				checkpointStartDelayMillis);
-
-			statsCallback.reportSubtaskStats(vertex.getJobvertexId(), subtaskStateStats);
-		}
-
-		return TaskAcknowledgeResult.SUCCESS;
 	}
 
 	public TaskAcknowledgeResult acknowledgeCoordinatorState(
 			OperatorCoordinatorCheckpointContext coordinatorInfo,
 			@Nullable StreamStateHandle stateHandle) {
 
-		if (discarded) {
-			return TaskAcknowledgeResult.DISCARDED;
-		}
-
-		final OperatorID operatorId = coordinatorInfo.operatorId();
-		OperatorState operatorState = operatorStates.get(operatorId);
-
-		// sanity check for better error reporting
-		if (!notYetAcknowledgedOperatorCoordinators.remove(operatorId)) {
-			return operatorState != null && operatorState.getCoordinatorState() != null
-					? TaskAcknowledgeResult.DUPLICATE
-					: TaskAcknowledgeResult.UNKNOWN;
-		}
-
-		if (stateHandle != null) {
-			if (operatorState == null) {
-				operatorState = new OperatorState(
-					operatorId, coordinatorInfo.currentParallelism(), coordinatorInfo.maxParallelism());
-				operatorStates.put(operatorId, operatorState);
+		synchronized (lock) {
+			if (discarded) {
+				return TaskAcknowledgeResult.DISCARDED;
 			}
-			operatorState.setCoordinatorState(stateHandle);
-		}
 
-		return TaskAcknowledgeResult.SUCCESS;
+			final OperatorID operatorId = coordinatorInfo.operatorId();
+			OperatorState operatorState = operatorStates.get(operatorId);
+
+			// sanity check for better error reporting
+			if (!notYetAcknowledgedOperatorCoordinators.remove(operatorId)) {
+				return operatorState != null && operatorState.getCoordinatorState() != null
+						? TaskAcknowledgeResult.DUPLICATE
+						: TaskAcknowledgeResult.UNKNOWN;
+			}
+
+			if (stateHandle != null) {
+				if (operatorState == null) {
+					operatorState = new OperatorState(
+						operatorId, coordinatorInfo.currentParallelism(), coordinatorInfo.maxParallelism());
+					operatorStates.put(operatorId, operatorState);
+				}
+				operatorState.setCoordinatorState(stateHandle);
+			}
+
+			return TaskAcknowledgeResult.SUCCESS;
+		}
 	}
 
 	/**
@@ -502,9 +506,12 @@ public class PendingCheckpoint {
 	 * @param state The state to acknowledge
 	 */
 	public void acknowledgeMasterState(String identifier, @Nullable MasterState state) {
-		if (!discarded) {
-			if (notYetAcknowledgedMasterStates.remove(identifier) && state != null) {
-				masterStates.add(state);
+
+		synchronized (lock) {
+			if (!discarded) {
+				if (notYetAcknowledgedMasterStates.remove(identifier) && state != null) {
+					masterStates.add(state);
+				}
 			}
 		}
 	}
@@ -543,14 +550,14 @@ public class PendingCheckpoint {
 
 	private void dispose(boolean releaseState) {
 
-		try {
-			numAcknowledgedTasks = -1;
-			if (!discarded && releaseState) {
-				executor.execute(new Runnable() {
-					@Override
-					public void run() {
+		synchronized (lock) {
+			try {
+				numAcknowledgedTasks = -1;
+				if (!discarded && releaseState) {
+					executor.execute(new Runnable() {
+						@Override
+						public void run() {
 
-						synchronized (operationLock) {
 							// discard the private states.
 							// unregistered shared states are still considered private at this point.
 							try {
@@ -563,15 +570,15 @@ public class PendingCheckpoint {
 								operatorStates.clear();
 							}
 						}
-					}
-				});
+					});
 
+				}
+			} finally {
+				discarded = true;
+				notYetAcknowledgedTasks.clear();
+				acknowledgedTasks.clear();
+				cancelCanceller();
 			}
-		} finally {
-			discarded = true;
-			notYetAcknowledgedTasks.clear();
-			acknowledgedTasks.clear();
-			cancelCanceller();
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -396,9 +396,6 @@ public class ExecutionGraph implements AccessExecutionGraph {
 
 	public void start(@Nonnull ComponentMainThreadExecutor jobMasterMainThreadExecutor) {
 		this.jobMasterMainThreadExecutor = jobMasterMainThreadExecutor;
-		if (checkpointCoordinator != null) {
-			checkpointCoordinator.start(this.jobMasterMainThreadExecutor);
-		}
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -467,14 +467,12 @@ public class ExecutionGraph implements AccessExecutionGraph {
 			new CheckpointFailureManager.FailJobCallback() {
 				@Override
 				public void failJob(Throwable cause) {
-					assertRunningInJobMasterMainThread();
-					failGlobal(cause);
+					getJobMasterMainThreadExecutor().execute(() -> failGlobal(cause));
 				}
 
 				@Override
 				public void failJobDueToTaskFailure(Throwable cause, ExecutionAttemptID failingTask) {
-					assertRunningInJobMasterMainThread();
-					failGlobalIfExecutionIsStillRunning(cause, failingTask);
+					getJobMasterMainThreadExecutor().execute(() -> failGlobalIfExecutionIsStillRunning(cause, failingTask));
 				}
 			}
 		);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -789,11 +789,13 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final String taskManagerLocationInfo = retrieveTaskManagerLocation(executionAttemptID);
 
 		if (checkpointCoordinator != null) {
-			try {
-				checkpointCoordinator.receiveAcknowledgeMessage(ackMessage, taskManagerLocationInfo);
-			} catch (Throwable t) {
-				log.warn("Error while processing checkpoint acknowledgement message", t);
-			}
+			ioExecutor.execute(() -> {
+				try {
+					checkpointCoordinator.receiveAcknowledgeMessage(ackMessage, taskManagerLocationInfo);
+				} catch (Throwable t) {
+					log.warn("Error while processing checkpoint acknowledgement message", t);
+				}
+			});
 		} else {
 			String errorMessage = "Received AcknowledgeCheckpoint message for job {} with no CheckpointCoordinator";
 			if (executionGraph.getState() == JobStatus.RUNNING) {
@@ -812,11 +814,13 @@ public abstract class SchedulerBase implements SchedulerNG {
 		final String taskManagerLocationInfo = retrieveTaskManagerLocation(decline.getTaskExecutionId());
 
 		if (checkpointCoordinator != null) {
-			try {
-				checkpointCoordinator.receiveDeclineMessage(decline, taskManagerLocationInfo);
-			} catch (Exception e) {
-				log.error("Error in CheckpointCoordinator while processing {}", decline, e);
-			}
+			ioExecutor.execute(() -> {
+				try {
+					checkpointCoordinator.receiveDeclineMessage(decline, taskManagerLocationInfo);
+				} catch (Exception e) {
+					log.error("Error in CheckpointCoordinator while processing {}", decline, e);
+				}
+			});
 		} else {
 			String errorMessage = "Received DeclineCheckpoint message for job {} with no CheckpointCoordinator";
 			if (executionGraph.getState() == JobStatus.RUNNING) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -58,7 +58,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 	public void testFailingCompletedCheckpointStoreAdd() throws Exception {
 		JobID jid = new JobID();
 
-		final ManuallyTriggeredScheduledExecutor mainThreadExecutor =
+		final ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
 			new ManuallyTriggeredScheduledExecutor();
 
 		final ExecutionAttemptID executionAttemptId = new ExecutionAttemptID();
@@ -72,12 +72,12 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(new ExecutionVertex[] { vertex })
 				.setCompletedCheckpointStore(new FailingCompletedCheckpointStore())
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		coord.triggerCheckpoint(triggerTimestamp, false);
 
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
@@ -111,7 +111,7 @@ public class CheckpointCoordinatorFailureTest extends TestLogger {
 
 		coord.receiveAcknowledgeMessage(acknowledgeMessage, "Unknown location");
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// make sure that the pending checkpoint has been discarded after we could not complete it
 		assertTrue(pendingCheckpoint.isDiscarded());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -210,8 +210,6 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 		final long checkpointId = cc.getPendingCheckpoints().values().iterator().next().getCheckpointId();
 		cc.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, execId, checkpointId), "Unknown location");
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertEquals(0, cc.getNumberOfPendingCheckpoints());
 
 		assertEquals(1, cc.getNumberOfRetainedSuccessfulCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorMasterHooksTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.checkpoint;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -445,7 +444,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 
 	private CheckpointCoordinator instantiateCheckpointCoordinator(
 		JobID jid,
-		ScheduledExecutor mainThreadExecutor,
+		ScheduledExecutor testingScheduledExecutor,
 		ExecutionVertex... ackVertices) {
 
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
@@ -457,7 +456,7 @@ public class CheckpointCoordinatorMasterHooksTest {
 			true,
 			false,
 			0);
-		final CheckpointCoordinator checkpointCoordinator = new CheckpointCoordinator(
+		return new CheckpointCoordinator(
 				jid,
 				chkConfig,
 				new ExecutionVertex[0],
@@ -468,16 +467,11 @@ public class CheckpointCoordinatorMasterHooksTest {
 				new StandaloneCompletedCheckpointStore(10),
 				new MemoryStateBackend(),
 				Executors.directExecutor(),
-				new ManuallyTriggeredScheduledExecutor(),
+				testingScheduledExecutor,
 				SharedStateRegistry.DEFAULT_FACTORY,
 				new CheckpointFailureManager(
 					0,
 					NoOpFailJobCall.INSTANCE));
-		checkpointCoordinator.start(
-			new ComponentMainThreadExecutorServiceAdapter(
-				mainThreadExecutor,
-				Thread.currentThread()));
-		return checkpointCoordinator;
 	}
 
 	private static <T> T mockGeneric(Class<?> clazz) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -191,8 +191,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				subtaskState);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -308,8 +306,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForCheckpoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			CompletedCheckpoint success = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, success.getJobId());
@@ -337,8 +333,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			checkpointId = checkpointIDCounter.getLast();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForSavepoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertNotNull(savepointFuture.get());
 
@@ -480,8 +474,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				taskOperatorSubtaskStates);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -629,8 +621,6 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				taskOperatorSubtaskStates);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorRestoringTest.java
@@ -101,14 +101,14 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 		SAME_PARALLELISM;
 	}
 
-	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
+	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
-		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	/**
@@ -154,12 +154,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
 				.setCompletedCheckpointStore(store)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -192,7 +192,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -281,13 +281,13 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					.setCheckpointIDCounter(checkpointIDCounter)
 					.setCompletedCheckpointStore(store)
 					.setTasks(new ExecutionVertex[] { stateful1, stateless1 })
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			//trigger a checkpoint and wait to become a completed checkpoint
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			long checkpointId = checkpointIDCounter.getLast();
@@ -309,7 +309,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForCheckpoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			CompletedCheckpoint success = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, success.getJobId());
@@ -333,12 +333,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 					StateObjectCollection.singleton(serializedKeyGroupStatesForSavepoint),
 					StateObjectCollection.empty()));
 
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			checkpointId = checkpointIDCounter.getLast();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec1.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStatesForSavepoint), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertNotNull(savepointFuture.get());
 
@@ -423,12 +423,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -481,7 +481,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -588,12 +588,12 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -630,7 +630,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 
 		List<CompletedCheckpoint> completedCheckpoints = coord.getSuccessfulCheckpoints();
@@ -830,7 +830,7 @@ public class CheckpointCoordinatorRestoringTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setTasks(newJobVertex1.getTaskVertices())
 				.setCompletedCheckpointStore(standaloneCompletedCheckpointStore)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		coord.restoreLatestCheckpointedState(tasks, false, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -109,17 +109,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 	private static final String TASK_MANAGER_LOCATION_INFO = "Unknown location";
 
-	private ManuallyTriggeredScheduledExecutor timer;
-
-	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
+	private ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor;
 
 	@Rule
 	public TemporaryFolder tmpFolder = new TemporaryFolder();
 
 	@Before
 	public void setUp() throws Exception {
-		timer = new ManuallyTriggeredScheduledExecutor();
-		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+		manuallyTriggeredScheduledExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	@Test
@@ -137,7 +134,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -166,7 +163,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -195,7 +192,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should not succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertTrue(checkpointFuture.isCompletedExceptionally());
 
 			// still, nothing should be happening
@@ -244,7 +241,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkPointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkPointFuture.isCompletedExceptionally());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
@@ -300,7 +297,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
@@ -308,7 +305,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
 
 			// we have one task scheduled that will cancel after timeout
-			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			PendingCheckpoint checkpoint = coord.getPendingCheckpoints().get(checkpointId);
@@ -345,7 +342,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertTrue(checkpoint.isDiscarded());
 
 			// the canceler is also removed
-			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			// validate that we have no new pending checkpoint
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -386,24 +383,24 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			// trigger second checkpoint, should also succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp + 2, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(2, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(2, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			Iterator<Map.Entry<Long, PendingCheckpoint>> it = coord.getPendingCheckpoints().entrySet().iterator();
 			long checkpoint1Id = it.next().getKey();
@@ -450,7 +447,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// validate that we have only one pending checkpoint left
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			// validate that it is the same second checkpoint from earlier
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
@@ -498,18 +495,18 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			// validate that we have a pending checkpoint
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(1, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(1, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			long checkpointId = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			PendingCheckpoint checkpoint = coord.getPendingCheckpoints().get(checkpointId);
@@ -558,7 +555,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// the checkpoint is internally converted to a successful checkpoint and the
 			// pending checkpoint object is disposed
@@ -569,7 +566,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
 			// the canceler should be removed now
-			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			// validate that the subtasks states have registered their shared states.
 			{
@@ -594,17 +591,17 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// ---------------
 			final long timestampNew = timestamp + 7;
 			coord.triggerCheckpoint(timestampNew, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
-			assertEquals(0, mainThreadExecutor.getScheduledTasks().size());
+			assertEquals(0, manuallyTriggeredScheduledExecutor.getScheduledTasks().size());
 
 			CompletedCheckpoint successNew = coord.getSuccessfulCheckpoints().get(0);
 			assertEquals(jid, successNew.getJobId());
@@ -664,7 +661,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -673,7 +670,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp1, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -693,7 +690,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp2, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
@@ -719,7 +716,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the first checkpoint should be confirmed
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -732,7 +729,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// send the last remaining ack for the second checkpoint
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -799,7 +796,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2, ackVertex3 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -808,7 +805,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 				coord.triggerCheckpoint(timestamp1, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -843,7 +840,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// trigger the first checkpoint. this should succeed
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 				coord.triggerCheckpoint(timestamp2, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture2.isCompletedExceptionally());
 
 			assertEquals(2, coord.getNumberOfPendingCheckpoints());
@@ -886,7 +883,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2, new CheckpointMetrics(), taskOperatorSubtaskStates22), TASK_MANAGER_LOCATION_INFO);
 
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed, and the first discarded
 			// actually both pending checkpoints are discarded, and the second has been transformed
@@ -965,13 +962,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			// trigger a checkpoint, partially acknowledged
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
@@ -987,7 +984,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpoint.getCheckpointId(), new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
 			// triggers cancelling
-			mainThreadExecutor.triggerScheduledTasks();
+			manuallyTriggeredScheduledExecutor.triggerScheduledTasks();
 			assertTrue("Checkpoint was not canceled by the timeout", checkpoint.isDiscarded());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(0, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1031,12 +1028,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			long checkpointId = coord.getPendingCheckpoints().keySet().iterator().next();
@@ -1096,12 +1093,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasksToTrigger(new ExecutionVertex[] { triggerVertex })
 				.setTasksToWaitFor(new ExecutionVertex[] {triggerVertex, ackVertex1, ackVertex2})
 				.setTasksToCommitTo(new ExecutionVertex[0])
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		final CompletableFuture<CompletedCheckpoint> checkpointFuture =
 			coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(checkpointFuture.isCompletedExceptionally());
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -1213,7 +1210,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// trigger the first checkpoint. this should succeed
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
 		CompletableFuture<CompletedCheckpoint> savepointFuture = coord.triggerSavepoint(timestamp, savepointDir);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(savepointFuture.isDone());
 
 		// validate that we have a pending savepoint
@@ -1260,7 +1257,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// acknowledge the other task.
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// the checkpoint is internally converted to a successful checkpoint and the
 		// pending checkpoint object is disposed
@@ -1294,14 +1291,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// ---------------
 		final long timestampNew = timestamp + 7;
 		savepointFuture = coord.triggerSavepoint(timestampNew, savepointDir);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(savepointFuture.isDone());
 
 		long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1355,7 +1352,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
 				.setCheckpointIDCounter(counter)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(10))
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
@@ -1363,19 +1360,19 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Trigger savepoint and checkpoint
 		CompletableFuture<CompletedCheckpoint> savepointFuture1 = coord.triggerSavepoint(timestamp, savepointDir);
 
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		long savepointId1 = counter.getLast();
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture1 =
 			coord.triggerCheckpoint(timestamp + 1, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertEquals(2, coord.getNumberOfPendingCheckpoints());
 		assertFalse(checkpointFuture1.isCompletedExceptionally());
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture2 =
 			coord.triggerCheckpoint(timestamp + 2, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(checkpointFuture2.isCompletedExceptionally());
 		long checkpointId2 = counter.getLast();
 		assertEquals(3, coord.getNumberOfPendingCheckpoints());
@@ -1384,7 +1381,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1394,12 +1391,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		CompletableFuture<CompletedCheckpoint> checkpointFuture3 =
 			coord.triggerCheckpoint(timestamp + 3, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(checkpointFuture3.isCompletedExceptionally());
 		assertEquals(2, coord.getNumberOfPendingCheckpoints());
 
 		CompletableFuture<CompletedCheckpoint> savepointFuture2 = coord.triggerSavepoint(timestamp + 4, savepointDir);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		long savepointId2 = counter.getLast();
 		assertFalse(savepointFuture2.isCompletedExceptionally());
 		assertEquals(3, coord.getNumberOfPendingCheckpoints());
@@ -1408,7 +1405,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(2, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1421,7 +1418,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(3, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1470,15 +1467,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(timer)
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
 			for (int i = 0; i < maxConcurrentAttempts; i++) {
-				timer.triggerPeriodicScheduledTasks();
-				mainThreadExecutor.triggerAll();
+				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+				manuallyTriggeredScheduledExecutor.triggerAll();
 			}
 
 			assertEquals(maxConcurrentAttempts, numCalls.get());
@@ -1489,20 +1485,20 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// now, once we acknowledge one checkpoint, it should trigger the next one
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID, 1L), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			final Collection<ScheduledFuture<?>> periodicScheduledTasks =
-				timer.getPeriodicScheduledTask();
+				manuallyTriggeredScheduledExecutor.getPeriodicScheduledTask();
 			assertEquals(1, periodicScheduledTasks.size());
 
-			timer.triggerPeriodicScheduledTasks();
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(maxConcurrentAttempts + 1, numCalls.get());
 
 			// no further checkpoints should happen
-			timer.triggerPeriodicScheduledTasks();
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertEquals(maxConcurrentAttempts + 1, numCalls.get());
 
 			coord.shutdown(JobStatus.FINISHED);
@@ -1543,15 +1539,14 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(timer)
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
 			do {
-				timer.triggerPeriodicScheduledTasks();
-				mainThreadExecutor.triggerAll();
+				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+				manuallyTriggeredScheduledExecutor.triggerAll();
 			}
 			while (coord.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
@@ -1567,8 +1562,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// after a while, there should be the new checkpoints
 			do {
-				timer.triggerPeriodicScheduledTasks();
-				mainThreadExecutor.triggerAll();
+				manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+				manuallyTriggeredScheduledExecutor.triggerAll();
 			}
 			while (coord.getNumberOfPendingCheckpoints() < maxConcurrentAttempts);
 
@@ -1617,14 +1612,13 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					.setTasksToWaitFor(new ExecutionVertex[] { ackVertex })
 					.setTasksToCommitTo(new ExecutionVertex[] { commitVertex })
 					.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-					.setTimer(timer)
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			coord.startCheckpointScheduler();
 
-			timer.triggerPeriodicScheduledTasks();
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			// no checkpoint should have started so far
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 
@@ -1632,8 +1626,8 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			currentState.set(ExecutionState.RUNNING);
 
 			// the coordinator should start checkpointing now
-			timer.triggerPeriodicScheduledTasks();
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertTrue(coord.getNumberOfPendingCheckpoints() > 0);
 		}
@@ -1667,7 +1661,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setTasks(new ExecutionVertex[] { vertex1 })
 				.setCheckpointIDCounter(checkpointIDCounter)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		List<CompletableFuture<CompletedCheckpoint>> savepointFutures = new ArrayList<>();
@@ -1684,7 +1678,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			assertFalse(savepointFuture.isDone());
 		}
 
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// ACK all savepoints
 		long checkpointId = checkpointIDCounter.getLast();
@@ -1692,7 +1686,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jobId, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
 		}
 
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		// After ACKs, all should be completed
 		for (CompletableFuture<CompletedCheckpoint> savepointFuture : savepointFutures) {
 			assertNotNull(savepointFuture.get());
@@ -1713,7 +1707,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			new CheckpointCoordinatorBuilder()
 				.setCheckpointCoordinatorConfiguration(chkConfig)
 				.setCompletedCheckpointStore(new StandaloneCompletedCheckpointStore(2))
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		String savepointDir = tmpFolder.newFolder().getAbsolutePath();
@@ -1741,12 +1735,12 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			CheckpointCoordinator coord =
 				new CheckpointCoordinatorBuilder()
 					.setCheckpointCoordinatorConfiguration(chkConfig)
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			CompletableFuture<CompletedCheckpoint> checkpointFuture =
 				coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			assertFalse(checkpointFuture.isCompletedExceptionally());
 
 			for (PendingCheckpoint checkpoint : coord.getPendingCheckpoints().values()) {
@@ -1962,7 +1956,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// set up the coordinator and validate the initial state
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		CheckpointStatsTracker tracker = mock(CheckpointStatsTracker.class);
@@ -1974,7 +1968,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Trigger a checkpoint and verify callback
 		CompletableFuture<CompletedCheckpoint> checkpointFuture =
 			coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		assertFalse(checkpointFuture.isCompletedExceptionally());
 
 		verify(tracker, times(1))
@@ -1992,7 +1986,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
 				.setCompletedCheckpointStore(store)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 
 		store.addCheckpoint(new CompletedCheckpoint(
@@ -2047,7 +2041,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				.setJobId(jid)
 				.setTasks(arrayExecutionVertices)
 				.setCompletedCheckpointStore(store)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.setSharedStateRegistryFactory(
 					deleteExecutor -> {
 						SharedStateRegistry instance = new SharedStateRegistry(deleteExecutor);
@@ -2209,7 +2203,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		final CompletableFuture<CompletedCheckpoint> savepointFuture = coordinator
 				.triggerSynchronousSavepoint(10L, false, "test-dir");
 
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 		final PendingCheckpoint syncSavepoint = declineSynchronousSavepoint(jobId, coordinator, attemptID1, expectedRootCause);
 
 		assertTrue(syncSavepoint.isDiscarded());
@@ -2241,7 +2235,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		CheckpointCoordinator coord =
 			new CheckpointCoordinatorBuilder()
 				.setCheckpointIDCounter(idCounter)
-				.setMainThreadExecutor(mainThreadExecutor)
+				.setTimer(manuallyTriggeredScheduledExecutor)
 				.build();
 		idCounter.setOwner(coord);
 
@@ -2256,7 +2250,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 					null,
 					true,
 					false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 			try {
 				onCompletionPromise.get();
 				fail("should not trigger periodic checkpoint after stop the coordinator.");
@@ -2280,7 +2274,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		return new CheckpointCoordinatorBuilder()
 			.setJobId(jobId)
 			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
-			.setMainThreadExecutor(mainThreadExecutor)
+			.setTimer(manuallyTriggeredScheduledExecutor)
 			.build();
 	}
 
@@ -2293,7 +2287,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		return new CheckpointCoordinatorBuilder()
 			.setJobId(jobId)
 			.setTasks(new ExecutionVertex[]{ vertex1, vertex2 })
-			.setMainThreadExecutor(mainThreadExecutor)
+			.setTimer(manuallyTriggeredScheduledExecutor)
 			.setFailureManager(failureManager)
 			.build();
 	}
@@ -2322,7 +2316,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			.setTasksToTrigger(new ExecutionVertex[] { triggerVertex1, triggerVertex2 })
 			.setTasksToWaitFor(new ExecutionVertex[] { ackVertex1, ackVertex2 })
 			.setTasksToCommitTo(new ExecutionVertex[] {})
-			.setMainThreadExecutor(mainThreadExecutor)
+			.setTimer(manuallyTriggeredScheduledExecutor)
 			.build();
 	}
 
@@ -2348,7 +2342,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// trigger the checkpoint
 		coord.triggerCheckpoint(timestamp, false);
-		mainThreadExecutor.triggerAll();
+		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getPendingCheckpoints().size());
 		long checkpointId = Iterables.getOnlyElement(coord.getPendingCheckpoints().keySet());
@@ -2406,7 +2400,7 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTest.java
@@ -554,9 +554,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			// acknowledge the other task.
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
 
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
-
 			// the checkpoint is internally converted to a successful checkpoint and the
 			// pending checkpoint object is disposed
 			assertTrue(checkpoint.isDiscarded());
@@ -596,8 +593,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -715,8 +710,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the first checkpoint should be confirmed
 			assertEquals(1, coord.getNumberOfPendingCheckpoints());
@@ -728,8 +721,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// send the last remaining ack for the second checkpoint
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID3, checkpointId2), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());
@@ -881,9 +872,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID1, checkpointId1, new CheckpointMetrics(), taskOperatorSubtaskStates11), TASK_MANAGER_LOCATION_INFO);
 
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID2, checkpointId2, new CheckpointMetrics(), taskOperatorSubtaskStates22), TASK_MANAGER_LOCATION_INFO);
-
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			// now, the second checkpoint should be confirmed, and the first discarded
 			// actually both pending checkpoints are discarded, and the second has been transformed
@@ -1256,8 +1244,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 		// acknowledge the other task.
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId, new CheckpointMetrics(), taskOperatorSubtaskStates1), TASK_MANAGER_LOCATION_INFO);
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		// the checkpoint is internally converted to a successful checkpoint and the
 		// pending checkpoint object is disposed
@@ -1297,8 +1283,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		long checkpointIdNew = coord.getPendingCheckpoints().entrySet().iterator().next().getKey();
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointIdNew), TASK_MANAGER_LOCATION_INFO);
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1380,8 +1364,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// 2nd checkpoint should subsume the 1st checkpoint, but not the savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, checkpointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, checkpointId2), TASK_MANAGER_LOCATION_INFO);
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1404,8 +1386,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// 2nd savepoint should subsume the last checkpoint, but not the 1st savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId2), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId2), TASK_MANAGER_LOCATION_INFO);
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(1, coord.getNumberOfPendingCheckpoints());
 		assertEquals(2, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1417,8 +1397,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 		// Ack first savepoint
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID1, savepointId1), TASK_MANAGER_LOCATION_INFO);
 		coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, attemptID2, savepointId1), TASK_MANAGER_LOCATION_INFO);
-		// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-		manuallyTriggeredScheduledExecutor.triggerAll();
 
 		assertEquals(0, coord.getNumberOfPendingCheckpoints());
 		assertEquals(3, coord.getNumberOfRetainedSuccessfulCheckpoints());
@@ -1484,12 +1462,11 @@ public class CheckpointCoordinatorTest extends TestLogger {
 
 			// now, once we acknowledge one checkpoint, it should trigger the next one
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, ackAttemptID, 1L), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			final Collection<ScheduledFuture<?>> periodicScheduledTasks =
 				manuallyTriggeredScheduledExecutor.getPeriodicScheduledTask();
 			assertEquals(1, periodicScheduledTasks.size());
+			final ScheduledFuture scheduledFuture = periodicScheduledTasks.iterator().next();
 
 			manuallyTriggeredScheduledExecutor.triggerPeriodicScheduledTasks();
 			manuallyTriggeredScheduledExecutor.triggerAll();
@@ -1686,7 +1663,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jobId, attemptID1, checkpointId), TASK_MANAGER_LOCATION_INFO);
 		}
 
-		manuallyTriggeredScheduledExecutor.triggerAll();
 		// After ACKs, all should be completed
 		for (CompletableFuture<CompletedCheckpoint> savepointFuture : savepointFutures) {
 			assertNotNull(savepointFuture.get());
@@ -2399,8 +2375,6 @@ public class CheckpointCoordinatorTest extends TestLogger {
 				taskStateSnapshot);
 
 			coord.receiveAcknowledgeMessage(acknowledgeCheckpoint, TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorTestingUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.mock.Whitebox;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
@@ -674,9 +673,6 @@ public class CheckpointCoordinatorTestingUtils {
 
 		private ScheduledExecutor timer = new ManuallyTriggeredScheduledExecutor();
 
-		private ScheduledExecutor mainThreadExecutor =
-			new ManuallyTriggeredScheduledExecutor();
-
 		private SharedStateRegistryFactory sharedStateRegistryFactory =
 			SharedStateRegistry.DEFAULT_FACTORY;
 
@@ -755,11 +751,6 @@ public class CheckpointCoordinatorTestingUtils {
 			return this;
 		}
 
-		public CheckpointCoordinatorBuilder setMainThreadExecutor(ScheduledExecutor mainThreadExecutor) {
-			this.mainThreadExecutor = mainThreadExecutor;
-			return this;
-		}
-
 		public CheckpointCoordinatorBuilder setSharedStateRegistryFactory(
 			SharedStateRegistryFactory sharedStateRegistryFactory) {
 			this.sharedStateRegistryFactory = sharedStateRegistryFactory;
@@ -773,7 +764,7 @@ public class CheckpointCoordinatorTestingUtils {
 		}
 
 		public CheckpointCoordinator build() {
-			final CheckpointCoordinator checkpointCoordinator = new CheckpointCoordinator(
+			return new CheckpointCoordinator(
 				jobId,
 				checkpointCoordinatorConfiguration,
 				tasksToTrigger,
@@ -787,11 +778,6 @@ public class CheckpointCoordinatorTestingUtils {
 				timer,
 				sharedStateRegistryFactory,
 				failureManager);
-			checkpointCoordinator.start(
-				new ComponentMainThreadExecutorServiceAdapter(
-					mainThreadExecutor,
-					Thread.currentThread()));
-			return checkpointCoordinator;
 		}
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -98,7 +98,7 @@ public class CheckpointStateRestoreTest {
 			tasks.add(stateful);
 			tasks.add(stateless);
 
-			ManuallyTriggeredScheduledExecutor mainThreadExecutor =
+			ManuallyTriggeredScheduledExecutor manuallyTriggeredScheduledExecutor =
 				new ManuallyTriggeredScheduledExecutor();
 
 			CheckpointCoordinator coord =
@@ -107,13 +107,13 @@ public class CheckpointStateRestoreTest {
 					.setTasksToTrigger(new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 })
 					.setTasksToWaitFor(new ExecutionVertex[] { stateful1, stateful2, stateful3, stateless1, stateless2 })
 					.setTasksToCommitTo(new ExecutionVertex[0])
-					.setMainThreadExecutor(mainThreadExecutor)
+					.setTimer(manuallyTriggeredScheduledExecutor)
 					.build();
 
 			// create ourselves a checkpoint with state
 			final long timestamp = 34623786L;
 			coord.triggerCheckpoint(timestamp, false);
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			PendingCheckpoint pending = coord.getPendingCheckpoints().values().iterator().next();
 			final long checkpointId = pending.getCheckpointId();
@@ -134,7 +134,7 @@ public class CheckpointStateRestoreTest {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			mainThreadExecutor.triggerAll();
+			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStateRestoreTest.java
@@ -133,8 +133,6 @@ public class CheckpointStateRestoreTest {
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statefulExec3.getAttemptId(), checkpointId, new CheckpointMetrics(), subtaskStates), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec1.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
 			coord.receiveAcknowledgeMessage(new AcknowledgeCheckpoint(jid, statelessExec2.getAttemptId(), checkpointId), TASK_MANAGER_LOCATION_INFO);
-			// CheckpointCoordinator#completePendingCheckpoint is async, we have to finish the completion manually
-			manuallyTriggeredScheduledExecutor.triggerAll();
 
 			assertEquals(1, coord.getNumberOfRetainedSuccessfulCheckpoints());
 			assertEquals(0, coord.getNumberOfPendingCheckpoints());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -146,6 +146,8 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 			.setAllocationTimeout(timeout)
 			.build();
 
+		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
 			100,
 			100,
@@ -166,8 +168,6 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 				store,
 				new MemoryStateBackend(),
 				CheckpointStatsTrackerTest.createTestTracker());
-
-		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		return executionGraph;
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ExecutionGraphCheckpointCoordinatorTest.java
@@ -20,24 +20,16 @@ package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Time;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
-import org.apache.flink.runtime.concurrent.Executors;
-import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
-import org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils;
-import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.TestingExecutionGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
-import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
-import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.util.TestLogger;
@@ -45,14 +37,11 @@ import org.apache.flink.util.TestLogger;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -142,82 +131,9 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 		assertThat(storeShutdownFuture.get(), is(JobStatus.FINISHED));
 	}
 
-	/**
-	 * The case is designed to check the race condition between {@link ExecutionGraph} and
-	 * {@link CheckpointCoordinator}. There should be no checkpoint accepted after
-	 * {@link CheckpointFailureManager} decides to fail the {@link ExecutionGraph}.
-	 */
-	@Test
-	public void testNoCheckpointAcceptedWhileFailingExecutionGraph() throws Exception {
-		CheckpointIDCounter counter = new TestingCheckpointIDCounter(new CompletableFuture<>());
-
-		TestingCompletedCheckpointStore store = new TestingCompletedCheckpointStore(new CompletableFuture<>());
-
-		final ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-		ExecutionGraph graph = createExecutionGraphAndEnableCheckpointing(
-			counter,
-			store,
-			new ComponentMainThreadExecutorServiceAdapter(mainThreadExecutor, Thread.currentThread()));
-
-		final CheckpointCoordinator checkpointCoordinator = graph.getCheckpointCoordinator();
-
-		assertThat(checkpointCoordinator, Matchers.notNullValue());
-		assertThat(checkpointCoordinator.isShutdown(), is(false));
-
-		graph.scheduleForExecution();
-		ExecutionGraphTestUtils.switchToRunning(graph);
-
-		// trigger a normal checkpoint which we will fail/decline later
-		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), true);
-		mainThreadExecutor.triggerAll();
-		final long checkpointId = checkpointCoordinator.getPendingCheckpoints().keySet().iterator().next();
-
-		// trigger a forced checkpoint which could avoid failing the pre-checking
-		// this checkpoint would be acknowledged after the first one declined
-		checkpointCoordinator.triggerCheckpoint(
-			System.currentTimeMillis(),
-			new CheckpointProperties(
-				true,
-				CheckpointType.CHECKPOINT,
-				true,
-				true,
-				true,
-				true,
-				true),
-			null,
-			false,
-			false);
-		mainThreadExecutor.triggerAll();
-
-		// now we decline the first checkpoint and acknowledge the second checkpoint
-		// the first declined message should fail the execution graph and abort all pending checkpoints
-		// so the second acknowledged checkpoint should be abandoned when the ack arrived
-		final ExecutionAttemptID attemptId =
-			graph.getAllExecutionVertices().iterator().next().getCurrentExecutionAttempt().getAttemptId();
-		final DeclineCheckpoint decline = new DeclineCheckpoint(graph.getJobID(), attemptId, checkpointId);
-		final AcknowledgeCheckpoint ack = new AcknowledgeCheckpoint(graph.getJobID(), attemptId, checkpointId + 1);
-		checkpointCoordinator.receiveDeclineMessage(decline, "localhost");
-		checkpointCoordinator.receiveAcknowledgeMessage(ack, "localhost");
-
-		mainThreadExecutor.triggerAll();
-
-		assertEquals(0, store.completedCheckpoints.size());
-	}
-
-	private ExecutionGraph createExecutionGraphAndEnableCheckpointing(
-		CheckpointIDCounter counter,
-		CompletedCheckpointStore store) throws Exception {
-
-		return createExecutionGraphAndEnableCheckpointing(
-			counter,
-			store,
-			ComponentMainThreadExecutorServiceAdapter.forMainThread());
-	}
-
 	private ExecutionGraph createExecutionGraphAndEnableCheckpointing(
 			CheckpointIDCounter counter,
-			CompletedCheckpointStore store,
-			ComponentMainThreadExecutor mainThreadExecutor) throws Exception {
+			CompletedCheckpointStore store) throws Exception {
 		final Time timeout = Time.days(1L);
 
 		JobVertex jobVertex = new JobVertex("MockVertex");
@@ -228,14 +144,11 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 			.setJobGraph(new JobGraph(jobVertex))
 			.setRpcTimeout(timeout)
 			.setAllocationTimeout(timeout)
-			.setIoExecutor(Executors.directExecutor())
 			.build();
 
-		final ExecutionJobVertex executionJobVertex = executionGraph.getVerticesTopologically().iterator().next();
-
 		CheckpointCoordinatorConfiguration chkConfig = new CheckpointCoordinatorConfiguration(
-			1000000,
-			1000000,
+			100,
+			100,
 			100,
 			1,
 			CheckpointRetentionPolicy.NEVER_RETAIN_AFTER_TERMINATION,
@@ -245,23 +158,21 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 
 		executionGraph.enableCheckpointing(
 				chkConfig,
-				Collections.singletonList(executionJobVertex),
-				Collections.singletonList(executionJobVertex),
-				Collections.singletonList(executionJobVertex),
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList(),
 				Collections.emptyList(),
 				counter,
 				store,
 				new MemoryStateBackend(),
 				CheckpointStatsTrackerTest.createTestTracker());
 
-		executionGraph.start(mainThreadExecutor);
+		executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		return executionGraph;
 	}
 
 	private static final class TestingCheckpointIDCounter implements CheckpointIDCounter {
-
-		private final AtomicLong counter = new AtomicLong(0);
 
 		private final CompletableFuture<JobStatus> shutdownStatus;
 
@@ -279,25 +190,23 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 
 		@Override
 		public long getAndIncrement() {
-			return counter.getAndIncrement();
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 
 		@Override
 		public long get() {
-			return counter.get();
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 
 		@Override
 		public void setCount(long newId) {
-			counter.set(newId);
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 	}
 
 	private static final class TestingCompletedCheckpointStore implements CompletedCheckpointStore {
 
 		private final CompletableFuture<JobStatus> shutdownStatus;
-
-		private final List<CompletedCheckpoint> completedCheckpoints = new ArrayList<>();
 
 		private TestingCompletedCheckpointStore(CompletableFuture<JobStatus> shutdownStatus) {
 			this.shutdownStatus = shutdownStatus;
@@ -310,7 +219,12 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 
 		@Override
 		public void addCheckpoint(CompletedCheckpoint checkpoint) {
-			completedCheckpoints.add(checkpoint);
+			throw new UnsupportedOperationException("Not implemented.");
+		}
+
+		@Override
+		public CompletedCheckpoint getLatestCheckpoint(boolean isPreferCheckpointForRecovery) {
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 
 		@Override
@@ -320,12 +234,12 @@ public class ExecutionGraphCheckpointCoordinatorTest extends TestLogger {
 
 		@Override
 		public List<CompletedCheckpoint> getAllCheckpoints() {
-			return completedCheckpoints;
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 
 		@Override
 		public int getNumberOfRetainedCheckpoints() {
-			return completedCheckpoints.size();
+			throw new UnsupportedOperationException("Not implemented.");
 		}
 
 		@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/FailoverStrategyCheckpointCoordinatorTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -50,15 +49,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * Tests for the interaction between the {@link FailoverStrategy} and the {@link CheckpointCoordinator}.
  */
 public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
-
-	private ManuallyTriggeredScheduledExecutor timer;
-
-	private ManuallyTriggeredScheduledExecutor mainThreadExecutor;
+	private ManuallyTriggeredScheduledExecutor manualThreadExecutor;
 
 	@Before
 	public void setUp() {
-		timer = new ManuallyTriggeredScheduledExecutor();
-		mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
+		manualThreadExecutor = new ManuallyTriggeredScheduledExecutor();
 	}
 
 	/**
@@ -90,29 +85,24 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 			new StandaloneCompletedCheckpointStore(1),
 			new MemoryStateBackend(),
 			Executors.directExecutor(),
-			timer,
+			manualThreadExecutor,
 			SharedStateRegistry.DEFAULT_FACTORY,
 			mock(CheckpointFailureManager.class));
 
-		checkpointCoordinator.start(
-			new ComponentMainThreadExecutorServiceAdapter(
-				mainThreadExecutor,
-				Thread.currentThread()));
-
-			// switch current execution's state to running to allow checkpoint could be triggered.
+		// switch current execution's state to running to allow checkpoint could be triggered.
 		mockExecutionRunning(executionVertex);
 
 		checkpointCoordinator.startCheckpointScheduler();
 		assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
 		// only trigger the periodic scheduling
 		// we can't trigger all scheduled task, because there is also a cancellation scheduled
-		timer.triggerPeriodicScheduledTasks();
-		mainThreadExecutor.triggerAll();
+		manualThreadExecutor.triggerPeriodicScheduledTasks();
+		manualThreadExecutor.triggerAll();
 		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 
 		for (int i = 1; i < maxConcurrentCheckpoints; i++) {
 			checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
-			mainThreadExecutor.triggerAll();
+			manualThreadExecutor.triggerAll();
 			assertEquals(i + 1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 			assertTrue(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
 		}
@@ -120,7 +110,7 @@ public class FailoverStrategyCheckpointCoordinatorTest extends TestLogger {
 		// as we only support limited concurrent checkpoints, after checkpoint triggered more than the limits,
 		// the currentPeriodicTrigger would been assigned as null.
 		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
-		mainThreadExecutor.triggerAll();
+		manualThreadExecutor.triggerAll();
 		assertFalse(checkpointCoordinator.isCurrentPeriodicTriggerAvailable());
 		assertEquals(maxConcurrentCheckpoints, checkpointCoordinator.getNumberOfPendingCheckpoints());
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/PendingCheckpointTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.checkpoint;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -27,22 +26,17 @@ import org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTestingUtils.Str
 import org.apache.flink.runtime.checkpoint.PendingCheckpoint.TaskAcknowledgeResult;
 import org.apache.flink.runtime.checkpoint.hooks.MasterHooks;
 import org.apache.flink.runtime.concurrent.Executors;
-import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinator;
-import org.apache.flink.runtime.state.CheckpointMetadataOutputStream;
-import org.apache.flink.runtime.state.CheckpointStorageLocation;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
-import org.apache.flink.runtime.state.CheckpointedStateScope;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestingStreamStateHandle;
 import org.apache.flink.runtime.state.filesystem.FsCheckpointStorageLocation;
-import org.apache.flink.util.ExceptionUtils;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -71,7 +65,6 @@ import java.util.concurrent.ScheduledFuture;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -165,7 +158,7 @@ public class PendingCheckpointTest {
 		future = pending.getCompletionFuture();
 
 		assertFalse(future.isDone());
-		pending.abort(CheckpointFailureReason.CHECKPOINT_EXPIRED);
+		pending.abort(CheckpointFailureReason.CHECKPOINT_DECLINED);
 		assertTrue(future.isDone());
 
 		// Abort subsumed
@@ -173,7 +166,7 @@ public class PendingCheckpointTest {
 		future = pending.getCompletionFuture();
 
 		assertFalse(future.isDone());
-		pending.abort(CheckpointFailureReason.CHECKPOINT_SUBSUMED);
+		pending.abort(CheckpointFailureReason.CHECKPOINT_DECLINED);
 		assertTrue(future.isDone());
 
 		// Finalize (all ACK'd)
@@ -183,7 +176,7 @@ public class PendingCheckpointTest {
 		assertFalse(future.isDone());
 		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
 		assertTrue(pending.areTasksFullyAcknowledged());
-		pending.finalizeCheckpoint().get();
+		pending.finalizeCheckpoint();
 		assertTrue(future.isDone());
 
 		// Finalize (missing ACKs)
@@ -192,11 +185,10 @@ public class PendingCheckpointTest {
 
 		assertFalse(future.isDone());
 		try {
-			pending.finalizeCheckpoint().get();
+			pending.finalizeCheckpoint();
 			fail("Did not throw expected Exception");
-		} catch (Throwable t) {
+		} catch (IllegalStateException ignored) {
 			// Expected
-			assertTrue(ExceptionUtils.findThrowable(t, IllegalStateException.class).isPresent());
 		}
 	}
 
@@ -269,7 +261,7 @@ public class PendingCheckpointTest {
 			pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
 			verify(callback, times(1)).reportSubtaskStats(nullable(JobVertexID.class), any(SubtaskStateStats.class));
 
-			pending.finalizeCheckpoint().get();
+			pending.finalizeCheckpoint();
 			verify(callback, times(1)).reportCompletedCheckpoint(any(String.class));
 		}
 
@@ -499,142 +491,6 @@ public class PendingCheckpointTest {
 		assertTrue(handle2.isDisposed());
 	}
 
-	@Test
-	public void testAsyncFinalizeCheckpoint() throws Exception {
-		CheckpointProperties props = new CheckpointProperties(false, CheckpointType.SAVEPOINT, false, false, false, false, false);
-
-		ManuallyTriggeredScheduledExecutor ioExecutor = new ManuallyTriggeredScheduledExecutor();
-		ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-
-		CompletedCheckpointStore completedCheckpointStore = new StandaloneCompletedCheckpointStore(10);
-		PendingCheckpoint pending = createPendingCheckpoint(
-			props,
-			Collections.emptyList(),
-			Collections.emptyList(),
-			ioExecutor,
-			mainThreadExecutor,
-			completedCheckpointStore);
-
-		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		CompletableFuture<CompletedCheckpoint> checkpointCompletableFuture = pending.finalizeCheckpoint();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-		ioExecutor.triggerAll();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-		mainThreadExecutor.triggerAll();
-		assertNotNull(checkpointCompletableFuture.get());
-		assertEquals(1, completedCheckpointStore.getNumberOfRetainedCheckpoints());
-	}
-
-	@Test
-	public void testAsyncFinalizeCheckpointFailed() throws Exception {
-		CheckpointProperties props = new CheckpointProperties(false, CheckpointType.SAVEPOINT, false, false, false, false, false);
-
-		ManuallyTriggeredScheduledExecutor ioExecutor = new ManuallyTriggeredScheduledExecutor();
-		ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-
-		final Map<ExecutionAttemptID, ExecutionVertex> ackTasks = new HashMap<>(ACK_TASKS);
-
-		final StandaloneCompletedCheckpointStore completedCheckpointStore = new StandaloneCompletedCheckpointStore(10);
-		PendingCheckpoint pending = new PendingCheckpoint(
-			new JobID(),
-			0,
-			1,
-			ackTasks,
-			Collections.emptyList(),
-			Collections.emptyList(),
-			props,
-			new FailingCheckpointStorageLocation(),
-			ioExecutor,
-			mainThreadExecutor,
-			new CompletableFuture<>(),
-			completedCheckpointStore);
-
-		pending.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		CompletableFuture<CompletedCheckpoint> checkpointCompletableFuture = pending.finalizeCheckpoint();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-		ioExecutor.triggerAll();
-
-		assertTrue(checkpointCompletableFuture.isCompletedExceptionally());
-		assertEquals(0, completedCheckpointStore.getNumberOfRetainedCheckpoints());
-	}
-
-	@Test
-	public void testAbortingAfterAsyncFinalization() throws Exception {
-		final CheckpointProperties props = new CheckpointProperties(false, CheckpointType.SAVEPOINT, false, false, false, false, false);
-
-		final ManuallyTriggeredScheduledExecutor ioExecutor = new ManuallyTriggeredScheduledExecutor();
-		final ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-
-		final CompletedCheckpointStore completedCheckpointStore = new StandaloneCompletedCheckpointStore(10);
-		final PendingCheckpoint checkpoint = createPendingCheckpoint(
-			props,
-			Collections.emptyList(),
-			Collections.emptyList(),
-			ioExecutor,
-			mainThreadExecutor,
-			completedCheckpointStore);
-
-		checkpoint.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		final CompletableFuture<CompletedCheckpoint> checkpointCompletableFuture = checkpoint.finalizeCheckpoint();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-		ioExecutor.triggerAll();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-
-		checkpoint.abort(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
-		completedCheckpointStore.shutdown(JobStatus.CANCELED);
-
-		mainThreadExecutor.triggerAll();
-		// trigger the async cleanup operations
-		ioExecutor.triggerAll();
-		assertTrue(checkpointCompletableFuture.isCompletedExceptionally());
-
-		assertEquals(0, completedCheckpointStore.getNumberOfRetainedCheckpoints());
-
-		final FsCheckpointStorageLocation location =
-			(FsCheckpointStorageLocation) checkpoint.getCheckpointStorageLocation();
-		assertFalse(LocalFileSystem.getSharedInstance().exists(location.getCheckpointDirectory()));
-	}
-
-	@Test
-	public void testAbortingBeforeAsyncFinalization() throws Exception {
-		final CheckpointProperties props = new CheckpointProperties(false, CheckpointType.SAVEPOINT, false, false, false, false, false);
-
-		final ManuallyTriggeredScheduledExecutor ioExecutor = new ManuallyTriggeredScheduledExecutor();
-		final ManuallyTriggeredScheduledExecutor mainThreadExecutor = new ManuallyTriggeredScheduledExecutor();
-
-		final CompletedCheckpointStore completedCheckpointStore = new StandaloneCompletedCheckpointStore(10);
-		final PendingCheckpoint checkpoint = createPendingCheckpoint(
-			props,
-			Collections.emptyList(),
-			Collections.emptyList(),
-			ioExecutor,
-			mainThreadExecutor,
-			completedCheckpointStore);
-
-		checkpoint.acknowledgeTask(ATTEMPT_ID, null, new CheckpointMetrics());
-		final CompletableFuture<CompletedCheckpoint> checkpointCompletableFuture = checkpoint.finalizeCheckpoint();
-
-		assertFalse(checkpointCompletableFuture.isDone());
-		checkpoint.abort(CheckpointFailureReason.CHECKPOINT_COORDINATOR_SHUTDOWN);
-		completedCheckpointStore.shutdown(JobStatus.CANCELED);
-
-		ioExecutor.triggerAll();
-
-		mainThreadExecutor.triggerAll();
-		assertTrue(checkpointCompletableFuture.isCompletedExceptionally());
-
-		assertEquals(0, completedCheckpointStore.getNumberOfRetainedCheckpoints());
-
-		final FsCheckpointStorageLocation location =
-			(FsCheckpointStorageLocation) checkpoint.getCheckpointStorageLocation();
-		assertFalse(LocalFileSystem.getSharedInstance().exists(location.getCheckpointDirectory()));
-	}
-
 	// ------------------------------------------------------------------------
 
 	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props) throws IOException {
@@ -647,20 +503,6 @@ public class PendingCheckpointTest {
 
 	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props, Collection<String> masterStateIdentifiers) throws IOException {
 		return createPendingCheckpoint(props, Collections.emptyList(), masterStateIdentifiers, Executors.directExecutor());
-	}
-
-	private PendingCheckpoint createPendingCheckpoint(CheckpointProperties props, Collection<OperatorID> operatorCoordinators, Collection<String> masterStateIdentifiers, Executor executor) throws IOException {
-		return createPendingCheckpoint(props, operatorCoordinators, masterStateIdentifiers, executor, Executors.directExecutor());
-	}
-
-	private PendingCheckpoint createPendingCheckpoint(
-		CheckpointProperties props,
-		Collection<OperatorID> operatorCoordinators,
-		Collection<String> masterStateIdentifiers,
-		Executor executor,
-		Executor mainThreadExecutor) throws IOException {
-
-		return createPendingCheckpoint(props, operatorCoordinators, masterStateIdentifiers, executor, mainThreadExecutor, new StandaloneCompletedCheckpointStore(1));
 	}
 
 	private PendingCheckpoint createPendingCheckpointWithCoordinators(
@@ -694,17 +536,15 @@ public class PendingCheckpointTest {
 			CheckpointProperties props,
 			Collection<OperatorID> operatorCoordinators,
 			Collection<String> masterStateIdentifiers,
-			Executor executor,
-			Executor mainThreadExecutor,
-			CompletedCheckpointStore completedCheckpointStore) throws IOException {
+			Executor executor) throws IOException {
 
 		final Path checkpointDir = new Path(tmpFolder.newFolder().toURI());
 		final FsCheckpointStorageLocation location = new FsCheckpointStorageLocation(
-			LocalFileSystem.getSharedInstance(),
-			checkpointDir, checkpointDir, checkpointDir,
-			CheckpointStorageLocationReference.getDefault(),
-			1024,
-			4096);
+				LocalFileSystem.getSharedInstance(),
+				checkpointDir, checkpointDir, checkpointDir,
+				CheckpointStorageLocationReference.getDefault(),
+				1024,
+				4096);
 
 		final Map<ExecutionAttemptID, ExecutionVertex> ackTasks = new HashMap<>(ACK_TASKS);
 
@@ -718,9 +558,7 @@ public class PendingCheckpointTest {
 			props,
 			location,
 			executor,
-			mainThreadExecutor,
-			new CompletableFuture<>(),
-			completedCheckpointStore);
+			new CompletableFuture<>());
 	}
 
 	private static OperatorCoordinatorCheckpointContext createOperatorCoordinator() {
@@ -789,30 +627,6 @@ public class PendingCheckpointTest {
 		@Override
 		public SimpleVersionedSerializer<String> createCheckpointDataSerializer() {
 			return new StringSerializer();
-		}
-	}
-
-	private static class FailingCheckpointStorageLocation implements CheckpointStorageLocation {
-
-		@Override
-		public CheckpointMetadataOutputStream createMetadataOutputStream() throws IOException {
-			throw new IOException("Create meta data output stream failed");
-		}
-
-		@Override
-		public void disposeOnFailure() throws IOException {
-
-		}
-
-		@Override
-		public CheckpointStorageLocationReference getLocationReference() {
-			return null;
-		}
-
-		@Override
-		public CheckpointStateOutputStream createCheckpointStateOutputStream(
-			CheckpointedStateScope scope) throws IOException {
-			return null;
 		}
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -158,7 +158,6 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 		assertNull(client.checkExists().forPath(CHECKPOINT_PATH + ZooKeeperCompletedCheckpointStore.checkpointIdToPath(checkpoint.getCheckpointID())));
 
 		sharedStateRegistry.close();
-		store = createCompletedCheckpoints(1);
 		store.recover();
 
 		assertEquals(0, store.getNumberOfRetainedCheckpoints());
@@ -193,7 +192,6 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 		// Recover again
 		sharedStateRegistry.close();
-		store = createCompletedCheckpoints(1);
 		store.recover();
 
 		CompletedCheckpoint recovered = store.getLatestCheckpoint(false);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest.java
@@ -51,7 +51,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.hamcrest.Matchers.empty;
@@ -95,13 +94,8 @@ public class AdaptedRestartPipelinedRegionStrategyNGAbortPendingCheckpointsTest 
 		final CheckpointCoordinator checkpointCoordinator = executionGraph.getCheckpointCoordinator();
 		checkState(checkpointCoordinator != null);
 
-		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(), false);
-		// there is an async call in IO thread
-		// here we need to retry to make sure the callback of the async call could be executed
-		manualMainThreadExecutor.triggerAll();
-		while (!checkpointTriggeredLatch.await(10, TimeUnit.MILLISECONDS)) {
-			manualMainThreadExecutor.triggerAll();
-		}
+		checkpointCoordinator.triggerCheckpoint(System.currentTimeMillis(),  false);
+		checkpointTriggeredLatch.await();
 		assertEquals(1, checkpointCoordinator.getNumberOfPendingCheckpoints());
 		long checkpointId = checkpointCoordinator.getPendingCheckpoints().keySet().iterator().next();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ArchivedExecutionGraphTest.java
@@ -103,6 +103,8 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			.setJobGraph(jobGraph)
 			.build();
 
+		runtimeGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
+
 		List<ExecutionJobVertex> jobVertices = new ArrayList<>();
 		jobVertices.add(runtimeGraph.getJobVertex(v1ID));
 		jobVertices.add(runtimeGraph.getJobVertex(v2ID));
@@ -135,8 +137,6 @@ public class ArchivedExecutionGraphTest extends TestLogger {
 			statsTracker);
 
 		runtimeGraph.setJsonPlan("{}");
-
-		runtimeGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
 		runtimeGraph.getJobVertex(v2ID).getTaskVertices()[0].getCurrentExecutionAttempt().fail(new RuntimeException("This exception was thrown on purpose."));
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
-import org.apache.flink.runtime.state.CheckpointListener;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -298,15 +297,13 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 	private static String runJobAndGetExternalizedCheckpoint(StateBackend backend, File checkpointDir, @Nullable String externalCheckpoint, ClusterClient<?> client) throws Exception {
 		JobGraph initialJobGraph = getJobGraph(backend, externalCheckpoint);
 		NotifyingInfiniteTupleSource.countDownLatch = new CountDownLatch(PARALLELISM);
-		NotifyingInfiniteTupleSource.checkpointCompletedLatch = new CountDownLatch(PARALLELISM);
 
 		ClientUtils.submitJob(client, initialJobGraph);
 
 		// wait until all sources have been started
 		NotifyingInfiniteTupleSource.countDownLatch.await();
-		// wait the checkpoint completing
-		NotifyingInfiniteTupleSource.checkpointCompletedLatch.await();
 
+		waitUntilExternalizedCheckpointCreated(checkpointDir, initialJobGraph.getJobID());
 		client.cancel(initialJobGraph.getJobID()).get();
 		waitUntilCanceled(initialJobGraph.getJobID(), client);
 
@@ -319,6 +316,16 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 			throw new AssertionError("No complete checkpoint could be found.");
 		} else {
 			return checkpoint.get().toString();
+		}
+	}
+
+	private static void waitUntilExternalizedCheckpointCreated(File checkpointDir, JobID jobId) throws InterruptedException, IOException {
+		while (true) {
+			Thread.sleep(50);
+			Optional<Path> externalizedCheckpoint = findExternalizedCheckpoint(checkpointDir, jobId);
+			if (externalizedCheckpoint.isPresent()) {
+				break;
+			}
 		}
 	}
 
@@ -373,15 +380,11 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 	/**
 	 * Infinite source which notifies when all of its sub tasks have been started via the count down latch.
 	 */
-	public static class NotifyingInfiniteTupleSource
-		extends ManualWindowSpeedITCase.InfiniteTupleSource
-		implements CheckpointListener {
+	public static class NotifyingInfiniteTupleSource extends ManualWindowSpeedITCase.InfiniteTupleSource {
 
 		private static final long serialVersionUID = 8120981235081181746L;
 
 		private static CountDownLatch countDownLatch;
-
-		private static CountDownLatch checkpointCompletedLatch;
 
 		public NotifyingInfiniteTupleSource(int numKeys) {
 			super(numKeys);
@@ -394,13 +397,6 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 			}
 
 			super.run(out);
-		}
-
-		@Override
-		public void notifyCheckpointComplete(long checkpointId) throws Exception {
-			if (checkpointCompletedLatch != null) {
-				checkpointCompletedLatch.countDown();
-			}
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

* This PR reverts the commits of FLINK-16945 and FLINK-14971, because we can't find a simple and clean solution of FLINK-16770.
* We decide to revert the commits which cause the inconsistent state of `CompletedCheckpointStore`. So the releasing of 1.11 could get rid of blocking by this. When we have implemented the complete solution, we could have these commits back at that time.

## Brief change log

* Reverts commits of https://github.com/apache/flink/pull/11648, https://github.com/apache/flink/pull/11627 and https://github.com/apache/flink/pull/11347

## Verifying this change

* This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
