### PR TITLE
[FLINK-17373][table] Support the NULL type for function calls

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -718,6 +718,10 @@ public final class DataTypes {
 	 *
 	 * <p>The null type is an extension to the SQL standard.
 	 *
+	 * <p>Note: The runtime does not support this type. It is a pure helper type during translation and
+	 * planning. Table columns cannot be declared with this type. Functions cannot declare return types
+	 * of this type.
+	 *
 	 * @see NullType
 	 */
 	public static DataType NULL() {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/NullType.java
@@ -33,6 +33,10 @@ import java.util.List;
  * well as bridging to formats such as JSON or Avro that define such a type as well.
  *
  * <p>The serialized string representation is {@code NULL}.
+ *
+ * <p>Note: The runtime does not support this type. It is a pure helper type during translation and
+ * planning. Table columns cannot be declared with this type. Functions cannot declare return types
+ * of this type.
  */
 @PublicEvolving
 public final class NullType extends LogicalType {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeGeneralization.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeGeneralization.java
@@ -184,6 +184,10 @@ public final class LogicalTypeGeneralization {
 
 		if (foundType != null) {
 			final LogicalType typeWithNullability = foundType.copy(hasNullableTypes);
+			// NULL is reserved for untyped literals only
+			if (hasRoot(typeWithNullability, NULL)) {
+				return Optional.empty();
+			}
 			return Optional.of(typeWithNullability);
 		}
 		return Optional.empty();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeGeneralizationTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/LogicalTypeGeneralizationTest.java
@@ -107,7 +107,7 @@ public class LogicalTypeGeneralizationTest {
 				// NULL only
 				{
 					Arrays.asList(new NullType(), new NullType()),
-					new NullType()
+					null
 				},
 
 				// NULL with other types

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -452,6 +452,12 @@ public class InputTypeStrategiesTest {
 				.expectErrorMessage("Invalid number of arguments. At least 1 arguments expected but 0 passed."),
 
 			TestSpec.forStrategy(
+				"Array strategy fails for null arguments",
+				InputTypeStrategies.SPECIFIC_FOR_ARRAY)
+				.calledWithArgumentTypes(DataTypes.NULL())
+				.expectErrorMessage("Invalid input arguments."),
+
+			TestSpec.forStrategy(
 				"Map strategy infers common types",
 				InputTypeStrategies.SPECIFIC_FOR_MAP)
 				.calledWithArgumentTypes(

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/stream/sql/NullTypeTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/plan/stream/sql/NullTypeTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.annotation.DataTypeHint;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.table.planner.utils.JavaStreamTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Test;
+
+/**
+ * Tests for usages of {@link DataTypes#NULL()}.
+ */
+public class NullTypeTest extends TableTestBase {
+
+	private final JavaStreamTableTestUtil util = javaStreamTestUtil();
+
+	@Test
+	public void testValues() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Illegal use of 'NULL'");
+		util.verifyPlan("SELECT * FROM (VALUES (1, NULL), (2, NULL)) AS T(a, b)");
+	}
+
+	@Test
+	public void testValuesWithoutTypeCoercion() {
+		// should work if we enable type coercion, works already in Table API
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Illegal use of 'NULL'");
+		util.verifyPlan("SELECT * FROM (VALUES (1, NULL), (2, 1)) AS T(a, b)");
+	}
+
+	@Test
+	public void testSetOperationWithoutTypeCoercion() {
+		// we might want to support type coercion here
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Parameters must be of the same type");
+		util.verifyPlan("SELECT ARRAY[1,2] IN (ARRAY[1], ARRAY[1,2], ARRAY[NULL, NULL, NULL])");
+	}
+
+	@Test
+	public void testBuiltInFunction() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Illegal use of 'NULL'");
+		util.verifyPlan("SELECT ABS(NULL)");
+	}
+
+	@Test
+	public void testArrayConstructor() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Parameters must be of the same type");
+		util.verifyPlan("SELECT ARRAY[NULL]");
+	}
+
+	@Test
+	public void testMapConstructor() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("Parameters must be of the same type");
+		util.verifyPlan("SELECT MAP[NULL, NULL]");
+	}
+
+	@Test
+	public void testFunctionReturningNull() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("SQL validation failed. Invalid function call");
+		util.addTemporarySystemFunction("NullTypeFunction", NullTypeFunction.class);
+		util.verifyPlan("SELECT NullTypeFunction(12)");
+	}
+
+	@Test
+	public void testNestedNull() {
+		expectedException().expect(ValidationException.class);
+		expectedException().expectMessage("SQL validation failed. Invalid function call");
+		util.addTemporarySystemFunction("NestedNullTypeFunction", NestedNullTypeFunction.class);
+		util.verifyPlan("SELECT NestedNullTypeFunction(12)");
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Function that contains an invalid null type.
+	 */
+	@SuppressWarnings("unused")
+	public static class NullTypeFunction extends ScalarFunction {
+
+		public @DataTypeHint("NULL") Object eval(Integer i) {
+			return null;
+		}
+	}
+
+	/**
+	 * Function that contains an invalid nested null type.
+	 */
+	@SuppressWarnings("unused")
+	public static class NestedNullTypeFunction extends ScalarFunction {
+
+		public @DataTypeHint("ARRAY<NULL>") Object eval(Integer i) {
+			return null;
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/calcite/FlinkTypeFactoryTest.scala
@@ -18,8 +18,12 @@
 
 package org.apache.flink.table.planner.calcite
 
-import org.apache.flink.table.types.logical.{ArrayType, BigIntType, BooleanType, DateType, DecimalType, DoubleType, FloatType, IntType, LocalZonedTimestampType, LogicalType, MapType, RowType, SmallIntType, TimeType, TimestampType, TinyIntType, VarBinaryType, VarCharType}
+import java.time.DayOfWeek
 
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot
+import org.apache.flink.table.types.logical._
 import org.junit.{Assert, Test}
 
 class FlinkTypeFactoryTest {
@@ -35,11 +39,13 @@ class FlinkTypeFactoryTest {
           typeFactory.createFieldTypeFromLogicalType(t.copy(true)))
       )
 
-      Assert.assertEquals(
-        t.copy(false),
-        FlinkTypeFactory.toLogicalType(
-          typeFactory.createFieldTypeFromLogicalType(t.copy(false)))
-      )
+      if (!hasRoot(t, LogicalTypeRoot.NULL)) {
+        Assert.assertEquals(
+          t.copy(false),
+          FlinkTypeFactory.toLogicalType(
+            typeFactory.createFieldTypeFromLogicalType(t.copy(false)))
+        )
+      }
 
       // twice for cache.
       Assert.assertEquals(
@@ -48,13 +54,16 @@ class FlinkTypeFactoryTest {
           typeFactory.createFieldTypeFromLogicalType(t.copy(true)))
       )
 
-      Assert.assertEquals(
-        t.copy(false),
-        FlinkTypeFactory.toLogicalType(
-          typeFactory.createFieldTypeFromLogicalType(t.copy(false)))
-      )
+      if (!hasRoot(t, LogicalTypeRoot.NULL)) {
+        Assert.assertEquals(
+          t.copy(false),
+          FlinkTypeFactory.toLogicalType(
+            typeFactory.createFieldTypeFromLogicalType(t.copy(false)))
+        )
+      }
     }
 
+    test(new NullType())
     test(new BooleanType())
     test(new TinyIntType())
     test(new VarCharType(VarCharType.MAX_LENGTH))
@@ -72,6 +81,9 @@ class FlinkTypeFactoryTest {
     test(new ArrayType(new DoubleType()))
     test(new MapType(new DoubleType(), new VarCharType(VarCharType.MAX_LENGTH)))
     test(RowType.of(new DoubleType(), new VarCharType(VarCharType.MAX_LENGTH)))
+    test(new RawType[DayOfWeek](
+      classOf[DayOfWeek],
+      new KryoSerializer[DayOfWeek](classOf[DayOfWeek], new ExecutionConfig)))
   }
 
   @Test def testDecimalInferType(): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -259,6 +259,20 @@ abstract class TableTestUtilBase(test: TableTestBase, isStreamingMode: Boolean) 
     getTableEnv.registerFunction(name, function)
   }
 
+  /**
+   * Registers a [[UserDefinedFunction]] according to FLIP-65.
+   */
+  def addTemporarySystemFunction(name: String, function: UserDefinedFunction): Unit = {
+    getTableEnv.createTemporarySystemFunction(name, function)
+  }
+
+  /**
+   * Registers a [[UserDefinedFunction]] class according to FLIP-65.
+   */
+  def addTemporarySystemFunction(name: String, function: Class[_ <: UserDefinedFunction]): Unit = {
+    getTableEnv.createTemporarySystemFunction(name, function)
+  }
+
   def verifyPlan(sql: String): Unit = {
     doVerifyPlan(
       sql,
@@ -562,13 +576,6 @@ abstract class TableTestUtil(
     val table = testingTableEnv.createTable(operation)
     testingTableEnv.registerTable(name, table)
     testingTableEnv.scan(name)
-  }
-
-  /**
-   * Registers a [[UserDefinedFunction]] according to FLIP-65.
-   */
-  def addTemporarySystemFunction(name: String, function: UserDefinedFunction): Unit = {
-    testingTableEnv.createTemporarySystemFunction(name, function)
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the change

Enables support for untyped NULL literals in function calls. The null type remains a helper type. We don't expose this type through the DDL or allow it as a function return type. It will not be used during runtime for serialization. The PR might not cover all cases where NULL enters the system, entry points of NULL into the type factory should be avoided.

## Brief change log

- Don't allow a NULL type during type generalization
- Generate a null literal for FLIP-65 functions

## Verifying this change

This change added tests and can be verified as follows: `FunctionITCase`, `NullTypeTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
