### PR TITLE
[FLINK-17003][table-sql-parser] Support parsing LIKE clause in a CREATE TABLE statement.

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -39,6 +39,10 @@
     "org.apache.flink.sql.parser.ddl.SqlDropTable"
     "org.apache.flink.sql.parser.ddl.SqlDropView"
     "org.apache.flink.sql.parser.ddl.SqlTableColumn"
+    "org.apache.flink.sql.parser.ddl.SqlTableLike"
+    "org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption"
+    "org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy"
+    "org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption"
     "org.apache.flink.sql.parser.ddl.SqlTableOption"
     "org.apache.flink.sql.parser.ddl.SqlUseCatalog"
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase"
@@ -78,7 +82,9 @@
     "FUNCTIONS"
     "IF"
     "OVERWRITE"
+    "OVERWRITING"
     "PARTITIONED"
+    "PARTITIONS"
     "RAW"
     "RENAME"
     "SCALA"
@@ -408,7 +414,9 @@
     # not in core, added in Flink
     "IF"
     "OVERWRITE"
+    "OVERWRITING"
     "PARTITIONED"
+    "PARTITIONS"
   ]
 
   # List of non-reserved keywords to remove;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateCatalog.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateCatalog.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-import org.apache.flink.sql.parser.error.SqlValidateException;
-
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -40,7 +37,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * CREATE CATALOG DDL sql call.
  */
