### PR TITLE
[FLINK-17257][yarn][test] Fix AbstractYarnClusterTest not compiling with hadoop 2.10.

### DIFF
--- a/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/AbstractYarnClusterTest.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.impl.YarnClientImpl;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.util.Records;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -82,26 +83,21 @@ public class AbstractYarnClusterTest extends TestLogger {
 		ApplicationId applicationId,
 		YarnApplicationState yarnApplicationState,
 		FinalApplicationStatus finalApplicationStatus) {
-		return ApplicationReport.newInstance(
-			applicationId,
-			ApplicationAttemptId.newInstance(applicationId, 0),
-			"user",
-			"queue",
-			"name",
-			"localhost",
-			42,
-			null,
-			yarnApplicationState,
-			null,
-			null,
-			1L,
-			2L,
-			finalApplicationStatus,
-			null,
-			null,
-			1.0f,
-			null,
-			null);
+
+		ApplicationReport applicationReport = Records.newRecord(ApplicationReport.class);
+		applicationReport.setApplicationId(applicationId);
+		applicationReport.setCurrentApplicationAttemptId(ApplicationAttemptId.newInstance(applicationId, 0));
+		applicationReport.setUser("user");
+		applicationReport.setQueue("queue");
+		applicationReport.setName("name");
+		applicationReport.setHost("localhost");
+		applicationReport.setRpcPort(42);
+		applicationReport.setYarnApplicationState(yarnApplicationState);
+		applicationReport.setStartTime(1L);
+		applicationReport.setFinishTime(2L);
+		applicationReport.setFinalApplicationStatus(finalApplicationStatus);
+		applicationReport.setProgress(1.0f);
+		return applicationReport;
 	}
 
 	private static final class TestingYarnClient extends YarnClientImpl {


### PR DESCRIPTION
## What is the purpose of the change

In AbstractYarnClusterTest, we create ApplicationReport with the static method ApplicationReport.newInstance, which is annotated as private and unstable. This method is no longer compatible in Hadoop 2.10.

As a workaround, we can create ApplicationReport with its default constructor and set only the fields that we need.

## Verifying this change

This is a pure testing change which does not affect the production codes. Manually tested with Hadoop 2.4, 2.8, 2.10 and 3.2.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
