### PR TITLE
[FLINK-17021][table-planner-blink] Blink batch planner set GlobalDataExchangeMode

### DIFF
--- a/docs/_includes/generated/execution_config_configuration.html
+++ b/docs/_includes/generated/execution_config_configuration.html
@@ -54,11 +54,9 @@ By default no operator is disabled.</td>
         </tr>
         <tr>
             <td><h5>table.exec.shuffle-mode</h5><br> <span class="label label-primary">Batch</span></td>
-            <td style="word-wrap: break-word;">"batch"</td>
+            <td style="word-wrap: break-word;">"ALL_EDGES_BLOCKING"</td>
             <td>String</td>
-            <td>Sets exec shuffle mode. Only batch or pipelined can be set.
-batch: the job will run stage by stage. 
-pipelined: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when the sender holds resource to wait to send data to the receiver.</td>
+            <td>Sets exec shuffle mode.<br />Accepted values are:<ul><li><span markdown="span">`ALL_EDGES_BLOCKING`</span>: All edges will use blocking shuffle.</li><li><span markdown="span">`FORWARD_EDGES_PIPELINED`</span>: Forward edges will use pipelined shuffle, others blocking.</li><li><span markdown="span">`POINTWISE_EDGES_PIPELINED`</span>: Pointwise edges will use pipelined shuffle, others blocking. Pointwise edges include forward and rescale edges.</li><li><span markdown="span">`ALL_EDGES_PIPELINED`</span>: All edges will use pipelined shuffle.</li><li><span markdown="span">`batch`</span>: the same as <span markdown="span">`ALL_EDGES_BLOCKING`</span>. Deprecated.</li><li><span markdown="span">`pipelined`</span>: the same as <span markdown="span">`ALL_EDGES_PIPELINED`</span>. Deprecated.</li></ul>Note: Blocking shuffle means data will be fully produced before sent to consumer tasks. Pipelined shuffle means data will be sent to consumer tasks once produced.</td>
         </tr>
         <tr>
             <td><h5>table.exec.sort.async-merge-enabled</h5><br> <span class="label label-primary">Batch</span></td>

