### PR TITLE
[FLINK-16971][python][sql-client] Support Python UDF in SQL Client.

### DIFF
--- a/docs/dev/table/sqlClient.md
+++ b/docs/dev/table/sqlClient.md
@@ -352,30 +352,42 @@ Both `connector` and `format` allow to define a property version (which is curre
 
 ### User-defined Functions
 
-The SQL Client allows users to create custom, user-defined functions to be used in SQL queries. Currently, these functions are restricted to be defined programmatically in Java/Scala classes.
+The SQL Client allows users to create custom, user-defined functions to be used in SQL queries. Currently, these functions are restricted to be defined programmatically in Java/Scala classes or Python files.
 
-In order to provide a user-defined function, you need to first implement and compile a function class that extends `ScalarFunction`, `AggregateFunction` or `TableFunction` (see [User-defined Functions]({{ site.baseurl }}/dev/table/functions/udfs.html)). One or more functions can then be packaged into a dependency JAR for the SQL Client.
+In order to provide a Java/Scala user-defined function, you need to first implement and compile a function class that extends `ScalarFunction`, `AggregateFunction` or `TableFunction` (see [User-defined Functions]({{ site.baseurl }}/dev/table/functions/udfs.html)). One or more functions can then be packaged into a dependency JAR for the SQL Client.
+
+In order to provide a Python user-defined function, you need to write a Python function and decorate it with the `pyflink.table.udf.udf` or `pyflink.table.udf.udtf` decorator (see [Python UDFs]({{ site.baseurl }}/dev/table/python/python_udfs.html)). One or more functions can then be placed into a Python file. The Python file and related dependencies need to be specified via the configuration (see [Python Configuration]({{ site.baseurl }}/dev/table/python/python_config.html)) in environment file or the command line options (see [Command Line Usage]({{ site.baseurl }}/ops/cli.html#usage)).
 
 All functions must be declared in an environment file before being called. For each item in the list of `functions`, one must specify
 
 - a `name` under which the function is registered,
-- the source of the function using `from` (restricted to be `class` for now),
+- the source of the function using `from` (restricted to be `class` (Java/Scala UDF) or `python` (Python UDF) for now),
+
+The Java/Scala UDF must specify:
+
 - the `class` which indicates the fully qualified class name of the function and an optional list of `constructor` parameters for instantiation.
+
+The Python UDF must specify:
+
+- the `fully-qualified-name` which indicates the fully qualified name, i.e the "[module name].[object name]" of the function.
 
 {% highlight yaml %}
 functions:
-  - name: ...               # required: name of the function
-    from: class             # required: source of the function (can only be "class" for now)
-    class: ...              # required: fully qualified class name of the function
-    constructor:            # optional: constructor parameters of the function class
-      - ...                 # optional: a literal parameter with implicit type
-      - class: ...          # optional: full class name of the parameter
-        constructor:        # optional: constructor parameters of the parameter's class
-          - type: ...       # optional: type of the literal parameter
-            value: ...      # optional: value of the literal parameter
+  - name: java_udf               # required: name of the function
+    from: class                  # required: source of the function
+    class: ...                   # required: fully qualified class name of the function
+    constructor:                 # optional: constructor parameters of the function class
+      - ...                      # optional: a literal parameter with implicit type
+      - class: ...               # optional: full class name of the parameter
+        constructor:             # optional: constructor parameters of the parameter's class
+          - type: ...            # optional: type of the literal parameter
+            value: ...           # optional: value of the literal parameter
+  - name: python_udf             # required: name of the function
+    from: python                 # required: source of the function 
+    fully-qualified-name: ...    # required: fully qualified class name of the function      
 {% endhighlight %}
 
-Make sure that the order and types of the specified parameters strictly match one of the constructors of your function class.
+For Java/Scala UDF, make sure that the order and types of the specified parameters strictly match one of the constructors of your function class.
 
 #### Constructor Parameters
 

--- a/docs/dev/table/sqlClient.zh.md
+++ b/docs/dev/table/sqlClient.zh.md
@@ -351,31 +351,42 @@ Both `connector` and `format` allow to define a property version (which is curre
 {% top %}
 
 ### User-defined Functions
+The SQL Client allows users to create custom, user-defined functions to be used in SQL queries. Currently, these functions are restricted to be defined programmatically in Java/Scala classes or Python files.
 
-The SQL Client allows users to create custom, user-defined functions to be used in SQL queries. Currently, these functions are restricted to be defined programmatically in Java/Scala classes.
+In order to provide a Java/Scala user-defined function, you need to first implement and compile a function class that extends `ScalarFunction`, `AggregateFunction` or `TableFunction` (see [User-defined Functions]({{ site.baseurl }}/dev/table/functions/udfs.html)). One or more functions can then be packaged into a dependency JAR for the SQL Client.
 
-In order to provide a user-defined function, you need to first implement and compile a function class that extends `ScalarFunction`, `AggregateFunction` or `TableFunction` (see [User-defined Functions]({{ site.baseurl }}/dev/table/functions/udfs.html)). One or more functions can then be packaged into a dependency JAR for the SQL Client.
+In order to provide a Python user-defined function, you need to write a Python function and decorate it with the `pyflink.table.udf.udf` or `pyflink.table.udf.udtf` decorator (see [Python UDFs]({{ site.baseurl }}/dev/table/python/python_udfs.html)). One or more functions can then be placed into a Python file. The Python file and related dependencies need to be specified via the configuration (see [Python Configuration]({{ site.baseurl }}/dev/table/python/python_config.html)) in environment file or the command line options (see [Command Line Usage]({{ site.baseurl }}/ops/cli.html#usage)).
 
 All functions must be declared in an environment file before being called. For each item in the list of `functions`, one must specify
 
 - a `name` under which the function is registered,
-- the source of the function using `from` (restricted to be `class` for now),
+- the source of the function using `from` (restricted to be `class` (Java/Scala UDF) or `python` (Python UDF) for now),
+
+The Java/Scala UDF must specify:
+
 - the `class` which indicates the fully qualified class name of the function and an optional list of `constructor` parameters for instantiation.
+
+The Python UDF must specify:
+
+- the `fully-qualified-name` which indicates the fully qualified name, i.e the "[module name].[object name]" of the function.
 
 {% highlight yaml %}
 functions:
-  - name: ...               # required: name of the function
-    from: class             # required: source of the function (can only be "class" for now)
-    class: ...              # required: fully qualified class name of the function
-    constructor:            # optional: constructor parameters of the function class
-      - ...                 # optional: a literal parameter with implicit type
-      - class: ...          # optional: full class name of the parameter
-        constructor:        # optional: constructor parameters of the parameter's class
-          - type: ...       # optional: type of the literal parameter
-            value: ...      # optional: value of the literal parameter
+  - name: java_udf               # required: name of the function
+    from: class                  # required: source of the function
+    class: ...                   # required: fully qualified class name of the function
+    constructor:                 # optional: constructor parameters of the function class
+      - ...                      # optional: a literal parameter with implicit type
+      - class: ...               # optional: full class name of the parameter
+        constructor:             # optional: constructor parameters of the parameter's class
+          - type: ...            # optional: type of the literal parameter
+            value: ...           # optional: value of the literal parameter
+  - name: python_udf             # required: name of the function
+    from: python                 # required: source of the function 
+    fully-qualified-name: ...    # required: fully qualified class name of the function      
 {% endhighlight %}
 
-Make sure that the order and types of the specified parameters strictly match one of the constructors of your function class.
+For Java/Scala UDF, make sure that the order and types of the specified parameters strictly match one of the constructors of your function class.
 
 #### Constructor Parameters
 

--- a/flink-table/flink-sql-client/bin/sql-client.sh
+++ b/flink-table/flink-sql-client/bin/sql-client.sh
@@ -58,18 +58,19 @@ log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4
 
 # get path of jar in /opt if it exist
 FLINK_SQL_CLIENT_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-sql-client.*.jar")
+FLINK_PYTHON_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-python.*.jar")
 
 # check if SQL client is already in classpath and must not be shipped manually
 if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar ]]; then
 
     # start client without jar
-    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.table.client.SqlClient "$@"
+    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_PYTHON_JAR"`" org.apache.flink.table.client.SqlClient "$@"
 
 # check if SQL client jar is in /opt
 elif [ -n "$FLINK_SQL_CLIENT_JAR" ]; then
 
     # start client with jar
-    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
+    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR:$FLINK_PYTHON_JAR"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
 
 # write error message to stderr
 else

--- a/flink-table/flink-sql-client/bin/sql-client.sh
+++ b/flink-table/flink-sql-client/bin/sql-client.sh
@@ -58,10 +58,16 @@ log_setting=(-Dlog.file="$log" -Dlog4j.configuration=file:"$FLINK_CONF_DIR"/log4
 
 # get path of jar in /opt if it exist
 FLINK_SQL_CLIENT_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-sql-client.*.jar")
-FLINK_PYTHON_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-python.*.jar")
+
+if [[ ! "$CC_CLASSPATH" =~ .*flink-python.*.jar ]]; then
+	FLINK_PYTHON_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-python.*.jar")
+	if [ -n "$FLINK_PYTHON_JAR" ]; then
+		CC_CLASSPATH="$CC_CLASSPATH:$FLINK_PYTHON_JAR"
+	fi
+fi
 
 # check if SQL client is already in classpath and must not be shipped manually
-if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar && "$CC_CLASSPATH" =~ .*flink-python.*.jar ]]; then
+if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar ]]; then
 
     # start client without jar
     exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.table.client.SqlClient "$@"
@@ -69,14 +75,8 @@ if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar && "$CC_CLASSPATH" =~ .*flink-
 # check if SQL client jar is in /opt
 elif [ -n "$FLINK_SQL_CLIENT_JAR" ]; then
 
-	classpath="$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR"
-
-	if [ -n "$FLINK_PYTHON_JAR" ]; then
-		classpath="$classpath:$FLINK_PYTHON_JAR"
-	fi
-
     # start client with jar
-    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$classpath"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
+    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
 
 # write error message to stderr
 else

--- a/flink-table/flink-sql-client/bin/sql-client.sh
+++ b/flink-table/flink-sql-client/bin/sql-client.sh
@@ -61,16 +61,22 @@ FLINK_SQL_CLIENT_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-sql-client.*.jar")
 FLINK_PYTHON_JAR=$(find "$FLINK_OPT_DIR" -regex ".*flink-python.*.jar")
 
 # check if SQL client is already in classpath and must not be shipped manually
-if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar ]]; then
+if [[ "$CC_CLASSPATH" =~ .*flink-sql-client.*.jar && "$CC_CLASSPATH" =~ .*flink-python.*.jar ]]; then
 
     # start client without jar
