### PR TITLE
[FLINK-17352][docs] Fix doc links using site.baseurl w/ link tag

### DIFF
--- a/docs/concepts/flink-architecture.md
+++ b/docs/concepts/flink-architecture.md
@@ -54,10 +54,10 @@ The Flink runtime consists of two types of processes:
     There must always be at least one TaskManager.
 
 The Flink Master and TaskManagers can be started in various ways: directly on
-the machines as a [standalone cluster]({{ site.baseurl }}{% link
+the machines as a [standalone cluster]({% link
 ops/deployment/cluster_setup.md %}), in containers, or managed by resource
-frameworks like [YARN]({{ site.baseurl }}{% link ops/deployment/yarn_setup.md
-%}) or [Mesos]({{ site.baseurl }}{% link ops/deployment/mesos.md %}).
+frameworks like [YARN]({% link ops/deployment/yarn_setup.md
+%}) or [Mesos]({% link ops/deployment/mesos.md %}).
 TaskManagers connect to Flink Masters, announcing themselves as available, and
 are assigned work.
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -27,13 +27,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The [Hands-on Tutorials]({{ site.baseurl }}{% link tutorials/index.md %}) explain the basic concepts
+The [Hands-on Tutorials]({% link tutorials/index.md %}) explain the basic concepts
 of stateful and timely stream processing that underlie Flink's APIs, and provide examples of how
 these mechanisms are used in applications. Stateful stream processing is introduced in the context
-of [Data Pipelines & ETL]({{ site.baseurl }}{% link tutorials/etl.md %}#stateful-transformations)
-and is further developed in the section on [Fault Tolerance]({{ site.baseurl }}{% link
+of [Data Pipelines & ETL]({% link tutorials/etl.md %}#stateful-transformations)
+and is further developed in the section on [Fault Tolerance]({% link
 tutorials/fault_tolerance.md %}). Timely stream processing is introduced in the section on
-[Streaming Analytics]({{ site.baseurl }}{% link tutorials/streaming_analytics.md %}).
+[Streaming Analytics]({% link tutorials/streaming_analytics.md %}).
 
 This _Concepts in Depth_ section provides a deeper understanding of how Flink's architecture and runtime 
 implement these concepts.
@@ -45,17 +45,16 @@ Flink offers different levels of abstraction for developing streaming/batch appl
 <img src="{{ site.baseurl }}/fig/levels_of_abstraction.svg" alt="Programming levels of abstraction" class="offset" width="80%" />
 
   - The lowest level abstraction simply offers **stateful and timely stream processing**. It is
-    embedded into the [DataStream API]({{ site.baseurl}}{% link
-    dev/datastream_api.md %}) via the [Process Function]({{ site.baseurl }}{%
-    link dev/stream/operators/process_function.md %}). It allows users to freely
-    process events from one or more streams, and provides consistent, fault tolerant
-    *state*. In addition, users can register event time and processing time
-    callbacks, allowing programs to realize sophisticated computations.
+    embedded into the [DataStream API]({% link dev/datastream_api.md %}) via the [Process
+    Function]({% link dev/stream/operators/process_function.md %}). It allows
+    users to freely process events from one or more streams, and provides consistent, fault tolerant
+    *state*. In addition, users can register event time and processing time callbacks, allowing
+    programs to realize sophisticated computations.
 
   - In practice, many applications do not need the low-level
     abstractions described above, and can instead program against the **Core APIs**: the
-    [DataStream API]({{ site.baseurl }}{% link dev/datastream_api.md %})
-    (bounded/unbounded streams) and the [DataSet API]({{ site.baseurl }}{% link
+    [DataStream API]({% link dev/datastream_api.md %})
+    (bounded/unbounded streams) and the [DataSet API]({% link
     dev/batch/index.md %}) (bounded data sets). These fluent APIs offer the
     common building blocks for data processing, like various forms of
     user-specified transformations, joins, aggregations, windows, state, etc.
@@ -69,7 +68,7 @@ Flink offers different levels of abstraction for developing streaming/batch appl
 
   - The **Table API** is a declarative DSL centered around *tables*, which may
     be dynamically changing tables (when representing streams).  The [Table
-    API]({{ site.baseurl }}{% link dev/table/index.md %}) follows the
+    API]({% link dev/table/index.md %}) follows the
     (extended) relational model: Tables have a schema attached (similar to
     tables in relational databases) and the API offers comparable operations,
     such as select, project, join, group-by, aggregate, etc.  Table API

--- a/docs/concepts/index.zh.md
+++ b/docs/concepts/index.zh.md
@@ -27,13 +27,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The [Hands-on Tutorials]({{ site.baseurl }}{% link tutorials/index.zh.md %}) explain the basic concepts
+The [Hands-on Tutorials]({% link tutorials/index.zh.md %}) explain the basic concepts
 of stateful and timely stream processing that underlie Flink's APIs, and provide examples of how
 these mechanisms are used in applications. Stateful stream processing is introduced in the context
-of [Data Pipelines & ETL]({{ site.baseurl }}{% link tutorials/etl.zh.md %}#stateful-transformations)
-and is further developed in the section on [Fault Tolerance]({{ site.baseurl }}{% link
+of [Data Pipelines & ETL]({% link tutorials/etl.zh.md %}#stateful-transformations)
+and is further developed in the section on [Fault Tolerance]({% link
 tutorials/fault_tolerance.zh.md %}). Timely stream processing is introduced in the section on
-[Streaming Analytics]({{ site.baseurl }}{% link tutorials/streaming_analytics.zh.md %}).
+[Streaming Analytics]({% link tutorials/streaming_analytics.zh.md %}).
 
 This _Concepts in Depth_ section provides a deeper understanding of how Flink's architecture and runtime 
 implement these concepts.
@@ -54,8 +54,8 @@ Flink offers different levels of abstraction for developing streaming/batch appl
 
   - In practice, many applications do not need the low-level
     abstractions described above, and can instead program against the **Core APIs**: the
-    [DataStream API]({{ site.baseurl }}{% link dev/datastream_api.zh.md %})
-    (bounded/unbounded streams) and the [DataSet API]({{ site.baseurl }}{% link
+    [DataStream API]({% link dev/datastream_api.zh.md %})
+    (bounded/unbounded streams) and the [DataSet API]({% link
     dev/batch/index.zh.md %}) (bounded data sets). These fluent APIs offer the
     common building blocks for data processing, like various forms of
     user-specified transformations, joins, aggregations, windows, state, etc.
@@ -69,7 +69,7 @@ Flink offers different levels of abstraction for developing streaming/batch appl
 
   - The **Table API** is a declarative DSL centered around *tables*, which may
     be dynamically changing tables (when representing streams).  The [Table
-    API]({{ site.baseurl }}{% link dev/table/index.zh.md %}) follows the
+    API]({% link dev/table/index.zh.md %}) follows the
     (extended) relational model: Tables have a schema attached (similar to
     tables in relational databases) and the API offers comparable operations,
     such as select, project, join, group-by, aggregate, etc.  Table API

--- a/docs/concepts/stateful-stream-processing.md
+++ b/docs/concepts/stateful-stream-processing.md
@@ -47,11 +47,11 @@ and [savepoints]({{ site.baseurl }}{%link ops/state/savepoints.md %}).
 Knowledge about the state also allows for rescaling Flink applications, meaning
 that Flink takes care of redistributing state across parallel instances.
 
-[Queryable state]({{ site.baseurl }}{% link dev/stream/state/queryable_state.md
+[Queryable state]({% link dev/stream/state/queryable_state.md
 %}) allows you to access state from outside of Flink during runtime.
 
 When working with state, it might also be useful to read about [Flink's state
-backends]({{ site.baseurl }}{% link ops/state/state_backends.md %}). Flink
+backends]({% link ops/state/state_backends.md %}). Flink
 provides different state backends that specify how and where state is stored.
 
 * This will be replaced by the TOC
@@ -123,7 +123,7 @@ to enable and configure checkpointing.
 stream source (such as message queue or broker) needs to be able to rewind the
 stream to a defined recent point. [Apache Kafka](http://kafka.apache.org) has
 this ability and Flink's connector to Kafka exploits this. See [Fault
-Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}{% link
+Tolerance Guarantees of Data Sources and Sinks]({% link
 dev/connectors/guarantees.md %}) for more information about the guarantees
 provided by Flink's connectors.
 
@@ -247,7 +247,7 @@ If state was snapshotted incrementally, the operators start with the state of
 the latest full snapshot and then apply a series of incremental snapshot
 updates to that state.
 
-See [Restart Strategies]({{ site.baseurl }}{% link dev/task_failure_recovery.md
+See [Restart Strategies]({% link dev/task_failure_recovery.md
 %}#restart-strategies) for more information.
 
 ### State Backends
@@ -255,7 +255,7 @@ See [Restart Strategies]({{ site.baseurl }}{% link dev/task_failure_recovery.md
 `TODO: expand this section`
 
 The exact data structures in which the key/values indexes are stored depends on
-the chosen [state backend]({{ site.baseurl }}{% link
+the chosen [state backend]({% link
 ops/state/state_backends.md %}). One state backend stores data in an in-memory
 hash map, another state backend uses [RocksDB](http://rocksdb.org) as the
 key/value store.  In addition to defining the data structure that holds the
@@ -276,7 +276,7 @@ All programs that use checkpointing can resume execution from a **savepoint**.
 Savepoints allow both updating your programs and your Flink cluster without
 losing any state.
 
-[Savepoints]({{ site.baseurl }}{% link ops/state/savepoints.md %}) are
+[Savepoints]({% link ops/state/savepoints.md %}) are
 **manually triggered checkpoints**, which take a snapshot of the program and
 write it out to a state backend. They rely on the regular checkpointing
 mechanism for this.

--- a/docs/concepts/stateful-stream-processing.zh.md
+++ b/docs/concepts/stateful-stream-processing.zh.md
@@ -47,11 +47,11 @@ and [savepoints]({{ site.baseurl }}{%link ops/state/savepoints.zh.md %}).
 Knowledge about the state also allows for rescaling Flink applications, meaning
 that Flink takes care of redistributing state across parallel instances.
 
-[Queryable state]({{ site.baseurl }}{% link dev/stream/state/queryable_state.zh.md
+[Queryable state]({% link dev/stream/state/queryable_state.zh.md
 %}) allows you to access state from outside of Flink during runtime.
 
 When working with state, it might also be useful to read about [Flink's state
-backends]({{ site.baseurl }}{% link ops/state/state_backends.zh.md %}). Flink
+backends]({% link ops/state/state_backends.zh.md %}). Flink
 provides different state backends that specify how and where state is stored.
 
 * This will be replaced by the TOC
@@ -123,7 +123,7 @@ to enable and configure checkpointing.
 stream source (such as message queue or broker) needs to be able to rewind the
 stream to a defined recent point. [Apache Kafka](http://kafka.apache.org) has
 this ability and Flink's connector to Kafka exploits this. See [Fault
-Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}{% link
+Tolerance Guarantees of Data Sources and Sinks]({% link
 dev/connectors/guarantees.zh.md %}) for more information about the guarantees
 provided by Flink's connectors.
 
@@ -247,7 +247,7 @@ If state was snapshotted incrementally, the operators start with the state of
 the latest full snapshot and then apply a series of incremental snapshot
 updates to that state.
 
-See [Restart Strategies]({{ site.baseurl }}{% link dev/task_failure_recovery.zh.md
+See [Restart Strategies]({% link dev/task_failure_recovery.zh.md
 %}#restart-strategies) for more information.
 
 ### State Backends
@@ -255,7 +255,7 @@ See [Restart Strategies]({{ site.baseurl }}{% link dev/task_failure_recovery.zh.
 `TODO: expand this section`
 
 The exact data structures in which the key/values indexes are stored depends on
-the chosen [state backend]({{ site.baseurl }}{% link
+the chosen [state backend]({% link
 ops/state/state_backends.zh.md %}). One state backend stores data in an in-memory
 hash map, another state backend uses [RocksDB](http://rocksdb.org) as the
 key/value store.  In addition to defining the data structure that holds the
@@ -276,7 +276,7 @@ All programs that use checkpointing can resume execution from a **savepoint**.
 Savepoints allow both updating your programs and your Flink cluster without
 losing any state.
 
-[Savepoints]({{ site.baseurl }}{% link ops/state/savepoints.zh.md %}) are
+[Savepoints]({% link ops/state/savepoints.zh.md %}) are
 **manually triggered checkpoints**, which take a snapshot of the program and
 write it out to a state backend. They rely on the regular checkpointing
 mechanism for this.

--- a/docs/concepts/timely-stream-processing.md
+++ b/docs/concepts/timely-stream-processing.md
@@ -183,7 +183,7 @@ evaluation of event time windows.
 For this reason, streaming programs may explicitly expect some *late* elements.
 Late elements are elements that arrive after the system's event time clock (as
 signaled by the watermarks) has already passed the time of the late element's
-timestamp. See [Allowed Lateness]({{ site.baseurl }}{% link
+timestamp. See [Allowed Lateness]({% link
 dev/stream/operators/windows.md %}#allowed-lateness) for more information on
 how to work with late elements in event time windows.
 

--- a/docs/concepts/timely-stream-processing.zh.md
+++ b/docs/concepts/timely-stream-processing.zh.md
@@ -183,7 +183,7 @@ evaluation of event time windows.
 For this reason, streaming programs may explicitly expect some *late* elements.
 Late elements are elements that arrive after the system's event time clock (as
 signaled by the watermarks) has already passed the time of the late element's
-timestamp. See [Allowed Lateness]({{ site.baseurl }}{% link
+timestamp. See [Allowed Lateness]({% link
 dev/stream/operators/windows.zh.md %}#allowed-lateness) for more information on
 how to work with late elements in event time windows.
 

--- a/docs/dev/event_time.md
+++ b/docs/dev/event_time.md
@@ -25,13 +25,13 @@ under the License.
 -->
 
 In this section you will learn about writing time-aware Flink programs. Please
-take a look at [Timely Stream Processing]({{site.baseurl}}{% link
+take a look at [Timely Stream Processing]({% link
 concepts/timely-stream-processing.md %}) to learn about the concepts behind
 timely stream processing.
 
 For information about how to use time in Flink programs refer to
-[windowing]({{site.baseurl}}{% link dev/stream/operators/windows.md %}) and
-[ProcessFunction]({{ site.baseurl }}{% link
+[windowing]({% link dev/stream/operators/windows.md %}) and
+[ProcessFunction]({% link
 dev/stream/operators/process_function.md %}).
 
 * toc

--- a/docs/dev/stream/state/broadcast_state.md
+++ b/docs/dev/stream/state/broadcast_state.md
@@ -26,7 +26,7 @@ under the License.
 {:toc}
 
 In this section you will learn about how to use broadcast state in practise. Please refer to [Stateful Stream
-Processing]({{site.baseurl}}{% link concepts/stateful-stream-processing.md %})
+Processing]({% link concepts/stateful-stream-processing.md %})
 to learn about the concepts behind stateful stream processing. 
 
 ## Provided APIs

--- a/docs/dev/stream/state/index.md
+++ b/docs/dev/stream/state/index.md
@@ -27,7 +27,7 @@ under the License.
 
 In this section you will learn about the APIs that Flink provides for writing
 stateful programs. Please take a look at [Stateful Stream
-Processing]({{site.baseurl}}{% link concepts/stateful-stream-processing.md %})
+Processing]({% link concepts/stateful-stream-processing.md %})
 to learn about the concepts behind stateful stream processing.
 
 {% top %}

--- a/docs/dev/stream/state/state.md
+++ b/docs/dev/stream/state/state.md
@@ -24,7 +24,7 @@ under the License.
 
 In this section you will learn about the APIs that Flink provides for writing
 stateful programs. Please take a look at [Stateful Stream
-Processing]({{site.baseurl}}{% link concepts/stateful-stream-processing.md %})
+Processing]({% link concepts/stateful-stream-processing.md %})
 to learn about the concepts behind stateful stream processing.
 
 * ToC
@@ -499,7 +499,7 @@ val counts: DataStream[(String, Int)] = stream
 ## Operator State
 
 *Operator State* (or *non-keyed state*) is state that is is bound to one
-parallel operator instance. The [Kafka Connector]({{ site.baseurl }}{% link
+parallel operator instance. The [Kafka Connector]({% link
 dev/connectors/kafka.md %}) is a good motivating example for the use of
 Operator State in Flink. Each parallel instance of the Kafka consumer maintains
 a map of topic partitions and offsets as its Operator State.

--- a/docs/tutorials/datastream_api.md
+++ b/docs/tutorials/datastream_api.md
@@ -83,7 +83,7 @@ public class Person {
 Person person = new Person("Fred Flintstone", 35);
 {% endhighlight %}
 
-Flink's serializer [supports schema evolution for POJO types]({{ site.baseurl }}{% link dev/stream/state/schema_evolution.md %}#pojo-types).
+Flink's serializer [supports schema evolution for POJO types]({% link dev/stream/state/schema_evolution.md %}#pojo-types).
 
 ### Scala tuples and case classes
 
@@ -229,9 +229,9 @@ instructions in the README, do the first exercise:
 ## Further Reading
 
 - [Flink Serialization Tuning Vol. 1: Choosing your Serializer — if you can](https://flink.apache.org/news/2020/04/15/flink-serialization-tuning-vol-1.html)
-- [Anatomy of a Flink Program]({{ site.baseurl }}{% link dev/api_concepts.md %}#anatomy-of-a-flink-program)
-- [Data Sources]({{ site.baseurl }}{% link dev/datastream_api.md %}#data-sources)
-- [Data Sinks]({{ site.baseurl }}{% link dev/datastream_api.md %}#data-sinks)
-- [DataStream Connectors]({{ site.baseurl }}{% link dev/connectors/index.md %})
+- [Anatomy of a Flink Program]({% link dev/api_concepts.md %}#anatomy-of-a-flink-program)
+- [Data Sources]({% link dev/datastream_api.md %}#data-sources)
+- [Data Sinks]({% link dev/datastream_api.md %}#data-sinks)
+- [DataStream Connectors]({% link dev/connectors/index.md %})
 
 {% top %}

--- a/docs/tutorials/datastream_api.zh.md
+++ b/docs/tutorials/datastream_api.zh.md
@@ -83,7 +83,7 @@ public class Person {
 Person person = new Person("Fred Flintstone", 35);
 {% endhighlight %}
 
-Flink's serializer [supports schema evolution for POJO types]({{ site.baseurl }}{% link dev/stream/state/schema_evolution.zh.md %}#pojo-types).
+Flink's serializer [supports schema evolution for POJO types]({% link dev/stream/state/schema_evolution.zh.md %}#pojo-types).
 
 ### Scala tuples and case classes
 
@@ -229,9 +229,9 @@ instructions in the README, do the first exercise:
 ## Further Reading
 
 - [Flink Serialization Tuning Vol. 1: Choosing your Serializer — if you can](https://flink.apache.org/news/2020/04/15/flink-serialization-tuning-vol-1.html)
-- [Anatomy of a Flink Program]({{ site.baseurl }}{% link dev/api_concepts.zh.md %}#anatomy-of-a-flink-program)
-- [Data Sources]({{ site.baseurl }}{% link dev/datastream_api.zh.md %}#data-sources)
-- [Data Sinks]({{ site.baseurl }}{% link dev/datastream_api.zh.md %}#data-sinks)
-- [DataStream Connectors]({{ site.baseurl }}{% link dev/connectors/index.zh.md %})
+- [Anatomy of a Flink Program]({% link dev/api_concepts.zh.md %}#anatomy-of-a-flink-program)
+- [Data Sources]({% link dev/datastream_api.zh.md %}#data-sources)
+- [Data Sinks]({% link dev/datastream_api.zh.md %}#data-sinks)
+- [DataStream Connectors]({% link dev/connectors/index.zh.md %})
 
 {% top %}

--- a/docs/tutorials/etl.md
+++ b/docs/tutorials/etl.md
@@ -29,7 +29,7 @@ that take data from one or more sources, perform some transformations and/or enr
 then store the results somewhere. In this tutorial we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
-Note that Flink's [Table and SQL APIs]({{ site.baseurl }}{% link dev/table/index.md %})
+Note that Flink's [Table and SQL APIs]({% link dev/table/index.md %})
 are well suited for many ETL use cases. But regardless of whether you ultimately use
 the DataStream API directly, or not, having a solid understanding the basics presented here will
 prove valuable.
@@ -293,7 +293,7 @@ Your applications are certainly capable of using state without getting Flink inv
 * **durable**: Flink state is fault-tolerant, i.e., it is automatically checkpointed at regular intervals, and is restored upon failure
 * **vertically scalable**: Flink state can be kept in embedded RocksDB instances that scale by adding more local disk
 * **horizontally scalable**: Flink state is redistributed as your cluster grows and shrinks
-* **queryable**: Flink state can be queried externally via the [Queryable State API]({{ site.baseurl }}{% link dev/stream/state/queryable_state.md %}).
+* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.md %}).
 
 In this section you will learn how to work with Flink's APIs that manage keyed state.
 
@@ -413,14 +413,14 @@ You might want to do this, for example, after a period of inactivity for a given
 to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
 applications.
 
-There's also a [State Time-to-Live (TTL)]({{ site.baseurl }}{% link dev/stream/state/state.md
+There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.md
 %}#state-time-to-live-ttl) option that you can configure with the state descriptor that specifies
 when you want the state for stale keys to be automatically cleared.
 
 ### Non-keyed State
 
 It is also possible to work with managed state in non-keyed contexts. This is sometimes called
-[operator state]({{ site.baseurl }}{% link dev/stream/state/state.md %}#operator-state). The
+[operator state]({% link dev/stream/state/state.md %}#operator-state). The
 interfaces involved are somewhat different, and since it is unusual for user-defined functions to
 need non-keyed state, it is not covered here. This feature is most often used in the implementation
 of sources and sinks. 
@@ -530,7 +530,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [DataStream Transformations]({{ site.baseurl }}{% link dev/stream/operators/index.md %}#datastream-transformations)
-- [Stateful Stream Processing]({{ site.baseurl }}{% link concepts/stateful-stream-processing.md %})
+- [DataStream Transformations]({% link dev/stream/operators/index.md %}#datastream-transformations)
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.md %})
 
 {% top %}

--- a/docs/tutorials/etl.zh.md
+++ b/docs/tutorials/etl.zh.md
@@ -29,7 +29,7 @@ that take data from one or more sources, perform some transformations and/or enr
 then store the results somewhere. In this tutorial we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
-Note that Flink's [Table and SQL APIs]({{ site.baseurl }}{% link dev/table/index.zh.md %})
+Note that Flink's [Table and SQL APIs]({% link dev/table/index.zh.md %})
 are well suited for many ETL use cases. But regardless of whether you ultimately use
 the DataStream API directly, or not, having a solid understanding the basics presented here will
 prove valuable.
@@ -293,7 +293,7 @@ Your applications are certainly capable of using state without getting Flink inv
 * **durable**: Flink state is fault-tolerant, i.e., it is automatically checkpointed at regular intervals, and is restored upon failure
 * **vertically scalable**: Flink state can be kept in embedded RocksDB instances that scale by adding more local disk
 * **horizontally scalable**: Flink state is redistributed as your cluster grows and shrinks
-* **queryable**: Flink state can be queried externally via the [Queryable State API]({{ site.baseurl }}{% link dev/stream/state/queryable_state.zh.md %}).
+* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.zh.md %}).
 
 In this section you will learn how to work with Flink's APIs that manage keyed state.
 
@@ -413,14 +413,14 @@ You might want to do this, for example, after a period of inactivity for a given
 to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
 applications.
 
-There's also a [State Time-to-Live (TTL)]({{ site.baseurl }}{% link dev/stream/state/state.zh.md
+There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.zh.md
 %}#state-time-to-live-ttl) option that you can configure with the state descriptor that specifies
 when you want the state for stale keys to be automatically cleared.
 
 ### Non-keyed State
 
 It is also possible to work with managed state in non-keyed contexts. This is sometimes called
-[operator state]({{ site.baseurl }}{% link dev/stream/state/state.zh.md %}#operator-state). The
+[operator state]({% link dev/stream/state/state.zh.md %}#operator-state). The
 interfaces involved are somewhat different, and since it is unusual for user-defined functions to
 need non-keyed state, it is not covered here. This feature is most often used in the implementation
 of sources and sinks. 
@@ -530,7 +530,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [DataStream Transformations]({{ site.baseurl }}{% link dev/stream/operators/index.zh.md %}#datastream-transformations)
-- [Stateful Stream Processing]({{ site.baseurl }}{% link concepts/stateful-stream-processing.zh.md %})
+- [DataStream Transformations]({% link dev/stream/operators/index.zh.md %}#datastream-transformations)
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.zh.md %})
 
 {% top %}

--- a/docs/tutorials/event_driven.md
+++ b/docs/tutorials/event_driven.md
@@ -38,8 +38,8 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 ### Example
 
 If you've done the
-[hands-on exercise]({{ site.baseurl }}{% link tutorials/streaming_analytics.md %}#hands-on)
-in the [Streaming Analytics tutorial]({{ site.baseurl }}{% link tutorials/streaming_analytics.md %}),
+[hands-on exercise]({% link tutorials/streaming_analytics.md %}#hands-on)
+in the [Streaming Analytics tutorial]({% link tutorials/streaming_analytics.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 
@@ -177,7 +177,7 @@ Things to consider:
 
 * What happens with late events? Events that are behind the watermark (i.e., late) are being
   dropped. If you want to do something better than this, consider using a side output, which is
-  explained in the [next section]({{ site.baseurl }}{% link tutorials/event_driven.md
+  explained in the [next section]({% link tutorials/event_driven.md
   %}#side-outputs).
 
 * This example uses a `MapState` where the keys are timestamps, and sets a `Timer` for that same
@@ -302,7 +302,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [ProcessFunction]({{ site.baseurl }}{% link dev/stream/operators/process_function.md %})
-- [Side Outputs]({{ site.baseurl }}{% link dev/stream/side_output.md %})
+- [ProcessFunction]({% link dev/stream/operators/process_function.md %})
+- [Side Outputs]({% link dev/stream/side_output.md %})
 
 {% top %}

--- a/docs/tutorials/event_driven.zh.md
+++ b/docs/tutorials/event_driven.zh.md
@@ -38,8 +38,8 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 ### Example
 
 If you've done the
-[hands-on exercise]({{ site.baseurl }}{% link tutorials/streaming_analytics.zh.md %}#hands-on)
-in the [Streaming Analytics tutorial]({{ site.baseurl }}{% link tutorials/streaming_analytics.zh.md %}),
+[hands-on exercise]({% link tutorials/streaming_analytics.zh.md %}#hands-on)
+in the [Streaming Analytics tutorial]({% link tutorials/streaming_analytics.zh.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 
@@ -177,7 +177,7 @@ Things to consider:
 
 * What happens with late events? Events that are behind the watermark (i.e., late) are being
   dropped. If you want to do something better than this, consider using a side output, which is
-  explained in the [next section]({{ site.baseurl }}{% link tutorials/event_driven.zh.md
+  explained in the [next section]({% link tutorials/event_driven.zh.md
   %}#side-outputs).
 
 * This example uses a `MapState` where the keys are timestamps, and sets a `Timer` for that same
@@ -302,7 +302,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [ProcessFunction]({{ site.baseurl }}{% link dev/stream/operators/process_function.zh.md %})
-- [Side Outputs]({{ site.baseurl }}{% link dev/stream/side_output.zh.md %})
+- [ProcessFunction]({% link dev/stream/operators/process_function.zh.md %})
+- [Side Outputs]({% link dev/stream/side_output.zh.md %})
 
 {% top %}

--- a/docs/tutorials/fault_tolerance.md
+++ b/docs/tutorials/fault_tolerance.md
@@ -186,23 +186,23 @@ once, the following must be true:
 
 ## Hands-on
 
-The [Flink Operations Playground]({{ site.baseurl }}{% link
+The [Flink Operations Playground]({% link
 getting-started/docker-playgrounds/flink-operations-playground.md %}) includes a section on
-[Observing Failure & Recovery]({{ site.baseurl }}{% link
+[Observing Failure & Recovery]({% link
 getting-started/docker-playgrounds/flink-operations-playground.md %}#observing-failure--recovery).
 
 {% top %}
 
 ## Further Reading
 
-- [Stateful Stream Processing]({{ site.baseurl }}{% link concepts/stateful-stream-processing.md %})
-- [State Backends]({{ site.baseurl }}{% link ops/state/state_backends.md %})
-- [Fault Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}{% link dev/connectors/guarantees.md %})
-- [Enabling and Configuring Checkpointing]({{ site.baseurl }}{% link dev/stream/state/checkpointing.md %})
-- [Checkpoints]({{ site.baseurl }}{% link ops/state/checkpoints.md %})
-- [Savepoints]({{ site.baseurl }}{% link ops/state/savepoints.md %})
-- [Tuning Checkpoints and Large State]({{ site.baseurl }}{% link ops/state/large_state_tuning.md %})
-- [Monitoring Checkpointing]({{ site.baseurl }}{% link monitoring/checkpoint_monitoring.md %})
-- [Task Failure Recovery]({{ site.baseurl }}{% link dev/task_failure_recovery.md %})
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.md %})
+- [State Backends]({% link ops/state/state_backends.md %})
+- [Fault Tolerance Guarantees of Data Sources and Sinks]({% link dev/connectors/guarantees.md %})
+- [Enabling and Configuring Checkpointing]({% link dev/stream/state/checkpointing.md %})
+- [Checkpoints]({% link ops/state/checkpoints.md %})
+- [Savepoints]({% link ops/state/savepoints.md %})
+- [Tuning Checkpoints and Large State]({% link ops/state/large_state_tuning.md %})
+- [Monitoring Checkpointing]({% link monitoring/checkpoint_monitoring.md %})
+- [Task Failure Recovery]({% link dev/task_failure_recovery.md %})
 
 {% top %}

--- a/docs/tutorials/fault_tolerance.zh.md
+++ b/docs/tutorials/fault_tolerance.zh.md
@@ -186,23 +186,23 @@ once, the following must be true:
 
 ## Hands-on
 
-The [Flink Operations Playground]({{ site.baseurl }}{% link
+The [Flink Operations Playground]({% link
 getting-started/docker-playgrounds/flink-operations-playground.zh.md %}) includes a section on
-[Observing Failure & Recovery]({{ site.baseurl }}{% link
+[Observing Failure & Recovery]({% link
 getting-started/docker-playgrounds/flink-operations-playground.zh.md %}#observing-failure--recovery).
 
 {% top %}
 
 ## Further Reading
 
-- [Stateful Stream Processing]({{ site.baseurl }}{% link concepts/stateful-stream-processing.zh.md %})
-- [State Backends]({{ site.baseurl }}{% link ops/state/state_backends.zh.md %})
-- [Fault Tolerance Guarantees of Data Sources and Sinks]({{ site.baseurl }}{% link dev/connectors/guarantees.zh.md %})
-- [Enabling and Configuring Checkpointing]({{ site.baseurl }}{% link dev/stream/state/checkpointing.zh.md %})
-- [Checkpoints]({{ site.baseurl }}{% link ops/state/checkpoints.zh.md %})
-- [Savepoints]({{ site.baseurl }}{% link ops/state/savepoints.zh.md %})
-- [Tuning Checkpoints and Large State]({{ site.baseurl }}{% link ops/state/large_state_tuning.zh.md %})
-- [Monitoring Checkpointing]({{ site.baseurl }}{% link monitoring/checkpoint_monitoring.zh.md %})
-- [Task Failure Recovery]({{ site.baseurl }}{% link dev/task_failure_recovery.zh.md %})
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.zh.md %})
+- [State Backends]({% link ops/state/state_backends.zh.md %})
+- [Fault Tolerance Guarantees of Data Sources and Sinks]({% link dev/connectors/guarantees.zh.md %})
+- [Enabling and Configuring Checkpointing]({% link dev/stream/state/checkpointing.zh.md %})
+- [Checkpoints]({% link ops/state/checkpoints.zh.md %})
+- [Savepoints]({% link ops/state/savepoints.zh.md %})
+- [Tuning Checkpoints and Large State]({% link ops/state/large_state_tuning.zh.md %})
+- [Monitoring Checkpointing]({% link monitoring/checkpoint_monitoring.zh.md %})
+- [Task Failure Recovery]({% link dev/task_failure_recovery.zh.md %})
 
 {% top %}

--- a/docs/tutorials/streaming_analytics.md
+++ b/docs/tutorials/streaming_analytics.md
@@ -59,7 +59,7 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark
 Generator that Flink will use to track the progress of event time. This will be covered in the
-section below on [Working with Watermarks]({{ site.baseurl }}{% link
+section below on [Working with Watermarks]({% link
 tutorials/streaming_analytics.md %}#working-with-watermarks), but first we should explain what
 watermarks are.
 
@@ -253,7 +253,7 @@ that behavior yourself with a custom Trigger.
 A global window assigner assigns every event (with the same key) to the same global window. This is
 only useful if you are going to do your own custom windowing, with a custom Trigger. In many cases
 where this might seem useful you will be better off using a `ProcessFunction` as described
-[in another section]({{ site.baseurl }}{% link tutorials/event_driven.md %}#process-functions).
+[in another section]({% link tutorials/event_driven.md %}#process-functions).
 
 ### Window Functions
 
@@ -365,7 +365,7 @@ the window API that give you more control over this.
 
 You can arrange for the events that would be dropped to be collected to an alternate output stream
 instead, using a mechanism called
-[Side Outputs]({{ site.baseurl }}{% link tutorials/event_driven.md %}#side-outputs).
+[Side Outputs]({% link tutorials/event_driven.md %}#side-outputs).
 Here is an example of what that might look like:
 
 {% highlight java %}
@@ -421,8 +421,8 @@ long and close at 1:00.
 
 Note, however, that the tumbling and sliding window assigners take an optional offset parameter
 that can be used to change the alignment of the windows. See
-[Tumbling Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.md %}#tumbling-windows) and
-[Sliding Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.md %}#sliding-windows) for details.
+[Tumbling Windows]({% link dev/stream/operators/windows.md %}#tumbling-windows) and
+[Sliding Windows]({% link dev/stream/operators/windows.md %}#sliding-windows) for details.
 
 #### Windows Can Follow Windows
 
@@ -469,7 +469,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [Timely Stream Processing]({{ site.baseurl }}{% link concepts/timely-stream-processing.md %})
-- [Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.md %})
+- [Timely Stream Processing]({% link concepts/timely-stream-processing.md %})
+- [Windows]({% link dev/stream/operators/windows.md %})
 
 {% top %}

--- a/docs/tutorials/streaming_analytics.zh.md
+++ b/docs/tutorials/streaming_analytics.zh.md
@@ -59,7 +59,7 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark
 Generator that Flink will use to track the progress of event time. This will be covered in the
-section below on [Working with Watermarks]({{ site.baseurl }}{% link
+section below on [Working with Watermarks]({% link
 tutorials/streaming_analytics.zh.md %}#working-with-watermarks), but first we should explain what
 watermarks are.
 
@@ -253,7 +253,7 @@ that behavior yourself with a custom Trigger.
 A global window assigner assigns every event (with the same key) to the same global window. This is
 only useful if you are going to do your own custom windowing, with a custom Trigger. In many cases
 where this might seem useful you will be better off using a `ProcessFunction` as described
-[in another section]({{ site.baseurl }}{% link tutorials/event_driven.zh.md %}#process-functions).
+[in another section]({% link tutorials/event_driven.zh.md %}#process-functions).
 
 ### Window Functions
 
@@ -365,7 +365,7 @@ the window API that give you more control over this.
 
 You can arrange for the events that would be dropped to be collected to an alternate output stream
 instead, using a mechanism called
-[Side Outputs]({{ site.baseurl }}{% link tutorials/event_driven.zh.md %}#side-outputs).
+[Side Outputs]({% link tutorials/event_driven.zh.md %}#side-outputs).
 Here is an example of what that might look like:
 
 {% highlight java %}
@@ -421,8 +421,8 @@ long and close at 1:00.
 
 Note, however, that the tumbling and sliding window assigners take an optional offset parameter
 that can be used to change the alignment of the windows. See
-[Tumbling Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.zh.md %}#tumbling-windows) and
-[Sliding Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.zh.md %}#sliding-windows) for details.
+[Tumbling Windows]({% link dev/stream/operators/windows.zh.md %}#tumbling-windows) and
+[Sliding Windows]({% link dev/stream/operators/windows.zh.md %}#sliding-windows) for details.
 
 #### Windows Can Follow Windows
 
@@ -469,7 +469,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [Timely Stream Processing]({{ site.baseurl }}{% link concepts/timely-stream-processing.zh.md %})
-- [Windows]({{ site.baseurl }}{% link dev/stream/operators/windows.zh.md %})
+- [Timely Stream Processing]({% link concepts/timely-stream-processing.zh.md %})
+- [Windows]({% link dev/stream/operators/windows.zh.md %})
 
 {% top %}


### PR DESCRIPTION
## What is the purpose of the change

There are 100+ broken links in the docs, due to misuse of the `{% link %}` liquid tag. This tag includes site.baseurl automatically, so specifying

`{{ site.baseurl }}{% link foo.md %}` includes the baseurl twice. Since the baseurl in development is empty, it's easy to make a mess without realizing it.

## Brief change log

Removed site.baseurl everywhere it could be found in combination with the link tag.
