### PR TITLE
[FLINK-17182][network] Stop waiting on the buffer provide when exclusive buffer fulfills the required buffers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/BufferProvider.java
@@ -61,6 +61,13 @@ public interface BufferProvider extends AvailabilityProvider {
 	boolean addBufferListener(BufferListener listener);
 
 	/**
+	 * Removes a buffer availability listener from the buffer provider.
+	 *
+	 * <p>Returns <code>true</code> if the listener is actually removed from the buffer provider.
+	 */
+	boolean removeBufferListener(BufferListener listener);
+
+	/**
 	 * Returns whether the buffer provider has been destroyed.
 	 */
 	boolean isDestroyed();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/LocalBufferPool.java
@@ -380,6 +380,13 @@ class LocalBufferPool implements BufferPool {
 	}
 
 	@Override
+	public boolean removeBufferListener(BufferListener listener) {
+		synchronized (availableMemorySegments) {
+			return registeredListeners.remove(listener);
+		}
+	}
+
+	@Override
 	public void setNumBuffers(int numBuffers) throws IOException {
 		int numExcessBuffers;
 		CompletableFuture<?> toNotify = null;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NoOpBufferPool.java
@@ -55,6 +55,11 @@ public class NoOpBufferPool implements BufferPool {
 	}
 
 	@Override
+	public boolean removeBufferListener(BufferListener listener) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public boolean isDestroyed() {
 		throw new UnsupportedOperationException();
 	}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/util/TestPooledBufferProvider.java
@@ -101,6 +101,11 @@ public class TestPooledBufferProvider implements BufferProvider {
 	}
 
 	@Override
+	public boolean removeBufferListener(BufferListener listener) {
+		return bufferRecycler.removeListener(listener);
+	}
+
+	@Override
 	public boolean isDestroyed() {
 		return false;
 	}
@@ -156,6 +161,12 @@ public class TestPooledBufferProvider implements BufferProvider {
 				}
 
 				return false;
+			}
+		}
+
+		boolean removeListener(BufferListener listener) {
+			synchronized (listenerRegistrationLock) {
+				return registeredListeners.remove(listener);
 			}
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR tries to fix the issue caused by not stopping waiting on the buffer provider when the required buffers are fulfilled when recycling the exclusive buffers. If we do not stop waiting, we could not reuse the floating buffers returned when recycling the exclusive buffers. 

Special care needs to taken that there might be case that the listener has been picked out from the buffer pool for notifying of new buffer when the input channel is adding exclusive buffer. In this case, the listener would not actually removed from the provider and we could not reset the waiting flag, otherwise the listener might be added twice in the buffer provider.

## Brief change log

- fa6a9de78920441c0b562e936b8a438776ab4bbe removes the listener when the when exclusive buffer fulfills the required buffers.

## Verifying this change

This change added tests and can be verified as follows:

- Add UT to verify the waiting is stopped as expected.
- The failure in [FLINK-17182](https://issues.apache.org/jira/browse/FLINK-17182) does not occurs when running that UT repeatedly. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**