### PR TITLE
[FLINK-17211] Enable JUnit 4 tests in flink-sql-parser module

### DIFF
--- a/flink-table/flink-sql-parser/pom.xml
+++ b/flink-table/flink-sql-parser/pom.xml
@@ -175,10 +175,19 @@ under the License.
 			<type>test-jar</type>
 		</dependency>
 		<!-- Because Calcite tests use Junit5 and we extend from its SqlParserTest,
-			 add this dependency to make Junit4 tests compatible with Junit5 environment. -->
+			 we need the Junit5 runner. -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.5.2</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- As we switched to JUnit5 runner to use the Calcite tests infrastructure we need
+		 	 to add this dependency to make our own Junit4 tests compatible with the Junit5
+		 	 environment.-->
+		<dependency>
+			<groupId>org.junit.vintage</groupId>
+			<artifactId>junit-vintage-engine</artifactId>
 			<version>5.5.2</version>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Added junit 4 vintage engine to run junit 4 tests in junit 5 environment.

## Verifying this change

Execute `mvn clean install` in `flink-sql-parser` module. Check these tests are executed:
* org.apache.flink.sql.parser.TableApiIdentifierParsingTest
* org.apache.flink.sql.parser.FlinkDDLDataTypeTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
