### PR TITLE
[FLINK-16473][doc][jdbc] add documentation for JDBCCatalog and PostgresCatalog

### DIFF
--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -49,7 +49,15 @@ The `JDBCCatalog` enables users to connect Flink to relational databases over JD
 
 `PostgresCatalog` is the only implementation of JDBC Catalog at the moment.
 
-To set a `JDBCcatalog`,
+#### Usage of JDBCCatalog
+
+Set a `JDBCatalog` with the following parameters:
+
+- name: required, name of the catalog
+- default database: required, default database to connect to
+- username: required, username of Postgres account
+- password: required, password of the account
+- base url: required, should be of format "jdbc:postgresql://<ip>:<port>", and should not contain database name here
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java" markdown="1">
@@ -62,7 +70,7 @@ String name            = "mypg";
 String defaultDatabase = "mydb";
 String username        = "...";
 String password        = "...";
-String baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+String baseUrl         = "..."
 
 JDBCCatalog catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
 tableEnv.registerCatalog("mypg", catalog);
@@ -77,17 +85,17 @@ tableEnv.useCatalog("mypg");
 val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
 val tableEnv = TableEnvironment.create(settings)
 
-val name            = "mypg";
-val defaultDatabase = "mydb";
-val username        = "...";
-val password        = "...";
-val baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+val name            = "mypg"
+val defaultDatabase = "mydb"
+val username        = "..."
+val password        = "..."
+val baseUrl         = "..."
 
-val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
-tableEnv.registerCatalog("mypg", catalog);
+val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl)
+tableEnv.registerCatalog("mypg", catalog)
 
 // set the JDBCCatalog as the current catalog of the session
-tableEnv.useCatalog("mypg");
+tableEnv.useCatalog("mypg")
 {% endhighlight %}
 </div>
 <div data-lang="YAML" markdown="1">
@@ -105,7 +113,20 @@ catalogs:
      default-database: mydb
      username: ...
      password: ...
-     base-url: jdbc:postgresql://<ip>:<port>
+     base-url: ...
+{% endhighlight %}
+</div>
+<div data-lang="DDL" markdown="1">
+{% highlight sql %}
+CREATE CATALOG mypg WITH(
+    'type'='jdbc',
+    'default-database'='...',
+    'username'='...',
+    'password'='...',
+    'base-url'='...'
+);
+
+USE CATALOG mypg;
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -98,6 +98,19 @@ tableEnv.registerCatalog("mypg", catalog)
 tableEnv.useCatalog("mypg")
 {% endhighlight %}
 </div>
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+CREATE CATALOG mypg WITH(
+    'type'='jdbc',
+    'default-database'='...',
+    'username'='...',
+    'password'='...',
+    'base-url'='...'
+);
+
+USE CATALOG mypg;
+{% endhighlight %}
+</div>
 <div data-lang="YAML" markdown="1">
 {% highlight yaml %}
 
@@ -114,19 +127,6 @@ catalogs:
      username: ...
      password: ...
      base-url: ...
-{% endhighlight %}
-</div>
-<div data-lang="DDL" markdown="1">
-{% highlight sql %}
-CREATE CATALOG mypg WITH(
-    'type'='jdbc',
-    'default-database'='...',
-    'username'='...',
-    'password'='...',
-    'base-url'='...'
-);
-
-USE CATALOG mypg;
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/catalogs.md
+++ b/docs/dev/table/catalogs.md
@@ -28,6 +28,10 @@ One of the most crucial aspects of data processing is managing metadata.
 It may be transient metadata like temporary tables, or UDFs registered against the table environment.
 Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified API for managing metadata and making it accessible from the Table API and SQL Queries. 
 
+Catalog enables users to reference existing metadata in their data systems, and automatically maps them to Flink's corresponding metadata. 
+For example, Flink can map JDBC tables to Flink table automatically, and users don't have to manually re-writing DDLs in Flink.
+Catalog greatly simplifies steps required to get started with Flink with users' existing system, and greatly enhanced user experiences.
+
 * This will be replaced by the TOC
 {:toc}
 
@@ -36,6 +40,76 @@ Or permanent metadata, like that in a Hive Metastore. Catalogs provide a unified
 ### GenericInMemoryCatalog
 
 The `GenericInMemoryCatalog` is an in-memory implementation of a catalog. All objects will be available only for the lifetime of the session.
