### PR TITLE
[FLINK-17311][python][AZP] Add the logic of compressed in tgz before uploading artifacts

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -15,4 +15,4 @@
 setuptools>=18.0
 wheel
 apache-beam==2.19.0
-cython==0.28.1
+cython==0.29.16

--- a/tools/azure-pipelines/build-python-wheels.yml
+++ b/tools/azure-pipelines/build-python-wheels.yml
@@ -25,16 +25,21 @@ jobs:
       - script: STAGE=compile ${{parameters.environment}} ./tools/azure_controller.sh compile
         displayName: Build
 
-      # upload artifacts for building wheels
-      - task: PublishPipelineArtifact@1
-        inputs:
-          path: $(CACHE_FLINK_DIR)
-          artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
-
       - script: |
           VERSION=$(mvn --file pom.xml org.apache.maven.plugins:maven-help-plugin:3.1.0:evaluate -Dexpression=project.version -q -DforceStdout)
           echo "##vso[task.setvariable variable=VERSION;isOutput=true]$VERSION"
         name: set_version
+
+      - script: |
+          cd $(Pipeline.Workspace)
+          tar czf $(Pipeline.Workspace)/flink.tar.gz flink_cache/flink-dist/target/flink-$(set_version.VERSION)-bin/flink-$(set_version.VERSION)
+        displayName: Compress in tgz
+
+      # upload artifacts for building wheels
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: $(Pipeline.Workspace)/flink.tar.gz
+          artifactName: FlinkCompileCacheDir-${{parameters.stage_name}}
 
   - job: build_wheels
     dependsOn: compile_${{parameters.stage_name}}
@@ -52,9 +57,10 @@ jobs:
       # download artifacts
       - task: DownloadPipelineArtifact@2
         inputs:
-          path: $(CACHE_FLINK_DIR)
+          path: $(Pipeline.Workspace)
           artifact: FlinkCompileCacheDir-${{parameters.stage_name}}
       - script: |
+          tar zxf $(Pipeline.Workspace)/flink.tar.gz -C $(Pipeline.Workspace)
           mkdir -p flink-dist/target/flink-$(VERSION)-bin
           ln -snf $(CACHE_FLINK_DIR)/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION) `pwd`/flink-dist/target/flink-$(VERSION)-bin/flink-$(VERSION)
         displayName: Recreate 'flink-dist/target' symlink


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will Add the logic of compressing compiled result to flink.tar.gz before uploading artifact*

## Brief change log

  - *Add the logic of compressing compiled result to flink.tar.gz before uploading artifact in build-python-wheels.yml*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
