### PR TITLE
[FLINK-16763][python][doc] Replace BatchTableEnvironment with StreamTableEnvironment for Python UDF examples

### DIFF
--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -146,7 +146,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-table_env = BatchTableEnvironment.create(env)
+table_env = StreamTableEnvironment.create(env)
 
 # register the Python function
 table_env.register_function("hash_code", udf(HashCode(), DataTypes.BIGINT(), DataTypes.BIGINT()))

--- a/docs/dev/table/functions/udfs.md
+++ b/docs/dev/table/functions/udfs.md
@@ -146,6 +146,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
+# use StreamTableEnvironment since Python UDF is not supported in the old planner under batch mode
 table_env = StreamTableEnvironment.create(env)
 
 # register the Python function

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -146,7 +146,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-table_env = BatchTableEnvironment.create(env)
+table_env = StreamTableEnvironment.create(env)
 
 # register the Python function
 table_env.register_function("hash_code", udf(HashCode(), DataTypes.BIGINT(), DataTypes.BIGINT()))

--- a/docs/dev/table/functions/udfs.zh.md
+++ b/docs/dev/table/functions/udfs.zh.md
@@ -146,6 +146,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
+# use StreamTableEnvironment since Python UDF is not supported in the old planner under batch mode
 table_env = StreamTableEnvironment.create(env)
 
 # register the Python function

--- a/docs/dev/table/python/python_udfs.md
+++ b/docs/dev/table/python/python_udfs.md
@@ -44,7 +44,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-table_env = BatchTableEnvironment.create(env)
+table_env = StreamTableEnvironment.create(env)
 
 # register the Python function
 table_env.register_function("hash_code", udf(HashCode(), DataTypes.BIGINT(), DataTypes.BIGINT()))

--- a/docs/dev/table/python/python_udfs.md
+++ b/docs/dev/table/python/python_udfs.md
@@ -44,6 +44,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
+# use StreamTableEnvironment since Python UDF is not supported in the old planner under batch mode
 table_env = StreamTableEnvironment.create(env)
 
 # register the Python function

--- a/docs/dev/table/python/python_udfs.zh.md
+++ b/docs/dev/table/python/python_udfs.zh.md
@@ -44,7 +44,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
-table_env = BatchTableEnvironment.create(env)
+table_env = StreamTableEnvironment.create(env)
 
 # register the Python function
 table_env.register_function("hash_code", udf(HashCode(), DataTypes.BIGINT(), DataTypes.BIGINT()))

--- a/docs/dev/table/python/python_udfs.zh.md
+++ b/docs/dev/table/python/python_udfs.zh.md
@@ -44,6 +44,7 @@ class HashCode(ScalarFunction):
   def eval(self, s):
     return hash(s) * self.factor
 
+# use StreamTableEnvironment since Python UDF is not supported in the old planner under batch mode
 table_env = StreamTableEnvironment.create(env)
 
 # register the Python function


### PR DESCRIPTION

## What is the purpose of the change

Replace BatchTableEnvironment with StreamTableEnvironment for Python UDF examples since for flink-1.10, Python UDF is not supported in old planner under batch mode.

## Brief change log

  - Replace BatchTableEnvironment with StreamTableEnvironment for Python UDF examples in the document


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
