### PR TITLE
[FLINK-17110]Make configuration in Env configurable

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
@@ -23,13 +23,18 @@ import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.util.Collections;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 
 
 /**
@@ -62,5 +67,23 @@ public class ExecutionEnvironmentTest extends TestLogger implements Serializable
 		} catch (Exception e) {
 			fail("Consecutive #getExecutionPlan calls caused an exception.");
 		}
+	}
+
+	/**
+	 * Tests that verifies that {@link ExecutionEnvironment#configure} will merge user configuration
+	 * to system configuration.
+	 */
+	@Test
+	public void testMergeConfiguration() {
+		ExecutionEnvironment envFromConfiguration = ExecutionEnvironment.getExecutionEnvironment();
+
+		Configuration configuration = new Configuration();
+		configuration.set(PipelineOptions.CLASSPATHS, Collections.singletonList("file:///test1.jar"));
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(configuration, Thread.currentThread().getContextClassLoader());
+
+		assertEquals(envFromConfiguration.getConfiguration().get(PipelineOptions.CLASSPATHS), Collections.singletonList("file:///test1.jar"));
+
 	}
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ExecutionEnvironmentTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.io.DiscardingOutputFormat;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;

--- a/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/ExecutionEnvironment.java
@@ -51,7 +51,6 @@ import org.apache.flink.api.java.utils.PlanGenerator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.PipelineOptions;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.core.execution.DefaultExecutorServiceLoader;
 import org.apache.flink.core.execution.DetachedJobExecutionResult;
@@ -380,7 +379,7 @@ public class ExecutionEnvironment {
 	}
 
 	/**
-	 * Sets all relevant options contained in the {@link ReadableConfig} such as e.g.
+	 * Sets all relevant options contained in the {@link Configuration} such as e.g.
 	 * {@link PipelineOptions#CACHED_FILES}. It will reconfigure
 	 * {@link ExecutionEnvironment} and {@link ExecutionConfig}.
 	 *
@@ -388,11 +387,14 @@ public class ExecutionEnvironment {
 	 * {@code configuration}. If a key is not present, the current value of a field will remain
 	 * untouched.
 	 *
+	 * <p>the {@code configuration} will be also merged into {@link ExecutionEnvironment#configuration},
+	 * which will be used to generate job graph and create cluster to run the job graph.
+	 *
 	 * @param configuration a configuration to read the values from
 	 * @param classLoader a class loader to use when loading classes
 	 */
 	@PublicEvolving
-	public void configure(ReadableConfig configuration, ClassLoader classLoader) {
+	public void configure(Configuration configuration, ClassLoader classLoader) {
 		configuration.getOptional(DeploymentOptions.JOB_LISTENERS)
 			.ifPresent(listeners -> registerCustomListeners(classLoader, listeners));
 		configuration.getOptional(PipelineOptions.CACHED_FILES)
@@ -401,6 +403,8 @@ public class ExecutionEnvironment {
 				this.cacheFile.addAll(DistributedCache.parseCachedFilesFromString(f));
 			});
 		config.configure(configuration, classLoader);
+
+		this.configuration.addAll(configuration);
 	}
 
 	private void registerCustomListeners(final ClassLoader classLoader, final List<String> listeners) {

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -29,7 +29,7 @@ import org.apache.flink.api.java.operators.DataSource
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, TupleTypeInfoBase, ValueTypeInfo}
 import org.apache.flink.api.java.{CollectionEnvironment, ExecutionEnvironment => JavaEnv}
-import org.apache.flink.configuration.{Configuration, ReadableConfig}
+import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.execution.{JobClient, JobListener, PipelineExecutor}
 import org.apache.flink.core.fs.Path
 import org.apache.flink.types.StringValue
@@ -193,7 +193,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
   }
 
   /**
-   * Sets all relevant options contained in the [[ReadableConfig]] such as e.g.
+   * Sets all relevant options contained in the [[Configuration]] such as e.g.
    * [[org.apache.flink.configuration.PipelineOptions#CACHED_FILES]]. It will reconfigure
    * [[ExecutionEnvironment]] and [[ExecutionConfig]].
    *
@@ -205,7 +205,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    * @param classLoader   a class loader to use when loading classes
    */
   @PublicEvolving
