### PR TITLE
[FLINK-17220][python] Clean test environment after finishing test

### DIFF
--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -30,10 +30,12 @@ deps =
     pytest
     grpcio>=1.17.0,<=1.26.0
     grpcio-tools>=1.3.5,<=1.14.2
+    pef
 commands =
     python --version
     pytest --durations=0
     bash ./dev/run_pip_test.sh
+    pef apache-flink grpcio grpcio-tools -y
 # Replace the default installation command with a custom retry installation script, because on high-speed
 # networks, downloading a package may raise a ConnectionResetError: [Errno 104] Peer reset connection.
 install_command = {toxinidir}/dev/install_command.sh {opts} {packages}


### PR DESCRIPTION
## What is the purpose of the change

*Currently, we will run Python 3.5/3.6/3.7 for the Python tests. This pull request will clean test environment after finishing the tests of a specific Python version. It could reduce the disk usage.*

## Brief change log

  - *use command pef to uninstall dependency in tox*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