--- a/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
+++ b/flink-end-to-end-tests/flink-tpcds-test/src/main/java/org/apache/flink/table/tpcds/TpcdsTestProgram.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.tpcds;
 
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.streaming.api.transformations.ShuffleMode;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
@@ -123,8 +122,6 @@ public class TpcdsTestProgram {
 		TableEnvironment tEnv = TableEnvironment.create(environmentSettings);
 
 		//config Optimizer parameters
-		tEnv.getConfig().getConfiguration()
-				.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, ShuffleMode.BATCH.toString());
 		tEnv.getConfig().getConfiguration()
 				.setInteger(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
 		tEnv.getConfig().getConfiguration()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/ExecutionConfigOptions.java
@@ -20,8 +20,11 @@ package org.apache.flink.table.api.config;
 
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.configuration.description.TextElement.code;
+import static org.apache.flink.configuration.description.TextElement.text;
 
 /**
  * This class holds configuration constants used by Flink's table module.
@@ -216,9 +219,35 @@ public class ExecutionConfigOptions {
 	@Documentation.TableOption(execMode = Documentation.ExecMode.BATCH)
 	public static final ConfigOption<String> TABLE_EXEC_SHUFFLE_MODE =
 		key("table.exec.shuffle-mode")
-			.defaultValue("batch")
-			.withDescription("Sets exec shuffle mode. Only batch or pipelined can be set.\n" +
-				"batch: the job will run stage by stage. \n" +
-				"pipelined: the job will run in streaming mode, but it may cause resource deadlock that receiver waits for resource to start when " +
-				"the sender holds resource to wait to send data to the receiver.");
+			.stringType()
+			.defaultValue("ALL_EDGES_BLOCKING")
+			.withDescription(
+				Description.builder()
+					.text("Sets exec shuffle mode.")
+					.linebreak()
+					.text("Accepted values are:")
+					.list(
+						text("%s: All edges will use blocking shuffle.",
+							code("ALL_EDGES_BLOCKING")),
+						text(
+							"%s: Forward edges will use pipelined shuffle, others blocking.",
+							code("FORWARD_EDGES_PIPELINED")),
+						text(
+							"%s: Pointwise edges will use pipelined shuffle, others blocking. " +
+								"Pointwise edges include forward and rescale edges.",
+							code("POINTWISE_EDGES_PIPELINED")),
+						text(
+							"%s: All edges will use pipelined shuffle.",
+							code("ALL_EDGES_PIPELINED")),
+						text(
+							"%s: the same as %s. Deprecated.",
+							code("batch"), code("ALL_EDGES_BLOCKING")),
+						text(
+							"%s: the same as %s. Deprecated.",
+							code("pipelined"), code("ALL_EDGES_PIPELINED"))
+					)
+					.text("Note: Blocking shuffle means data will be fully produced before sent to consumer tasks. " +
+						"Pipelined shuffle means data will be sent to consumer tasks once produced.")
+					.build());
+
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ShuffleModeUtils.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/utils/ShuffleModeUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+
+/**
+ * Utility class to load job-wide shuffle mode.
+ */
+public class ShuffleModeUtils {
+
+	static final String ALL_EDGES_BLOCKING_LEGACY = "batch";
+
+	static final String ALL_EDGES_PIPELINED_LEGACY = "pipelined";
+
+	static GlobalDataExchangeMode getShuffleModeAsGlobalDataExchangeMode(final Configuration configuration) {
+		final String value = configuration.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE);
+
+		try {
+			return GlobalDataExchangeMode.valueOf(convertLegacyShuffleMode(value).toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new IllegalArgumentException(
+				String.format("Unsupported value %s for config %s.", value, ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE.key()));
+		}
+	}
+
+	private static String convertLegacyShuffleMode(final String shuffleMode) {
+		switch (shuffleMode.toLowerCase()) {
+			case ALL_EDGES_BLOCKING_LEGACY:
+				return GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString();
+			case ALL_EDGES_PIPELINED_LEGACY:
+				return GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString();
+			default:
+				return shuffleMode;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExchange.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchExecExchange.scala
@@ -41,6 +41,8 @@ import org.apache.calcite.rel.{RelDistribution, RelNode, RelWriter}
 
 import java.util
 
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+
 import scala.collection.JavaConversions._
 
 /**
@@ -92,7 +94,7 @@ class BatchExecExchange(
       case Some(mode) if mode eq ShuffleMode.BATCH => mode
       case _ =>
         if (tableConf.getString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE)
-            .equalsIgnoreCase(ShuffleMode.BATCH.toString)) {
+            .equalsIgnoreCase(GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString)) {
           ShuffleMode.BATCH
         } else {
           ShuffleMode.UNDEFINED

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/ShuffleModeUtilsTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/ShuffleModeUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link ShuffleModeUtils}.
+ */
+public class ShuffleModeUtilsTest extends TestLogger {
+
+	@Test
+	public void testGetValidShuffleMode() {
+		final Configuration configuration = new Configuration();
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, GlobalDataExchangeMode.ALL_EDGES_BLOCKING.toString());
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_BLOCKING, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED.toString());
+		assertEquals(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED.toString());
+		assertEquals(GlobalDataExchangeMode.POINTWISE_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString());
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+	}
+
+	@Test
+	public void testGetLegacyShuffleMode() {
+		final Configuration configuration = new Configuration();
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, ShuffleModeUtils.ALL_EDGES_BLOCKING_LEGACY);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_BLOCKING, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, ShuffleModeUtils.ALL_EDGES_PIPELINED_LEGACY);
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+	}
+
+	@Test
+	public void testGetShuffleModeIgnoreCases() {
+		final Configuration configuration = new Configuration();
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Forward_edges_PIPELINED");
+		assertEquals(GlobalDataExchangeMode.FORWARD_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "Pipelined");
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_PIPELINED, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+	}
+
+	@Test
+	public void testGetDefaultShuffleMode() {
+		final Configuration configuration = new Configuration();
+		assertEquals(GlobalDataExchangeMode.ALL_EDGES_BLOCKING, ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetInvalidShuffleMode() {
+		final Configuration configuration = new Configuration();
+		configuration.setString(ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, "invalid-value");
+		ShuffleModeUtils.getShuffleModeAsGlobalDataExchangeMode(configuration);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -47,6 +47,8 @@ import org.junit.{Assert, Before}
 import java.lang.{Iterable => JIterable}
 import java.util.regex.Pattern
 
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
+
 import scala.collection.JavaConverters._
 import scala.collection.Seq
 import scala.collection.mutable.ArrayBuffer
@@ -475,6 +477,8 @@ object BatchTestBase {
 
   def configForMiniCluster(conf: TableConfig): Unit = {
     conf.getConfiguration.setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, DEFAULT_PARALLELISM)
-    conf.getConfiguration.setString(TABLE_EXEC_SHUFFLE_MODE, ShuffleMode.PIPELINED.toString)
+    conf.getConfiguration.setString(
+      TABLE_EXEC_SHUFFLE_MODE,
+      GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -24,7 +24,6 @@ import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.{LocalStreamEnvironment, StreamExecutionEnvironment}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecEnv}
-import org.apache.flink.streaming.api.transformations.ShuffleMode
 import org.apache.flink.streaming.api.{TimeCharacteristic, environment}
 import org.apache.flink.table.api._
 import org.apache.flink.table.api.config.ExecutionConfigOptions
@@ -72,6 +71,8 @@ import org.junit.rules.{ExpectedException, TemporaryFolder, TestName}
 
 import _root_.java.math.{BigDecimal => JBigDecimal}
 import _root_.java.util
+
+import org.apache.flink.streaming.api.graph.GlobalDataExchangeMode
 
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.io.Source
@@ -505,7 +506,8 @@ abstract class TableTestUtil(
     TestingTableEnvironment.create(setting, catalogManager, tableConfig)
   val tableEnv: TableEnvironment = testingTableEnv
   tableEnv.getConfig.getConfiguration.setString(
-    ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE, ShuffleMode.PIPELINED.toString)
+    ExecutionConfigOptions.TABLE_EXEC_SHUFFLE_MODE,
+    GlobalDataExchangeMode.ALL_EDGES_PIPELINED.toString)
 
   private val env: StreamExecutionEnvironment = getPlanner.getExecEnv
   env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)


### PR DESCRIPTION
## What is the purpose of the change

Blink planner config option "table.exec.shuffle-mode" should be extended to set GlobalDataExchangeMode for a job.
This PR is based on #11774.

## Brief change log

  - *config "table.exec.shuffle-mode" is extended*


## Verifying this change

  - *Added unit tests ShuffleModeUtilsTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
