### PR TITLE
[FLINK-17264][scripts] Fix broken taskmanager.sh by using -eq to compare num_lines

### DIFF
--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -645,7 +645,7 @@ extractExecutionParams() {
     local EXECUTION_PREFIX="BASH_JAVA_UTILS_EXEC_RESULT:"
 
     local num_lines=$(echo "$execution_config" | wc -l)
-    if ! [[ ${num_lines} == 1 ]]; then
+    if [[ ${num_lines} -ne 1 ]]; then
         echo "[ERROR] Unexpected result ($num_lines lines): $execution_config" 1>&2
         echo "[ERROR] extractExecutionParams only accepts exactly one line as the input" 1>&2
         exit 1


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Start a taskmanager on Mac via taskmanager.sh will get the following error.

```
wangyang-pc:build-target danrtsey.wy$ ./bin/taskmanager.sh start-foreground [ERROR] Unexpected result ( 1 lines): BASH_JAVA_UTILS_EXEC_RESULT:-Xmx536870902 -Xms536870902 -XX:MaxDirectMemorySize=268435458 -XX:MaxMetaspaceSize=268435456 [ERROR] extractExecutionParams only accepts exactly one line as the input [ERROR] Could not get JVM parameters properly.
```
 

The root cause is FLINK-17023 introduce the following change and it could not work as expected.

```
local num_lines=$(echo "$execution_config" | wc -l)
```
On linux environment, the output is "1". However, on Mac, it is "      1". Maybe we need to add `tr -d '[:space:]'` after `wc`.


## Brief change log

* Add `tr -d '[:space:]'`


## Verifying this change

* Manually test on Mac
* Covered by existing test on linux

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
