### PR TITLE
[FLINK-17253] Support viewfs for hadoop version < 2.7

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriter.java
@@ -57,7 +57,7 @@ public class HadoopRecoverableWriter implements RecoverableWriter {
 		this.fs = checkNotNull(fs);
 
 		// This writer is only supported on a subset of file systems
-		if (!"hdfs".equalsIgnoreCase(fs.getScheme())) {
+		if (!("hdfs".equalsIgnoreCase(fs.getScheme()) || "viewfs".equalsIgnoreCase(fs.getScheme()))) {
 			throw new UnsupportedOperationException(
 					"Recoverable writers on Hadoop are only supported for HDFS");
 		}

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest.java
@@ -34,6 +34,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -44,6 +45,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for the {@link HadoopRecoverableWriter} with Hadoop versions pre Hadoop 2.7.
@@ -139,6 +141,14 @@ public class HadoopRecoverableWriterOldHadoopWithNoTruncateSupportTest {
 			// this is the expected exception and we check also if the root cause is the hadoop < 2.7 version
 			assertTrue(e.getCause() instanceof IllegalStateException);
 		}
+	}
+
+	@Test
+	public void testRecoverableWriterWithViewfsScheme() {
+		final org.apache.hadoop.fs.FileSystem mockViewfs = Mockito.mock(org.apache.hadoop.fs.FileSystem.class);
+		when(mockViewfs.getScheme()).thenReturn("viewfs");
+		// Creating the writer should not throw UnsupportedOperationException.
+		RecoverableWriter recoverableWriter = new HadoopRecoverableWriter(mockViewfs);
 	}
 
 	private RecoverableFsDataOutputStream getOpenStreamToFileWithContent(


### PR DESCRIPTION
## What is the purpose of the change

[[FLINK-14170]](https://issues.apache.org/jira/browse/FLINK-14170) introduced Hadoop version check to support older hadoop versions. However the check only included "hdfs" scheme but not "viewfs".
We are using StreamingFileSink to write data to our federated cluster and we are using cdh-2.6 hadoop version and we are hit with exception:

java.lang.UnsupportedOperationException: Recoverable writers on Hadoop are only supported for HDFS and for Hadoop version 2.7 or newer
	
## Brief change log

Removed the hadoop < 2.7 version check if scheme is viewfs in HadoopRecoverableWriter

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 