### PR TITLE
[FLINK-16423][e2e] Introduce timeouts for HA tests

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_ha.sh
+++ b/flink-end-to-end-tests/test-scripts/common_ha.sh
@@ -23,10 +23,9 @@ source "${END_TO_END_DIR}"/test-scripts/common.sh
 # flag indicating if we have already cleared up things after a test
 CLEARED=0
 
-JM_WATCHDOG_PID=0
-TM_WATCHDOG_PID=0
-
 function stop_watchdogs() {
+    JM_WATCHDOG_PID=`cat $TEST_DATA_DIR/jm_watchdog.pid`
+    TM_WATCHDOG_PID=`cat $TEST_DATA_DIR/tm_watchdog.pid`
     if [ ${CLEARED} -eq 0 ]; then
 
         if ! [ ${JM_WATCHDOG_PID} -eq 0 ]; then
@@ -115,6 +114,7 @@ function start_jm_cmd {
 function start_ha_jm_watchdog() {
     jm_watchdog $1 $2 ${@:3} &
     JM_WATCHDOG_PID=$!
+    echo $JM_WATCHDOG_PID > $TEST_DATA_DIR/jm_watchdog.pid
     echo "Running JM watchdog @ ${JM_WATCHDOG_PID}"
 }
 
@@ -179,6 +179,7 @@ function ha_tm_watchdog() {
 function start_ha_tm_watchdog() {
     ha_tm_watchdog $1 $2 &
     TM_WATCHDOG_PID=$!
+    echo $TM_WATCHDOG_PID > $TEST_DATA_DIR/tm_watchdog.pid
     echo "Running TM watchdog @ ${TM_WATCHDOG_PID}"
 }
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -20,6 +20,8 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_ha.sh
 
+TEST_TIMEOUT_SECONDS=600
+
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
 
 function ha_cleanup() {
@@ -100,4 +102,21 @@ STATE_BACKEND_FILE_ASYNC=${2:-true}
 STATE_BACKEND_ROCKS_INCREMENTAL=${3:-false}
 ZOOKEEPER_VERSION=${4:-3.4}
 
-run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL} ${ZOOKEEPER_VERSION}
+function kill_test_watchdog() {
+    local watchdog_pid=`cat $TEST_DATA_DIR/job_watchdog.pid`
+    echo "Stopping job timeout watchdog (with pid=$watchdog_pid)"
+    kill $watchdog_pid
+}
+on_exit kill_test_watchdog
+
+( 
+    cmdpid=$BASHPID; 
+    (sleep $TEST_TIMEOUT_SECONDS; # set a timeout of 10 minutes for this test
+    echo "Test (pid: $cmdpid) did not finish after $TEST_TIMEOUT_SECONDS seconds."
+    echo "Printing Flink logs and killing it:"
+    cat ${FLINK_DIR}/log/* 
+    kill "$cmdpid") & watchdog_pid=$!
+    echo $watchdog_pid > $TEST_DATA_DIR/job_watchdog.pid
+    run_ha_test 4 ${STATE_BACKEND_TYPE} ${STATE_BACKEND_FILE_ASYNC} ${STATE_BACKEND_ROCKS_INCREMENTAL} ${ZOOKEEPER_VERSION}
+)
+

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -20,6 +20,10 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_ha.sh
 
+#
+# NOTE: This script requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
+#
+
 TEST_TIMEOUT_SECONDS=600
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar

--- a/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_datastream.sh
@@ -24,7 +24,7 @@ source "$(dirname "$0")"/common_ha.sh
 # NOTE: This script requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
 #
 
-TEST_TIMEOUT_SECONDS=600
+TEST_TIMEOUT_SECONDS=540
 
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/DataStreamAllroundTestProgram.jar
 

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -20,7 +20,7 @@
 source "$(dirname "$0")"/common.sh
 source "$(dirname "$0")"/common_ha.sh
 
-TEST_TIMEOUT_SECONDS=600
+TEST_TIMEOUT_SECONDS=540
 TEST_PROGRAM_JAR_NAME=DataStreamAllroundTestProgram.jar
 TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/${TEST_PROGRAM_JAR_NAME}
 FLINK_LIB_DIR=${FLINK_DIR}/lib

--- a/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
+++ b/flink-end-to-end-tests/test-scripts/test_ha_per_job_cluster_datastream.sh
@@ -26,6 +26,10 @@ TEST_PROGRAM_JAR=${END_TO_END_DIR}/flink-datastream-allround-test/target/${TEST_
 FLINK_LIB_DIR=${FLINK_DIR}/lib
 JOB_ID="00000000000000000000000000000000"
 
+#
+# NOTE: This script requires at least Bash version >= 4. Mac OS in 2020 still ships 3.x
+#
+
 function ha_cleanup() {
   stop_watchdogs
   kill_all 'StandaloneJobClusterEntryPoint'


### PR DESCRIPTION
## What is the purpose of the change

Before this change, HA tests were waiting indefinitely for certain conditions to be met.
This change introduces a timeout (10 minutes) in the test scripts that kills the test and prints the Flink logs for debugging.


## Brief change log

- Change the HA watchdogs to store their state in files rather than variables (so that different bash processes can access them)
- launch HA test and a watchdog that sleeps for 10 minutes. If the test doesn't finish in 10, the watchdog will kill the test.
