### PR TITLE
[FLINK-16485][python] Support vectorized Python UDF in batch mode of old planner

### DIFF
--- a/flink-python/pyflink/table/tests/test_pandas_udf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udf.py
@@ -26,7 +26,7 @@ from pyflink.table.tests.test_udf import SubtractOne
 from pyflink.table.udf import udf
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
-    PyFlinkBlinkBatchTableTestCase, PyFlinkBlinkStreamTableTestCase
+    PyFlinkBlinkBatchTableTestCase, PyFlinkBlinkStreamTableTestCase, PyFlinkBatchTableTestCase
 
 
 class PandasUDFTests(unittest.TestCase):
@@ -372,6 +372,26 @@ class BlinkPandasUDFITTests(object):
 class StreamPandasUDFITTests(PandasUDFITTests,
                              PyFlinkStreamTableTestCase):
     pass
+
+
+class BatchPandasUDFITTests(PyFlinkBatchTableTestCase):
+
+    def test_basic_functionality(self):
+        self.t_env.register_function(
+            "add_one",
+            udf(lambda i: i + 1, DataTypes.BIGINT(), DataTypes.BIGINT(), udf_type="pandas"))
+
+        self.t_env.register_function("add", add)
+
+        # general Python UDF
+        self.t_env.register_function(
+            "subtract_one", udf(SubtractOne(), DataTypes.BIGINT(), DataTypes.BIGINT()))
+
+        t = self.t_env.from_elements([(1, 2, 3), (2, 5, 6), (3, 1, 9)], ['a', 'b', 'c'])
+        t = t.where("add_one(b) <= 3") \
+            .select("a, b + 1, add(a + 1, subtract_one(c)) + 2, add(add_one(a), 1L)")
+        result = self.collect(t)
+        self.assert_equals(result, ["1,3,6,3", "3,2,14,5"])
 
 
 class BlinkBatchPandasUDFITTests(PandasUDFITTests,

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonScalarFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonScalarFunctionFlatMap.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.python;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.functions.python.PythonEnv;
+import org.apache.flink.table.functions.python.PythonFunctionInfo;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+
+/**
+ * The abstract base {@link RichFlatMapFunction} used to invoke Python {@link ScalarFunction}
+ * functions for the old planner.
+ */
+@Internal
+public abstract class AbstractPythonScalarFunctionFlatMap extends AbstractPythonStatelessFunctionFlatMap {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * The Python {@link ScalarFunction}s to be executed.
+	 */
+	public final PythonFunctionInfo[] scalarFunctions;
+
+	/**
+	 * The offset of the fields which should be forwarded.
+	 */
+	private final int[] forwardedFields;
+
+	public AbstractPythonScalarFunctionFlatMap(
+		Configuration config,
+		PythonFunctionInfo[] scalarFunctions,
+		RowType inputType,
+		RowType outputType,
+		int[] udfInputOffsets,
+		int[] forwardedFields) {
+		super(config, inputType, outputType, udfInputOffsets);
+		this.scalarFunctions = Preconditions.checkNotNull(scalarFunctions);
+		this.forwardedFields = Preconditions.checkNotNull(forwardedFields);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		RowTypeInfo forwardedInputTypeInfo = new RowTypeInfo(
+			Arrays.stream(forwardedFields)
+				.mapToObj(i -> inputType.getFields().get(i))
+				.map(RowType.RowField::getType)
+				.map(TypeConversions::fromLogicalToDataType)
+				.map(TypeConversions::fromDataTypeToLegacyInfo)
+				.toArray(TypeInformation[]::new));
+		forwardedInputSerializer = forwardedInputTypeInfo.createSerializer(getRuntimeContext().getExecutionConfig());
+	}
+
+	@Override
+	public PythonEnv getPythonEnv() {
+		return scalarFunctions[0].getPythonFunction().getPythonEnv();
+	}
+
+	@Override
+	public void bufferInput(Row input) {
+		Row forwardedFieldsRow = Row.project(input, forwardedFields);
+		if (getRuntimeContext().getExecutionConfig().isObjectReuseEnabled()) {
+			forwardedFieldsRow = forwardedInputSerializer.copy(forwardedFieldsRow);
+		}
+		forwardedInputQueue.add(forwardedFieldsRow);
+	}
+
+	@Override
+	public int getForwardedFieldsCount() {
+		return forwardedFields.length;
+	}
+}

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
@@ -169,7 +169,7 @@ public abstract class AbstractPythonStatelessFunctionFlatMap
 		this.jobOptions = buildJobOptions(config);
 	}
 
-	public PythonConfig getPythonConfig() {
+	protected PythonConfig getPythonConfig() {
 		return config;
 	}
 

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/AbstractPythonStatelessFunctionFlatMap.java
@@ -169,6 +169,10 @@ public abstract class AbstractPythonStatelessFunctionFlatMap
 		this.jobOptions = buildJobOptions(config);
 	}
 
