### PR TITLE
[FLINK-17251] [table] supports INSERT statement in TableEnvironment#executeSql and Table#executeInsert api

### DIFF
--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -697,6 +697,27 @@ class Table(object):
         """
         self._j_table.printSchema()
 
+    def execute_insert(self, table_path, overwrite=False):
+        """
+        Writes the :class:`~pyflink.table.Table` to a :class:`~pyflink.table.TableSink` that was
+        registered under the specified name, and then execute the insert operation.
+        For the path resolution algorithm see :func:`~TableEnvironment.use_database`.
+
+        Example:
+        ::
+
+            >>> tab.execute_insert("sink")
+
+        :param table_path: The path of the registered :class:`~pyflink.table.TableSink` to which
+               the :class:`~pyflink.table.Table` is written.
+        :type table_path: str
+        :param overwrite: The flag that indicates whether the insert should overwrite
+               existing data or not.
+        :type overwrite: bool
+        :return: The table result.
+        """
+        self._j_table.executeInsert(table_path, overwrite)
+
     def __str__(self):
         return self._j_table.toString()
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1416,4 +1416,61 @@ public interface Table {
 	 * </pre>
 	 */
 	FlatAggregateTable flatAggregate(Expression tableAggregateFunction);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified path,
+	 * and then execute the insert operation.
+	 *
+	 * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or
+	 * {@link TableEnvironment#useCatalog(String)} for the rules on the path resolution.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   Table table = tableEnv.fromQuery("select * from MyTable");
+	 *   TableResult tableResult = table.executeInsert("MySink");
+	 *   tableResult...
+	 * }
+	 * </pre>
+	 *
+	 * @param tablePath The path of the registered TableSink to which the Table is written.
+	 * @return The insert operation execution result.
+	 */
+	TableResult executeInsert(String tablePath);
+
+	/**
+	 * Writes the {@link Table} to a {@link TableSink} that was registered under the specified path,
+	 * and then execute the insert operation.
+	 *
+	 * <p>See the documentation of {@link TableEnvironment#useDatabase(String)} or
+	 * {@link TableEnvironment#useCatalog(String)} for the rules on the path resolution.
+	 *
+	 * <p>A batch {@link Table} can only be written to a
+	 * {@code org.apache.flink.table.sinks.BatchTableSink}, a streaming {@link Table} requires a
+	 * {@code org.apache.flink.table.sinks.AppendStreamTableSink}, a
+	 * {@code org.apache.flink.table.sinks.RetractStreamTableSink}, or an
+	 * {@code org.apache.flink.table.sinks.UpsertStreamTableSink}.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   Table table = tableEnv.fromQuery("select * from MyTable");
+	 *   TableResult tableResult = table.executeInsert("MySink", true);
+	 *   tableResult...
+	 * }
+	 * </pre>
+	 *
+	 * @param tablePath The path of the registered TableSink to which the Table is written.
+	 * @param overwrite The flag that indicates whether the insert should overwrite existing data or not.
+	 * @return The insert operation execution result.
+	 */
+	TableResult executeInsert(String tablePath, boolean overwrite);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -635,7 +635,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	@Override
-	public TableResult executeOperations(List<ModifyOperation> operations) {
+	public TableResult executeInternal(List<ModifyOperation> operations) {
 		if (operations.size() != 1) {
 			throw new TableException("Only one ModifyOperation is supported now.");
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -121,7 +121,7 @@ import java.util.stream.StreamSupport;
  * not bind to any particular {@code StreamExecutionEnvironment}.
  */
 @Internal
-public class TableEnvironmentImpl implements TableEnvironment {
+public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	// Flag that tells if the TableSource/TableSink used in this environment is stream table source/sink,
 	// and this should always be true. This avoids too many hard code.
 	private static final boolean IS_STREAM_TABLE = true;
@@ -635,6 +635,15 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	}
 
 	@Override
+	public TableResult executeOperations(List<ModifyOperation> operations) {
+		if (operations.size() != 1) {
+			throw new TableException("Only one ModifyOperation is supported now.");
+		}
+
+		return executeOperation(operations.get(0));
+	}
+
+	@Override
 	public void sqlUpdate(String stmt) {
 		List<Operation> operations = parser.parse(stmt);
 
@@ -905,6 +914,16 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	public JobExecutionResult execute(String jobName) throws Exception {
 		Pipeline pipeline = execEnv.createPipeline(translateAndClearBuffer(), tableConfig, jobName);
 		return execEnv.execute(pipeline);
+	}
+
+	@Override
+	public Parser getParser() {
+		return parser;
+	}
+
+	@Override
+	public CatalogManager getCatalogManager() {
+		return catalogManager;
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.operations.ModifyOperation;
+
+import java.util.List;
+
+/**
+ * An internal interface of {@link TableEnvironment}
+ * that defines extended methods used for {@link TableImpl}.
+ */
+@Internal
+public interface TableEnvironmentInternal extends TableEnvironment {
+
+	/**
+	 * Return a {@link Parser} that provides methods for parsing a SQL string.
+	 *
+	 * @return initialized {@link Parser}.
+	 */
+	Parser getParser();
+
+	/**
+	 * Returns a {@link CatalogManager} that deals with all catalog objects.
+	 */
+	CatalogManager getCatalogManager();
+
+	/**
+	 * Execute the given operations and return the execution result.
+	 *
+	 * @param operations The operations to be executed.
+	 * @return the affected row counts (-1 means unknown).
+	 */
+	TableResult executeOperations(List<ModifyOperation> operations);
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -47,10 +47,10 @@ public interface TableEnvironmentInternal extends TableEnvironment {
 	CatalogManager getCatalogManager();
 
 	/**
-	 * Execute the given operations and return the execution result.
+	 * Execute the given modify operations and return the execution result.
 	 *
 	 * @param operations The operations to be executed.
 	 * @return the affected row counts (-1 means unknown).
 	 */
-	TableResult executeOperations(List<ModifyOperation> operations);
+	TableResult executeInternal(List<ModifyOperation> operations);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -30,6 +30,9 @@ import java.util.List;
 /**
  * An internal interface of {@link TableEnvironment}
  * that defines extended methods used for {@link TableImpl}.
+ *
+ * <p>Once old planner is removed, this class also can be removed.
+ * By then, these methods can be moved into TableEnvironmentImpl.
  */
 @Internal
 interface TableEnvironmentInternal extends TableEnvironment {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -32,7 +32,7 @@ import java.util.List;
  * that defines extended methods used for {@link TableImpl}.
  */
 @Internal
-public interface TableEnvironmentInternal extends TableEnvironment {
+interface TableEnvironmentInternal extends TableEnvironment {
 
 	/**
 	 * Return a {@link Parser} that provides methods for parsing a SQL string.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -561,7 +561,7 @@ public class TableImpl implements Table {
 				overwrite,
 				Collections.emptyMap());
 
-		return tableEnvironment.executeOperations(Collections.singletonList(operation));
+		return tableEnvironment.executeInternal(Collections.singletonList(operation));
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  * Implementation for {@link TableResult}.
  */
 @Internal
-public class TableResultImpl implements TableResult {
+class TableResultImpl implements TableResult {
 	public static final TableResult TABLE_RESULT_OK = TableResultImpl.builder()
 			.resultKind(ResultKind.SUCCESS)
 			.tableSchema(TableSchema.builder().field("result", DataTypes.STRING()).build())

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Executor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 
@@ -57,4 +58,13 @@ public interface Executor {
 	 */
 	JobExecutionResult execute(Pipeline pipeline) throws Exception;
 
+	/**
+	 * Executes the given pipeline asynchronously.
+	 *
+	 * @param pipeline the pipeline to execute
+	 * @return A {@link JobClient} that can be used to communicate with the submitted job,
+	 *         completed on submission succeeded.
+	 * @throws Exception which occurs during job execution.
+	 */
+	JobClient executeAsync(Pipeline pipeline) throws Exception;
 }

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/ExecutorMock.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.utils;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.delegation.Executor;
 
@@ -38,6 +39,11 @@ public class ExecutorMock implements Executor {
 
 	@Override
 	public JobExecutionResult execute(Pipeline pipeline) throws Exception {
+		return null;
+	}
+
+	@Override
+	public JobClient executeAsync(Pipeline pipeline) throws Exception {
 		return null;
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/delegation/ExecutorBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.delegation;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.api.TableConfig;
@@ -49,6 +50,11 @@ public abstract class ExecutorBase implements Executor {
 	@Override
 	public JobExecutionResult execute(Pipeline pipeline) throws Exception {
 		return executionEnvironment.execute((StreamGraph) pipeline);
+	}
+
+	@Override
+	public JobClient executeAsync(Pipeline pipeline) throws Exception {
+		return executionEnvironment.executeAsync((StreamGraph) pipeline);
 	}
 
 	protected String getNonEmptyJobName(String jobName) {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -38,6 +38,7 @@ import org.junit.runners.Parameterized
 import org.junit.{Assert, Before, Test}
 
 import _root_.java.io.File
+import _root_.java.lang.{Long => JLong}
 import _root_.java.util
 
 import _root_.scala.collection.mutable
@@ -256,6 +257,86 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
   }
 
   @Test
+  def testExecuteSqlWithInsertInto(): Unit = {
+    val sinkPath = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("first"), Array(STRING)), "MySink1")
+    checkEmptyFile(sinkPath)
+    val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
+    checkInsertTableResult(tableResult)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+    assertFirstValues(sinkPath)
+  }
+
+  @Test
+  def testExecuteSqlAndSqlUpdate(): Unit = {
+    val sink1Path = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("first"), Array(STRING)), "MySink1")
+    val sink2Path = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("last"), Array(STRING)), "MySink2")
+    checkEmptyFile(sink1Path)
+    checkEmptyFile(sink2Path)
+
+    val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
+    checkInsertTableResult(tableResult)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    checkEmptyFile(sink2Path)
+
+    // delete first csv file
+    new File(sink1Path).delete()
+    assertFalse(new File(sink1Path).exists())
+
+    val table2 = tEnv.sqlQuery("select last from MyTable")
+    tEnv.insertInto(table2, "MySink2")
+    tEnv.execute("test2")
+    assertFalse(new File(sink1Path).exists())
+    assertLastValues(sink2Path)
+  }
+
+  @Test
+  def testExecuteSqlAndToDataStream(): Unit = {
+    if (!tableEnvName.equals("StreamTableEnvironment")) {
+      return
+    }
+    val streamEnv = StreamExecutionEnvironment.getExecutionEnvironment
+    val streamTableEnv = StreamTableEnvironment.create(streamEnv, settings)
+    TestTableSourceSinks.createPersonCsvTemporaryTable(streamTableEnv, "MyTable")
+    val sink1Path = TestTableSourceSinks.createCsvTemporarySinkTable(
+      streamTableEnv, new TableSchema(Array("first"), Array(STRING)), "MySink1")
+    checkEmptyFile(sink1Path)
+
+    val table = streamTableEnv.sqlQuery("select last from MyTable where id > 0")
+    val resultSet = streamTableEnv.toAppendStream(table, classOf[Row])
+    val sink = new TestingAppendSink
+    resultSet.addSink(sink)
+
+    val tableResult = streamTableEnv.executeSql("insert into MySink1 select first from MyTable")
+    checkInsertTableResult(tableResult)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+    assertFirstValues(sink1Path)
+
+    // the DataStream program is not executed
+    assertFalse(sink.isInitialized)
+
+    deleteFile(sink1Path)
+
+    streamEnv.execute("test2")
+    assertEquals(getExpectedLastValues.sorted, sink.getAppendResults.sorted)
+    // the table program is not executed again
+    assertFileNotExist(sink1Path)
+  }
+
+  @Test
   def testClearOperation(): Unit = {
     TestCollectionTableFactory.reset()
     val tableEnv = TableEnvironmentImpl.create(settings)
@@ -317,6 +398,16 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
   private def assertFileNotExist(path: String): Unit = {
     assertFalse(new File(path).exists())
   }
+
+  private def checkInsertTableResult(tableResult: TableResult): Unit = {
+    assertTrue(tableResult.getJobClient.isPresent)
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
+    val it = tableResult.collect()
+    assertTrue(it.hasNext)
+    assertEquals(Row.of(JLong.valueOf(-1L)), it.next())
+    assertFalse(it.hasNext)
+  }
+
 }
 
 object TableEnvironmentITCase {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -337,6 +337,20 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
   }
 
   @Test
+  def testExecuteInsert(): Unit = {
+    val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink")
+    checkEmptyFile(sinkPath)
+    val table = tEnv.sqlQuery("select first from MyTable")
+    val tableResult = table.executeInsert("MySink")
+    checkInsertTableResult(tableResult)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+    assertFirstValues(sinkPath)
+  }
+
+  @Test
   def testClearOperation(): Unit = {
     TestCollectionTableFactory.reset()
     val tableEnv = TableEnvironmentImpl.create(settings)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -272,6 +272,11 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
 
   @Test
   def testExecuteSqlWithInsertOverwrite(): Unit = {
+    if(isStreaming) {
+      // Streaming mode not support overwrite for FileSystemTableSink.
+      return
+    }
+
     val sinkPath = _tempFolder.newFolder().toString
     tEnv.sqlUpdate(
       s"""
