### PR TITLE
[FLINK-17206][table] refactor function catalog to support delayed UDF initialization.

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -690,8 +690,7 @@ public final class FunctionCatalog {
 
 		@Override
 		public FunctionLanguage getFunctionLanguage() {
-			throw new UnsupportedOperationException(
-				"This CatalogFunction is a InlineCatalogFunction. This method should not be called.");
+			return FunctionLanguage.JAVA;
 		}
 
 		public FunctionDefinition getDefinition() {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -646,6 +646,9 @@ public final class FunctionCatalog {
 		return FunctionDefinitionUtil.createFunctionDefinition(name, function.getClassName());
 	}
 
+	/**
+	 * The CatalogFunction which holds a instantiated UDF.
+	 */
 	private static class InlineCatalogFunction implements CatalogFunction {
 
 		private final FunctionDefinition definition;


### PR DESCRIPTION
## What is the purpose of the change

*This pull request refactors the `FunctionCatalog` to support delayed UDF initialization.*


## Brief change log

  - *Add a new static nested class `UninstantiatedSystemFunction` to  store the uninstantiated temporary system function.*
  - *Add new methods in FunctionCatalog to support registering uninstantiated function.*


## Verifying this change

This change is already covered by existing tests, such as *FunctionCatalogTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
