### PR TITLE
[Flink-16662] [table-blink/clients]Fix the bug that the blink Planner failed to generate JobGraph when use the udf in checkpointing mode.

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/FlinkPipelineTranslationUtil.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/FlinkPipelineTranslationUtil.java
@@ -46,6 +46,23 @@ public final class FlinkPipelineTranslationUtil {
 	}
 
 	/**
+	 * Transmogrifies the given {@link Pipeline} under the userClassloader to a {@link JobGraph}.
+	 */
+	public static JobGraph getJobGraphUnderUserClassLoader(
+		final ClassLoader userClassloader,
+		final Pipeline pipeline,
+		final Configuration configuration,
+		final int defaultParallelism) {
+		final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			Thread.currentThread().setContextClassLoader(userClassloader);
+			return FlinkPipelineTranslationUtil.getJobGraph(pipeline, configuration, defaultParallelism);
+		} finally {
+			Thread.currentThread().setContextClassLoader(contextClassLoader);
+		}
+	}
+
+	/**
 	 * Extracts the execution plan (as JSON) from the given {@link Pipeline}.
 	 */
 	public static String translateToJSONExecutionPlan(Pipeline pipeline) {

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -60,8 +60,7 @@ public enum PackagedProgramUtils {
 			@Nullable JobID jobID,
 			boolean suppressOutput) throws ProgramInvocationException {
 		final Pipeline pipeline = getPipelineFromProgram(packagedProgram, configuration,  defaultParallelism, suppressOutput);
-		final JobGraph jobGraph = FlinkPipelineTranslationUtil.getJobGraph(pipeline, configuration, defaultParallelism);
-
+		final JobGraph jobGraph = FlinkPipelineTranslationUtil.getJobGraphUnderUserClassLoader(packagedProgram.getUserCodeClassLoader(), pipeline, configuration, defaultParallelism);
 		if (jobID != null) {
 			jobGraph.setJobID(jobID);
 		}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request is to fix the bug that the blink Planner failed to generate JobGraph when use the udf in checkpointing mode.  

## Brief change log
  -  Use the user classloader in PackagedProgramUtils as the thread context classloader before FlinkPipelineTranslationUtil#getJobGraph method

## Verifying this change

- Crate TableEnvironment use blink planner
- UDFs being shipped.
- Checkpointing enabled.
- Created table through a sql query that references a UDF.
- The table is converted to a retract stream.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
