### PR TITLE
[hotfix] Set kafka-schema-registry-client to 4.1.0 in NOTICE

### DIFF
--- a/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -10,6 +10,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
-- io.confluent:common-utils:3.3.1
-- io.confluent:kafka-schema-registry-client:3.3.1
+- io.confluent:common-utils:4.1.0
+- io.confluent:kafka-schema-registry-client:4.1.0
 - org.apache.zookeeper:zookeeper:3.4.10


### PR DESCRIPTION

## What is the purpose of the change

The dependency version in the pom file differs from the version in the NOTICE file: https://github.com/apache/flink/blob/master/flink-formats/flink-avro-confluent-registry/pom.xml#L33


