### PR TITLE
[FLINK-17169][table-blink] Refactor BaseRow to use RowKind instead of byte header

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/RowKind.java
+++ b/flink-core/src/main/java/org/apache/flink/types/RowKind.java
@@ -29,7 +29,7 @@ public enum RowKind {
 	/**
 	 * Insertion operation.
 	 */
-	INSERT,
+	INSERT("+I", (byte) 0),
 
 	/**
 	 * Update operation with the previous content of the updated row.
@@ -38,7 +38,7 @@ public enum RowKind {
 	 * to retract the previous row first. It is useful in cases of a non-idempotent update, i.e., an
 	 * update of a row that is not uniquely identifiable by a key.
 	 */
-	UPDATE_BEFORE,
+	UPDATE_BEFORE("-U", (byte) 1),
 
 	/**
 	 * Update operation with new content of the updated row.
@@ -47,10 +47,69 @@ public enum RowKind {
 	 * needs to retract the previous row first. OR it describes an idempotent update, i.e., an update
 	 * of a row that is uniquely identifiable by a key.
 	 */
-	UPDATE_AFTER,
+	UPDATE_AFTER("+U", (byte) 2),
 
 	/**
 	 * Deletion operation.
 	 */
-	DELETE
+	DELETE("-D", (byte) 3);
+
+	private final String shortString;
+
+	private final byte value;
+
+	/**
+	 * Creates a {@link RowKind} enum with the given short string and byte value representation of
+	 * the {@link RowKind}.
+	 */
+	RowKind(String shortString, byte value) {
+		this.shortString = shortString;
+		this.value = value;
+	}
+
+	/**
+	 * Returns a short string representation of this {@link RowKind}.
+	 *
+	 * <p><ul>
+	 *     <li>"+I" represents {@link #INSERT}.</li>
+	 *     <li>"+U" represents {@link #UPDATE_BEFORE}.</li>
+	 *     <li>"-U" represents {@link #UPDATE_AFTER}.</li>
+	 *     <li>"-D" represents {@link #DELETE}.</li>
+	 * </ul>
+	 */
+	public String shortString() {
+		return shortString;
+	}
+
+	/**
+	 * Returns the byte value representation of this {@link RowKind}. The byte value is used
+	 * for serialization and deserialization.
+	 *
+	 * <p><ul>
+	 * 	 <li>"0" represents {@link #INSERT}.</li>
+	 * 	 <li>"1" represents {@link #UPDATE_BEFORE}.</li>
+	 * 	 <li>"2" represents {@link #UPDATE_AFTER}.</li>
+	 * 	 <li>"3" represents {@link #DELETE}.</li>
+	 * </ul>
+	 */
+	public byte toByteValue() {
+		return value;
+	}
+
+	/**
+	 * Creates a {@link RowKind} from the given byte value. Each {@link RowKind} has a byte
+	 * value representation.
+	 *
+	 * @see #toByteValue() for mapping of byte value and {@link RowKind}.
+	 */
+	public static RowKind fromByteValue(byte value) {
+		switch (value) {
+			case 0: return INSERT;
+			case 1: return UPDATE_BEFORE;
+			case 2: return UPDATE_AFTER;
+			case 3: return DELETE;
+			default: throw new UnsupportedOperationException(
+				"Unsupported byte value '" + value + "' for row kind.");
+		}
+	}
 }

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/AbstractBaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/AbstractBaseRowPythonScalarFunctionOperator.java
@@ -89,7 +89,7 @@ public abstract class AbstractBaseRowPythonScalarFunctionOperator
 	public void bufferInput(BaseRow input) {
 		// always copy the projection result as the generated Projection reuses the projection result
 		BaseRow forwardedFields = forwardedFieldProjection.apply(input).copy();
-		forwardedFields.setHeader(input.getHeader());
+		forwardedFields.setRowKind(input.getRowKind());
 		forwardedInputQueue.add(forwardedFields);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperator.java
@@ -71,7 +71,7 @@ public class BaseRowPythonScalarFunctionOperator extends AbstractBaseRowPythonSc
 		byte[] rawUdfResult;
 		while ((rawUdfResult = userDefinedFunctionResultQueue.poll()) != null) {
 			BaseRow input = forwardedInputQueue.poll();
-			reuseJoinedRow.setHeader(input.getHeader());
+			reuseJoinedRow.setRowKind(input.getRowKind());
 			bais.setBuffer(rawUdfResult, 0, rawUdfResult.length);
 			BaseRow udfResult = udfOutputTypeSerializer.deserialize(baisWrapper);
 			baseRowWrapper.collect(reuseJoinedRow.replace(input, udfResult));

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperator.java
@@ -120,7 +120,7 @@ public class BaseRowArrowPythonScalarFunctionOperator extends AbstractBaseRowPyt
 			}
 			for (int i = 0; i < root.getRowCount(); i++) {
 				BaseRow input = forwardedInputQueue.poll();
-				reuseJoinedRow.setHeader(input.getHeader());
+				reuseJoinedRow.setRowKind(input.getRowKind());
 				baseRowWrapper.collect(reuseJoinedRow.replace(input, arrowReader.read(i)));
 			}
 		}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperator.java
@@ -106,7 +106,7 @@ public class BaseRowPythonTableFunctionOperator
 	public void bufferInput(BaseRow input) {
 		// always copy the input BaseRow
 		BaseRow forwardedFields = forwardedInputSerializer.copy(input);
-		forwardedFields.setHeader(input.getHeader());
+		forwardedFields.setRowKind(input.getRowKind());
 		forwardedInputQueue.add(forwardedFields);
 	}
 
@@ -156,7 +156,7 @@ public class BaseRowPythonTableFunctionOperator
 				input = forwardedInputQueue.poll();
 			} else if (input != null) {
 				if (!isFinishResult) {
-					reuseJoinedRow.setHeader(input.getHeader());
+					reuseJoinedRow.setRowKind(input.getRowKind());
 					bais.setBuffer(rawUdtfResult, 0, rawUdtfResult.length);
 					BaseRow udtfResult = udtfOutputTypeSerializer.deserialize(baisWrapper);
 					baseRowWrapper.collect(reuseJoinedRow.replace(input, udtfResult));

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/BaseRowPythonScalarFunctionOperatorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
@@ -37,6 +36,7 @@ import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.runtime.utils.PassThroughPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
@@ -80,7 +80,9 @@ public class BaseRowPythonScalarFunctionOperatorTest
 		if (accumulateMsg) {
 			return baserow(fields);
 		} else {
-			return BaseRowUtil.setRetract(baserow(fields));
+			BaseRow row = baserow(fields);
+			row.setRowKind(RowKind.DELETE);
+			return row;
 		}
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/BaseRowArrowPythonScalarFunctionOperatorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.arrow.ArrowUtils;
 import org.apache.flink.table.runtime.arrow.ArrowWriter;
@@ -40,6 +39,7 @@ import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.runtime.utils.PassThroughArrowPythonScalarFunctionRunner;
 import org.apache.flink.table.runtime.utils.PythonTestUtils;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
@@ -77,7 +77,9 @@ public class BaseRowArrowPythonScalarFunctionOperatorTest
 		if (accumulateMsg) {
 			return baserow(fields);
 		} else {
-			return BaseRowUtil.setRetract(baserow(fields));
+			BaseRow row = baserow(fields);
+			row.setRowKind(RowKind.DELETE);
+			return row;
 		}
 	}
 

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperatorTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/table/BaseRowPythonTableFunctionOperatorTest.java
@@ -25,12 +25,12 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonFunctionRunner;
 import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.functions.python.PythonFunctionInfo;
 import org.apache.flink.table.runtime.typeutils.PythonTypeUtils;
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor;
 import org.apache.flink.table.runtime.utils.PassThroughPythonTableFunctionRunner;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -59,7 +59,9 @@ public class BaseRowPythonTableFunctionOperatorTest
 		if (accumulateMsg) {
 			return baserow(fields);
 		} else {
-			return BaseRowUtil.setRetract(baserow(fields));
+			BaseRow row = baserow(fields);
+			row.setRowKind(RowKind.DELETE);
+			return row;
 		}
 	}
 