+	public PythonConfig getPythonConfig() {
+		return config;
+	}
+
 	@Override
 	@SuppressWarnings("unchecked")
 	public void open(Configuration parameters) throws Exception {
@@ -200,6 +204,7 @@ public abstract class AbstractPythonStatelessFunctionFlatMap
 		bais = new ByteArrayInputStreamWithPos();
 		baisWrapper = new DataInputViewStreamWrapper(bais);
 
+		userDefinedFunctionOutputType = new RowType(outputType.getFields().subList(getForwardedFieldsCount(), outputType.getFieldCount()));
 		userDefinedFunctionTypeSerializer = PythonTypeUtils.toFlinkTypeSerializer(userDefinedFunctionOutputType);
 
 		this.pythonFunctionRunner = createPythonFunctionRunner();
@@ -247,6 +252,8 @@ public abstract class AbstractPythonStatelessFunctionFlatMap
 	public abstract void bufferInput(Row input);
 
 	public abstract void emitResults() throws IOException;
+
+	public abstract int getForwardedFieldsCount();
 
 	protected PythonEnvironmentManager createPythonEnvironmentManager() throws IOException {
 		PythonDependencyInfo dependencyInfo = PythonDependencyInfo.create(

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonTableFunctionFlatMap.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/functions/python/PythonTableFunctionFlatMap.java
@@ -36,8 +36,6 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.calcite.rel.core.JoinRelType;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The {@link RichFlatMapFunction} used to invoke Python {@link TableFunction} functions for the
@@ -75,15 +73,11 @@ public final class PythonTableFunctionFlatMap extends AbstractPythonStatelessFun
 
 	@Override
 	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
 		RowTypeInfo forwardedInputTypeInfo = (RowTypeInfo) TypeConversions.fromDataTypeToLegacyInfo(
 			TypeConversions.fromLogicalToDataType(inputType));
 		forwardedInputSerializer = forwardedInputTypeInfo.createSerializer(getRuntimeContext().getExecutionConfig());
-
-		List<RowType.RowField> udtfOutputDataFields = new ArrayList<>(
-			outputType.getFields().subList(inputType.getFieldCount(), outputType.getFieldCount()));
-		userDefinedFunctionOutputType = new RowType(udtfOutputDataFields);
-
-		super.open(parameters);
 	}
 
 	@Override
@@ -145,6 +139,11 @@ public final class PythonTableFunctionFlatMap extends AbstractPythonStatelessFun
 			}
 			lastIsFinishResult = isFinishResult;
 		}
+	}
+
+	@Override
+	public int getForwardedFieldsCount() {
+		return inputType.getFieldCount();
 	}
 
 	private boolean isFinishResult(byte[] rawUdtfResult) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetPythonCalc.scala
@@ -29,15 +29,17 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.table.api.internal.BatchTableEnvImpl
 import org.apache.flink.table.calcite.FlinkTypeFactory
-import org.apache.flink.table.functions.python.PythonFunctionInfo
+import org.apache.flink.table.functions.python.{PythonFunctionInfo, PythonFunctionKind}
 import org.apache.flink.table.plan.nodes.CommonPythonCalc
-import org.apache.flink.table.plan.nodes.dataset.DataSetPythonCalc.PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME
+import org.apache.flink.table.plan.nodes.dataset.DataSetPythonCalc.{ARROW_PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME, PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME}
 import org.apache.flink.table.plan.schema.RowSchema
+import org.apache.flink.table.plan.util.PythonUtil.containsPythonCall
 import org.apache.flink.table.types.logical.RowType
 import org.apache.flink.table.types.utils.TypeConversions
 import org.apache.flink.types.Row
 
 import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 /**
   * Flink RelNode for Python ScalarFunctions.
@@ -91,7 +93,12 @@ class DataSetPythonCalc(
     inputRowType: RowType,
     outputRowType: RowType,
     calcProgram: RexProgram) = {
-    val clazz = loadClass(PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME)
+    val clazz = if (calcProgram.getExprList.asScala.exists(
+      containsPythonCall(_, PythonFunctionKind.PANDAS))) {
+      loadClass(ARROW_PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME)
+    } else {
+      loadClass(PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME)
+    }
     val ctor = clazz.getConstructor(
       classOf[Configuration],
       classOf[Array[PythonFunctionInfo]],
@@ -115,4 +122,7 @@ class DataSetPythonCalc(
 object DataSetPythonCalc {
   val PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME =
     "org.apache.flink.table.runtime.functions.python.PythonScalarFunctionFlatMap"
+
+  val ARROW_PYTHON_SCALAR_FUNCTION_FLAT_MAP_NAME =
+    "org.apache.flink.table.runtime.functions.python.arrow.ArrowPythonScalarFunctionFlatMap"
 }


### PR DESCRIPTION

## What is the purpose of the change

*This pull request add the support of vectorized Python UDF in batch mode of old planner*

## Brief change log

  - *Introduce ArrowPythonScalarFunctionFlatMap*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added tests BatchPandasUDFITTests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