+
+### JDBCCatalog
+
+The `JDBCCatalog` enables users to connect Flink to relational databases over JDBC protocol.
+
+#### PostgresCatalog
+
+`PostgresCatalog` is the only implementation of JDBC Catalog at the moment.
+
+To set a `JDBCcatalog`,
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+
+EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+String name            = "mypg";
+String defaultDatabase = "mydb";
+String username        = "...";
+String password        = "...";
+String baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+
+JDBCCatalog catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
+tableEnv.registerCatalog("mypg", catalog);
+
+// set the JDBCCatalog as the current catalog of the session
+tableEnv.useCatalog("mypg");
+{% endhighlight %}
+</div>
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+
+val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val tableEnv = TableEnvironment.create(settings)
+
+val name            = "mypg";
+val defaultDatabase = "mydb";
+val username        = "...";
+val password        = "...";
+val baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+
+val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
+tableEnv.registerCatalog("mypg", catalog);
+
+// set the JDBCCatalog as the current catalog of the session
+tableEnv.useCatalog("mypg");
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+{% highlight yaml %}
+
+execution:
+    planner: blink
+    ...
+    current-catalog: mypg  # set the JDBCCatalog as the current catalog of the session
+    current-database: mydb
+    
+catalogs:
+   - name: mypg
+     type: jdbc
+     default-database: mydb
+     username: ...
+     password: ...
+     base-url: jdbc:postgresql://<ip>:<port>
+{% endhighlight %}
+</div>
+</div>
+
 
 ### HiveCatalog
 

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -37,6 +37,76 @@ Catalog 提供了元数据信息，例如数据库、表、分区、视图以及
 
 `GenericInMemoryCatalog` 是基于内存实现的 Catalog，所有元数据只在 session 的生命周期内可用。
 
+### JDBCCatalog
+
+The `JDBCCatalog` enables users to connect Flink to relational databases over JDBC protocol.
+
+#### PostgresCatalog
+
+`PostgresCatalog` is the only implementation of JDBC Catalog at the moment.
+
+To set a `JDBCcatalog`,
+
+<div class="codetabs" markdown="1">
+<div data-lang="Java" markdown="1">
+{% highlight java %}
+
+EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+String name            = "mypg";
+String defaultDatabase = "mydb";
+String username        = "...";
+String password        = "...";
+String baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+
+JDBCCatalog catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
+tableEnv.registerCatalog("mypg", catalog);
+
+// set the JDBCCatalog as the current catalog of the session
+tableEnv.useCatalog("mypg");
+{% endhighlight %}
+</div>
+<div data-lang="Scala" markdown="1">
+{% highlight scala %}
+
+val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
+val tableEnv = TableEnvironment.create(settings)
+
+val name            = "mypg";
+val defaultDatabase = "mydb";
+val username        = "...";
+val password        = "...";
+val baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+
+val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
+tableEnv.registerCatalog("mypg", catalog);
+
+// set the JDBCCatalog as the current catalog of the session
+tableEnv.useCatalog("mypg");
+{% endhighlight %}
+</div>
+<div data-lang="YAML" markdown="1">
+{% highlight yaml %}
+
+execution:
+    planner: blink
+    ...
+    current-catalog: mypg  # set the JDBCCatalog as the current catalog of the session
+    current-database: mydb
+    
+catalogs:
+   - name: mypg
+     type: jdbc
+     default-database: mydb
+     username: ...
+     password: ...
+     base-url: jdbc:postgresql://<ip>:<port>
+{% endhighlight %}
+</div>
+</div>
+
+
 ### HiveCatalog
 
 `HiveCatalog` 有两个用途：作为原生 Flink 元数据的持久化存储，以及作为读写现有 Hive 元数据的接口。 

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -45,7 +45,15 @@ The `JDBCCatalog` enables users to connect Flink to relational databases over JD
 
 `PostgresCatalog` is the only implementation of JDBC Catalog at the moment.
 
-To set a `JDBCcatalog`,
+#### Usage of JDBCCatalog
+
+Set a `JDBCatalog` with the following parameters:
+
+- name: required, name of the catalog
+- default database: required, default database to connect to
+- username: required, username of Postgres account
+- password: required, password of the account
+- base url: required, should be of format "jdbc:postgresql://<ip>:<port>", and should not contain database name here
 
 <div class="codetabs" markdown="1">
 <div data-lang="Java" markdown="1">
@@ -58,7 +66,7 @@ String name            = "mypg";
 String defaultDatabase = "mydb";
 String username        = "...";
 String password        = "...";