@@ -101,7 +103,7 @@ public class BaseRowPythonTableFunctionOperatorTest
 				@Override
 				public BaseRow copy(BaseRow element) {
 					BaseRow row = binaryrow(element.getLong(0));
-					row.setHeader(element.getHeader());
+					row.setRowKind(element.getRowKind());
 					return row;
 				}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -160,7 +160,7 @@ object CalcCodeGenerator {
       val projectionExpressionCode = projectionExpression.code
 
       val header = if (retainHeader) {
-        s"${projectionExpression.resultTerm}.setHeader($inputTerm.getHeader());"
+        s"${projectionExpression.resultTerm}.setRowKind($inputTerm.getRowKind());"
       } else {
         ""
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -34,11 +34,11 @@ import org.apache.flink.table.runtime.util.MurmurHashUtil
 import org.apache.flink.table.types.DataType
 import org.apache.flink.table.types.logical.LogicalTypeRoot._
 import org.apache.flink.table.types.logical._
-import org.apache.flink.types.Row
+import org.apache.flink.types.{Row, RowKind}
+
 import java.lang.reflect.Method
 import java.lang.{Boolean => JBoolean, Byte => JByte, Double => JDouble, Float => JFloat, Integer => JInt, Long => JLong, Short => JShort}
 import java.util.concurrent.atomic.AtomicInteger
-
 import org.apache.flink.table.planner.codegen.GenerateUtils.{generateInputFieldUnboxing, generateNonNullField}
 
 object CodeGenUtils {
@@ -82,6 +82,8 @@ object CodeGenUtils {
   val JOINED_ROW: String = className[JoinedRow]
 
   val GENERIC_ROW: String = className[GenericRow]
+
+  val ROW_KIND: String = className[RowKind]
 
   val DECIMAL_TERM: String = className[Decimal]
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -181,7 +181,7 @@ object CorrelateCodeGenerator {
         ctx.addReusableOutputRecord(functionResultType, classOf[GenericRow], nullRowTerm)
         ctx.addReusableNullRow(nullRowTerm, functionResultType.getFieldCount)
         val header = if (retainHeader) {
-          s"$nullRowTerm.setHeader(${exprGenerator.input1Term}.getHeader());"
+          s"$nullRowTerm.setRowKind(${exprGenerator.input1Term}.getRowKind());"
         } else {
           ""
         }
@@ -199,7 +199,7 @@ object CorrelateCodeGenerator {
         ctx.addReusableOutputRecord(returnType, classOf[GenericRow], outputTerm)
 
         val header = if (retainHeader) {
-          s"$outputTerm.setHeader(${CodeGenUtils.DEFAULT_INPUT1_TERM}.getHeader());"
+          s"$outputTerm.setRowKind(${CodeGenUtils.DEFAULT_INPUT1_TERM}.getRowKind());"
         } else {
           ""
         }
@@ -232,7 +232,7 @@ object CorrelateCodeGenerator {
         ctx.addReusableOutputRecord(returnType, classOf[JoinedRow], joinedRowTerm)
         ctx.addReusableNullRow(nullRowTerm, functionResultType.getFieldCount)
         val header = if (retainHeader) {
-          s"$joinedRowTerm.setHeader(${exprGenerator.input1Term}.getHeader());"
+          s"$joinedRowTerm.setRowKind(${exprGenerator.input1Term}.getRowKind());"
         } else {
           ""
         }
@@ -311,7 +311,7 @@ object CorrelateCodeGenerator {
       if (swallowInputOnly) {
         // output right only
         val header = if (retainHeader) {
-          s"$udtfInputTerm.setHeader($inputTerm.getHeader());"
+          s"$udtfInputTerm.setRowKind($inputTerm.getRowKind());"
         } else {
           ""
         }
@@ -324,7 +324,7 @@ object CorrelateCodeGenerator {
         collectorCtx.addReusableOutputRecord(resultType, classOf[GenericRow], outputTerm)
 
         val header = if (retainHeader) {
-          s"$outputTerm.setHeader($inputTerm.getHeader());"
+          s"$outputTerm.setRowKind($inputTerm.getRowKind());"
         } else {
           ""
         }
@@ -350,7 +350,7 @@ object CorrelateCodeGenerator {
       collectorCtx.addReusableOutputRecord(resultType, classOf[JoinedRow], joinedRowTerm)
 
       val header = if (retainHeader) {
-        s"$joinedRowTerm.setHeader($inputTerm.getHeader());"
+        s"$joinedRowTerm.setRowKind($inputTerm.getRowKind());"
       } else {
         ""
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/EqualiserCodeGenerator.scala
@@ -40,7 +40,7 @@ class EqualiserCodeGenerator(fieldTypes: Array[LogicalType]) {
     val className = newName(name)
     val header =
       s"""
-         |if ($LEFT_INPUT.getHeader() != $RIGHT_INPUT.getHeader()) {
+         |if ($LEFT_INPUT.getRowKind() != $RIGHT_INPUT.getRowKind()) {
          |  return false;
          |}
        """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
@@ -49,7 +49,7 @@ object ExpandCodeGenerator {
       val projectionResultExpr = exprGenerator.generateResultExpression(
         projectionExprs, outputType, classOf[BoxedWrapperRow])
       val header = if (retainHeader) {
-        s"${projectionResultExpr.resultTerm}.setHeader($inputTerm.getHeader());"
+        s"${projectionResultExpr.resultTerm}.setRowKind($inputTerm.getRowKind());"
       } else {
         ""
       }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -244,7 +244,7 @@ object LookupJoinCodeGenerator {
     ctx.addReusableOutputRecord(resultType, classOf[JoinedRow], joinedRowTerm)
 
     val header = if (retainHeader) {
-      s"$joinedRowTerm.setHeader($inputTerm.getHeader());"
+      s"$joinedRowTerm.setRowKind($inputTerm.getRowKind());"
     } else {
       ""
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/AggsHandlerCodeGenerator.scala
@@ -538,9 +538,9 @@ class AggsHandlerCodeGenerator(
               $BASE_ROW tempBaseRow = convertToBaseRow($recordInputName);
               result.replace(key, tempBaseRow);
               if (isRetract) {
-                result.setHeader(${className[BaseRowUtil]}.RETRACT_MSG);
+                result.setRowKind($ROW_KIND.DELETE);
               } else {
-                result.setHeader(${className[BaseRowUtil]}.ACCUMULATE_MSG);
+                result.setRowKind($ROW_KIND.INSERT);
               }
               $COLLECTOR_TERM.collect(result);
             }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamExecGroupWindowAggregateBase.scala
@@ -314,7 +314,7 @@ abstract class StreamExecGroupWindowAggregateBase(
     if (emitStrategy.produceUpdates) {
       // mark this operator will send retraction and set new trigger
       newBuilder
-        .withSendRetraction()
+        .produceUpdates()
         .triggering(emitStrategy.getTrigger)
         .withAllowedLateness(Duration.ofMillis(emitStrategy.getAllowLateness))
     }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/utils/WindowEmitStrategy.scala
@@ -63,7 +63,7 @@ class WindowEmitStrategy(
 
   def produceUpdates: Boolean = {
     if (isEventTime) {
-      allowLateness > 0 || earlyFireDelayEnabled || lateFireDelayEnabled
+      earlyFireDelayEnabled || lateFireDelayEnabled
     } else {
       earlyFireDelayEnabled
     }

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/BaseRowTestUtil.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/BaseRowTestUtil.java
@@ -62,14 +62,16 @@ public class BaseRowTestUtil {
 	private static String genericRowToString(GenericRow row, TimeZone tz, boolean withHeader) {
 		StringBuilder sb = new StringBuilder();
 		if (withHeader) {
-			sb.append(row.getHeader()).append("|");
+			sb.append(row.getRowKind().shortString());
 		}
+		sb.append("(");
 		for (int i = 0; i < row.getArity(); i++) {
 			if (i > 0) {
 				sb.append(",");
 			}
 			sb.append(fieldToString(row.getField(i), tz));
 		}
+		sb.append(")");
 		return sb.toString();
 	}
 
@@ -83,7 +85,7 @@ public class BaseRowTestUtil {
 		} else {
 			int fieldNum = baseRow.getArity();
 			GenericRow row = new GenericRow(fieldNum);
-			row.setHeader(baseRow.getHeader());
+			row.setRowKind(baseRow.getRowKind());
 			for (int i = 0; i < fieldNum; i++) {
 				if (baseRow.isNullAt(i)) {
 					row.setField(i, null);

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/WindowAggregateTest.xml
@@ -134,6 +134,32 @@ Calc(select=[EXPR$0, wAvg, w$start AS EXPR$2, w$end AS EXPR$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testWindowAggregateWithLateFire">
+    <Resource name="sql">
+      <![CDATA[
+SELECT TUMBLE_START(`rowtime`, INTERVAL '1' SECOND), COUNT(*) cnt
+FROM MyTable
+GROUP BY TUMBLE(`rowtime`, INTERVAL '1' SECOND)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[TUMBLE_START($0)], cnt=[$1])
++- LogicalAggregate(group=[{0}], cnt=[COUNT()])
+   +- LogicalProject($f0=[$TUMBLE($4, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[w$start AS EXPR$0, cnt], changelogMode=[I,UA])
++- GroupWindowAggregate(window=[TumblingGroupWindow('w$, rowtime, 1000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS cnt, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime], emit=[late delay 5000 millisecond], changelogMode=[I,UA])
+   +- Exchange(distribution=[single], changelogMode=[I])
+      +- Calc(select=[rowtime], changelogMode=[I])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime], changelogMode=[I])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testHopWindowWithProctime">
     <Resource name="sql">
       <![CDATA[
@@ -176,86 +202,6 @@ GroupWindowAggregate(window=[TumblingGroupWindow('w$, proctime, 3024000000)], se
 +- Exchange(distribution=[single])
    +- Calc(select=[proctime])
       +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testTumbleFunNotInGroupBy">
-    <Resource name="sql">
-      <![CDATA[
-SELECT weightedAvg(c, a) FROM
-    (SELECT a, b, c,
-        TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as ping_start
-     FROM MyTable
-         GROUP BY a, b, c, TUMBLE(rowtime, INTERVAL '15' MINUTE)) AS t1
-GROUP BY b
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[$1])
-+- LogicalAggregate(group=[{0}], EXPR$0=[weightedAvg($1, $2)])
-   +- LogicalProject(b=[$1], c=[$2], a=[$0])
-      +- LogicalAggregate(group=[{0, 1, 2, 3}])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[EXPR$0])
-+- GroupAggregate(groupBy=[b], select=[b, weightedAvg(c, a) AS EXPR$0])
-   +- Exchange(distribution=[hash[b]])
-      +- GroupWindowAggregate(groupBy=[a, b, c], window=[TumblingGroupWindow('w$, rowtime, 900000)], select=[a, b, c])
-         +- Exchange(distribution=[hash[a, b, c]])
-            +- Calc(select=[a, b, c, rowtime])
-               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testMultiHopWindows">
-    <Resource name="sql">
-      <![CDATA[
-SELECT
-   HOP_START(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR),
-   HOP_END(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR),
-   count(*),
-   sum(c)
-FROM MyTable
-GROUP BY HOP(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR)
-UNION ALL
-SELECT
-   HOP_START(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY),
-   HOP_END(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY),
-   count(*),
-   sum(c)
-FROM MyTable
-GROUP BY HOP(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY)
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalUnion(all=[true])
-:- LogicalProject(EXPR$0=[HOP_START($0)], EXPR$1=[HOP_END($0)], EXPR$2=[$1], EXPR$3=[$2])
-:  +- LogicalAggregate(group=[{0}], EXPR$2=[COUNT()], EXPR$3=[SUM($1)])
-:     +- LogicalProject($f0=[HOP($4, 60000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], c=[$2])
-:        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-+- LogicalProject(EXPR$0=[HOP_START($0)], EXPR$1=[HOP_END($0)], EXPR$2=[$1], EXPR$3=[$2])
-   +- LogicalAggregate(group=[{0}], EXPR$2=[COUNT()], EXPR$3=[SUM($1)])
-      +- LogicalProject($f0=[HOP($4, 60000:INTERVAL MINUTE, 86400000:INTERVAL DAY)], c=[$2])
-         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Union(all=[true], union=[EXPR$0, EXPR$1, EXPR$2, EXPR$3])
-:- Calc(select=[w$start AS EXPR$0, w$end AS EXPR$1, EXPR$2, EXPR$3])
-:  +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, rowtime, 3600000, 60000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS EXPR$2, SUM(c) AS EXPR$3, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-:     +- Exchange(distribution=[single], reuse_id=[1])
-:        +- Calc(select=[rowtime, c])
-:           +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-+- Calc(select=[w$start AS EXPR$0, w$end AS EXPR$1, EXPR$2, EXPR$3])
-   +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, rowtime, 86400000, 60000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS EXPR$2, SUM(c) AS EXPR$3, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-      +- Reused(reference_id=[1])
 ]]>
     </Resource>
   </TestCase>
@@ -473,6 +419,40 @@ GroupWindowAggregate(window=[SessionGroupWindow('w$, $f2, 60000)], select=[SUM(a
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTumbleFunAndRegularAggFunInGroupBy">
+    <Resource name="sql">
+      <![CDATA[
+SELECT weightedAvg(c, a) FROM
+    (SELECT a, b, c, count(*) d,
+        TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as ping_start
+     FROM MyTable
+         GROUP BY a, b, c, TUMBLE(rowtime, INTERVAL '15' MINUTE)) AS t1
+GROUP BY b, d, ping_start
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$3])
++- LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[weightedAvg($3, $4)])
+   +- LogicalProject(b=[$1], d=[$4], ping_start=[TUMBLE_START($3)], c=[$2], a=[$0])
+      +- LogicalAggregate(group=[{0, 1, 2, 3}], d=[COUNT()])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- GroupAggregate(groupBy=[b, d, ping_start], select=[b, d, ping_start, weightedAvg(c, a) AS EXPR$0])
+   +- Exchange(distribution=[hash[b, d, ping_start]])
+      +- Calc(select=[b, d, w$start AS ping_start, c, a])
+         +- GroupWindowAggregate(groupBy=[a, b, c], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[a, b, c, COUNT(*) AS d, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+            +- Exchange(distribution=[hash[a, b, c]])
+               +- Calc(select=[a, b, c, rowtime])
+                  +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTumbleFunction">
     <Resource name="sql">
       <![CDATA[
@@ -537,6 +517,86 @@ Calc(select=[EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTumbleFunNotInGroupBy">
+    <Resource name="sql">
+      <![CDATA[
+SELECT weightedAvg(c, a) FROM
+    (SELECT a, b, c,
+        TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as ping_start
+     FROM MyTable
+         GROUP BY a, b, c, TUMBLE(rowtime, INTERVAL '15' MINUTE)) AS t1
+GROUP BY b
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[$1])
++- LogicalAggregate(group=[{0}], EXPR$0=[weightedAvg($1, $2)])
+   +- LogicalProject(b=[$1], c=[$2], a=[$0])
+      +- LogicalAggregate(group=[{0, 1, 2, 3}])
+         +- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[EXPR$0])
++- GroupAggregate(groupBy=[b], select=[b, weightedAvg(c, a) AS EXPR$0])
+   +- Exchange(distribution=[hash[b]])
+      +- GroupWindowAggregate(groupBy=[a, b, c], window=[TumblingGroupWindow('w$, rowtime, 900000)], select=[a, b, c])
+         +- Exchange(distribution=[hash[a, b, c]])
+            +- Calc(select=[a, b, c, rowtime])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiHopWindows">
+    <Resource name="sql">
+      <![CDATA[
+SELECT
+   HOP_START(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR),
+   HOP_END(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR),
+   count(*),
+   sum(c)
+FROM MyTable
+GROUP BY HOP(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' HOUR)
+UNION ALL
+SELECT
+   HOP_START(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY),
+   HOP_END(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY),
+   count(*),
+   sum(c)
+FROM MyTable
+GROUP BY HOP(rowtime, INTERVAL '1' MINUTE, INTERVAL '1' DAY)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalUnion(all=[true])
+:- LogicalProject(EXPR$0=[HOP_START($0)], EXPR$1=[HOP_END($0)], EXPR$2=[$1], EXPR$3=[$2])
+:  +- LogicalAggregate(group=[{0}], EXPR$2=[COUNT()], EXPR$3=[SUM($1)])
+:     +- LogicalProject($f0=[HOP($4, 60000:INTERVAL MINUTE, 3600000:INTERVAL HOUR)], c=[$2])
+:        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
++- LogicalProject(EXPR$0=[HOP_START($0)], EXPR$1=[HOP_END($0)], EXPR$2=[$1], EXPR$3=[$2])
+   +- LogicalAggregate(group=[{0}], EXPR$2=[COUNT()], EXPR$3=[SUM($1)])
+      +- LogicalProject($f0=[HOP($4, 60000:INTERVAL MINUTE, 86400000:INTERVAL DAY)], c=[$2])
+         +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Union(all=[true], union=[EXPR$0, EXPR$1, EXPR$2, EXPR$3])
+:- Calc(select=[w$start AS EXPR$0, w$end AS EXPR$1, EXPR$2, EXPR$3])
+:  +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, rowtime, 3600000, 60000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS EXPR$2, SUM(c) AS EXPR$3, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+:     +- Exchange(distribution=[single], reuse_id=[1])
+:        +- Calc(select=[rowtime, c])
+:           +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
++- Calc(select=[w$start AS EXPR$0, w$end AS EXPR$1, EXPR$2, EXPR$3])
+   +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, rowtime, 86400000, 60000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS EXPR$2, SUM(c) AS EXPR$3, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+      +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testTumblingWindowWithProctime">
     <Resource name="sql">
       <![CDATA[select sum(a), max(b) from MyTable1 group by TUMBLE(c, INTERVAL '1' SECOND)]]>
@@ -554,40 +614,6 @@ LogicalProject(EXPR$0=[$1], EXPR$1=[$2])
 GroupWindowAggregate(window=[TumblingGroupWindow('w$, $f2, 1000)], select=[SUM(a) AS EXPR$0, MAX(b) AS EXPR$1])
 +- Exchange(distribution=[single])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable1, source: [CollectionTableSource(a, b)]]], fields=[a, b])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testTumbleFunAndRegularAggFunInGroupBy">
-    <Resource name="sql">
-      <![CDATA[
-SELECT weightedAvg(c, a) FROM
-    (SELECT a, b, c, count(*) d,
-        TUMBLE_START(rowtime, INTERVAL '15' MINUTE) as ping_start
-     FROM MyTable
-         GROUP BY a, b, c, TUMBLE(rowtime, INTERVAL '15' MINUTE)) AS t1
-GROUP BY b, d, ping_start
-      ]]>
-    </Resource>
-    <Resource name="planBefore">
-      <![CDATA[
-LogicalProject(EXPR$0=[$3])
-+- LogicalAggregate(group=[{0, 1, 2}], EXPR$0=[weightedAvg($3, $4)])
-   +- LogicalProject(b=[$1], d=[$4], ping_start=[TUMBLE_START($3)], c=[$2], a=[$0])
-      +- LogicalAggregate(group=[{0, 1, 2, 3}], d=[COUNT()])
-         +- LogicalProject(a=[$0], b=[$1], c=[$2], $f3=[$TUMBLE($4, 900000:INTERVAL MINUTE)])
-            +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-]]>
-    </Resource>
-    <Resource name="planAfter">
-      <![CDATA[
-Calc(select=[EXPR$0])
-+- GroupAggregate(groupBy=[b, d, ping_start], select=[b, d, ping_start, weightedAvg(c, a) AS EXPR$0])
-   +- Exchange(distribution=[hash[b, d, ping_start]])
-      +- Calc(select=[b, d, w$start AS ping_start, c, a])
-         +- GroupWindowAggregate(groupBy=[a, b, c], window=[TumblingGroupWindow('w$, rowtime, 900000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[a, b, c, COUNT(*) AS d, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
-            +- Exchange(distribution=[hash[a, b, c]])
-               +- Calc(select=[a, b, c, rowtime])
-                  +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>
@@ -635,6 +661,32 @@ Union(all=[true], union=[EXPR$0])
 +- Calc(select=[1 AS EXPR$0])
    +- GroupWindowAggregate(window=[SlidingGroupWindow('w$, rowtime, 7200000, 3600000)], select=[])
       +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testWindowAggregateWithAllowLatenessOnly">
+    <Resource name="sql">
+      <![CDATA[
+SELECT TUMBLE_START(`rowtime`, INTERVAL '1' SECOND), COUNT(*) cnt
+FROM MyTable
+GROUP BY TUMBLE(`rowtime`, INTERVAL '1' SECOND)
+]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EXPR$0=[TUMBLE_START($0)], cnt=[$1])
++- LogicalAggregate(group=[{0}], cnt=[COUNT()])
+   +- LogicalProject($f0=[$TUMBLE($4, 1000:INTERVAL SECOND)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[w$start AS EXPR$0, cnt], changelogMode=[I])
++- GroupWindowAggregate(window=[TumblingGroupWindow('w$, rowtime, 1000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[COUNT(*) AS cnt, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime], changelogMode=[I])
+   +- Exchange(distribution=[single], changelogMode=[I])
+      +- Calc(select=[rowtime], changelogMode=[I])
+         +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime], changelogMode=[I])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/AbstractTwoInputStreamOperatorWithTTLTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/AbstractTwoInputStreamOperatorWithTTLTest.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.dataformat.BaseRow
 import org.apache.flink.table.planner.runtime.harness.HarnessTestBase.TestingBaseRowKeySelector
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.HEAP_BACKEND
 import org.apache.flink.table.runtime.operators.join.temporal.BaseTwoInputStreamOperatorWithStateRetention
-import org.apache.flink.table.runtime.util.StreamRecordUtils.record
+import org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord
 
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.{Description, TypeSafeMatcher}
@@ -63,8 +63,8 @@ class AbstractTwoInputStreamOperatorWithTTLTest
     operatorUnderTest = new StubOperatorWithStateTTL(minRetentionTime, maxRetentionTime)
     testHarness = createTestHarness(operatorUnderTest)
     testHarness.open()
-    recordAForFirstKey = record(1L: JLong, "hello")
-    recordBForFirstKey = record(1L: JLong, "world")
+    recordAForFirstKey = insertRecord(1L: JLong, "hello")
+    recordBForFirstKey = insertRecord(1L: JLong, "world")
   }
 
   @After

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/GroupAggregateHarnessTest.scala
@@ -20,14 +20,14 @@ package org.apache.flink.table.planner.runtime.harness
 
 import org.apache.flink.api.common.time.Time
 import org.apache.flink.api.scala._
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.scala.internal.StreamTableEnvironmentImpl
 import org.apache.flink.table.api.{EnvironmentSettings, Types}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor
-import org.apache.flink.table.runtime.util.StreamRecordUtils.{binaryrow, retractBinaryRow}
+import org.apache.flink.table.runtime.util.StreamRecordUtils.binaryRecord
 import org.apache.flink.types.Row
+import org.apache.flink.types.RowKind._
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.junit.{Before, Test}
@@ -75,57 +75,57 @@ class GroupAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     // register cleanup timer with 3001
     testHarness.setProcessingTime(1)
 
-    // accumulate
-    testHarness.processElement(new StreamRecord(binaryrow("aaa", 1L: JLong), 1))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 1L: JLong), 1))
+    // insertion
+    testHarness.processElement(binaryRecord(INSERT,"aaa", 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "aaa", 1L: JLong))
 
-    // accumulate
-    testHarness.processElement(new StreamRecord(binaryrow("bbb", 1L: JLong), 2))
-    expectedOutput.add(new StreamRecord(binaryrow("bbb", 1L: JLong), 2))
+    // insertion
+    testHarness.processElement(binaryRecord(INSERT, "bbb", 1L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "bbb", 1L: JLong))
 
-    // retract for insertion
-    testHarness.processElement(new StreamRecord(binaryrow("aaa", 2L: JLong), 3))
-    expectedOutput.add(new StreamRecord(retractBinaryRow( "aaa", 1L: JLong), 3))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 3L: JLong), 3))
+    // update for insertion
+    testHarness.processElement(binaryRecord(INSERT, "aaa", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "aaa", 1L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "aaa", 3L: JLong))
 
     // retract for deletion
-    testHarness.processElement(new StreamRecord(retractBinaryRow("aaa", 2L: JLong), 3))
-    expectedOutput.add(new StreamRecord(retractBinaryRow("aaa", 3L: JLong), 3))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 1L: JLong), 3))
+    testHarness.processElement(binaryRecord(DELETE, "aaa", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "aaa", 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "aaa", 1L: JLong))
 
-    // accumulate
-    testHarness.processElement(new StreamRecord(binaryrow("ccc", 3L: JLong), 4))
-    expectedOutput.add(new StreamRecord(binaryrow("ccc", 3L: JLong), 4))
+    // insertion
+    testHarness.processElement(binaryRecord(INSERT, "ccc", 3L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "ccc", 3L: JLong))
 
     // trigger cleanup timer and register cleanup timer with 6002
     testHarness.setProcessingTime(3002)
 
     // retract after clean up
-    testHarness.processElement(new StreamRecord(retractBinaryRow("ccc", 3L: JLong), 4))
+    testHarness.processElement(binaryRecord(UPDATE_BEFORE, "ccc", 3L: JLong))
     // not output
 
     // accumulate
-    testHarness.processElement(new StreamRecord(binaryrow("aaa", 4L: JLong), 5))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 4L: JLong), 5))
-    testHarness.processElement(new StreamRecord(binaryrow("bbb", 2L: JLong), 6))
-    expectedOutput.add(new StreamRecord(binaryrow("bbb", 2L: JLong), 6))
+    testHarness.processElement(binaryRecord(INSERT, "aaa", 4L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "aaa", 4L: JLong))
+    testHarness.processElement(binaryRecord(INSERT, "bbb", 2L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "bbb", 2L: JLong))
 
     // retract
-    testHarness.processElement(new StreamRecord(binaryrow("aaa", 5L: JLong), 7))
-    expectedOutput.add(new StreamRecord(retractBinaryRow("aaa", 4L: JLong), 7))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 9L: JLong), 7))
+    testHarness.processElement(binaryRecord(INSERT, "aaa", 5L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "aaa", 4L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "aaa", 9L: JLong))
 
     // accumulate
-    testHarness.processElement(new StreamRecord(binaryrow("eee", 6L: JLong), 8))
-    expectedOutput.add(new StreamRecord(binaryrow("eee", 6L: JLong), 8))
+    testHarness.processElement(binaryRecord(INSERT, "eee", 6L: JLong))
+    expectedOutput.add(binaryRecord(INSERT, "eee", 6L: JLong))
 
     // retract
-    testHarness.processElement(new StreamRecord(binaryrow("aaa", 7L: JLong), 9))
-    expectedOutput.add(new StreamRecord(retractBinaryRow("aaa", 9L: JLong), 9))
-    expectedOutput.add(new StreamRecord(binaryrow("aaa", 16L: JLong), 9))
-    testHarness.processElement(new StreamRecord(binaryrow("bbb", 3L: JLong), 10))
-    expectedOutput.add(new StreamRecord(retractBinaryRow("bbb", 2L: JLong), 10))
-    expectedOutput.add(new StreamRecord(binaryrow("bbb", 5L: JLong), 10))
+    testHarness.processElement(binaryRecord(INSERT,"aaa", 7L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "aaa", 9L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "aaa", 16L: JLong))
+    testHarness.processElement(binaryRecord(INSERT, "bbb", 3L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_BEFORE, "bbb", 2L: JLong))
+    expectedOutput.add(binaryRecord(UPDATE_AFTER, "bbb", 5L: JLong))
 
     val result = testHarness.getOutput
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.api.{EnvironmentSettings, Types}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.utils.{Top3WithMapView, Top3WithRetractInput}
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor
-import org.apache.flink.table.runtime.util.StreamRecordUtils.{insertRecord, retractRecord}
+import org.apache.flink.table.runtime.util.StreamRecordUtils.{insertRecord, deleteRecord}
 import org.apache.flink.types.Row
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -77,21 +77,21 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
 
     testHarness.processElement(insertRecord(1: JInt, 2: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 1: JInt, 1: JInt))
     expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
     expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
 
     testHarness.processElement(insertRecord(1: JInt, 3: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 2: JInt, 2: JInt))
     expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
     expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
     expectedOutput.add(insertRecord(1: JInt, 3: JInt, 3: JInt))
 
     testHarness.processElement(insertRecord(1: JInt, 2: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 2: JInt, 2: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 3: JInt, 3: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 3: JInt, 3: JInt))
     expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
     expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
     expectedOutput.add(insertRecord(1: JInt, 3: JInt, 3: JInt))
@@ -137,24 +137,24 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     // output with three columns: key, value, value. The value is in the top3 of the key
     expectedOutput.add(insertRecord(1: JInt, 1: JInt))
 
-    testHarness.processElement(retractRecord(1: JInt))
-    expectedOutput.add(retractRecord(1: JInt, 1: JInt))
+    testHarness.processElement(deleteRecord(1: JInt))
+    expectedOutput.add(deleteRecord(1: JInt, 1: JInt))
 
     testHarness.processElement(insertRecord(3: JInt))
     expectedOutput.add(insertRecord(3: JInt, 3: JInt))
 
     testHarness.processElement(insertRecord(4: JInt))
-    expectedOutput.add(retractRecord(3: JInt, 3: JInt))
+    expectedOutput.add(deleteRecord(3: JInt, 3: JInt))
     expectedOutput.add(insertRecord(3: JInt, 3: JInt))
     expectedOutput.add(insertRecord(4: JInt, 4: JInt))
 
-    testHarness.processElement(retractRecord(3: JInt))
-    expectedOutput.add(retractRecord(3: JInt, 3: JInt))
-    expectedOutput.add(retractRecord(4: JInt, 4: JInt))
+    testHarness.processElement(deleteRecord(3: JInt))
+    expectedOutput.add(deleteRecord(3: JInt, 3: JInt))
+    expectedOutput.add(deleteRecord(4: JInt, 4: JInt))
     expectedOutput.add(insertRecord(4: JInt, 4: JInt))
 
     testHarness.processElement(insertRecord(5: JInt))
-    expectedOutput.add(retractRecord(4: JInt, 4: JInt))
+    expectedOutput.add(deleteRecord(4: JInt, 4: JInt))
     expectedOutput.add(insertRecord(4: JInt, 4: JInt))
     expectedOutput.add(insertRecord(5: JInt, 5: JInt))
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/harness/TableAggregateHarnessTest.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.api.{EnvironmentSettings, Types}
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
 import org.apache.flink.table.planner.utils.{Top3WithMapView, Top3WithRetractInput}
 import org.apache.flink.table.runtime.util.BaseRowHarnessAssertor
-import org.apache.flink.table.runtime.util.StreamRecordUtils.{record, retractRecord}
+import org.apache.flink.table.runtime.util.StreamRecordUtils.{insertRecord, retractRecord}
 import org.apache.flink.types.Row
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -72,38 +72,38 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     testHarness.setProcessingTime(1)
 
     // input with two columns: key and value
-    testHarness.processElement(record(1: JInt, 1: JInt))
+    testHarness.processElement(insertRecord(1: JInt, 1: JInt))
     // output with three columns: key, value, value. The value is in the top3 of the key
-    expectedOutput.add(record(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
 
-    testHarness.processElement(record(1: JInt, 2: JInt))
+    testHarness.processElement(insertRecord(1: JInt, 2: JInt))
     expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
-    expectedOutput.add(record(1: JInt, 1: JInt, 1: JInt))
-    expectedOutput.add(record(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
 
-    testHarness.processElement(record(1: JInt, 3: JInt))
+    testHarness.processElement(insertRecord(1: JInt, 3: JInt))
     expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
     expectedOutput.add(retractRecord(1: JInt, 2: JInt, 2: JInt))
-    expectedOutput.add(record(1: JInt, 1: JInt, 1: JInt))
-    expectedOutput.add(record(1: JInt, 2: JInt, 2: JInt))
-    expectedOutput.add(record(1: JInt, 3: JInt, 3: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 1: JInt, 1: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 3: JInt, 3: JInt))
 
-    testHarness.processElement(record(1: JInt, 2: JInt))
+    testHarness.processElement(insertRecord(1: JInt, 2: JInt))
     expectedOutput.add(retractRecord(1: JInt, 1: JInt, 1: JInt))
     expectedOutput.add(retractRecord(1: JInt, 2: JInt, 2: JInt))
     expectedOutput.add(retractRecord(1: JInt, 3: JInt, 3: JInt))
-    expectedOutput.add(record(1: JInt, 2: JInt, 2: JInt))
-    expectedOutput.add(record(1: JInt, 2: JInt, 2: JInt))
-    expectedOutput.add(record(1: JInt, 3: JInt, 3: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 3: JInt, 3: JInt))
 
     // ingest data with key value of 2
-    testHarness.processElement(record(2: JInt, 2: JInt))
-    expectedOutput.add(record(2: JInt, 2: JInt, 2: JInt))
+    testHarness.processElement(insertRecord(2: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(2: JInt, 2: JInt, 2: JInt))
 
     // trigger cleanup timer
     testHarness.setProcessingTime(3002)
-    testHarness.processElement(record(1: JInt, 2: JInt))
-    expectedOutput.add(record(1: JInt, 2: JInt, 2: JInt))
+    testHarness.processElement(insertRecord(1: JInt, 2: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 2: JInt, 2: JInt))
 
     val result = testHarness.getOutput
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)
@@ -133,30 +133,30 @@ class TableAggregateHarnessTest(mode: StateBackendMode) extends HarnessTestBase(
     testHarness.setProcessingTime(1)
 
     // input with two columns: key and value
-    testHarness.processElement(record(1: JInt))
+    testHarness.processElement(insertRecord(1: JInt))
     // output with three columns: key, value, value. The value is in the top3 of the key
-    expectedOutput.add(record(1: JInt, 1: JInt))
+    expectedOutput.add(insertRecord(1: JInt, 1: JInt))
 
     testHarness.processElement(retractRecord(1: JInt))
     expectedOutput.add(retractRecord(1: JInt, 1: JInt))
 
-    testHarness.processElement(record(3: JInt))
-    expectedOutput.add(record(3: JInt, 3: JInt))
+    testHarness.processElement(insertRecord(3: JInt))
+    expectedOutput.add(insertRecord(3: JInt, 3: JInt))
 
-    testHarness.processElement(record(4: JInt))
+    testHarness.processElement(insertRecord(4: JInt))
     expectedOutput.add(retractRecord(3: JInt, 3: JInt))
-    expectedOutput.add(record(3: JInt, 3: JInt))
-    expectedOutput.add(record(4: JInt, 4: JInt))
+    expectedOutput.add(insertRecord(3: JInt, 3: JInt))
+    expectedOutput.add(insertRecord(4: JInt, 4: JInt))
 
     testHarness.processElement(retractRecord(3: JInt))
     expectedOutput.add(retractRecord(3: JInt, 3: JInt))
     expectedOutput.add(retractRecord(4: JInt, 4: JInt))
-    expectedOutput.add(record(4: JInt, 4: JInt))
+    expectedOutput.add(insertRecord(4: JInt, 4: JInt))
 
-    testHarness.processElement(record(5: JInt))
+    testHarness.processElement(insertRecord(5: JInt))
     expectedOutput.add(retractRecord(4: JInt, 4: JInt))
-    expectedOutput.add(record(4: JInt, 4: JInt))
-    expectedOutput.add(record(5: JInt, 5: JInt))
+    expectedOutput.add(insertRecord(4: JInt, 4: JInt))
+    expectedOutput.add(insertRecord(5: JInt, 5: JInt))
 
     val result = testHarness.getOutput
     assertor.assertOutputEqualsSorted("result mismatch", expectedOutput, result)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/CalcITCase.scala
@@ -66,7 +66,7 @@ class CalcITCase extends StreamingTestBase {
     result.addSink(sink)
     env.execute()
 
-    val expected = List("0|1,1,1")
+    val expected = List("+I(1,1,1)")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 
@@ -99,7 +99,7 @@ class CalcITCase extends StreamingTestBase {
     result.addSink(sink)
     env.execute()
 
-    val expected = List("0|Hello,Worlds,1","0|Hello again,Worlds,2")
+    val expected = List("+I(Hello,Worlds,1)","+I(Hello again,Worlds,2)")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/RankITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/RankITCase.scala
@@ -741,7 +741,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "(true,3,book,b,3,2)",
       "(true,4,book,a,1,2)")
 
-    assertEquals(expected, sink.getRawResults)
+    assertEquals(expected.mkString("\n"), sink.getRawResults.mkString("\n"))
   }
 
   @Test
@@ -1026,10 +1026,10 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "(true,book,4,1)",
       "(true,book,1,2)",
       "(true,book,1,3)",
-      "(true,book,2,2)",
       "(false,book,4,1)",
-      "(true,book,4,2)",
+      "(true,book,2,2)",
       "(false,book,3,1)",
+      "(true,book,4,2)",
       "(true,book,1,4)",
       "(true,book,4,3)",
       "(true,book,4,4)",
@@ -1040,7 +1040,7 @@ class RankITCase(mode: StateBackendMode) extends StreamingWithStateTestBase(mode
       "(true,fruit,4,2)",
       "(true,fruit,5,2)",
       "(true,fruit,5,3)")
-    assertEquals(expected, sink.getRawResults)
+    assertEquals(expected.mkString("\n"), sink.getRawResults.mkString("\n"))
 
     val updatedExpected = List(
       "book,4,5",

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/ValuesITCase.scala
@@ -43,7 +43,7 @@ class ValuesITCase extends StreamingTestBase {
     result.addSink(sink).setParallelism(1)
     env.execute()
 
-    val expected = List("0|1,Alice", "0|1,Bob")
+    val expected = List("+I(1,Alice)", "+I(1,Bob)")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
@@ -75,13 +75,14 @@ object TestSinkUtil {
 
   def genericRowToString(row: GenericRow, tz: TimeZone): String = {
     val sb = StringBuilder.newBuilder
-    sb.append(row.getHeader).append("|")
+    sb.append(row.getRowKind.shortString).append("(")
     for (i <- 0 until row.getArity) {
       if (i > 0) {
         sb.append(",")
       }
       sb.append(fieldToString(row.getField(i), tz))
     }
+    sb.append(")")
     sb.toString
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BaseRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BaseRow.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.types.RowKind;
+
 /**
  * An interface for row used internally in Flink Table/SQL.
  *
@@ -36,13 +38,16 @@ public interface BaseRow extends TypeGetterSetters {
 	int getArity();
 
 	/**
-	 * The header represents the type of this Row. Now just used in streaming.
-	 * Now there are two message: ACCUMULATE_MSG and RETRACT_MSG.
+	 * Returns the kind of change that this row describes in a changelog.
+	 *
+	 * @see RowKind
 	 */
-	byte getHeader();
+	RowKind getRowKind();
 
 	/**
-	 * Set the byte header.
+	 * Sets the kind of change that this row describes in a changelog.
+	 *
+	 * @see RowKind
 	 */
-	void setHeader(byte header);
+	void setRowKind(RowKind kind);
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRowWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/BinaryRowWriter.java
@@ -19,6 +19,7 @@ package org.apache.flink.table.dataformat;
 
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.runtime.util.SegmentsUtil;
+import org.apache.flink.types.RowKind;
 
 /**
  * Writer for {@link BinaryRow}.
@@ -68,8 +69,9 @@ public final class BinaryRowWriter extends AbstractBinaryWriter {
 		SegmentsUtil.bitSet(segment, 0, pos + BinaryRow.HEADER_SIZE_IN_BITS);
 	}
 
-	public void writeHeader(byte header) {
-		segment.put(0, header);
+	public void writeRowKind(RowKind kind) {
+		byte kindValue = kind.toByteValue();
+		segment.put(0, kindValue);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ColumnarRow.java
@@ -20,12 +20,13 @@ package org.apache.flink.table.dataformat;
 
 import org.apache.flink.table.dataformat.vector.BytesColumnVector.Bytes;
 import org.apache.flink.table.dataformat.vector.VectorizedColumnBatch;
+import org.apache.flink.types.RowKind;
 
 /**
  * Columnar row to support access to vector column data. It is a row view in {@link VectorizedColumnBatch}.
  */
 public final class ColumnarRow implements BaseRow {
-	private byte header;
+	private RowKind rowKind = RowKind.INSERT;
 	private VectorizedColumnBatch vectorizedColumnBatch;
 	private int rowId;
 
@@ -51,13 +52,13 @@ public final class ColumnarRow implements BaseRow {
 	}
 
 	@Override
-	public byte getHeader() {
-		return header;
+	public RowKind getRowKind() {
+		return rowKind;
 	}
 
 	@Override
-	public void setHeader(byte header) {
-		this.header = header;
+	public void setRowKind(RowKind kind) {
+		this.rowKind = kind;
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/GenericRow.java
@@ -124,7 +124,7 @@ public final class GenericRow extends ObjectArrayRow {
 	public static GenericRow copyReference(GenericRow row) {
 		final GenericRow newRow = new GenericRow(row.fields.length);
 		System.arraycopy(row.fields, 0, newRow.fields, 0, row.fields.length);
-		newRow.setHeader(row.getHeader());
+		newRow.setRowKind(row.getRowKind());
 		return newRow;
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/JoinedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/JoinedRow.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.types.RowKind;
+
 /**
  * Join two row to one row.
  */
@@ -24,7 +26,7 @@ public final class JoinedRow implements BaseRow {
 
 	private BaseRow row1;
 	private BaseRow row2;
-	private byte header;
+	private RowKind rowKind = RowKind.INSERT;
 
 	public JoinedRow() {}
 
@@ -45,13 +47,13 @@ public final class JoinedRow implements BaseRow {
 	}
 
 	@Override
-	public byte getHeader() {
-		return header;
+	public RowKind getRowKind() {
+		return rowKind;
 	}
 
 	@Override
-	public void setHeader(byte header) {
-		this.header = header;
+	public void setRowKind(RowKind kind) {
+		this.rowKind = kind;
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/NestedRow.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.dataformat;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.runtime.util.SegmentsUtil;
+import org.apache.flink.types.RowKind;
 
 import static org.apache.flink.table.dataformat.BinaryFormat.readBinaryFieldFromSegments;
 import static org.apache.flink.table.dataformat.BinaryRow.calculateBitSetWidthInBytes;
@@ -68,13 +69,15 @@ public final class NestedRow extends BinarySection implements BaseRow {
 	}
 
 	@Override
-	public byte getHeader() {
-		return SegmentsUtil.getByte(segments, offset);
+	public RowKind getRowKind() {
+		byte kindValue = SegmentsUtil.getByte(segments, offset);
+		return RowKind.fromByteValue(kindValue);
 	}
 
 	@Override
-	public void setHeader(byte header) {
-		SegmentsUtil.setByte(segments, offset, header);
+	public void setRowKind(RowKind kind) {
+		byte kindValue = kind.toByteValue();
+		SegmentsUtil.setByte(segments, offset, kindValue);
 	}
 
 	private void setNotNullAt(int i) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/ObjectArrayRow.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.table.dataformat;
 
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
@@ -27,7 +27,7 @@ import java.util.Arrays;
  */
 public abstract class ObjectArrayRow implements BaseRow {
 
-	private byte header;
+	private RowKind rowKind = RowKind.INSERT; // INSERT as default
 
 	protected final Object[] fields;
 
@@ -41,13 +41,13 @@ public abstract class ObjectArrayRow implements BaseRow {
 	}
 
 	@Override
-	public byte getHeader() {
-		return header;
+	public RowKind getRowKind() {
+		return rowKind;
 	}
 
 	@Override
-	public void setHeader(byte header) {
-		this.header = header;
+	public void setRowKind(RowKind kind) {
+		this.rowKind = kind;
 	}
 
 	@Override
@@ -113,13 +113,7 @@ public abstract class ObjectArrayRow implements BaseRow {
 	@Override
 	public String toString() {
 		StringBuilder sb = new StringBuilder();
-		sb.append("(");
-		if (BaseRowUtil.isAccumulateMsg(this)) {
-			sb.append("+");
-		} else {
-			sb.append("-");
-		}
-		sb.append("|");
+		sb.append(rowKind.shortString()).append("(");
 		for (int i = 0; i < fields.length; i++) {
 			if (i != 0) {
 				sb.append(",");
@@ -132,14 +126,14 @@ public abstract class ObjectArrayRow implements BaseRow {
 
 	@Override
 	public int hashCode() {
-		return 31 * Byte.hashCode(getHeader()) + Arrays.hashCode(fields);
+		return 31 * rowKind.hashCode() + Arrays.hashCode(fields);
 	}
 
 	@Override
 	public boolean equals(Object o) {
 		if (o != null && o instanceof ObjectArrayRow) {
 			ObjectArrayRow other = (ObjectArrayRow) o;
-			return header == other.header && Arrays.equals(fields, other.fields);
+			return rowKind == other.rowKind && Arrays.equals(fields, other.fields);
 		} else {
 			return false;
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/UpdatableRow.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/dataformat/UpdatableRow.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.dataformat;
 
+import org.apache.flink.types.RowKind;
+
 /**
  * Wrap row to a updatable Generic Row.
  */
@@ -42,13 +44,13 @@ public final class UpdatableRow implements BaseRow {
 	}
 
 	@Override
-	public byte getHeader() {
-		return row.getHeader();
+	public RowKind getRowKind() {
+		return row.getRowKind();
 	}
 
 	@Override
-	public void setHeader(byte header) {
-		row.setHeader(header);
+	public void setRowKind(RowKind kind) {
+		row.setRowKind(kind);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGlobalGroupAggFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/aggregate/MiniBatchGlobalGroupAggFunction.java
@@ -31,14 +31,12 @@ import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.bundle.MapBundleFunction;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
 import javax.annotation.Nullable;
 
 import java.util.Map;
-
-import static org.apache.flink.table.dataformat.util.BaseRowUtil.ACCUMULATE_MSG;
-import static org.apache.flink.table.dataformat.util.BaseRowUtil.RETRACT_MSG;
 
 /**
  * Aggregate Function used for the global groupby (without window) aggregate in miniBatch mode.
@@ -95,7 +93,6 @@ public class MiniBatchGlobalGroupAggFunction extends MapBundleFunction<BaseRow, 
 	// stores the accumulators
 	private transient ValueState<BaseRow> accState = null;
 
-
 	/**
 	 * Creates a {@link MiniBatchGlobalGroupAggFunction}.
 	 *
@@ -104,9 +101,9 @@ public class MiniBatchGlobalGroupAggFunction extends MapBundleFunction<BaseRow, 
 	 * @param genRecordEqualiser The code generated equaliser used to equal BaseRow.
 	 * @param accTypes The accumulator types.
 	 * @param indexOfCountStar The index of COUNT(*) in the aggregates.
-	 *                          -1 when the input doesn't contain COUNT(*), i.e. doesn't contain retraction messages.
-	 *                          We make sure there is a COUNT(*) if input stream contains retraction.
-	 * @param generateUpdateBefore Whether this operator will generate retraction.
+	 *                          -1 when the input doesn't contain COUNT(*), i.e. doesn't contain UPDATE_BEFORE or DELETE messages.
+	 *                          We make sure there is a COUNT(*) if input stream contains UPDATE_BEFORE or DELETE messages.
+	 * @param generateUpdateBefore Whether this operator will generate UPDATE_BEFORE messages.
 	 */
 	public MiniBatchGlobalGroupAggFunction(
 			GeneratedAggsHandleFunction genLocalAggsHandler,
@@ -198,19 +195,19 @@ public class MiniBatchGlobalGroupAggFunction extends MapBundleFunction<BaseRow, 
 					if (!equaliser.equalsWithoutHeader(prevAggValue, newAggValue)) {
 						// new row is not same with prev row
 						if (generateUpdateBefore) {
-							// prepare retraction message for previous row
-							resultRow.replace(currentKey, prevAggValue).setHeader(RETRACT_MSG);
+							// prepare UPDATE_BEFORE message for previous row
+							resultRow.replace(currentKey, prevAggValue).setRowKind(RowKind.UPDATE_BEFORE);
 							out.collect(resultRow);
 						}
-						// prepare accumulation message for new row
-						resultRow.replace(currentKey, newAggValue).setHeader(ACCUMULATE_MSG);
+						// prepare UPDATE_AFTER message for new row
+						resultRow.replace(currentKey, newAggValue).setRowKind(RowKind.UPDATE_AFTER);
 						out.collect(resultRow);
 					}
 					// new row is same with prev row, no need to output
 				} else {
 					// this is the first, output new result
-					// prepare accumulation message for new row
-					resultRow.replace(currentKey, newAggValue).setHeader(ACCUMULATE_MSG);
+					// prepare INSERT message for new row
+					resultRow.replace(currentKey, newAggValue).setRowKind(RowKind.INSERT);
 					out.collect(resultRow);
 				}
 
@@ -218,8 +215,8 @@ public class MiniBatchGlobalGroupAggFunction extends MapBundleFunction<BaseRow, 
 				// we retracted the last record for this key
 				// sent out a delete message
 				if (!firstRow) {
-					// prepare delete message for previous row
-					resultRow.replace(currentKey, prevAggValue).setHeader(RETRACT_MSG);
+					// prepare DELETE message for previous row
+					resultRow.replace(currentKey, prevAggValue).setRowKind(RowKind.DELETE);
 					out.collect(resultRow);
 				}
 				// and clear all state

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateFunctionHelper.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.runtime.operators.deduplicate;
 
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.table.dataformat.BaseRow;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
@@ -35,26 +35,40 @@ class DeduplicateFunctionHelper {
 	 *
 	 * @param currentRow latest row received by deduplicate function
 	 * @param generateUpdateBefore whether need to send UPDATE_BEFORE message for updates
-	 * @param state state of function
+	 * @param state state of function, null if generateUpdateBefore is false
 	 * @param out underlying collector
 	 */
 	static void processLastRow(
 			BaseRow currentRow,
 			boolean generateUpdateBefore,
+			boolean generateInsert,
 			ValueState<BaseRow> state,
 			Collector<BaseRow> out) throws Exception {
-		// Check message should be accumulate
-		Preconditions.checkArgument(BaseRowUtil.isAccumulateMsg(currentRow));
-		if (generateUpdateBefore) {
-			// state stores complete row if generateUpdateBefore is true
+		// check message should be insert only.
+		Preconditions.checkArgument(currentRow.getRowKind() == RowKind.INSERT);
+
+		if (generateUpdateBefore || generateInsert) {
+			// use state to keep the previous row content if we need to generate UPDATE_BEFORE
+			// or use to distinguish the first row, if we need to generate INSERT
 			BaseRow preRow = state.value();
 			state.update(currentRow);
-			if (preRow != null) {
-				preRow.setHeader(BaseRowUtil.RETRACT_MSG);
-				out.collect(preRow);
+			if (preRow == null) {
+				// the first row, send INSERT message
+				currentRow.setRowKind(RowKind.INSERT);
+				out.collect(currentRow);
+			} else {
+				if (generateUpdateBefore) {
+					preRow.setRowKind(RowKind.UPDATE_BEFORE);
+					out.collect(preRow);
+				}
+				currentRow.setRowKind(RowKind.UPDATE_AFTER);
+				out.collect(currentRow);
 			}
+		} else {
+			// always send UPDATE_AFTER if INSERT is not needed
+			currentRow.setRowKind(RowKind.UPDATE_AFTER);
+			out.collect(currentRow);
 		}
-		out.collect(currentRow);
 	}
 
 	/**
@@ -63,17 +77,19 @@ class DeduplicateFunctionHelper {
 	 * @param currentRow latest row received by deduplicate function
 	 * @param state state of function
 	 * @param out underlying collector
-	 * @throws Exception
 	 */
-	static void processFirstRow(BaseRow currentRow, ValueState<Boolean> state, Collector<BaseRow> out)
-			throws Exception {
-		// Check message should be accumulate
-		Preconditions.checkArgument(BaseRowUtil.isAccumulateMsg(currentRow));
-		// ignore record with timestamp bigger than preRow
+	static void processFirstRow(
+			BaseRow currentRow,
+			ValueState<Boolean> state,
+			Collector<BaseRow> out) throws Exception {
+		// check message should be insert only.
+		Preconditions.checkArgument(currentRow.getRowKind() == RowKind.INSERT);
+		// ignore record if it is not first row
 		if (state.value() != null) {
 			return;
 		}
 		state.update(true);
+		// emit the first row which is INSERT message
 		out.collect(currentRow);
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepLastRowFunction.java
@@ -45,6 +45,7 @@ public class MiniBatchDeduplicateKeepLastRowFunction
 
 	private final BaseRowTypeInfo rowTypeInfo;
 	private final boolean generateUpdateBefore;
+	private final boolean generateInsert;
 	private final TypeSerializer<BaseRow> typeSerializer;
 	private final long minRetentionTime;
 	// state stores complete row.
@@ -53,11 +54,13 @@ public class MiniBatchDeduplicateKeepLastRowFunction
 	public MiniBatchDeduplicateKeepLastRowFunction(
 			BaseRowTypeInfo rowTypeInfo,
 			boolean generateUpdateBefore,
+			boolean generateInsert,
 			TypeSerializer<BaseRow> typeSerializer,
 			long minRetentionTime) {
 		this.minRetentionTime = minRetentionTime;
 		this.rowTypeInfo = rowTypeInfo;
 		this.generateUpdateBefore = generateUpdateBefore;
+		this.generateInsert = generateInsert;
 		this.typeSerializer = typeSerializer;
 	}
 
@@ -85,7 +88,7 @@ public class MiniBatchDeduplicateKeepLastRowFunction
 			BaseRow currentKey = entry.getKey();
 			BaseRow currentRow = entry.getValue();
 			ctx.setCurrentKey(currentKey);
-			processLastRow(currentRow, generateUpdateBefore, state, out);
+			processLastRow(currentRow, generateUpdateBefore, generateInsert, state, out);
 		}
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinRunner.java
@@ -239,7 +239,7 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<BaseRow, BaseRow> {
 			if (rightRows == null || rightRows.isEmpty()) {
 				if (isLeftOuterJoin) {
 					BaseRow outRow = new JoinedRow(leftRow, nullRow);
-					outRow.setHeader(leftRow.getHeader());
+					outRow.setRowKind(leftRow.getRowKind());
 					realOutput.complete(Collections.singleton(outRow));
 				} else {
 					realOutput.complete(Collections.emptyList());
@@ -248,7 +248,7 @@ public class AsyncLookupJoinRunner extends RichAsyncFunction<BaseRow, BaseRow> {
 				List<BaseRow> outRows = new ArrayList<>();
 				for (BaseRow rightRow : rightRows) {
 					BaseRow outRow = new JoinedRow(leftRow, rightRow);
-					outRow.setHeader(leftRow.getHeader());
+					outRow.setRowKind(leftRow.getRowKind());
 					outRows.add(outRow);
 				}
 				realOutput.complete(outRows);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinRunner.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinRunner.java
@@ -83,7 +83,7 @@ public class LookupJoinRunner extends ProcessFunction<BaseRow, BaseRow> {
 
 		if (isLeftOuterJoin && !collector.isCollected()) {
 			outRow.replace(in, nullRow);
-			outRow.setHeader(in.getHeader());
+			outRow.setRowKind(in.getRowKind());
 			out.collect(outRow);
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/stream/StreamingSemiAntiJoinOperator.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.runtime.operators.join.stream.state.JoinRecordStat
 import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateView;
 import org.apache.flink.table.runtime.operators.join.stream.state.OuterJoinRecordStateViews;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
+import org.apache.flink.types.RowKind;
 
 /**
  * Streaming unbounded Join operator which supports SEMI/ANTI JOIN.
@@ -105,9 +106,12 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 			}
 		}
 		if (BaseRowUtil.isAccumulateMsg(input)) {
+			// erase RowKind for state updating
+			input.setRowKind(RowKind.INSERT);
 			leftRecordStateView.addRecord(input, associatedRecords.size());
 		} else { // input is retract
-			input.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+			// erase RowKind for state updating
+			input.setRowKind(RowKind.INSERT);
 			leftRecordStateView.retractRecord(input);
 		}
 	}
@@ -118,14 +122,17 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 	 *
 	 * <p>Following is the pseudo code to describe the core logic of this method.
 	 *
+	 * <p>Note: "+I" represents "INSERT", "-D" represents "DELETE", "+U" represents "UPDATE_AFTER",
+	 * "-U" represents "UPDATE_BEFORE".
+	 *
 	 * <pre>
 	 * if input record is accumulate
 	 * | state.add(record)
 	 * | if there is no matched rows on the other side, skip
 	 * | if there are matched rows on the other side
 	 * | | if the matched num in the matched rows == 0
-	 * | |   if anti join, send -[other]s
-	 * | |   if semi join, send +[other]s
+	 * | |   if anti join, send -D[other]s
+	 * | |   if semi join, send +I/+U[other]s (using input RowKind)
 	 * | | if the matched num in the matched rows > 0, skip
 	 * | | otherState.update(other, old+1)
 	 * | endif
@@ -136,8 +143,8 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 	 * | if there are matched rows on the other side
 	 * | | if the matched num in the matched rows == 0, this should never happen!
 	 * | | if the matched num in the matched rows == 1
-	 * | |   if semi join, send -[other]
-	 * | |   if anti join, send +[other]
+	 * | |   if semi join, send -D/-U[other] (using input RowKind)
+	 * | |   if anti join, send +I[other]
 	 * | | if the matched num in the matched rows > 1, skip
 	 * | | otherState.update(other, old-1)
 	 * | endif
@@ -147,8 +154,12 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 	@Override
 	public void processElement2(StreamRecord<BaseRow> element) throws Exception {
 		BaseRow input = element.getValue();
+		boolean isAccumulateMsg = BaseRowUtil.isAccumulateMsg(input);
+		RowKind inputRowKind = input.getRowKind();
+		input.setRowKind(RowKind.INSERT); // erase RowKind for later state updating
+
 		AssociatedRecords associatedRecords = AssociatedRecords.of(input, false, leftRecordStateView, joinCondition);
-		if (BaseRowUtil.isAccumulateMsg(input)) {
+		if (isAccumulateMsg) { // record is accumulate
 			rightRecordStateView.addRecord(input);
 			if (!associatedRecords.isEmpty()) {
 				// there are matched rows on the other side
@@ -156,22 +167,20 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 					BaseRow other = outerRecord.record;
 					if (outerRecord.numOfAssociations == 0) {
 						if (isAntiJoin) {
-							// send -[other]
-							other.setHeader(BaseRowUtil.RETRACT_MSG);
-							collector.collect(other);
-							// set header back to ACCUMULATE_MSG, because we will update the other row to state
-							other.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+							// send -D[other]
+							other.setRowKind(RowKind.DELETE);
 						} else {
-							// send +[other]
-							// the header of other is ACCUMULATE_MSG
-							collector.collect(other);
+							// send +I/+U[other] (using input RowKind)
+							other.setRowKind(inputRowKind);
 						}
+						collector.collect(other);
+						// set header back to INSERT, because we will update the other row to state
+						other.setRowKind(RowKind.INSERT);
 					} // ignore when number > 0
 					leftRecordStateView.updateNumOfAssociations(other, outerRecord.numOfAssociations + 1);
 				}
 			} // ignore when associated number == 0
 		} else { // retract input
-			input.setHeader(BaseRowUtil.ACCUMULATE_MSG);
 			rightRecordStateView.retractRecord(input);
 			if (!associatedRecords.isEmpty()) {
 				// there are matched rows on the other side
@@ -179,15 +188,15 @@ public class StreamingSemiAntiJoinOperator extends AbstractStreamingJoinOperator
 					BaseRow other = outerRecord.record;
 					if (outerRecord.numOfAssociations == 1) {
 						if (!isAntiJoin) {
-							// send -[other]
-							other.setHeader(BaseRowUtil.RETRACT_MSG);
-							collector.collect(other);
-							// set header back to ACCUMULATE_MSG, because we will update the other row to state
-							other.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+							// send -D/-U[other] (using input RowKind)
+							other.setRowKind(inputRowKind);
 						} else {
-							// send +[other]
-							collector.collect(other);
+							// send +I[other]
+							other.setRowKind(RowKind.INSERT);
 						}
+						collector.collect(other);
+						// set RowKind back, because we will update the other row to state
+						other.setRowKind(RowKind.INSERT);
 					} // ignore when number > 0
 					leftRecordStateView.updateNumOfAssociations(other, outerRecord.numOfAssociations - 1);
 				}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalProcessTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalProcessTimeJoinOperator.java
@@ -84,7 +84,7 @@ public class TemporalProcessTimeJoinOperator
 
 		BaseRow leftSideRow = element.getValue();
 		if (joinCondition.apply(leftSideRow, rightSideRow)) {
-			outRow.setHeader(leftSideRow.getHeader());
+			outRow.setRowKind(leftSideRow.getRowKind());
 			outRow.replace(leftSideRow, rightSideRow);
 			collector.collect(outRow);
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperator.java
@@ -36,6 +36,7 @@ import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.generated.GeneratedJoinCondition;
 import org.apache.flink.table.runtime.generated.JoinCondition;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
+import org.apache.flink.types.RowKind;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -153,7 +154,9 @@ public class TemporalRowTimeJoinOperator
 			TIMERS_STATE_NAME, VoidNamespaceSerializer.INSTANCE, this);
 		collector = new TimestampedCollector<>(output);
 		outRow = new JoinedRow();
-		outRow.setHeader(BaseRowUtil.ACCUMULATE_MSG);
+		// all the output records should be INSERT only,
+		// because current temporal join only supports INSERT only left stream
+		outRow.setRowKind(RowKind.INSERT);
 	}
 
 	@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/AbstractTopNFunction.java
@@ -29,12 +29,12 @@ import org.apache.flink.streaming.api.operators.KeyContext;
 import org.apache.flink.table.dataformat.BaseRow;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.JoinedRow;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.functions.KeyedProcessFunctionWithCleanupState;
 import org.apache.flink.table.runtime.generated.GeneratedRecordComparator;
 import org.apache.flink.table.runtime.keyselector.BaseRowKeySelector;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
 import org.slf4j.Logger;
@@ -243,37 +243,49 @@ public abstract class AbstractTopNFunction extends KeyedProcessFunctionWithClean
 				"topn.cache.size", () -> heapSize);
 	}
 
-	protected void collect(Collector<BaseRow> out, BaseRow inputRow) {
-		BaseRowUtil.setAccumulate(inputRow);
-		out.collect(inputRow);
-	}
-
-	/**
-	 * Send DELETE messages.
-	 */
-	protected void delete(Collector<BaseRow> out, BaseRow inputRow) {
-		BaseRowUtil.setRetract(inputRow);
-		out.collect(inputRow);
-	}
-
-	/**
-	 * This is with-row-number version of above delete() method.
-	 */
-	protected void delete(Collector<BaseRow> out, BaseRow inputRow, long rank) {
+	protected void collectInsert(Collector<BaseRow> out, BaseRow inputRow, long rank) {
 		if (isInRankRange(rank)) {
-			out.collect(createOutputRow(inputRow, rank, BaseRowUtil.RETRACT_MSG));
+			out.collect(createOutputRow(inputRow, rank, RowKind.INSERT));
 		}
 	}
 
-	protected void collect(Collector<BaseRow> out, BaseRow inputRow, long rank) {
+	protected void collectInsert(Collector<BaseRow> out, BaseRow inputRow) {
+		inputRow.setRowKind(RowKind.INSERT);
+		out.collect(inputRow);
+	}
+
+	protected void collectDelete(Collector<BaseRow> out, BaseRow inputRow, long rank) {
 		if (isInRankRange(rank)) {
-			out.collect(createOutputRow(inputRow, rank, BaseRowUtil.ACCUMULATE_MSG));
+			out.collect(createOutputRow(inputRow, rank, RowKind.DELETE));
 		}
 	}
 
-	protected void retract(Collector<BaseRow> out, BaseRow inputRow, long rank) {
+	protected void collectDelete(Collector<BaseRow> out, BaseRow inputRow) {
+		inputRow.setRowKind(RowKind.DELETE);
+		out.collect(inputRow);
+	}
+
+	protected void collectUpdateAfter(Collector<BaseRow> out, BaseRow inputRow, long rank) {
+		if (isInRankRange(rank)) {
+			out.collect(createOutputRow(inputRow, rank, RowKind.UPDATE_AFTER));
+		}
+	}
+
+	protected void collectUpdateAfter(Collector<BaseRow> out, BaseRow inputRow) {
+		inputRow.setRowKind(RowKind.UPDATE_AFTER);
+		out.collect(inputRow);
+	}
+
+	protected void collectUpdateBefore(Collector<BaseRow> out, BaseRow inputRow, long rank) {
 		if (generateUpdateBefore && isInRankRange(rank)) {
-			out.collect(createOutputRow(inputRow, rank, BaseRowUtil.RETRACT_MSG));
+			out.collect(createOutputRow(inputRow, rank, RowKind.UPDATE_BEFORE));
+		}
+	}
+
+	protected void collectUpdateBefore(Collector<BaseRow> out, BaseRow inputRow) {
+		if (generateUpdateBefore) {
+			inputRow.setRowKind(RowKind.UPDATE_BEFORE);
+			out.collect(inputRow);
 		}
 	}
 
@@ -290,16 +302,16 @@ public abstract class AbstractTopNFunction extends KeyedProcessFunctionWithClean
 		return rankStart > 1;
 	}
 
-	private BaseRow createOutputRow(BaseRow inputRow, long rank, byte header) {
+	private BaseRow createOutputRow(BaseRow inputRow, long rank, RowKind rowKind) {
 		if (outputRankNumber) {
 			GenericRow rankRow = new GenericRow(1);
 			rankRow.setField(0, rank);
 
 			outputRow.replace(inputRow, rankRow);
-			outputRow.setHeader(header);
+			outputRow.setRowKind(rowKind);
 			return outputRow;
 		} else {
-			inputRow.setHeader(header);
+			inputRow.setRowKind(rowKind);
 			return inputRow;
 		}
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunction.java
@@ -49,7 +49,9 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * The function could handle retract stream. Input stream could only contain acc, delete or retract record.
+ * A TopN function could handle updating stream.
+ *
+ * <p>Input stream can contain any change kind: INSERT, DELETE, UPDATE_BEFORE and UPDATE_AFTER.
  */
 public class RetractableTopNFunction extends AbstractTopNFunction {
 
@@ -198,14 +200,15 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
 			throws Exception {
 		Iterator<Map.Entry<BaseRow, Long>> iterator = sortedMap.entrySet().iterator();
-		long curRank = 0L;
+		long currentRank = 0L;
+		BaseRow currentRow = null;
 		boolean findsSortKey = false;
-		while (iterator.hasNext() && isInRankEnd(curRank)) {
+		while (iterator.hasNext() && isInRankEnd(currentRank)) {
 			Map.Entry<BaseRow, Long> entry = iterator.next();
 			BaseRow key = entry.getKey();
 			if (!findsSortKey && key.equals(sortKey)) {
-				curRank += entry.getValue();
-				collect(out, inputRow, curRank);
+				currentRank += entry.getValue();
+				currentRow = inputRow;
 				findsSortKey = true;
 			} else if (findsSortKey) {
 				List<BaseRow> inputs = dataState.get(key);
@@ -218,17 +221,22 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 					}
 				} else {
 					int i = 0;
-					while (i < inputs.size() && isInRankEnd(curRank)) {
-						curRank += 1;
+					while (i < inputs.size() && isInRankEnd(currentRank)) {
 						BaseRow prevRow = inputs.get(i);
-						retract(out, prevRow, curRank - 1);
-						collect(out, prevRow, curRank);
+						collectUpdateBefore(out, prevRow, currentRank);
+						collectUpdateAfter(out, currentRow, currentRank);
+						currentRow = prevRow;
+						currentRank += 1;
 						i++;
 					}
 				}
 			} else {
-				curRank += entry.getValue();
+				currentRank += entry.getValue();
 			}
+		}
+		if (isInRankEnd(currentRank)) {
+			// there is no enough elements in Top-N, emit INSERT message for the new record.
+			collectInsert(out, currentRow, currentRank);
 		}
 	}
 
@@ -276,10 +284,10 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			}
 		}
 		if (toDelete != null) {
-			delete(out, toDelete);
+			collectDelete(out, toDelete);
 		}
 		if (toCollect != null) {
-			collect(out, inputRow);
+			collectInsert(out, inputRow);
 		}
 	}
 
@@ -287,9 +295,10 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			SortedMap<BaseRow, Long> sortedMap, BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out)
 			throws Exception {
 		Iterator<Map.Entry<BaseRow, Long>> iterator = sortedMap.entrySet().iterator();
-		long curRank = 0L;
+		long currentRank = 0L;
+		BaseRow prevRow = null;
 		boolean findsSortKey = false;
-		while (iterator.hasNext() && isInRankEnd(curRank)) {
+		while (iterator.hasNext() && isInRankEnd(currentRank)) {
 			Map.Entry<BaseRow, Long> entry = iterator.next();
 			BaseRow key = entry.getKey();
 			if (!findsSortKey && key.equals(sortKey)) {
@@ -303,18 +312,19 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 					}
 				} else {
 					Iterator<BaseRow> inputIter = inputs.iterator();
-					while (inputIter.hasNext() && isInRankEnd(curRank)) {
-						curRank += 1;
-						BaseRow prevRow = inputIter.next();
-						if (!findsSortKey && equaliser.equalsWithoutHeader(prevRow, inputRow)) {
-							delete(out, prevRow, curRank);
-							curRank -= 1;
+					while (inputIter.hasNext() && isInRankEnd(currentRank)) {
+						BaseRow currentRow = inputIter.next();
+						if (!findsSortKey && equaliser.equalsWithoutHeader(currentRow, inputRow)) {
+							prevRow = currentRow;
 							findsSortKey = true;
 							inputIter.remove();
 						} else if (findsSortKey) {
-							retract(out, prevRow, curRank + 1);
-							collect(out, prevRow, curRank);
+							collectUpdateBefore(out, prevRow, currentRank);
+							collectUpdateAfter(out, currentRow, currentRank);
+							prevRow = currentRow;
 						}
+						currentRank += 1;
+
 					}
 					if (inputs.isEmpty()) {
 						dataState.remove(key);
@@ -325,16 +335,21 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 			} else if (findsSortKey) {
 				List<BaseRow> inputs = dataState.get(key);
 				int i = 0;
-				while (i < inputs.size() && isInRankEnd(curRank)) {
-					curRank += 1;
-					BaseRow prevRow = inputs.get(i);
-					retract(out, prevRow, curRank + 1);
-					collect(out, prevRow, curRank);
+				while (i < inputs.size() && isInRankEnd(currentRank)) {
+					BaseRow currentRow = inputs.get(i);
+					collectUpdateBefore(out, prevRow, currentRank);
+					collectUpdateAfter(out, currentRow, currentRank);
+					prevRow = currentRow;
+					currentRank += 1;
 					i++;
 				}
 			} else {
-				curRank += entry.getValue();
+				currentRank += entry.getValue();
 			}
+		}
+		if (isInRankEnd(currentRank)) {
+			// there is no enough elements in Top-N, emit DELETE message for the retract record.
+			collectDelete(out, prevRow, currentRank);
 		}
 	}
 
@@ -362,13 +377,13 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 						curRank += 1;
 						BaseRow prevRow = inputIter.next();
 						if (!findsSortKey && equaliser.equalsWithoutHeader(prevRow, inputRow)) {
-							delete(out, prevRow, curRank);
+							collectDelete(out, prevRow, curRank);
 							curRank -= 1;
 							findsSortKey = true;
 							inputIter.remove();
 						} else if (findsSortKey) {
 							if (curRank == rankEnd) {
-								collect(out, prevRow, curRank);
+								collectInsert(out, prevRow, curRank);
 								break;
 							}
 						}
@@ -390,7 +405,7 @@ public class RetractableTopNFunction extends AbstractTopNFunction {
 					int index = Long.valueOf(rankEnd - curRank - 1).intValue();
 					List<BaseRow> inputs = dataState.get(key);
 					BaseRow toAdd = inputs.get(index);
-					collect(out, toAdd);
+					collectInsert(out, toAdd);
 					break;
 				}
 			} else {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunction.java
@@ -49,14 +49,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
- * The function could handle update input stream. It is a fast version of {@link RetractableTopNFunction} which only hold
- * top n data in state, and keep sorted map in heap.
+ * A TopN function could handle updating stream. It is a fast version of {@link RetractableTopNFunction}
+ * which only hold top n data in state, and keep sorted map in heap.
  * However, the function only works in some special scenarios:
  * 1. sort field collation is ascending and its mono is decreasing, or sort field collation is descending and its mono
  * is increasing
  * 2. input data has unique keys and unique key must contain partition key
- * 3. input stream could not contain delete record or retract record
+ * 3. input stream could not contain DELETE record or UPDATE_BEFORE record
  */
 public class UpdatableTopNFunction extends AbstractTopNFunction implements CheckpointedFunction {
 
@@ -249,8 +251,8 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 				int rank = rankAndInnerRank.f0;
 				int innerRank = rankAndInnerRank.f1;
 				rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), innerRank, true));
-				retract(out, oldRow.row, rank); // retract old record
-				collect(out, inputRow, rank);
+				collectUpdateBefore(out, oldRow.row, rank); // retract old record
+				collectUpdateAfter(out, inputRow, rank);
 				return;
 			}
 
@@ -267,7 +269,7 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 			// emit records
 			emitRecordsWithRowNumber(sortKey, inputRow, out, oldSortKey, oldRow, oldRank);
 		} else if (checkSortKeyInBufferRange(sortKey, buffer)) {
-			// it is an unique record but is in the topN, insert sort key into buffer
+			// it is a new record but is in the topN, insert sort key into buffer
 			int size = buffer.put(sortKey, rowKey);
 			rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
 
@@ -310,62 +312,72 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 	private void emitRecordsWithRowNumber(BaseRow sortKey, BaseRow inputRow, Collector<BaseRow> out, BaseRow oldSortKey,
 			RankRow oldRow, int oldRank) throws Exception {
 
-		int oldInnerRank = oldRow == null ? -1 : oldRow.innerRank;
 		Iterator<Map.Entry<BaseRow, Collection<BaseRow>>> iterator = buffer.entrySet().iterator();
-		int curRank = 0;
+		int currentRank = 0;
+		BaseRow currentRow = null;
 		// whether we have found the sort key in the buffer
 		boolean findsSortKey = false;
-		while (iterator.hasNext() && isInRankEnd(curRank)) {
+
+		while (iterator.hasNext() && isInRankEnd(currentRank)) {
 			Map.Entry<BaseRow, Collection<BaseRow>> entry = iterator.next();
 			BaseRow curSortKey = entry.getKey();
 			Collection<BaseRow> rowKeys = entry.getValue();
 			// meet its own sort key
 			if (!findsSortKey && curSortKey.equals(sortKey)) {
-				curRank += rowKeys.size();
-				if (oldRow != null) {
-					retract(out, oldRow.row, oldRank);
-				}
-				collect(out, inputRow, curRank);
+				currentRank += rowKeys.size();
+				currentRow = inputRow;
 				findsSortKey = true;
 			} else if (findsSortKey) {
 				if (oldSortKey == null) {
 					// this is a new row, emit updates for all rows in the topn
 					Iterator<BaseRow> rowKeyIter = rowKeys.iterator();
-					while (rowKeyIter.hasNext() && isInRankEnd(curRank)) {
-						curRank += 1;
+					while (rowKeyIter.hasNext() && isInRankEnd(currentRank)) {
 						BaseRow rowKey = rowKeyIter.next();
 						RankRow prevRow = rowKeyMap.get(rowKey);
-						retract(out, prevRow.row, curRank - 1);
-						collect(out, prevRow.row, curRank);
+						collectUpdateBefore(out, prevRow.row, currentRank);
+						collectUpdateAfter(out, currentRow, currentRank);
+						currentRow = prevRow.row;
+						currentRank += 1;
 					}
 				} else {
-					// current sort key is higher than old sort key,
-					// the rank of current record is changed, need to update the following rank
 					int compare = sortKeyComparator.compare(curSortKey, oldSortKey);
 					if (compare <= 0) {
+						// current sort key is higher than old sort key,
+						// the rank of current record is changed, need to update the following rank
 						Iterator<BaseRow> rowKeyIter = rowKeys.iterator();
-						int curInnerRank = 0;
-						while (rowKeyIter.hasNext() && isInRankEnd(curRank)) {
-							curRank += 1;
-							curInnerRank += 1;
-							if (compare == 0 && curInnerRank >= oldInnerRank) {
-								// match to the previous position
-								return;
-							}
-
+						while (rowKeyIter.hasNext() && currentRank < oldRank) {
 							BaseRow rowKey = rowKeyIter.next();
 							RankRow prevRow = rowKeyMap.get(rowKey);
-							retract(out, prevRow.row, curRank - 1);
-							collect(out, prevRow.row, curRank);
+							collectUpdateBefore(out, prevRow.row, currentRank);
+							collectUpdateAfter(out, currentRow, currentRank);
+							currentRow = prevRow.row;
+							currentRank += 1;
 						}
 					} else {
-						// current sort key is smaller than old sort key, the rank is not changed, so skip
-						return;
+						// current sort key is smaller than old sort key,
+						// the following rank is not changed, so skip
+						break;
 					}
 				}
 			} else {
-				curRank += rowKeys.size();
+				currentRank += rowKeys.size();
 			}
+		}
+		if (isInRankEnd(currentRank)) {
+			if (oldRow == null) {
+				// input is a new record, and there is no enough elements in Top-N
+				// so emit INSERT message for the new record.
+				collectInsert(out, currentRow, currentRank);
+			} else {
+				// input is an update record, current we reach the old rank position of
+				// the old record, so emit UPDATE_BEFORE and UPDATE_AFTER for this rank number
+				checkArgument(currentRank == oldRank);
+				collectUpdateBefore(out, oldRow.row, oldRank);
+				collectUpdateAfter(out, currentRow, currentRank);
+			}
+			// this is either a new record within top-n range or an update record,
+			// so top-n elements don't overflow, there is no need to remove records out of Top-N
+			return;
 		}
 
 		// remove the records associated to the sort key which is out of topN
@@ -406,24 +418,25 @@ public class UpdatableTopNFunction extends AbstractTopNFunction implements Check
 				// row content may change, so we need to update row in map
 				rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), oldRow.innerRank, true));
 			}
-			// row content may change, so a retract is needed
-			retract(out, oldRow.row, oldRow.innerRank);
-			collect(out, inputRow);
+			// row content may change, so a UPDATE_BEFORE is needed
+			collectUpdateBefore(out, oldRow.row);
+			collectUpdateAfter(out, inputRow);
 		} else if (checkSortKeyInBufferRange(sortKey, buffer)) {
-			// it is an unique record but is in the topN, insert sort key into buffer
+			// it is an new record but is in the topN, insert sort key into buffer
 			int size = buffer.put(sortKey, rowKey);
 			rowKeyMap.put(rowKey, new RankRow(inputRowSer.copy(inputRow), size, true));
-			collect(out, inputRow);
 			// remove retired element
 			if (buffer.getCurrentTopNum() > rankEnd) {
 				BaseRow lastRowKey = buffer.removeLast();
 				if (lastRowKey != null) {
 					RankRow lastRow = rowKeyMap.remove(lastRowKey);
 					dataState.remove(lastRowKey);
-					// always send a retraction message
-					delete(out, lastRow.row);
+					// always send a delete message
+					collectDelete(out, lastRow.row);
 				}
 			}
+			// new record in the TopN, send INSERT message
+			collectInsert(out, inputRow);
 		}
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperator.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo;
 import org.apache.flink.table.runtime.util.StreamRecordCollector;
+import org.apache.flink.types.RowKind;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,7 @@ public class StreamSortOperator extends TableStreamOperator<BaseRow> implements
 	public void processElement(StreamRecord<BaseRow> element) throws Exception {
 		BaseRow originalInput = element.getValue();
 		BinaryRow input = baseRowSerializer.toBinaryRow(originalInput).copy();
-		BaseRowUtil.setAccumulate(input);
+		input.setRowKind(RowKind.INSERT); // erase RowKind for state updating
 		long count = inputBuffer.getOrDefault(input, 0L);
 		if (BaseRowUtil.isAccumulateMsg(originalInput)) {
 			inputBuffer.put(input, count + 1);

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/TableAggregateWindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/TableAggregateWindowOperator.java
@@ -63,7 +63,7 @@ public class TableAggregateWindowOperator<K, W extends Window> extends WindowOpe
 		LogicalType[] aggResultTypes,
 		LogicalType[] windowPropertyTypes,
 		int rowtimeIndex,
-		boolean sendRetraction,
+		boolean produceUpdates,
 		long allowedLateness) {
 		super(windowTableAggregator,
 			windowAssigner,
@@ -74,7 +74,7 @@ public class TableAggregateWindowOperator<K, W extends Window> extends WindowOpe
 			aggResultTypes,
 			windowPropertyTypes,
 			rowtimeIndex,
-			sendRetraction,
+			produceUpdates,
 			allowedLateness);
 		this.tableAggWindowAggregator = windowTableAggregator;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperator.java
@@ -124,7 +124,7 @@ public abstract class WindowOperator<K, W extends Window>
 
 	private final LogicalType[] windowPropertyTypes;
 
-	protected final boolean sendRetraction;
+	protected final boolean produceUpdates;
 
 	private final int rowtimeIndex;
 
@@ -178,7 +178,7 @@ public abstract class WindowOperator<K, W extends Window>
 			LogicalType[] aggResultTypes,
 			LogicalType[] windowPropertyTypes,
 			int rowtimeIndex,
-			boolean sendRetraction,
+			boolean produceUpdates,
 			long allowedLateness) {
 		checkArgument(allowedLateness >= 0);
 		this.windowAggregator = checkNotNull(windowAggregator);
@@ -190,7 +190,7 @@ public abstract class WindowOperator<K, W extends Window>
 		this.aggResultTypes = checkNotNull(aggResultTypes);
 		this.windowPropertyTypes = checkNotNull(windowPropertyTypes);
 		this.allowedLateness = allowedLateness;
-		this.sendRetraction = sendRetraction;
+		this.produceUpdates = produceUpdates;
 
 		// rowtime index should >= 0 when in event time mode
 		checkArgument(!windowAssigner.isEventTime() || rowtimeIndex >= 0);
@@ -208,7 +208,7 @@ public abstract class WindowOperator<K, W extends Window>
 			LogicalType[] aggResultTypes,
 			LogicalType[] windowPropertyTypes,
 			int rowtimeIndex,
-			boolean sendRetraction,
+			boolean produceUpdates,
 			long allowedLateness) {
 		checkArgument(allowedLateness >= 0);
 		this.windowAssigner = checkNotNull(windowAssigner);
@@ -219,7 +219,7 @@ public abstract class WindowOperator<K, W extends Window>
 		this.aggResultTypes = checkNotNull(aggResultTypes);
 		this.windowPropertyTypes = checkNotNull(windowPropertyTypes);
 		this.allowedLateness = allowedLateness;
-		this.sendRetraction = sendRetraction;
+		this.produceUpdates = produceUpdates;
 
 		// rowtime index should >= 0 when in event time mode
 		checkArgument(!windowAssigner.isEventTime() || rowtimeIndex >= 0);
@@ -249,7 +249,7 @@ public abstract class WindowOperator<K, W extends Window>
 				new BaseRowSerializer(getExecutionConfig(), accumulatorTypes));
 		this.windowState = (InternalValueState<K, W, BaseRow>) getOrCreateKeyedState(windowSerializer, windowStateDescriptor);
 
-		if (sendRetraction) {
+		if (produceUpdates) {
 			LogicalType[] valueTypes = ArrayUtils.addAll(aggResultTypes, windowPropertyTypes);
 			StateDescriptor<ValueState<BaseRow>, BaseRow> previousStateDescriptor = new ValueStateDescriptor<>(
 					"previous-aggs",

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
@@ -56,7 +56,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *   .tumble(Duration.ofMinutes(1))	// sliding(...), session(...)
  *   .withEventTime()	// withProcessingTime()
  *   .withAllowedLateness(Duration.ZERO)
- *   .withSendRetraction()
+ *   .produceUpdates()
  *   .aggregate(AggregationsFunction, accTypes, windowTypes)
  *   .build();
  * </pre>
@@ -69,7 +69,7 @@ public class WindowOperatorBuilder {
 	protected LogicalType[] aggResultTypes;
 	protected LogicalType[] windowPropertyTypes;
 	protected long allowedLateness = 0L;
-	protected boolean sendRetraction = false;
+	protected boolean produceUpdates = false;
 	protected int rowtimeIndex = -1;
 
 	public static WindowOperatorBuilder builder() {
@@ -159,8 +159,8 @@ public class WindowOperatorBuilder {
 		return this;
 	}
 
-	public WindowOperatorBuilder withSendRetraction() {
-		this.sendRetraction = true;
+	public WindowOperatorBuilder produceUpdates() {
+		this.produceUpdates = true;
 		return this;
 	}
 
@@ -268,7 +268,7 @@ public class WindowOperatorBuilder {
 					windowOperatorBuilder.aggResultTypes,
 					windowOperatorBuilder.windowPropertyTypes,
 					windowOperatorBuilder.rowtimeIndex,
-					windowOperatorBuilder.sendRetraction,
+					windowOperatorBuilder.produceUpdates,
 					windowOperatorBuilder.allowedLateness);
 			} else {
 				//noinspection unchecked
@@ -282,7 +282,7 @@ public class WindowOperatorBuilder {
 					windowOperatorBuilder.aggResultTypes,
 					windowOperatorBuilder.windowPropertyTypes,
 					windowOperatorBuilder.rowtimeIndex,
-					windowOperatorBuilder.sendRetraction,
+					windowOperatorBuilder.produceUpdates,
 					windowOperatorBuilder.allowedLateness);
 			}
 		}
@@ -331,7 +331,7 @@ public class WindowOperatorBuilder {
 					windowOperatorBuilder.aggResultTypes,
 					windowOperatorBuilder.windowPropertyTypes,
 					windowOperatorBuilder.rowtimeIndex,
-					windowOperatorBuilder.sendRetraction,
+					windowOperatorBuilder.produceUpdates,
 					windowOperatorBuilder.allowedLateness);
 			} else {
 				//noinspection unchecked
@@ -346,7 +346,7 @@ public class WindowOperatorBuilder {
 					windowOperatorBuilder.aggResultTypes,
 					windowOperatorBuilder.windowPropertyTypes,
 					windowOperatorBuilder.rowtimeIndex,
-					windowOperatorBuilder.sendRetraction,
+					windowOperatorBuilder.produceUpdates,
 					windowOperatorBuilder.allowedLateness);
 			}
 		}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/operators/window/WindowOperatorBuilder.java
@@ -155,8 +155,6 @@ public class WindowOperatorBuilder {
 		checkArgument(!allowedLateness.isNegative());
 		if (allowedLateness.toMillis() > 0) {
 			this.allowedLateness = allowedLateness.toMillis();
-			// allow late element, which means this window will send retractions
-			this.sendRetraction = true;
 		}
 		return this;
 	}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/typeutils/BaseRowSerializer.java
@@ -146,7 +146,7 @@ public class BaseRowSerializer extends AbstractRowSerializer<BaseRow> {
 		} else {
 			ret = new GenericRow(from.getArity());
 		}
-		ret.setHeader(from.getHeader());
+		ret.setRowKind(from.getRowKind());
 		for (int i = 0; i < from.getArity(); i++) {
 			if (!from.isNullAt(i)) {
 				ret.setField(
@@ -184,7 +184,7 @@ public class BaseRowSerializer extends AbstractRowSerializer<BaseRow> {
 			reuseWriter = new BinaryRowWriter(reuseRow);
 		}
 		reuseWriter.reset();
-		reuseWriter.writeHeader(row.getHeader());
+		reuseWriter.writeRowKind(row.getRowKind());
 		for (int i = 0; i < types.length; i++) {
 			if (row.isNullAt(i)) {
 				reuseWriter.setNullAt(i);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BaseRowTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
 import org.apache.flink.table.runtime.typeutils.BinaryGenericSerializer;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -199,9 +200,9 @@ public class BaseRowTest {
 		assertEquals(18, row.getArity());
 
 		// test header
-		assertEquals(0, row.getHeader());
-		row.setHeader((byte) 1);
-		assertEquals(1, row.getHeader());
+		assertEquals(RowKind.INSERT, row.getRowKind());
+		row.setRowKind(RowKind.DELETE);
+		assertEquals(RowKind.DELETE, row.getRowKind());
 
 		// test get
 		assertTrue(row.getBoolean(0));

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/dataformat/BinaryRowTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.runtime.typeutils.BinaryRowSerializer;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.types.RowKind;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -309,7 +310,7 @@ public class BinaryRowTest {
 			assertFalse(row.anyNull());
 
 			// test header should not compute by anyNull
-			row.setHeader((byte) 1);
+			row.setRowKind(RowKind.UPDATE_BEFORE);
 			assertFalse(row.anyNull());
 
 			writer.setNullAt(2);
@@ -327,7 +328,7 @@ public class BinaryRowTest {
 		for (int i = 0; i < numFields; i++) {
 			BinaryRow row = new BinaryRow(numFields);
 			BinaryRowWriter writer = new BinaryRowWriter(row);
-			row.setHeader((byte) 17);
+			row.setRowKind(RowKind.DELETE);
 			assertFalse(row.anyNull());
 			writer.setNullAt(i);
 			assertTrue(row.anyNull());
@@ -394,15 +395,15 @@ public class BinaryRowTest {
 
 		writer.writeInt(0, 10);
 		writer.setNullAt(1);
-		writer.writeHeader((byte) 29);
+		writer.writeRowKind(RowKind.UPDATE_BEFORE);
 		writer.complete();
 
 		BinaryRow newRow = row.copy();
 		assertEquals(row, newRow);
-		assertEquals((byte) 29, newRow.getHeader());
+		assertEquals(RowKind.UPDATE_BEFORE, newRow.getRowKind());
 
-		newRow.setHeader((byte) 19);
-		assertEquals((byte) 19, newRow.getHeader());
+		newRow.setRowKind(RowKind.DELETE);
+		assertEquals(RowKind.DELETE, newRow.getRowKind());
 	}
 
 	@Test

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepFirstRowFunctionTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Tests for {@link DeduplicateKeepFirstRowFunction}.
@@ -47,15 +47,15 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 		DeduplicateKeepFirstRowFunction func = new DeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 1L, 13));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 1L, 13));
 		testHarness.close();
 
 		// Keep FirstRow in deduplicate will not send retraction
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 11));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
@@ -64,22 +64,22 @@ public class DeduplicateKeepFirstRowFunctionTest extends DeduplicateFunctionTest
 		DeduplicateKeepFirstRowFunction func = new DeduplicateKeepFirstRowFunction(minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 1L, 13));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		testHarness.processElement(record("book", 1L, 17));
-		testHarness.processElement(record("book", 2L, 18));
-		testHarness.processElement(record("book", 1L, 19));
+		testHarness.processElement(insertRecord("book", 1L, 17));
+		testHarness.processElement(insertRecord("book", 2L, 18));
+		testHarness.processElement(insertRecord("book", 1L, 19));
 
 		// Keep FirstRow in deduplicate will not send retraction
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 11));
 		//(1L,12),(2L,11) has retired, so output (1L,17) and (2L,18)
-		expectedOutput.add(record("book", 1L, 17));
-		expectedOutput.add(record("book", 2L, 18));
+		expectedOutput.add(insertRecord("book", 1L, 17));
+		expectedOutput.add(insertRecord("book", 2L, 18));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/DeduplicateKeepLastRowFunctionTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
@@ -36,11 +37,12 @@ import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBefore
  */
 public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestBase {
 
-	private DeduplicateKeepLastRowFunction createFunction(boolean generateUpdateBefore) {
+	private DeduplicateKeepLastRowFunction createFunction(boolean generateUpdateBefore, boolean generateInsert) {
 		return new DeduplicateKeepLastRowFunction(
 			minTime.toMilliseconds(),
 			inputRowType,
-			generateUpdateBefore);
+			generateUpdateBefore,
+			generateInsert);
 	}
 
 	private OneInputStreamOperatorTestHarness<BaseRow, BaseRow> createTestHarness(
@@ -52,7 +54,7 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 
 	@Test
 	public void testWithoutGenerateUpdateBefore() throws Exception {
-		DeduplicateKeepLastRowFunction func = createFunction(false);
+		DeduplicateKeepLastRowFunction func = createFunction(false, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(insertRecord("book", 1L, 12));
@@ -61,15 +63,34 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// we do not output INSERT if generateUpdateBefore is false for deduplication last row
 		expectedOutput.add(insertRecord("book", 1L, 12));
 		expectedOutput.add(insertRecord("book", 2L, 11));
-		expectedOutput.add(insertRecord("book", 1L, 13));
+		expectedOutput.add(updateAfterRecord("book", 1L, 13));
+		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+	}
+
+	@Test
+	public void testWithoutGenerateUpdateBeforeAndInsert() throws Exception {
+		DeduplicateKeepLastRowFunction func = createFunction(false, false);
+		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
+		testHarness.open();
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 1L, 13));
+		testHarness.close();
+
+		List<Object> expectedOutput = new ArrayList<>();
+		// we always produce UPDATE_AFTER if INSERT is not needed.
+		expectedOutput.add(updateAfterRecord("book", 1L, 12));
+		expectedOutput.add(updateAfterRecord("book", 2L, 11));
+		expectedOutput.add(updateAfterRecord("book", 1L, 13));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
 	public void testWithGenerateUpdateBefore() throws Exception {
-		DeduplicateKeepLastRowFunction func = createFunction(true);
+		DeduplicateKeepLastRowFunction func = createFunction(true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(insertRecord("book", 1L, 12));
@@ -77,18 +98,18 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 		testHarness.processElement(insertRecord("book", 1L, 13));
 		testHarness.close();
 
-		// Keep LastRow in deduplicate may send retraction
+		// Keep LastRow in deduplicate may send UPDATE_BEFORE
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 1L, 12));
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12));
-		expectedOutput.add(insertRecord("book", 1L, 13));
+		expectedOutput.add(updateAfterRecord("book", 1L, 13));
 		expectedOutput.add(insertRecord("book", 2L, 11));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
 	public void testWithGenerateUpdateBeforeAndStateTtl() throws Exception {
-		DeduplicateKeepLastRowFunction func = createFunction(true);
+		DeduplicateKeepLastRowFunction func = createFunction(true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
 		testHarness.processElement(insertRecord("book", 1L, 12));
@@ -100,16 +121,16 @@ public class DeduplicateKeepLastRowFunctionTest extends DeduplicateFunctionTestB
 		testHarness.processElement(insertRecord("book", 2L, 18));
 		testHarness.processElement(insertRecord("book", 1L, 19));
 
-		// Keep LastRow in deduplicate may send retraction
+		// Keep LastRow in deduplicate may send UPDATE_BEFORE
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 1L, 12));
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12));
-		expectedOutput.add(insertRecord("book", 1L, 13));
+		expectedOutput.add(updateAfterRecord("book", 1L, 13));
 		expectedOutput.add(insertRecord("book", 2L, 11));
-		// because (2L,11), (1L,13) retired, so there is no retract message send to downstream
+		// because (2L,11), (1L,13) retired, so no UPDATE_BEFORE message send to downstream
 		expectedOutput.add(insertRecord("book", 1L, 17));
 		expectedOutput.add(updateBeforeRecord("book", 1L, 17));
-		expectedOutput.add(insertRecord("book", 1L, 19));
+		expectedOutput.add(updateAfterRecord("book", 1L, 19));
 		expectedOutput.add(insertRecord("book", 2L, 18));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepFirstRowFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/deduplicate/MiniBatchDeduplicateKeepFirstRowFunctionTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Tests for {@link MiniBatchDeduplicateKeepFirstRowFunction}.
@@ -55,18 +55,18 @@ public class MiniBatchDeduplicateKeepFirstRowFunctionTest extends DeduplicateFun
 		MiniBatchDeduplicateKeepFirstRowFunction func = new MiniBatchDeduplicateKeepFirstRowFunction(typeSerializer, minTime.toMilliseconds());
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
 
 		// output is empty because bundle not trigger yet.
 		Assert.assertTrue(testHarness.getOutput().isEmpty());
 
-		testHarness.processElement(record("book", 1L, 13));
+		testHarness.processElement(insertRecord("book", 1L, 13));
 
 		// Keep FirstRow in deduplicate will not send retraction
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 11));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}
@@ -77,24 +77,24 @@ public class MiniBatchDeduplicateKeepFirstRowFunctionTest extends DeduplicateFun
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.setup();
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
 		// output is empty because bundle not trigger yet.
 		Assert.assertTrue(testHarness.getOutput().isEmpty());
-		testHarness.processElement(record("book", 1L, 13));
+		testHarness.processElement(insertRecord("book", 1L, 13));
 
 		testHarness.setStateTtlProcessingTime(30);
-		testHarness.processElement(record("book", 1L, 17));
-		testHarness.processElement(record("book", 2L, 18));
-		testHarness.processElement(record("book", 1L, 19));
+		testHarness.processElement(insertRecord("book", 1L, 17));
+		testHarness.processElement(insertRecord("book", 2L, 18));
+		testHarness.processElement(insertRecord("book", 1L, 19));
 
 		// Keep FirstRow in deduplicate
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 11));
 		//(1L,12),(2L,11) has retired, so output (1L,17) and (2L,18)
-		expectedOutput.add(record("book", 1L, 17));
-		expectedOutput.add(record("book", 2L, 18));
+		expectedOutput.add(insertRecord("book", 1L, 17));
+		expectedOutput.add(insertRecord("book", 2L, 18));
 		assertor.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/AsyncLookupJoinHarnessTest.java
@@ -64,7 +64,7 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Harness tests for {@link LookupJoinRunner} and {@link LookupJoinWithCalcRunner}.
@@ -98,11 +98,11 @@ public class AsyncLookupJoinHarnessTest {
 		testHarness.open();
 
 		synchronized (testHarness.getCheckpointLock()) {
-			testHarness.processElement(record(1, "a"));
-			testHarness.processElement(record(2, "b"));
-			testHarness.processElement(record(3, "c"));
-			testHarness.processElement(record(4, "d"));
-			testHarness.processElement(record(5, "e"));
+			testHarness.processElement(insertRecord(1, "a"));
+			testHarness.processElement(insertRecord(2, "b"));
+			testHarness.processElement(insertRecord(3, "c"));
+			testHarness.processElement(insertRecord(4, "d"));
+			testHarness.processElement(insertRecord(5, "e"));
 		}
 
 		// wait until all async collectors in the buffer have been emitted out.
@@ -112,10 +112,10 @@ public class AsyncLookupJoinHarnessTest {
 		}
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(3, "c", 3, "Jark"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jark"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -129,11 +129,11 @@ public class AsyncLookupJoinHarnessTest {
 		testHarness.open();
 
 		synchronized (testHarness.getCheckpointLock()) {
-			testHarness.processElement(record(1, "a"));
-			testHarness.processElement(record(2, "b"));
-			testHarness.processElement(record(3, "c"));
-			testHarness.processElement(record(4, "d"));
-			testHarness.processElement(record(5, "e"));
+			testHarness.processElement(insertRecord(1, "a"));
+			testHarness.processElement(insertRecord(2, "b"));
+			testHarness.processElement(insertRecord(3, "c"));
+			testHarness.processElement(insertRecord(4, "d"));
+			testHarness.processElement(insertRecord(5, "e"));
 		}
 
 		// wait until all async collectors in the buffer have been emitted out.
@@ -143,9 +143,9 @@ public class AsyncLookupJoinHarnessTest {
 		}
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -159,11 +159,11 @@ public class AsyncLookupJoinHarnessTest {
 		testHarness.open();
 
 		synchronized (testHarness.getCheckpointLock()) {
-			testHarness.processElement(record(1, "a"));
-			testHarness.processElement(record(2, "b"));
-			testHarness.processElement(record(3, "c"));
-			testHarness.processElement(record(4, "d"));
-			testHarness.processElement(record(5, "e"));
+			testHarness.processElement(insertRecord(1, "a"));
+			testHarness.processElement(insertRecord(2, "b"));
+			testHarness.processElement(insertRecord(3, "c"));
+			testHarness.processElement(insertRecord(4, "d"));
+			testHarness.processElement(insertRecord(5, "e"));
 		}
 
 		// wait until all async collectors in the buffer have been emitted out.
@@ -173,12 +173,12 @@ public class AsyncLookupJoinHarnessTest {
 		}
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(2, "b", null, null));
-		expectedOutput.add(record(3, "c", 3, "Jark"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
-		expectedOutput.add(record(5, "e", null, null));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(2, "b", null, null));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jark"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(5, "e", null, null));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -192,11 +192,11 @@ public class AsyncLookupJoinHarnessTest {
 		testHarness.open();
 
 		synchronized (testHarness.getCheckpointLock()) {
-			testHarness.processElement(record(1, "a"));
-			testHarness.processElement(record(2, "b"));
-			testHarness.processElement(record(3, "c"));
-			testHarness.processElement(record(4, "d"));
-			testHarness.processElement(record(5, "e"));
+			testHarness.processElement(insertRecord(1, "a"));
+			testHarness.processElement(insertRecord(2, "b"));
+			testHarness.processElement(insertRecord(3, "c"));
+			testHarness.processElement(insertRecord(4, "d"));
+			testHarness.processElement(insertRecord(5, "e"));
 		}
 
 		// wait until all async collectors in the buffer have been emitted out.
@@ -206,11 +206,11 @@ public class AsyncLookupJoinHarnessTest {
 		}
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(2, "b", null, null));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
-		expectedOutput.add(record(5, "e", null, null));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(2, "b", null, null));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(5, "e", null, null));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/LookupJoinHarnessTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/LookupJoinHarnessTest.java
@@ -51,7 +51,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Harness tests for {@link LookupJoinRunner} and {@link LookupJoinWithCalcRunner}.
@@ -78,17 +78,17 @@ public class LookupJoinHarnessTest {
 
 		testHarness.open();
 
-		testHarness.processElement(record(1, "a"));
-		testHarness.processElement(record(2, "b"));
-		testHarness.processElement(record(3, "c"));
-		testHarness.processElement(record(4, "d"));
-		testHarness.processElement(record(5, "e"));
+		testHarness.processElement(insertRecord(1, "a"));
+		testHarness.processElement(insertRecord(2, "b"));
+		testHarness.processElement(insertRecord(3, "c"));
+		testHarness.processElement(insertRecord(4, "d"));
+		testHarness.processElement(insertRecord(5, "e"));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(3, "c", 3, "Jark"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jark"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
@@ -102,16 +102,16 @@ public class LookupJoinHarnessTest {
 
 		testHarness.open();
 
-		testHarness.processElement(record(1, "a"));
-		testHarness.processElement(record(2, "b"));
-		testHarness.processElement(record(3, "c"));
-		testHarness.processElement(record(4, "d"));
-		testHarness.processElement(record(5, "e"));
+		testHarness.processElement(insertRecord(1, "a"));
+		testHarness.processElement(insertRecord(2, "b"));
+		testHarness.processElement(insertRecord(3, "c"));
+		testHarness.processElement(insertRecord(4, "d"));
+		testHarness.processElement(insertRecord(5, "e"));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
@@ -125,19 +125,19 @@ public class LookupJoinHarnessTest {
 
 		testHarness.open();
 
-		testHarness.processElement(record(1, "a"));
-		testHarness.processElement(record(2, "b"));
-		testHarness.processElement(record(3, "c"));
-		testHarness.processElement(record(4, "d"));
-		testHarness.processElement(record(5, "e"));
+		testHarness.processElement(insertRecord(1, "a"));
+		testHarness.processElement(insertRecord(2, "b"));
+		testHarness.processElement(insertRecord(3, "c"));
+		testHarness.processElement(insertRecord(4, "d"));
+		testHarness.processElement(insertRecord(5, "e"));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(2, "b", null, null));
-		expectedOutput.add(record(3, "c", 3, "Jark"));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
-		expectedOutput.add(record(5, "e", null, null));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(2, "b", null, null));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jark"));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(5, "e", null, null));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
@@ -151,18 +151,18 @@ public class LookupJoinHarnessTest {
 
 		testHarness.open();
 
-		testHarness.processElement(record(1, "a"));
-		testHarness.processElement(record(2, "b"));
-		testHarness.processElement(record(3, "c"));
-		testHarness.processElement(record(4, "d"));
-		testHarness.processElement(record(5, "e"));
+		testHarness.processElement(insertRecord(1, "a"));
+		testHarness.processElement(insertRecord(2, "b"));
+		testHarness.processElement(insertRecord(3, "c"));
+		testHarness.processElement(insertRecord(4, "d"));
+		testHarness.processElement(insertRecord(5, "e"));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, "a", 1, "Julian"));
-		expectedOutput.add(record(2, "b", null, null));
-		expectedOutput.add(record(3, "c", 3, "Jackson"));
-		expectedOutput.add(record(4, "d", 4, "Fabian"));
-		expectedOutput.add(record(5, "e", null, null));
+		expectedOutput.add(insertRecord(1, "a", 1, "Julian"));
+		expectedOutput.add(insertRecord(2, "b", null, null));
+		expectedOutput.add(insertRecord(3, "c", 3, "Jackson"));
+		expectedOutput.add(insertRecord(4, "d", 4, "Fabian"));
+		expectedOutput.add(insertRecord(5, "e", null, null));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RowTimeBoundedStreamJoinTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/join/RowTimeBoundedStreamJoinTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -59,31 +59,31 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		testHarness.processWatermark2(new Watermark(1));
 
 		// Test late data.
-		testHarness.processElement1(record(1L, "k1"));
+		testHarness.processElement1(insertRecord(1L, "k1"));
 		// Though (1L, "k1") is actually late, it will also be cached.
 		assertEquals(1, testHarness.numEventTimeTimers());
 
-		testHarness.processElement1(record(2L, "k1"));
-		testHarness.processElement2(record(2L, "k1"));
+		testHarness.processElement1(insertRecord(2L, "k1"));
+		testHarness.processElement2(insertRecord(2L, "k1"));
 
 		assertEquals(2, testHarness.numEventTimeTimers());
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
-		testHarness.processElement1(record(5L, "k1"));
-		testHarness.processElement2(record(15L, "k1"));
+		testHarness.processElement1(insertRecord(5L, "k1"));
+		testHarness.processElement2(insertRecord(15L, "k1"));
 		testHarness.processWatermark1(new Watermark(20));
 		testHarness.processWatermark2(new Watermark(20));
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
-		testHarness.processElement1(record(35L, "k1"));
+		testHarness.processElement1(insertRecord(35L, "k1"));
 
 		// The right rows with timestamp = 2 and 5 will be removed here.
 		// The left rows with timestamp = 2 and 15 will be removed here.
 		testHarness.processWatermark1(new Watermark(38));
 		testHarness.processWatermark2(new Watermark(38));
 
-		testHarness.processElement1(record(40L, "k2"));
-		testHarness.processElement2(record(39L, "k2"));
+		testHarness.processElement1(insertRecord(40L, "k2"));
+		testHarness.processElement2(insertRecord(39L, "k2"));
 		assertEquals(6, testHarness.numKeyedStateEntries());
 
 		// The right row with timestamp = 35 will be removed here.
@@ -94,14 +94,14 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(new Watermark(-19));
 		// This result is produced by the late row (1, "k1").
-		expectedOutput.add(record(1L, "k1", 2L, "k1"));
-		expectedOutput.add(record(2L, "k1", 2L, "k1"));
-		expectedOutput.add(record(5L, "k1", 2L, "k1"));
-		expectedOutput.add(record(5L, "k1", 15L, "k1"));
+		expectedOutput.add(insertRecord(1L, "k1", 2L, "k1"));
+		expectedOutput.add(insertRecord(2L, "k1", 2L, "k1"));
+		expectedOutput.add(insertRecord(5L, "k1", 2L, "k1"));
+		expectedOutput.add(insertRecord(5L, "k1", 15L, "k1"));
 		expectedOutput.add(new Watermark(0));
-		expectedOutput.add(record(35L, "k1", 15L, "k1"));
+		expectedOutput.add(insertRecord(35L, "k1", 15L, "k1"));
 		expectedOutput.add(new Watermark(18));
-		expectedOutput.add(record(40L, "k2", 39L, "k2"));
+		expectedOutput.add(insertRecord(40L, "k2", 39L, "k2"));
 		expectedOutput.add(new Watermark(41));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -123,21 +123,21 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		testHarness.processWatermark2(new Watermark(1));
 
 		// This row will not be cached.
-		testHarness.processElement2(record(2L, "k1"));
+		testHarness.processElement2(insertRecord(2L, "k1"));
 		assertEquals(0, testHarness.numKeyedStateEntries());
 
 		testHarness.processWatermark1(new Watermark(2));
 		testHarness.processWatermark2(new Watermark(2));
-		testHarness.processElement1(record(3L, "k1"));
-		testHarness.processElement2(record(3L, "k1"));
+		testHarness.processElement1(insertRecord(3L, "k1"));
+		testHarness.processElement2(insertRecord(3L, "k1"));
 
 		// Test for -10 boundary (13 - 10 = 3).
 		// This row from the right stream will be cached.
 		// The clean time for the left stream is 13 - 7 + 1 - 1 = 8
-		testHarness.processElement2(record(13L, "k1"));
+		testHarness.processElement2(insertRecord(13L, "k1"));
 
 		// Test for -7 boundary (13 - 7 = 6).
-		testHarness.processElement1(record(6L, "k1"));
+		testHarness.processElement1(insertRecord(6L, "k1"));
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
 		// Trigger the left timer with timestamp  8.
@@ -154,8 +154,8 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(new Watermark(-9));
 		expectedOutput.add(new Watermark(-8));
-		expectedOutput.add(record(3L, "k1", 13L, "k1"));
-		expectedOutput.add(record(6L, "k1", 13L, "k1"));
+		expectedOutput.add(insertRecord(3L, "k1", 13L, "k1"));
+		expectedOutput.add(insertRecord(6L, "k1", 13L, "k1"));
 		expectedOutput.add(new Watermark(0));
 		expectedOutput.add(new Watermark(8));
 
@@ -173,8 +173,8 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 
 		testHarness.open();
 
-		testHarness.processElement1(record(1L, "k1"));
-		testHarness.processElement2(record(1L, "k2"));
+		testHarness.processElement1(insertRecord(1L, "k1"));
+		testHarness.processElement2(insertRecord(1L, "k2"));
 		assertEquals(2, testHarness.numEventTimeTimers());
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
@@ -190,41 +190,41 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		assertEquals(0, testHarness.numEventTimeTimers());
 		assertEquals(0, testHarness.numKeyedStateEntries());
 
-		testHarness.processElement1(record(2L, "k1"));
-		testHarness.processElement2(record(2L, "k2"));
+		testHarness.processElement1(insertRecord(2L, "k1"));
+		testHarness.processElement2(insertRecord(2L, "k2"));
 		// The late rows with timestamp = 2 will not be cached, but a null padding result for the left
 		// row will be emitted.
 		assertEquals(0, testHarness.numKeyedStateEntries());
 		assertEquals(0, testHarness.numEventTimeTimers());
 
 		// Make sure the common (inner) join can be performed.
-		testHarness.processElement1(record(19L, "k1"));
-		testHarness.processElement1(record(20L, "k1"));
-		testHarness.processElement2(record(26L, "k1"));
-		testHarness.processElement2(record(25L, "k1"));
-		testHarness.processElement1(record(21L, "k1"));
-		testHarness.processElement2(record(39L, "k2"));
-		testHarness.processElement2(record(40L, "k2"));
-		testHarness.processElement1(record(50L, "k2"));
-		testHarness.processElement1(record(49L, "k2"));
-		testHarness.processElement2(record(41L, "k2"));
+		testHarness.processElement1(insertRecord(19L, "k1"));
+		testHarness.processElement1(insertRecord(20L, "k1"));
+		testHarness.processElement2(insertRecord(26L, "k1"));
+		testHarness.processElement2(insertRecord(25L, "k1"));
+		testHarness.processElement1(insertRecord(21L, "k1"));
+		testHarness.processElement2(insertRecord(39L, "k2"));
+		testHarness.processElement2(insertRecord(40L, "k2"));
+		testHarness.processElement1(insertRecord(50L, "k2"));
+		testHarness.processElement1(insertRecord(49L, "k2"));
+		testHarness.processElement2(insertRecord(41L, "k2"));
 		testHarness.processWatermark1(new Watermark(100));
 		testHarness.processWatermark2(new Watermark(100));
 
 		List<Object> expectedOutput = new ArrayList<>();
 		// The timestamp 14 is set with the triggered timer.
-		expectedOutput.add(record(1L, "k1", null, null));
+		expectedOutput.add(insertRecord(1L, "k1", null, null));
 		expectedOutput.add(new Watermark(5));
 		expectedOutput.add(new Watermark(9));
-		expectedOutput.add(record(2L, "k1", null, null));
-		expectedOutput.add(record(20L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 26L, "k1"));
-		expectedOutput.add(record(49L, "k2", 40L, "k2"));
-		expectedOutput.add(record(49L, "k2", 41L, "k2"));
-		expectedOutput.add(record(50L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(2L, "k1", null, null));
+		expectedOutput.add(insertRecord(20L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 26L, "k1"));
+		expectedOutput.add(insertRecord(49L, "k2", 40L, "k2"));
+		expectedOutput.add(insertRecord(49L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(50L, "k2", 41L, "k2"));
 		// The timestamp 32 is set with the triggered timer.
-		expectedOutput.add(record(19L, "k1", null, null));
+		expectedOutput.add(insertRecord(19L, "k1", null, null));
 		expectedOutput.add(new Watermark(91));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -241,8 +241,8 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 
 		testHarness.open();
 
-		testHarness.processElement1(record(1L, "k1"));
-		testHarness.processElement2(record(1L, "k2"));
+		testHarness.processElement1(insertRecord(1L, "k1"));
+		testHarness.processElement2(insertRecord(1L, "k2"));
 		assertEquals(2, testHarness.numEventTimeTimers());
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
@@ -258,41 +258,41 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		assertEquals(0, testHarness.numEventTimeTimers());
 		assertEquals(0, testHarness.numKeyedStateEntries());
 
-		testHarness.processElement1(record(2L, "k1"));
-		testHarness.processElement2(record(2L, "k2"));
+		testHarness.processElement1(insertRecord(2L, "k1"));
+		testHarness.processElement2(insertRecord(2L, "k2"));
 		// The late rows with timestamp = 2 will not be cached, but a null padding result for the right
 		// row will be emitted.
 		assertEquals(0, testHarness.numKeyedStateEntries());
 		assertEquals(0, testHarness.numEventTimeTimers());
 
 		// Make sure the common (inner) join can be performed.
-		testHarness.processElement1(record(19L, "k1"));
-		testHarness.processElement1(record(20L, "k1"));
-		testHarness.processElement2(record(26L, "k1"));
-		testHarness.processElement2(record(25L, "k1"));
-		testHarness.processElement1(record(21L, "k1"));
-		testHarness.processElement2(record(39L, "k2"));
-		testHarness.processElement2(record(40L, "k2"));
-		testHarness.processElement1(record(50L, "k2"));
-		testHarness.processElement1(record(49L, "k2"));
-		testHarness.processElement2(record(41L, "k2"));
+		testHarness.processElement1(insertRecord(19L, "k1"));
+		testHarness.processElement1(insertRecord(20L, "k1"));
+		testHarness.processElement2(insertRecord(26L, "k1"));
+		testHarness.processElement2(insertRecord(25L, "k1"));
+		testHarness.processElement1(insertRecord(21L, "k1"));
+		testHarness.processElement2(insertRecord(39L, "k2"));
+		testHarness.processElement2(insertRecord(40L, "k2"));
+		testHarness.processElement1(insertRecord(50L, "k2"));
+		testHarness.processElement1(insertRecord(49L, "k2"));
+		testHarness.processElement2(insertRecord(41L, "k2"));
 		testHarness.processWatermark1(new Watermark(100));
 		testHarness.processWatermark2(new Watermark(100));
 
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(new Watermark(5));
 		// The timestamp 18 is set with the triggered timer.
-		expectedOutput.add(record(null, null, 1L, "k2"));
+		expectedOutput.add(insertRecord(null, null, 1L, "k2"));
 		expectedOutput.add(new Watermark(9));
-		expectedOutput.add(record(null, null, 2L, "k2"));
-		expectedOutput.add(record(20L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 26L, "k1"));
-		expectedOutput.add(record(49L, "k2", 40L, "k2"));
-		expectedOutput.add(record(49L, "k2", 41L, "k2"));
-		expectedOutput.add(record(50L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(null, null, 2L, "k2"));
+		expectedOutput.add(insertRecord(20L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 26L, "k1"));
+		expectedOutput.add(insertRecord(49L, "k2", 40L, "k2"));
+		expectedOutput.add(insertRecord(49L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(50L, "k2", 41L, "k2"));
 		// The timestamp 56 is set with the triggered timer.
-		expectedOutput.add(record(null, null, 39L, "k2"));
+		expectedOutput.add(insertRecord(null, null, 39L, "k2"));
 		expectedOutput.add(new Watermark(91));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -310,8 +310,8 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 
 		testHarness.open();
 
-		testHarness.processElement1(record(1L, "k1"));
-		testHarness.processElement2(record(1L, "k2"));
+		testHarness.processElement1(insertRecord(1L, "k1"));
+		testHarness.processElement2(insertRecord(1L, "k2"));
 		assertEquals(2, testHarness.numEventTimeTimers());
 		assertEquals(4, testHarness.numKeyedStateEntries());
 
@@ -327,47 +327,47 @@ public class RowTimeBoundedStreamJoinTest extends TimeBoundedStreamJoinTestBase 
 		assertEquals(0, testHarness.numEventTimeTimers());
 		assertEquals(0, testHarness.numKeyedStateEntries());
 
-		testHarness.processElement1(record(2L, "k1"));
-		testHarness.processElement2(record(2L, "k2"));
+		testHarness.processElement1(insertRecord(2L, "k1"));
+		testHarness.processElement2(insertRecord(2L, "k2"));
 		// The late rows with timestamp = 2 will not be cached, but a null padding result for the right
 		// row will be emitted.
 		assertEquals(0, testHarness.numKeyedStateEntries());
 		assertEquals(0, testHarness.numEventTimeTimers());
 
 		// Make sure the common (inner) join can be performed.
-		testHarness.processElement1(record(19L, "k1"));
-		testHarness.processElement1(record(20L, "k1"));
-		testHarness.processElement2(record(26L, "k1"));
-		testHarness.processElement2(record(25L, "k1"));
-		testHarness.processElement1(record(21L, "k1"));
+		testHarness.processElement1(insertRecord(19L, "k1"));
+		testHarness.processElement1(insertRecord(20L, "k1"));
+		testHarness.processElement2(insertRecord(26L, "k1"));
+		testHarness.processElement2(insertRecord(25L, "k1"));
+		testHarness.processElement1(insertRecord(21L, "k1"));
 
-		testHarness.processElement2(record(39L, "k2"));
-		testHarness.processElement2(record(40L, "k2"));
-		testHarness.processElement1(record(50L, "k2"));
-		testHarness.processElement1(record(49L, "k2"));
-		testHarness.processElement2(record(41L, "k2"));
+		testHarness.processElement2(insertRecord(39L, "k2"));
+		testHarness.processElement2(insertRecord(40L, "k2"));
+		testHarness.processElement1(insertRecord(50L, "k2"));
+		testHarness.processElement1(insertRecord(49L, "k2"));
+		testHarness.processElement2(insertRecord(41L, "k2"));
 		testHarness.processWatermark1(new Watermark(100));
 		testHarness.processWatermark2(new Watermark(100));
 
 		List<Object> expectedOutput = new ArrayList<>();
 		// The timestamp 14 is set with the triggered timer.
-		expectedOutput.add(record(1L, "k1", null, null));
+		expectedOutput.add(insertRecord(1L, "k1", null, null));
 		expectedOutput.add(new Watermark(5));
 		// The timestamp 18 is set with the triggered timer.
-		expectedOutput.add(record(null, null, 1L, "k2"));
+		expectedOutput.add(insertRecord(null, null, 1L, "k2"));
 		expectedOutput.add(new Watermark(9));
-		expectedOutput.add(record(2L, "k1", null, null));
-		expectedOutput.add(record(null, null, 2L, "k2"));
-		expectedOutput.add(record(20L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 25L, "k1"));
-		expectedOutput.add(record(21L, "k1", 26L, "k1"));
-		expectedOutput.add(record(49L, "k2", 40L, "k2"));
-		expectedOutput.add(record(49L, "k2", 41L, "k2"));
-		expectedOutput.add(record(50L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(2L, "k1", null, null));
+		expectedOutput.add(insertRecord(null, null, 2L, "k2"));
+		expectedOutput.add(insertRecord(20L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 25L, "k1"));
+		expectedOutput.add(insertRecord(21L, "k1", 26L, "k1"));
+		expectedOutput.add(insertRecord(49L, "k2", 40L, "k2"));
+		expectedOutput.add(insertRecord(49L, "k2", 41L, "k2"));
+		expectedOutput.add(insertRecord(50L, "k2", 41L, "k2"));
 		// The timestamp 32 is set with the triggered timer.
-		expectedOutput.add(record(19L, "k1", null, null));
+		expectedOutput.add(insertRecord(19L, "k1", null, null));
 		// The timestamp 56 is set with the triggered timer.
-		expectedOutput.add(record(null, null, 39L, "k2"));
+		expectedOutput.add(insertRecord(null, null, 39L, "k2"));
 		expectedOutput.add(new Watermark(91));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
  * Tests for {@link AppendOnlyTopNFunction}.
@@ -58,13 +58,13 @@ public class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 2L, 12));
 		expectedOutput.add(insertRecord("book", 2L, 19));
-		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(deleteRecord("book", 2L, 19));
 		expectedOutput.add(insertRecord("book", 2L, 11));
 		expectedOutput.add(insertRecord("fruit", 1L, 33));
-		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33));
+		expectedOutput.add(deleteRecord("fruit", 1L, 33));
 		expectedOutput.add(insertRecord("fruit", 1L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/AppendOnlyTopNFunctionTest.java
@@ -26,8 +26,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.retractRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
  * Tests for {@link AppendOnlyTopNFunction}.
@@ -47,22 +47,22 @@ public class AppendOnlyTopNFunctionTest extends TopNFunctionTestBase {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 12));
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 2L, 11));
-		expectedOutput.add(record("fruit", 1L, 33));
-		expectedOutput.add(retractRecord("fruit", 1L, 33));
-		expectedOutput.add(record("fruit", 1L, 22));
+		expectedOutput.add(insertRecord("book", 2L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 2L, 11));
+		expectedOutput.add(insertRecord("fruit", 1L, 33));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33));
+		expectedOutput.add(insertRecord("fruit", 1L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
@@ -69,18 +70,25 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 1L, 12)
+		// ("book", 2L, 19)
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
-		expectedOutput.add(deleteRecord("book", 1L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		// ("book", 4L, 11)
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
+		// UB ("book", 1L, 12)
+		expectedOutput.add(updateAfterRecord("book", 2L, 19, 2L));
+		// ("book", 5L, 11)
+		expectedOutput.add(updateAfterRecord("book", 5L, 11, 2L));
+		// ("fruit", 4L, 33)
+		// ("fruit", 3L, 44)
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		// ("fruit", 5L, 22)
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
+		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -103,23 +111,30 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 1L, 12)
+		// ("book", 2L, 19)
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		// ("book", 4L, 11)
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
-		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
+		// UB ("book", 1L, 12)
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateAfterRecord("book", 5L, 11, 2L));
+		// ("fruit", 4L, 33)
+		// ("fruit", 3L, 44)
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		// ("fruit", 5L, 22)
 		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
 		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
+		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -136,20 +151,26 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.processElement(insertRecord("fruit", 5L, 22));
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 1L, 12)
+		// ("book", 2L, 19)
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		// ("book", 4L, 11)
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
+		// ("fruit", 4L, 33)
+		// ("fruit", 3L, 44)
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		// ("fruit", 5L, 22)
 		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
 		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
@@ -163,12 +184,12 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.open();
 		testHarness.processElement(insertRecord("book", 1L, 10));
 
-		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
 		expectedOutput.add(updateBeforeRecord("book", 4L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 2L));
-		expectedOutput.add(insertRecord("book", 1L, 10, 1L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 10, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 2L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
 	}
 
@@ -230,17 +251,26 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 2L, 12)
+		// ("book", 2L, 19)
 		expectedOutput.add(insertRecord("book", 2L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		// ("book", 2L, 11)
 		expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
-		expectedOutput.add(insertRecord("book", 2L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateAfterRecord("book", 2L, 12, 2L));
+		// ("fruit", 1L, 33)
 		expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+
+		// ("fruit", 1L, 44)
+		// nothing, because it's Top-1
+
+		// ("fruit", 1L, 22)
 		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
-		expectedOutput.add(insertRecord("fruit", 1L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 1L, 22, 1L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -283,16 +313,22 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 1L, 12)
+		// ("book", 2L, 19)
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		// ("book", 4L, 11)
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
+		// ("fruit", 4L, 33)
+		// ("fruit", 3L, 44)
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		// ("fruit", 5L, 22)
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -345,15 +381,22 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
+		// ("book", 1L, 12)
+		// ("fruit", 5L, 22)
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		// UB ("book", 1L, 12)
 		expectedOutput.add(deleteRecord("book", 1L, 12, 1L));
-		expectedOutput.add(deleteRecord("fruit", 5L, 22, 1L));
+		// ("fruit", 4L, 11)
+		expectedOutput.add(updateBeforeRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 11, 1L));
 		expectedOutput.add(insertRecord("fruit", 5L, 22, 2L));
-		expectedOutput.add(insertRecord("fruit", 4L, 11, 1L));
+
 		// after idle state expired
+		// ("fruit", 8L, 100)
+		// ("book", 1L, 12)
 		expectedOutput.add(insertRecord("fruit", 8L, 100, 1L));
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
-		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/RetractableTopNFunctionTest.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.retractRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
  * Tests for {@link RetractableTopNFunction}.
@@ -58,28 +58,28 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 				true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(retractRecord("book", 1L, 12));
-		testHarness.processElement(record("book", 5L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(updateBeforeRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 5L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
 		expectedOutput.add(deleteRecord("book", 1L, 12, 2L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 5L, 11, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
@@ -92,33 +92,33 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 			true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(retractRecord("book", 1L, 12));
-		testHarness.processElement(record("book", 5L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(updateBeforeRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 5L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
-		expectedOutput.add(retractRecord("book", 1L, 12, 2L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 5L, 11, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(retractRecord("fruit", 4L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
@@ -128,26 +128,26 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 				true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(retractRecord("fruit", 4L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 
@@ -161,12 +161,12 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 10));
+		testHarness.processElement(insertRecord("book", 1L, 10));
 
-		expectedOutput.add(retractRecord("book", 1L, 12, 2L));
-		expectedOutput.add(retractRecord("book", 4L, 11, 1L));
-		expectedOutput.add(record("book", 4L, 11, 2L));
-		expectedOutput.add(record("book", 1L, 10, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 2L));
+		expectedOutput.add(insertRecord("book", 1L, 10, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
@@ -178,22 +178,22 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
 		expectedOutput.add(deleteRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 4L, 11));
-		expectedOutput.add(record("fruit", 4L, 33));
-		expectedOutput.add(record("fruit", 3L, 44));
+		expectedOutput.add(insertRecord("book", 4L, 11));
+		expectedOutput.add(insertRecord("fruit", 4L, 33));
+		expectedOutput.add(insertRecord("fruit", 3L, 44));
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 5L, 22));
+		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
@@ -207,10 +207,10 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 10));
+		testHarness.processElement(insertRecord("book", 1L, 10));
 
 		expectedOutput.add(deleteRecord("book", 1L, 12));
-		expectedOutput.add(record("book", 1L, 10));
+		expectedOutput.add(insertRecord("book", 1L, 10));
 		assertorWithoutRowNumber
 				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 		testHarness.close();
@@ -221,24 +221,24 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 12, 2L));
-		expectedOutput.add(record("book", 2L, 11, 1L));
-		expectedOutput.add(record("fruit", 1L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 1L, 33, 1L));
-		expectedOutput.add(record("fruit", 1L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -248,22 +248,22 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 12));
-		expectedOutput.add(record("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 2L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
 		expectedOutput.add(deleteRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 2L, 11));
-		expectedOutput.add(record("fruit", 1L, 33));
+		expectedOutput.add(insertRecord("book", 2L, 11));
+		expectedOutput.add(insertRecord("fruit", 1L, 33));
 		expectedOutput.add(deleteRecord("fruit", 1L, 33));
-		expectedOutput.add(record("fruit", 1L, 22));
+		expectedOutput.add(insertRecord("fruit", 1L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -274,23 +274,23 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 				true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -301,23 +301,23 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
 		expectedOutput.add(deleteRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 4L, 11));
-		expectedOutput.add(record("fruit", 4L, 33));
-		expectedOutput.add(record("fruit", 3L, 44));
+		expectedOutput.add(insertRecord("book", 4L, 11));
+		expectedOutput.add(insertRecord("fruit", 4L, 33));
+		expectedOutput.add(insertRecord("fruit", 3L, 44));
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 5L, 22));
+		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -330,30 +330,30 @@ public class RetractableTopNFunctionTest extends TopNFunctionTestBase {
 		testHarness.open();
 		// register cleanup timer with 20L
 		testHarness.setProcessingTime(0L);
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 
 		// register cleanup timer with 29L
 		testHarness.setProcessingTime(9L);
-		testHarness.processElement(retractRecord("book", 1L, 12));
-		testHarness.processElement(record("fruit", 4L, 11));
+		testHarness.processElement(updateBeforeRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("fruit", 4L, 11));
 
 		// trigger the first cleanup timer and register cleanup timer with 4000
 		testHarness.setProcessingTime(20L);
-		testHarness.processElement(record("fruit", 8L, 100));
-		testHarness.processElement(record("book", 1L, 12));
+		testHarness.processElement(insertRecord("fruit", 8L, 100));
+		testHarness.processElement(insertRecord("book", 1L, 12));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
 		expectedOutput.add(deleteRecord("book", 1L, 12, 1L));
 		expectedOutput.add(deleteRecord("fruit", 5L, 22, 1L));
-		expectedOutput.add(record("fruit", 5L, 22, 2L));
-		expectedOutput.add(record("fruit", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 11, 1L));
 		// after idle state expired
-		expectedOutput.add(record("fruit", 8L, 100, 1L));
-		expectedOutput.add(record("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("fruit", 8L, 100, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
@@ -44,8 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.retractRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
  * Base Tests for all subclass of {@link AbstractTopNFunction}.
@@ -145,28 +145,28 @@ abstract class TopNFunctionTestBase {
 			false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 3L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("book", 5L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 3L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("book", 5L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		// Notes: Delete message will be sent even disable generate retraction when not output rankNumber.
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
 		expectedOutput.add(deleteRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 4L, 11));
+		expectedOutput.add(insertRecord("book", 4L, 11));
 		expectedOutput.add(deleteRecord("book", 1L, 12));
-		expectedOutput.add(record("book", 5L, 11));
-		expectedOutput.add(record("fruit", 4L, 33));
-		expectedOutput.add(record("fruit", 3L, 44));
+		expectedOutput.add(insertRecord("book", 5L, 11));
+		expectedOutput.add(insertRecord("fruit", 4L, 33));
+		expectedOutput.add(insertRecord("fruit", 3L, 44));
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 5L, 22));
+		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -177,27 +177,27 @@ abstract class TopNFunctionTestBase {
 				true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("book", 5L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("book", 5L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		// Notes: Retract message will not be sent if disable generate retraction and output rankNumber.
 		// Because partition key + rankNumber decomposes a uniqueKey.
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
-		expectedOutput.add(record("book", 5L, 11, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
@@ -207,30 +207,30 @@ abstract class TopNFunctionTestBase {
 				true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("book", 5L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("book", 5L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 1L, 12, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 4L, 11, 1L));
-		expectedOutput.add(record("book", 1L, 12, 2L));
-		expectedOutput.add(retractRecord("book", 1L, 12, 2L));
-		expectedOutput.add(record("book", 5L, 11, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 1L));
-		expectedOutput.add(record("fruit", 3L, 44, 2L));
-		expectedOutput.add(retractRecord("fruit", 4L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(record("fruit", 4L, 33, 2L));
-		expectedOutput.add(record("fruit", 5L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
+		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
+		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
+		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -241,21 +241,21 @@ abstract class TopNFunctionTestBase {
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("fruit", 3L, 44));
-		expectedOutput.add(retractRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 4L, 33));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("fruit", 3L, 44));
+		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44));
+		expectedOutput.add(insertRecord("fruit", 4L, 33));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -265,24 +265,24 @@ abstract class TopNFunctionTestBase {
 		AbstractTopNFunction func = createFunction(RankType.ROW_NUMBER, new VariableRankRange(1), true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 12, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 2L, 11, 1L));
-		expectedOutput.add(record("book", 2L, 12, 2L));
-		expectedOutput.add(record("fruit", 1L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 1L, 33, 1L));
-		expectedOutput.add(record("fruit", 1L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 12, 2L));
+		expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -293,22 +293,22 @@ abstract class TopNFunctionTestBase {
 				false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 12));
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 4L, 11));
-		testHarness.processElement(record("fruit", 4L, 33));
-		testHarness.processElement(record("fruit", 3L, 44));
-		testHarness.processElement(record("fruit", 5L, 22));
+		testHarness.processElement(insertRecord("book", 1L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 4L, 11));
+		testHarness.processElement(insertRecord("fruit", 4L, 33));
+		testHarness.processElement(insertRecord("fruit", 3L, 44));
+		testHarness.processElement(insertRecord("fruit", 5L, 22));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 1L, 12));
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 4L, 11));
-		expectedOutput.add(record("fruit", 4L, 33));
-		expectedOutput.add(record("fruit", 3L, 44));
-		expectedOutput.add(retractRecord("fruit", 3L, 44));
-		expectedOutput.add(record("fruit", 5L, 22));
+		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 4L, 11));
+		expectedOutput.add(insertRecord("fruit", 4L, 33));
+		expectedOutput.add(insertRecord("fruit", 3L, 44));
+		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44));
+		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 
@@ -322,11 +322,11 @@ abstract class TopNFunctionTestBase {
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(record("book", 1L, 10));
+		testHarness.processElement(insertRecord("book", 1L, 10));
 		testHarness.close();
 
-		expectedOutput.add(retractRecord("book", 1L, 12));
-		expectedOutput.add(record("book", 1L, 10));
+		expectedOutput.add(updateBeforeRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 1L, 10));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/TopNFunctionTestBase.java
@@ -45,6 +45,7 @@ import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
@@ -168,7 +169,7 @@ abstract class TopNFunctionTestBase {
 		expectedOutput.add(deleteRecord("fruit", 3L, 44));
 		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -191,14 +192,14 @@ abstract class TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 5L, 11, 2L));
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		assertorWithRowNumber.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
+		assertorWithRowNumber.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -220,19 +221,19 @@ abstract class TopNFunctionTestBase {
 		expectedOutput.add(insertRecord("book", 1L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 1L));
+		expectedOutput.add(updateAfterRecord("book", 4L, 11, 1L));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 4L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 1L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12, 2L));
 		expectedOutput.add(updateBeforeRecord("book", 1L, 12, 2L));
-		expectedOutput.add(insertRecord("book", 5L, 11, 2L));
+		expectedOutput.add(updateAfterRecord("book", 5L, 11, 2L));
 		expectedOutput.add(insertRecord("fruit", 4L, 33, 1L));
 		expectedOutput.add(insertRecord("fruit", 3L, 44, 2L));
 		expectedOutput.add(updateBeforeRecord("fruit", 4L, 33, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 5L, 22, 1L));
 		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44, 2L));
-		expectedOutput.add(insertRecord("fruit", 4L, 33, 2L));
-		expectedOutput.add(insertRecord("fruit", 5L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33, 2L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -252,12 +253,12 @@ abstract class TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 2L, 19));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
-		expectedOutput.add(insertRecord("book", 1L, 12));
+		expectedOutput.add(updateAfterRecord("book", 1L, 12));
 		expectedOutput.add(insertRecord("fruit", 3L, 44));
 		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44));
-		expectedOutput.add(insertRecord("fruit", 4L, 33));
+		expectedOutput.add(updateAfterRecord("fruit", 4L, 33));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -277,14 +278,14 @@ abstract class TopNFunctionTestBase {
 		expectedOutput.add(insertRecord("book", 2L, 12, 1L));
 		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
+		expectedOutput.add(updateAfterRecord("book", 2L, 11, 1L));
 		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
-		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
-		expectedOutput.add(insertRecord("book", 2L, 12, 2L));
+		expectedOutput.add(updateAfterRecord("book", 2L, 12, 2L));
 		expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
 		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
-		expectedOutput.add(insertRecord("fruit", 1L, 22, 1L));
+		expectedOutput.add(updateAfterRecord("fruit", 1L, 22, 1L));
 		assertorWithRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	@Test
@@ -303,14 +304,14 @@ abstract class TopNFunctionTestBase {
 		List<Object> expectedOutput = new ArrayList<>();
 		expectedOutput.add(insertRecord("book", 1L, 12));
 		expectedOutput.add(insertRecord("book", 2L, 19));
-		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(deleteRecord("book", 2L, 19));
 		expectedOutput.add(insertRecord("book", 4L, 11));
 		expectedOutput.add(insertRecord("fruit", 4L, 33));
 		expectedOutput.add(insertRecord("fruit", 3L, 44));
-		expectedOutput.add(updateBeforeRecord("fruit", 3L, 44));
+		expectedOutput.add(deleteRecord("fruit", 3L, 44));
 		expectedOutput.add(insertRecord("fruit", 5L, 22));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
@@ -322,13 +323,13 @@ abstract class TopNFunctionTestBase {
 		testHarness.setup();
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(insertRecord("book", 1L, 10));
+		testHarness.processElement(insertRecord("book", 5L, 10));
 		testHarness.close();
 
-		expectedOutput.add(updateBeforeRecord("book", 1L, 12));
-		expectedOutput.add(insertRecord("book", 1L, 10));
+		expectedOutput.add(deleteRecord("book", 1L, 12));
+		expectedOutput.add(insertRecord("book", 5L, 10));
 		assertorWithoutRowNumber
-				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
+				.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 
 	OneInputStreamOperatorTestHarness<BaseRow, BaseRow> createTestHarness(

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/rank/UpdatableTopNFunctionTest.java
@@ -27,8 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.retractRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateBeforeRecord;
 
 /**
  * Tests for {@link UpdatableTopNFunction}.
@@ -61,22 +61,22 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new VariableRankRange(1), true, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 18));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 18));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 2L, 18));
-		expectedOutput.add(record("fruit", 1L, 44));
-		expectedOutput.add(retractRecord("fruit", 1L, 44));
-		expectedOutput.add(record("fruit", 1L, 33));
-		expectedOutput.add(retractRecord("fruit", 1L, 33));
-		expectedOutput.add(record("fruit", 1L, 22));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 2L, 18));
+		expectedOutput.add(insertRecord("fruit", 1L, 44));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 44));
+		expectedOutput.add(insertRecord("fruit", 1L, 33));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33));
+		expectedOutput.add(insertRecord("fruit", 1L, 22));
 		assertorWithoutRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -88,25 +88,25 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new VariableRankRange(1), true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 2L, 12));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("fruit", 1L, 44));
-		testHarness.processElement(record("fruit", 1L, 33));
-		testHarness.processElement(record("fruit", 1L, 22));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 2L, 12));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("fruit", 1L, 44));
+		testHarness.processElement(insertRecord("fruit", 1L, 33));
+		testHarness.processElement(insertRecord("fruit", 1L, 22));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 1L));
-		expectedOutput.add(record("book", 2L, 12, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 12, 1L));
-		expectedOutput.add(record("book", 2L, 11, 1L));
-		expectedOutput.add(record("fruit", 1L, 44, 1L));
-		expectedOutput.add(retractRecord("fruit", 1L, 44, 1L));
-		expectedOutput.add(record("fruit", 1L, 33, 1L));
-		expectedOutput.add(retractRecord("fruit", 1L, 33, 1L));
-		expectedOutput.add(record("fruit", 1L, 22, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 12, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 12, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 44, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 44, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(updateBeforeRecord("fruit", 1L, 33, 1L));
+		expectedOutput.add(insertRecord("fruit", 1L, 22, 1L));
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
 	}
@@ -117,33 +117,33 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new ConstantRankRange(1, 2), true, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 3L, 16));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 3L, 15));
-		testHarness.processElement(record("book", 4L, 2));
-		testHarness.processElement(record("book", 2L, 1));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 3L, 16));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 3L, 15));
+		testHarness.processElement(insertRecord("book", 4L, 2));
+		testHarness.processElement(insertRecord("book", 2L, 1));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 3L, 16, 1L));
-		expectedOutput.add(retractRecord("book", 3L, 16, 1L));
-		expectedOutput.add(record("book", 3L, 16, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 2L, 11, 1L));
-		expectedOutput.add(retractRecord("book", 3L, 16, 2L));
-		expectedOutput.add(record("book", 3L, 15, 2L));
-		expectedOutput.add(retractRecord("book", 3L, 15, 2L));
-		expectedOutput.add(retractRecord("book", 2L, 11, 1L));
-		expectedOutput.add(record("book", 2L, 11, 2L));
-		expectedOutput.add(record("book", 4L, 2, 1L));
-		expectedOutput.add(retractRecord("book", 2L, 11, 2L));
-		expectedOutput.add(retractRecord("book", 4L, 2, 1L));
-		expectedOutput.add(record("book", 2L, 1, 1L));
-		expectedOutput.add(record("book", 4L, 2, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 3L, 16, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 3L, 16, 1L));
+		expectedOutput.add(insertRecord("book", 3L, 16, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 3L, 16, 2L));
+		expectedOutput.add(insertRecord("book", 3L, 15, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 3L, 15, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 2, 1L));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 11, 2L));
+		expectedOutput.add(updateBeforeRecord("book", 4L, 2, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 1, 1L));
+		expectedOutput.add(insertRecord("book", 4L, 2, 2L));
 
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
@@ -155,25 +155,25 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new ConstantRankRange(1, 2), false, true);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 3L, 16));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 3L, 15));
-		testHarness.processElement(record("book", 4L, 2));
-		testHarness.processElement(record("book", 2L, 1));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 3L, 16));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 3L, 15));
+		testHarness.processElement(insertRecord("book", 4L, 2));
+		testHarness.processElement(insertRecord("book", 2L, 1));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19, 1L));
-		expectedOutput.add(record("book", 2L, 19, 2L));
-		expectedOutput.add(record("book", 3L, 16, 1L));
-		expectedOutput.add(record("book", 3L, 16, 2L));
-		expectedOutput.add(record("book", 2L, 11, 1L));
-		expectedOutput.add(record("book", 3L, 15, 2L));
-		expectedOutput.add(record("book", 2L, 11, 2L));
-		expectedOutput.add(record("book", 4L, 2, 1L));
-		expectedOutput.add(record("book", 2L, 1, 1L));
-		expectedOutput.add(record("book", 4L, 2, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 19, 2L));
+		expectedOutput.add(insertRecord("book", 3L, 16, 1L));
+		expectedOutput.add(insertRecord("book", 3L, 16, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 1L));
+		expectedOutput.add(insertRecord("book", 3L, 15, 2L));
+		expectedOutput.add(insertRecord("book", 2L, 11, 2L));
+		expectedOutput.add(insertRecord("book", 4L, 2, 1L));
+		expectedOutput.add(insertRecord("book", 2L, 1, 1L));
+		expectedOutput.add(insertRecord("book", 4L, 2, 2L));
 
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
@@ -185,25 +185,25 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new ConstantRankRange(1, 2), true, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 3L, 16));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 3L, 15));
-		testHarness.processElement(record("book", 4L, 2));
-		testHarness.processElement(record("book", 2L, 1));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 3L, 16));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 3L, 15));
+		testHarness.processElement(insertRecord("book", 4L, 2));
+		testHarness.processElement(insertRecord("book", 2L, 1));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(record("book", 3L, 16));
-		expectedOutput.add(retractRecord("book", 2L, 19));
-		expectedOutput.add(record("book", 2L, 11));
-		expectedOutput.add(retractRecord("book", 3L, 16));
-		expectedOutput.add(record("book", 3L, 15));
-		expectedOutput.add(record("book", 4L, 2));
-		expectedOutput.add(retractRecord("book", 3L, 15));
-		expectedOutput.add(record("book", 2L, 1));
-		expectedOutput.add(retractRecord("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 3L, 16));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 2L, 11));
+		expectedOutput.add(updateBeforeRecord("book", 3L, 16));
+		expectedOutput.add(insertRecord("book", 3L, 15));
+		expectedOutput.add(insertRecord("book", 4L, 2));
+		expectedOutput.add(updateBeforeRecord("book", 3L, 15));
+		expectedOutput.add(insertRecord("book", 2L, 1));
+		expectedOutput.add(updateBeforeRecord("book", 2L, 11));
 
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());
@@ -215,22 +215,22 @@ public class UpdatableTopNFunctionTest extends TopNFunctionTestBase {
 				new ConstantRankRange(1, 2), false, false);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(func);
 		testHarness.open();
-		testHarness.processElement(record("book", 2L, 19));
-		testHarness.processElement(record("book", 3L, 16));
-		testHarness.processElement(record("book", 2L, 11));
-		testHarness.processElement(record("book", 3L, 15));
-		testHarness.processElement(record("book", 4L, 2));
-		testHarness.processElement(record("book", 2L, 1));
+		testHarness.processElement(insertRecord("book", 2L, 19));
+		testHarness.processElement(insertRecord("book", 3L, 16));
+		testHarness.processElement(insertRecord("book", 2L, 11));
+		testHarness.processElement(insertRecord("book", 3L, 15));
+		testHarness.processElement(insertRecord("book", 4L, 2));
+		testHarness.processElement(insertRecord("book", 2L, 1));
 		testHarness.close();
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("book", 2L, 19));
-		expectedOutput.add(record("book", 3L, 16));
-		expectedOutput.add(record("book", 2L, 11));
-		expectedOutput.add(record("book", 3L, 15));
-		expectedOutput.add(record("book", 4L, 2));
+		expectedOutput.add(insertRecord("book", 2L, 19));
+		expectedOutput.add(insertRecord("book", 3L, 16));
+		expectedOutput.add(insertRecord("book", 2L, 11));
+		expectedOutput.add(insertRecord("book", 3L, 15));
+		expectedOutput.add(insertRecord("book", 4L, 2));
 		expectedOutput.add(deleteRecord("book", 3L, 15));
-		expectedOutput.add(record("book", 2L, 1));
+		expectedOutput.add(insertRecord("book", 2L, 1));
 
 		assertorWithRowNumber
 				.assertOutputEqualsSorted("output wrong.", expectedOutput, testHarness.getOutput());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/ProcTimeSortOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/ProcTimeSortOperatorTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Tests for {@link ProcTimeSortOperator}.
@@ -68,29 +68,29 @@ public class ProcTimeSortOperatorTest {
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
 		testHarness.open();
 		testHarness.setProcessingTime(0L);
-		testHarness.processElement(record(3, 3L, "Hello world", 3));
-		testHarness.processElement(record(2, 2L, "Hello", 2));
-		testHarness.processElement(record(6, 2L, "Luke Skywalker", 6));
-		testHarness.processElement(record(5, 3L, "I am fine.", 5));
-		testHarness.processElement(record(7, 1L, "Comment#1", 7));
-		testHarness.processElement(record(9, 4L, "Comment#3", 9));
+		testHarness.processElement(insertRecord(3, 3L, "Hello world", 3));
+		testHarness.processElement(insertRecord(2, 2L, "Hello", 2));
+		testHarness.processElement(insertRecord(6, 2L, "Luke Skywalker", 6));
+		testHarness.processElement(insertRecord(5, 3L, "I am fine.", 5));
+		testHarness.processElement(insertRecord(7, 1L, "Comment#1", 7));
+		testHarness.processElement(insertRecord(9, 4L, "Comment#3", 9));
 		testHarness.setProcessingTime(1L);
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(2, 2L, "Hello", 2));
-		expectedOutput.add(record(3, 3L, "Hello world", 3));
-		expectedOutput.add(record(5, 3L, "I am fine.", 5));
-		expectedOutput.add(record(6, 2L, "Luke Skywalker", 6));
-		expectedOutput.add(record(7, 1L, "Comment#1", 7));
-		expectedOutput.add(record(9, 4L, "Comment#3", 9));
+		expectedOutput.add(insertRecord(2, 2L, "Hello", 2));
+		expectedOutput.add(insertRecord(3, 3L, "Hello world", 3));
+		expectedOutput.add(insertRecord(5, 3L, "I am fine.", 5));
+		expectedOutput.add(insertRecord(6, 2L, "Luke Skywalker", 6));
+		expectedOutput.add(insertRecord(7, 1L, "Comment#1", 7));
+		expectedOutput.add(insertRecord(9, 4L, "Comment#3", 9));
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 
-		testHarness.processElement(record(10, 4L, "Comment#4", 10));
-		testHarness.processElement(record(8, 4L, "Comment#2", 8));
-		testHarness.processElement(record(1, 1L, "Hi", 2));
-		testHarness.processElement(record(1, 1L, "Hi", 1));
-		testHarness.processElement(record(4, 3L, "Helloworld, how are you?", 4));
-		testHarness.processElement(record(4, 5L, "Hello, how are you?", 4));
+		testHarness.processElement(insertRecord(10, 4L, "Comment#4", 10));
+		testHarness.processElement(insertRecord(8, 4L, "Comment#2", 8));
+		testHarness.processElement(insertRecord(1, 1L, "Hi", 2));
+		testHarness.processElement(insertRecord(1, 1L, "Hi", 1));
+		testHarness.processElement(insertRecord(4, 3L, "Helloworld, how are you?", 4));
+		testHarness.processElement(insertRecord(4, 5L, "Hello, how are you?", 4));
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
@@ -102,16 +102,16 @@ public class ProcTimeSortOperatorTest {
 		testHarness = createTestHarness(operator);
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(record(5, 3L, "I am fine.", 6));
+		testHarness.processElement(insertRecord(5, 3L, "I am fine.", 6));
 		testHarness.setProcessingTime(1L);
 
-		expectedOutput.add(record(1, 1L, "Hi", 2));
-		expectedOutput.add(record(1, 1L, "Hi", 1));
-		expectedOutput.add(record(4, 3L, "Helloworld, how are you?", 4));
-		expectedOutput.add(record(4, 5L, "Hello, how are you?", 4));
-		expectedOutput.add(record(5, 3L, "I am fine.", 6));
-		expectedOutput.add(record(8, 4L, "Comment#2", 8));
-		expectedOutput.add(record(10, 4L, "Comment#4", 10));
+		expectedOutput.add(insertRecord(1, 1L, "Hi", 2));
+		expectedOutput.add(insertRecord(1, 1L, "Hi", 1));
+		expectedOutput.add(insertRecord(4, 3L, "Helloworld, how are you?", 4));
+		expectedOutput.add(insertRecord(4, 5L, "Hello, how are you?", 4));
+		expectedOutput.add(insertRecord(5, 3L, "I am fine.", 6));
+		expectedOutput.add(insertRecord(8, 4L, "Comment#2", 8));
+		expectedOutput.add(insertRecord(10, 4L, "Comment#4", 10));
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/RowTimeSortOperatorTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Tests for {@link RowTimeSortOperator}.
@@ -70,32 +70,32 @@ public class RowTimeSortOperatorTest {
 		RowTimeSortOperator operator = createSortOperator(inputRowType, rowTimeIdx, gComparator);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
 		testHarness.open();
-		testHarness.processElement(record(3, 3L, "Hello world", 3));
-		testHarness.processElement(record(2, 2L, "Hello", 2));
-		testHarness.processElement(record(6, 2L, "Luke Skywalker", 6));
-		testHarness.processElement(record(5, 3L, "I am fine.", 5));
-		testHarness.processElement(record(7, 1L, "Comment#1", 7));
-		testHarness.processElement(record(9, 4L, "Comment#3", 9));
-		testHarness.processElement(record(10, 4L, "Comment#4", 10));
-		testHarness.processElement(record(8, 4L, "Comment#2", 8));
-		testHarness.processElement(record(1, 1L, "Hi", 2));
-		testHarness.processElement(record(1, 1L, "Hi", 1));
-		testHarness.processElement(record(4, 3L, "Helloworld, how are you?", 4));
-		testHarness.processElement(record(4, 5L, "Hello, how are you?", 4));
+		testHarness.processElement(insertRecord(3, 3L, "Hello world", 3));
+		testHarness.processElement(insertRecord(2, 2L, "Hello", 2));
+		testHarness.processElement(insertRecord(6, 2L, "Luke Skywalker", 6));
+		testHarness.processElement(insertRecord(5, 3L, "I am fine.", 5));
+		testHarness.processElement(insertRecord(7, 1L, "Comment#1", 7));
+		testHarness.processElement(insertRecord(9, 4L, "Comment#3", 9));
+		testHarness.processElement(insertRecord(10, 4L, "Comment#4", 10));
+		testHarness.processElement(insertRecord(8, 4L, "Comment#2", 8));
+		testHarness.processElement(insertRecord(1, 1L, "Hi", 2));
+		testHarness.processElement(insertRecord(1, 1L, "Hi", 1));
+		testHarness.processElement(insertRecord(4, 3L, "Helloworld, how are you?", 4));
+		testHarness.processElement(insertRecord(4, 5L, "Hello, how are you?", 4));
 		testHarness.processWatermark(new Watermark(4L));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1, 1L, "Hi", 2));
-		expectedOutput.add(record(1, 1L, "Hi", 1));
-		expectedOutput.add(record(7, 1L, "Comment#1", 7));
-		expectedOutput.add(record(2, 2L, "Hello", 2));
-		expectedOutput.add(record(6, 2L, "Luke Skywalker", 6));
-		expectedOutput.add(record(3, 3L, "Hello world", 3));
-		expectedOutput.add(record(4, 3L, "Helloworld, how are you?", 4));
-		expectedOutput.add(record(5, 3L, "I am fine.", 5));
-		expectedOutput.add(record(8, 4L, "Comment#2", 8));
-		expectedOutput.add(record(9, 4L, "Comment#3", 9));
-		expectedOutput.add(record(10, 4L, "Comment#4", 10));
+		expectedOutput.add(insertRecord(1, 1L, "Hi", 2));
+		expectedOutput.add(insertRecord(1, 1L, "Hi", 1));
+		expectedOutput.add(insertRecord(7, 1L, "Comment#1", 7));
+		expectedOutput.add(insertRecord(2, 2L, "Hello", 2));
+		expectedOutput.add(insertRecord(6, 2L, "Luke Skywalker", 6));
+		expectedOutput.add(insertRecord(3, 3L, "Hello world", 3));
+		expectedOutput.add(insertRecord(4, 3L, "Helloworld, how are you?", 4));
+		expectedOutput.add(insertRecord(5, 3L, "I am fine.", 5));
+		expectedOutput.add(insertRecord(8, 4L, "Comment#2", 8));
+		expectedOutput.add(insertRecord(9, 4L, "Comment#3", 9));
+		expectedOutput.add(insertRecord(10, 4L, "Comment#4", 10));
 		expectedOutput.add(new Watermark(4L));
 
 		// do a snapshot, data could be recovered from state
@@ -110,10 +110,10 @@ public class RowTimeSortOperatorTest {
 		testHarness.initializeState(snapshot);
 		testHarness.open();
 		// late data will be dropped
-		testHarness.processElement(record(5, 3L, "I am fine.", 6));
+		testHarness.processElement(insertRecord(5, 3L, "I am fine.", 6));
 		testHarness.processWatermark(new Watermark(5L));
 
-		expectedOutput.add(record(4, 5L, "Hello, how are you?", 4));
+		expectedOutput.add(insertRecord(4, 5L, "Hello, how are you?", 4));
 		expectedOutput.add(new Watermark(5L));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
@@ -139,30 +139,30 @@ public class RowTimeSortOperatorTest {
 		RowTimeSortOperator operator = createSortOperator(inputRowType, rowTimeIdx, null);
 		OneInputStreamOperatorTestHarness<BaseRow, BaseRow> testHarness = createTestHarness(operator);
 		testHarness.open();
-		testHarness.processElement(record(3L, 2L, "Hello world", 3));
-		testHarness.processElement(record(2L, 2L, "Hello", 2));
-		testHarness.processElement(record(6L, 3L, "Luke Skywalker", 6));
-		testHarness.processElement(record(5L, 3L, "I am fine.", 5));
-		testHarness.processElement(record(7L, 4L, "Comment#1", 7));
-		testHarness.processElement(record(9L, 4L, "Comment#3", 9));
-		testHarness.processElement(record(10L, 4L, "Comment#4", 10));
-		testHarness.processElement(record(8L, 4L, "Comment#2", 8));
-		testHarness.processElement(record(1L, 1L, "Hi", 2));
-		testHarness.processElement(record(1L, 1L, "Hi", 1));
-		testHarness.processElement(record(4L, 3L, "Helloworld, how are you?", 4));
+		testHarness.processElement(insertRecord(3L, 2L, "Hello world", 3));
+		testHarness.processElement(insertRecord(2L, 2L, "Hello", 2));
+		testHarness.processElement(insertRecord(6L, 3L, "Luke Skywalker", 6));
+		testHarness.processElement(insertRecord(5L, 3L, "I am fine.", 5));
+		testHarness.processElement(insertRecord(7L, 4L, "Comment#1", 7));
+		testHarness.processElement(insertRecord(9L, 4L, "Comment#3", 9));
+		testHarness.processElement(insertRecord(10L, 4L, "Comment#4", 10));
+		testHarness.processElement(insertRecord(8L, 4L, "Comment#2", 8));
+		testHarness.processElement(insertRecord(1L, 1L, "Hi", 2));
+		testHarness.processElement(insertRecord(1L, 1L, "Hi", 1));
+		testHarness.processElement(insertRecord(4L, 3L, "Helloworld, how are you?", 4));
 		testHarness.processWatermark(new Watermark(9L));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record(1L, 1L, "Hi", 2));
-		expectedOutput.add(record(1L, 1L, "Hi", 1));
-		expectedOutput.add(record(2L, 2L, "Hello", 2));
-		expectedOutput.add(record(3L, 2L, "Hello world", 3));
-		expectedOutput.add(record(4L, 3L, "Helloworld, how are you?", 4));
-		expectedOutput.add(record(5L, 3L, "I am fine.", 5));
-		expectedOutput.add(record(6L, 3L, "Luke Skywalker", 6));
-		expectedOutput.add(record(7L, 4L, "Comment#1", 7));
-		expectedOutput.add(record(8L, 4L, "Comment#2", 8));
-		expectedOutput.add(record(9L, 4L, "Comment#3", 9));
+		expectedOutput.add(insertRecord(1L, 1L, "Hi", 2));
+		expectedOutput.add(insertRecord(1L, 1L, "Hi", 1));
+		expectedOutput.add(insertRecord(2L, 2L, "Hello", 2));
+		expectedOutput.add(insertRecord(3L, 2L, "Hello world", 3));
+		expectedOutput.add(insertRecord(4L, 3L, "Helloworld, how are you?", 4));
+		expectedOutput.add(insertRecord(5L, 3L, "I am fine.", 5));
+		expectedOutput.add(insertRecord(6L, 3L, "Luke Skywalker", 6));
+		expectedOutput.add(insertRecord(7L, 4L, "Comment#1", 7));
+		expectedOutput.add(insertRecord(8L, 4L, "Comment#2", 8));
+		expectedOutput.add(insertRecord(9L, 4L, "Comment#3", 9));
 		expectedOutput.add(new Watermark(9L));
 
 		// do a snapshot, data could be recovered from state
@@ -177,10 +177,10 @@ public class RowTimeSortOperatorTest {
 		testHarness.initializeState(snapshot);
 		testHarness.open();
 		// late data will be dropped
-		testHarness.processElement(record(5L, 3L, "I am fine.", 6));
+		testHarness.processElement(insertRecord(5L, 3L, "I am fine.", 6));
 		testHarness.processWatermark(new Watermark(10L));
 
-		expectedOutput.add(record(10L, 4L, "Comment#4", 10));
+		expectedOutput.add(insertRecord(10L, 4L, "Comment#4", 10));
 		expectedOutput.add(new Watermark(10L));
 
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/sort/StreamSortOperatorTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 
 /**
  * Tests for {@link StreamSortOperator}.
@@ -63,16 +63,16 @@ public class StreamSortOperatorTest {
 		StreamSortOperator operator = createSortOperator();
 		OneInputStreamOperatorTestHarness<BaseRow, BinaryRow> testHarness = createTestHarness(operator);
 		testHarness.open();
-		testHarness.processElement(record("hi", 1));
-		testHarness.processElement(record("hello", 2));
-		testHarness.processElement(record("world", 3));
-		testHarness.processElement(record("word", 4));
+		testHarness.processElement(insertRecord("hi", 1));
+		testHarness.processElement(insertRecord("hello", 2));
+		testHarness.processElement(insertRecord("world", 3));
+		testHarness.processElement(insertRecord("word", 4));
 
 		List<Object> expectedOutput = new ArrayList<>();
-		expectedOutput.add(record("hello", 2));
-		expectedOutput.add(record("hi", 1));
-		expectedOutput.add(record("word", 4));
-		expectedOutput.add(record("world", 3));
+		expectedOutput.add(insertRecord("hello", 2));
+		expectedOutput.add(insertRecord("hi", 1));
+		expectedOutput.add(insertRecord("word", 4));
+		expectedOutput.add(insertRecord("world", 3));
 
 		// do a snapshot, data could be recovered from state
 		OperatorSubtaskState snapshot = testHarness.snapshot(0L, 0);
@@ -85,16 +85,16 @@ public class StreamSortOperatorTest {
 		testHarness = createTestHarness(operator);
 		testHarness.initializeState(snapshot);
 		testHarness.open();
-		testHarness.processElement(record("abc", 1));
-		testHarness.processElement(record("aa", 1));
+		testHarness.processElement(insertRecord("abc", 1));
+		testHarness.processElement(insertRecord("aa", 1));
 		testHarness.close();
 
-		expectedOutput.add(record("aa", 1));
-		expectedOutput.add(record("abc", 1));
-		expectedOutput.add(record("hello", 2));
-		expectedOutput.add(record("hi", 1));
-		expectedOutput.add(record("word", 4));
-		expectedOutput.add(record("world", 3));
+		expectedOutput.add(insertRecord("aa", 1));
+		expectedOutput.add(insertRecord("abc", 1));
+		expectedOutput.add(insertRecord("hello", 2));
+		expectedOutput.add(insertRecord("hi", 1));
+		expectedOutput.add(insertRecord("word", 4));
+		expectedOutput.add(insertRecord("world", 3));
 		assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
 	}
 

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/operators/window/WindowOperatorContractTest.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.baserow;
-import static org.apache.flink.table.runtime.util.StreamRecordUtils.record;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -82,11 +82,11 @@ public class WindowOperatorContractTest {
 		when(mockAssigner.assignWindows(any(), anyLong()))
 				.thenReturn(Collections.singletonList(new TimeWindow(0, 0)));
 
-		testHarness.processElement(record("String", 1, 0L));
+		testHarness.processElement(insertRecord("String", 1, 0L));
 
 		verify(mockAssigner, times(1)).assignWindows(eq(baserow("String", 1, 0L)), eq(0L));
 
-		testHarness.processElement(record("String", 1, 0L));
+		testHarness.processElement(insertRecord("String", 1, 0L));
 
 		verify(mockAssigner, times(2)).assignWindows(eq(baserow("String", 1, 0L)), eq(0L));
 	}
@@ -107,7 +107,7 @@ public class WindowOperatorContractTest {
 
 		shouldFireOnElement(mockTrigger);
 
-		testHarness.processElement(record("String", 1, 0L));
+		testHarness.processElement(insertRecord("String", 1, 0L));
 
 		verify(mockAggregate, times(2)).getValue(anyTimeWindow());
 		verify(mockAggregate, times(1)).getValue(eq(new TimeWindow(0, 2)));
@@ -130,7 +130,7 @@ public class WindowOperatorContractTest {
 
 		shouldFireOnElement(mockTrigger);
 
-		testHarness.processElement(record("String", 1, 0L));
+		testHarness.processElement(insertRecord("String", 1, 0L));
 
 		verify(mockAggregate, times(2)).emitValue(anyTimeWindow(), any(), any());
 		verify(mockAggregate, times(1)).emitValue(eq(new TimeWindow(0, 2)), any(), any());
@@ -152,7 +152,7 @@ public class WindowOperatorContractTest {
 		when(mockAssigner.assignWindows(anyGenericRow(), anyLong()))
 				.thenReturn(Arrays.asList(new TimeWindow(2, 4), new TimeWindow(0, 2)));
 
-		testHarness.processElement(record("String", 42, 1L));
+		testHarness.processElement(insertRecord("String", 42, 1L));
 
 		verify(mockTrigger).onElement(eq(baserow("String", 42, 1L)), eq(1L), eq(new TimeWindow(2, 4)));
 		verify(mockTrigger).onElement(eq(baserow("String", 42, 1L)), eq(1L), eq(new TimeWindow(0, 2)));
@@ -175,7 +175,7 @@ public class WindowOperatorContractTest {
 
 		assertEquals(0, testHarness.getOutput().size());
 
-		testHarness.processElement(record("String", 42, 0L));
+		testHarness.processElement(insertRecord("String", 42, 0L));
 
 		verify(mockAssigner).mergeWindows(eq(new TimeWindow(2, 4)), any(), anyMergeCallback());
 		verify(mockAssigner).mergeWindows(eq(new TimeWindow(0, 2)), any(), anyMergeCallback());

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BaseRowHarnessAssertor.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/BaseRowHarnessAssertor.java
@@ -56,7 +56,6 @@ public class BaseRowHarnessAssertor {
 		this(typeInfos, new StringComparator());
 	}
 
-
 	/**
 	 * Compare the two queues containing operator/task output by converting them to an array first.
 	 * Asserts two converted array should be same.

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/GenericRowRecordSortComparator.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/GenericRowRecordSortComparator.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.runtime.util;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.TypeGetterSetters;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.RowKind;
 
 import java.io.Serializable;
 import java.util.Comparator;
@@ -43,10 +44,10 @@ public class GenericRowRecordSortComparator implements Comparator<GenericRow>, S
 
 	@Override
 	public int compare(GenericRow row1, GenericRow row2) {
-		byte header1 = row1.getHeader();
-		byte header2 = row2.getHeader();
-		if (header1 != header2) {
-			return header1 - header2;
+		RowKind kind1 = row1.getRowKind();
+		RowKind kind2 = row2.getRowKind();
+		if (kind1 != kind2) {
+			return kind1.toByteValue() - kind2.toByteValue();
 		} else {
 			Object key1 = TypeGetterSetters.get(row1, sortKeyIdx, sortKeyType);
 			Object key2 = TypeGetterSetters.get(row2, sortKeyIdx, sortKeyType);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -45,7 +45,7 @@ public class StreamRecordUtils {
 	 * @param fields input object array
 	 * @return generated StreamRecord
 	 */
-	public static StreamRecord<BaseRow> record(Object... fields) {
+	public static StreamRecord<BaseRow> insertRecord(Object... fields) {
 		return new StreamRecord<>(baserow(fields));
 	}
 
@@ -55,7 +55,7 @@ public class StreamRecordUtils {
 	 * @param fields input object array
 	 * @return generated StreamRecord
 	 */
-	public static StreamRecord<BaseRow> retractRecord(Object... fields) {
+	public static StreamRecord<BaseRow> updateBeforeRecord(Object... fields) {
 		BaseRow row = baserow(fields);
 		BaseRowUtil.setRetract(row);
 		return new StreamRecord<>(row);

--- a/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
+++ b/flink-table/flink-table-runtime-blink/src/test/java/org/apache/flink/table/runtime/util/StreamRecordUtils.java
@@ -28,9 +28,9 @@ import org.apache.flink.table.dataformat.BinaryString;
 import org.apache.flink.table.dataformat.Decimal;
 import org.apache.flink.table.dataformat.GenericRow;
 import org.apache.flink.table.dataformat.SqlTimestamp;
-import org.apache.flink.table.dataformat.util.BaseRowUtil;
 import org.apache.flink.table.runtime.typeutils.BaseArraySerializer;
 import org.apache.flink.table.runtime.typeutils.BaseRowSerializer;
+import org.apache.flink.types.RowKind;
 
 import static org.apache.flink.table.dataformat.BinaryString.fromString;
 
@@ -40,7 +40,18 @@ import static org.apache.flink.table.dataformat.BinaryString.fromString;
 public class StreamRecordUtils {
 
 	/**
-	 * Receives a object array, generates an acc BaseRow based on the array, wraps the BaseRow in a StreamRecord.
+	 * Creates n new {@link StreamRecord} of {@link BaseRow} based on the given fields array
+	 * and the give RowKind.
+	 */
+	public static StreamRecord<BaseRow> record(RowKind rowKind, Object... fields) {
+		BaseRow row = baserow(fields);
+		row.setRowKind(rowKind);
+		return new StreamRecord<>(row);
+	}
+
+	/**
+	 * Creates n new {@link StreamRecord} of {@link BaseRow} based on the given fields array
+	 * and a default INSERT RowKind.
 	 *
 	 * @param fields input object array
 	 * @return generated StreamRecord
@@ -50,26 +61,48 @@ public class StreamRecordUtils {
 	}
 
 	/**
-	 * Receives a object array, generates a retract BaseRow based on the array, wraps the BaseRow in a StreamRecord.
+	 * Creates n new {@link StreamRecord} of {@link BinaryRow} based on the given fields array
+	 * and the given RowKind.
+	 */
+	public static StreamRecord<BaseRow> binaryRecord(RowKind rowKind, Object... fields) {
+		BinaryRow row = binaryrow(fields);
+		row.setRowKind(rowKind);
+		return new StreamRecord<>(row);
+	}
+
+	/**
+	 * Creates n new {@link StreamRecord} of {@link BaseRow} based on the given fields array
+	 * and a default UPDATE_BEFORE RowKind.
 	 *
 	 * @param fields input object array
 	 * @return generated StreamRecord
 	 */
 	public static StreamRecord<BaseRow> updateBeforeRecord(Object... fields) {
 		BaseRow row = baserow(fields);
-		BaseRowUtil.setRetract(row);
+		row.setRowKind(RowKind.UPDATE_BEFORE);
 		return new StreamRecord<>(row);
 	}
 
 	/**
-	 * Receives a object array, generates a delete BaseRow based on the array, wraps the BaseRow in a StreamRecord.
+	 * Creates n new {@link StreamRecord} of {@link BaseRow} based on the given fields array
+	 * and a default UPDATE_AFTER RowKind.
+	 */
+	public static StreamRecord<BaseRow> updateAfterRecord(Object... fields) {
+		BaseRow row = baserow(fields);
+		row.setRowKind(RowKind.UPDATE_AFTER);
+		return new StreamRecord<>(row);
+	}
+
+	/**
+	 * Creates n new {@link StreamRecord} of {@link BaseRow} based on the given fields array
+	 * and a default DELETE RowKind.
 	 *
 	 * @param fields input object array
 	 * @return generated StreamRecord
 	 */
 	public static StreamRecord<BaseRow> deleteRecord(Object... fields) {
 		BaseRow row = baserow(fields);
-		BaseRowUtil.setRetract(row);
+		row.setRowKind(RowKind.DELETE);
 		return new StreamRecord<>(row);
 	}
 
@@ -144,15 +177,6 @@ public class StreamRecordUtils {
 
 		writer.complete();
 		return row;
-	}
-
-	/**
-	 * Generate a retraction BinaryRow based on the given object fields.
-	 */
-	public static BinaryRow retractBinaryRow(Object... fields) {
-		BinaryRow br = binaryrow(fields);
-		BaseRowUtil.setRetract(br);
-		return br;
 	}
 
 	private StreamRecordUtils() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This is a pre-step of FLINK-16996. We refactor `BaseRow#get/setHeader` to `get/setRowKind` in this PR. And update all the existing code to send "insert/delete/update_before/update_after" messages instead of "+/-" messages. 

## Brief change log

- Update all the code to use RowKind instead of header. 
- String representation of BaseRow is `I(a, b, c)` instead of `(+|a, b, c)` now.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes, the `RowKind`
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
