### PR TITLE
[FLINK-17117][SQL-Blink]Remove useless cast class code for processElement method in SourceCon…

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CalcCodeGenerator.scala
@@ -25,9 +25,9 @@ import org.apache.flink.table.runtime.generated.GeneratedFunction
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.runtime.typeutils.BaseRowTypeInfo
 import org.apache.flink.table.types.logical.RowType
-
 import org.apache.calcite.plan.RelOptCluster
 import org.apache.calcite.rex._
+import org.apache.flink.table.planner.codegen.CodeGenUtils.boxedTypeTermForType
 
 import scala.collection.JavaConversions._
 
@@ -46,6 +46,8 @@ object CalcCodeGenerator {
     val inputType = inputTransform.getOutputType.asInstanceOf[BaseRowTypeInfo].toRowType
     // filter out time attributes
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
+    val inputTypeTerm = boxedTypeTermForType(inputType)
+    val inputTermConverter: String  => String = term => s"($inputTypeTerm) $term"
     val processCode = generateProcessCode(
       ctx,
       inputType,
@@ -66,7 +68,8 @@ object CalcCodeGenerator {
         processCode,
         inputType,
         inputTerm = inputTerm,
-        lazyInputUnboxingCode = true)
+        lazyInputUnboxingCode = true,
+        converter = inputTermConverter)
 
     new CodeGenOperatorFactory(genOperator)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -697,10 +697,10 @@ object CodeGenUtils {
    * and NO NULL CHECKING is required as it might have been done by surrounding layers.
    */
   def genToInternal(ctx: CodeGeneratorContext, t: DataType): String => String = {
+    val iTerm = boxedTypeTermForType(fromDataTypeToLogicalType(t))
     if (isConverterIdentity(t)) {
-      term => s"$term"
+      term => s"($iTerm) $term"
     } else {
-      val iTerm = boxedTypeTermForType(fromDataTypeToLogicalType(t))
       val eTerm = typeTerm(t.getConversionClass)
       val converter = ctx.addReusableObject(
         DataFormatConverters.getConverterForDataType(t),

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -251,8 +251,11 @@ object CorrelateCodeGenerator {
       throw new TableException(s"Unsupported JoinRelType: $joinType for correlate join.")
     }
 
+    val inputTypeTerm = boxedTypeTermForType(inputType)
+    val inputTermConverter: String  => String = term => s"($inputTypeTerm) $term"
+
     val genOperator = OperatorCodeGenerator.generateOneInputStreamOperator[BaseRow, BaseRow](
-      ctx, ruleDescription, body, inputType)
+      ctx, ruleDescription, body, inputType, converter = inputTermConverter)
     new CodeGenOperatorFactory(genOperator)
   }
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/ExpandCodeGenerator.scala
@@ -22,8 +22,8 @@ import org.apache.flink.table.api.TableConfig
 import org.apache.flink.table.dataformat.{BaseRow, BoxedWrapperRow}
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory
 import org.apache.flink.table.types.logical.RowType
-
 import org.apache.calcite.rex.RexNode
+import org.apache.flink.table.planner.codegen.CodeGenUtils.boxedTypeTermForType
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
@@ -39,6 +39,8 @@ object ExpandCodeGenerator {
       retainHeader: Boolean = false,
       opName: String): CodeGenOperatorFactory[BaseRow] = {
     val inputTerm = CodeGenUtils.DEFAULT_INPUT1_TERM
+    val inputTypeTerm = boxedTypeTermForType(inputType)
+    val inputTermConverter: String  => String = term => s"($inputTypeTerm) $term"
 
     val exprGenerator = new ExprCodeGenerator(ctx, false)
       .bindInput(inputType, inputTerm = inputTerm)
@@ -67,7 +69,8 @@ object ExpandCodeGenerator {
       processCode,
       inputType,
       inputTerm = inputTerm,
-      lazyInputUnboxingCode = false)
+      lazyInputUnboxingCode = false,
+      converter = inputTermConverter)
 
     new CodeGenOperatorFactory(genOperator)
   }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
@@ -100,7 +100,7 @@ object OperatorCodeGenerator extends Logging {
 
         @Override
         public void processElement($STREAM_RECORD $ELEMENT) throws Exception {
-          $inputTypeTerm $inputTerm = ($inputTypeTerm) ${converter(s"$ELEMENT.getValue()")};
+          $inputTypeTerm $inputTerm = ${converter(s"$ELEMENT.getValue()")};
           ${ctx.reusePerRecordCode()}
           ${ctx.reuseLocalVariableCode()}
           ${if (lazyInputUnboxingCode) "" else ctx.reuseInputUnboxingCode()}

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -666,12 +666,15 @@ object AggCodeGenHelper {
       inputType: RowType): GeneratedOperator[OneInputStreamOperator[BaseRow, BaseRow]] = {
     ctx.addReusableMember("private boolean hasInput = false;")
     ctx.addReusableMember(s"$STREAM_RECORD element = new $STREAM_RECORD((Object)null);")
+    val inputTypeTerm = boxedTypeTermForType(inputType)
+    val inputTermConverter: String  => String = term => s"($inputTypeTerm) $term"
     OperatorCodeGenerator.generateOneInputStreamOperator(
       ctx,
       name,
       processCode,
       inputType,
       endInputCode = Some(endInputCode),
-      lazyInputUnboxingCode = true)
+      lazyInputUnboxingCode = true,
+      converter = inputTermConverter)
   }
 }


### PR DESCRIPTION
# What is the purpose of the change

![image](https://user-images.githubusercontent.com/18002496/80060767-f1024080-8561-11ea-9dcb-8925001577c1.png)

 

This method `generateOneInputStreamOperator` when OperatorCodeGenerator  generates SourceConversion:

```
@Override
public void processElement($STREAM_RECORD $ELEMENT) throws Exception {
  $inputTypeTerm $inputTerm = ($inputTypeTerm) ${converter(s"$ELEMENT.getValue()")};
  ${ctx.reusePerRecordCode()}
  ${ctx.reuseLocalVariableCode()}
  ${if (lazyInputUnboxingCode) "" else ctx.reuseInputUnboxingCode()}
  $processCode
}
 

 $inputTypeTerm $inputTerm = ($inputTypeTerm) ${converter(s"$ELEMENT.getValue()")};
ScanUtil calls generateOneInputStreamOperator


val generatedOperator = OperatorCodeGenerator.generateOneInputStreamOperator[Any, BaseRow](
  ctx,
  convertName,
  processCode,
  outputRowType,
  converter = inputTermConverter)

//inputTermConverter
val (inputTermConverter, inputRowType) = {
  val convertFunc = CodeGenUtils.genToInternal(ctx, inputType)
  internalInType match {
    case rt: RowType => (convertFunc, rt)
    case _ => ((record: String) => s"$GENERIC_ROW.of(${convertFunc(record)})",
        RowType.of(internalInType))
  }
}
```
There is an useless cast class code:
```
$inputTypeTerm $inputTerm = ($inputTypeTerm) ${converter(s"$ELEMENT.getValue()")};
```
CodeGenUtils.scala  :  genToInternal

```
def genToInternal(ctx: CodeGeneratorContext, t: DataType): String => String = {
  val iTerm = boxedTypeTermForType(fromDataTypeToLogicalType(t))
  if (isConverterIdentity(t)) {
    term => s"($iTerm) $term"
  } else {
    val eTerm = boxedTypeTermForExternalType(t)
    val converter = ctx.addReusableObject(
      DataFormatConverters.getConverterForDataType(t),
      "converter")
    term => s"($iTerm) $converter.toInternal(($eTerm) $term)"
  }
}
```
 
The code `($iTerm) ` and `($inputTypeTerm)` are same.

This method `genToInternal ` is used elsewhere, so the `($iTerm)` code can't be delete.
For the following code example : ([detail address |https://travis-ci.com/github/flink-ci/flink/jobs/322393094])
```
result$224 = javaResult$225 == null ? null : ((x x x x )converter$226.toInternal((java.lang.String) javaResult$225));  
```
So I used converter parameter


# Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

# Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
The S3 file system connector: (no)
# Documentation

Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not documented)