### PR TITLE
[FLINK-17268][connector/common] Fix the bug of missing records during SplitFetcher wakeup.

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
@@ -33,8 +33,8 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 	private final SplitReader<E, SplitT> splitReader;
 	private final BlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
 	private final Consumer<Collection<String>> splitFinishedCallback;
-	private RecordsWithSplitIds<E> lastRecords;
-	private Thread runningThread;
+	private final Thread runningThread;
+	private volatile RecordsWithSplitIds<E> lastRecords;
 	private volatile boolean wakeup;
 
 	FetchTask(
@@ -52,16 +52,28 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 
 	@Override
 	public boolean run() throws InterruptedException {
-		if (lastRecords == null) {
-			lastRecords = splitReader.fetch();
-		}
-		if (!wakeup) {
-			elementsQueue.put(lastRecords);
-			splitFinishedCallback.accept(lastRecords.finishedSplits());
-		}
-		synchronized (this) {
-			wakeup = false;
-			lastRecords = null;
+		try {
+			if (!isWakenUp() && lastRecords == null) {
+				lastRecords = splitReader.fetch();
+			}
+
+			if (!isWakenUp()) {
+				// The order matters here. We must first put the last records into the queue.
+				// This ensures the handling of the fetched records is atomic to wakeup.
+				elementsQueue.put(lastRecords);
+				// The callback does not throw InterruptedException.
+				splitFinishedCallback.accept(lastRecords.finishedSplits());
+				lastRecords = null;
+			}
+		} finally {
+			// clean up the potential wakeup effect. It is possible that the fetcher is waken up
+			// after the clean up. In that case, either the wakeup flag will be set or the
+			// running thread will be interrupted. The next invocation of run() will see that and
+			// just skip.
+			if (isWakenUp()) {
+				Thread.interrupted();
+				wakeup = false;
+			}
 		}
 		// The return value of fetch task does not matter.
 		return true;
@@ -69,14 +81,23 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
 
 	@Override
 	public void wakeUp() {
-		synchronized (this) {
-			wakeup = true;
-			if (lastRecords == null) {
-				splitReader.wakeUp();
-			} else {
-				runningThread.interrupt();
-			}
+		// Set the wakeup flag first.
+		wakeup = true;
+		if (lastRecords == null) {
+			// Two possible cases:
+			// 1. The splitReader is reading or is about to read the records.
+			// 2. The records has been enqueued and set to null.
+			// In case 1, we just wakeup the split reader. In case 2, the next run might be skipped.
+			// In any case, the records won't be enqueued in the ongoing run().
+			splitReader.wakeUp();
+		} else {
+			// The task might be blocking on enqueuing the records, just interrupt.
+			runningThread.interrupt();
 		}
+	}
+
+	private boolean isWakenUp() {
+		return wakeup || runningThread.isInterrupted();
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -233,7 +233,7 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 	 * synchronize to ensure the wake up logic do not touch a different invocation.
 	 */
 	void wakeUp(boolean taskOnly) {
-		// Synchronize to make sure the wake up only work for the current invocation of runOnce().
+		// Synchronize to make sure the wake up only works for the current invocation of runOnce().
 		synchronized (wakeUp) {
 			// Do not wake up repeatedly.
 			if (wakeUp.compareAndSet(false, true)) {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -29,10 +29,10 @@ import org.apache.flink.util.ThrowableCatchingRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +73,9 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 	/** An executor service with two threads. One for the fetcher and one for the future completing thread. */
 	private final ExecutorService executors;
 
+	/** Indicating the split fetcher manager has closed or not. */
+	private volatile boolean closed;
+
 	/**
 	 * Create a split fetcher manager.
 	 *
@@ -100,11 +103,12 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 		this.splitReaderFactory = splitReaderFactory;
 		this.uncaughtFetcherException = new AtomicReference<>(null);
 		this.fetcherIdGenerator = new AtomicInteger(0);
-		this.fetchers = new HashMap<>();
+		this.fetchers = new ConcurrentHashMap<>();
 
 		// Create the executor with a thread factory that fails the source reader if one of
 		// the fetcher thread exits abnormally.
 		this.executors = Executors.newCachedThreadPool(r -> new Thread(r, "SourceFetcher"));
+		this.closed = false;
 	}
 
 	public abstract void addSplits(List<SplitT> splitsToAdd);
@@ -113,7 +117,16 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 		executors.submit(new ThrowableCatchingRunnable(errorHandler, fetcher));
 	}
 
-	protected SplitFetcher<E, SplitT> createSplitFetcher() {
+	/**
+	 * Synchronize method to ensure no fetcher is created after the split fetcher manager has closed.
+	 *
+	 * @return the created split fetcher.
+	 * @throws IllegalStateException if the split fetcher manager has closed.
+	 */
+	protected synchronized SplitFetcher<E, SplitT> createSplitFetcher() {
+		if (closed) {
+			throw new IllegalStateException("The split fetcher manager has closed.");
+		}
 		// Create SplitReader.
 		SplitReader<E, SplitT> splitReader = splitReaderFactory.get();
 
@@ -127,7 +140,14 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 		return splitFetcher;
 	}
 
-	public void close(long timeoutMs) throws Exception {
+	/**
+	 * Close the split fetcher manager.
+	 *
+	 * @param timeoutMs the max time in milliseconds to wait.
+	 * @throws Exception when failed to close the split fetcher manager.
+	 */
+	public synchronized void close(long timeoutMs) throws Exception {
+		closed = true;
 		fetchers.values().forEach(SplitFetcher::shutdown);
 		executors.shutdown();
 		if (!executors.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS)) {

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderTestBase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderTestBase.java
@@ -75,7 +75,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		// Add a split to start the fetcher.
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Poll 5 records and let it block on the element queue which only have capacity of 1;
-		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, 5, Boundedness.BOUNDED)) {
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, 5)) {
 			List<SplitT> newSplits = new ArrayList<>();
 			for (int i = 1; i < NUM_SPLITS; i++) {
 				newSplits.add(getSplit(i, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
@@ -94,7 +94,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		ValidatingSourceOutput output = new ValidatingSourceOutput();
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Consumer all the records in the s;oit.
-		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT)) {
 			// Now let the main thread poll again.
 			assertEquals("The status should be ", SourceReader.Status.AVAILABLE_LATER, reader.pollNext(output));
 		}
@@ -105,7 +105,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		ValidatingSourceOutput output = new ValidatingSourceOutput();
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Consumer all the records in the split.
-		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT)) {
 			CompletableFuture<?> future = reader.isAvailable();
 			assertFalse("There should be no records ready for poll.", future.isDone());
 			// Add a split to the reader so there are more records to be read.
@@ -122,7 +122,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		List<SplitT> splits = getSplits(NUM_SPLITS, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED);
 		// Poll 5 records. That means split 0 and 1 will at index 2, split 1 will at index 1.
 		try (SourceReader<Integer, SplitT> reader =
-				consumeRecords(splits, output, NUM_SPLITS * NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+				consumeRecords(splits, output, NUM_SPLITS * NUM_RECORDS_PER_SPLIT)) {
 			List<SplitT> state = reader.snapshotState();
 			assertEquals("The snapshot should only have 10 splits. ", NUM_SPLITS, state.size());
 			for (int i = 0; i < NUM_SPLITS; i++) {
@@ -145,8 +145,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 	private SourceReader<Integer, SplitT> consumeRecords(
 			List<SplitT> splits,
 			ValidatingSourceOutput output,
-			int n,
-			Boundedness boundedness) throws Exception {
+			int n) throws Exception {
 		SourceReader<Integer, SplitT> reader = createReader();
 		// Add splits to start the fetcher.
 		reader.addSplits(splits);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderTestBase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderTestBase.java
@@ -48,6 +48,7 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 
 	protected static final int NUM_SPLITS = 10;
 	protected static final int NUM_RECORDS_PER_SPLIT = 10;
+	protected static final int TOTAL_NUM_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
 
 	@Rule
 	public ExpectedException expectedException = ExpectedException.none();
@@ -57,32 +58,35 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 	 */
 	@Test
 	public void testRead() throws Exception {
-		SourceReader<Integer, SplitT> reader = createReader();
-		reader.addSplits(getSplits(NUM_SPLITS, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
-		ValidatingSourceOutput output = new ValidatingSourceOutput();
-		while (output.count < 100) {
-			reader.pollNext(output);
+		try (SourceReader<Integer, SplitT> reader = createReader()) {
+			reader.addSplits(getSplits(NUM_SPLITS, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
+			ValidatingSourceOutput output = new ValidatingSourceOutput();
+			while (output.count < TOTAL_NUM_RECORDS) {
+				reader.pollNext(output);
+			}
+			output.validate();
 		}
-		output.validate();
 	}
 
 	@Test
 	public void testAddSplitToExistingFetcher() throws Exception {
+		Thread.sleep(10);
 		ValidatingSourceOutput output = new ValidatingSourceOutput();
 		// Add a split to start the fetcher.
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Poll 5 records and let it block on the element queue which only have capacity of 1;
-		SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, 5, Boundedness.BOUNDED);
-		List<SplitT> newSplits = new ArrayList<>();
-		for (int i = 1; i < NUM_SPLITS; i++) {
-			newSplits.add(getSplit(i, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
-		}
-		reader.addSplits(newSplits);
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, 5, Boundedness.BOUNDED)) {
+			List<SplitT> newSplits = new ArrayList<>();
+			for (int i = 1; i < NUM_SPLITS; i++) {
+				newSplits.add(getSplit(i, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
+			}
+			reader.addSplits(newSplits);
 
-		while (output.count() < 100) {
-			reader.pollNext(output);
+			while (output.count() < NUM_RECORDS_PER_SPLIT * NUM_SPLITS) {
+				reader.pollNext(output);
+			}
+			output.validate();
 		}
-		output.validate();
 	}
 
 	@Test (timeout = 30000L)
@@ -90,9 +94,10 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		ValidatingSourceOutput output = new ValidatingSourceOutput();
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Consumer all the records in the s;oit.
-		SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED);
-		// Now let the main thread poll again.
-		assertEquals("The status should be ", SourceReader.Status.AVAILABLE_LATER, reader.pollNext(output));
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+			// Now let the main thread poll again.
+			assertEquals("The status should be ", SourceReader.Status.AVAILABLE_LATER, reader.pollNext(output));
+		}
 	}
 
 	@Test (timeout = 30000L)
@@ -100,14 +105,14 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		ValidatingSourceOutput output = new ValidatingSourceOutput();
 		List<SplitT> splits = Collections.singletonList(getSplit(0, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED));
 		// Consumer all the records in the split.
-		SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED);
-
-		CompletableFuture<?> future = reader.isAvailable();
-		assertFalse("There should be no records ready for poll.", future.isDone());
-		// Add a split to the reader so there are more records to be read.
-		reader.addSplits(Collections.singletonList(getSplit(1, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)));
-		// THe future should be completed fairly soon. Otherwise the test will hit timeout and fail.
-		future.get();
+		try (SourceReader<Integer, SplitT> reader = consumeRecords(splits, output, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+			CompletableFuture<?> future = reader.isAvailable();
+			assertFalse("There should be no records ready for poll.", future.isDone());
+			// Add a split to the reader so there are more records to be read.
+			reader.addSplits(Collections.singletonList(getSplit(1, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)));
+			// THe future should be completed fairly soon. Otherwise the test will hit timeout and fail.
+			future.get();
+		}
 	}
 
 	@Test (timeout = 30000L)
@@ -116,13 +121,14 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		// Add a split to start the fetcher.
 		List<SplitT> splits = getSplits(NUM_SPLITS, NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED);
 		// Poll 5 records. That means split 0 and 1 will at index 2, split 1 will at index 1.
-		SourceReader<Integer, SplitT> reader =
-				consumeRecords(splits, output, NUM_SPLITS * NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED);
-
-		List<SplitT> state = reader.snapshotState();
-		assertEquals("The snapshot should only have 10 splits. ", NUM_SPLITS, state.size());
-		for (int i = 0; i < NUM_SPLITS; i++) {
-			assertEquals("The first four splits should have been fully consumed.", NUM_RECORDS_PER_SPLIT, getIndex(state.get(i)));
+		try (SourceReader<Integer, SplitT> reader =
+				consumeRecords(splits, output, NUM_SPLITS * NUM_RECORDS_PER_SPLIT, Boundedness.BOUNDED)) {
+			List<SplitT> state = reader.snapshotState();
+			assertEquals("The snapshot should only have 10 splits. ", NUM_SPLITS, state.size());
+			for (int i = 0; i < NUM_SPLITS; i++) {
+				assertEquals("The first four splits should have been fully consumed.",
+						NUM_RECORDS_PER_SPLIT, getIndex(state.get(i)));
+			}
 		}
 	}
 
@@ -177,10 +183,12 @@ public abstract class SourceReaderTestBase<SplitT extends SourceSplit> extends T
 		}
 
 		public void validate() {
-			assertEquals("Should be 100 distinct elements in total", 100, consumedValues.size());
-			assertEquals("Should be 100 elements in total", 100, count);
+
+			assertEquals(String.format("Should be %d distinct elements in total", TOTAL_NUM_RECORDS),
+					TOTAL_NUM_RECORDS, consumedValues.size());
+			assertEquals(String.format("Should be %d elements in total", TOTAL_NUM_RECORDS), TOTAL_NUM_RECORDS, count);
 			assertEquals("The min value should be 0", 0, min);
-			assertEquals("The max value should be 99", 99, max);
+			assertEquals("The max value should be " + (TOTAL_NUM_RECORDS - 1), TOTAL_NUM_RECORDS - 1, max);
 		}
 
 		public int count() {

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -1,0 +1,114 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader.fetcher;
+
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit test for {@link SplitFetcher}.
+ */
+public class SplitFetcherTest {
+	private static final int NUM_SPLITS = 3;
+	private static final int NUM_RECORDS_PER_SPLIT = 10_000;
+	private static final int INTERRUPT_RECORDS_INTERVAL = 10;
+	private static final int NUM_TOTAL_RECORDS = NUM_RECORDS_PER_SPLIT * NUM_SPLITS;
+	@Test
+	public void testWakeup() throws InterruptedException {
+		BlockingQueue<RecordsWithSplitIds<int[]>> elementQueue = new ArrayBlockingQueue<>(1);
+		SplitFetcher<int[], MockSourceSplit> fetcher =
+				new SplitFetcher<>(
+						0,
+						elementQueue,
+						new MockSplitReader(2, true, true),
+						() -> {});
+
+		// Prepare the splits.
+		List<MockSourceSplit> splits = new ArrayList<>();
+		for (int i = 0; i < NUM_SPLITS; i++) {
+			splits.add(new MockSourceSplit(i, 0, NUM_RECORDS_PER_SPLIT));
+			int base = i * NUM_RECORDS_PER_SPLIT;
+			for (int j = base; j < base + NUM_RECORDS_PER_SPLIT; j++) {
+				splits.get(splits.size() - 1).addRecord(j);
+			}
+		}
+		// Add splits to the fetcher.
+		fetcher.addSplits(splits);
+
+		// A thread drives the fetcher.
+		Thread fetcherThread = new Thread(fetcher, "FetcherThread");
+
+		SortedSet<Integer> recordsRead = Collections.synchronizedSortedSet(new TreeSet<>());
+
+		// A thread waking up the split fetcher frequently.
+		AtomicInteger wakeupTimes = new AtomicInteger(0);
+		AtomicBoolean stop = new AtomicBoolean(false);
+		Thread interrupter = new Thread("Interrupter") {
+			@Override
+			public void run() {
+				int lastInterrupt = 0;
+				while (recordsRead.size() < NUM_TOTAL_RECORDS && !stop.get()) {
+					int numRecordsRead = recordsRead.size();
+					if (numRecordsRead >= lastInterrupt + INTERRUPT_RECORDS_INTERVAL) {
+						fetcher.wakeUp(false);
+						wakeupTimes.incrementAndGet();
+						lastInterrupt = numRecordsRead;
+					}
+				}
+			}
+		};
+
+		try {
+			fetcherThread.start();
+			interrupter.start();
+
+			while (recordsRead.size() < NUM_SPLITS * NUM_RECORDS_PER_SPLIT) {
+				elementQueue.take().recordsBySplits().values().forEach(records ->
+						// Ensure there is no duplicate records.
+						records.forEach(arr -> assertTrue(recordsRead.add(arr[0]))));
+			}
+
+			assertEquals(NUM_TOTAL_RECORDS, recordsRead.size());
+			assertEquals(0, (int) recordsRead.first());
+			assertEquals(NUM_TOTAL_RECORDS - 1, (int) recordsRead.last());
+			assertTrue(wakeupTimes.get() > 0);
+		} finally {
+			stop.set(true);
+			fetcher.shutdown();
+			fetcherThread.join();
+			interrupter.join();
+		}
+	}
+}

--- a/flink-connectors/flink-connector-base/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-base/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceSplit.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceSplit.java
@@ -105,4 +105,10 @@ public class MockSourceSplit implements SourceSplit, Serializable {
 				Arrays.equals(records.toArray(new Integer[0]), that.records.toArray(new Integer[0])) &&
 				endIndex == that.endIndex;
 	}
+
+	@Override
+	public String toString() {
+		return String.format("MockSourceSplit(id=%d, num_records=%d, endIndex=%d, currentIndex=%d)",
+				id, records.size(), endIndex, index);
+	}
 }


### PR DESCRIPTION
## What is the purpose of the change
This patch fixes a bug that when `SplitFetcher.wakeup()` is invoked, the fetcher thread may be interrupted and thus lose the record.

## Brief change log
1. Fix the wakeup handling in `SplitFetcher`
2. Added unit tests for wakeup correctness.
3. Fixed a bug in `MockSplitReader` to handle interruptions.

## Verifying this change

Added unit test `SplitFetcherTest` for the correctness of wakeup. The tests keeps waking up a fetcher thread to ensure the result delivered by the fetcher thread is still in order without duplication.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
