### PR TITLE
[FLINK-16411][Azure] Use Maven cache in the same data center

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -50,6 +50,8 @@ jobs:
       restoreKeys: $(CACHE_FALLBACK_KEY)
       path: $(MAVEN_CACHE_FOLDER)
     continueOnError: true # continue the build even if the cache fails.
+    # do not use cache on the "Default" queue
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
     displayName: Cache Maven local repo
   - script: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_11_X64"
@@ -111,7 +113,9 @@ jobs:
       restoreKeys: $(CACHE_FALLBACK_KEY)
       path: $(MAVEN_CACHE_FOLDER)
     continueOnError: true # continue the build even if the cache fails.
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
     displayName: Cache Maven local repo
+
   - script: |
       echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_11_X64"
       echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_11_X64/bin:$PATH"

--- a/tools/ci/alibaba-mirror-settings.xml
+++ b/tools/ci/alibaba-mirror-settings.xml
@@ -1,0 +1,28 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<settings>
+  <mirrors>
+    <mirror>
+      <id>alicloud-mvn-mirror</id>
+      <name>Alibaba Maven mirror</name>
+      <url>http://mavenmirror.alicloud.dak8s.net:8888/repository/maven-central/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -14,26 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-MAVEN_VERSION="3.2.5"
-MAVEN_CACHE_DIR=${HOME}/maven_cache
-MAVEN_VERSIONED_DIR=${MAVEN_CACHE_DIR}/apache-maven-${MAVEN_VERSION}
-
-export MVN_GLOBAL_OPTIONS=""
-# see https://developercommunity.visualstudio.com/content/problem/851041/microsoft-hosted-agents-run-into-maven-central-tim.html
-MVN_GLOBAL_OPTIONS+="-Dmaven.wagon.http.pool=false "
-# use google mirror everywhere
-MVN_GLOBAL_OPTIONS+="--settings $CI_DIR/google-mirror-settings.xml "
-# logging 
-MVN_GLOBAL_OPTIONS+="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn "
-# suppress snapshot updates
-MVN_GLOBAL_OPTIONS+="--no-snapshot-updates "
-# enable non-interactive batch mode
-MVN_GLOBAL_OPTIONS+="-B "
-# globally control the build profile details
-MVN_GLOBAL_OPTIONS+="$PROFILE "
-
 # Utility for invoking Maven in CI
 function run_mvn {
 	MVN_CMD="mvn"
@@ -68,6 +48,25 @@ function setup_maven {
 	echo "Installed Maven ${MAVEN_VERSION} to ${M2_HOME}"
 }
 
+function set_mirror_config {
+	if [[ "$MAVEN_MIRROR_CONFIG_FILE" != "" ]]; then
+		echo "[WARN] Maven mirror already configured to $MAVEN_MIRROR_CONFIG_FILE"
+		exit 0;
+	fi
+
+	echo "Checking for availability of CI Maven mirror"
+	# test if alibaba mirror is available
+	curl --silent --max-time 10 http://mavenmirror.alicloud.dak8s.net:8888/repository/maven-central/ | grep "Nexus Repository Manager"
+
+	if [[ "$?" == "0" ]]; then
+		echo "Using Alibaba mirror"
+		MAVEN_MIRROR_CONFIG_FILE="$CI_DIR/alibaba-mirror-settings.xml"
+	else
+		echo "Using Google mirror"
+		MAVEN_MIRROR_CONFIG_FILE="$CI_DIR/google-mirror-settings.xml"
+	fi
+}
+
 function collect_coredumps {
 	local SEARCHDIR=$1
 	local TARGET_DIR=$2
@@ -77,3 +76,28 @@ function collect_coredumps {
 		mv $file $TARGET_DIR/
 	done
 }
+
+
+CI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+MAVEN_VERSION="3.2.5"
+MAVEN_CACHE_DIR=${HOME}/maven_cache
+MAVEN_VERSIONED_DIR=${MAVEN_CACHE_DIR}/apache-maven-${MAVEN_VERSION}
+
+
+MAVEN_MIRROR_CONFIG_FILE=""
+set_mirror_config
+
+export MVN_GLOBAL_OPTIONS=""
+# see https://developercommunity.visualstudio.com/content/problem/851041/microsoft-hosted-agents-run-into-maven-central-tim.html
+MVN_GLOBAL_OPTIONS+="-Dmaven.wagon.http.pool=false "
+# use google mirror everywhere
+MVN_GLOBAL_OPTIONS+="--settings $MAVEN_MIRROR_CONFIG_FILE "
+# logging 
+MVN_GLOBAL_OPTIONS+="-Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn "
+# suppress snapshot updates
+MVN_GLOBAL_OPTIONS+="--no-snapshot-updates "
+# enable non-interactive batch mode
+MVN_GLOBAL_OPTIONS+="-B "
+# globally control the build profile details
+MVN_GLOBAL_OPTIONS+="$PROFILE "


### PR DESCRIPTION
## What is the purpose of the change

It is a known problem (https://github.com/microsoft/azure-pipelines-tasks/issues/11864) that the Caching task in AZP is slow.
This PR is introducing a check if the mirror in the datacenter is reachable. If so, we'll use it, instead of Google's mirror.

## Verifying this change

I've triggered this also to a private AZP to validate the conditions: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=298&view=results

