### PR TITLE
[FLINK-17215][python][docs] Clean the build document for Pyflink

### DIFF
--- a/docs/flinkDev/building.md
+++ b/docs/flinkDev/building.md
@@ -62,11 +62,7 @@ If you want to build a PyFlink package that can be used for pip installation, yo
 Then go to the root directory of flink source code and run this command to build the sdist package and wheel package:
 
 {% highlight bash %}
-# Note: we need this temporarily due to a bug
-VERSION=`grep "^version:" docs/_config.yml | awk -F'\"' '{print $2}'`
-cd flink-python; perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${VERSION}\"#" pyflink/version.py
-# build packages
-python3 setup.py sdist bdist_wheel
+cd flink-python; python3 setup.py sdist bdist_wheel
 {% endhighlight %}
 
 The sdist and wheel package will be found under `./flink-python/dist/`. Either of them could be used for pip installation, such as:

--- a/docs/flinkDev/building.zh.md
+++ b/docs/flinkDev/building.zh.md
@@ -62,11 +62,7 @@ mvn clean install -DskipTests -Dfast
 之后，进入Flink源码根目录，并执行以下命令，构建PyFlink的源码发布包和wheel包：
 
 {% highlight bash %}
-# 注: 执行以下命令设置版本（临时性需要）
-VERSION=`grep "^version:" docs/_config.yml | awk -F'\"' '{print $2}'`
-cd flink-python; perl -pi -e "s#^__version__ = \".*\"#__version__ = \"${VERSION}\"#" pyflink/version.py
-# 打包
-python3 setup.py sdist bdist_wheel
+cd flink-python; python3 setup.py sdist bdist_wheel
 {% endhighlight %}
 
 构建好的源码发布包和wheel包位于`./flink-python/dist/`目录下。它们均可使用pip安装,比如:


### PR DESCRIPTION

## What is the purpose of the change

Previously the build document of Pyflink has been adjusted in https://github.com/apache/flink/pull/11013, however, we can clean it now as we have picked the fix in FLINK-15638 into the 1.9.


## Brief change log

  - Clean the build document of PyFlink


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

