### PR TITLE
[FLINK-15006][table-planner] Add option to shuffle-by-partition when dynamic inserting

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSinkRule.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchExecSinkRule.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.rules.physical.batch
 
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.filesystem.FileSystemTableFactory
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistribution
 import org.apache.flink.table.planner.plan.nodes.FlinkConventions
 import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSink
@@ -53,9 +54,16 @@ class BatchExecSinkRule extends ConverterRule(
             val dynamicPartIndices =
               dynamicPartFields.map(partitionSink.getTableSchema.getFieldNames.indexOf(_))
 
-            requiredTraitSet = requiredTraitSet.plus(
-              FlinkRelDistribution.hash(dynamicPartIndices
-                  .map(Integer.valueOf), requireStrict = false))
+            val shuffleEnable = sinkNode
+                .catalogTable
+                .getProperties
+                .get(FileSystemTableFactory.SINK_SHUFFLE_BY_PARTITION.key())
+
+            if (shuffleEnable != null && shuffleEnable.toBoolean) {
+              requiredTraitSet = requiredTraitSet.plus(
+                FlinkRelDistribution.hash(dynamicPartIndices
+                    .map(Integer.valueOf), requireStrict = false))
+            }
 
             if (partitionSink.configurePartitionGrouping(true)) {
               // default to asc.

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.xml
@@ -19,7 +19,6 @@ limitations under the License.
   <TestCase name="testDynamic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink SELECT a, b, c FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -27,22 +26,38 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Sort(orderBy=[b ASC, c ASC])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDynamicShuffleBy">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[`default_catalog`.`default_database`.`sinkShuffleBy`], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[`default_catalog`.`default_database`.`sinkShuffleBy`], fields=[a, b, c])
++- Sort(orderBy=[b ASC, c ASC])
    +- Exchange(distribution=[hash[b, c]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPartial">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -50,23 +65,19 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Sort(orderBy=[c ASC])
-   +- Exchange(distribution=[hash[c]])
-      +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
-         +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+   +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testStatic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -74,7 +85,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -82,19 +92,16 @@ Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testWrongFields">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testWrongStatic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable]]>
-
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
+++ b/flink-table/flink-table-planner-blink/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.xml
@@ -19,7 +19,6 @@ limitations under the License.
   <TestCase name="testDynamic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink SELECT a, b, c FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -27,21 +26,36 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], b=[$1], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDynamicShuffleBy">
+    <Resource name="sql">
+      <![CDATA[INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalSink(name=[`default_catalog`.`default_database`.`sinkShuffleBy`], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+Sink(name=[`default_catalog`.`default_database`.`sinkShuffleBy`], fields=[a, b, c])
 +- Exchange(distribution=[hash[b, c]])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testPartial">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, c FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -49,22 +63,18 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], c=[$2])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
 Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
-+- Exchange(distribution=[hash[c]])
-   +- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
-      +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
++- Calc(select=[a, 1:BIGINT AS EXPR$1, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testStatic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1, c=1) SELECT a FROM MyTable]]>
-
     </Resource>
     <Resource name="planBefore">
       <![CDATA[
@@ -72,7 +82,6 @@ LogicalSink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c]
 +- LogicalProject(a=[$0], EXPR$1=[1:BIGINT], EXPR$2=[1:BIGINT])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
 ]]>
-
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
@@ -80,19 +89,16 @@ Sink(name=[`default_catalog`.`default_database`.`sink`], fields=[a, b, c])
 +- Calc(select=[a, 1:BIGINT AS EXPR$1, 1:BIGINT AS EXPR$2])
    +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
 ]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testWrongFields">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (b=1) SELECT a, b, c FROM MyTable]]>
-
     </Resource>
   </TestCase>
   <TestCase name="testWrongStatic">
     <Resource name="sql">
       <![CDATA[INSERT INTO sink PARTITION (a=1) SELECT b, c FROM MyTable]]>
-
     </Resource>
   </TestCase>
 </Root>

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/PartitionableSinkTest.scala
@@ -18,12 +18,9 @@
 
 package org.apache.flink.table.planner.plan.batch.sql
 
-import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
-import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{SqlDialect, TableConfig, ValidationException}
-import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase
 import org.apache.flink.table.planner.utils.TableTestBase
 
 import org.junit.Test
@@ -32,14 +29,23 @@ class PartitionableSinkTest extends TableTestBase {
 
   private val util = batchTestUtil()
   util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
-  PartitionableSinkITCase.registerTableSink(
-    util.tableEnv,
-    "sink",
-    new RowTypeInfo(
-      Array[TypeInformation[_]](Types.LONG, Types.LONG, Types.LONG),
-      Array("a", "b", "c")),
-    grouping = true,
-    Array("b", "c"))
+  createTable("sink", shuffleBy = false)
+
+  private def createTable(name: String, shuffleBy: Boolean): Unit = {
+    util.tableEnv.sqlUpdate(
+      s"""
+         |create table $name (
+         |  a bigint,
+         |  b bigint,
+         |  c bigint
+         |) partitioned by (b, c) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '/non',
+         |  ${if (shuffleBy) "'sink.shuffle-by-partition.enable'='true'," else ""}
+         |  'format' = 'testcsv'
+         |)
+         |""".stripMargin)
+  }
 
   @Test
   def testStatic(): Unit = {
@@ -49,6 +55,12 @@ class PartitionableSinkTest extends TableTestBase {
   @Test
   def testDynamic(): Unit = {
     util.verifySqlUpdate("INSERT INTO sink SELECT a, b, c FROM MyTable")
+  }
+
+  @Test
+  def testDynamicShuffleBy(): Unit = {
+    createTable("sinkShuffleBy", shuffleBy = true)
+    util.verifySqlUpdate("INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/PartitionableSinkTest.scala
@@ -18,12 +18,9 @@
 
 package org.apache.flink.table.planner.plan.stream.sql
 
-import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
-import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{SqlDialect, TableConfig, ValidationException}
-import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase
 import org.apache.flink.table.planner.utils.TableTestBase
 
 import org.junit.Test
@@ -32,14 +29,23 @@ class PartitionableSinkTest extends TableTestBase {
 
   private val util = streamTestUtil()
   util.addTableSource[(Long, Long, Long)]("MyTable", 'a, 'b, 'c)
-  PartitionableSinkITCase.registerTableSink(
-    util.tableEnv,
-    "sink",
-    new RowTypeInfo(
-      Array[TypeInformation[_]](Types.LONG, Types.LONG, Types.LONG),
-      Array("a", "b", "c")),
-    grouping = false,
-    Array("b", "c"))
+  createTable("sink", shuffleBy = false)
+
+  private def createTable(name: String, shuffleBy: Boolean): Unit = {
+    util.tableEnv.sqlUpdate(
+      s"""
+         |create table $name (
+         |  a bigint,
+         |  b bigint,
+         |  c bigint
+         |) partitioned by (b, c) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '/non',
+         |  ${if (shuffleBy) "'sink.shuffle-by-partition.enable'='true'," else ""}
+         |  'format' = 'testcsv'
+         |)
+         |""".stripMargin)
+  }
 
   @Test
   def testStatic(): Unit = {
@@ -49,6 +55,12 @@ class PartitionableSinkTest extends TableTestBase {
   @Test
   def testDynamic(): Unit = {
     util.verifySqlUpdate("INSERT INTO sink SELECT a, b, c FROM MyTable")
+  }
+
+  @Test
+  def testDynamicShuffleBy(): Unit = {
+    createTable("sinkShuffleBy", shuffleBy = true)
+    util.verifySqlUpdate("INSERT INTO sinkShuffleBy SELECT a, b, c FROM MyTable")
   }
 
   @Test

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -31,6 +31,7 @@ import org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR
 import org.apache.flink.table.descriptors.DescriptorProperties
 import org.apache.flink.table.descriptors.Schema.SCHEMA
 import org.apache.flink.table.factories.TableSinkFactory
+import org.apache.flink.table.filesystem.FileSystemTableFactory
 import org.apache.flink.table.planner.runtime.batch.sql.PartitionableSinkITCase._
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
@@ -264,6 +265,7 @@ object PartitionableSinkITCase {
       partitionColumns: Array[String]): Unit = {
     val properties = new DescriptorProperties()
     properties.putString("supports-grouping", grouping.toString)
+    properties.putString(FileSystemTableFactory.SINK_SHUFFLE_BY_PARTITION.key(), "true")
     properties.putString(CONNECTOR_TYPE, "TestPartitionableSink")
     partitionColumns.zipWithIndex.foreach { case (part, i) =>
       properties.putString("partition-column." + i, part)

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -110,9 +110,9 @@ public class FileSystemTableFactory implements
 		properties.add(DescriptorProperties.PARTITION_KEYS + ".#." +
 				DescriptorProperties.PARTITION_KEYS_NAME);
 		properties.add(PARTITION_DEFAULT_NAME.key());
+
 		properties.add(SINK_ROLLING_POLICY_FILE_SIZE.key());
 		properties.add(SINK_ROLLING_POLICY_TIME_INTERVAL.key());
-
 		properties.add(SINK_SHUFFLE_BY_PARTITION.key());
 
 		// format

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -81,6 +81,13 @@ public class FileSystemTableFactory implements
 			.defaultValue(60L * 1000L)
 			.withDescription("The maximum time duration a part file can stay open before rolling (by default 60 sec).");
 
+	public static final ConfigOption<Boolean> SINK_SHUFFLE_BY_PARTITION = key("sink.shuffle-by-partition.enable")
+			.booleanType()
+			.defaultValue(false)
+			.withDescription("The option to enable shuffle data by dynamic partition fields in sink" +
+					" phase, this can greatly reduce the number of file for filesystem sink but may" +
+					" lead data skew, the default value is disabled.");
+
 	@Override
 	public Map<String, String> requiredContext() {
 		Map<String, String> context = new HashMap<>();
@@ -105,6 +112,8 @@ public class FileSystemTableFactory implements
 		properties.add(PARTITION_DEFAULT_NAME.key());
 		properties.add(SINK_ROLLING_POLICY_FILE_SIZE.key());
 		properties.add(SINK_ROLLING_POLICY_TIME_INTERVAL.key());
+
+		properties.add(SINK_SHUFFLE_BY_PARTITION.key());
 
 		// format
 		properties.add(FORMAT);


### PR DESCRIPTION

## What is the purpose of the change

When partition values are rare or have skew, if we shuffle by dynamic partitions, will break the performance.
We can have an option to close shuffle in such cases:
‘sink.shuffle-by-partition.enable’ = ...

## Brief change log

- Modify `BatchExecSinkRule` and `StreamExecSinkRule` to default not shuffle

## Verifying this change

`PartitionSinkTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no