### PR TITLE
[FLINK-17223][AZP] Clean up disk space on Azure-hosted builders

### DIFF
--- a/tools/azure-pipelines/jobs-template.yml
+++ b/tools/azure-pipelines/jobs-template.yml
@@ -35,6 +35,11 @@ jobs:
     # See also https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#workspace 
 
   steps:
+  # if on Azure, free up disk space
+  - script: ./tools/azure-pipelines/free_disk_space.sh
+    target: host
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Free up disk space
   # The cache task is persisting the .m2 directory between builds, so that
   # we do not have to re-download all dependencies from maven central for 
   # each build. The hope is that downloading the cache is faster than
@@ -100,6 +105,11 @@ jobs:
       misc:
         module: misc
   steps:
+  # if on Azure, free up disk space
+  - script: ./tools/azure-pipelines/free_disk_space.sh
+    target: host
+    condition: not(eq('${{parameters.test_pool_definition.name}}', 'Default'))
+    displayName: Free up disk space
 
   # download artifacts
   - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## What is the purpose of the change

Due to a recent change in the machines provided by Azure, the available disk space has reduced on these machines (https://github.com/actions/virtual-environments/issues/709).
This has caused some of our build profiles to run out of disk space.

## Brief change log

- Add a conditional step, executed on the host (not within the container) that cleans up the disk space on azure provided machines.

## Verifying this change

This change has been tested here: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=302&view=results