### PR TITLE
[hotfix][config][docs] Deprecate taskmanager.numberOfTaskSlots in mesos_task_manager_configuration.html

### DIFF
--- a/docs/_includes/generated/mesos_task_manager_configuration.html
+++ b/docs/_includes/generated/mesos_task_manager_configuration.html
@@ -86,11 +86,5 @@
             <td>String</td>
             <td>A comma separated list of URIs of custom artifacts to be downloaded into the sandbox of Mesos workers.</td>
         </tr>
-        <tr>
-            <td><h5>taskmanager.numberOfTaskSlots</h5></td>
-            <td style="word-wrap: break-word;">1</td>
-            <td>Integer</td>
-            <td>The number of parallel operator or user function instances that a single TaskManager can run. If this value is larger than 1, a single TaskManager takes multiple instances of a function or operator. That way, the TaskManager can utilize multiple CPU cores, but at the same time, the available memory is divided between the different operator or function instances. This value is typically proportional to the number of physical CPU cores that the TaskManager's machine has (e.g., equal to the number of cores, or half the number of cores).</td>
-        </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## What is the purpose of the change

Deprecate taskmanager.numberOfTaskSlots in mesos_task_manager_configuration.html
