### PR TITLE
[FLINK-15971][python] Adjust the default value of bundle size and bundle time

### DIFF
--- a/docs/_includes/generated/python_configuration.html
+++ b/docs/_includes/generated/python_configuration.html
@@ -34,7 +34,7 @@
         </tr>
         <tr>
             <td><h5>python.fn-execution.arrow.batch.size</h5></td>
-            <td style="word-wrap: break-word;">1000</td>
+            <td style="word-wrap: break-word;">10000</td>
             <td>Integer</td>
             <td>The maximum number of elements to include in an arrow batch for Python user-defined function execution. The arrow batch size should not exceed the bundle size. Otherwise, the bundle size will be used as the arrow batch size.</td>
         </tr>
@@ -46,7 +46,7 @@
         </tr>
         <tr>
             <td><h5>python.fn-execution.bundle.size</h5></td>
-            <td style="word-wrap: break-word;">1000</td>
+            <td style="word-wrap: break-word;">100000</td>
             <td>Integer</td>
             <td>The maximum number of elements to include in a bundle for Python user-defined function execution. The elements are processed asynchronously. One bundle of elements are processed before processing the next bundle of elements. A larger value can improve the throughput, but at the cost of more memory usage and higher latency.</td>
         </tr>

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -33,7 +33,7 @@ public class PythonOptions {
 	 */
 	public static final ConfigOption<Integer> MAX_BUNDLE_SIZE = ConfigOptions
 		.key("python.fn-execution.bundle.size")
-		.defaultValue(1000)
+		.defaultValue(100000)
 		.withDescription("The maximum number of elements to include in a bundle for Python " +
 			"user-defined function execution. The elements are processed asynchronously. " +
 			"One bundle of elements are processed before processing the next bundle of elements. " +
@@ -54,7 +54,7 @@ public class PythonOptions {
 	 */
 	public static final ConfigOption<Integer> MAX_ARROW_BATCH_SIZE = ConfigOptions
 		.key("python.fn-execution.arrow.batch.size")
-		.defaultValue(1000)
+		.defaultValue(10000)
 		.withDescription("The maximum number of elements to include in an arrow batch for Python " +
 			"user-defined function execution. The arrow batch size should not exceed the " +
 			"bundle size. Otherwise, the bundle size will be used as the arrow batch size.");


### PR DESCRIPTION
## What is the purpose of the change

*Currently the default value for "python.fn-execution.bundle.size" is 1000 and the default value for "python.fn-execution.bundle.time" is 1000ms. This pull request will adjust the default value of bundle size and bundle time which works best in most scenarios.*


## Brief change log

  - *Adjust default value of python.fn-execution.bundle.size and python.fn-execution.bundle.time in PythonOptions.java*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

## How does this patch test
### Test Code


    @udf(input_types=[DataTypes.STRING(False)], result_type=DataTypes.STRING(False))
    def inc(x):
        import time
        time.sleep(10)
        return x

    t_env.register_function("inc", inc)

    #num_rows = 100000000
    num_rows = 20000000
    num = 1000
    # every element will be prefix
    prefix = "1" * num
    # num_rows = 1
    t_env.from_table_source(RangeStringTableSource(1, num_rows, 1, prefix)).alias("id") \
         .select("inc(id)") \
         .insert_into("sink")

    beg_time = time.time()
    t_env.execute("perf_test")
    print("consume time: " + str(time.time() - beg_time))


## Test Data
4 Byte(30kw row data)
100 Byte(10kw row data)
1k Byte(2kw row data)