### PR TITLE
[FLINK-17148][python] Support converting pandas DataFrame to Flink Table

### DIFF
--- a/docs/dev/table/python/conversion_of_pandas.md
+++ b/docs/dev/table/python/conversion_of_pandas.md
@@ -1,0 +1,48 @@
+---
+title: "Conversion between PyFlink Table and Pandas DataFrame"
+nav-parent_id: python_tableapi
+nav-pos: 50
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+It supports to convert between PyFlink Table and Pandas DataFrame.
+
+* This will be replaced by the TOC
+{:toc}
+
+## Convert Pandas DataFrame to PyFlink Table
+
+It supports to create a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
+using Arrow columnar format at client side and the serialized data will be processed and deserialized in Arrow source
+during execution. The Arrow source could also be used in streaming jobs and it will properly handle the checkpoint
+and provides the exactly once guarantees.
+
+The following example shows how to create a PyFlink Table from a Pandas DataFrame:
+
+{% highlight python %}
+import pandas as pd
+import numpy as np
+
+# Create a Pandas DataFrame
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+
+# Create a PyFlink Table from a Pandas DataFrame
+table = t_env.from_pandas(pdf)
+{% endhighlight %}

--- a/docs/dev/table/python/conversion_of_pandas.md
+++ b/docs/dev/table/python/conversion_of_pandas.md
@@ -1,5 +1,5 @@
 ---
-title: "Conversion between PyFlink Table and Pandas DataFrame"
+title: "Conversions between PyFlink Table and Pandas DataFrame"
 nav-parent_id: python_tableapi
 nav-pos: 50
 ---
