### PR TITLE
[FLINK-17313]fix type validation error when sink table ddl exists column with precision of decimal/varchar

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
@@ -169,8 +169,7 @@ public final class TypeMappingUtils {
 										logicalFieldName,
 										physicalFieldType,
 										physicalFieldName,
-										"TableSource return type"),
-								cause));
+										"TableSource return type"), cause));
 		} else {
 			checkIfCompatible(
 					logicalFieldType,
@@ -182,8 +181,7 @@ public final class TypeMappingUtils {
 									logicalFieldName,
 									physicalFieldType,
 									physicalFieldName,
-									"TableSink consumed type"),
-								cause));
+									"TableSink consumed type"), cause));
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/TypeMappingUtils.java
@@ -164,24 +164,24 @@ public final class TypeMappingUtils {
 					logicalFieldType,
 					(cause) -> new ValidationException(
 								String.format("Type %s of table field '%s' does not match with " +
-									"the physical type %s of the '%s' field of the %s.",
+									"the physical type %s of the '%s' field of the TableSource return type.",
 										logicalFieldType,
 										logicalFieldName,
 										physicalFieldType,
-										physicalFieldName,
-										"TableSource return type"), cause));
+										physicalFieldName),
+								cause));
 		} else {
 			checkIfCompatible(
 					logicalFieldType,
 					physicalFieldType,
 					(cause) -> new ValidationException(
 								String.format("Type %s of table field '%s' does not match with " +
-									"the physical type %s of the '%s' field of the %s.",
+									"the physical type %s of the '%s' field of the TableSink consumed type.",
 									logicalFieldType,
 									logicalFieldName,
 									physicalFieldType,
-									physicalFieldName,
-									"TableSink consumed type"), cause));
+									physicalFieldName),
+								cause));
 		}
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* Now TypeMappingUtils#checkPhysicalLogicalTypeCompatible method doesn't consider the different physical and logical type validation logic of source and sink: logical type should be able to cover the physical type in source, but physical type should be able to cover the logic type in sink vice verse. Besides, the decimal type should be taken more carefully, when target type is Legacy(Decimal), it should be able to accept any precision decimal type.*
* This pr aims to solve the above problem.*


## Brief change log

  - 9b24a40 correct the validation logc

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
