### PR TITLE
[FLINK-17197][runtime] switch ContinuousFileReaderOperator state to FAILED on error

### DIFF
--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileMonitoringFunction;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
@@ -148,23 +147,6 @@ public class ContinuousFileProcessingTest {
 
 		} catch (FileNotFoundException e) {
 			Assert.assertEquals("The provided file path " + format.getFilePath() + " does not exist.", e.getMessage());
-		}
-	}
-
-	@Test(expected = ExpectedTestException.class)
-	public void testExceptionHandling() throws Exception {
-		TextInputFormat format = new TextInputFormat(new Path(hdfsURI + "/" + UUID.randomUUID() + "/")) {
-			@Override
-			public void close() {
-				throw new ExpectedTestException();
-			}
-		};
-
-		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> harness = createHarness(format);
-		harness.getExecutionConfig().setAutoWatermarkInterval(10);
-		harness.setTimeCharacteristic(TimeCharacteristic.IngestionTime);
-		try (OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> tester = harness) {
-			tester.open();
 		}
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -78,7 +78,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * </ol></p>
  * <p>Using {@link MailboxExecutor} allows to avoid explicit synchronization. At most one mail should be enqueued at any
  * given time.</p>
- * <p>Using FSM approach allows to explicitly define states and enforce {@link ReaderState#TRANSITIONS transitions} between them.</p>
+ * <p>Using FSM approach allows to explicitly define states and enforce {@link ReaderState#VALID_TRANSITIONS transitions} between them.</p>
  */
 @Internal
 class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
@@ -166,7 +166,7 @@ class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
 		/**
 		 * Possible transition FROM each state.
 		 */
-		private static final Map<ReaderState, Set<ReaderState>> TRANSITIONS;
+		private static final Map<ReaderState, Set<ReaderState>> VALID_TRANSITIONS;
 		static {
 			Map<ReaderState, Set<ReaderState>> tmpTransitions = new HashMap<>();
 			tmpTransitions.put(IDLE, EnumSet.of(OPENING, CLOSED, FAILED));
@@ -175,7 +175,7 @@ class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
 			tmpTransitions.put(CLOSING, EnumSet.of(CLOSED, FAILED));
 			tmpTransitions.put(FAILED, EnumSet.of(CLOSED));
 			tmpTransitions.put(CLOSED, EnumSet.noneOf(ReaderState.class));
-			TRANSITIONS = new EnumMap<>(tmpTransitions);
+			VALID_TRANSITIONS = new EnumMap<>(tmpTransitions);
 		}
 
 		public boolean isAcceptingSplits() {
@@ -187,7 +187,7 @@ class ContinuousFileReaderOperator<OUT> extends AbstractStreamOperator<OUT>
 		}
 
 		public boolean canSwitchTo(ReaderState next) {
-			return TRANSITIONS
+			return VALID_TRANSITIONS
 					.getOrDefault(this, EnumSet.noneOf(ReaderState.class))
 					.contains(next);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorTest.java
@@ -39,6 +39,16 @@ import static org.junit.Assert.fail;
 public class ContinuousFileReaderOperatorTest {
 
 	@Test(expected = ExpectedTestException.class)
+	public void testExceptionRethrownFromClose() throws Exception {
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> harness = createHarness(failingFormat());
+		harness.getExecutionConfig().setAutoWatermarkInterval(10);
+		harness.setTimeCharacteristic(TimeCharacteristic.IngestionTime);
+		try (OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> tester = harness) {
+			tester.open();
+		}
+	}
+
+	@Test(expected = ExpectedTestException.class)
 	public void testExceptionRethrownFromProcessElement() throws Exception {
 		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> harness = createHarness(failingFormat());
 		harness.getExecutionConfig().setAutoWatermarkInterval(10);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.mailbox.Mail;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Test;
+
+import static org.junit.Assert.fail;
+
+/**
+ * {@link ContinuousFileReaderOperator} test.
+ */
+public class ContinuousFileReaderOperatorTest {
+
+	@Test(expected = ExpectedTestException.class)
+	public void testExceptionRethrownFromProcessElement() throws Exception {
+		OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> harness = createHarness(failingFormat());
+		harness.getExecutionConfig().setAutoWatermarkInterval(10);
+		harness.setTimeCharacteristic(TimeCharacteristic.IngestionTime);
+		try (OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, String> tester = harness) {
+			tester.open();
+			tester.processElement(new StreamRecord<>(new TimestampedFileInputSplit(0L, 1, new Path(), 0L, 0L, new String[]{})));
+			for (Mail m : harness.getTaskMailbox().drain()) {
+				m.run();
+			}
+			fail("should throw from processElement");
+		}
+	}
+
+	private FileInputFormat<String> failingFormat() {
+		return new FileInputFormat<String>() {
+			@Override
+			public boolean reachedEnd() {
+				return false;
+			}
+
+			@Override
+			public String nextRecord(String reuse) {
+				throw new ExpectedTestException();
+			}
+
+			@Override
+			public void open(FileInputSplit fileSplit) {
+				throw new ExpectedTestException();
+			}
+
+			@Override
+			public void close() {
+				throw new ExpectedTestException();
+			}
+
+			@Override
+			public void configure(Configuration parameters) {
+			}
+		};
+	}
+
+	private <T> OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, T> createHarness(FileInputFormat<T> format) throws Exception {
+		ExecutionConfig config = new ExecutionConfig();
+		return new OneInputStreamOperatorTestHarness<>(
+				new ContinuousFileReaderOperatorFactory<>(format, TypeExtractor.getInputFormatTypes(format), config),
+				TypeExtractor.getForClass(TimestampedFileInputSplit.class).createSerializer(config));
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, `ContinuousFileReaderOperator` switches state to `CLOSED` on processing error.
But such a transition is illegal and leads to an exception. This exception hides the original one.
This PR introduces a new state `FAILED` for this situation, so that:
1. no processing can be done
1. it still can be disposed

## Verifying this change

Added `ContinuousFileReaderOperatorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
