### PR TITLE
[FLINK-17111][table] Support SHOW VIEWS in Flink SQL

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -345,13 +345,23 @@ class TableEnvironment(object):
 
     def list_tables(self):
         """
-        Gets the names of all tables in the current database of the current catalog.
+        Gets the names of all tables and views in the current database of the current catalog.
 
-        :return: List of table names in the current database of the current catalog.
+        :return: List of table and view names in the current database of the current catalog.
         :rtype: list[str]
         """
         j_table_name_array = self._j_tenv.listTables()
         return [item for item in j_table_name_array]
+
+    def list_views(self):
+        """
+        Gets the names of all views in the current database of the current catalog.
+
+        :return: List of view names in the current database of the current catalog.
+        :rtype: list[str]
+        """
+        j_view_name_array = self._j_tenv.listViews()
+        return [item for item in j_view_name_array]
 
     def list_user_defined_functions(self):
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -346,6 +346,7 @@ class TableEnvironment(object):
     def list_tables(self):
         """
         Gets the names of all tables and views in the current database of the current catalog.
+        It returns both temporary and permanent tables and views.
 
         :return: List of table and view names in the current database of the current catalog.
         :rtype: list[str]
@@ -356,6 +357,7 @@ class TableEnvironment(object):
     def list_views(self):
         """
         Gets the names of all views in the current database of the current catalog.
+        It returns both temporary and permanent views.
 
         :return: List of view names in the current database of the current catalog.
         :rtype: list[str]

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -50,7 +50,8 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
             'createFunction',
             'dropFunction',
             'createTemporaryFunction',
-            'dropTemporaryFunction'}
+            'dropTemporaryFunction',
+            'listViews'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-python/pyflink/table/tests/test_environment_completeness.py
+++ b/flink-python/pyflink/table/tests/test_environment_completeness.py
@@ -50,8 +50,7 @@ class EnvironmentAPICompletenessTests(PythonAPICompletenessTestCase, unittest.Te
             'createFunction',
             'dropFunction',
             'createTemporaryFunction',
-            'dropTemporaryFunction',
-            'listViews'}
+            'dropTemporaryFunction'}
 
     @classmethod
     def java_method_name(cls, python_method_name):

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -55,6 +55,7 @@
     "org.apache.flink.sql.parser.dql.SqlShowDatabases"
     "org.apache.flink.sql.parser.dql.SqlShowFunctions"
     "org.apache.flink.sql.parser.dql.SqlShowTables"
+    "org.apache.flink.sql.parser.dql.SqlShowViews"
     "org.apache.flink.sql.parser.dql.SqlRichDescribeTable"
     "org.apache.flink.sql.parser.type.ExtendedSqlCollectionTypeNameSpec"
     "org.apache.flink.sql.parser.type.ExtendedSqlRowTypeNameSpec"
@@ -91,6 +92,7 @@
     "STRING"
     "TABLES"
     "USE"
+    "VIEWS"
     "WATERMARK"
   ]
 
@@ -441,6 +443,7 @@
     "SqlShowTables()"
     "SqlRichDescribeTable()"
     "SqlAlterTable()"
