### PR TITLE
[FLINK-16160][table-planner-blink] Fix proctime()/rowtime() doesn't w…

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -122,7 +122,7 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
 		return Optional.empty();
 	}
 
-	private static <T1> TableSchema calculateSourceSchema(TableSource<T1> source, boolean isBatch) {
+	public static <T1> TableSchema calculateSourceSchema(TableSource<T1> source, boolean isBatch) {
 		TableSchema tableSchema = source.getTableSchema();
 		if (isBatch) {
 			return tableSchema;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/sources/TableSourceValidation.java
@@ -69,10 +69,19 @@ public class TableSourceValidation {
 	 * Checks if the given {@link TableSource} defines a rowtime attribute.
 	 *
 	 * @param tableSource The table source to check.
-	 * @return true if the given table source defines rotime attribute
+	 * @return true if the given table source defines rowtime attribute
 	 */
 	public static boolean hasRowtimeAttribute(TableSource<?> tableSource) {
 		return !getRowtimeAttributes(tableSource).isEmpty();
+	}
+
+	/**
+	 * Checks if the given {@link TableSource} defines a proctime attribute.
+	 * @param tableSource The table source to check.
+	 * @return true if the given table source defines proctime attribute.
+	 */
+	public static boolean hasProctimeAttribute(TableSource<?> tableSource) {
+		return getProctimeAttribute(tableSource).isPresent();
 	}
 
 	private static void validateSingleRowtimeAttribute(List<RowtimeAttributeDescriptor> rowtimeAttributes) {

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -18,15 +18,27 @@
 
 package org.apache.flink.table.planner.catalog;
 
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.factories.TableFactoryUtil;
+import org.apache.flink.table.factories.TableSourceFactory;
+import org.apache.flink.table.factories.TableSourceFactoryContextImpl;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
 import org.apache.flink.table.planner.sources.TableSourceUtil;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.table.sources.TableSourceValidation;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimestampKind;
@@ -38,6 +50,7 @@ import org.apache.calcite.schema.TemporalTable;
 import org.apache.calcite.schema.impl.AbstractTable;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a wrapper for {@link CatalogBaseTable} in {@link org.apache.calcite.schema.Schema}.
@@ -119,7 +132,7 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 		return statistic;
 	}
 
-	private static RelDataType getRowType(RelDataTypeFactory typeFactory,
+	private RelDataType getRowType(RelDataTypeFactory typeFactory,
 			CatalogBaseTable catalogBaseTable,
 			boolean isStreamingMode) {
 		final FlinkTypeFactory flinkTypeFactory = (FlinkTypeFactory) typeFactory;
@@ -148,6 +161,24 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 				}
 			}
 		}
+
+		// The following block is a workaround to support tables defined by TableEnvironment.connect() and
+		// the actual table sources implement DefinedProctimeAttribute/DefinedRowtimeAttributes.
+		// It should be removed after we remove DefinedProctimeAttribute/DefinedRowtimeAttributes.
+		Optional<TableSource<?>> sourceOpt = findAndCreateTableSource();
+		if (isStreamingMode
+			&& tableSchema.getTableColumns().stream().noneMatch(TableColumn::isGenerated)
+			&& tableSchema.getWatermarkSpecs().isEmpty()
+			&& sourceOpt.isPresent()) {
+			TableSource<?> source = sourceOpt.get();
+			if (TableSourceValidation.hasProctimeAttribute(source)
+					|| TableSourceValidation.hasRowtimeAttribute(source)) {
+				// If the table is defined by TableEnvironment.connect(), and use the legacy proctime and rowtime
+				// descriptors, the TableSchema should fallback to ConnectorCatalogTable#calculateSourceSchema
+				tableSchema = ConnectorCatalogTable.calculateSourceSchema(source, false);
+			}
+		}
+
 		return TableSourceUtil.getSourceRowType(flinkTypeFactory,
 			tableSchema,
 			scala.Option.empty(),
@@ -162,5 +193,32 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
 	@Override
 	public String getSysEndFieldName() {
 		return "sys_end";
+	}
+
+	private Optional<TableSource<?>> findAndCreateTableSource() {
+		Optional<TableSource<?>> tableSource = Optional.empty();
+		try {
+			if (catalogBaseTable instanceof CatalogTableImpl) {
+				// Use an empty config for TableSourceFactoryContextImpl since we can't fetch the
+				// actual TableConfig here. And currently the empty config do not affect the logic.
+				ReadableConfig config = new TableConfig().getConfiguration();
+				TableSourceFactory.Context context =
+					new TableSourceFactoryContextImpl(tableIdentifier, (CatalogTable) catalogBaseTable, config);
+				TableSource<?> source = TableFactoryUtil.findAndCreateTableSource(context);
+				if (source instanceof StreamTableSource) {
+					if (!isStreamingMode && !((StreamTableSource) source).isBounded()) {
+						throw new ValidationException("Cannot query on an unbounded source in batch mode, but " +
+							tableIdentifier.asSummaryString() + " is unbounded.");
+					}
+					tableSource = Optional.of(source);
+				} else {
+					throw new ValidationException("Catalog tables only support " +
+						"StreamTableSource and InputFormatTableSource.");
+				}
+			}
+		} catch (Exception e) {
+			tableSource = Optional.empty();
+		}
+		return tableSource;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-table/flink-table-planner-blink/src/test/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -35,3 +35,4 @@ org.apache.flink.table.planner.utils.TestDataTypeTableSourceFactory
 org.apache.flink.table.planner.utils.TestDataTypeTableSourceWithTimeFactory
 org.apache.flink.table.planner.utils.TestStreamTableSourceFactory
 org.apache.flink.table.planner.utils.TestFileInputFormatTableSourceFactory
+org.apache.flink.table.planner.utils.TestTableSourceWithTimeFactory

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/LegacyTableSourceTest.xml
@@ -132,6 +132,64 @@ Calc(select=[name, w$end AS EXPR$1, EXPR$2])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testLegacyRowTimeTableGroupWindow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT name,
+    TUMBLE_END(rowtime, INTERVAL '10' MINUTE),
+    AVG(val)
+FROM rowTimeT WHERE val > 100
+    GROUP BY name, TUMBLE(rowtime, INTERVAL '10' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[AVG($2)])
+   +- LogicalProject(name=[$2], $f1=[$TUMBLE($3, 600000:INTERVAL MINUTE)], val=[$1])
+      +- LogicalFilter(condition=[>($1, 100)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, rowTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, w$end AS EXPR$1, EXPR$2])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w$, rowtime, 600000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[name, rowtime, val], where=[>(val, 100)])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, rowTimeT]], fields=[id, val, name, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLegacyProcTimeTableGroupWindow">
+    <Resource name="sql">
+      <![CDATA[
+SELECT name,
+    TUMBLE_END(proctime, INTERVAL '10' MINUTE),
+    AVG(val)
+FROM procTimeT WHERE val > 100
+    GROUP BY name, TUMBLE(proctime, INTERVAL '10' MINUTE)
+      ]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(name=[$0], EXPR$1=[TUMBLE_END($1)], EXPR$2=[$2])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[AVG($2)])
+   +- LogicalProject(name=[$2], $f1=[$TUMBLE($3, 600000:INTERVAL MINUTE)], val=[$1])
+      +- LogicalFilter(condition=[>($1, 100)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, procTimeT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Calc(select=[name, w$end AS EXPR$1, EXPR$2])
++- GroupWindowAggregate(groupBy=[name], window=[TumblingGroupWindow('w$, proctime, 600000)], properties=[w$start, w$end, w$proctime], select=[name, AVG(val) AS EXPR$2, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime])
+   +- Exchange(distribution=[hash[name]])
+      +- Calc(select=[name, proctime, val], where=[>(val, 100)])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, procTimeT]], fields=[id, val, name, proctime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilterFullyPushDown">
     <Resource name="sql">
       <![CDATA[SELECT * FROM FilterableTable WHERE amount > 2 AND amount < 10]]>


### PR DESCRIPTION
…ork for TableEnvironment.connect().createTemporaryTable()


## What is the purpose of the change
Since FLINK-14490, proctime()/rowtime() doesn't work  for TableEnvironment.connect().createTemporaryTable(), The root cause is:
- proctime()/rowtime() are used along with DefinedRowtimeAttributes/DefinedProctimeAttribute and ConnectorCatalogTable.  The original code path stores the ConnectorCatalogTable object in Catalog and in validate phrase, the RowType is derived from ConnectorCatalogTable.getSchema which contains time indicator. After FLINK-14490, we store CatalogTableImpl object in Catalog and in validate phrase, the RowType is derived from CatalogTableImpl.getSchema which doesn't contain time indicator.
- In SqlToRel phrase, FlinkCalciteCatalogReader converts ConnectorCatalogTable to TableSourceTable and converts CatalogTable to CatalogSourceTable. The TableSourceTable would be converted to LogicalTableScan directly and contains time indicator. Otherwise the CatalogSourceTable would be converted to a LogicalTableScan whose time indicator is erased(by FLINK-16345).
This PR fix it.

## Brief change log
- instantiate the TableSource in CatalogSchemaTable and check if it's a DefinedRowtimeAttributes/DefinedProctimeAttribute instance. If so, rewrite the TableSchema to patch the time indicator(as it is in ConnectorCatalogTable#calculateSourceSchema)
- Avoid erasing time indicator in CatalogSourceTable if the TableSource is a DefinedRowtimeAttributes/DefinedProctimeAttribute instance

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
