### PR TITLE
[FLINK-17188][python] Use pip instead of conda to install flake8 and sphinx

### DIFF
--- a/flink-python/dev/lint-python.sh
+++ b/flink-python/dev/lint-python.sh
@@ -244,6 +244,7 @@ function install_py_env() {
 # Install tox.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_tox() {
+    source $CONDA_HOME/bin/activate
     if [ -f "$TOX_PATH" ]; then
         $PIP_PATH uninstall tox -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
@@ -257,57 +258,62 @@ function install_tox() {
     # tox 3.14.0 depends on both 0.19 and 0.23 of importlib_metadata at the same time and
     # conda will try to install both these two versions and it will cause problems occasionally.
     # Using pip as the package manager could avoid this problem.
-    $PIP_PATH install -q virtualenv==16.0.0 tox==3.14.0 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q virtualenv==16.0.0 tox==3.14.0 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "pip install tox failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
+    conda deactivate
 }
 
 # Install flake8.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_flake8() {
+    source $CONDA_HOME/bin/activate
     if [ -f "$FLAKE8_PATH" ]; then
-        $CONDA_PATH remove -p $CONDA_HOME flake8 -y -q 2>&1 >/dev/null
+        $PIP_PATH uninstall flake8 -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "conda remove flake8 failed \
+            echo "pip uninstall flake8 failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
         fi
     fi
 
-    $CONDA_PATH install -p $CONDA_HOME -c anaconda flake8 -y -q 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q flake8==3.7.9 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "conda install flake8 failed \
+        echo "pip install flake8 failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
+    conda deactivate
 }
 
 # Install sphinx.
 # In some situations,you need to run the script with "sudo". e.g. sudo ./lint-python.sh
 function install_sphinx() {
+    source $CONDA_HOME/bin/activate
     if [ -f "$SPHINX_PATH" ]; then
-        $CONDA_PATH remove -p $CONDA_HOME sphinx -y -q 2>&1 >/dev/null
+        $PIP_PATH uninstall Sphinx -y -q 2>&1 >/dev/null
         if [ $? -ne 0 ]; then
-            echo "conda remove sphinx failed \
+            echo "pip uninstall sphinx failed \
             please try to exec the script again.\
             if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
             exit 1
         fi
     fi
 
-    $CONDA_PATH install -p $CONDA_HOME -c anaconda sphinx -y -q 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q Sphinx==2.4.4 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
-        echo "conda install sphinx failed \
+        echo "pip install sphinx failed \
         please try to exec the script again.\
         if failed many times, you can try to exec in the form of sudo ./lint-python.sh -f"
         exit 1
     fi
+    conda deactivate
 }
 
 function need_install_component() {
@@ -604,7 +610,6 @@ CURRENT_DIR="$(cd "$( dirname "$0" )" && pwd)"
 
 # FLINK_PYTHON_DIR is "flink/flink-python"
 FLINK_PYTHON_DIR=$(dirname "$CURRENT_DIR")
-pushd "$FLINK_PYTHON_DIR" &> /dev/null
 
 # conda home path
 CONDA_HOME=$CURRENT_DIR/.conda
@@ -755,6 +760,7 @@ fi
 # install environment
 install_environment
 
+pushd "$FLINK_PYTHON_DIR" &> /dev/null
 # exec all selected checks
 if [ $skip_checks -eq 0 ]; then
     check_stage


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will use pip instead of conda to install flake8 and sphinx. We found our Azure machine always can't connect to anaconda channel, but we can use pip to install large packages such as apache-beam, pyarrow, numpy and so on. So I choose to use pip to install flake8 and sphinx*


## Brief change log

  - *Use pip to install flake8 and sphinx in lint-python.sh*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
