### PR TITLE
[FLINK-16641][network] Announce sender's backlog to solve the deadlock issue without exclusive buffers

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -30,7 +30,7 @@
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>Number of exclusive network buffers to use for each outgoing/incoming channel (subpartition/inputchannel) in the credit-based flow control model. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+            <td>Number of exclusive network buffers to use for each outgoing/incoming channel (subpartition/input channel) in the credit-based flow control model. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization. The minimum valid value that can be configured is 0. When 0 buffers-per-channel is configured, the exclusive network buffers used per downstream incoming channel will be 0, but for each upstream outgoing channel, max(1, configured value) will be used. In other words we ensure that, for performance reasons, there is at least one buffer per outgoing channel regardless of the configuration.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -48,7 +48,7 @@
             <td><h5>taskmanager.network.memory.buffers-per-channel</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>Number of exclusive network buffers to use for each outgoing/incoming channel (subpartition/inputchannel) in the credit-based flow control model. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.</td>
+            <td>Number of exclusive network buffers to use for each outgoing/incoming channel (subpartition/input channel) in the credit-based flow control model. It should be configured at least 2 for good performance. 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization. The minimum valid value that can be configured is 0. When 0 buffers-per-channel is configured, the exclusive network buffers used per downstream incoming channel will be 0, but for each upstream outgoing channel, max(1, configured value) will be used. In other words we ensure that, for performance reasons, there is at least one buffer per outgoing channel regardless of the configuration.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.memory.floating-buffers-per-gate</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -154,7 +154,11 @@ public class NettyShuffleEnvironmentOptions {
 
     /**
      * Number of network buffers to use for each outgoing/incoming channel (subpartition/input
-     * channel).
+     * channel). The minimum valid value that can be configured is 0. When 0 buffers-per-channel is
+     * configured, the exclusive network buffers used per downstream incoming channel will be 0, but
+     * for each upstream outgoing channel, max(1, configured value) will be used. In other words we
+     * ensure that, for performance reasons, there is at least one buffer per outgoing channel
+     * regardless of the configuration.
      *
      * <p>Reasoning: 1 buffer for in-flight data in the subpartition + 1 buffer for parallel
      * serialization.
@@ -164,9 +168,18 @@ public class NettyShuffleEnvironmentOptions {
             key("taskmanager.network.memory.buffers-per-channel")
                     .defaultValue(2)
                     .withDescription(
-                            "Number of exclusive network buffers to use for each outgoing/incoming channel (subpartition/inputchannel)"
-                                    + " in the credit-based flow control model. It should be configured at least 2 for good performance."
-                                    + " 1 buffer is for receiving in-flight data in the subpartition and 1 buffer is for parallel serialization.");
+                            "Number of exclusive network buffers to use for each outgoing/incoming "
+                                    + "channel (subpartition/input channel) in the credit-based flow"
+                                    + " control model. It should be configured at least 2 for good "
+                                    + "performance. 1 buffer is for receiving in-flight data in the"
+                                    + " subpartition and 1 buffer is for parallel serialization. The"
+                                    + " minimum valid value that can be configured is 0. When 0 "
+                                    + "buffers-per-channel is configured, the exclusive network "
+                                    + "buffers used per downstream incoming channel will be 0, but "
+                                    + "for each upstream outgoing channel, max(1, configured value)"
+                                    + " will be used. In other words we ensure that, for performance"
+                                    + " reasons, there is at least one buffer per outgoing channel "
+                                    + "regardless of the configuration.");
 
     /**
      * Number of extra network buffers to use for each outgoing/incoming gate (result

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkSequenceViewReader.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionProvider;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 
@@ -42,6 +43,9 @@ public interface NetworkSequenceViewReader {
     @Nullable
     BufferAndAvailability getNextBuffer() throws IOException;
 
+    /** Returns true if the producer backlog need to be announced to the consumer. */
+    boolean needAnnounceBacklog();
+
     /**
      * The credits from consumer are added in incremental way.
      *
@@ -56,11 +60,11 @@ public interface NetworkSequenceViewReader {
     void acknowledgeAllRecordsProcessed();
 
     /**
-     * Checks whether this reader is available or not.
+     * Checks whether this reader is available or not and returns the backlog at the same time.
      *
-     * @return True if the reader is available.
+     * @return A boolean flag indicating whether the reader is available together with the backlog.
      */
-    boolean isAvailable();
+    ResultSubpartitionView.AvailabilityWithBacklog getAvailabilityAndBacklog();
 
     boolean isRegisteredAsAvailable();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPool.java
@@ -167,12 +167,16 @@ public class NetworkBufferPool
     public List<MemorySegment> requestMemorySegments(int numberOfSegmentsToRequest)
             throws IOException {
         checkArgument(
-                numberOfSegmentsToRequest > 0,
-                "Number of buffers to request must be larger than 0.");
+                numberOfSegmentsToRequest >= 0,
+                "Number of buffers to request must be non-negative.");
 
         synchronized (factoryLock) {
             if (isDestroyed) {
                 throw new IllegalStateException("Network buffer pool has already been destroyed.");
+            }
+
+            if (numberOfSegmentsToRequest == 0) {
+                return Collections.emptyList();
             }
 
             tryRedistributeBuffers(numberOfSegmentsToRequest);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -343,6 +343,20 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
                     }
                 }
             }
+        } else if (msgClazz == NettyMessage.BacklogAnnouncement.class) {
+            NettyMessage.BacklogAnnouncement announcement = (NettyMessage.BacklogAnnouncement) msg;
+
+            RemoteInputChannel inputChannel = inputChannels.get(announcement.receiverId);
+            if (inputChannel == null || inputChannel.isReleased()) {
+                cancelRequestFor(announcement.receiverId);
+                return;
+            }
+
+            try {
+                inputChannel.onSenderBacklog(announcement.backlog);
+            } catch (Throwable throwable) {
+                inputChannel.onError(throwable);
+            }
         } else {
             throw new IllegalStateException(
                     "Received unknown message from producer: " + msg.getClass());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -39,6 +39,8 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdap
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
@@ -400,6 +402,9 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
             // It is no need to notify credit or resume data consumption for the released channel.
             if (!outboundMessage.inputChannel.isReleased()) {
                 Object msg = outboundMessage.buildMessage();
+                if (msg == null) {
+                    continue;
+                }
 
                 // Write and flush and wait until this is done before
                 // trying to continue with the next input channel.
@@ -436,6 +441,7 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
             this.inputChannel = inputChannel;
         }
 
+        @Nullable
         abstract Object buildMessage();
     }
 