@@ -45,4 +45,15 @@ pdf = pd.DataFrame(np.random.rand(1000, 2))
 
 # Create a PyFlink Table from a Pandas DataFrame
 table = t_env.from_pandas(pdf)
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified column names
+table = t_env.from_pandas(pdf, ['f0', 'f1'])
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified column types
+table = t_env.from_pandas(pdf, [DataTypes.DOUBLE(), DataTypes.DOUBLE()])
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified row type
+table = t_env.from_pandas(pdf,
+                          DataTypes.ROW([DataTypes.FIELD("f0", DataTypes.DOUBLE()),
+                                         DataTypes.FIELD("f1", DataTypes.DOUBLE())])
 {% endhighlight %}

--- a/docs/dev/table/python/conversion_of_pandas.zh.md
+++ b/docs/dev/table/python/conversion_of_pandas.zh.md
@@ -1,5 +1,5 @@
 ---
-title: "PyFlink Table和Pandas DataFrame互转"
+title: "PyFlink Table 和 Pandas DataFrame 互转"
 nav-parent_id: python_tableapi
 nav-pos: 50
 ---
@@ -45,4 +45,15 @@ pdf = pd.DataFrame(np.random.rand(1000, 2))
 
 # Create a PyFlink Table from a Pandas DataFrame
 table = t_env.from_pandas(pdf)
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified column names
+table = t_env.from_pandas(pdf, ['f0', 'f1'])
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified column types
+table = t_env.from_pandas(pdf, [DataTypes.DOUBLE(), DataTypes.DOUBLE()])
+
+# Create a PyFlink Table from a Pandas DataFrame with the specified row type
+table = t_env.from_pandas(pdf,
+                          DataTypes.ROW([DataTypes.FIELD("f0", DataTypes.DOUBLE()),
+                                         DataTypes.FIELD("f1", DataTypes.DOUBLE())])
 {% endhighlight %}

--- a/docs/dev/table/python/conversion_of_pandas.zh.md
+++ b/docs/dev/table/python/conversion_of_pandas.zh.md
@@ -1,0 +1,48 @@
+---
+title: "PyFlink Table和Pandas DataFrame互转"
+nav-parent_id: python_tableapi
+nav-pos: 50
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+It supports to convert between PyFlink Table and Pandas DataFrame.
+
+* This will be replaced by the TOC
+{:toc}
+
+## Convert Pandas DataFrame to PyFlink Table
+
+It supports to create a PyFlink Table from a Pandas DataFrame. Internally, it will serialize the Pandas DataFrame
+using Arrow columnar format at client side and the serialized data will be processed and deserialized in Arrow source
+during execution. The Arrow source could also be used in streaming jobs and it will properly handle the checkpoint
+and provides the exactly once guarantees.
+
+The following example shows how to create a PyFlink Table from a Pandas DataFrame:
+
+{% highlight python %}
+import pandas as pd
+import numpy as np
+
+# Create a Pandas DataFrame
+pdf = pd.DataFrame(np.random.rand(1000, 2))
+
+# Create a PyFlink Table from a Pandas DataFrame
+table = t_env.from_pandas(pdf)
+{% endhighlight %}

--- a/docs/dev/table/python/index.md
+++ b/docs/dev/table/python/index.md
@@ -32,5 +32,6 @@ Apache Flink has provided Python Table API support since 1.9.0.
 - [Installation]({{ site.baseurl }}/dev/table/python/installation.html): Introduction of how to set up the Python Table API execution environment.
 - [User-defined Functions]({{ site.baseurl }}/dev/table/python/python_udfs.html): Explanation of how to define Python user-defined functions.
 - [Vectorized User-defined Functions]({{ site.baseurl }}/dev/table/python/vectorized_python_udfs.html): Explanation of how to define vectorized Python user-defined functions.
+- [Conversion between PyFlink Table and Pandas DataFrame]({{ site.baseurl }}/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
 - [Dependency Management]({{ site.baseurl }}/dev/table/python/dependency_management.html): Specification of how to use third-part dependencies in a Python Table API program.
 - [Configuration]({{ site.baseurl }}/dev/table/python/python_config.html): Description of the config options available for Python Table API programs.

--- a/docs/dev/table/python/index.md
+++ b/docs/dev/table/python/index.md
@@ -32,6 +32,6 @@ Apache Flink has provided Python Table API support since 1.9.0.
 - [Installation]({{ site.baseurl }}/dev/table/python/installation.html): Introduction of how to set up the Python Table API execution environment.
 - [User-defined Functions]({{ site.baseurl }}/dev/table/python/python_udfs.html): Explanation of how to define Python user-defined functions.
 - [Vectorized User-defined Functions]({{ site.baseurl }}/dev/table/python/vectorized_python_udfs.html): Explanation of how to define vectorized Python user-defined functions.
-- [Conversion between PyFlink Table and Pandas DataFrame]({{ site.baseurl }}/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
+- [Conversions between PyFlink Table and Pandas DataFrame]({{ site.baseurl }}/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
 - [Dependency Management]({{ site.baseurl }}/dev/table/python/dependency_management.html): Specification of how to use third-part dependencies in a Python Table API program.
 - [Configuration]({{ site.baseurl }}/dev/table/python/python_config.html): Description of the config options available for Python Table API programs.

--- a/docs/dev/table/python/index.zh.md
+++ b/docs/dev/table/python/index.zh.md
@@ -32,6 +32,6 @@ Apache Flink has provided Python Table API support since 1.9.0.
 - [环境安装]({{ site.baseurl }}/zh/dev/table/python/installation.html): Introduction of how to set up the Python Table API execution environment.
 - [自定义函数]({{ site.baseurl }}/zh/dev/table/python/python_udfs.html): Explanation of how to define Python user-defined functions.
 - [自定义向量化函数]({{ site.baseurl }}/zh/dev/table/python/vectorized_python_udfs.html): Explanation of how to define vectorized Python user-defined functions.
-- [PyFlink Table和Pandas DataFrame互转]({{ site.baseurl }}/zh/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
+- [PyFlink Table 和 Pandas DataFrame 互转]({{ site.baseurl }}/zh/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
 - [依赖管理]({{ site.baseurl }}/zh/dev/table/python/dependency_management.html): Specification of how to use third-part dependencies in a Python Table API program.
 - [配置]({{ site.baseurl }}/zh/dev/table/python/python_config.html): Description of the config options available for Python Table API programs.

--- a/docs/dev/table/python/index.zh.md
+++ b/docs/dev/table/python/index.zh.md
@@ -32,5 +32,6 @@ Apache Flink has provided Python Table API support since 1.9.0.
 - [环境安装]({{ site.baseurl }}/zh/dev/table/python/installation.html): Introduction of how to set up the Python Table API execution environment.
 - [自定义函数]({{ site.baseurl }}/zh/dev/table/python/python_udfs.html): Explanation of how to define Python user-defined functions.
 - [自定义向量化函数]({{ site.baseurl }}/zh/dev/table/python/vectorized_python_udfs.html): Explanation of how to define vectorized Python user-defined functions.
+- [PyFlink Table和Pandas DataFrame互转]({{ site.baseurl }}/zh/dev/table/python/conversion_of_pandas.html): Explanation of how to convert between PyFlink Table and Pandas DataFrame.
 - [依赖管理]({{ site.baseurl }}/zh/dev/table/python/dependency_management.html): Specification of how to use third-part dependencies in a Python Table API program.
 - [配置]({{ site.baseurl }}/zh/dev/table/python/python_config.html): Description of the config options available for Python Table API programs.

--- a/flink-python/pyflink/table/serializers.py
+++ b/flink-python/pyflink/table/serializers.py
@@ -1,0 +1,53 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.serializers import Serializer
+from pyflink.table.utils import arrow_to_pandas, pandas_to_arrow
+
+
+class ArrowSerializer(Serializer):
+    """
+    Serializes pandas.Series into Arrow streaming format data.
+    """
+
+    def __init__(self, schema, row_type, timezone):
+        super(ArrowSerializer, self).__init__()
+        self._schema = schema
+        self._field_types = row_type.field_types()
+        self._timezone = timezone
+
+    def __repr__(self):
+        return "ArrowSerializer"
+
+    def dump_to_stream(self, iterator, stream):
+        writer = None
+        try:
+            for cols in iterator:
+                batch = pandas_to_arrow(self._schema, self._timezone, self._field_types, cols)
+                if writer is None:
+                    import pyarrow as pa
+                    writer = pa.RecordBatchStreamWriter(stream, batch.schema)
+                writer.write_batch(batch)
+        finally:
+            if writer is not None:
+                writer.close()
+
+    def load_from_stream(self, stream):
+        import pyarrow as pa
+        reader = pa.ipc.open_stream(stream)
+        for batch in reader:
+            yield arrow_to_pandas(self._timezone, self._field_types, [batch])

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -1129,8 +1129,8 @@ class TableEnvironment(object):
         Example:
         ::
 
-            # use the second parameter to specify custom field names
             >>> pdf = pd.DataFrame(np.random.rand(1000, 2))
+            # use the second parameter to specify custom field names
             >>> table_env.from_pandas(pdf, ["a", "b"])
             # use the second parameter to specify custom field types
             >>> table_env.from_pandas(pdf, [DataTypes.DOUBLE(), DataTypes.DOUBLE()]))
@@ -1141,13 +1141,10 @@ class TableEnvironment(object):
 
         :param pdf: The pandas DataFrame.
         :param schema: The schema of the converted table.
-        :type schema: RowType or list[str] or list[DataType]
         :param splits_num: The number of splits the given Pandas DataFrame will be split into. It
                            determines the number of parallel source tasks.
                            If not specified, the default parallelism will be used.
-        :type splits_num: int
         :return: The result table.
-        :rtype: Table
         """
 
         import pandas as pd

--- a/flink-python/pyflink/table/tests/test_pandas_conversion.py
+++ b/flink-python/pyflink/table/tests/test_pandas_conversion.py
@@ -1,0 +1,147 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import datetime
+import decimal
+
+from pyflink.table.types import DataTypes, Row
+from pyflink.testing import source_sink_utils
+from pyflink.testing.test_case_utils import PyFlinkBlinkBatchTableTestCase, \
+    PyFlinkBlinkStreamTableTestCase, PyFlinkStreamTableTestCase
+
+
+class PandasConversionTestBase(object):
+
+    @classmethod
+    def setUpClass(cls):
+        super(PandasConversionTestBase, cls).setUpClass()
+        cls.data = [(1, 1, 1, 1, True, 1.1, 1.2, 'hello', bytearray(b"aaa"),
+                     decimal.Decimal('1000000000000000000.01'), datetime.date(2014, 9, 13),
+                     datetime.time(hour=1, minute=0, second=1),
+                     datetime.datetime(1970, 1, 1, 0, 0, 0, 123000), ['hello', '中文'],
+                     Row(a=1, b='hello', c=datetime.datetime(1970, 1, 1, 0, 0, 0, 123000),
+                         d=[1, 2])),
+                    (2, 2, 2, 2, False, 2.1, 2.2, 'world', bytearray(b"bbb"),
+                     decimal.Decimal('1000000000000000000.02'), datetime.date(2014, 9, 13),
+                     datetime.time(hour=1, minute=0, second=1),
+                     datetime.datetime(1970, 1, 1, 0, 0, 0, 123000), ['hello', '中文'],
+                     Row(a=1, b='hello', c=datetime.datetime(1970, 1, 1, 0, 0, 0, 123000),
+                         d=[1, 2]))]
+        cls.data_type = DataTypes.ROW(
+            [DataTypes.FIELD("f1", DataTypes.TINYINT()),
+             DataTypes.FIELD("f2", DataTypes.SMALLINT()),
+             DataTypes.FIELD("f3", DataTypes.INT()),
+             DataTypes.FIELD("f4", DataTypes.BIGINT()),
+             DataTypes.FIELD("f5", DataTypes.BOOLEAN()),
+             DataTypes.FIELD("f6", DataTypes.FLOAT()),
+             DataTypes.FIELD("f7", DataTypes.DOUBLE()),
+             DataTypes.FIELD("f8", DataTypes.STRING()),
+             DataTypes.FIELD("f9", DataTypes.BYTES()),
+             DataTypes.FIELD("f10", DataTypes.DECIMAL(38, 18)),
+             DataTypes.FIELD("f11", DataTypes.DATE()),
+             DataTypes.FIELD("f12", DataTypes.TIME()),
+             DataTypes.FIELD("f13", DataTypes.TIMESTAMP(3)),
+             DataTypes.FIELD("f14", DataTypes.ARRAY(DataTypes.STRING())),
+             DataTypes.FIELD("f15", DataTypes.ROW(
+                 [DataTypes.FIELD("a", DataTypes.INT()),
+                  DataTypes.FIELD("b", DataTypes.STRING()),
+                  DataTypes.FIELD("c", DataTypes.TIMESTAMP(3)),
+                  DataTypes.FIELD("d", DataTypes.ARRAY(DataTypes.INT()))]))])
+        cls.pdf = cls.create_pandas_data_frame()
+
+    @classmethod
+    def create_pandas_data_frame(cls):
+        data_dict = {}
+        for j, name in enumerate(cls.data_type.names):
+            data_dict[name] = [cls.data[i][j] for i in range(len(cls.data))]
+        # need convert to numpy types
+        import numpy as np
+        data_dict["f1"] = np.int8(data_dict["f1"])
+        data_dict["f2"] = np.int16(data_dict["f2"])
+        data_dict["f3"] = np.int32(data_dict["f3"])
+        data_dict["f4"] = np.int64(data_dict["f4"])
+        data_dict["f6"] = np.float32(data_dict["f6"])
+        data_dict["f7"] = np.float64(data_dict["f7"])
+        data_dict["f15"] = [row.as_dict() for row in data_dict["f15"]]
+        import pandas as pd
+        return pd.DataFrame(data=data_dict,
+                            columns=['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9',
+                                     'f10', 'f11', 'f12', 'f13', 'f14', 'f15'])
+
+
+class PandasConversionTests(PandasConversionTestBase):
+
+    def test_from_pandas_with_incorrect_schema(self):
+        fields = self.data_type.fields.copy()
+        fields[0], fields[7] = fields[7], fields[0]  # swap str with tinyint
+        wrong_schema = DataTypes.ROW(fields)  # should be DataTypes.STRING()
+        with self.assertRaisesRegex(Exception, "Expected a string.*got int8"):
+            self.t_env.from_pandas(self.pdf, schema=wrong_schema)
+
+    def test_from_pandas_with_names(self):
+        # skip decimal as currently only decimal(38, 18) is supported
+        pdf = self.pdf.drop(['f10', 'f11', 'f12', 'f13', 'f14', 'f15'], axis=1)
+        new_names = list(map(str, range(len(pdf.columns))))
+        table = self.t_env.from_pandas(pdf, schema=new_names)
+        self.assertEqual(new_names, table.get_schema().get_field_names())
+        table = self.t_env.from_pandas(pdf, schema=tuple(new_names))
+        self.assertEqual(new_names, table.get_schema().get_field_names())
+
+    def test_from_pandas_with_types(self):
+        new_types = self.data_type.field_types()
+        new_types[0] = DataTypes.BIGINT()
+        table = self.t_env.from_pandas(self.pdf, schema=new_types)
+        self.assertEqual(new_types, table.get_schema().get_field_data_types())
+        table = self.t_env.from_pandas(self.pdf, schema=tuple(new_types))
+        self.assertEqual(new_types, table.get_schema().get_field_data_types())
+
+
+class PandasConversionITTests(PandasConversionTestBase):
+
+    def test_from_pandas(self):
+        table = self.t_env.from_pandas(self.pdf, self.data_type, 5)
+        self.assertEqual(self.data_type, table.get_schema().to_row_data_type())
+
+        table = table.filter("f1 < 2")
+        table_sink = source_sink_utils.TestAppendSink(
+            self.data_type.field_names(),
+            self.data_type.field_types())
+        self.t_env.register_table_sink("Results", table_sink)
+        table.insert_into("Results")
+        self.t_env.execute("test")
+        actual = source_sink_utils.results()
+        self.assert_equals(actual,
+                           ["1,1,1,1,true,1.1,1.2,hello,[97, 97, 97],"
+                            "1000000000000000000.010000000000000000,2014-09-13,01:00:01,"
+                            "1970-01-01 00:00:00.123,[hello, 中文],1,hello,"
+                            "1970-01-01 00:00:00.123,[1, 2]"])
+
+
+class StreamPandasConversionTests(PandasConversionITTests,
+                                  PyFlinkStreamTableTestCase):
+    pass
+
+
+class BlinkBatchPandasConversionTests(PandasConversionTests,
+                                      PandasConversionITTests,
+                                      PyFlinkBlinkBatchTableTestCase):
+    pass
+
+
+class BlinkStreamPandasConversionTests(PandasConversionITTests,
+                                       PyFlinkBlinkStreamTableTestCase):
+    pass

--- a/flink-python/pyflink/table/tests/test_types.py
+++ b/flink-python/pyflink/table/tests/test_types.py
@@ -845,7 +845,7 @@ class DataTypeConvertTests(unittest.TestCase):
         converted_python_types = [_from_java_type(item) for item in java_types]
 
         expected = [DataTypes.VARCHAR(2147483647),
-                    DataTypes.DECIMAL(10, 0),
+                    DataTypes.DECIMAL(38, 18),
                     DataTypes.DECIMAL(12, 5)]
         self.assertEqual(converted_python_types, expected)
 

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1800,7 +1800,7 @@ def _from_java_type(j_data_type):
             if type_info == BasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO:
                 data_type = DataTypes.ARRAY(DataTypes.STRING())
             elif type_info == BasicTypeInfo.BIG_DEC_TYPE_INFO:
-                data_type = DataTypes.DECIMAL(10, 0)
+                data_type = DataTypes.DECIMAL(38, 18)
             elif type_info.getClass() == \
                 get_java_class(gateway.jvm.org.apache.flink.table.runtime.typeutils
                                .BigDecimalTypeInfo):
@@ -2269,6 +2269,76 @@ def _create_type_verifier(data_type, name=None):
             verify_value(obj)
 
     return verify
+
+
+def create_arrow_schema(field_names, field_types):
+    """
+    Create an Arrow schema with the specified filed names and types.
+    """
+    import pyarrow as pa
+    fields = [pa.field(field_name, to_arrow_type(field_type), field_type._nullable)
+              for field_name, field_type in zip(field_names, field_types)]
+    return pa.schema(fields)
+
+
+def from_arrow_type(arrow_type, nullable=True):
+    """
+    Convert Arrow type to Flink data type.
+    """
+    from pyarrow import types
+    if types.is_boolean(arrow_type):
+        return BooleanType(nullable)
+    elif types.is_int8(arrow_type):
+        return TinyIntType(nullable)
+    elif types.is_int16(arrow_type):
+        return SmallIntType(nullable)
+    elif types.is_int32(arrow_type):
+        return IntType(nullable)
+    elif types.is_int64(arrow_type):
+        return BigIntType(nullable)
+    elif types.is_float32(arrow_type):
+        return FloatType(nullable)
+    elif types.is_float64(arrow_type):
+        return DoubleType(nullable)
+    elif types.is_decimal(arrow_type):
+        return DecimalType(arrow_type.precision, arrow_type.scale, nullable)
+    elif types.is_string(arrow_type):
+        return VarCharType(0x7fffffff, nullable)
+    elif types.is_fixed_size_binary(arrow_type):
+        return BinaryType(arrow_type.byte_width, nullable)
+    elif types.is_binary(arrow_type):
+        return VarBinaryType(0x7fffffff, nullable)
+    elif types.is_date32(arrow_type):
+        return DateType(nullable)
+    elif types.is_time32(arrow_type):
+        if str(arrow_type) == 'time32[s]':
+            return TimeType(0, nullable)
+        else:
+            return TimeType(3, nullable)
+    elif types.is_time64(arrow_type):
+        if str(arrow_type) == 'time64[us]':
+            return TimeType(6, nullable)
+        else:
+            return TimeType(9, nullable)
+    elif types.is_timestamp(arrow_type):
+        if arrow_type.unit == 's':
+            return TimestampType(0, nullable)
+        elif arrow_type.unit == 'ms':
+            return TimestampType(3, nullable)
+        elif arrow_type.unit == 'us':
+            return TimestampType(6, nullable)
+        else:
+            return TimestampType(9, nullable)
+    elif types.is_list(arrow_type):
+        return ArrayType(from_arrow_type(arrow_type.value_type), nullable)
+    elif types.is_struct(arrow_type):
+        if any(types.is_struct(field.type) for field in arrow_type):
+            raise TypeError("Nested RowType is not supported in conversion from Arrow: " +
+                            str(arrow_type))
+        return RowType([RowField(field.name, from_arrow_type(field.type, field.nullable))
+                        for field in arrow_type])
+    else:
+        raise TypeError("Unsupported data type to convert to Arrow type: " + str(dt))
 
 
 def to_arrow_type(data_type):

--- a/flink-python/pyflink/table/utils.py
+++ b/flink-python/pyflink/table/utils.py
@@ -1,0 +1,69 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.table.types import DataType, LocalZonedTimestampType
+
+
+def pandas_to_arrow(schema, timezone, field_types, series):
+    import pyarrow as pa
+
+    def create_array(s, t):
+        try:
+            return pa.Array.from_pandas(s, mask=s.isnull(), type=t)
+        except pa.ArrowException as e:
+            error_msg = "Exception thrown when converting pandas.Series (%s) to " \
+                        "pyarrow.Array (%s)."
+            raise RuntimeError(error_msg % (s.dtype, t), e)
+
+    arrays = [create_array(
+        tz_convert_to_internal(series[i], field_types[i], timezone),
+        schema.types[i]) for i in range(0, len(schema))]
+    return pa.RecordBatch.from_arrays(arrays, schema)
+
+
+def arrow_to_pandas(timezone, field_types, batches):
+    import pyarrow as pa
+    table = pa.Table.from_batches(batches)
+    return [tz_convert_from_internal(c.to_pandas(date_as_object=True), t, timezone)
+            for c, t in zip(table.itercolumns(), field_types)]
+
+
+def tz_convert_from_internal(s, t: DataType, local_tz):
+    """
+    Converts the timestamp series from internal according to the specified local timezone.
+
+    Returns the same series if the series is not a timestamp series. Otherwise,
+    returns a converted series.
+    """
+    if type(t) == LocalZonedTimestampType:
+        return s.dt.tz_localize(local_tz)
+    else:
+        return s
+
+
+def tz_convert_to_internal(s, t: DataType, local_tz):
+    """
+    Converts the timestamp series to internal according to the specified local timezone.
+    """
+    if type(t) == LocalZonedTimestampType:
+        from pandas.api.types import is_datetime64_dtype, is_datetime64tz_dtype
+        if is_datetime64_dtype(s.dtype):
+            return s.dt.tz_localize(None)
+        elif is_datetime64tz_dtype(s.dtype):
+            return s.dt.tz_convert(local_tz).dt.tz_localize(None)
+    return s

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/AbstractArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/AbstractArrowSourceFunction.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.runtime.arrow.ArrowReader;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * An Arrow {@link SourceFunction} which takes the serialized arrow record batch data as input.
+ *
+ * @param <OUT> The type of the records produced by this source.
+ */
+@Internal
+public abstract class AbstractArrowSourceFunction<OUT>
+		extends RichParallelSourceFunction<OUT>
+		implements ResultTypeQueryable<OUT>, CheckpointedFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(AbstractArrowSourceFunction.class);
+
+	static {
+		ArrowUtils.checkArrowUsable();
+	}
+
+	/**
+	 * The type of the records produced by this source.
+	 */
+	final DataType dataType;
+
+	/**
+	 * The array of byte array of the source data. Each element is an array
+	 * representing an arrow batch.
+	 */
+	private final byte[][] arrowData;
+
+	/**
+	 * Allocator which is used for byte buffer allocation.
+	 */
+	private transient BufferAllocator allocator;
+
+	/**
+	 * Container that holds a set of vectors for the source data to emit.
+	 */
+	private transient VectorSchemaRoot root;
+
+	private transient volatile boolean running;
+
+	/**
+	 * The indexes of the collection of source data to emit. Each element is a tuple of
+	 * the index of the arrow batch and the staring index inside the arrow batch.
+	 */
+	private transient Deque<Tuple2<Integer, Integer>> indexesToEmit;
+
+	/**
+	 * The indexes of the source data which have not been emitted.
+	 */
+	private transient ListState<Tuple2<Integer, Integer>> checkpointedState;
+
+	AbstractArrowSourceFunction(DataType dataType, byte[][] arrowData) {
+		this.dataType = Preconditions.checkNotNull(dataType);
+		this.arrowData = Preconditions.checkNotNull(arrowData);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("ArrowSourceFunction", 0, Long.MAX_VALUE);
+		root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema((RowType) dataType.getLogicalType()), allocator);
+		running = true;
+	}
+
+	@Override
+	public void close() throws Exception {
+		try {
+			super.close();
+		} finally {
+			if (root != null) {
+				root.close();
+				root = null;
+			}
+			if (allocator != null) {
+				allocator.close();
+				allocator = null;
+			}
+		}
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		Preconditions.checkState(this.checkpointedState == null,
+			"The " + getClass().getSimpleName() + " has already been initialized.");
+
+		this.checkpointedState = context.getOperatorStateStore().getListState(
+			new ListStateDescriptor<>(
+				"arrow-source-state",
+				new TupleSerializer<>(
+					(Class<Tuple2<Integer, Integer>>) (Class<?>) Tuple2.class,
+					new TypeSerializer[]{IntSerializer.INSTANCE, IntSerializer.INSTANCE})
+			)
+		);
+
+		this.indexesToEmit = new ArrayDeque<>();
+		if (context.isRestored()) {
+			// upon restoring
+			for (Tuple2<Integer, Integer> v : this.checkpointedState.get()) {
+				this.indexesToEmit.add(v);
+			}
+			LOG.info("Subtask {} restored state: {}.", getRuntimeContext().getIndexOfThisSubtask(), indexesToEmit);
+		} else {
+			// the first time the job is executed
+			final int stepSize = getRuntimeContext().getNumberOfParallelSubtasks();
+			final int taskIdx = getRuntimeContext().getIndexOfThisSubtask();
+
+			for (int i = taskIdx; i < arrowData.length; i += stepSize) {
+				this.indexesToEmit.add(Tuple2.of(i, 0));
+			}
+			LOG.info("Subtask {} has no restore state, initialized with {}.", taskIdx, indexesToEmit);
+		}
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		Preconditions.checkState(this.checkpointedState != null,
+			"The " + getClass().getSimpleName() + " state has not been properly initialized.");
+
+		this.checkpointedState.clear();
+		for (Tuple2<Integer, Integer> v : indexesToEmit) {
+			this.checkpointedState.add(v);
+		}
+	}
+
+	@Override
+	public void run(SourceContext<OUT> ctx) throws Exception {
+		VectorLoader vectorLoader = new VectorLoader(root);
+		while (running && !indexesToEmit.isEmpty()) {
+			Tuple2<Integer, Integer> indexToEmit = indexesToEmit.peek();
+			ArrowRecordBatch arrowRecordBatch = loadBatch(indexToEmit.f0);
+			vectorLoader.load(arrowRecordBatch);
+			arrowRecordBatch.close();
+
+			ArrowReader<OUT> arrowReader = createArrowReader(root);
+			int rowCount = root.getRowCount();
+			int nextRowId = indexToEmit.f1;
+			while (nextRowId < rowCount) {
+				OUT element = arrowReader.read(nextRowId);
+				synchronized (ctx.getCheckpointLock()) {
+					ctx.collect(element);
+					indexToEmit.setField(++nextRowId, 1);
+				}
+			}
+
+			synchronized (ctx.getCheckpointLock()) {
+				indexesToEmit.pop();
+			}
+		}
+	}
+
+	@Override
+	public void cancel() {
+		running = false;
+	}
+
+	abstract ArrowReader<OUT> createArrowReader(VectorSchemaRoot root);
+
+	/**
+	 * Load the specified batch of data to process.
+	 */
+	private ArrowRecordBatch loadBatch(int nextIndexOfArrowDataToProcess) throws IOException {
+		ByteArrayInputStream bais = new ByteArrayInputStream(arrowData[nextIndexOfArrowDataToProcess]);
+		return MessageSerializer.deserializeRecordBatch(new ReadChannel(Channels.newChannel(bais)), allocator);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/AbstractArrowTableSource.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/AbstractArrowTableSource.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+
+/**
+ * A {@link StreamTableSource} for serialized arrow record batch data.
+ */
+@Internal
+public abstract class AbstractArrowTableSource<T> implements StreamTableSource<T> {
+
+	final DataType dataType;
+	final byte[][] arrowData;
+
+	AbstractArrowTableSource(DataType dataType, byte[][] arrowData) {
+		this.dataType = dataType;
+		this.arrowData = arrowData;
+	}
+
+	@Override
+	public boolean isBounded() {
+		return true;
+	}
+
+	@Override
+	public TableSchema getTableSchema() {
+		return DataTypeUtils.expandCompositeTypeToSchema(dataType);
+	}
+
+	@Override
+	public DataType getProducedDataType() {
+		return dataType;
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.arrow.ArrowReader;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.runtime.types.TypeInfoDataTypeConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/**
+ * An Arrow {@link SourceFunction} which takes {@link RowData} as the type of the produced records.
+ */
+@Internal
+public class ArrowSourceFunction extends AbstractArrowSourceFunction<RowData> {
+
+	private static final long serialVersionUID = 1L;
+
+	ArrowSourceFunction(DataType dataType, byte[][] arrowData) {
+		super(dataType, arrowData);
+	}
+
+	@Override
+	ArrowReader<RowData> createArrowReader(VectorSchemaRoot root) {
+		return ArrowUtils.createRowDataArrowReader(root, (RowType) dataType.getLogicalType());
+	}
+
+	@Override
+	public TypeInformation<RowData> getProducedType() {
+		return (TypeInformation<RowData>) TypeInfoDataTypeConverter.fromDataTypeToTypeInfo(dataType);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSource.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/ArrowTableSource.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+
+/**
+ * An Arrow TableSource which takes {@link RowData} as the type of the produced records.
+ */
+@Internal
+public class ArrowTableSource extends AbstractArrowTableSource<RowData> {
+	public ArrowTableSource(DataType dataType, byte[][] arrowData) {
+		super(dataType, arrowData);
+	}
+
+	@Override
+	public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
+		return execEnv.addSource(new ArrowSourceFunction(dataType, arrowData));
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunction.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.runtime.arrow.ArrowReader;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+
+/**
+ * An Arrow {@link SourceFunction} which takes {@link Row} as the type of the produced records.
+ */
+@Internal
+public class RowArrowSourceFunction extends AbstractArrowSourceFunction<Row> {
+
+	private static final long serialVersionUID = 1L;
+
+	RowArrowSourceFunction(DataType dataType, byte[][] arrowData) {
+		super(dataType, arrowData);
+	}
+
+	@Override
+	ArrowReader<Row> createArrowReader(VectorSchemaRoot root) {
+		return ArrowUtils.createRowArrowReader(root, (RowType) dataType.getLogicalType());
+	}
+
+	@Override
+	public TypeInformation<Row> getProducedType() {
+		return (TypeInformation<Row>) TypeConversions.fromDataTypeToLegacyInfo(dataType);
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/RowArrowTableSource.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/sources/RowArrowTableSource.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.Row;
+
+/**
+ * An Arrow TableSource which takes {@link Row} as the type of the produced records.
+ */
+@Internal
+public class RowArrowTableSource extends AbstractArrowTableSource<Row> {
+	public RowArrowTableSource(DataType dataType, byte[][] arrowData) {
+		super(dataType, arrowData);
+	}
+
+	@Override
+	public DataStream<Row> getDataStream(StreamExecutionEnvironment execEnv) {
+		return execEnv.addSource(new RowArrowSourceFunction(dataType, arrowData));
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/arrow/ArrowPythonScalarFunctionFlatMap.java
@@ -77,7 +77,7 @@ public final class ArrowPythonScalarFunctionFlatMap extends AbstractPythonScalar
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
 
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("reader", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("reader", 0, Long.MAX_VALUE);
 		reader = new ArrowStreamReader(bais, allocator);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/ArrowPythonScalarFunctionOperator.java
@@ -77,7 +77,7 @@ public class ArrowPythonScalarFunctionOperator extends AbstractRowPythonScalarFu
 	@Override
 	public void open() throws Exception {
 		super.open();
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("reader", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("reader", 0, Long.MAX_VALUE);
 		reader = new ArrowStreamReader(bais, allocator);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/scalar/arrow/RowDataArrowPythonScalarFunctionOperator.java
@@ -76,7 +76,7 @@ public class RowDataArrowPythonScalarFunctionOperator extends AbstractRowDataPyt
 	@Override
 	public void open() throws Exception {
 		super.open();
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("reader", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("reader", 0, Long.MAX_VALUE);
 		reader = new ArrowStreamReader(bais, allocator);
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/runners/python/scalar/arrow/AbstractArrowPythonScalarFunctionRunner.java
@@ -50,15 +50,7 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 	private static final String SCHEMA_ARROW_CODER_URN = "flink:coder:schema:scalar_function:arrow:v1";
 
 	static {
-		// Arrow requires the property io.netty.tryReflectionSetAccessible to
-		// be set to true for JDK >= 9. Please refer to ARROW-5412 for more details.
-		if (System.getProperty("io.netty.tryReflectionSetAccessible") == null) {
-			System.setProperty("io.netty.tryReflectionSetAccessible", "true");
-		} else if (!io.netty.util.internal.PlatformDependent.hasDirectBufferNoCleanerConstructor()) {
-			throw new RuntimeException("Vectorized Python UDF depends on " +
-				"DirectByteBuffer.<init>(long, int) which is not available. Please set the " +
-				"system property 'io.netty.tryReflectionSetAccessible' to 'true'.");
-		}
+		ArrowUtils.checkArrowUsable();
 	}
 
 	/**
@@ -110,7 +102,7 @@ public abstract class AbstractArrowPythonScalarFunctionRunner<IN> extends Abstra
 	@Override
 	public void open() throws Exception {
 		super.open();
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("writer", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("writer", 0, Long.MAX_VALUE);
 		root = VectorSchemaRoot.create(ArrowUtils.toArrowSchema(getInputType()), allocator);
 		arrowWriter = createArrowWriter();
 		arrowStreamWriter = new ArrowStreamWriter(root, null, baos);

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowArrowReaderWriterTest.java
@@ -102,7 +102,7 @@ public class RowArrowReaderWriterTest extends ArrowReaderWriterTestBase<Row> {
 			rowFields.add(new RowType.RowField("f" + i, fieldTypes.get(i)));
 		}
 		rowType = new RowType(rowFields);
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("stdout", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("stdout", 0, Long.MAX_VALUE);
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowDataArrowReaderWriterTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/RowDataArrowReaderWriterTest.java
@@ -140,7 +140,7 @@ public class RowDataArrowReaderWriterTest extends ArrowReaderWriterTestBase<RowD
 			rowFields.add(new RowType.RowField("f" + i, fieldTypes.get(i)));
 		}
 		rowType = new RowType(rowFields);
-		allocator = ArrowUtils.ROOT_ALLOCATOR.newChildAllocator("stdout", 0, Long.MAX_VALUE);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("stdout", 0, Long.MAX_VALUE);
 	}
 
 	@Override

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.runtime.arrow.ArrowWriter;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.testutils.DeeplyEqualsChecker;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Tests for {@link ArrowSourceFunction}.
+ */
+public class ArrowSourceFunctionTest extends ArrowSourceFunctionTestBase<RowData> {
+
+	private static List<LogicalType> fieldTypes = new ArrayList<>();
+	private static RowType rowType;
+	private static DataType dataType;
+	private static RowDataSerializer serializer;
+	private static BufferAllocator allocator;
+
+	public ArrowSourceFunctionTest() {
+		super(VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator),
+			serializer,
+			Comparator.comparing(o -> o.getString(0)),
+			new DeeplyEqualsChecker()
+				.withCustomCheck(
+					(o1, o2) -> o1 instanceof RowData && o2 instanceof RowData,
+					(o1, o2, checker) -> deepEqualsBaseRow(
+						(RowData) o1,
+						(RowData) o2,
+						(RowDataSerializer) serializer.duplicate(),
+						(RowDataSerializer) serializer.duplicate())));
+	}
+
+	private static boolean deepEqualsBaseRow(
+		RowData should, RowData is,
+		RowDataSerializer serializer1, RowDataSerializer serializer2) {
+		if (should.getArity() != is.getArity()) {
+			return false;
+		}
+		BinaryRowData row1 = serializer1.toBinaryRow(should);
+		BinaryRowData row2 = serializer2.toBinaryRow(is);
+
+		return Objects.equals(row1, row2);
+	}
+
+	@BeforeClass
+	public static void init() {
+		fieldTypes.add(new VarCharType());
+		List<RowType.RowField> rowFields = new ArrayList<>();
+		for (int i = 0; i < fieldTypes.size(); i++) {
+			rowFields.add(new RowType.RowField("f" + i, fieldTypes.get(i)));
+		}
+		rowType = new RowType(rowFields);
+		dataType = TypeConversions.fromLogicalToDataType(rowType);
+		serializer = new RowDataSerializer(
+			new ExecutionConfig(), fieldTypes.toArray(new LogicalType[0]));
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("stdout", 0, Long.MAX_VALUE);
+	}
+
+	@Override
+	public Tuple2<List<RowData>, Integer> getTestData() {
+		return Tuple2.of(
+			Arrays.asList(
+				GenericRowData.of(BinaryStringData.fromString("aaa")),
+				GenericRowData.of(BinaryStringData.fromString("bbb")),
+				GenericRowData.of(BinaryStringData.fromString("ccc")),
+				GenericRowData.of(BinaryStringData.fromString("ddd")),
+				GenericRowData.of(BinaryStringData.fromString("eee"))),
+			3);
+	}
+
+	@Override
+	public ArrowWriter<RowData> createArrowWriter() {
+		return ArrowUtils.createRowDataArrowWriter(root, rowType);
+	}
+
+	@Override
+	public AbstractArrowSourceFunction<RowData> createArrowSourceFunction(byte[][] arrowData) {
+		return new ArrowSourceFunction(dataType, arrowData);
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/ArrowSourceFunctionTestBase.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.testutils.MultiShotLatch;
+import org.apache.flink.core.testutils.OneShotLatch;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.operators.StreamSource;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.runtime.arrow.ArrowWriter;
+import org.apache.flink.testutils.CustomEqualityMatcher;
+import org.apache.flink.testutils.DeeplyEqualsChecker;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertThat;
+
+/**
+ * Abstract test base for the Arrow source function processing.
+ */
+public abstract class ArrowSourceFunctionTestBase<T> {
+
+	final VectorSchemaRoot root;
+	private final TypeSerializer<T> typeSerializer;
+	private final Comparator<T> comparator;
+	private final DeeplyEqualsChecker checker;
+
+	ArrowSourceFunctionTestBase(VectorSchemaRoot root, TypeSerializer<T> typeSerializer, Comparator<T> comparator) {
+		this(root, typeSerializer, comparator, new DeeplyEqualsChecker());
+	}
+
+	ArrowSourceFunctionTestBase(VectorSchemaRoot root, TypeSerializer<T> typeSerializer, Comparator<T> comparator, DeeplyEqualsChecker checker) {
+		this.root = Preconditions.checkNotNull(root);
+		this.typeSerializer = Preconditions.checkNotNull(typeSerializer);
+		this.comparator = Preconditions.checkNotNull(comparator);
+		this.checker = Preconditions.checkNotNull(checker);
+	}
+
+	@Test
+	public void testRestore() throws Exception {
+		Tuple2<List<T>, Integer> testData = getTestData();
+		final AbstractArrowSourceFunction<T> arrowSourceFunction =
+			createTestArrowSourceFunction(testData.f0, testData.f1);
+
+		final AbstractStreamOperatorTestHarness<T> testHarness =
+			new AbstractStreamOperatorTestHarness<>(new StreamSource<>(arrowSourceFunction), 1, 1, 0);
+		testHarness.open();
+
+		final Throwable[] error = new Throwable[1];
+		final MultiShotLatch latch = new MultiShotLatch();
+		final AtomicInteger numOfEmittedElements = new AtomicInteger(0);
+		final List<T> results = new ArrayList<>();
+
+		final DummySourceContext<T> sourceContext = new DummySourceContext<T>() {
+			@Override
+			public void collect(T element) {
+				if (numOfEmittedElements.get() == 2) {
+					latch.trigger();
+					// fail the source function at the the second element
+					throw new RuntimeException("Fail the arrow source");
+				}
+				results.add(typeSerializer.copy(element));
+				numOfEmittedElements.incrementAndGet();
+			}
+		};
+
+		// run the source asynchronously
+		Thread runner = new Thread(() -> {
+			try {
+				arrowSourceFunction.run(sourceContext);
+			} catch (Throwable t) {
+				if (!t.getMessage().equals("Fail the arrow source")) {
+					error[0] = t;
+				}
+			}
+		});
+		runner.start();
+
+		if (!latch.isTriggered()) {
+			latch.await();
+		}
+
+		OperatorSubtaskState snapshot;
+		synchronized (sourceContext.getCheckpointLock()) {
+			snapshot = testHarness.snapshot(0, 0);
+		}
+
+		runner.join();
+		testHarness.close();
+
+		final AbstractArrowSourceFunction<T> arrowSourceFunction2 =
+			createTestArrowSourceFunction(testData.f0, testData.f1);
+		AbstractStreamOperatorTestHarness<T> testHarnessCopy =
+			new AbstractStreamOperatorTestHarness<>(new StreamSource<>(arrowSourceFunction2), 1, 1, 0);
+		testHarnessCopy.initializeState(snapshot);
+		testHarnessCopy.open();
+
+		// run the source asynchronously
+		Thread runner2 = new Thread(() -> {
+			try {
+				arrowSourceFunction2.run(new DummySourceContext<T>() {
+					@Override
+					public void collect(T element) {
+						results.add(typeSerializer.copy(element));
+						if (numOfEmittedElements.incrementAndGet() == testData.f0.size()) {
+							latch.trigger();
+						}
+					}
+				});
+			} catch (Throwable t) {
+				error[0] = t;
+			}
+		});
+		runner2.start();
+
+		if (!latch.isTriggered()) {
+			latch.await();
+		}
+		runner2.join();
+
+		Assert.assertNull(error[0]);
+		Assert.assertEquals(testData.f0.size(), numOfEmittedElements.get());
+		checkElementsEquals(results, testData.f0);
+	}
+
+	@Test
+	public void testParallelProcessing() throws Exception {
+		Tuple2<List<T>, Integer> testData = getTestData();
+		final AbstractArrowSourceFunction<T> arrowSourceFunction =
+			createTestArrowSourceFunction(testData.f0, testData.f1);
+
+		final AbstractStreamOperatorTestHarness<T> testHarness =
+			new AbstractStreamOperatorTestHarness<>(new StreamSource<>(arrowSourceFunction), 2, 2, 0);
+		testHarness.open();
+
+		final Throwable[] error = new Throwable[2];
+		final OneShotLatch latch = new OneShotLatch();
+		final AtomicInteger numOfEmittedElements = new AtomicInteger(0);
+		final List<T> results = new ArrayList<>();
+
+		// run the source asynchronously
+		Thread runner = new Thread(() -> {
+			try {
+				arrowSourceFunction.run(new DummySourceContext<T>() {
+					@Override
+					public void collect(T element) {
+						results.add(typeSerializer.copy(element));
+						if (numOfEmittedElements.incrementAndGet() == testData.f0.size()) {
+							latch.trigger();
+						}
+					}
+				});
+			} catch (Throwable t) {
+				error[0] = t;
+			}
+		});
+		runner.start();
+
+		final AbstractArrowSourceFunction<T> arrowSourceFunction2 =
+			createTestArrowSourceFunction(testData.f0, testData.f1);
+		final AbstractStreamOperatorTestHarness<T> testHarness2 =
+			new AbstractStreamOperatorTestHarness<>(new StreamSource<>(arrowSourceFunction2), 2, 2, 1);
+		testHarness2.open();
+
+		// run the source asynchronously
+		Thread runner2 = new Thread(() -> {
+			try {
+				arrowSourceFunction2.run(new DummySourceContext<T>() {
+					@Override
+					public void collect(T element) {
+						results.add(typeSerializer.copy(element));
+						if (numOfEmittedElements.incrementAndGet() == testData.f0.size()) {
+							latch.trigger();
+						}
+					}
+				});
+			} catch (Throwable t) {
+				error[1] = t;
+			}
+		});
+		runner2.start();
+
+		if (!latch.isTriggered()) {
+			latch.await();
+		}
+
+		runner.join();
+		runner2.join();
+		testHarness.close();
+		testHarness2.close();
+
+		Assert.assertNull(error[0]);
+		Assert.assertNull(error[1]);
+		Assert.assertEquals(testData.f0.size(), numOfEmittedElements.get());
+		checkElementsEquals(results, testData.f0);
+	}
+
+	public abstract Tuple2<List<T>, Integer> getTestData();
+
+	public abstract ArrowWriter<T> createArrowWriter();
+
+	public abstract AbstractArrowSourceFunction<T> createArrowSourceFunction(byte[][] arrowData);
+
+	private void checkElementsEquals(List<T> actual, List<T> expected) {
+		Assert.assertEquals(actual.size(), expected.size());
+		actual.sort(comparator);
+		expected.sort(comparator);
+		for (int i = 0; i < expected.size(); i++) {
+			assertThat(actual.get(i), CustomEqualityMatcher.deeplyEquals(expected.get(i)).withChecker(checker));
+		}
+	}
+
+	/**
+	 * Create continuous monitoring function with 1 reader-parallelism and interval.
+	 */
+	private AbstractArrowSourceFunction<T> createTestArrowSourceFunction(
+			List<T> testData, int batches) throws IOException {
+		ArrowWriter<T> arrowWriter = createArrowWriter();
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ArrowStreamWriter arrowStreamWriter = new ArrowStreamWriter(root, null, baos);
+		arrowStreamWriter.start();
+		List<List<T>> subLists = Lists.partition(testData, testData.size() / batches + 1);
+		for (List<T> subList : subLists) {
+			for (T value : subList) {
+				arrowWriter.write(value);
+			}
+			arrowWriter.finish();
+			arrowStreamWriter.writeBatch();
+			arrowWriter.reset();
+		}
+
+		AbstractArrowSourceFunction<T> arrowSourceFunction = createArrowSourceFunction(
+			ArrowUtils.readArrowBatches(
+				Channels.newChannel(new ByteArrayInputStream(baos.toByteArray()))));
+		arrowSourceFunction.setRuntimeContext(Mockito.mock(RuntimeContext.class));
+		return arrowSourceFunction;
+	}
+
+	private abstract static class DummySourceContext<T>
+		implements SourceFunction.SourceContext<T> {
+
+		private final Object lock = new Object();
+
+		@Override
+		public void collectWithTimestamp(T element, long timestamp) {
+		}
+
+		@Override
+		public void emitWatermark(Watermark mark) {
+		}
+
+		@Override
+		public void markAsTemporarilyIdle() {
+		}
+
+		@Override
+		public Object getCheckpointLock() {
+			return lock;
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunctionTest.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/arrow/sources/RowArrowSourceFunctionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.arrow.sources;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
+import org.apache.flink.table.runtime.arrow.ArrowUtils;
+import org.apache.flink.table.runtime.arrow.ArrowWriter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Tests for {@link RowArrowSourceFunction}.
+ */
+public class RowArrowSourceFunctionTest extends ArrowSourceFunctionTestBase<Row> {
+
+	private static List<LogicalType> fieldTypes = new ArrayList<>();
+	private static RowType rowType;
+	private static DataType dataType;
+	private static BufferAllocator allocator;
+
+	public RowArrowSourceFunctionTest() {
+		super(VectorSchemaRoot.create(ArrowUtils.toArrowSchema(rowType), allocator),
+			new RowSerializer(new TypeSerializer[]{StringSerializer.INSTANCE}),
+			Comparator.comparing(o -> (String) (o.getField(0))));
+	}
+
+	@BeforeClass
+	public static void init() {
+		fieldTypes.add(new VarCharType());
+		List<RowType.RowField> rowFields = new ArrayList<>();
+		for (int i = 0; i < fieldTypes.size(); i++) {
+			rowFields.add(new RowType.RowField("f" + i, fieldTypes.get(i)));
+		}
+		rowType = new RowType(rowFields);
+		dataType = TypeConversions.fromLogicalToDataType(rowType);
+		allocator = ArrowUtils.getRootAllocator().newChildAllocator("stdout", 0, Long.MAX_VALUE);
+	}
+
+	@Override
+	public Tuple2<List<Row>, Integer> getTestData() {
+		return Tuple2.of(Arrays.asList(Row.of("aaa"), Row.of("bbb"), Row.of("ccc"), Row.of("ddd"), Row.of("eee")), 3);
+	}
+
+	@Override
+	public ArrowWriter<Row> createArrowWriter() {
+		return ArrowUtils.createRowArrowWriter(root, rowType);
+	}
+
+	@Override
+	public AbstractArrowSourceFunction<Row> createArrowSourceFunction(byte[][] arrowData) {
+		return new RowArrowSourceFunction(dataType, arrowData);
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add the support for converting pandas dataframe to flink table.*

## Brief change log

  - *Introduce ArrowSourceFunction and ArrowTableSource which takes the serialized byte array of arrow record batch as the source data*
  - *Add TableEnvironment.from_pandas which could be used to convert pandas dataframe to flink table*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added Java tests ArrowSourceFunctionTest and RowArrowSourceFunctionTest*
  - *Added Python tests test_pandas_conversion.py*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