-public class SqlCreateCatalog extends SqlCreate implements ExtendedSqlNode {
+public class SqlCreateCatalog extends SqlCreate {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE CATALOG", SqlKind.OTHER_DDL);
 
@@ -100,10 +97,5 @@ public class SqlCreateCatalog extends SqlCreate implements ExtendedSqlNode {
 
 	public String catalogName() {
 		return catalogName.names.get(0);
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateDatabase.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-import org.apache.flink.sql.parser.error.SqlValidateException;
-
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -43,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * CREATE Database DDL sql call.
  */
-public class SqlCreateDatabase extends SqlCreate implements ExtendedSqlNode {
+public class SqlCreateDatabase extends SqlCreate {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE DATABASE", SqlKind.OTHER_DDL);
 
@@ -90,11 +87,6 @@ public class SqlCreateDatabase extends SqlCreate implements ExtendedSqlNode {
 
 	public boolean isIfNotExists() {
 		return ifNotExists;
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateFunction.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-import org.apache.flink.sql.parser.error.SqlValidateException;
-
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -41,7 +38,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * CREATE FUNCTION DDL sql call.
  */
-public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
+public class SqlCreateFunction extends SqlCreate {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE FUNCTION", SqlKind.CREATE_FUNCTION);
 
@@ -66,7 +63,7 @@ public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
 		super(OPERATOR, pos, false, ifNotExists);
 		this.functionIdentifier = requireNonNull(functionIdentifier);
 		this.functionClassName = requireNonNull(functionClassName);
-		this.isSystemFunction = requireNonNull(isSystemFunction);
+		this.isSystemFunction = isSystemFunction;
 		this.isTemporary = isTemporary;
 		this.functionLanguage = functionLanguage;
 	}
@@ -102,11 +99,6 @@ public class SqlCreateFunction extends SqlCreate implements ExtendedSqlNode {
 			writer.keyword("LANGUAGE");
 			writer.keyword(functionLanguage);
 		}
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-		// no-op
 	}
 
 	public boolean isIfNotExists() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateView.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-import org.apache.flink.sql.parser.error.SqlValidateException;
-
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlCreate;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -43,7 +40,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * CREATE VIEW DDL sql call.
  */
-public class SqlCreateView extends SqlCreate implements ExtendedSqlNode {
+public class SqlCreateView extends SqlCreate {
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CREATE_VIEW", SqlKind.CREATE_VIEW);
 
 	private final SqlIdentifier viewName;
@@ -119,10 +116,5 @@ public class SqlCreateView extends SqlCreate implements ExtendedSqlNode {
 		writer.sep(",", false);
 		writer.newlineAndIndent();
 		writer.print("  ");
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-		// no-op
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropDatabase.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-
 import org.apache.calcite.sql.SqlDrop;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -35,7 +33,7 @@ import java.util.List;
 /**
  * DROP DATABASE DDL sql call.
  */
-public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
+public class SqlDropDatabase extends SqlDrop {
 	private static final SqlOperator OPERATOR =
 		new SqlSpecialOperator("DROP DATABASE", SqlKind.OTHER_DDL);
 
@@ -83,10 +81,6 @@ public class SqlDropDatabase extends SqlDrop implements ExtendedSqlNode {
 		} else {
 			writer.keyword("RESTRICT");
 		}
-	}
-
-	public void validate() {
-		// no-op
 	}
 
 	public String[] fullDatabaseName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropFunction.java
@@ -18,9 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-import org.apache.flink.sql.parser.error.SqlValidateException;
-
 import org.apache.calcite.sql.SqlDrop;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -39,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * DROP FUNCTION DDL sql call.
  */
-public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
+public class SqlDropFunction extends SqlDrop {
 
 	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("DROP FUNCTION", SqlKind.DROP_FUNCTION);
 
@@ -57,7 +54,7 @@ public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
 			boolean isSystemFunction) {
 		super(OPERATOR, pos, ifExists);
 		this.functionIdentifier = requireNonNull(functionIdentifier);
-		this.isSystemFunction = requireNonNull(isSystemFunction);
+		this.isSystemFunction = isSystemFunction;
 		this.isTemporary = isTemporary;
 	}
 
@@ -81,11 +78,6 @@ public class SqlDropFunction extends SqlDrop implements ExtendedSqlNode {
 			writer.keyword("IF EXISTS");
 		}
 		functionIdentifier.unparse(writer, leftPrec, rightPrec);
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-		// no-op
 	}
 
 	public String[] getFunctionIdentifier() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropTable.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-
 import org.apache.calcite.sql.SqlDrop;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -35,7 +33,7 @@ import java.util.List;
 /**
  * DROP TABLE DDL sql call.
  */
-public class SqlDropTable extends SqlDrop implements ExtendedSqlNode {
+public class SqlDropTable extends SqlDrop {
 	private static final SqlOperator OPERATOR =
 		new SqlSpecialOperator("DROP TABLE", SqlKind.DROP_TABLE);
 
@@ -77,10 +75,6 @@ public class SqlDropTable extends SqlDrop implements ExtendedSqlNode {
 			writer.keyword("IF EXISTS");
 		}
 		tableName.unparse(writer, leftPrec, rightPrec);
-	}
-
-	public void validate() {
-		// no-op
 	}
 
 	public String[] fullTableName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropView.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropView.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.sql.parser.ddl;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
-
 import org.apache.calcite.sql.SqlDrop;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
@@ -35,7 +33,7 @@ import java.util.List;
 /**
  * DROP VIEW DDL sql call.
  */
-public class SqlDropView extends SqlDrop implements ExtendedSqlNode {
+public class SqlDropView extends SqlDrop {
 	private static final SqlOperator OPERATOR =
 		new SqlSpecialOperator("DROP VIEW", SqlKind.DROP_VIEW);
 
@@ -62,10 +60,6 @@ public class SqlDropView extends SqlDrop implements ExtendedSqlNode {
 			writer.keyword("IF EXISTS");
 		}
 		viewName.unparse(writer, leftPrec, rightPrec);
-	}
-
-	public void validate() {
-		// no-op
 	}
 
 	public String[] fullViewName() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ExtendedSqlNode;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import javax.annotation.Nonnull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.singletonList;
+
+/**
+ * A {@code LIKE} clause in a {@code CREATE TABLE} statement.
+ *
+ * <p>It enables to use an existing table descriptor to define a new, adjusted/extended table.
+ * Users can control the way particular features of both declarations are merged using {@link MergingStrategy}
+ * and {@link FeatureOption}.
+ *
+ * <p>Example:
+ * A DDL like the one below for creating a `derived_table`
+ * <pre>{@code
+ * CREATE TABLE base_table_1 (
+ *     id BIGINT,
+ *     name STRING,
+ *     tstmp TIMESTAMP,
+ *     PRIMARY KEY(id)
+ * ) WITH (
+ *     ‘connector’: ‘kafka’,
+ *     ‘connector.starting-offset’: ‘12345’,
+ *     ‘format’: ‘json’
+ * )
+ *
+ * CREATE TEMPORARY TABLE derived_table (
+ *     WATERMARK FOR tstmp AS tsmp - INTERVAL '5' SECOND
+ * )
+ * WITH (
+ *     ‘connector.starting-offset’: ‘0’
+ * )
+ * LIKE base_table (
+ *   OVERWRITING OPTIONS,
+ *   EXCLUDING CONSTRAINTS
+ * )}</pre>
+ *
+ * <p>is equivalent to:
+ *
+ * <pre>{@code
+ * CREATE TEMPORARY TABLE derived_table (
+ *     id BIGINT,
+ *     name STRING,
+ *     tstmp TIMESTAMP,
+ *     WATERMARK FOR tstmp AS tsmp - INTERVAL '5' SECOND
+ * ) WITH (
+ *     ‘connector’: ‘kafka’,
+ *     ‘connector.starting-offset’: ‘0’,
+ *     ‘format’: ‘json’
+ * )
+ * }</pre>
+ */
+public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
+	/**
+	 * A strategy that describes how the features of the parent source table
+	 * should be merged with the features of the newly created table.
+	 *
+	 * <ul>
+	 *     <li>EXCLUDING - does not include the given feature of the source table</li>
+	 *     <li>INCLUDING - includes feature of the source table, fails on duplicate entries,
+	 *          e.g. if an option with the same key exists in both tables.</li>
+	 *     <li>OVERWRITING - includes feature of the source table, overwrites duplicate entries of the
+	 *          source table with properties of the new table, e.g. if an option with the same key
+	 *          exists in both tables, the one from the current statement will be used.</li>
+	 * </ul>
+	 */
+	public enum MergingStrategy {
+		INCLUDING,
+		EXCLUDING,
+		OVERWRITING
+	}
+
+	/**
+	 * A feature of a table descriptor that will be merged into the new table.
+	 * The way how a certain feature will be merged into the final descriptor is controlled with
+	 * {@link MergingStrategy}.
+	 * <ul>
+	 *     <li>ALL - a shortcut to change the default merging strategy if none provided</li>
+	 *     <li>CONSTRAINTS - constraints such as primary and unique keys</li>
+	 *     <li>GENERATED - computed columns</li>
+	 *     <li>PARTITIONS - partition of the tables</li>
+	 *     <li>OPTIONS - connector options that decribed connector and format properties</li>
+	 * </ul>
+	 *
+	 * <p>Example:
+	 * <pre>{@code
+	 * LIKE `sourceTable` (
+	 *   INCLUDING ALL
+	 *   OVERWRITING OPTIONS
+	 *   EXCLUDING PARTITIONS
+	 * )
+	 * }</pre>
+	 * is equivalent to:
+	 * <pre>{@code
+	 * LIKE `sourceTable` (
+	 *   INCLUDING GENERATED
+	 *   INCLUDING CONSTRAINTS
+	 *   OVERWRITING OPTIONS
+	 *   EXCLUDING PARTITIONS
+	 * )
+	 * }</pre>
+	 */
+	public enum FeatureOption {
+		ALL,
+		CONSTRAINTS,
+		GENERATED,
+		PARTITIONS,
+		OPTIONS
+	}
+
+	private final SqlIdentifier sourceTable;
+	private final List<SqlTableLikeOption> options;
+
+	private static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("LIKE TABLE", SqlKind.OTHER);
+
+	public SqlTableLike(
+			SqlParserPos pos,
+			SqlIdentifier sourceTable,
+			List<SqlTableLikeOption> options) {
+		super(pos);
+		this.sourceTable = sourceTable;
+		this.options = options;
+	}
+
+	@Nonnull
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Nonnull
+	@Override
+	public List<SqlNode> getOperandList() {
+		return singletonList(sourceTable);
+	}
+
+	public SqlIdentifier getSourceTable() {
+		return sourceTable;
+	}
+
+	public List<SqlTableLikeOption> getOptions() {
+		return options;
+	}
+
+	private static final Map<FeatureOption, List<MergingStrategy>> invalidCombinations = new HashMap<>();
+
+	static {
+		invalidCombinations.put(FeatureOption.ALL, singletonList(MergingStrategy.OVERWRITING));
+		invalidCombinations.put(FeatureOption.PARTITIONS, singletonList(MergingStrategy.OVERWRITING));
+		invalidCombinations.put(FeatureOption.CONSTRAINTS, singletonList(MergingStrategy.OVERWRITING));
+	}
+
+	@Override
+	public void validate() throws SqlValidateException {
+		long distinctFeatures = options.stream().map(SqlTableLikeOption::getFeatureOption).distinct().count();
+		if (distinctFeatures != options.size()) {
+			throw new SqlValidateException(pos, "Each like option feature can be declared only once.");
+		}
+
+		for (SqlTableLikeOption option : options) {
+			if (invalidCombinations.get(option.featureOption).contains(option.mergingStrategy)) {
+				throw new SqlValidateException(
+					pos,
+					String.format(
+						"Illegal merging strategy '%s' for '%s' option.",
+						option.getMergingStrategy(),
+						option.getFeatureOption()));
+			}
+		}
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("LIKE");
+		sourceTable.unparse(writer, leftPrec, rightPrec);
+		SqlWriter.Frame frame = writer.startList("(", ")");
+		for (SqlTableLikeOption option : options) {
+			writer.newlineAndIndent();
+			writer.print("  ");
+			writer.keyword(option.mergingStrategy.toString());
+			writer.keyword(option.featureOption.toString());
+		}
+		writer.newlineAndIndent();
+		writer.endList(frame);
+	}
+
+	/**
+	 * A pair of {@link MergingStrategy} and {@link FeatureOption}.
+	 *
+	 * @see MergingStrategy
+	 * @see FeatureOption
+	 */
+	public static class SqlTableLikeOption {
+		private final MergingStrategy mergingStrategy;
+		private final FeatureOption featureOption;
+
+		public SqlTableLikeOption(
+				MergingStrategy mergingStrategy,
+				FeatureOption featureOption) {
+			this.mergingStrategy = mergingStrategy;
+			this.featureOption = featureOption;
+		}
+
+		public MergingStrategy getMergingStrategy() {
+			return mergingStrategy;
+		}
+
+		public FeatureOption getFeatureOption() {
+			return featureOption;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) {
+				return true;
+			}
+			if (o == null || getClass() != o.getClass()) {
+				return false;
+			}
+			SqlTableLikeOption that = (SqlTableLikeOption) o;
+			return mergingStrategy == that.mergingStrategy &&
+				featureOption == that.featureOption;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(mergingStrategy, featureOption);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("%s %s", mergingStrategy, featureOption);
+		}
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dml/RichSqlInsert.java
@@ -18,9 +18,7 @@
 
 package org.apache.flink.sql.parser.dml;
 
-import org.apache.flink.sql.parser.ExtendedSqlNode;
 import org.apache.flink.sql.parser.SqlProperty;
-import org.apache.flink.sql.parser.error.SqlValidateException;
 
 import org.apache.calcite.sql.SqlInsert;
 import org.apache.calcite.sql.SqlInsertKeyword;
@@ -36,7 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 
 /** A {@link SqlInsert} that have some extension functions like partition, overwrite. **/
-public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
+public class RichSqlInsert extends SqlInsert {
 	private final SqlNodeList staticPartitions;
 
 	private final SqlNodeList extendedKeywords;
@@ -162,10 +160,5 @@ public class RichSqlInsert extends SqlInsert implements ExtendedSqlNode {
 			}
 		}
 		return null;
-	}
-
-	@Override
-	public void validate() throws SqlValidateException {
-		// no-op
 	}
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowTables.java
@@ -47,7 +47,7 @@ public class SqlShowTables extends SqlCall {
 
 	@Override
 	public List<SqlNode> getOperandList() {
-		return Collections.EMPTY_LIST;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser;
+
+import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlTableLike;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption;
+import org.apache.flink.sql.parser.error.SqlValidateException;
+import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
+
+import org.apache.calcite.config.Lex;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for parsing and validating {@link SqlTableLike} clause.
+ */
+public class CreateTableLikeTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testNoOptions() throws SqlParseException {
+		SqlNode actualNode = createFlinkParser(
+			"CREATE TABLE t (\n" +
+				"   a STRING\n" +
+				")\n" +
+				"LIKE b")
+			.parseStmt();
+
+		assertThat(
+			actualNode,
+			hasLikeClause(
+				allOf(
+					pointsTo("b"),
+					hasNoOptions()
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testCreateTableLike() throws SqlParseException {
+		SqlNode actualNode = createFlinkParser(
+			"CREATE TABLE t (\n" +
+			"   a STRING\n" +
+			")\n" +
+			"LIKE b (\n" +
+			"   EXCLUDING PARTITIONS\n" +
+			"   OVERWRITING GENERATED\n" +
+			"   OVERWRITING OPTIONS\n" +
+			")")
+			.parseStmt();
+
+		assertThat(
+			actualNode,
+			hasLikeClause(
+				allOf(
+					pointsTo("b"),
+					hasOptions(
+						option(MergingStrategy.EXCLUDING, FeatureOption.PARTITIONS),
+						option(MergingStrategy.OVERWRITING, FeatureOption.GENERATED),
+						option(MergingStrategy.OVERWRITING, FeatureOption.OPTIONS)
+					)
+				)
+			)
+		);
+	}
+
+	@Test
+	public void testCreateTableLikeCannotDuplicateOptions() throws SqlParseException {
+		ExtendedSqlNode extendedSqlNode = (ExtendedSqlNode) createFlinkParser(
+			"CREATE TABLE t (\n" +
+			"   a STRING\n" +
+			")\n" +
+			"LIKE b (\n" +
+			"   EXCLUDING PARTITIONS\n" +
+			"   INCLUDING PARTITIONS\n" +
+			")")
+			.parseStmt();
+
+		thrown.expect(SqlValidateException.class);
+		thrown.expectMessage("Each like option feature can be declared only once.");
+		extendedSqlNode.validate();
+	}
+
+	@Test
+	public void testInvalidOverwritingForPartition() throws SqlParseException {
+		ExtendedSqlNode extendedSqlNode = (ExtendedSqlNode) createFlinkParser(
+			"CREATE TABLE t (\n" +
+			"   a STRING\n" +
+			")\n" +
+			"LIKE b (\n" +
+			"   OVERWRITING PARTITIONS" +
+			")")
+			.parseStmt();
+
+		thrown.expect(SqlValidateException.class);
+		thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'PARTITIONS' option.");
+		extendedSqlNode.validate();
+	}
+
+	@Test
+	public void testInvalidOverwritingForAll() throws SqlParseException {
+		ExtendedSqlNode extendedSqlNode = (ExtendedSqlNode) createFlinkParser(
+			"CREATE TABLE t (\n" +
+			"   a STRING\n" +
+			")\n" +
+			"LIKE b (\n" +
+			"   OVERWRITING ALL" +
+			")")
+			.parseStmt();
+
+		thrown.expect(SqlValidateException.class);
+		thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'ALL' option.");
+		extendedSqlNode.validate();
+	}
+
+	@Test
+	public void testInvalidOverwritingForConstraints() throws SqlParseException {
+		ExtendedSqlNode extendedSqlNode = (ExtendedSqlNode) createFlinkParser(
+			"CREATE TABLE t (\n" +
+			"   a STRING\n" +
+			")\n" +
+			"LIKE b (\n" +
+			"   OVERWRITING CONSTRAINTS" +
+			")")
+			.parseStmt();
+
+		thrown.expect(SqlValidateException.class);
+		thrown.expectMessage("Illegal merging strategy 'OVERWRITING' for 'CONSTRAINTS' option.");
+		extendedSqlNode.validate();
+	}
+
+	@Test
+	public void testInvalidNoOptions() throws SqlParseException {
+		thrown.expect(SqlParseException.class);
+		thrown.expectMessage("Encountered \")\" at line 4, column 9.\n" +
+			"Was expecting one of:\n" +
+			"    \"EXCLUDING\" ...\n" +
+			"    \"INCLUDING\" ...\n" +
+			"    \"OVERWRITING\" ...");
+		createFlinkParser(
+			"CREATE TABLE t (\n" +
+				"   a STRING\n" +
+				")\n" +
+				"LIKE b ()")
+			.parseStmt();
+	}
+
+	@Test
+	public void testInvalidNoSourceTable() throws SqlParseException {
+		thrown.expect(SqlParseException.class);
+		thrown.expectMessage("Encountered \"(\" at line 4, column 6.\n" +
+			"Was expecting one of:\n" +
+			"    <BRACKET_QUOTED_IDENTIFIER> ...\n" +
+			"    <QUOTED_IDENTIFIER> ...\n" +
+			"    <BACK_QUOTED_IDENTIFIER> ...\n" +
+			"    <IDENTIFIER> ...\n" +
+			"    <UNICODE_QUOTED_IDENTIFIER> ...\n");
+		createFlinkParser(
+			"CREATE TABLE t (\n" +
+				"   a STRING\n" +
+				")\n" +
+				"LIKE (" +
+				"   INCLUDING ALL" +
+				")")
+			.parseStmt();
+	}
+
+	public static SqlTableLikeOption option(MergingStrategy mergingStrategy, FeatureOption featureOption) {
+		return new SqlTableLikeOption(mergingStrategy, featureOption);
+	}
+
+	private static Matcher<SqlTableLike> hasOptions(SqlTableLikeOption... optionMatchers) {
+		return new FeatureMatcher<SqlTableLike, List<SqlTableLikeOption>>(
+			equalTo(Arrays.asList(optionMatchers)),
+			"like options equal to",
+			"like options") {
+			@Override
+			protected List<SqlTableLikeOption> featureValueOf(SqlTableLike actual) {
+				return actual.getOptions();
+			}
+		};
+	}
+
+	private static Matcher<SqlTableLike> hasNoOptions() {
+		return new FeatureMatcher<SqlTableLike, List<SqlTableLikeOption>>(
+			empty(),
+			"like options are empty",
+			"like options") {
+			@Override
+			protected List<SqlTableLikeOption> featureValueOf(SqlTableLike actual) {
+				return actual.getOptions();
+			}
+		};
+	}
+
+	private static Matcher<SqlTableLike> pointsTo(String... table) {
+		return new FeatureMatcher<SqlTableLike, String[]>(
+			equalTo(table),
+			"source table identifier pointing to",
+			"source table identifier") {
+
+			@Override
+			protected String[] featureValueOf(SqlTableLike actual) {
+				return actual.getSourceTable().names.toArray(new String[0]);
+			}
+		};
+	}
+
+	private static Matcher<SqlNode> hasLikeClause(Matcher<SqlTableLike> likeMatcher) {
+		return new FeatureMatcher<SqlNode, SqlTableLike>(
+			likeMatcher,
+			"create table statement has like clause",
+			"like clause") {
+
+			@Override
+			protected SqlTableLike featureValueOf(SqlNode actual) {
+				if (!(actual instanceof SqlCreateTable)) {
+					throw new AssertionError("Node is not a CREATE TABLE stmt.");
+				}
+				return ((SqlCreateTable) actual).getTableLike().orElse(null);
+			}
+		};
+	}
+
+	private SqlParser createFlinkParser(String expr) {
+		SqlParser.Config parserConfig = SqlParser.configBuilder()
+			.setParserFactory(FlinkSqlParserImpl.FACTORY)
+			.setLex(Lex.JAVA)
+			.setIdentifierMaxLength(256)
+			.build();
+
+		return SqlParser.create(expr, parserConfig);
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -616,11 +616,18 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			+ "select 'nom', 0, timestamp '1970-01-01 00:00:00',\n"
 			+ "  1, 1, 1, false\n"
 			+ "from (values 'a')";
-		sql(sql2).node(new ValidationMatcher());
+		sql(sql2).ok("INSERT INTO `EMP` (`EMPNO`, `ENAME`, `JOB`, `MGR`, `HIREDATE`, `SAL`," +
+			" `COMM`, `DEPTNO`, `SLACKER`)\n"
+			+ "PARTITION (`EMPNO` = '1', `JOB` = 'job')\n"
+			+ "(SELECT 'nom', 0, TIMESTAMP '1970-01-01 00:00:00', 1, 1, 1, FALSE\n"
+			+ "FROM (VALUES (ROW('a'))))");
 		final String sql3 = "insert into empnullables (empno, ename)\n"
 			+ "partition(ename='b')\n"
 			+ "select 1 from (values 'a')";
-		sql(sql3).node(new ValidationMatcher());
+		sql(sql3).ok("INSERT INTO `EMPNULLABLES` (`EMPNO`, `ENAME`)\n"
+			+ "PARTITION (`ENAME` = 'b')\n"
+			+ "(SELECT 1\n"
+			+ "FROM (VALUES (ROW('a'))))");
 	}
 
 	@Test
@@ -757,7 +764,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	@Test
 	public void testCreateViewWithEmptyFields() {
 		String sql = "CREATE VIEW v1 AS SELECT 1";
-		sql(sql).node(new ValidationMatcher());
+		sql(sql).ok(
+			"CREATE VIEW `V1`\n"
+				+ "AS\n"
+				+ "SELECT 1"
+		);
 	}
 
 	@Test

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -24,19 +24,14 @@ import org.apache.flink.sql.parser.impl.FlinkSqlParserImpl;
 
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.SqlParserTest;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Test;
 
-import java.io.Reader;
-import java.util.function.UnaryOperator;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-
 
 /** FlinkSqlParserImpl tests. **/
 public class FlinkSqlParserImplTest extends SqlParserTest {
@@ -44,11 +39,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	@Override
 	protected SqlParserImplFactory parserImplFactory() {
 		return FlinkSqlParserImpl.FACTORY;
-	}
-
-	protected SqlParser getSqlParser(Reader source,
-			UnaryOperator<SqlParser.ConfigBuilder> transform) {
-		return super.getSqlParser(source, transform);
 	}
 
 	@Test
@@ -586,6 +576,33 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			"  ^a^.b.c = 'ab',\n" +
 			"  a.b.c1 = 'aabb')\n";
 		sql(sql).fails("(?s).*Encountered \"a\" at line 6, column 3.\n.*");
+	}
+
+	@Test
+	public void testCreateTableWithLikeClause() {
+		final String sql = "create table source_table(\n" +
+			"  a int,\n" +
+			"  b bigint,\n" +
+			"  c string\n" +
+			")\n" +
+			"LIKE parent_table (\n" +
+			"   INCLUDING ALL\n" +
+			"   OVERWRITING OPTIONS\n" +
+			"   EXCLUDING PARTITIONS\n" +
+			"   INCLUDING GENERATED\n" +
+			")";
+		final String expected = "CREATE TABLE `SOURCE_TABLE` (\n" +
+			"  `A`  INTEGER,\n" +
+			"  `B`  BIGINT,\n" +
+			"  `C`  STRING\n" +
+			")\n" +
+			"LIKE `PARENT_TABLE` (\n" +
+			"  INCLUDING ALL\n" +
+			"  OVERWRITING OPTIONS\n" +
+			"  EXCLUDING PARTITIONS\n" +
+			"  INCLUDING GENERATED\n" +
+			")";
+		sql(sql).ok(expected);
 	}
 
 	@Test


### PR DESCRIPTION


## What is the purpose of the change

This PR implements parsing and validation of LIKE clause in a CREATE TABLE statement. It verifies valid combinations of merging strategies and table descriptor features.


## Verifying this change

Adds tests in:
* org.apache.flink.sql.parser.CreateTableLikeTest
* org.apache.flink.sql.parser.FlinkSqlParserImplTest#testCreateTableWithLikeClause

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? will be documented later
