### PR TITLE
[FLINK-17323][task] return NO_MORE_DATA from ChannelStateReader for unknown channels

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateReaderImplTest.java
@@ -91,16 +91,16 @@ public class ChannelStateReaderImplTest {
 		reader.readInputData(CHANNEL, getBuffer(DATA.length));
 	}
 
-	@Test(expected = Exception.class)
+	@Test(expected = IllegalStateException.class)
 	public void testReadClosed() throws Exception {
 		reader.close();
 		reader.readInputData(CHANNEL, getBuffer(DATA.length));
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testReadWrongChannelState() throws IOException {
-		InputChannelInfo wrongChannel = new InputChannelInfo(CHANNEL.getGateIdx() + 1, CHANNEL.getInputChannelIdx() + 1);
-		reader.readInputData(wrongChannel, getBuffer(DATA.length));
+	@Test
+	public void testReadUnknownChannelState() throws IOException {
+		InputChannelInfo unknownChannel = new InputChannelInfo(CHANNEL.getGateIdx() + 1, CHANNEL.getInputChannelIdx() + 1);
+		assertEquals(NO_MORE_DATA, reader.readInputData(unknownChannel, getBuffer(DATA.length)));
 	}
 
 	private TaskStateSnapshot taskStateSnapshot(Collection<InputChannelStateHandle> inputChannelStateHandles) {


### PR DESCRIPTION
## What is the purpose of the change

ChannelStateReader expects requests only for channels or subpartitions that have state.  
In case of upscaling or starting from scratch this behavior is incorrect. 
It should return NO_MORE_DATA.

## Verifying this change

`ChannelStateReaderImplTest` was changed accordingly to cover this case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