-  def configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit = {
+  def configure(configuration: Configuration, classLoader: ClassLoader): Unit = {
     javaEnv.configure(configuration, classLoader)
   }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -742,7 +742,7 @@ public class StreamExecutionEnvironment {
 	}
 
 	/**
-	 * Sets all relevant options contained in the {@link ReadableConfig} such as e.g.
+	 * Sets all relevant options contained in the {@link Configuration} such as e.g.
 	 * {@link StreamPipelineOptions#TIME_CHARACTERISTIC}. It will reconfigure
 	 * {@link StreamExecutionEnvironment}, {@link ExecutionConfig} and {@link CheckpointConfig}.
 	 *
@@ -750,11 +750,14 @@ public class StreamExecutionEnvironment {
 	 * {@code configuration}. If a key is not present, the current value of a field will remain
 	 * untouched.
 	 *
+	 * <p>the {@code configuration} will be also merged into {@link StreamExecutionEnvironment#configuration},
+	 * which will be used to generate job graph and create cluster to run the job graph.
+	 *
 	 * @param configuration a configuration to read the values from
 	 * @param classLoader a class loader to use when loading classes
 	 */
 	@PublicEvolving
-	public void configure(ReadableConfig configuration, ClassLoader classLoader) {
+	public void configure(Configuration configuration, ClassLoader classLoader) {
 		configuration.getOptional(StreamPipelineOptions.TIME_CHARACTERISTIC)
 			.ifPresent(this::setStreamTimeCharacteristic);
 		Optional.ofNullable(loadStateBackend(configuration, classLoader))
@@ -772,6 +775,8 @@ public class StreamExecutionEnvironment {
 			});
 		config.configure(configuration, classLoader);
 		checkpointCfg.configure(configuration);
+
+		this.configuration.addAll(configuration);
 	}
 
 	private void registerCustomListeners(final ClassLoader classLoader, final List<String> listeners) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentComplexConfigurationTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
-import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.core.execution.JobListener;
 import org.apache.flink.runtime.state.StateBackend;
@@ -35,6 +35,7 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -44,7 +45,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Tests for configuring {@link StreamExecutionEnvironment} via
- * {@link StreamExecutionEnvironment#configure(ReadableConfig, ClassLoader)} with complex types.
+ * {@link StreamExecutionEnvironment#configure(Configuration, ClassLoader)} with complex types.
  *
  * @see StreamExecutionEnvironmentConfigurationTest
  */
@@ -123,6 +124,20 @@ public class StreamExecutionEnvironmentComplexConfigurationTest {
 		assertThat(envFromConfiguration.getJobListeners().get(1), instanceOf(BasicJobExecutedCounter.class));
 	}
 
+	@Test
+	public void testMergeConfiguration() {
+		StreamExecutionEnvironment envFromConfiguration = StreamExecutionEnvironment.getExecutionEnvironment();
+
+		Configuration configuration = new Configuration();
+		configuration.set(PipelineOptions.CLASSPATHS, Collections.singletonList("file:///test1.jar"));
+
+		// mutate config according to configuration
+		envFromConfiguration.configure(configuration, Thread.currentThread().getContextClassLoader());
+
+		assertEquals(envFromConfiguration.getConfiguration().get(PipelineOptions.CLASSPATHS), Collections.singletonList("file:///test1.jar"));
+
+	}
+
 	/**
 	 * JobSubmitted counter listener for unit test.
 	 */
@@ -138,6 +153,7 @@ public class StreamExecutionEnvironmentComplexConfigurationTest {
 		public void onJobExecuted(@Nullable JobExecutionResult jobExecutionResult, @Nullable Throwable throwable) {
 
 		}
+
 	}
 
 	/**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironmentConfigurationTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.api.environment;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.ExecutionConfigTest;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 
 import org.junit.Test;
@@ -38,7 +37,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Tests for configuring {@link StreamExecutionEnvironment} via
- * {@link StreamExecutionEnvironment#configure(ReadableConfig, ClassLoader)}.
+ * {@link StreamExecutionEnvironment#configure(Configuration, ClassLoader)}.
  *
  * @see StreamExecutionEnvironmentComplexConfigurationTest
  */

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/StreamExecutionEnvironment.scala
@@ -426,7 +426,7 @@ class StreamExecutionEnvironment(javaEnv: JavaEnv) {
    * @param classLoader   a class loader to use when loading classes
    */
   @PublicEvolving
-  def configure(configuration: ReadableConfig, classLoader: ClassLoader): Unit = {
+  def configure(configuration: Configuration, classLoader: ClassLoader): Unit = {
     javaEnv.configure(configuration, classLoader)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyExecutionEnvironment.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/util/DummyExecutionEnvironment.java
@@ -157,7 +157,7 @@ public class DummyExecutionEnvironment extends ExecutionEnvironment {
 	}
 
 	@Override
-	public void configure(ReadableConfig configuration, ClassLoader classLoader) {
+	public void configure(Configuration configuration, ClassLoader classLoader) {
 		//
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

* make it possible for users to modify configuration in program for job graph such as Jars and Classpaths for running the job.

## Brief change log
* make configuration in StreamExecutionEnvironment/ExecutionEnvironment configurable by configure in configure.
* use PipelineExecutorUtils to generate job graph to make sure that the configuration work in all use case.

## Verifying this change

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - *Added tests in ExecutionEnvironmentTest and StreamExecutionEnvironmentConfigurationTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs in configure)
