### PR TITLE
[FLINK-10911][scala-shell] Enable flink-scala-shell with Scala 2.12

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -143,6 +143,12 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-scala-shell_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- Default file system support. The Hadoop and MapR dependencies -->
 		<!--       are optional, so not being added to the dist jar        -->
 
@@ -442,24 +448,6 @@ under the License.
 	</dependencies>
 
 	<profiles>
-		<profile>
-			<id>scala-2.11</id>
-			<activation>
-				<property>
-					<name>!scala-2.12</name>
-				</property>
-			</activation>
-			<!-- Scala Shell doesn't currently work with Scala 2.12 so only include
-			when building for Scala 2.11. -->
-			<dependencies>
-				<dependency>
-					<groupId>org.apache.flink</groupId>
-					<artifactId>flink-scala-shell_${scala.binary.version}</artifactId>
-					<version>${project.version}</version>
-				</dependency>
-			</dependencies>
-		</profile>
-
 		<profile>
 			<!-- Copies that shaded Hadoop uber jar to the dist folder. -->
 			<id>include-hadoop</id>

--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -19,6 +19,7 @@
 package org.apache.flink.api.scala
 
 import java.io._
+import java.nio.file.Files
 
 import org.apache.flink.annotation.Internal
 import org.apache.flink.client.cli.{CliFrontend, CliFrontendParser}
@@ -182,6 +183,12 @@ object FlinkShell {
     val settings = new Settings()
     settings.usejavacp.value = true
     settings.Yreplsync.value = true
+    val outputDir = Files.createTempDirectory("flink-repl");
+    val interpArguments = List(
+      "-Yrepl-class-based",
+      "-Yrepl-outdir", s"${outputDir.toFile.getAbsolutePath}"
+    )
+    settings.processArguments(interpArguments, true)
 
     try {
       repl.process(settings)

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@ under the License.
 		<module>flink-end-to-end-tests</module>
 		<module>flink-test-utils-parent</module>
 		<module>flink-state-backends</module>
+		<module>flink-scala-shell</module>
 		<module>flink-libraries</module>
 		<module>flink-table</module>
 		<module>flink-quickstart</module>
@@ -778,11 +779,6 @@ under the License.
 					<name>!scala-2.12</name>
 				</property>
 			</activation>
-			<!-- Scala Shell doesn't currently work with Scala 2.12 so only include
-			when building for Scala 2.11. -->
-			<modules>
-				<module>flink-scala-shell</module>
-			</modules>
 			<build>
 				<plugins>
 					<!-- make sure we don't have any _2.10 or _2.12 dependencies when building
@@ -827,29 +823,6 @@ under the License.
 			</activation>
 			<build>
 				<plugins>
-					<!-- don't run tests that don't work for Scala 2.12, because not all of the
-					required test dependencies are available for Scala 2.12. The Kafka 0.9 connector
-					still works with Scala 2.12 because it only needs the scala-version-independent
-					kafka-clients dependency at runtime. -->
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>build-helper-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>regex-property</id>
-								<goals>
-									<goal>regex-property</goal>
-								</goals>
-								<configuration>
-									<name>maven.test.skip</name>
-									<value>${project.artifactId}</value>
-									<regex>(flink-scala-shell.*)</regex>
-									<replacement>true</replacement>
-									<failIfNoMatch>false</failIfNoMatch>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
 					<!-- make sure we don't have any _2.10 or _2.11 dependencies when building
 					for Scala 2.12 -->
 					<plugin>


### PR DESCRIPTION
## What is the purpose of the change

This PR is to enable flink-scala-shell with scala-2.12. Previous we disable it because flink scala shell doesn't work with scala 2.12, but now it seems not true. The CI is passed and I also verify it in my local machine. flink scala-shell works well with scala 2.12.

## Brief change log

Just enable flink-scala-shell with scala 2.12 in pom file

## Verifying this change

This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
