### PR TITLE
[FLINK-14258][table][filesystem] Integrate file system connector to streaming sink

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFsStreamingSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/ParquetFsStreamingSinkITCase.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Checkpoint ITCase for {@link ParquetFileSystemFormatFactory}.
+ */
+public class ParquetFsStreamingSinkITCase extends FsStreamingSinkITCaseBase {
+
+	@Override
+	public String[] additionalProperties() {
+		List<String> ret = new ArrayList<>();
+		ret.add("'format'='parquet'");
+		ret.add("'format.parquet.compression'='gzip'");
+		return ret.toArray(new String[0]);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream
+
+import org.apache.flink.api.common.typeinfo.Types
+import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.util.FiniteTestSource
+import org.apache.flink.table.api.Expressions.$
+import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, TableUtils}
+import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
+import org.apache.flink.types.Row
+
+import org.junit.Assert.assertEquals
+import org.junit.rules.Timeout
+import org.junit.{Before, Rule, Test}
+
+import scala.collection.Seq
+
+import scala.collection.JavaConversions._
+
+/**
+  * Streaming sink ITCase base, test checkpoint.
+  */
+abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
+
+  @Rule
+  def timeoutPerTest: Timeout = Timeout.seconds(20)
+
+  protected var resultPath: String = _
+
+  private val data = Seq(
+    Row.of(Integer.valueOf(1), "a", "b", "c", "12345"),
+    Row.of(Integer.valueOf(2), "p", "q", "r", "12345"),
+    Row.of(Integer.valueOf(3), "x", "y", "z", "12345"))
+
+  @Before
+  override def before(): Unit = {
+    super.before()
+    resultPath = tempFolder.newFolder().toURI.toString
+
+    env.setParallelism(1)
+    env.enableCheckpointing(100)
+
+    val stream = new DataStream(env.getJavaEnv.addSource(
+      new FiniteTestSource[Row](data: _*),
+      new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
+
+    tEnv.createTemporaryView("my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"))
+  }
+
+  def additionalProperties(): Array[String] = Array()
+
+  @Test
+  def testNonPart(): Unit = {
+    test(false)
+  }
+
+  @Test
+  def testPart(): Unit = {
+    test(true)
+  }
+
+  private def test(partition: Boolean): Unit = {
+    val ddl = s"""
+                 |create table sink_table (
+                 |  a int,
+                 |  b string,
+                 |  c string,
+                 |  d string,
+                 |  e string
+                 |)
+                 |${if (partition) "partitioned by (d, e)" else ""}
+                 |with (
+                 |  'connector' = 'filesystem',
+                 |  'path' = '$resultPath',
+                 |  ${additionalProperties().mkString(",\n")}
+                 |)
+       """.stripMargin
+    tEnv.sqlUpdate(ddl)
+
+    tEnv.insertInto("sink_table", tEnv.sqlQuery("select * from my_table"))
+    tEnv.execute("insert")
+
+    check(
+      ddl,
+      "select * from sink_table",
+      data ++ data)
+  }
+
+  def check(ddl: String, sqlQuery: String, expectedResult: Seq[Row]): Unit = {
+    val setting = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build()
+    val tEnv = TableEnvironment.create(setting)
+    tEnv.sqlUpdate(ddl)
+
+    val result = TableUtils.collectToList(tEnv.sqlQuery(sqlQuery))
+
+    assertEquals(
+      expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
+      result.map(TestSinkUtil.rowToString(_)).sorted)
+  }
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FsStreamingSinkTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/FsStreamingSinkTestCsvITCase.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase
+import org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory.USE_BULK_WRITER
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.Seq
+
+/**
+  * Test checkpoint for file system table factory with testcsv format.
+  */
+@RunWith(classOf[Parameterized])
+class FsStreamingSinkTestCsvITCase(useBulkWriter: Boolean) extends FsStreamingSinkITCaseBase {
+
+  override def additionalProperties(): Array[String] = {
+    super.additionalProperties() ++
+        Seq("'format' = 'testcsv'", s"'$USE_BULK_WRITER' = '$useBulkWriter'") ++
+        (if (useBulkWriter) Seq() else Seq("'sink.rolling-policy.file-size' = '1'"))
+  }
+}
+
+object FsStreamingSinkTestCsvITCase {
+  @Parameterized.Parameters(name = "useBulkWriter-{0}")
+  def parameters(): java.util.Collection[Boolean] = {
+    java.util.Arrays.asList(true, false)
+  }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -78,11 +78,14 @@ public class FileSystemTableSink implements
 	/**
 	 * Construct a file system table sink.
 	 *
+	 * @param isBounded whether the input of sink is bounded.
 	 * @param schema schema of the table.
 	 * @param path directory path of the file system table.
 	 * @param partitionKeys partition keys of the table.
 	 * @param defaultPartName The default partition name in case the dynamic partition column value
 	 *                        is null/empty string.
+	 * @param rollingFileSize the maximum part file size before rolling.
+	 * @param rollingTimeInterval the maximum time duration a part file can stay open before rolling.
 	 * @param formatProperties format properties.
 	 */
 	public FileSystemTableSink(
@@ -366,8 +369,7 @@ public class FileSystemTableSink implements
 	}
 
 	/**
-	 * Table {@link RollingPolicy}, now it is a {@link CheckpointRollingPolicy}.
-	 * Because partition commit is hard to support false.
+	 * Table {@link RollingPolicy}, it extends {@link CheckpointRollingPolicy} for bulk writers.
 	 */
 	private static class TableRollingPolicy extends CheckpointRollingPolicy<BaseRow, String> {
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -26,8 +26,15 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
+import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
+import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
+import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.dataformat.BaseRow;
@@ -39,6 +46,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,10 +62,13 @@ public class FileSystemTableSink implements
 		PartitionableTableSink,
 		OverwritableTableSink {
 
+	private final boolean isBounded;
 	private final TableSchema schema;
 	private final List<String> partitionKeys;
 	private final Path path;
 	private final String defaultPartName;
+	private final long rollingFileSize;
+	private final long rollingTimeInterval;
 	private final Map<String, String> formatProperties;
 
 	private boolean overwrite = false;
@@ -75,14 +86,20 @@ public class FileSystemTableSink implements
 	 * @param formatProperties format properties.
 	 */
 	public FileSystemTableSink(
+			boolean isBounded,
 			TableSchema schema,
 			Path path,
 			List<String> partitionKeys,
 			String defaultPartName,
+			long rollingFileSize,
+			long rollingTimeInterval,
 			Map<String, String> formatProperties) {
+		this.isBounded = isBounded;
 		this.schema = schema;
 		this.path = path;
 		this.defaultPartName = defaultPartName;
+		this.rollingFileSize = rollingFileSize;
+		this.rollingTimeInterval = rollingTimeInterval;
 		this.formatProperties = formatProperties;
 		this.partitionKeys = partitionKeys;
 	}
@@ -95,17 +112,48 @@ public class FileSystemTableSink implements
 				schema.getFieldDataTypes(),
 				partitionKeys.toArray(new String[0]));
 
-		FileSystemOutputFormat.Builder<BaseRow> builder = new FileSystemOutputFormat.Builder<>();
-		builder.setPartitionComputer(computer);
-		builder.setDynamicGrouped(dynamicGrouping);
-		builder.setPartitionColumns(partitionKeys.toArray(new String[0]));
-		builder.setFormatFactory(createOutputFormatFactory());
-		builder.setMetaStoreFactory(createTableMetaStoreFactory(path));
-		builder.setOverwrite(overwrite);
-		builder.setStaticPartitions(staticPartitions);
-		builder.setTempPath(toStagingPath());
-		return dataStream.writeUsingOutputFormat(builder.build())
-				.setParallelism(dataStream.getParallelism());
+		if (isBounded) {
+			FileSystemOutputFormat.Builder<BaseRow> builder = new FileSystemOutputFormat.Builder<>();
+			builder.setPartitionComputer(computer);
+			builder.setDynamicGrouped(dynamicGrouping);
+			builder.setPartitionColumns(partitionKeys.toArray(new String[0]));
+			builder.setFormatFactory(createOutputFormatFactory());
+			builder.setMetaStoreFactory(createTableMetaStoreFactory(path));
+			builder.setOverwrite(overwrite);
+			builder.setStaticPartitions(staticPartitions);
+			builder.setTempPath(toStagingPath());
+			return dataStream.writeUsingOutputFormat(builder.build())
+					.setParallelism(dataStream.getParallelism());
+		} else {
+			if (overwrite) {
+				throw new IllegalStateException("Streaming mode not support overwrite.");
+			}
+
+			Object writer = createWriter();
+
+			TableBucketAssigner assigner = new TableBucketAssigner(computer);
+			TableRollingPolicy rollingPolicy = new TableRollingPolicy(
+					!(writer instanceof Encoder),
+					rollingFileSize,
+					rollingTimeInterval);
+
+			StreamingFileSink<BaseRow> sink;
+			if (writer instanceof Encoder) {
+				//noinspection unchecked
+				sink = StreamingFileSink.forRowFormat(
+						path, new ProjectionEncoder((Encoder<BaseRow>) writer, computer))
+						.withBucketAssigner(assigner)
+						.withRollingPolicy(rollingPolicy).build();
+			} else {
+				//noinspection unchecked
+				sink = StreamingFileSink.forBulkFormat(
+						path, new ProjectionBulkFactory((BulkWriter.Factory<BaseRow>) writer, computer))
+						.withBucketAssigner(assigner)
+						.withRollingPolicy(rollingPolicy).build();
+			}
+
+			return dataStream.addSink(sink).setParallelism(dataStream.getParallelism());
+		}
 	}
 
 	private Path toStagingPath() {
@@ -121,7 +169,15 @@ public class FileSystemTableSink implements
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private OutputFormatFactory<BaseRow> createOutputFormatFactory() {
+		Object writer = createWriter();
+		return writer instanceof Encoder ?
+				path -> createEncoderOutputFormat((Encoder<BaseRow>) writer, path) :
+				path -> createBulkWriterOutputFormat((BulkWriter.Factory<BaseRow>) writer, path);
+	}
+
+	private Object createWriter() {
 		FileSystemFormatFactory formatFactory = createFormatFactory(formatProperties);
 		FileSystemFormatFactory.WriterContext context = new FileSystemFormatFactory.WriterContext() {
 
@@ -144,17 +200,14 @@ public class FileSystemTableSink implements
 		Optional<Encoder<BaseRow>> encoder = formatFactory.createEncoder(context);
 		Optional<BulkWriter.Factory<BaseRow>> bulk = formatFactory.createBulkWriterFactory(context);
 
-		if (!encoder.isPresent() && !bulk.isPresent()) {
+		if (encoder.isPresent()) {
+			return encoder.get();
+		} else if (bulk.isPresent()) {
+			return bulk.get();
+		} else {
 			throw new TableException(
 					formatFactory + " format should implement at least one Encoder or BulkWriter");
 		}
-		return encoder
-				.<OutputFormatFactory<BaseRow>>map(en -> path -> createEncoderOutputFormat(en, path))
-				.orElseGet(() -> {
-					// Optional is not serializable.
-					BulkWriter.Factory<BaseRow> bulkWriterFactory = bulk.get();
-					return path -> createBulkWriterOutputFormat(bulkWriterFactory, path);
-				});
 	}
 
 	private static OutputFormat<BaseRow> createBulkWriterOutputFormat(
@@ -283,5 +336,126 @@ public class FileSystemTableSink implements
 	public boolean configurePartitionGrouping(boolean supportsGrouping) {
 		this.dynamicGrouping = supportsGrouping;
 		return dynamicGrouping;
+	}
+
+	/**
+	 * Table bucket assigner, wrap {@link PartitionComputer}.
+	 */
+	private static class TableBucketAssigner implements BucketAssigner<BaseRow, String> {
+
+		private final PartitionComputer<BaseRow> computer;
+
+		private TableBucketAssigner(PartitionComputer<BaseRow> computer) {
+			this.computer = computer;
+		}
+
+		@Override
+		public String getBucketId(BaseRow element, Context context) {
+			try {
+				return PartitionPathUtils.generatePartitionPath(
+						computer.generatePartValues(element));
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public SimpleVersionedSerializer<String> getSerializer() {
+			return SimpleVersionedStringSerializer.INSTANCE;
+		}
+	}
+
+	/**
+	 * Table {@link RollingPolicy}, now it is a {@link CheckpointRollingPolicy}.
+	 * Because partition commit is hard to support false.
+	 */
+	private static class TableRollingPolicy extends CheckpointRollingPolicy<BaseRow, String> {
+
+		private final boolean rollOnCheckpoint;
+		private final long rollingFileSize;
+		private final long rollingTimeInterval;
+
+		private TableRollingPolicy(
+				boolean rollOnCheckpoint,
+				long rollingFileSize,
+				long rollingTimeInterval) {
+			this.rollOnCheckpoint = rollOnCheckpoint;
+			Preconditions.checkArgument(rollingFileSize > 0L);
+			Preconditions.checkArgument(rollingTimeInterval > 0L);
+			this.rollingFileSize = rollingFileSize;
+			this.rollingTimeInterval = rollingTimeInterval;
+		}
+
+		@Override
+		public boolean shouldRollOnCheckpoint(PartFileInfo<String> partFileState) {
+			try {
+				return rollOnCheckpoint || partFileState.getSize() > rollingFileSize;
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		@Override
+		public boolean shouldRollOnEvent(
+				PartFileInfo<String> partFileState,
+				BaseRow element) throws IOException {
+			return partFileState.getSize() > rollingFileSize;
+		}
+
+		@Override
+		public boolean shouldRollOnProcessingTime(
+				PartFileInfo<String> partFileState,
+				long currentTime) {
+			return currentTime - partFileState.getCreationTime() >= rollingTimeInterval;
+		}
+	}
+
+	private static class ProjectionEncoder implements Encoder<BaseRow> {
+
+		private final Encoder<BaseRow> encoder;
+		private final RowDataPartitionComputer computer;
+
+		private ProjectionEncoder(Encoder<BaseRow> encoder, RowDataPartitionComputer computer) {
+			this.encoder = encoder;
+			this.computer = computer;
+		}
+
+		@Override
+		public void encode(BaseRow element, OutputStream stream) throws IOException {
+			encoder.encode(computer.projectColumnsToWrite(element), stream);
+		}
+	}
+
+	private static class ProjectionBulkFactory implements BulkWriter.Factory<BaseRow> {
+
+		private final BulkWriter.Factory<BaseRow> factory;
+		private final RowDataPartitionComputer computer;
+
+		private ProjectionBulkFactory(BulkWriter.Factory<BaseRow> factory, RowDataPartitionComputer computer) {
+			this.factory = factory;
+			this.computer = computer;
+		}
+
+		@Override
+		public BulkWriter<BaseRow> create(FSDataOutputStream out) throws IOException {
+			BulkWriter<BaseRow> writer = factory.create(out);
+			return new BulkWriter<BaseRow>() {
+
+				@Override
+				public void addElement(BaseRow element) throws IOException {
+					writer.addElement(computer.projectColumnsToWrite(element));
+				}
+
+				@Override
+				public void flush() throws IOException {
+					writer.flush();
+				}
+
+				@Override
+				public void finish() throws IOException {
+					writer.finish();
+				}
+			};
+		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
@@ -88,7 +88,9 @@ public class PartitionPathUtils {
 			suffixBuf.append(escapePathName(e.getValue()));
 			i++;
 		}
-		suffixBuf.append(Path.SEPARATOR);
+		if (partitionSpec.size() > 0) {
+			suffixBuf.append(Path.SEPARATOR);
+		}
 		return suffixBuf.toString();
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionPathUtils.java
@@ -77,6 +77,9 @@ public class PartitionPathUtils {
 	 * @return An escaped, valid partition name.
 	 */
 	public static String generatePartitionPath(LinkedHashMap<String, String> partitionSpec) {
+		if (partitionSpec.isEmpty()) {
+			return "";
+		}
 		StringBuilder suffixBuf = new StringBuilder();
 		int i = 0;
 		for (Map.Entry<String, String> e : partitionSpec.entrySet()) {
@@ -88,9 +91,7 @@ public class PartitionPathUtils {
 			suffixBuf.append(escapePathName(e.getValue()));
 			i++;
 		}
-		if (partitionSpec.size() > 0) {
-			suffixBuf.append(Path.SEPARATOR);
-		}
+		suffixBuf.append(Path.SEPARATOR);
 		return suffixBuf.toString();
 	}
 


### PR DESCRIPTION

## What is the purpose of the change

Integrate file system connector to streaming sink.

## Brief change log

- Integrate streaming file sink in `FileSystemTableSink`
- Add `ROLLING_POLICY`s

## Verifying this change

- `FsStreamingSinkCsvITCaseBase`
- `ParquetFsStreamingSinkITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (no
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
