### PR TITLE
[hotfix][docs] svg figure has overlapping text

### DIFF
--- a/docs/fig/program_dataflow.svg
+++ b/docs/fig/program_dataflow.svg
@@ -1,34 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   version="1.1"
-   width="632.86151"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="1.0beta1 (d565813, 2019-09-28)"
+   sodipodi:docname="program_dataflow.svg"
+   id="svg2"
    height="495.70895"
-   id="svg2">
+   width="632.86151"
+   version="1.1">
+  <sodipodi:namedview
+     inkscape:current-layer="g2989"
+     inkscape:window-maximized="0"
+     inkscape:window-y="23"
+     inkscape:window-x="0"
+     inkscape:cy="149.91695"
+     inkscape:cx="371.40705"
+     inkscape:zoom="1.3289991"
+     showgrid="false"
+     id="namedview104"
+     inkscape:window-height="1441"
+     inkscape:window-width="1936"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     inkscape:document-rotation="0"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
   <defs
      id="defs4" />
   <metadata
@@ -39,508 +44,525 @@ under the License.
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-89.288343,-87.370121)"
-     id="layer1">
-    <g
-       transform="translate(65.132093,66.963871)"
-       id="g2989">
-      <text
-         x="571.35248"
-         y="45.804131"
-         id="text2991"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Source</text>
-      <text
-         x="25.304533"
-         y="37.765511"
-         id="text2993"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">DataStream</text>
-      <text
-         x="107.97513"
-         y="37.765511"
-         id="text2995"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&lt;</text>
-      <text
-         x="116.22718"
-         y="37.765511"
-         id="text2997"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#5b9bd5;font-family:Courier New">String</text>
-      <text
-         x="166.0396"
-         y="37.765511"
-         id="text2999"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&gt; </text>
-      <text
-         x="182.69376"
-         y="37.765511"
-         id="text3001"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">lines = </text>
-      <text
-         x="248.86023"
-         y="37.765511"
-         id="text3003"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">env.</text>
-      <text
-         x="282.01849"
-         y="37.765511"
-         id="text3005"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">addSource</text>
-      <text
-         x="356.58704"
-         y="37.765511"
-         id="text3007"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(</text>
-      <text
-         x="282.01849"
-         y="54.269619"
-         id="text3009"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#2f5597;font-family:Courier New">new</text>
-      <text
-         x="315.17673"
-         y="54.269619"
-         id="text3011"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">FlinkKafkaConsumer</text>
-      <text
-         x="464.3139"
-         y="54.269619"
-         id="text3013"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&lt;&gt;(…));</text>
-      <text
-         x="25.304533"
-         y="87.277847"
-         id="text3015"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">DataStream</text>
-      <text
-         x="107.97513"
-         y="87.277847"
-         id="text3017"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&lt;</text>
-      <text
-         x="116.22718"
-         y="87.277847"
-         id="text3019"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#5b9bd5;font-family:Courier New">Event</text>
-      <text
-         x="157.78754"
-         y="87.277847"
-         id="text3021"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&gt; events = </text>
-      <text
-         x="248.86023"
-         y="87.277847"
-         id="text3023"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">lines.</text>
-      <text
-         x="298.52261"
-         y="87.277847"
-         id="text3025"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">map</text>
-      <text
-         x="323.57883"
-         y="87.277847"
-         id="text3027"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">((line) </text>
-      <text
-         x="389.7453"
-         y="87.277847"
-         id="text3029"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#2f5597;font-family:Courier New">-</text>
-      <text
-         x="397.99738"
-         y="87.277847"
-         id="text3031"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#2f5597;font-family:Courier New">&gt;</text>
-      <text
-         x="414.50146"
-         y="87.277847"
-         id="text3033"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">parse</text>
-      <text
-         x="456.06183"
-         y="87.277847"
-         id="text3035"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(line));</text>
-      <text
-         x="25.304533"
-         y="120.28607"
-         id="text3037"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">DataStream</text>
-      <text
-         x="107.97513"
-         y="120.28607"
-         id="text3039"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&lt;</text>
-      <text
-         x="116.22718"
-         y="120.28607"
-         id="text3041"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#5b9bd5;font-family:Courier New">Statistics</text>
-      <text
-         x="199.19786"
-         y="120.28607"
-         id="text3043"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">&gt; stats = events</text>
-      <text
-         x="91.471016"
-         y="136.79018"
-         id="text3045"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">.</text>
-      <text
-         x="99.723068"
-         y="136.79018"
-         id="text3047"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">keyBy</text>
-      <text
-         x="141.13339"
-         y="136.79018"
-         id="text3049"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(</text>
-      <text
-         x="149.38544"
-         y="136.79018"
-         id="text3051"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#548235;font-family:Courier New">&quot;id&quot;</text>
-      <text
-         x="182.69376"
-         y="136.79018"
-         id="text3053"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">)</text>
-      <text
-         x="91.471016"
-         y="153.2943"
-         id="text3055"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">.</text>
-      <text
-         x="99.723068"
-         y="153.2943"
-         id="text3057"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">timeWindow</text>
-      <text
-         x="182.69376"
-         y="153.2943"
-         id="text3059"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(</text>
-      <text
-         x="190.94582"
-         y="153.2943"
-         id="text3061"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">Time.seconds</text>
-      <text
-         x="290.27054"
-         y="153.2943"
-         id="text3063"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(10))</text>
-      <text
-         x="91.471016"
-         y="169.79842"
-         id="text3065"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">.</text>
-      <text
-         x="99.723068"
-         y="169.79842"
-         id="text3067"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">apply</text>
-      <text
-         x="141.13339"
-         y="169.79842"
-         id="text3069"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(</text>
-      <text
-         x="149.38544"
-         y="169.79842"
-         id="text3071"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#2f5597;font-family:Courier New">new</text>
-      <text
-         x="182.69376"
-         y="169.79842"
-         id="text3073"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">MyWindowAggregationFunction</text>
-      <text
-         x="406.24942"
-         y="169.79842"
-         id="text3075"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">());</text>
-      <text
-         x="25.304533"
-         y="202.80663"
-         id="text3077"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">stats.</text>
-      <text
-         x="74.816864"
-         y="202.80663"
-         id="text3079"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#843c0c;font-family:Courier New">addSink</text>
-      <text
-         x="132.88133"
-         y="202.80663"
-         id="text3081"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(</text>
-      <text
-         x="141.13339"
-         y="202.80663"
-         id="text3083"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:bold;text-align:start;text-anchor:start;fill:#2f5597;font-family:Courier New">new</text>
-      <text
-         x="174.4417"
-         y="202.80663"
-         id="text3085"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">BucketingSink</text>
-      <text
-         x="265.36435"
-         y="202.80663"
-         id="text3087"
-         xml:space="preserve"
-         style="font-size:13.80343914px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Courier New">(path));</text>
-      <path
-         d="m 32.445583,379.40702 c 0,-17.70441 14.309815,-32.05174 31.957962,-32.05174 17.648146,0 31.957961,14.34733 31.957961,32.05174 0,17.68566 -14.309815,32.03298 -31.957961,32.03298 -17.648147,0 -31.957962,-14.34732 -31.957962,-32.03298"
-         id="path3089"
-         style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <text
-         x="46.974251"
-         y="383.34982"
-         id="text3091"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Source</text>
-      <path
-         d="m 170.44246,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.05174,14.34733 32.05174,32.05174 0,17.68566 -14.34733,32.03298 -32.05174,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
-         id="path3093"
-         style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <text
-         x="187.06161"
-         y="383.34982"
-         id="text3095"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">map()</text>
-      <path
-         d="m 104.1822,375.18722 50.16875,0 0,-4.2198 8.43961,8.4396 -8.43961,8.4396 0,-4.2198 -50.16875,0 z"
-         id="path3097"
-         style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 532.55767,21.023988 c 4.93248,0 8.90847,0.675168 8.90847,1.500373 l 0,17.49811 c 0,0.825205 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 l 0,17.516864 c 0,0.806451 -3.97599,1.481619 -8.90847,1.481619"
-         id="path3099"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 532.55767,70.573832 c 4.93248,0 8.90847,0.675168 8.90847,1.481619 l 0,9.771184 c 0,0.825206 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 l 0,9.771185 c 0,0.825205 -3.97599,1.481619 -8.90847,1.481619"
-         id="path3101"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 532.08881,104.65107 c 4.93248,0 8.90847,0.65641 8.90847,1.48162 l 0,33.83343 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.67517 -8.90847,1.48162 l 0,33.85218 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
-         id="path3103"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 532.08881,188.2594 c 4.93248,0 8.90847,0.67517 8.90847,1.48162 l 0,9.62115 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.65641 -8.90847,1.48161 l 0,9.62115 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
-         id="path3105"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <text
-         x="571.35248"
-         y="86.226501"
-         id="text3107"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Transformation</text>
-      <text
-         x="571.35248"
-         y="145.72234"
-         id="text3109"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Transformation</text>
-      <text
-         x="94.209488"
-         y="313.34818"
-         id="text3111"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Source</text>
-      <text
-         x="88.508072"
-         y="326.85153"
-         id="text3113"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Operator</text>
-      <path
-         d="m 242.17908,375.18722 50.16875,0 0,-4.2198 8.4396,8.4396 -8.4396,8.4396 0,-4.2198 -50.16875,0 z"
-         id="path3115"
-         style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 308.43934,379.40702 c 0,-17.70441 14.34732,-32.05174 32.05173,-32.05174 17.68566,0 32.03299,14.34733 32.03299,32.05174 0,17.68566 -14.34733,32.03298 -32.03299,32.03298 -17.70441,0 -32.05173,-14.34732 -32.05173,-32.03298"
-         id="path3117"
-         style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <text
-         x="318.24503"
-         y="371.34683"
-         id="text3119"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">keyBy</text>
-      <text
-         x="349.15274"
-         y="371.34683"
-         id="text3121"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">()/</text>
-      <text
-         x="314.79416"
-         y="383.34982"
-         id="text3123"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">window()/</text>
-      <text
-         x="322.29605"
-         y="395.35281"
-         id="text3125"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">apply()</text>
-      <path
-         d="m 380.17596,375.18722 50.16875,0 0,-4.2198 8.4396,8.4396 -8.4396,8.4396 0,-4.2198 -50.16875,0 z"
-         id="path3127"
-         style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 446.45497,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.03298,14.34733 32.03298,32.05174 0,17.68566 -14.32857,32.03298 -32.03298,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
-         id="path3129"
-         style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <text
-         x="467.4761"
-         y="383.34982"
-         id="text3131"
-         xml:space="preserve"
-         style="font-size:10.05250454px;font-style:normal;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Sink</text>
-      <path
-         d="m 240.45365,250.46865 17.01049,0 0,-16.2603 33.98347,0 0,16.2603 16.99173,0 -33.98347,16.24154 z"
-         id="path3133"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <text
-         x="227.00369"
-         y="313.34818"
-         id="text3135"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Transformation</text>
-      <text
-         x="242.00743"
-         y="326.85153"
-         id="text3137"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Operators</text>
-      <text
-         x="438.99158"
-         y="313.34818"
-         id="text3139"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Sink</text>
-      <text
-         x="426.08835"
-         y="326.85153"
-         id="text3141"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Operator</text>
-      <path
-         d="m 451.65002,333.72064 5.6264,8.21454 -1.03151,0.69393 -5.6264,-8.19579 1.03151,-0.71268 z m 6.4516,6.11402 0.76895,5.53263 -4.89497,-2.70067 4.12602,-2.83196 z"
-         id="path3143"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 89.591069,331.58261 -4.688668,8.04575 1.069017,0.63766 4.688668,-8.06451 -1.069017,-0.6189 z m -5.682665,6.02025 -0.356339,5.58889 4.669913,-3.07577 -4.313574,-2.51312 z"
-         id="path3145"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 234.03956,329.40706 -12.92197,12.80944 0.88147,0.88147 12.92196,-12.79068 -0.88146,-0.90023 z m -13.35333,10.59639 -1.80045,5.28882 5.32633,-1.74418 -3.52588,-3.54464 z"
-         id="path3147"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 301.21879,329.40706 15.51012,14.72242 -0.86272,0.90023 -15.51011,-14.72242 0.86271,-0.90023 z m 15.88521,12.49062 1.91298,5.27006 -5.34509,-1.63166 3.43211,-3.6384 z"
-         id="path3149"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 241.72897,447.91784 -87.19047,-54.5761 0.65641,-1.06902 87.20923,54.5761 -0.67517,1.06902 z m -87.13421,-52.32554 -2.90697,-4.78244 5.57014,0.54389 -2.66317,4.23855 z"
-         id="path3151"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <text
-         x="245.67148"
-         y="463.08081"
-         id="text3153"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Stream</text>
-      <path
-         d="m 291.37259,447.9741 102.90688,-49.34354 -0.54388,-1.12528 -102.90689,49.34354 0.54389,1.12528 z m 102.58806,-47.11174 3.41335,-4.4261 -5.5889,-0.0938 2.17555,4.51987 z"
-         id="path3155"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 270.77996,440.92234 0,-39.79741 -1.25656,0 0,39.79741 1.25656,0 z m 1.87547,-38.54085 -2.49438,-5.00749 -2.51312,5.00749 5.0075,0 z"
-         id="path3157"
-         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.01875467px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1;stroke-dasharray:none" />
-      <text
-         x="571.35248"
-         y="205.12807"
-         id="text3159"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Sink</text>
-      <path
-         d="m 516.93503,463.33418 c 0,8.15828 -1.10652,14.75993 -2.45686,14.75993 l -241.14758,0 c -1.36909,0 -2.47561,6.62039 -2.47561,14.77868 0,-8.15829 -1.08777,-14.77868 -2.45687,-14.77868 l -241.147571,0 c -1.369091,0 -2.475617,-6.60165 -2.475617,-14.75993"
-         id="path3161"
-         style="fill:none;stroke:#000000;stroke-width:1.25656307px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <text
-         x="214.03168"
-         y="513.79102"
-         id="text3163"
-         xml:space="preserve"
-         style="font-size:11.2528038px;font-style:italic;font-weight:normal;text-align:start;text-anchor:start;fill:#000000;font-family:Verdana">Streaming Dataflow</text>
-      <text
+     transform="translate(-24.15625,-20.40625)"
+     id="g2989"
+     style="opacity:1;stop-opacity:1">
+    <text
+       x="571.35248"
+       y="45.804131"
+       id="text2991"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <text
+       x="25.304533"
+       y="37.765511"
+       id="text2993"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="37.765511"
+       id="text2995"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="37.765511"
+       id="text2997"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">String</text>
+    <text
+       x="166.0396"
+       y="37.765511"
+       id="text2999"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; </text>
+    <text
+       x="182.69376"
+       y="37.765511"
+       id="text3001"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">lines = </text>
+    <text
+       x="248.86023"
+       y="37.765511"
+       id="text3003"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">env.</text>
+    <text
+       x="282.01849"
+       y="37.765511"
+       id="text3005"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">addSource</text>
+    <text
+       x="356.58704"
+       y="37.765511"
+       id="text3007"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="282.01849"
+       y="54.269619"
+       id="text3009"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="315.17673"
+       y="54.269619"
+       id="text3011"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">FlinkKafkaConsumer</text>
+    <text
+       x="464.3139"
+       y="54.269619"
+       id="text3013"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;&gt;(…));</text>
+    <text
+       x="25.304533"
+       y="87.277847"
+       id="text3015"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="87.277847"
+       id="text3017"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="87.277847"
+       id="text3019"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">Event</text>
+    <text
+       x="157.78754"
+       y="87.277847"
+       id="text3021"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; events = </text>
+    <text
+       x="248.86023"
+       y="87.277847"
+       id="text3023"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">lines.</text>
+    <text
+       x="298.52261"
+       y="87.277847"
+       id="text3025"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">map</text>
+    <text
+       x="323.57883"
+       y="87.277847"
+       id="text3027"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">((line) </text>
+    <text
+       x="389.7453"
+       y="87.277847"
+       id="text3029"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">-</text>
+    <text
+       x="397.99738"
+       y="87.277847"
+       id="text3031"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">&gt;</text>
+    <text
+       x="414.50146"
+       y="87.277847"
+       id="text3033"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">parse</text>
+    <text
+       x="456.06183"
+       y="87.277847"
+       id="text3035"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(line));</text>
+    <text
+       x="25.304533"
+       y="120.28607"
+       id="text3037"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">DataStream</text>
+    <text
+       x="107.97513"
+       y="120.28607"
+       id="text3039"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&lt;</text>
+    <text
+       x="116.22718"
+       y="120.28607"
+       id="text3041"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#5b9bd5">Statistics</text>
+    <text
+       x="199.19786"
+       y="120.28607"
+       id="text3043"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">&gt; stats = events</text>
+    <text
+       x="91.471016"
+       y="136.79018"
+       id="text3045"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="136.79018"
+       id="text3047"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">keyBy</text>
+    <text
+       x="141.13339"
+       y="136.79018"
+       id="text3049"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="149.38544"
+       y="136.79018"
+       id="text3051"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#548235">&quot;id&quot;</text>
+    <text
+       x="182.69376"
+       y="136.79018"
+       id="text3053"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">)</text>
+    <text
+       x="91.471016"
+       y="153.2943"
+       id="text3055"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="153.2943"
+       id="text3057"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">timeWindow</text>
+    <text
+       x="182.69376"
+       y="153.2943"
+       id="text3059"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="190.94582"
+       y="153.2943"
+       id="text3061"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">Time.seconds</text>
+    <text
+       x="290.27054"
+       y="153.2943"
+       id="text3063"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(10))</text>
+    <text
+       x="91.471016"
+       y="169.79842"
+       id="text3065"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">.</text>
+    <text
+       x="99.723068"
+       y="169.79842"
+       id="text3067"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">apply</text>
+    <text
+       x="141.13339"
+       y="169.79842"
+       id="text3069"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="149.38544"
+       y="169.79842"
+       id="text3071"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="182.69376"
+       y="169.79842"
+       id="text3073"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">MyWindowAggregationFunction</text>
+    <text
+       x="406.24942"
+       y="169.79842"
+       id="text3075"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">());</text>
+    <text
+       x="25.304533"
+       y="202.2049"
+       id="text3077"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">stats.</text>
+    <text
+       x="74.816864"
+       y="202.62952"
+       id="text3079"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#843c0c">addSink</text>
+    <text
+       x="132.88133"
+       y="202.80663"
+       id="text3081"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(</text>
+    <text
+       x="141.13339"
+       y="202.16539"
+       id="text3083"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:bold;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#2f5597">new</text>
+    <text
+       x="174.4417"
+       y="202.19572"
+       id="text3085"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">BucketingSink</text>
+    <text
+       x="281.16571"
+       y="202.05418"
+       id="text3087"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:13.8034px;font-family:'Courier New';text-align:start;text-anchor:start;fill:#000000">(path));</text>
+    <path
+       d="m 32.445583,379.40702 c 0,-17.70441 14.309815,-32.05174 31.957962,-32.05174 17.648146,0 31.957961,14.34733 31.957961,32.05174 0,17.68566 -14.309815,32.03298 -31.957961,32.03298 -17.648147,0 -31.957962,-14.34732 -31.957962,-32.03298"
+       id="path3089"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="46.974251"
+       y="383.34982"
+       id="text3091"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <path
+       d="m 170.44246,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.05174,14.34733 32.05174,32.05174 0,17.68566 -14.34733,32.03298 -32.05174,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
+       id="path3093"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="187.06161"
+       y="383.34982"
+       id="text3095"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">map()</text>
+    <path
+       d="m 104.1822,375.18722 h 50.16875 v -4.2198 l 8.43961,8.4396 -8.43961,8.4396 v -4.2198 H 104.1822 Z"
+       id="path3097"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.55767,21.023988 c 4.93248,0 8.90847,0.675168 8.90847,1.500373 v 17.49811 c 0,0.825205 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 v 17.516864 c 0,0.806451 -3.97599,1.481619 -8.90847,1.481619"
+       id="path3099"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.55767,70.573832 c 4.93248,0 8.90847,0.675168 8.90847,1.481619 v 9.771184 c 0,0.825206 3.99475,1.481619 8.90847,1.481619 -4.91372,0 -8.90847,0.675168 -8.90847,1.481619 v 9.771185 c 0,0.825205 -3.97599,1.481619 -8.90847,1.481619"
+       id="path3101"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.08881,104.65107 c 4.93248,0 8.90847,0.65641 8.90847,1.48162 v 33.83343 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.67517 -8.90847,1.48162 v 33.85218 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
+       id="path3103"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 532.08881,188.2594 c 4.93248,0 8.90847,0.67517 8.90847,1.48162 v 9.62115 c 0,0.8252 3.99474,1.48162 8.90847,1.48162 -4.91373,0 -8.90847,0.65641 -8.90847,1.48161 v 9.62115 c 0,0.80645 -3.97599,1.48162 -8.90847,1.48162"
+       id="path3105"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="571.35248"
+       y="86.226501"
+       id="text3107"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="571.35248"
+       y="145.72234"
+       id="text3109"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="94.209488"
+       y="313.34818"
+       id="text3111"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Source</text>
+    <text
+       x="88.508072"
+       y="326.85153"
+       id="text3113"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operator</text>
+    <path
+       d="m 242.17908,375.18722 h 50.16875 v -4.2198 l 8.4396,8.4396 -8.4396,8.4396 v -4.2198 h -50.16875 z"
+       id="path3115"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 308.43934,379.40702 c 0,-17.70441 14.34732,-32.05174 32.05173,-32.05174 17.68566,0 32.03299,14.34733 32.03299,32.05174 0,17.68566 -14.34733,32.03298 -32.03299,32.03298 -17.70441,0 -32.05173,-14.34732 -32.05173,-32.03298"
+       id="path3117"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="318.24503"
+       y="371.34683"
+       id="text3119"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">keyBy</text>
+    <text
+       x="349.15274"
+       y="371.34683"
+       id="text3121"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">()/</text>
+    <text
+       x="314.79416"
+       y="383.34982"
+       id="text3123"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">window()/</text>
+    <text
+       x="322.29605"
+       y="395.35281"
+       id="text3125"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">apply()</text>
+    <path
+       d="m 380.17596,375.18722 h 50.16875 v -4.2198 l 8.4396,8.4396 -8.4396,8.4396 v -4.2198 h -50.16875 z"
+       id="path3127"
+       style="fill:#bfbfbf;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 446.45497,379.40702 c 0,-17.70441 14.34733,-32.05174 32.03298,-32.05174 17.70441,0 32.03298,14.34733 32.03298,32.05174 0,17.68566 -14.32857,32.03298 -32.03298,32.03298 -17.68565,0 -32.03298,-14.34732 -32.03298,-32.03298"
+       id="path3129"
+       style="fill:#ffd966;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <text
+       x="467.4761"
+       y="383.34982"
+       id="text3131"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:10.0525px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <path
+       d="m 240.45365,250.46865 h 17.01049 v -16.2603 h 33.98347 v 16.2603 h 16.99173 l -33.98347,16.24154 z"
+       id="path3133"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="227.00369"
+       y="313.34818"
+       id="text3135"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Transformation</text>
+    <text
+       x="242.00743"
+       y="326.85153"
+       id="text3137"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operators</text>
+    <text
+       x="438.99158"
+       y="313.34818"
+       id="text3139"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <text
+       x="426.08835"
+       y="326.85153"
+       id="text3141"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Operator</text>
+    <path
+       d="m 451.65002,333.72064 5.6264,8.21454 -1.03151,0.69393 -5.6264,-8.19579 z m 6.4516,6.11402 0.76895,5.53263 -4.89497,-2.70067 z"
+       id="path3143"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 89.591069,331.58261 -4.688668,8.04575 1.069017,0.63766 4.688668,-8.06451 z m -5.682665,6.02025 -0.356339,5.58889 4.669913,-3.07577 z"
+       id="path3145"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 234.03956,329.40706 -12.92197,12.80944 0.88147,0.88147 12.92196,-12.79068 z m -13.35333,10.59639 -1.80045,5.28882 5.32633,-1.74418 z"
+       id="path3147"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 301.21879,329.40706 15.51012,14.72242 -0.86272,0.90023 -15.51011,-14.72242 z m 15.88521,12.49062 1.91298,5.27006 -5.34509,-1.63166 z"
+       id="path3149"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 241.72897,447.91784 -87.19047,-54.5761 0.65641,-1.06902 87.20923,54.5761 z m -87.13421,-52.32554 -2.90697,-4.78244 5.57014,0.54389 z"
+       id="path3151"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="245.67148"
+       y="463.08081"
+       id="text3153"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Stream</text>
+    <path
+       d="m 291.37259,447.9741 102.90688,-49.34354 -0.54388,-1.12528 -102.90689,49.34354 z m 102.58806,-47.11174 3.41335,-4.4261 -5.5889,-0.0938 2.17555,4.51987 z"
+       id="path3155"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 270.77996,440.92234 v -39.79741 h -1.25656 v 39.79741 z m 1.87547,-38.54085 -2.49438,-5.00749 -2.51312,5.00749 z"
+       id="path3157"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.0187547px;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="571.35248"
+       y="205.12807"
+       id="text3159"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Sink</text>
+    <path
+       d="m 516.93503,463.33418 c 0,8.15828 -1.10652,14.75993 -2.45686,14.75993 H 273.33059 c -1.36909,0 -2.47561,6.62039 -2.47561,14.77868 0,-8.15829 -1.08777,-14.77868 -2.45687,-14.77868 H 27.250539 c -1.369091,0 -2.475617,-6.60165 -2.475617,-14.75993"
+       id="path3161"
+       style="fill:none;stroke:#000000;stroke-width:1.25656px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:connector-curvature="0" />
+    <text
+       x="214.03168"
+       y="513.79102"
+       id="text3163"
+       xml:space="preserve"
+       style="font-style:italic;font-weight:normal;font-size:11.2528px;font-family:Verdana;text-align:start;text-anchor:start;fill:#000000">Streaming Dataflow</text>
+    <text
+       x="-125.25892"
+       y="179.02612"
+       transform="translate(24.15625,20.40625)"
+       id="text3257"
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"><tspan
          x="-125.25892"
          y="179.02612"
-         transform="translate(24.15625,20.40625)"
-         id="text3257"
-         xml:space="preserve"
-         style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"><tspan
-           x="-125.25892"
-           y="179.02612"
-           id="tspan3259"></tspan></text>
-    </g>
+         id="tspan3259" /></text>
   </g>
 </svg>


### PR DESCRIPTION
In this part of this svg figure, there's some misplaced text where it says "BucketingSink(path)":

<img width="789" alt="Screen Shot 2020-04-20 at 10 21 36 AM" src="https://user-images.githubusercontent.com/43608/79730701-8054ed00-82f1-11ea-9d40-a7efff305ca2.png">

Here is it moved over so the text no longer overlaps:

<img width="806" alt="Screen Shot 2020-04-20 at 10 21 47 AM" src="https://user-images.githubusercontent.com/43608/79730783-9ebae880-82f1-11ea-839a-776770e6f49c.png">