+    "SqlShowViews()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -323,6 +323,20 @@ SqlShowFunctions SqlShowFunctions() :
 }
 
 /**
+ * Parse a "Show Views" metadata query command.
+ */
+SqlShowViews SqlShowViews() :
+{
+    SqlParserPos pos;
+}
+{
+    <SHOW> <VIEWS> { pos = getPos(); }
+    {
+        return new SqlShowViews(pos);
+    }
+}
+
+/**
 * Parse a "Show Tables" metadata query command.
 */
 SqlShowTables SqlShowTables() :

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowViews.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlShowViews.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.dql;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * SHOW VIEWS sql call.
+ */
+public class SqlShowViews extends SqlCall {
+
+	public static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("SHOW VIEWS", SqlKind.OTHER);
+
+	public SqlShowViews(SqlParserPos pos) {
+		super(pos);
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return Collections.EMPTY_LIST;
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		writer.keyword("SHOW VIEWS");
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -795,6 +795,11 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 		sql(sql).ok(expected);
 	}
 
+	@Test
+	public void testShowViews() {
+		sql("show views").ok("SHOW VIEWS");
+	}
+
 	// Override the test because our ROW field type default is nullable,
 	// which is different with Calcite.
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -759,7 +759,9 @@ public interface TableEnvironment {
 	/**
 	 * Gets the names of all views available in the current namespace (the current database of the current catalog).
 	 * It returns both temporary and permanent views.
+	 *
 	 * @return A list of the names of all registered views in the current database of the current catalog.
+	 * @see #listTemporaryViews()
 	 */
 	String[] listViews();
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -757,6 +757,13 @@ public interface TableEnvironment {
 	String[] listTables();
 
 	/**
+	 * Gets the names of all views available in the current namespace (the current database of the current catalog).
+	 * It returns both temporary and permanent views.
+	 * @return A list of the names of all registered views in the current database of the current catalog.
+	 */
+	String[] listViews();
+
+	/**
 	 * Gets the names of all temporary tables and views available in the current namespace (the current
 	 * database of the current catalog).
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -522,6 +522,14 @@ public class TableEnvironmentImpl implements TableEnvironment {
 	}
 
 	@Override
+	public String[] listViews() {
+		return catalogManager.listViews()
+			.stream()
+			.sorted()
+			.toArray(String[]::new);
+	}
+
+	@Override
 	public String[] listTemporaryTables() {
 		return catalogManager.listTemporaryTables()
 			.stream()

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -79,6 +79,7 @@ import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
+import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
@@ -143,7 +144,7 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			"Unsupported SQL query! executeSql() only accepts a single SQL statement of type " +
 			"CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, " +
 			"CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, CREATE CATALOG, USE CATALOG, USE [CATALOG.]DATABASE, " +
-			"SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW.";
+			"SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW, SHOW VIEWS.";
 
 	/**
 	 * Provides necessary methods for {@link ConnectTableDescriptor}.
@@ -804,6 +805,8 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			return buildShowResult(listTables());
 		} else if (operation instanceof ShowFunctionsOperation) {
 			return buildShowResult(listFunctions());
+		} else if (operation instanceof ShowViewsOperation) {
+			return buildShowResult(listViews());
 		} else {
 			throw new TableException(UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG);
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -396,8 +396,7 @@ public final class CatalogManager {
 	 * @return names of registered temporary views
 	 */
 	public Set<String> listTemporaryViews() {
-		return listTemporaryTablesInternal(getCurrentCatalog(), getCurrentDatabase())
-			.filter(e -> e.getValue() instanceof CatalogView)
+		return listTemporaryViewsInternal(getCurrentCatalog(), getCurrentDatabase())
 			.map(e -> e.getKey().getObjectName())
 			.collect(Collectors.toSet());
 	}
@@ -437,13 +436,19 @@ public final class CatalogManager {
 		try {
 			return Stream.concat(
 				currentCatalog.listViews(getCurrentDatabase()).stream(),
-				listTemporaryTablesInternal(catalogName, databaseName)
-					.filter(e -> e.getValue() instanceof CatalogView)
+				listTemporaryViewsInternal(catalogName, databaseName)
 					.map(e -> e.getKey().getObjectName())
 			).collect(Collectors.toSet());
 		} catch (DatabaseNotExistException e) {
 			throw new ValidationException("Current database does not exist", e);
 		}
+	}
+
+	private Stream<Map.Entry<ObjectIdentifier, CatalogBaseTable>> listTemporaryViewsInternal(
+			String catalogName,
+			String databaseName) {
+		return listTemporaryTablesInternal(catalogName, databaseName)
+			.filter(e -> e.getValue() instanceof CatalogView);
 	}
 
 	/**

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -416,6 +416,37 @@ public final class CatalogManager {
 	}
 
 	/**
+	 * Returns an array of names of all views(both temporary and permanent) registered in
+	 * the namespace of the current catalog and database.
+	 *
+	 * @return names of all registered views
+	 */
+	public Set<String> listViews() {
+		return listViews(getCurrentCatalog(), getCurrentDatabase());
+	}
+
+	/**
+	 * Returns an array of names of all views(both temporary and permanent) registered in
+	 * the namespace of the current catalog and database.
+	 *
+	 * @return names of registered views
+	 */
+	public Set<String> listViews(String catalogName, String databaseName) {
+		Catalog currentCatalog = catalogs.get(getCurrentCatalog());
+
+		try {
+			return Stream.concat(
+				currentCatalog.listViews(getCurrentDatabase()).stream(),
+				listTemporaryTablesInternal(catalogName, databaseName)
+					.filter(e -> e.getValue() instanceof CatalogView)
+					.map(e -> e.getKey().getObjectName())
+			).collect(Collectors.toSet());
+		} catch (DatabaseNotExistException e) {
+			throw new ValidationException("Current database does not exist", e);
+		}
+	}
+
+	/**
 	 * Lists all available schemas in the root of the catalog manager. It is not equivalent to listing all catalogs
 	 * as it includes also different catalog parts of the temporary objects.
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ShowViewsOperation.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+/**
+ * Operation to describe a SHOW VIEWS statement.
+ */
+public class ShowViewsOperation implements ShowOperation {
+
+	@Override
+	public String asSummaryString() {
+		return "SHOW VIEWS";
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -41,6 +41,7 @@ import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
 import org.apache.flink.sql.parser.dql.SqlShowFunctions;
 import org.apache.flink.sql.parser.dql.SqlShowTables;
+import org.apache.flink.sql.parser.dql.SqlShowViews;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -66,6 +67,7 @@ import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
+import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
@@ -191,6 +193,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertCreateView((SqlCreateView) validated));
 		} else if (validated instanceof SqlDropView) {
 			return Optional.of(converter.convertDropView((SqlDropView) validated));
+		} else if (validated instanceof SqlShowViews) {
+			return Optional.of(converter.convertShowViews((SqlShowViews) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -568,6 +572,11 @@ public class SqlToOperationConverter {
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		return new DropViewOperation(identifier, sqlDropView.getIfExists(), sqlDropView.isTemporary());
+	}
+
+	/** Convert SHOW VIEWS statement. */
+	private Operation convertShowViews(SqlShowViews sqlShowViews) {
+		return new ShowViewsOperation();
 	}
 
 	/** Fallback method for sql query. */

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -19,10 +19,9 @@
 package org.apache.flink.table.planner.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
-import org.apache.flink.sql.parser.dql.{SqlShowCatalogs, SqlShowDatabases, SqlShowFunctions, SqlShowTables}
+import org.apache.flink.sql.parser.dql.{SqlShowCatalogs, SqlShowDatabases, SqlShowFunctions, SqlShowTables, SqlShowViews}
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader
-
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.config.NullCollation
 import org.apache.calcite.plan._
@@ -34,7 +33,6 @@ import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
 import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
-
 import java.lang.{Boolean => JBoolean}
 import java.util
 import java.util.function.{Function => JFunction}
@@ -127,7 +125,8 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlShowCatalogs]
         || sqlNode.isInstanceOf[SqlShowDatabases]
         || sqlNode.isInstanceOf[SqlShowTables]
-        || sqlNode.isInstanceOf[SqlShowFunctions]) {
+        || sqlNode.isInstanceOf[SqlShowFunctions]
+        || sqlNode.isInstanceOf[SqlShowViews]) {
         return sqlNode
       }
       validator.validate(sqlNode)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -40,6 +40,7 @@ import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
 import org.apache.flink.sql.parser.dql.SqlShowFunctions;
 import org.apache.flink.sql.parser.dql.SqlShowTables;
+import org.apache.flink.sql.parser.dql.SqlShowViews;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -66,6 +67,7 @@ import org.apache.flink.table.operations.ShowCatalogsOperation;
 import org.apache.flink.table.operations.ShowDatabasesOperation;
 import org.apache.flink.table.operations.ShowFunctionsOperation;
 import org.apache.flink.table.operations.ShowTablesOperation;
+import org.apache.flink.table.operations.ShowViewsOperation;
 import org.apache.flink.table.operations.UseCatalogOperation;
 import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.ddl.AlterCatalogFunctionOperation;
@@ -183,6 +185,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertCreateView((SqlCreateView) validated));
 		} else if (validated instanceof SqlDropView) {
 			return Optional.of(converter.convertDropView((SqlDropView) validated));
+		} else if (validated instanceof SqlShowViews) {
+			return Optional.of(converter.convertShowViews((SqlShowViews) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -521,6 +525,11 @@ public class SqlToOperationConverter {
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
 		return new DropViewOperation(identifier, sqlDropView.getIfExists(), sqlDropView.isTemporary());
+	}
+
+	/** Convert SHOW VIEWS statement. */
+	private Operation convertShowViews(SqlShowViews sqlShowViews) {
+		return new ShowViewsOperation();
 	}
 
 	/**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -495,6 +495,12 @@ abstract class TableEnvImpl(
       .sorted
   }
 
+  override def listViews(): Array[String] = {
+    catalogManager.listViews().asScala
+      .toArray
+      .sorted
+  }
+
   override def listTemporaryTables(): Array[String] = {
     catalogManager.listTemporaryTables().asScala
       .toArray

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -129,12 +129,12 @@ abstract class TableEnvImpl(
     "Unsupported SQL query! sqlUpdate() only accepts a single SQL statement of type " +
       "INSERT, CREATE TABLE, DROP TABLE, ALTER TABLE, USE CATALOG, USE [CATALOG.]DATABASE, " +
       "CREATE DATABASE, DROP DATABASE, ALTER DATABASE, CREATE FUNCTION, DROP FUNCTION, " +
-      "ALTER FUNCTION."
+      "ALTER FUNCTION, CREATE VIEW, DROP VIEW."
   private val UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG =
     "Unsupported SQL query! executeSql() only accepts a single SQL statement of type " +
       "CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, " +
       "CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, USE CATALOG, USE [CATALOG.]DATABASE, " +
-      "SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS."
+      "SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW."
 
   private def isStreamingMode: Boolean = this match {
     case _: BatchTableEnvImpl => false
@@ -563,6 +563,7 @@ abstract class TableEnvImpl(
     val operation = operations.get(0)
     operation match {
       case _: CreateTableOperation | _: DropTableOperation | _: AlterTableOperation |
+           _: CreateViewOperation | _: DropViewOperation |
            _: CreateDatabaseOperation | _: DropDatabaseOperation | _: AlterDatabaseOperation |
            _: CreateCatalogFunctionOperation | _: CreateTempSystemFunctionOperation |
            _: DropCatalogFunctionOperation | _: DropTempSystemFunctionOperation |

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -134,7 +134,8 @@ abstract class TableEnvImpl(
     "Unsupported SQL query! executeSql() only accepts a single SQL statement of type " +
       "CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, " +
       "CREATE FUNCTION, DROP FUNCTION, ALTER FUNCTION, USE CATALOG, USE [CATALOG.]DATABASE, " +
-      "SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW."
+      "SHOW CATALOGS, SHOW DATABASES, SHOW TABLES, SHOW FUNCTIONS, CREATE VIEW, DROP VIEW, " +
+      "SHOW VIEWS."
 
   private def isStreamingMode: Boolean = this match {
     case _: BatchTableEnvImpl => false
@@ -569,7 +570,7 @@ abstract class TableEnvImpl(
            _: DropCatalogFunctionOperation | _: DropTempSystemFunctionOperation |
            _: AlterCatalogFunctionOperation | _: UseCatalogOperation | _: UseDatabaseOperation |
            _: ShowCatalogsOperation | _: ShowDatabasesOperation | _: ShowTablesOperation |
-           _: ShowFunctionsOperation =>
+           _: ShowFunctionsOperation | _: ShowViewsOperation =>
         executeOperation(operation)
       case _ =>
         throw new TableException(UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG)
@@ -728,6 +729,8 @@ abstract class TableEnvImpl(
             dropViewOperation.isIfExists)
         }
         TableResultImpl.TABLE_RESULT_OK
+      case _: ShowViewsOperation =>
+        buildShowResult(listViews())
       case _ => throw new TableException("Unsupported operation: " + operation)
     }
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/calcite/FlinkPlannerImpl.scala
@@ -19,10 +19,9 @@
 package org.apache.flink.table.calcite
 
 import org.apache.flink.sql.parser.ExtendedSqlNode
-import org.apache.flink.sql.parser.dql.{SqlShowCatalogs, SqlShowDatabases, SqlShowFunctions, SqlShowTables}
+import org.apache.flink.sql.parser.dql.{SqlShowCatalogs, SqlShowDatabases, SqlShowFunctions, SqlShowTables, SqlShowViews}
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.catalog.CatalogReader
-
 import org.apache.calcite.plan.RelOptTable.ViewExpander
 import org.apache.calcite.plan._
 import org.apache.calcite.rel.RelRoot
@@ -32,7 +31,6 @@ import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
 import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
-
 import _root_.java.lang.{Boolean => JBoolean}
 import _root_.java.util
 import _root_.java.util.function.{Function => JFunction}
@@ -125,7 +123,8 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlShowCatalogs]
         || sqlNode.isInstanceOf[SqlShowDatabases]
         || sqlNode.isInstanceOf[SqlShowTables]
-        || sqlNode.isInstanceOf[SqlShowFunctions]) {
+        || sqlNode.isInstanceOf[SqlShowFunctions]
+        || sqlNode.isInstanceOf[SqlShowViews]) {
         return sqlNode
       }
       validator.validate(sqlNode)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -257,6 +257,37 @@ class BatchTableEnvironmentTest extends TableTestBase {
     util.tableEnv.executeSql("select * from MyTable")
   }
 
+  @Test
+  def testExecuteSqlWithCreateDropView(): Unit = {
+    val util = batchTestUtil()
+
+    val createTableStmt =
+      """
+        |CREATE TABLE tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'true'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+    assertTrue(util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.tbl1")))
+
+    val tableResult2 = util.tableEnv.executeSql("CREATE VIEW view1 AS SELECT * FROM tbl1")
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+    assertTrue(util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.view1")))
+
+    val tableResult3 = util.tableEnv.executeSql("DROP VIEW view1")
+    assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)
+    assertFalse(util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
+      .tableExists(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.view1")))
+  }
+
   private def checkData(expected: util.Iterator[Row], actual: util.Iterator[Row]): Unit = {
     while (expected.hasNext && actual.hasNext) {
       assertEquals(expected.next(), actual.next())

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -308,11 +308,14 @@ class BatchTableEnvironmentTest extends TableTestBase {
     val tableResult2 = util.tableEnv.executeSql("CREATE VIEW view1 AS SELECT * FROM tbl1")
     assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
 
-    val tableResult3 = util.tableEnv.executeSql("SHOW VIEWS")
-    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
+    val tableResult3 = util.tableEnv.executeSql("CREATE TEMPORARY VIEW view2 AS SELECT * FROM tbl1")
+    assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)
+
+    val tableResult4 = util.tableEnv.executeSql("SHOW VIEWS")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult4.getResultKind)
     checkData(
       util.tableEnv.listViews().map(Row.of(_)).toList.asJava.iterator(),
-      tableResult3.collect())
+      tableResult4.collect())
   }
 
   private def checkData(expected: util.Iterator[Row], actual: util.Iterator[Row]): Unit = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -62,6 +62,8 @@ class MockTableEnvironment extends TableEnvironment {
 
   override def listTables(): Array[String] = ???
 
+  override def listViews(): Array[String] = ???
+
   override def listUserDefinedFunctions(): Array[String] = ???
 
   override def listFunctions(): Array[String] = ???


### PR DESCRIPTION
## What is the purpose of the change

FLINK-17106 introduces create/drop view in Flink SQL. But we can't list views from TableEnvironment or SQL. This PR supports SHOW VIEWS in Flink SQL. BTW: We follows the Hive style which lists all tables and views with SHOW TABLES and lists only views with SHOW VIEWS. 

## Brief change log 
- 546d367 Add show views syntax in sql parser
- fe6f4d9 Add listViews interface in TableEnvironment
- 39fb3f9 hotfix create/drop view in batch mode for legacy planner
- 05288fe Support SHOW VIEWS in blink planner
- 28223e2 Support SHOW VIEWS in legacy planner

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