@@ -384,6 +389,10 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
 
   @Test
   def testExecuteInsertOverwrite(): Unit = {
+    if(isStreaming) {
+      // Streaming mode not support overwrite for FileSystemTableSink.
+      return
+    }
     val sinkPath = _tempFolder.newFolder().toString
     tEnv.sqlUpdate(
       s"""

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -33,9 +33,10 @@ import org.apache.flink.types.Row
 import org.apache.flink.util.{FileUtils, TestLogger}
 
 import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
-import org.junit.{Assert, Before, Test}
+import org.junit.{Assert, Before, Rule, Test}
 
 import _root_.java.io.{File, FileFilter}
 import _root_.java.lang.{Long => JLong}
@@ -45,6 +46,11 @@ import _root_.scala.collection.mutable
 
 @RunWith(classOf[Parameterized])
 class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends TestLogger {
+
+  private val _tempFolder = new TemporaryFolder()
+
+  @Rule
+  def tempFolder: TemporaryFolder = _tempFolder
 
   var tEnv: TableEnvironment = _
 
@@ -375,7 +381,8 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
 
   @Test
   def testExecuteInsert(): Unit = {
-    val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink")
+    val sinkPath = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("first"), Array(STRING)), "MySink")
     checkEmptyFile(sinkPath)
     val table = tEnv.sqlQuery("select first from MyTable")
     val tableResult = table.executeInsert("MySink")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/executor/StreamExecutor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/executor/StreamExecutor.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.dag.Pipeline;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
@@ -63,6 +64,11 @@ public class StreamExecutor implements Executor {
 	@Override
 	public JobExecutionResult execute(Pipeline pipeline) throws Exception {
 		return executionEnvironment.execute((StreamGraph) pipeline);
+	}
+
+	@Override
+	public JobClient executeAsync(Pipeline pipeline) throws Exception {
+		return executionEnvironment.executeAsync((StreamGraph) pipeline);
 	}
 
 	public StreamExecutionEnvironment getExecutionEnvironment() {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -576,7 +576,7 @@ abstract class TableEnvImpl(
     executeOperation(operations.get(0))
   }
 
-  override def executeOperations(operations: JList[ModifyOperation]): TableResult = {
+  override def executeInternal(operations: JList[ModifyOperation]): TableResult = {
     if (operations.size() != 1) {
       throw new TableException("Only one ModifyOperation is supported now.");
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -64,7 +64,7 @@ abstract class TableEnvImpl(
     val config: TableConfig,
     private val catalogManager: CatalogManager,
     private val moduleManager: ModuleManager)
-  extends TableEnvironment {
+  extends TableEnvironmentInternal {
 
   // Table API/SQL function catalog
   private[flink] val functionCatalog: FunctionCatalog =
@@ -576,6 +576,13 @@ abstract class TableEnvImpl(
     executeOperation(operations.get(0))
   }
 
+  override def executeOperations(operations: JList[ModifyOperation]): TableResult = {
+    if (operations.size() != 1) {
+      throw new TableException("Only one ModifyOperation is supported now.");
+    }
+    executeOperation(operations.get(0))
+  }
+
   override def sqlUpdate(stmt: String): Unit = {
     val operations = parser.parse(stmt)
 
@@ -915,6 +922,10 @@ abstract class TableEnvImpl(
     val dataSink = writeToSinkAndTranslate(table.getQueryOperation, insertOptions, sinkIdentifier)
     addToBuffer(dataSink)
   }
+
+  override def getParser: Parser = parser
+
+  override def getCatalogManager: CatalogManager = catalogManager
 
   private def getTableSink(objectIdentifier: ObjectIdentifier): Option[TableSink[_]] = {
     JavaScalaConversionUtil.toScala(catalogManager.getTable(objectIdentifier))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -325,6 +325,20 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFileNotExist(sink1Path)
   }
 
+  @Test
+  def testExecuteInsert(): Unit = {
+    val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink")
+    checkEmptyFile(sinkPath)
+    val table = tEnv.sqlQuery("select first from MyTable")
+    val tableResult = table.executeInsert("MySink")
+    checkInsertTableResult(tableResult)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+    assertFirstValues(sinkPath)
+  }
+
   private def registerCsvTableSink(
       tEnv: TableEnvironment,
       fieldNames: Array[String],

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/testTableSinks.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/testTableSinks.scala
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.DataSet
+import org.apache.flink.api.java.operators.DataSink
+import org.apache.flink.core.fs.FileSystem
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.sinks.{AppendStreamTableSink, BatchTableSink, OverwritableTableSink, TableSink}
+import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.utils.TypeConversions
+import org.apache.flink.types.Row
+
+/**
+  * An [[OverwritableTableSink]] for testing.
+  */
+final class TestingOverwritableTableSink private (
+    path: String,
+    fieldNames: Array[String],
+    fieldTypes: Array[TypeInformation[_]])
+  extends AppendStreamTableSink[Row]
+  with BatchTableSink[Row]
+  with OverwritableTableSink {
+
+  var overwrite = false
+
+  def this (path: String) = {
+    this(path, null, null)
+  }
+
+  override def setOverwrite(overwrite: Boolean): Unit = {
+    this.overwrite = overwrite
+  }
+
+  override def consumeDataSet(dataSet: DataSet[Row]): DataSink[_] = {
+    val writeMode = if (overwrite) {
+      FileSystem.WriteMode.OVERWRITE
+    } else {
+      FileSystem.WriteMode.NO_OVERWRITE
+    }
+    dataSet.writeAsText(path, writeMode).setParallelism(1)
+  }
+
+  override def consumeDataStream(dataStream: DataStream[Row]): DataStreamSink[_] = {
+    val writeMode = if (overwrite) {
+      FileSystem.WriteMode.OVERWRITE
+    } else {
+      FileSystem.WriteMode.NO_OVERWRITE
+    }
+    dataStream.writeAsText(path, writeMode).setParallelism(1)
+  }
+
+  override def getConsumedDataType: DataType = getTableSchema.toRowDataType
+
+  def getTableSchema: TableSchema = {
+    val dataTypes: Array[DataType] = fieldTypes.map(TypeConversions.fromLegacyInfoToDataType)
+    TableSchema.builder().fields(fieldNames, dataTypes).build()
+  }
+
+  override def configure(
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[Row] = {
+    if (this.fieldNames != null || this.fieldTypes != null) {
+      throw new IllegalStateException(
+        "TestingOverwritableTableSink has already been configured field names and field types.")
+    }
+    new TestingOverwritableTableSink(path, fieldNames, fieldTypes)
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change

*FLINK-16366 has introduced executeSql method in TableEnvironment, but INSERT statement is not supported because FLINK-17126 is not finished at that moment. This PR aims to support INSERT statement in TableEnvironment#executeSql and introduce Table#executeInsert api*


## Brief change log

  - *TableEnvironment#executeSql supports INSERT statement*
  - *Introduce Table#executeInsert API*


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended TableEnvironmentITCase test to verify INSERT statement and Table#executeInsert method*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