-String baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+String baseUrl         = "..."
 
 JDBCCatalog catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
 tableEnv.registerCatalog("mypg", catalog);
@@ -73,17 +81,17 @@ tableEnv.useCatalog("mypg");
 val settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build()
 val tableEnv = TableEnvironment.create(settings)
 
-val name            = "mypg";
-val defaultDatabase = "mydb";
-val username        = "...";
-val password        = "...";
-val baseUrl         = "jdbc:postgresql://<ip>:<port>"; # should not contain database name here
+val name            = "mypg"
+val defaultDatabase = "mydb"
+val username        = "..."
+val password        = "..."
+val baseUrl         = "..."
 
-val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl);
-tableEnv.registerCatalog("mypg", catalog);
+val catalog = new JDBCCatalog(name, defaultDatabase, username, password, baseUrl)
+tableEnv.registerCatalog("mypg", catalog)
 
 // set the JDBCCatalog as the current catalog of the session
-tableEnv.useCatalog("mypg");
+tableEnv.useCatalog("mypg")
 {% endhighlight %}
 </div>
 <div data-lang="YAML" markdown="1">
@@ -101,7 +109,20 @@ catalogs:
      default-database: mydb
      username: ...
      password: ...
-     base-url: jdbc:postgresql://<ip>:<port>
+     base-url: ...
+{% endhighlight %}
+</div>
+<div data-lang="DDL" markdown="1">
+{% highlight sql %}
+CREATE CATALOG mypg WITH(
+    'type'='jdbc',
+    'default-database'='...',
+    'username'='...',
+    'password'='...',
+    'base-url'='...'
+);
+
+USE CATALOG mypg;
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/catalogs.zh.md
+++ b/docs/dev/table/catalogs.zh.md
@@ -94,6 +94,19 @@ tableEnv.registerCatalog("mypg", catalog)
 tableEnv.useCatalog("mypg")
 {% endhighlight %}
 </div>
+<div data-lang="SQL" markdown="1">
+{% highlight sql %}
+CREATE CATALOG mypg WITH(
+    'type'='jdbc',
+    'default-database'='...',
+    'username'='...',
+    'password'='...',
+    'base-url'='...'
+);
+
+USE CATALOG mypg;
+{% endhighlight %}
+</div>
 <div data-lang="YAML" markdown="1">
 {% highlight yaml %}
 
@@ -110,19 +123,6 @@ catalogs:
      username: ...
      password: ...
      base-url: ...
-{% endhighlight %}
-</div>
-<div data-lang="DDL" markdown="1">
-{% highlight sql %}
-CREATE CATALOG mypg WITH(
-    'type'='jdbc',
-    'default-database'='...',
-    'username'='...',
-    'password'='...',
-    'base-url'='...'
-);
-
-USE CATALOG mypg;
 {% endhighlight %}
 </div>
 </div>

--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1256,6 +1256,10 @@ To use JDBC connector, need to choose an actual driver to use. Here are drivers 
 | PostgreSQL  |   org.postgresql   |      postgresql      | [Download](https://jdbc.postgresql.org/download.html) |
 | Derby       |  org.apache.derby  |        derby         | [Download](http://db.apache.org/derby/derby_downloads.html) |
 
+**Catalog**
+
+JDBC Connector can be used together with [`JDBCCatalog`]({{ site.baseurl }}/dev/table/catalogs.html#jdbccatalog) to greatly simplify development effort and improve user experience.
+
 <br/>
 
 The connector can be defined as follows:

--- a/docs/dev/table/connect.zh.md
+++ b/docs/dev/table/connect.zh.md
@@ -1256,6 +1256,10 @@ To use JDBC connector, need to choose an actual driver to use. Here are drivers 
 | PostgreSQL  |   org.postgresql   |      postgresql      | [Download](https://jdbc.postgresql.org/download.html) |
 | Derby       |  org.apache.derby  |        derby         | [Download](http://db.apache.org/derby/derby_downloads.html) |
 
+**Catalog**
+
+JDBC Connector can be used together with [`JDBCCatalog`]({{ site.baseurl }}/dev/table/catalogs.html#jdbccatalog) to greatly simplify development effort and improve user experience.
+
 <br/>
 
 The connector can be defined as follows:


### PR DESCRIPTION
## What is the purpose of the change

add documentation for JDBCCatalog and PostgresCatalog

## Brief change log

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