-    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_PYTHON_JAR"`" org.apache.flink.table.client.SqlClient "$@"
+    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" org.apache.flink.table.client.SqlClient "$@"
 
 # check if SQL client jar is in /opt
 elif [ -n "$FLINK_SQL_CLIENT_JAR" ]; then
 
+	classpath="$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR"
+
+	if [ -n "$FLINK_PYTHON_JAR" ]; then
+		classpath="$classpath:$FLINK_PYTHON_JAR"
+	fi
+
     # start client with jar
-    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$CC_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS:$FLINK_SQL_CLIENT_JAR:$FLINK_PYTHON_JAR"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
+    exec $JAVA_RUN $JVM_ARGS "${log_setting[@]}" -classpath "`manglePathList "$classpath"`" org.apache.flink.table.client.SqlClient "$@" --jar "`manglePath $FLINK_SQL_CLIENT_JAR`"
 
 # write error message to stderr
 else

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -96,12 +96,6 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-python_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- CLI for SQL CLI client -->
 		<dependency>
 			<groupId>org.jline</groupId>
@@ -504,6 +498,13 @@ under the License.
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-1.2-api</artifactId>
 			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-python_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -96,6 +96,12 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-python_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- CLI for SQL CLI client -->
 		<dependency>
 			<groupId>org.jline</groupId>

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -153,7 +153,7 @@ public class ExecutionContext<ClusterID> {
 
 		this.flinkConfig = flinkConfig;
 
-		if (hasPythonFunction(environment)) {
+		if (containsPythonFunction(environment)) {
 			dependencies = addPythonDependency(dependencies);
 		}
 
@@ -709,7 +709,7 @@ public class ExecutionContext<ClusterID> {
 		}
 	}
 
-	private boolean hasPythonFunction(Environment environment) {
+	private boolean containsPythonFunction(Environment environment) {
 		return environment.getFunctions().values().stream().anyMatch(f ->
 			FunctionDescriptorValidator.FROM_VALUE_PYTHON.equals(
 				f.getDescriptor().toProperties().get(FunctionDescriptorValidator.FROM)));
@@ -725,13 +725,11 @@ public class ExecutionContext<ClusterID> {
 				.getProtectionDomain().getCodeSource().getLocation();
 			if (Paths.get(location.toURI()).toFile().isFile()) {
 				newDependencies.add(location);
-			} else {
-				throw new FlinkException("flink-python module detected but is not a jar file: " + location + ".");
 			}
-		} catch (URISyntaxException | ClassNotFoundException | FlinkException e) {
-			LOG.warn("Python UDF detected but flink-python jar not found. " +
-				"If you starts SQL-Client via `sql-client.sh`, " +
-				"please add the flink-python jar via `-j` command option manually.", e);
+		} catch (URISyntaxException | ClassNotFoundException e) {
+			throw new SqlExecutionException("Python UDF detected but flink-python jar not found. " +
+				"If you starts SQL-Client via `sql-client.sh`, please add the flink-python jar " +
+				"via `-j` command option manually.", e);
 		}
 		return newDependencies;
 	}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -450,6 +450,7 @@ public class ExecutionContext<ClusterID> {
 		final boolean noInheritedState = sessionState == null;
 		// Step 0.0 Initialize the table configuration.
 		final TableConfig config = new TableConfig();
+		config.addConfiguration(flinkConfig);
 		environment.getConfiguration().asMap().forEach((k, v) ->
 				config.getConfiguration().setString(k, v));
 		config.setSqlDialect(environment.getExecution().getSqlDialect());
@@ -525,7 +526,6 @@ public class ExecutionContext<ClusterID> {
 			CatalogManager catalogManager,
 			ModuleManager moduleManager,
 			FunctionCatalog functionCatalog) {
-		config.addConfiguration(flinkConfig);
 		if (environment.getExecution().isStreamingPlanner()) {
 			streamExecEnv = createStreamExecutionEnvironment();
 			execEnv = null;

--- a/flink-table/flink-sql-client/src/test/resources/test-sql-client-python-functions.yaml
+++ b/flink-table/flink-sql-client/src/test/resources/test-sql-client-python-functions.yaml
@@ -1,0 +1,32 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+#==============================================================================
+# TEST ENVIRONMENT FILE
+# This test file is to check whether the functions can be successfully registered.
+#==============================================================================
+
+execution:
+  planner: blink
+  type: batch
+  result-mode: table
+
+functions:
+  - name: pythonUDF
+    from: python
+    fully-qualified-name: test.func1

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptor.java
@@ -29,6 +29,7 @@ import java.util.Map;
 public class FunctionDescriptor implements Descriptor {
 	private String from;
 	private ClassInstance classInstance;
+	private String fullyQualifiedName;
 
 	/**
 	 * Creates a function from a class description.
@@ -36,6 +37,14 @@ public class FunctionDescriptor implements Descriptor {
 	public FunctionDescriptor fromClass(ClassInstance classType) {
 		from = FunctionDescriptorValidator.FROM_VALUE_CLASS;
 		this.classInstance = classType;
+		this.fullyQualifiedName = null;
+		return this;
+	}
+
+	public FunctionDescriptor fromPython(String fullyQualifiedName) {
+		from = FunctionDescriptorValidator.FROM_VALUE_PYTHON;
+		this.fullyQualifiedName = fullyQualifiedName;
+		this.classInstance = null;
 		return this;
 	}
 
@@ -50,6 +59,9 @@ public class FunctionDescriptor implements Descriptor {
 		}
 		if (classInstance != null) {
 			properties.putProperties(classInstance.toProperties());
+		}
+		if (fullyQualifiedName != null) {
+			properties.putString(PythonFunctionValidator.FULLY_QUALIFIED_NAME, fullyQualifiedName);
 		}
 		return properties.asMap();
 	}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptor.java
@@ -41,13 +41,6 @@ public class FunctionDescriptor implements Descriptor {
 		return this;
 	}
 
-	public FunctionDescriptor fromPython(String fullyQualifiedName) {
-		from = FunctionDescriptorValidator.FROM_VALUE_PYTHON;
-		this.fullyQualifiedName = fullyQualifiedName;
-		this.classInstance = null;
-		return this;
-	}
-
 	/**
 	 * Converts this descriptor into a set of properties.
 	 */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptorValidator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/FunctionDescriptorValidator.java
@@ -33,11 +33,13 @@ public class FunctionDescriptorValidator implements DescriptorValidator {
 
 	public static final String FROM = "from";
 	public static final String FROM_VALUE_CLASS = "class";
+	public static final String FROM_VALUE_PYTHON = "python";
 
 	@Override
 	public void validate(DescriptorProperties properties) {
 		Map<String, Consumer<String>> enumValidation = new HashMap<>();
 		enumValidation.put(FROM_VALUE_CLASS, s -> new ClassInstanceValidator().validate(properties));
+		enumValidation.put(FROM_VALUE_PYTHON, s -> new PythonFunctionValidator().validate(properties));
 
 		// check for 'from'
 		if (properties.containsKey(FROM)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/PythonFunctionValidator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/PythonFunctionValidator.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.descriptors;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * Validator of python function.
  */
+@Internal
 public class PythonFunctionValidator implements DescriptorValidator {
 
 	public static final String FULLY_QUALIFIED_NAME = "fully-qualified-name";

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/PythonFunctionValidator.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/descriptors/PythonFunctionValidator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.descriptors;
+
+/**
+ * Validator of python function.
+ */
+public class PythonFunctionValidator implements DescriptorValidator {
+
+	public static final String FULLY_QUALIFIED_NAME = "fully-qualified-name";
+
+	@Override
+	public void validate(DescriptorProperties properties) {
+		properties.validateString(FULLY_QUALIFIED_NAME, false);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
@@ -122,7 +122,9 @@ public class FunctionService {
 				instance = PythonFunctionUtils.getPythonFunction(fullyQualifiedName, config);
 				break;
 			default:
-				throw new ValidationException("Unsupported function descriptor: " + properties);
+				throw new ValidationException(String.format(
+						"Unsupported function descriptor: %s",
+						properties.getString(FunctionDescriptorValidator.FROM)));
 		}
 
 		if (!UserDefinedFunction.class.isAssignableFrom(instance.getClass())) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/FunctionService.java
@@ -28,12 +28,12 @@ import org.apache.flink.table.descriptors.FunctionDescriptorValidator;
 import org.apache.flink.table.descriptors.HierarchyDescriptorValidator;
 import org.apache.flink.table.descriptors.LiteralValueValidator;
 import org.apache.flink.table.descriptors.PythonFunctionValidator;
+import org.apache.flink.table.functions.python.utils.PythonFunctionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -119,22 +119,7 @@ public class FunctionService {
 				break;
 			case FunctionDescriptorValidator.FROM_VALUE_PYTHON:
 				String fullyQualifiedName = properties.getString(PythonFunctionValidator.FULLY_QUALIFIED_NAME);
-				try {
-					Class pythonFunctionFactory = Class.forName(
-						"org.apache.flink.client.python.PythonFunctionFactory",
-						true,
-						Thread.currentThread().getContextClassLoader());
-					instance = pythonFunctionFactory.getMethod(
-						"getPythonFunction",
-						String.class,
-						ReadableConfig.class)
-						.invoke(null, fullyQualifiedName, config);
-				} catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException |
-						InvocationTargetException e) {
-					throw new IllegalStateException(
-						String.format(
-							"Instantiating python function '%s' failed.", fullyQualifiedName), e);
-				}
+				instance = PythonFunctionUtils.getPythonFunction(fullyQualifiedName, config);
 				break;
 			default:
 				throw new ValidationException("Unsupported function descriptor: " + properties);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
@@ -28,7 +28,7 @@ import java.lang.reflect.InvocationTargetException;
  * Utilities for creating PythonFunction.
  */
 @Internal
-public enum  PythonFunctionUtils {
+public enum PythonFunctionUtils {
 	;
 
 	public static PythonFunction getPythonFunction(String fullyQualifiedName, ReadableConfig config) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/utils/PythonFunctionUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.python.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.functions.python.PythonFunction;
+
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Utilities for creating PythonFunction.
+ */
+@Internal
+public enum  PythonFunctionUtils {
+	;
+
+	public static PythonFunction getPythonFunction(String fullyQualifiedName, ReadableConfig config) {
+		try {
+			Class pythonFunctionFactory = Class.forName(
+				"org.apache.flink.client.python.PythonFunctionFactory",
+				true,
+				Thread.currentThread().getContextClassLoader());
+			return (PythonFunction) pythonFunctionFactory.getMethod(
+				"getPythonFunction",
+				String.class,
+				ReadableConfig.class)
+				.invoke(null, fullyQualifiedName, config);
+		} catch (IllegalAccessException | ClassNotFoundException | NoSuchMethodException |
+			InvocationTargetException e) {
+			throw new IllegalStateException(
+				String.format(
+					"Instantiating python function '%s' failed.", fullyQualifiedName), e);
+		}
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request support registering Python UDF in SQL Client.*


## Brief change log

  - *Let the Sql client environment file parser module support "from: python".*
  - *Add `flink-python` jar to the classpath of SQL Client.*
  - *If the environment file contains python UDF, add the `flink-python` jar to user jars.*


## Verifying this change

This change is already covered by existing tests, such as *ExecutionContextTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
