### PR TITLE
[FLINK-17345][python][table] Support register and get Python UDF in Catalog.

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogMetadataTestBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogTestBase;
+import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.functions.hive.HiveGenericUDF;
 import org.apache.flink.table.functions.hive.HiveSimpleUDF;
@@ -66,5 +67,10 @@ public abstract class HiveCatalogMetadataTestBase extends CatalogTestBase {
 	@Override
 	protected CatalogFunction createAnotherFunction() {
 		return new CatalogFunctionImpl(HiveGenericUDF.class.getCanonicalName());
+	}
+
+	@Override
+	protected CatalogFunction createPythonFunction() {
+		return new CatalogFunctionImpl("test.func1", FunctionLanguage.PYTHON);
 	}
 }

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
@@ -83,6 +83,14 @@ public class PythonFunctionFactoryTest {
 	}
 
 	public static void testPythonFunctionFactory() {
+		// flink catalog
+		flinkTableEnv.sqlUpdate("create function func1 as 'test1.func1' language python");
+		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+
+		// flink catalog
+		flinkTableEnv.sqlUpdate("alter function func1 as 'test1.func1' language python");
+		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+
 		// flink temporary catalog
 		flinkTableEnv.sqlUpdate("create temporary function func1 as 'test1.func1' language python");
 		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
@@ -90,6 +98,14 @@ public class PythonFunctionFactoryTest {
 		// flink temporary system
 		flinkTableEnv.sqlUpdate("create temporary system function func1 as 'test1.func1' language python");
 		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+
+		// blink catalog
+		blinkTableEnv.sqlUpdate("create function func1 as 'test1.func1' language python");
+		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
+
+		// blink catalog
+		blinkTableEnv.sqlUpdate("alter function func1 as 'test1.func1' language python");
+		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
 
 		// blink temporary catalog
 		blinkTableEnv.sqlUpdate("create temporary function func1 as 'test1.func1' language python");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -41,7 +41,6 @@ import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.QueryOperationCatalogView;
@@ -999,9 +998,6 @@ public class TableEnvironmentImpl implements TableEnvironment {
 			if (alterCatalogFunctionOperation.isTemporary()) {
 				throw new ValidationException(
 					"Alter temporary catalog function is not supported");
-			} else if (function.getFunctionLanguage() == FunctionLanguage.PYTHON) {
-				throw new ValidationException(
-					"Alter Python catalog function is not supported");
 			} else {
 				Catalog catalog = getCatalogOrThrowException(
 					alterCatalogFunctionOperation.getFunctionIdentifier().getCatalogName());

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogFunctionImpl.java
@@ -67,6 +67,9 @@ public class CatalogFunctionImpl implements CatalogFunction {
 
 	@Override
 	public boolean isGeneric() {
+		if (functionLanguage == FunctionLanguage.PYTHON) {
+			return true;
+		}
 		try {
 			Class c = Class.forName(className);
 			if (UserDefinedFunction.class.isAssignableFrom(c)) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -567,13 +567,13 @@ public final class FunctionCatalog {
 					new ObjectPath(oi.getDatabaseName(), oi.getObjectName()));
 
 				FunctionDefinition fd;
-				if (catalog.getFunctionDefinitionFactory().isPresent()) {
+				if (catalog.getFunctionDefinitionFactory().isPresent() &&
+					catalogFunction.getFunctionLanguage() != FunctionLanguage.PYTHON) {
 					fd = catalog.getFunctionDefinitionFactory().get()
 						.createFunctionDefinition(oi.getObjectName(), catalogFunction);
 				} else {
 					// TODO update the FunctionDefinitionUtil once we drop the old function stack in DDL
-					fd = FunctionDefinitionUtil.createFunctionDefinition(
-						oi.getObjectName(), catalogFunction.getClassName());
+					fd = getFunctionDefinition(oi.getObjectName(), catalogFunction);
 				}
 
 				return Optional.of(

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/GenericInMemoryCatalogTest.java
@@ -164,4 +164,9 @@ public class GenericInMemoryCatalogTest extends CatalogTestBase {
 	protected CatalogFunction createAnotherFunction() {
 		return new CatalogFunctionImpl(TestSimpleUDF.class.getCanonicalName(), FunctionLanguage.SCALA);
 	}
+
+	@Override
+	protected CatalogFunction createPythonFunction() {
+		return new CatalogFunctionImpl("test.func1", FunctionLanguage.PYTHON);
+	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/catalog/CatalogTest.java
@@ -628,6 +628,16 @@ public abstract class CatalogTest {
 	}
 
 	@Test
+	public void testCreatePythonFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+		CatalogFunction pythonFunction = createPythonFunction();
+		catalog.createFunction(path1, createPythonFunction(), false);
+
+		CatalogFunction actual = catalog.getFunction(path1);
+		checkEquals(pythonFunction, actual);
+	}
+
+	@Test
 	public void testCreateFunction_DatabaseNotExistException() throws Exception {
 		assertFalse(catalog.databaseExists(db1));
 
@@ -661,6 +671,23 @@ public abstract class CatalogTest {
 		checkEquals(func, catalog.getFunction(path1));
 
 		CatalogFunction newFunc = createAnotherFunction();
+		catalog.alterFunction(path1, newFunc, false);
+		CatalogFunction actual = catalog.getFunction(path1);
+
+		assertFalse(func.getClassName().equals(actual.getClassName()));
+		checkEquals(newFunc, actual);
+	}
+
+	@Test
+	public void testAlterPythonFunction() throws Exception {
+		catalog.createDatabase(db1, createDb(), false);
+
+		CatalogFunction func = createFunction();
+		catalog.createFunction(path1, func, false);
+
+		checkEquals(func, catalog.getFunction(path1));
+
+		CatalogFunction newFunc = createPythonFunction();
 		catalog.alterFunction(path1, newFunc, false);
 		CatalogFunction actual = catalog.getFunction(path1);
 
@@ -1218,6 +1245,11 @@ public abstract class CatalogTest {
 	 * @return a CatalogFunction instance
 	 */
 	protected abstract CatalogFunction createFunction();
+
+	/**
+	 * Create a Python CatalogFunction instance by specific catalog implementation.
+	 */
+	protected abstract CatalogFunction createPythonFunction();
 
 	/**
 	 * Create another CatalogFunction instance by specific catalog implementation.

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -292,12 +292,6 @@ public class SqlToOperationConverter {
 			);
 		} else {
 			FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
-			if (language == FunctionLanguage.PYTHON && !sqlCreateFunction.isTemporary()) {
-				throw new ValidationException(String.format(
-					"Unsupported function type for Python function %s, " +
-					"only temporary function is supported.",
-					sqlCreateFunction.getFunctionClassName().getValueAs(String.class)));
-			}
 			CatalogFunction catalogFunction = new CatalogFunctionImpl(
 				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
 				language);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -288,12 +288,6 @@ public class SqlToOperationConverter {
 			);
 		} else {
 			FunctionLanguage language = parseLanguage(sqlCreateFunction.getFunctionLanguage());
-			if (language == FunctionLanguage.PYTHON && !sqlCreateFunction.isTemporary()) {
-				throw new ValidationException(String.format(
-					"Unsupported function type for Python function %s, " +
-						"only temporary function is supported.",
-					sqlCreateFunction.getFunctionClassName().getValueAs(String.class)));
-			}
 			CatalogFunction catalogFunction = new CatalogFunctionImpl(
 				sqlCreateFunction.getFunctionClassName().getValueAs(String.class),
 				language);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -907,8 +907,6 @@ abstract class TableEnvImpl(
       val function = alterFunctionOperation.getCatalogFunction
       if (alterFunctionOperation.isTemporary) {
         throw new ValidationException("Alter temporary catalog function is not supported")
-      } else if (function.getFunctionLanguage eq FunctionLanguage.PYTHON) {
-        throw new ValidationException("Alter Python catalog function is not supported");
       } else {
         val catalog = getCatalogOrThrowException(
           alterFunctionOperation.getFunctionIdentifier.getCatalogName)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request supports register and get Python UDF in catalog via sql ddl.*


## Brief change log

  - *Support register python catalog UDF via SQL DDL.*
  - *Support create, get and alter python catalog UDF in HiveCatalog.*

## Verifying this change

This change is already covered by existing tests, such as *PythonFunctionFactoryTest*, *HiveCatalogTest*, *GenericInMemoryCatalogTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
