### PR TITLE
[FLINK-17359] [flink-core] Fixing EntropyInjector to resolve entropy for ClassLoaderFixingFileSystem

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/EntropyInjector.java
@@ -99,6 +99,13 @@ public class EntropyInjector {
 			if (delegate instanceof EntropyInjectingFileSystem) {
 				return (EntropyInjectingFileSystem) delegate;
 			}
+			else if (delegate instanceof PluginFileSystemFactory.ClassLoaderFixingFileSystem) {
+				FileSystem innerFs = ((PluginFileSystemFactory.ClassLoaderFixingFileSystem) delegate).getInner();
+				if (innerFs instanceof EntropyInjectingFileSystem) {
+					return (EntropyInjectingFileSystem) innerFs;
+				}
+				return null;
+			}
 			else {
 				return null;
 			}

--- a/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/PluginFileSystemFactory.java
@@ -62,7 +62,7 @@ public class PluginFileSystemFactory implements FileSystemFactory {
 		}
 	}
 
-	private static class ClassLoaderFixingFileSystem extends FileSystem {
+	static class ClassLoaderFixingFileSystem extends FileSystem {
 		private final FileSystem inner;
 		private final ClassLoader loader;
 
@@ -184,6 +184,10 @@ public class PluginFileSystemFactory implements FileSystemFactory {
 			try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(loader)) {
 				return inner.rename(src, dst);
 			}
+		}
+
+		public FileSystem getInner() {
+			return inner;
 		}
 	}
 }

--- a/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/EntropyInjectorTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -160,6 +161,33 @@ public class EntropyInjectorTest {
 		} catch (IOException ignored) {}
 	}
 
+	@Test
+	public void testClassLoaderFixingFs() throws Exception {
+		final String entropyKey = "__ekey__";
+		final String entropyValue = "abc";
+
+		final File folder = TMP_FOLDER.newFolder();
+
+		final Path path = new Path(Path.fromLocalFile(folder), entropyKey + "/path/");
+		final Path pathWithEntropy = new Path(Path.fromLocalFile(folder), entropyValue + "/path/");
+
+		PluginFileSystemFactory pluginFsFactory = PluginFileSystemFactory.of(
+				new TestFileSystemFactory(entropyKey, entropyValue));
+		FileSystem testFs = pluginFsFactory.create(URI.create("test"));
+
+		FileSystemSafetyNet.initializeSafetyNetForThread();
+		FileSystem fs = FileSystemSafetyNet.wrapWithSafetyNetWhenActivated(testFs);
+		try  {
+			OutputStreamAndPath streamAndPath = EntropyInjector.createEntropyAware(
+					fs, path, WriteMode.NO_OVERWRITE);
+
+			assertEquals(pathWithEntropy, streamAndPath.path());
+		}
+		finally {
+			FileSystemSafetyNet.closeSafetyNetAndGuardedResourcesForThread();
+		}
+	}
+
 	// ------------------------------------------------------------------------
 
 	private static final class TestEntropyInjectingFs extends LocalFileSystem implements EntropyInjectingFileSystem {
@@ -181,6 +209,27 @@ public class EntropyInjectorTest {
 		@Override
 		public String generateEntropy() {
 			return entropy;
+		}
+	}
+
+	private static class TestFileSystemFactory implements FileSystemFactory {
+
+		private final String key;
+		private final String entropy;
+
+		TestFileSystemFactory(String key, String entropy) {
+			this.key = key;
+			this.entropy = entropy;
+		}
+
+		@Override
+		public String getScheme() {
+			return null;
+		}
+
+		@Override
+		public FileSystem create(URI fsUri) {
+			return new TestEntropyInjectingFs(key, entropy);
 		}
 	}
 }


### PR DESCRIPTION
## What is the purpose of the change

As mentioned in [FLINK-17359](https://issues.apache.org/jira/browse/FLINK-17359) this change addresses the issue of the EntropyInjector not resolving the entropyKey if the fileSystem is dynamically loaded as a plugin.

## Brief change log

- Added an extra condition to check if the fileSystem is of type `ClassLoaderFixingFileSystem`
- Added appropriate unit test

## Verifying this change

This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