@@ -447,8 +453,8 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
 
         @Override
         public Object buildMessage() {
-            return new AddCredit(
-                    inputChannel.getAndResetUnannouncedCredit(), inputChannel.getInputChannelId());
+            int credits = inputChannel.getAndResetUnannouncedCredit();
+            return credits > 0 ? new AddCredit(credits, inputChannel.getInputChannelId()) : null;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -34,6 +34,8 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /**
  * Simple wrapper for the subpartition view used in the new network credit-based mode.
  *
@@ -48,6 +50,8 @@ class CreditBasedSequenceNumberingViewReader
     private final InputChannelID receiverId;
 
     private final PartitionRequestQueue requestQueue;
+
+    private final int initialCredit;
 
     private volatile ResultSubpartitionView subpartitionView;
 
@@ -65,8 +69,10 @@ class CreditBasedSequenceNumberingViewReader
 
     CreditBasedSequenceNumberingViewReader(
             InputChannelID receiverId, int initialCredit, PartitionRequestQueue requestQueue) {
+        checkArgument(initialCredit >= 0, "Must be non-negative.");
 
         this.receiverId = receiverId;
+        this.initialCredit = initialCredit;
         this.numCreditsAvailable = initialCredit;
         this.requestQueue = requestQueue;
     }
@@ -125,11 +131,12 @@ class CreditBasedSequenceNumberingViewReader
      * buffers.
      *
      * @implSpec BEWARE: this must be in sync with {@link #getNextDataType(BufferAndBacklog)}, such
-     *     that {@code getNextDataType(bufferAndBacklog) != NONE <=> isAvailable()}!
+     *     that {@code getNextDataType(bufferAndBacklog) != NONE <=>
+     *     AvailabilityWithBacklog#isAvailable()}!
      */
     @Override
-    public boolean isAvailable() {
-        return subpartitionView.isAvailable(numCreditsAvailable);
+    public ResultSubpartitionView.AvailabilityWithBacklog getAvailabilityAndBacklog() {
+        return subpartitionView.getAvailabilityAndBacklog(numCreditsAvailable);
     }
 
     /**
@@ -139,8 +146,9 @@ class CreditBasedSequenceNumberingViewReader
      * <p>Returns the next data type only if the next buffer is an event or the reader has both
      * available credits and buffers.
      *
-     * @implSpec BEWARE: this must be in sync with {@link #isAvailable()}, such that {@code
-     *     getNextDataType(bufferAndBacklog) != NONE <=> isAvailable()}!
+     * @implSpec BEWARE: this must be in sync with {@link #getAvailabilityAndBacklog()}, such that
+     *     {@code getNextDataType(bufferAndBacklog) != NONE <=>
+     *     AvailabilityWithBacklog#isAvailable()}!
      * @param bufferAndBacklog current buffer and backlog including information about the next
      *     buffer
      * @return the next data type if the next buffer can be pulled immediately or {@link
@@ -165,8 +173,8 @@ class CreditBasedSequenceNumberingViewReader
     }
 
     @VisibleForTesting
-    boolean hasBuffersAvailable() {
-        return subpartitionView.isAvailable(Integer.MAX_VALUE);
+    ResultSubpartitionView.AvailabilityWithBacklog hasBuffersAvailable() {
+        return subpartitionView.getAvailabilityAndBacklog(Integer.MAX_VALUE);
     }
 
     @Nullable
@@ -184,6 +192,11 @@ class CreditBasedSequenceNumberingViewReader
         } else {
             return null;
         }
+    }
+
+    @Override
+    public boolean needAnnounceBacklog() {
+        return initialCredit == 0 && numCreditsAvailable == 0;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReader.java
@@ -108,6 +108,11 @@ class CreditBasedSequenceNumberingViewReader
 
     @Override
     public void resumeConsumption() {
+        if (initialCredit == 0) {
+            // reset available credit if no exclusive buffer is available at the
+            // consumer side for all floating buffers must have been released
+            numCreditsAvailable = 0;
+        }
         subpartitionView.resumeConsumption();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.RemoteInputChannel
 
 import javax.annotation.Nullable;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** An allocator used for requesting buffers in the client side netty handlers. */
@@ -69,6 +70,7 @@ class NetworkBufferAllocator {
      * @return The un-pooled network buffer.
      */
     Buffer allocateUnPooledNetworkBuffer(int size, Buffer.DataType dataType) {
+        checkArgument(size > 0, "Illegal buffer size, must be positive.");
         byte[] byteArray = new byte[size];
         MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NonBufferResponseDecoder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NonBufferResponseDecoder.java
@@ -23,6 +23,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 
 import java.net.ProtocolException;
 
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.BacklogAnnouncement;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 
@@ -59,6 +60,8 @@ class NonBufferResponseDecoder extends NettyMessageDecoder {
         switch (msgId) {
             case ErrorResponse.ID:
                 return DecodingResult.fullMessage(ErrorResponse.readFrom(fullFrameHeaderBuf));
+            case BacklogAnnouncement.ID:
+                return DecodingResult.fullMessage(BacklogAnnouncement.readFrom(fullFrameHeaderBuf));
             default:
                 throw new ProtocolException("Received unknown message from producer: " + msgId);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueue.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.io.network.NetworkSequenceViewReader;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import org.apache.flink.runtime.io.network.partition.ProducerFailedException;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel.BufferAndAvailability;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
 
@@ -44,6 +45,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
  * A nonEmptyReader of partition queues, which listens for channel writability changed events before
@@ -97,9 +99,20 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
      * availability, so there is no race condition here.
      */
     private void enqueueAvailableReader(final NetworkSequenceViewReader reader) throws Exception {
-        if (reader.isRegisteredAsAvailable() || !reader.isAvailable()) {
+        if (reader.isRegisteredAsAvailable()) {
             return;
         }
+
+        ResultSubpartitionView.AvailabilityWithBacklog availabilityWithBacklog =
+                reader.getAvailabilityAndBacklog();
+        if (!availabilityWithBacklog.isAvailable()) {
+            int backlog = availabilityWithBacklog.getBacklog();
+            if (backlog > 0 && reader.needAnnounceBacklog()) {
+                announceBacklog(reader, backlog);
+            }
+            return;
+        }
+
         // Queue an available reader for consumption. If the queue is empty,
         // we try trigger the actual write. Otherwise this will be handled by
         // the writeAndFlushNextMessageIfPossible calls.
@@ -176,6 +189,26 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
             throw new IllegalStateException(
                     "No reader for receiverId = " + receiverId + " exists.");
         }
+    }
+
+    /**
+     * Announces remaining backlog to the consumer after the available data notification or data
+     * consumption resumption.
+     */
+    private void announceBacklog(NetworkSequenceViewReader reader, int backlog) {
+        checkArgument(backlog > 0, "Backlog must be positive.");
+
+        NettyMessage.BacklogAnnouncement announcement =
+                new NettyMessage.BacklogAnnouncement(backlog, reader.getReceiverId());
+        ctx.channel()
+                .writeAndFlush(announcement)
+                .addListener(
+                        (ChannelFutureListener)
+                                future -> {
+                                    if (!future.isSuccess()) {
+                                        onChannelFutureFailure(future);
+                                    }
+                                });
     }
 
     @Override
@@ -324,6 +357,15 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
         reader.releaseAllResources();
     }
 
+    private void onChannelFutureFailure(ChannelFuture future) throws Exception {
+        if (future.cause() != null) {
+            handleException(future.channel(), future.cause());
+        } else {
+            handleException(
+                    future.channel(), new IllegalStateException("Sending cancelled by user."));
+        }
+    }
+
     // This listener is called after an element of the current nonEmptyReader has been
     // flushed. If successful, the listener triggers further processing of the
     // queues.
@@ -334,12 +376,8 @@ class PartitionRequestQueue extends ChannelInboundHandlerAdapter {
             try {
                 if (future.isSuccess()) {
                     writeAndFlushNextMessageIfPossible(future.channel());
-                } else if (future.cause() != null) {
-                    handleException(future.channel(), future.cause());
                 } else {
-                    handleException(
-                            future.channel(),
-                            new IllegalStateException("Sending cancelled by user."));
+                    onChannelFutureFailure(future);
                 }
             } catch (Throwable t) {
                 handleException(future.channel(), t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartition.java
@@ -276,7 +276,7 @@ final class BoundedBlockingSubpartition extends ResultSubpartition {
         return data.getSize();
     }
 
-    int getBuffersInBacklog() {
+    int getBuffersInBacklogUnsafe() {
         return numDataBuffersWritten;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -111,10 +111,12 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     }
 
     @Override
-    public boolean isAvailable(int numCreditsAvailable) {
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
         // We simply assume there are no events except EndOfPartitionEvent for bath jobs,
         // then it has no essential effect to ignore the judgement of next event buffer.
-        return (numCreditsAvailable > 0 || numDataBuffers == 0) && numDataAndEventBuffers > 0;
+        return new AvailabilityWithBacklog(
+                (numCreditsAvailable > 0 || numDataBuffers == 0) && numDataAndEventBuffers > 0,
+                numDataBuffers);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionDirectTransferReader.java
@@ -62,7 +62,7 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
             int numDataBuffers,
             int numDataAndEventBuffers)
             throws IOException {
-
+        checkArgument(numDataAndEventBuffers - numDataBuffers == 1, "Too many event buffers.");
         this.parent = checkNotNull(parent);
 
         checkNotNull(filePath);
@@ -91,10 +91,14 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
 
         updateStatistics(current);
 
-        // We simply assume all the data are non-events for batch jobs to avoid pre-fetching the
-        // next header
-        Buffer.DataType nextDataType =
-                numDataAndEventBuffers > 0 ? Buffer.DataType.DATA_BUFFER : Buffer.DataType.NONE;
+        // We simply assume all the data except for the last one (EndOfPartitionEvent)
+        // are non-events for batch jobs to avoid pre-fetching the next header
+        Buffer.DataType nextDataType = Buffer.DataType.NONE;
+        if (numDataBuffers > 0) {
+            nextDataType = Buffer.DataType.DATA_BUFFER;
+        } else if (numDataAndEventBuffers > 0) {
+            nextDataType = Buffer.DataType.EVENT_BUFFER;
+        }
         return BufferAndBacklog.fromBufferAndLookahead(
                 current, nextDataType, numDataBuffers, sequenceNumber++);
     }
@@ -110,7 +114,7 @@ public class BoundedBlockingSubpartitionDirectTransferReader implements ResultSu
     public boolean isAvailable(int numCreditsAvailable) {
         // We simply assume there are no events except EndOfPartitionEvent for bath jobs,
         // then it has no essential effect to ignore the judgement of next event buffer.
-        return numCreditsAvailable > 0 && numDataAndEventBuffers > 0;
+        return (numCreditsAvailable > 0 || numDataBuffers == 0) && numDataAndEventBuffers > 0;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionReader.java
@@ -160,12 +160,14 @@ final class BoundedBlockingSubpartitionReader implements ResultSubpartitionView 
     }
 
     @Override
-    public boolean isAvailable(int numCreditsAvailable) {
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+        boolean isAvailable;
         if (numCreditsAvailable > 0) {
-            return nextBuffer != null;
+            isAvailable = nextBuffer != null;
+        } else {
+            isAvailable = nextBuffer != null && !nextBuffer.isBuffer();
         }
-
-        return nextBuffer != null && !nextBuffer.isBuffer();
+        return new AvailabilityWithBacklog(isAvailable, dataBufferBacklog);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/NoOpResultSubpartitionView.java
@@ -51,8 +51,8 @@ public class NoOpResultSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
-    public boolean isAvailable(int numCreditsAvailable) {
-        return false;
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+        return new AvailabilityWithBacklog(false, 0);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -43,8 +43,9 @@ public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
     @GuardedBy("buffers")
     private boolean isPartialBufferCleanupRequired = false;
 
-    PipelinedApproximateSubpartition(int index, ResultPartition parent) {
-        super(index, parent);
+    PipelinedApproximateSubpartition(
+            int index, int receiverExclusiveBuffersPerChannel, ResultPartition parent) {
+        super(index, receiverExclusiveBuffersPerChannel, parent);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -45,6 +45,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -71,6 +72,12 @@ public class PipelinedSubpartition extends ResultSubpartition
     private static final Logger LOG = LoggerFactory.getLogger(PipelinedSubpartition.class);
 
     // ------------------------------------------------------------------------
+
+    /**
+     * Number of exclusive credits per input channel at the downstream tasks configured by {@link
+     * org.apache.flink.configuration.NettyShuffleEnvironmentOptions#NETWORK_BUFFERS_PER_CHANNEL}.
+     */
+    private final int receiverExclusiveBuffersPerChannel;
 
     /** All buffers of this subpartition. Access to the buffers is synchronized on this object. */
     final PrioritizedDeque<BufferConsumerWithPartialRecordLength> buffers =
@@ -112,8 +119,14 @@ public class PipelinedSubpartition extends ResultSubpartition
 
     // ------------------------------------------------------------------------
 
-    PipelinedSubpartition(int index, ResultPartition parent) {
+    PipelinedSubpartition(
+            int index, int receiverExclusiveBuffersPerChannel, ResultPartition parent) {
         super(index, parent);
+
+        checkArgument(
+                receiverExclusiveBuffersPerChannel >= 0,
+                "Buffers per channel must be non-negative.");
+        this.receiverExclusiveBuffersPerChannel = receiverExclusiveBuffersPerChannel;
     }
 
     @Override
@@ -310,6 +323,16 @@ public class PipelinedSubpartition extends ResultSubpartition
                 if (bufferConsumer.isFinished()) {
                     requireNonNull(buffers.poll()).getBufferConsumer().close();
                     decreaseBuffersInBacklogUnsafe(bufferConsumer.isBuffer());
+                }
+
+                // if we have an empty finished buffer and the exclusive credit is 0, we just return
+                // the empty buffer so that the downstream task can release the allocated credit for
+                // this empty buffer, this happens in two main scenarios currently:
+                // 1. all data of a buffer builder has been read and after that the buffer builder
+                // is finished
+                // 2. in approximate recovery mode, a partial record takes a whole buffer builder
+                if (receiverExclusiveBuffersPerChannel == 0 && bufferConsumer.isFinished()) {
+                    break;
                 }
 
                 if (buffer.readableBytes() > 0) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionView.java
@@ -85,8 +85,8 @@ public class PipelinedSubpartitionView implements ResultSubpartitionView {
     }
 
     @Override
-    public boolean isAvailable(int numCreditsAvailable) {
-        return parent.isAvailable(numCreditsAvailable);
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+        return parent.getAvailabilityAndBacklog(numCreditsAvailable);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
-import java.util.function.BiFunction;
 
 /** Factory for {@link ResultPartition} to use in {@link NettyShuffleEnvironment}. */
 public class ResultPartitionFactory {
@@ -156,15 +155,16 @@ public class ResultPartitionFactory {
                             bufferCompressor,
                             bufferPoolFactory);
 
-            BiFunction<Integer, PipelinedResultPartition, PipelinedSubpartition> factory;
-            if (type == ResultPartitionType.PIPELINED_APPROXIMATE) {
-                factory = PipelinedApproximateSubpartition::new;
-            } else {
-                factory = PipelinedSubpartition::new;
-            }
-
             for (int i = 0; i < subpartitions.length; i++) {
-                subpartitions[i] = factory.apply(i, pipelinedPartition);
+                if (type == ResultPartitionType.PIPELINED_APPROXIMATE) {
+                    subpartitions[i] =
+                            new PipelinedApproximateSubpartition(
+                                    i, networkBuffersPerChannel, pipelinedPartition);
+                } else {
+                    subpartitions[i] =
+                            new PipelinedSubpartition(
+                                    i, networkBuffersPerChannel, pipelinedPartition);
+                }
             }
 
             partition = pipelinedPartition;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -57,7 +57,7 @@ public class ResultPartitionFactory {
 
     private final BoundedBlockingSubpartitionType blockingSubpartitionType;
 
-    private final int networkBuffersPerChannel;
+    private final int configuredNetworkBuffersPerChannel;
 
     private final int floatingNetworkBuffersPerGate;
 
@@ -82,7 +82,7 @@ public class ResultPartitionFactory {
             BatchShuffleReadBufferPool batchShuffleReadBufferPool,
             ExecutorService batchShuffleReadIOExecutor,
             BoundedBlockingSubpartitionType blockingSubpartitionType,
-            int networkBuffersPerChannel,
+            int configuredNetworkBuffersPerChannel,
             int floatingNetworkBuffersPerGate,
             int networkBufferSize,
             boolean blockingShuffleCompressionEnabled,
@@ -94,7 +94,7 @@ public class ResultPartitionFactory {
 
         this.partitionManager = partitionManager;
         this.channelManager = channelManager;
-        this.networkBuffersPerChannel = networkBuffersPerChannel;
+        this.configuredNetworkBuffersPerChannel = configuredNetworkBuffersPerChannel;
         this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
         this.bufferPoolFactory = bufferPoolFactory;
         this.batchShuffleReadBufferPool = batchShuffleReadBufferPool;
@@ -159,11 +159,11 @@ public class ResultPartitionFactory {
                 if (type == ResultPartitionType.PIPELINED_APPROXIMATE) {
                     subpartitions[i] =
                             new PipelinedApproximateSubpartition(
-                                    i, networkBuffersPerChannel, pipelinedPartition);
+                                    i, configuredNetworkBuffersPerChannel, pipelinedPartition);
                 } else {
                     subpartitions[i] =
                             new PipelinedSubpartition(
-                                    i, networkBuffersPerChannel, pipelinedPartition);
+                                    i, configuredNetworkBuffersPerChannel, pipelinedPartition);
                 }
             }
 
@@ -269,7 +269,7 @@ public class ResultPartitionFactory {
         return () -> {
             Pair<Integer, Integer> pair =
                     NettyShuffleUtils.getMinMaxNetworkBuffersPerResultPartition(
-                            networkBuffersPerChannel,
+                            configuredNetworkBuffersPerChannel,
                             floatingNetworkBuffersPerGate,
                             sortShuffleMinParallelism,
                             sortShuffleMinBuffers,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -97,14 +97,8 @@ public abstract class ResultSubpartition {
 
     public abstract boolean isReleased();
 
-    /**
-     * Gets the number of non-event buffers in this subpartition.
-     *
-     * <p><strong>Beware:</strong> This method should only be used in tests in non-concurrent access
-     * scenarios since it does not make any concurrency guarantees.
-     */
-    @VisibleForTesting
-    abstract int getBuffersInBacklog();
+    /** Gets the number of non-event buffers in this subpartition. */
+    abstract int getBuffersInBacklogUnsafe();
 
     /**
      * Makes a best effort to get the current size of the queue. This method must not acquire locks

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartitionView.java
@@ -25,6 +25,8 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 
+import static org.apache.flink.util.Preconditions.checkArgument;
+
 /** A view to consume a {@link ResultSubpartition} instance. */
 public interface ResultSubpartitionView {
 
@@ -55,7 +57,33 @@ public interface ResultSubpartitionView {
 
     Throwable getFailureCause();
 
-    boolean isAvailable(int numCreditsAvailable);
+    AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable);
 
     int unsynchronizedGetNumberOfQueuedBuffers();
+
+    /**
+     * Availability of the {@link ResultSubpartitionView} and the backlog in the corresponding
+     * {@link ResultSubpartition}.
+     */
+    class AvailabilityWithBacklog {
+
+        private final boolean isAvailable;
+
+        private final int backlog;
+
+        public AvailabilityWithBacklog(boolean isAvailable, int backlog) {
+            checkArgument(backlog >= 0, "Backlog must be non-negative.");
+
+            this.isAvailable = isAvailable;
+            this.backlog = backlog;
+        }
+
+        public boolean isAvailable() {
+            return isAvailable;
+        }
+
+        public int getBacklog() {
+            return backlog;
+        }
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -334,9 +334,7 @@ public class BufferManager implements BufferListener, BufferRecycler {
                 }
             }
 
-            if (notificationResult != NotificationResult.BUFFER_NOT_USED) {
-                inputChannel.notifyBufferAvailable(1);
-            }
+            inputChannel.notifyBufferAvailable(1);
         } catch (Throwable t) {
             inputChannel.setError(t);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/BufferManager.java
@@ -134,11 +134,12 @@ public class BufferManager implements BufferListener, BufferRecycler {
 
     /** Requests exclusive buffers from the provider. */
     void requestExclusiveBuffers(int numExclusiveBuffers) throws IOException {
-        Collection<MemorySegment> segments = globalPool.requestMemorySegments(numExclusiveBuffers);
-        checkArgument(
-                !segments.isEmpty(),
-                "The number of exclusive buffers per channel should be larger than 0.");
+        checkArgument(numExclusiveBuffers >= 0, "Num exclusive buffers must be non-negative.");
+        if (numExclusiveBuffers == 0) {
+            return;
+        }
 
+        Collection<MemorySegment> segments = globalPool.requestMemorySegments(numExclusiveBuffers);
         synchronized (bufferQueue) {
             // AvailableBufferQueue::addExclusiveBuffer may release the previously allocated
             // floating buffer, which requires the caller to recycle these released floating

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -273,9 +273,10 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
     public void resumeConsumption() {
         checkState(!isReleased, "Channel released.");
 
+        ResultSubpartitionView subpartitionView = checkNotNull(this.subpartitionView);
         subpartitionView.resumeConsumption();
 
-        if (subpartitionView.isAvailable(Integer.MAX_VALUE)) {
+        if (subpartitionView.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable()) {
             notifyChannelNonEmpty();
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -216,6 +216,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
         }
 
         BufferAndBacklog next = subpartitionView.getNextBuffer();
+        // ignore the empty buffer directly
+        while (next != null && next.buffer().readableBytes() == 0) {
+            next.buffer().recycleBuffer();
+            next = subpartitionView.getNextBuffer();
+            numBuffersIn.inc();
+        }
 
         if (next == null) {
             if (subpartitionView.isReleased()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -452,10 +452,7 @@ public class RemoteInputChannel extends InputChannel {
      * @param backlog The number of unsent buffers in the producer's sub partition.
      */
     void onSenderBacklog(int backlog) throws IOException {
-        int numRequestedBuffers = bufferManager.requestFloatingBuffers(backlog + initialCredit);
-        if (numRequestedBuffers > 0 && unannouncedCredit.getAndAdd(numRequestedBuffers) == 0) {
-            notifyCreditAvailable();
-        }
+        notifyBufferAvailable(bufferManager.requestFloatingBuffers(backlog + initialCredit));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -451,7 +451,7 @@ public class RemoteInputChannel extends InputChannel {
      *
      * @param backlog The number of unsent buffers in the producer's sub partition.
      */
-    void onSenderBacklog(int backlog) throws IOException {
+    public void onSenderBacklog(int backlog) throws IOException {
         notifyBufferAvailable(bufferManager.requestFloatingBuffers(backlog + initialCredit));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -132,6 +132,7 @@ public class RemoteInputChannel extends InputChannel {
                 maxBackoff,
                 numBytesIn,
                 numBuffersIn);
+        checkArgument(networkBuffersPerChannel >= 0, "Must be non-negative.");
 
         this.initialCredit = networkBuffersPerChannel;
         this.connectionId = checkNotNull(connectionId);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -290,9 +290,6 @@ public class UnionInputGate extends InputGate {
 
     @Override
     public void resumeConsumption(InputChannelInfo channelInfo) throws IOException {
-        // BEWARE: consumption resumption only happens for streaming jobs in which all
-        // slots are allocated together so there should be no UnknownInputChannel. We
-        // will refactor the code to not rely on this assumption in the future.
         inputGatesByGateIndex.get(channelInfo.getGateIdx()).resumeConsumption(channelInfo);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -34,14 +34,30 @@ import static org.apache.flink.util.Preconditions.checkArgument;
  */
 public class NettyShuffleUtils {
 
+    /**
+     * Calculates and returns the number of required exclusive network buffers per input channel.
+     */
+    public static int getNetworkBuffersPerInputChannel(
+            final int configuredNetworkBuffersPerChannel) {
+        return configuredNetworkBuffersPerChannel;
+    }
+
+    /**
+     * Calculates and returns the floating network buffer pool size used by the input gate. The
+     * left/right value of the returned pair represent the min/max buffers require by the pool.
+     */
     public static Pair<Integer, Integer> getMinMaxFloatingBuffersPerInputGate(
             final int numFloatingBuffersPerGate) {
         // We should guarantee at-least one floating buffer for local channel state recovery.
         return Pair.of(1, numFloatingBuffersPerGate);
     }
 
+    /**
+     * Calculates and returns local network buffer pool size used by the result partition. The
+     * left/right value of the returned pair represent the min/max buffers require by the pool.
+     */
     public static Pair<Integer, Integer> getMinMaxNetworkBuffersPerResultPartition(
-            final int numBuffersPerChannel,
+            final int configuredNetworkBuffersPerChannel,
             final int numFloatingBuffersPerGate,
             final int sortShuffleMinParallelism,
             final int sortShuffleMinBuffers,
@@ -53,9 +69,15 @@ public class NettyShuffleUtils {
                         : numSubpartitions + 1;
         int max =
                 type.isBounded()
-                        ? numSubpartitions * numBuffersPerChannel + numFloatingBuffersPerGate
+                        ? numSubpartitions * configuredNetworkBuffersPerChannel
+                                + numFloatingBuffersPerGate
                         : Integer.MAX_VALUE;
-        return Pair.of(min, max);
+        // for each upstream hash-based blocking/pipelined subpartition, at least one buffer is
+        // needed even the configured network buffers per channel is 0 and this behavior is for
+        // performance. If it's not guaranteed that each subpartition can get at least one buffer,
+        // more partial buffers with little data will be outputted to network/disk and recycled to
+        // be used by other subpartitions which can not get a buffer for data caching.
+        return Pair.of(min, Math.max(min, max));
     }
 
     public static int computeNetworkBuffersForAnnouncing(
@@ -71,7 +93,7 @@ public class NettyShuffleUtils {
         // Each input channel will retain N exclusive network buffers, N = numBuffersPerChannel.
         // Each input gate is guaranteed to have a number of floating buffers.
         int requirementForInputs =
-                numBuffersPerChannel * numTotalInputChannels
+                getNetworkBuffersPerInputChannel(numBuffersPerChannel) * numTotalInputChannels
                         + getMinMaxFloatingBuffersPerInputGate(numFloatingBuffersPerGate).getRight()
                                 * numTotalInputGates;
 
@@ -96,7 +118,7 @@ public class NettyShuffleUtils {
 
     private static int getNumBuffersToAnnounceForResultPartition(
             ResultPartitionType type,
-            int numBuffersPerChannel,
+            int configuredNetworkBuffersPerChannel,
             int floatingBuffersPerGate,
             int sortShuffleMinParallelism,
             int sortShuffleMinBuffers,
@@ -104,7 +126,7 @@ public class NettyShuffleUtils {
 
         Pair<Integer, Integer> minAndMax =
                 getMinMaxNetworkBuffersPerResultPartition(
-                        numBuffersPerChannel,
+                        configuredNetworkBuffersPerChannel,
                         floatingBuffersPerGate,
                         sortShuffleMinParallelism,
                         sortShuffleMinBuffers,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -70,7 +70,7 @@ public class NettyShuffleUtils {
 
         // Each input channel will retain N exclusive network buffers, N = numBuffersPerChannel.
         // Each input gate is guaranteed to have a number of floating buffers.
-        int requirmentForInputs =
+        int requirementForInputs =
                 numBuffersPerChannel * numTotalInputChannels
                         + getMinMaxFloatingBuffersPerInputGate(numFloatingBuffersPerGate).getRight()
                                 * numTotalInputGates;
@@ -91,7 +91,7 @@ public class NettyShuffleUtils {
                             numSubs);
         }
 
-        return requirmentForInputs + requirementForOutputs;
+        return requirementForInputs + requirementForOutputs;
     }
 
     private static int getNumBuffersToAnnounceForResultPartition(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -111,7 +111,7 @@ public class RecordWriterTest {
             BufferOrEvent boe = parseBuffer(view.getNextBuffer().buffer(), i);
             assertTrue(boe.isEvent());
             assertEquals(barrier, boe.getEvent());
-            assertFalse(view.isAvailable(Integer.MAX_VALUE));
+            assertFalse(view.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         }
     }
 
@@ -372,7 +372,7 @@ public class RecordWriterTest {
 
             assertRecords += DeserializationUtils.deserializeRecords(expectedRecords, deserializer);
         }
-        assertFalse(view.isAvailable(Integer.MAX_VALUE));
+        assertFalse(view.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         Assert.assertEquals(numValues, assertRecords);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -294,8 +294,8 @@ public class NetworkBufferPoolTest extends TestLogger {
     @Test(expected = IllegalArgumentException.class)
     public void testRequestMemorySegmentsWithInvalidArgument() throws IOException {
         NetworkBufferPool globalPool = new NetworkBufferPool(10, 128);
-        // the number of requested buffers should be larger than zero
-        globalPool.requestMemorySegments(0);
+        // the number of requested buffers should be non-negative
+        globalPool.requestMemorySegments(-1);
         globalPool.destroy();
         fail("Should throw an IllegalArgumentException");
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CancelPartitionRequestTest.java
@@ -232,8 +232,8 @@ public class CancelPartitionRequestTest {
         public void acknowledgeAllRecordsProcessed() {}
 
         @Override
-        public boolean isAvailable(int numCreditsAvailable) {
-            return true;
+        public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+            return new AvailabilityWithBacklog(true, 0);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -246,6 +246,51 @@ public class CreditBasedPartitionRequestClientHandlerTest {
         }
     }
 
+    /** Verifies that {@link NettyMessage.BacklogAnnouncement} can be handled correctly. */
+    @Test
+    public void testReceiveBacklogAnnouncement() throws Exception {
+        int bufferSize = 1024;
+        int numBuffers = 10;
+        NetworkBufferPool networkBufferPool = new NetworkBufferPool(numBuffers, bufferSize);
+        SingleInputGate inputGate =
+                new SingleInputGateBuilder().setSegmentProvider(networkBufferPool).build();
+        RemoteInputChannel inputChannel = createRemoteInputChannel(inputGate, null);
+        inputGate.setInputChannels(inputChannel);
+
+        try {
+            BufferPool bufferPool = networkBufferPool.createBufferPool(8, 8);
+            inputGate.setBufferPool(bufferPool);
+            inputGate.setupChannels();
+
+            CreditBasedPartitionRequestClientHandler handler =
+                    new CreditBasedPartitionRequestClientHandler();
+            handler.addInputChannel(inputChannel);
+
+            assertEquals(2, inputChannel.getNumberOfAvailableBuffers());
+            assertEquals(0, inputChannel.unsynchronizedGetFloatingBuffersAvailable());
+
+            int backlog = 5;
+            NettyMessage.BacklogAnnouncement announcement =
+                    new NettyMessage.BacklogAnnouncement(backlog, inputChannel.getInputChannelId());
+            handler.channelRead(null, announcement);
+            assertEquals(7, inputChannel.getNumberOfAvailableBuffers());
+            assertEquals(7, inputChannel.getNumberOfRequiredBuffers());
+            assertEquals(backlog, inputChannel.getSenderBacklog());
+            assertEquals(5, inputChannel.unsynchronizedGetFloatingBuffersAvailable());
+
+            backlog = 12;
+            announcement =
+                    new NettyMessage.BacklogAnnouncement(backlog, inputChannel.getInputChannelId());
+            handler.channelRead(null, announcement);
+            assertEquals(10, inputChannel.getNumberOfAvailableBuffers());
+            assertEquals(14, inputChannel.getNumberOfRequiredBuffers());
+            assertEquals(backlog, inputChannel.getSenderBacklog());
+            assertEquals(8, inputChannel.unsynchronizedGetFloatingBuffersAvailable());
+        } finally {
+            releaseResource(inputGate, networkBufferPool);
+        }
+    }
+
     /**
      * Verifies that {@link RemoteInputChannel#onError(Throwable)} is called when a {@link
      * BufferResponse} is received but no available buffer in input channel.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReaderTest.java
@@ -26,11 +26,34 @@ import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link CreditBasedSequenceNumberingViewReader}. */
 public class CreditBasedSequenceNumberingViewReaderTest {
+
+    @Test
+    public void testResumeConsumption() throws Exception {
+        int numCredits = 2;
+        CreditBasedSequenceNumberingViewReader reader1 =
+                createNetworkSequenceViewReader(numCredits);
+
+        reader1.resumeConsumption();
+        assertEquals(numCredits, reader1.getNumCreditsAvailable());
+
+        reader1.addCredit(numCredits);
+        reader1.resumeConsumption();
+        assertEquals(2 * numCredits, reader1.getNumCreditsAvailable());
+
+        CreditBasedSequenceNumberingViewReader reader2 = createNetworkSequenceViewReader(0);
+
+        reader2.addCredit(numCredits);
+        assertEquals(numCredits, reader2.getNumCreditsAvailable());
+
+        reader2.resumeConsumption();
+        assertEquals(0, reader2.getNumCreditsAvailable());
+    }
 
     @Test
     public void testNeedAnnounceBacklog() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedSequenceNumberingViewReaderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.netty;
+
+import org.apache.flink.runtime.io.network.partition.NoOpResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link CreditBasedSequenceNumberingViewReader}. */
+public class CreditBasedSequenceNumberingViewReaderTest {
+
+    @Test
+    public void testNeedAnnounceBacklog() throws Exception {
+        int numCredits = 2;
+        CreditBasedSequenceNumberingViewReader reader1 =
+                createNetworkSequenceViewReader(numCredits);
+
+        assertFalse(reader1.needAnnounceBacklog());
+        reader1.addCredit(-numCredits);
+        assertFalse(reader1.needAnnounceBacklog());
+
+        CreditBasedSequenceNumberingViewReader reader2 = createNetworkSequenceViewReader(0);
+        assertTrue(reader2.needAnnounceBacklog());
+
+        reader2.addCredit(numCredits);
+        assertFalse(reader2.needAnnounceBacklog());
+
+        reader2.addCredit(-numCredits);
+        assertTrue(reader2.needAnnounceBacklog());
+    }
+
+    private CreditBasedSequenceNumberingViewReader createNetworkSequenceViewReader(
+            int initialCredit) throws Exception {
+        PartitionRequestQueue queue = new PartitionRequestQueue();
+        EmbeddedChannel channel = new EmbeddedChannel(queue);
+        channel.close();
+        CreditBasedSequenceNumberingViewReader reader =
+                new CreditBasedSequenceNumberingViewReader(
+                        new InputChannelID(), initialCredit, queue);
+        reader.requestSubpartitionView(
+                (ignored1, ignored2, ignored3) -> new NoOpResultSubpartitionView(),
+                new ResultPartitionID(),
+                0);
+        return reader;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Random;
 
+import static org.apache.flink.runtime.io.network.netty.NettyMessage.BacklogAnnouncement;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.NettyMessageEncoder;
@@ -145,6 +146,14 @@ public class NettyMessageClientSideSerializationTest extends TestLogger {
     @Test
     public void testCompressedBufferResponse() {
         testBufferResponse(false, true);
+    }
+
+    @Test
+    public void testBacklogAnnouncement() {
+        BacklogAnnouncement expected = new BacklogAnnouncement(1024, inputChannelId);
+        BacklogAnnouncement actual = encodeAndDecode(expected, channel);
+        assertEquals(expected.backlog, actual.backlog);
+        assertEquals(expected.receiverId, actual.receiverId);
     }
 
     private void testErrorResponse(ErrorResponse expect) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyMessageClientSideSerializationTest.java
@@ -182,7 +182,11 @@ public class NettyMessageClientSideSerializationTest extends TestLogger {
         }
 
         BufferResponse expected =
-                new BufferResponse(testBuffer, random.nextInt(), inputChannelId, random.nextInt());
+                new BufferResponse(
+                        testBuffer,
+                        random.nextInt(Integer.MAX_VALUE),
+                        inputChannelId,
+                        random.nextInt(Integer.MAX_VALUE));
         BufferResponse actual = encodeAndDecode(expected, channel);
 
         assertTrue(buffer.isRecycled());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -112,7 +112,7 @@ public class PartitionRequestQueueTest {
                 new ResultPartitionID(),
                 0);
         reader1.notifyDataAvailable();
-        assertTrue(reader1.isAvailable());
+        assertTrue(reader1.getAvailabilityAndBacklog().isAvailable());
         assertFalse(reader1.isRegisteredAsAvailable());
 
         channel.unsafe().outboundBuffer().setUserDefinedWritability(1, false);
@@ -127,7 +127,7 @@ public class PartitionRequestQueueTest {
                         new DefaultBufferResultSubpartitionView(buffersToWrite),
                 new ResultPartitionID(),
                 0);
-        assertTrue(reader2.isAvailable());
+        assertTrue(reader2.getAvailabilityAndBacklog().isAvailable());
         assertFalse(reader2.isRegisteredAsAvailable());
 
         reader2.notifyDataAvailable();
@@ -226,12 +226,10 @@ public class PartitionRequestQueueTest {
         }
 
         @Override
-        public boolean isAvailable(int numCreditsAvailable) {
-            if (numCreditsAvailable > 0) {
-                return buffersInBacklog.get() > 0;
-            }
-
-            return false;
+        public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+            int numBuffers = buffersInBacklog.get();
+            return new AvailabilityWithBacklog(
+                    numCreditsAvailable > 0 && numBuffers > 0, numBuffers);
         }
     }
 
@@ -261,8 +259,8 @@ public class PartitionRequestQueueTest {
         }
 
         @Override
-        public boolean isAvailable(int numCreditsAvailable) {
-            return true;
+        public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+            return new AvailabilityWithBacklog(true, 0);
         }
     }
 
@@ -325,8 +323,8 @@ public class PartitionRequestQueueTest {
 
     private static class NextIsEventResultSubpartitionView extends NoOpResultSubpartitionView {
         @Override
-        public boolean isAvailable(int numCreditsAvailable) {
-            return true;
+        public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+            return new AvailabilityWithBacklog(true, 0);
         }
     }
 
@@ -346,8 +344,9 @@ public class PartitionRequestQueueTest {
         final InputChannelID receiverId = new InputChannelID();
         final PartitionRequestQueue queue = new PartitionRequestQueue();
         final CreditBasedSequenceNumberingViewReader reader =
-                new CreditBasedSequenceNumberingViewReader(receiverId, 0, queue);
+                new CreditBasedSequenceNumberingViewReader(receiverId, 2, queue);
         final EmbeddedChannel channel = new EmbeddedChannel(queue);
+        reader.addCredit(-2);
 
         reader.requestSubpartitionView(partitionProvider, new ResultPartitionID(), 0);
         queue.notifyReaderCreated(reader);
@@ -367,7 +366,7 @@ public class PartitionRequestQueueTest {
         // the reader is not enqueued in the pipeline because no credits are available
         // -> it should still have the same number of pending buffers
         assertEquals(0, queue.getAvailableReaders().size());
-        assertTrue(reader.hasBuffersAvailable());
+        assertTrue(reader.hasBuffersAvailable().isAvailable());
         assertFalse(reader.isRegisteredAsAvailable());
         assertEquals(0, reader.getNumCreditsAvailable());
 
@@ -384,7 +383,7 @@ public class PartitionRequestQueueTest {
             assertTrue(reader.isRegisteredAsAvailable());
             assertThat(queue.getAvailableReaders(), contains(reader)); // contains only (this) one!
             assertEquals(i, reader.getNumCreditsAvailable());
-            assertTrue(reader.hasBuffersAvailable());
+            assertTrue(reader.hasBuffersAvailable().isAvailable());
         }
 
         // Flush the buffer to make the channel writable again and see the final results
@@ -393,7 +392,7 @@ public class PartitionRequestQueueTest {
 
         assertEquals(0, queue.getAvailableReaders().size());
         assertEquals(0, reader.getNumCreditsAvailable());
-        assertTrue(reader.hasBuffersAvailable());
+        assertTrue(reader.hasBuffersAvailable().isAvailable());
         assertFalse(reader.isRegisteredAsAvailable());
         for (int i = 1; i <= notifyNumCredits; i++) {
             assertThat(channel.readOutbound(), instanceOf(NettyMessage.BufferResponse.class));
@@ -430,22 +429,57 @@ public class PartitionRequestQueueTest {
         queue.notifyReaderCreated(reader);
         // we have adequate credits
         reader.addCredit(Integer.MAX_VALUE);
-        assertTrue(reader.isAvailable());
+        assertTrue(reader.getAvailabilityAndBacklog().isAvailable());
 
         reader.notifyDataAvailable();
         channel.runPendingTasks();
-        assertFalse(reader.isAvailable());
+        assertFalse(reader.getAvailabilityAndBacklog().isAvailable());
         assertEquals(1, subpartition.unsynchronizedGetNumberOfQueuedBuffers());
 
         queue.addCreditOrResumeConsumption(
                 receiverId, NetworkSequenceViewReader::resumeConsumption);
-        assertFalse(reader.isAvailable());
+        assertFalse(reader.getAvailabilityAndBacklog().isAvailable());
         assertEquals(0, subpartition.unsynchronizedGetNumberOfQueuedBuffers());
 
         Object data1 = channel.readOutbound();
         assertEquals(dataType1, ((NettyMessage.BufferResponse) data1).buffer.getDataType());
         Object data2 = channel.readOutbound();
         assertEquals(dataType2, ((NettyMessage.BufferResponse) data2).buffer.getDataType());
+    }
+
+    @Test
+    public void testAnnounceBacklog() throws Exception {
+        PipelinedSubpartition subpartition =
+                PipelinedSubpartitionTest.createPipelinedSubpartition();
+        subpartition.add(createEventBufferConsumer(4096, Buffer.DataType.DATA_BUFFER));
+        subpartition.add(createEventBufferConsumer(4096, Buffer.DataType.DATA_BUFFER));
+
+        PipelinedSubpartitionView view =
+                subpartition.createReadView(new NoOpBufferAvailablityListener());
+        ResultPartitionProvider partitionProvider =
+                (partitionId, index, availabilityListener) -> view;
+
+        PartitionRequestQueue queue = new PartitionRequestQueue();
+        InputChannelID receiverId = new InputChannelID();
+        CreditBasedSequenceNumberingViewReader reader =
+                new CreditBasedSequenceNumberingViewReader(receiverId, 0, queue);
+        EmbeddedChannel channel = new EmbeddedChannel(queue);
+
+        reader.requestSubpartitionView(partitionProvider, new ResultPartitionID(), 0);
+        queue.notifyReaderCreated(reader);
+
+        reader.notifyDataAvailable();
+        channel.runPendingTasks();
+        Object data = channel.readOutbound();
+        assertTrue(data instanceof NettyMessage.BacklogAnnouncement);
+        NettyMessage.BacklogAnnouncement announcement = (NettyMessage.BacklogAnnouncement) data;
+        assertEquals(receiverId, announcement.receiverId);
+        assertEquals(subpartition.getBuffersInBacklogUnsafe(), announcement.backlog);
+
+        subpartition.release();
+        reader.notifyDataAvailable();
+        channel.runPendingTasks();
+        assertNotNull(channel.readOutbound());
     }
 
     @Test
@@ -465,7 +499,7 @@ public class PartitionRequestQueueTest {
         final InputChannelID receiverId = new InputChannelID();
         final PartitionRequestQueue queue = new PartitionRequestQueue();
         final CreditBasedSequenceNumberingViewReader reader =
-                new CreditBasedSequenceNumberingViewReader(receiverId, 0, queue);
+                new CreditBasedSequenceNumberingViewReader(receiverId, 2, queue);
         final EmbeddedChannel channel = new EmbeddedChannel(queue);
 
         reader.requestSubpartitionView(partitionManager, partition.getPartitionId(), 0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -422,13 +422,11 @@ public class PartitionRequestQueueTest {
         InputChannelID receiverId = new InputChannelID();
         PartitionRequestQueue queue = new PartitionRequestQueue();
         CreditBasedSequenceNumberingViewReader reader =
-                new CreditBasedSequenceNumberingViewReader(receiverId, 0, queue);
+                new CreditBasedSequenceNumberingViewReader(receiverId, 2, queue);
         EmbeddedChannel channel = new EmbeddedChannel(queue);
 
         reader.requestSubpartitionView(partitionProvider, new ResultPartitionID(), 0);
         queue.notifyReaderCreated(reader);
-        // we have adequate credits
-        reader.addCredit(Integer.MAX_VALUE);
         assertTrue(reader.getAvailabilityAndBacklog().isAvailable());
 
         reader.notifyDataAvailable();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionAvailabilityTest.java
@@ -72,7 +72,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
         final List<BufferAndBacklog> data = drainAvailableData(reader);
 
         // assert
-        assertFalse(reader.isAvailable(Integer.MAX_VALUE));
+        assertFalse(reader.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         assertFalse(data.get(data.size() - 1).isDataAvailable());
 
         // cleanup
@@ -93,7 +93,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
         data.get(1).buffer().recycleBuffer();
 
         // assert
-        assertTrue(reader.isAvailable(Integer.MAX_VALUE));
+        assertTrue(reader.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         assertEquals(1, listener.numNotifications);
 
         // cleanup
@@ -112,7 +112,7 @@ public class BoundedBlockingSubpartitionAvailabilityTest {
         drainAllData(reader);
 
         // assert
-        assertFalse(reader.isAvailable(Integer.MAX_VALUE));
+        assertFalse(reader.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
 
         // cleanup
         reader.releaseAllResources();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -118,7 +118,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
         readLongs(
                 reader,
                 numLongs,
-                subpartition.getBuffersInBacklog(),
+                subpartition.getBuffersInBacklogUnsafe(),
                 compressionEnabled,
                 decompressor);
 
@@ -140,7 +140,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
             readLongs(
                     reader,
                     numLongs,
-                    subpartition.getBuffersInBacklog(),
+                    subpartition.getBuffersInBacklogUnsafe(),
                     compressionEnabled,
                     decompressor);
             reader.releaseAllResources();
@@ -163,7 +163,7 @@ public class BoundedBlockingSubpartitionWriteReadTest {
                         subpartition,
                         10,
                         numLongs,
-                        subpartition.getBuffersInBacklog(),
+                        subpartition.getBuffersInBacklogUnsafe(),
                         compressionEnabled);
         for (CheckedThread t : readerThreads) {
             t.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/FileChannelBoundedDataTest.java
@@ -142,7 +142,7 @@ public class FileChannelBoundedDataTest extends BoundedDataTestBase {
 
         // the next buffer is null in view because FileBufferReader has no available buffers for
         // reading ahead
-        assertFalse(subpartitionView.isAvailable(Integer.MAX_VALUE));
+        assertFalse(subpartitionView.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         // recycle a buffer to trigger notification of data available
         buffer1.buffer().recycleBuffer();
         assertTrue(listener.isAvailable);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/InputChannelTestUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.MemorySegmentProvider;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelBuilder;
 import org.apache.flink.runtime.io.network.partition.consumer.LocalInputChannel;
@@ -79,6 +80,13 @@ public class InputChannelTestUtils {
 
     public static SingleInputGate createSingleInputGate(int numberOfChannels) {
         return new SingleInputGateBuilder().setNumberOfChannels(numberOfChannels).build();
+    }
+
+    public static SingleInputGate createSingleInputGate(BufferPool bufferPool) {
+        return new SingleInputGateBuilder()
+                .setNumberOfChannels(2)
+                .setBufferPoolFactory(bufferPool)
+                .build();
     }
 
     public static SingleInputGate createSingleInputGate(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionWithReadViewTest.java
@@ -38,7 +38,7 @@ public class PipelinedApproximateSubpartitionWithReadViewTest
     @Override
     public void before() throws IOException {
         setup(ResultPartitionType.PIPELINED_APPROXIMATE);
-        subpartition = new PipelinedApproximateSubpartition(0, resultPartition);
+        subpartition = new PipelinedApproximateSubpartition(0, 2, resultPartition);
         availablityListener = new AwaitableBufferAvailablityListener();
         readView = subpartition.createReadView(availablityListener);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionTest.java
@@ -309,6 +309,6 @@ public class PipelinedSubpartitionTest extends SubpartitionTestBase {
     public static PipelinedSubpartition createPipelinedSubpartition() {
         final ResultPartition parent = PartitionTestUtils.createPartition();
 
-        return new PipelinedSubpartition(0, parent);
+        return new PipelinedSubpartition(0, 2, parent);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -85,7 +85,7 @@ public class PipelinedSubpartitionWithReadViewTest {
     @Before
     public void before() throws IOException {
         setup(ResultPartitionType.PIPELINED);
-        subpartition = new PipelinedSubpartition(0, resultPartition);
+        subpartition = new PipelinedSubpartition(0, 2, resultPartition);
         availablityListener = new AwaitableBufferAvailablityListener();
         readView = subpartition.createReadView(availablityListener);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -128,13 +128,13 @@ public class PipelinedSubpartitionWithReadViewTest {
         bufferBuilder = createBufferBuilder();
         subpartition.add(bufferBuilder.createBufferConsumer());
 
-        assertEquals(1, subpartition.getBuffersInBacklog());
+        assertEquals(1, subpartition.getBuffersInBacklogUnsafe());
         assertEquals(
                 1,
                 availablityListener
                         .getNumNotifications()); // notification from finishing previous buffer.
         assertNull(readView.getNextBuffer());
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledUnfinishedBufferConsumer(1024));
 
         // note that since the buffer builder is not finished, there is still a retained instance!
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertNextBuffer(readView, 1024, false, 0, false, false);
     }
 
@@ -157,7 +157,7 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledFinishedBufferConsumer(1025)); // finished
         subpartition.add(createFilledUnfinishedBufferConsumer(1024)); // not finished
 
-        assertEquals(1, subpartition.getBuffersInBacklog());
+        assertEquals(1, subpartition.getBuffersInBacklogUnsafe());
         assertThat(availablityListener.getNumNotifications(), greaterThan(0L));
         assertNextBuffer(readView, 1025, false, 0, false, true);
         // not notified, but we could still access the unfinished buffer
@@ -175,14 +175,14 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledUnfinishedBufferConsumer(1024)); // not finished
         long oldNumNotifications = availablityListener.getNumNotifications();
 
-        assertEquals(1, subpartition.getBuffersInBacklog());
+        assertEquals(1, subpartition.getBuffersInBacklogUnsafe());
 
         subpartition.flush();
         // buffer queue is > 1, should already be notified, no further notification necessary
         assertThat(oldNumNotifications, greaterThan(0L));
         assertEquals(oldNumNotifications, availablityListener.getNumNotifications());
 
-        assertEquals(2, subpartition.getBuffersInBacklog());
+        assertEquals(2, subpartition.getBuffersInBacklogUnsafe());
         assertNextBuffer(readView, 1025, true, 1, false, true);
         assertNextBuffer(readView, 1024, false, 0, false, false);
         assertNoNextBuffer(readView);
@@ -200,7 +200,7 @@ public class PipelinedSubpartitionWithReadViewTest {
         subpartition.add(createFilledFinishedBufferConsumer(1025)); // finished
         subpartition.add(createFilledUnfinishedBufferConsumer(1024)); // not finished
 
-        assertEquals(1, subpartition.getBuffersInBacklog());
+        assertEquals(1, subpartition.getBuffersInBacklogUnsafe());
         assertNextBuffer(readView, 1025, false, 0, false, true);
 
         long oldNumNotifications = availablityListener.getNumNotifications();
@@ -211,7 +211,7 @@ public class PipelinedSubpartitionWithReadViewTest {
         // calling again should not flush again
         assertEquals(oldNumNotifications + 1, availablityListener.getNumNotifications());
 
-        assertEquals(1, subpartition.getBuffersInBacklog());
+        assertEquals(1, subpartition.getBuffersInBacklogUnsafe());
         assertNextBuffer(readView, 1024, false, 0, false, false);
         assertNoNextBuffer(readView);
     }
@@ -228,7 +228,7 @@ public class PipelinedSubpartitionWithReadViewTest {
 
         subpartition.add(createFilledFinishedBufferConsumer(0));
         assertEquals(1, availablityListener.getNumNotifications());
-        assertEquals(2, subpartition.getBuffersInBacklog());
+        assertEquals(2, subpartition.getBuffersInBacklogUnsafe());
 
         subpartition.add(createFilledFinishedBufferConsumer(1024));
         assertEquals(1, availablityListener.getNumNotifications());
@@ -245,17 +245,18 @@ public class PipelinedSubpartitionWithReadViewTest {
     @Test
     public void testBasicPipelinedProduceConsumeLogic() throws Exception {
         // Empty => should return null
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
         assertNoNextBuffer(readView);
-        assertFalse(readView.isAvailable(0)); // also after getNextBuffer()
+        assertFalse(
+                readView.getAvailabilityAndBacklog(0).isAvailable()); // also after getNextBuffer()
         assertEquals(0, availablityListener.getNumNotifications());
 
         // Add data to the queue...
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
         assertEquals(1, subpartition.getTotalNumberOfBuffers());
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertEquals(
                 0, subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
 
@@ -266,16 +267,16 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(
                 BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertNoNextBuffer(readView);
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // Add data to the queue...
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
         assertEquals(2, subpartition.getTotalNumberOfBuffers());
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertEquals(
                 BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
@@ -285,22 +286,23 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(
                 2 * BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         assertNoNextBuffer(readView);
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // some tests with events
 
         // fill with: buffer, event, and buffer
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
         subpartition.add(createEventBufferConsumer(BUFFER_SIZE, Buffer.DataType.EVENT_BUFFER));
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
         subpartition.add(createFilledFinishedBufferConsumer(BUFFER_SIZE));
-        assertFalse(readView.isAvailable(0));
+        assertFalse(readView.getAvailabilityAndBacklog(0).isAvailable());
 
         assertEquals(5, subpartition.getTotalNumberOfBuffers());
-        assertEquals(1, subpartition.getBuffersInBacklog()); // two buffers (events don't count)
+        assertEquals(
+                1, subpartition.getBuffersInBacklogUnsafe()); // two buffers (events don't count)
         assertEquals(
                 2 * BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
@@ -311,25 +313,25 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(
                 3 * BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // the event
         assertNextEvent(readView, BUFFER_SIZE, null, false, 0, false, true);
         assertEquals(
                 4 * BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // the remaining buffer
         assertNextBuffer(readView, BUFFER_SIZE, false, 0, false, true);
         assertEquals(
                 5 * BUFFER_SIZE,
                 subpartition.getTotalNumberOfBytes()); // only updated when getting the buffer
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         // nothing more
         assertNoNextBuffer(readView);
-        assertEquals(0, subpartition.getBuffersInBacklog());
+        assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
         assertEquals(5, subpartition.getTotalNumberOfBuffers());
         assertEquals(5 * BUFFER_SIZE, subpartition.getTotalNumberOfBytes());
@@ -467,11 +469,11 @@ public class PipelinedSubpartitionWithReadViewTest {
             subpartition.finish();
         }
 
-        final int backlog = subpartition.getBuffersInBacklog();
+        final int backlog = subpartition.getBuffersInBacklogUnsafe();
 
         int numberOfConsumableBuffers = 0;
         try (final CloseableRegistry closeableRegistry = new CloseableRegistry()) {
-            while (readView.isAvailable(Integer.MAX_VALUE)) {
+            while (readView.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable()) {
                 ResultSubpartition.BufferAndBacklog bufferAndBacklog = readView.getNextBuffer();
                 assertNotNull(bufferAndBacklog);
 
@@ -572,14 +574,15 @@ public class PipelinedSubpartitionWithReadViewTest {
         assertEquals(numNotifications, availablityListener.getNumNotifications());
 
         // view not available and no buffer can be read
-        assertFalse(readView.isAvailable(Integer.MAX_VALUE));
+        assertFalse(readView.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         assertNoNextBuffer(readView);
     }
 
     private void resumeConsumptionAndCheckAvailability(int availableCredit, boolean dataAvailable) {
         readView.resumeConsumption();
 
-        assertEquals(dataAvailable, readView.isAvailable(availableCredit));
+        assertEquals(
+                dataAvailable, readView.getAvailabilityAndBacklog(availableCredit).isAvailable());
     }
 
     static void assertNextBuffer(
@@ -652,13 +655,16 @@ public class PipelinedSubpartitionWithReadViewTest {
             assertEquals(
                     "data available",
                     expectedIsDataAvailable,
-                    readView.isAvailable(Integer.MAX_VALUE));
+                    readView.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
             assertEquals("backlog", expectedBuffersInBacklog, bufferAndBacklog.buffersInBacklog());
             assertEquals(
                     "event available",
                     expectedIsEventAvailable,
                     bufferAndBacklog.isEventAvailable());
-            assertEquals("event available", expectedIsEventAvailable, readView.isAvailable(0));
+            assertEquals(
+                    "event available",
+                    expectedIsEventAvailable,
+                    readView.getAvailabilityAndBacklog(0).isAvailable());
 
             assertFalse("not recycled", bufferAndBacklog.buffer().isRecycled());
         } finally {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -137,7 +137,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertNotNull(subpartitionReader.getFailureCause());
         assertTrue(subpartitionReader.isReleased());
         assertEquals(0, subpartitionReader.unsynchronizedGetNumberOfQueuedBuffers());
-        assertTrue(subpartitionReader.isAvailable(0));
+        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
 
         readScheduler.getReleaseFuture().get();
         assertAllResourcesReleased();
@@ -173,7 +173,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
         waitUntilReadFinish();
         assertNotNull(subpartitionReader.getFailureCause());
-        assertTrue(subpartitionReader.isAvailable(0));
+        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
         assertAllResourcesReleased();
     }
 
@@ -188,7 +188,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
         assertTrue(subpartitionReader.isReleased());
         assertNotNull(subpartitionReader.getFailureCause());
-        assertTrue(subpartitionReader.isAvailable(0));
+        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
         assertAllResourcesReleased();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
@@ -209,7 +209,8 @@ public class SortMergeResultPartitionTest extends TestLogger {
 
                     if (!buffer.isBuffer()) {
                         ++numEndOfPartitionEvents;
-                        assertFalse(view.isAvailable(Integer.MAX_VALUE));
+                        assertFalse(
+                                view.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
                         view.releaseAllResources();
                     }
                     bufferAndBacklog = view.getNextBuffer();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
@@ -134,13 +134,13 @@ public class SortMergeSubpartitionReaderTest extends TestLogger {
                 createSortMergeSubpartitionReader(new CountingAvailabilityListener());
 
         assertNull(subpartitionReader.getNextBuffer());
-        assertFalse(subpartitionReader.isAvailable(Integer.MAX_VALUE));
+        assertFalse(subpartitionReader.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
 
         Queue<MemorySegment> segments = createsMemorySegments(numBuffersPerSubpartition);
         subpartitionReader.readBuffers(segments, FreeingBufferRecycler.INSTANCE);
 
         for (int i = numBuffersPerSubpartition - 1; i >= 0; --i) {
-            assertTrue(subpartitionReader.isAvailable(i));
+            assertTrue(subpartitionReader.getAvailabilityAndBacklog(i).isAvailable());
             ResultSubpartition.BufferAndBacklog bufferAndBacklog =
                     checkNotNull(subpartitionReader.getNextBuffer());
             assertEquals(
@@ -171,7 +171,7 @@ public class SortMergeSubpartitionReaderTest extends TestLogger {
             subpartitionReader.fail(new RuntimeException("Test exception."));
             assertTrue(subpartitionReader.getReleaseFuture().isDone());
             assertEquals(0, subpartitionReader.unsynchronizedGetNumberOfQueuedBuffers());
-            assertTrue(subpartitionReader.isAvailable(0));
+            assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
             assertTrue(subpartitionReader.isReleased());
 
             assertEquals(2, listener.numNotifications);
@@ -198,7 +198,7 @@ public class SortMergeSubpartitionReaderTest extends TestLogger {
             subpartitionReader.releaseAllResources();
             assertTrue(subpartitionReader.getReleaseFuture().isDone());
             assertEquals(0, subpartitionReader.unsynchronizedGetNumberOfQueuedBuffers());
-            assertTrue(subpartitionReader.isAvailable(0));
+            assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
             assertTrue(subpartitionReader.isReleased());
 
             assertEquals(1, listener.numNotifications);
@@ -233,7 +233,7 @@ public class SortMergeSubpartitionReaderTest extends TestLogger {
         Queue<MemorySegment> segments = createsMemorySegments(numBuffersPerSubpartition);
         subpartitionReader.readBuffers(segments, FreeingBufferRecycler.INSTANCE);
 
-        assertTrue(subpartitionReader.isAvailable(Integer.MAX_VALUE));
+        assertTrue(subpartitionReader.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
         subpartitionReader.releaseAllResources();
         assertNull(subpartitionReader.getNextBuffer());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SubpartitionTestBase.java
@@ -61,7 +61,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
         try {
             subpartition.finish();
             assertEquals(1, subpartition.getTotalNumberOfBuffers());
-            assertEquals(0, subpartition.getBuffersInBacklog());
+            assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
 
             BufferConsumer bufferConsumer = createFilledFinishedBufferConsumer(4096);
 
@@ -69,7 +69,7 @@ public abstract class SubpartitionTestBase extends TestLogger {
             assertTrue(bufferConsumer.isRecycled());
 
             assertEquals(1, subpartition.getTotalNumberOfBuffers());
-            assertEquals(0, subpartition.getBuffersInBacklog());
+            assertEquals(0, subpartition.getBuffersInBacklogUnsafe());
         } finally {
             if (subpartition != null) {
                 subpartition.release();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannelTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
@@ -33,12 +35,16 @@ import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
 import org.apache.flink.runtime.io.network.TestingPartitionRequestClient;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferListener.NotificationResult;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.buffer.NoOpBufferPool;
 import org.apache.flink.runtime.io.network.partition.InputChannelTestUtils;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
@@ -1407,6 +1413,75 @@ public class RemoteInputChannelTest {
     }
 
     @Test
+    public void testOnUpstreamBlockedAndResumed() throws Exception {
+        BufferPool bufferPool = new TestBufferPool();
+        SingleInputGate inputGate = createSingleInputGate(bufferPool);
+
+        RemoteInputChannel remoteChannel1 = createRemoteInputChannel(inputGate, 2);
+        RemoteInputChannel remoteChannel2 = createRemoteInputChannel(inputGate, 0);
+        inputGate.setup();
+        remoteChannel1.requestSubpartition(0);
+        remoteChannel2.requestSubpartition(1);
+
+        remoteChannel1.onSenderBacklog(2);
+        remoteChannel2.onSenderBacklog(2);
+
+        assertEquals(4, remoteChannel1.getNumberOfAvailableBuffers());
+        assertEquals(2, remoteChannel2.getNumberOfAvailableBuffers());
+
+        Buffer barrier =
+                EventSerializer.toBuffer(
+                        new CheckpointBarrier(
+                                1L, 123L, alignedWithTimeout(getDefault(), Integer.MAX_VALUE)),
+                        false);
+        remoteChannel1.onBuffer(barrier, 0, 0);
+        remoteChannel2.onBuffer(barrier, 0, 0);
+
+        assertEquals(4, remoteChannel1.getNumberOfAvailableBuffers());
+        assertEquals(0, remoteChannel2.getNumberOfAvailableBuffers());
+
+        remoteChannel1.resumeConsumption();
+        remoteChannel2.resumeConsumption();
+
+        assertEquals(4, remoteChannel1.getUnannouncedCredit());
+        assertEquals(0, remoteChannel2.getUnannouncedCredit());
+
+        remoteChannel1.onSenderBacklog(4);
+        remoteChannel2.onSenderBacklog(4);
+
+        assertEquals(6, remoteChannel1.getNumberOfAvailableBuffers());
+        assertEquals(4, remoteChannel2.getNumberOfAvailableBuffers());
+
+        assertEquals(6, remoteChannel1.getUnannouncedCredit());
+        assertEquals(4, remoteChannel2.getUnannouncedCredit());
+    }
+
+    @Test
+    public void testRequestBuffer() throws Exception {
+        BufferPool bufferPool = new TestBufferPool();
+        SingleInputGate inputGate = createSingleInputGate(bufferPool);
+
+        RemoteInputChannel remoteChannel1 = createRemoteInputChannel(inputGate, 2);
+        RemoteInputChannel remoteChannel2 = createRemoteInputChannel(inputGate, 0);
+        inputGate.setup();
+        remoteChannel1.requestSubpartition(0);
+        remoteChannel2.requestSubpartition(1);
+
+        remoteChannel1.onSenderBacklog(2);
+        remoteChannel2.onSenderBacklog(2);
+
+        for (int i = 4; i >= 0; --i) {
+            assertEquals(i, remoteChannel1.getNumberOfRequiredBuffers());
+            remoteChannel1.requestBuffer();
+        }
+
+        for (int i = 2; i >= 0; --i) {
+            assertEquals(i, remoteChannel2.getNumberOfRequiredBuffers());
+            remoteChannel2.requestBuffer();
+        }
+    }
+
+    @Test
     public void testPrioritySequenceNumbers() throws Exception {
         int sequenceNumber = 0;
         int bufferSize = 1;
@@ -1597,6 +1672,13 @@ public class RemoteInputChannelTest {
 
     private RemoteInputChannel createRemoteInputChannel(SingleInputGate inputGate) {
         return createRemoteInputChannel(inputGate, 0, 0);
+    }
+
+    private RemoteInputChannel createRemoteInputChannel(
+            SingleInputGate inputGate, int initialCredits) {
+        return InputChannelBuilder.newBuilder()
+                .setNetworkBuffersPerChannel(initialCredits)
+                .buildRemoteChannel(inputGate);
     }
 
     private RemoteInputChannel createRemoteInputChannel(
@@ -1952,6 +2034,15 @@ public class RemoteInputChannelTest {
             assertEquals(expectedId, partitionId);
             assertEquals(expectedSubpartitionIndex, subpartitionIndex);
             assertEquals(expectedDelayMs, delayMs);
+        }
+    }
+
+    private static final class TestBufferPool extends NoOpBufferPool {
+
+        @Override
+        public Buffer requestBuffer() {
+            MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(1024);
+            return new NetworkBuffer(segment, FreeingBufferRecycler.INSTANCE);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -102,11 +102,7 @@ public class SingleInputGateBuilder {
         NettyShuffleEnvironmentConfiguration config = environment.getConfiguration();
         this.bufferPoolFactory =
                 SingleInputGateFactory.createBufferPoolFactory(
-                        environment.getNetworkBufferPool(),
-                        config.networkBuffersPerChannel(),
-                        config.floatingNetworkBuffersPerGate(),
-                        numberOfChannels,
-                        partitionType);
+                        environment.getNetworkBufferPool(), config.floatingNetworkBuffersPerGate());
         this.segmentProvider = environment.getNetworkBufferPool();
         return this;
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/LocalRecoveryITCase.java
@@ -101,6 +101,8 @@ public class LocalRecoveryITCase extends TestLogger {
 
         public EventTimeWindowCheckpointingITCaseInstance(
                 StateBackendEnum backendEnum, boolean localRecoveryEnabled) {
+            super(backendEnum, 2);
+
             this.backendEnum = backendEnum;
             this.localRecoveryEnabled = localRecoveryEnabled;
         }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -224,7 +224,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
         }
     }
 
-    @Parameterized.Parameters(name = "{0} with {2} channels, p = {1}, timeout = {3}")
+    @Parameterized.Parameters(
+            name = "{0} with {2} channels, p = {1}, timeout = {3}, buffersPerChannel = {4}")
     public static Object[][] parameters() {
         Object[] defaults = {Topology.PIPELINE, 1, MIXED, 0};
 
@@ -243,6 +244,13 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
         };
         return Stream.of(runs)
                 .map(params -> addDefaults(params, defaults))
+                .map(
+                        params ->
+                                new Object[][] {
+                                    ArrayUtils.add(params, 0),
+                                    ArrayUtils.add(params, BUFFER_PER_CHANNEL)
+                                })
+                .flatMap(Arrays::stream)
                 .toArray(Object[][]::new);
     }
 
@@ -254,7 +262,11 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
     private final UnalignedSettings settings;
 
     public UnalignedCheckpointITCase(
-            Topology topology, int parallelism, ChannelType channelType, int timeout) {
+            Topology topology,
+            int parallelism,
+            ChannelType channelType,
+            int timeout,
+            int buffersPerChannel) {
         settings =
                 new UnalignedSettings(topology)
                         .setParallelism(parallelism)
@@ -266,7 +278,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                         // after triggering)
                         .setCheckpointTimeout(Duration.ofSeconds(30))
                         .setTolerableCheckpointFailures(3)
-                        .setAlignmentTimeout(timeout);
+                        .setAlignmentTimeout(timeout)
+                        .setBuffersPerChannel(buffersPerChannel);
     }
 
     @Test

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointTestBase.java
@@ -684,6 +684,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
         private Duration checkpointTimeout = CHECKPOINTING_TIMEOUT.defaultValue();
         private int failuresAfterSourceFinishes = 0;
         private ChannelType channelType = ChannelType.MIXED;
+        private int buffersPerChannel = 1;
 
         public UnalignedSettings(DagCreator dagCreator) {
             this.dagCreator = dagCreator;
@@ -734,6 +735,11 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
             return this;
         }
 
+        public UnalignedSettings setBuffersPerChannel(int buffersPerChannel) {
+            this.buffersPerChannel = buffersPerChannel;
+            return this;
+        }
+
         public void configure(StreamExecutionEnvironment env) {
             env.enableCheckpointing(Math.max(100L, parallelism * 50L));
             env.getCheckpointConfig().setAlignmentTimeout(Duration.ofMillis(alignmentTimeout));
@@ -770,8 +776,7 @@ public abstract class UnalignedCheckpointTestBase extends TestLogger {
                         restoreCheckpoint.toURI().toString());
             }
 
-            conf.set(
-                    NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, BUFFER_PER_CHANNEL);
+            conf.set(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL, buffersPerChannel);
             conf.set(NettyShuffleEnvironmentOptions.NETWORK_REQUEST_BACKOFF_MAX, 60000);
             conf.set(AkkaOptions.ASK_TIMEOUT_DURATION, Duration.ofMinutes(1));
             return conf;


### PR DESCRIPTION
## What is the purpose of the change

This is the second ingredient besides FLINK-16404 to solve the deadlock problem without exclusive buffers.

The scenario is as follows:

The data in subpartition with positive backlog can be sent without doubt because the exclusive credits would be feedback finally.
Without exclusive buffers, the receiver would not request floating buffers for 0 backlog. But when the new backlog is added into such subpartition, it has no way to notify the receiver side without positive credits ATM.
So it would result in waiting for each other between receiver and sender sides to cause deadlock. The sender waits for credit to notify backlog and the receiver waits for backlog to request floating credits.
To solve the above problem, the sender needs a separate message to announce backlog sometimes besides existing `BufferResponse`. Then the receiver can get this info to request floating buffers to feedback.

In the current implementation, the upstream task will announce backlog to the downstream task and the downstream task will allocate buffers (credit) to receive data from upstream. This PR enhances the current implementation in three main aspects:
1. If there is no initial credit, the upstream producer task will announce the available backlog to the downstream consumer task when available data is notified.
2. The downstream consumer task will release all allocated buffers (credit) on receiving the aligned checkpoint barrier. Besides, it will never allocate any credit before checkpoint completion.
3. For empty buffers of upstream task, instead of released directly, they will be sent to the downstream task to release the buffers (credit) allocated for these empty buffers.


## Brief change log

  - If there is no initial credit, the upstream producer task will announce the available backlog to the downstream consumer task when available data is notified.
  - The downstream consumer task will release all allocated buffers (credit) on receiving the aligned checkpoint barrier. Besides, it will never allocate any credit before checkpoint completion.
  - For empty buffers of upstream task, instead of released directly, they will be sent to the downstream task to release the buffers (credit) allocated for these empty buffers.

## Verifying this change

This change is verified by both existing tests and newly added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
