### PR TITLE
[FLINK-17267] [table] legacy planner supports explain insert operation and introduce TableEnvironment#explainSql/Introduce TableEnvironment#explainSql api api 

### DIFF
--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -70,6 +70,7 @@ from pyflink.table.sources import TableSource, CsvTableSource
 from pyflink.table.types import DataTypes, UserDefinedType, Row
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.udf import FunctionContext, ScalarFunction
+from pyflink.table.explain_detail import ExplainDetail
 
 __all__ = [
     'TableEnvironment',
@@ -93,5 +94,6 @@ __all__ = [
     'TableSchema',
     'FunctionContext',
     'ScalarFunction',
-    'SqlDialect'
+    'SqlDialect',
+    'ExplainDetail'
 ]

--- a/flink-python/pyflink/table/explain_detail.py
+++ b/flink-python/pyflink/table/explain_detail.py
@@ -1,0 +1,34 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+__all__ = ['ExplainDetail']
+
+
+class ExplainDetail(object):
+    """
+    ExplainDetail defines the types of details for explain result.
+    """
+
+    # The cost information on physical rel node estimated by optimizer.
+    # e.g. TableSourceScan(..., cumulative cost = {1.0E8 rows, 1.0E8 cpu, 2.4E9 io, 0.0 network,
+    # 0.0 memory}
+    ESTIMATED_COST = 0
+
+    # The changelog traits produced by a physical rel node.
+    # e.g. GroupAggregate(..., changelogMode=[I,UA,D])
+    CHANGELOG_TRAITS = 1

--- a/flink-python/pyflink/table/explain_detail.py
+++ b/flink-python/pyflink/table/explain_detail.py
@@ -29,6 +29,6 @@ class ExplainDetail(object):
     # 0.0 memory}
     ESTIMATED_COST = 0
 
-    # The changelog traits produced by a physical rel node.
+    # The changelog mode produced by a physical rel node.
     # e.g. GroupAggregate(..., changelogMode=[I,UA,D])
-    CHANGELOG_TRAITS = 1
+    CHANGELOG_MODE = 1

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -721,11 +721,10 @@ class Table(object):
 
     def explain(self, *extra_details):
         """
-        Returns the AST of this table and the execution plan to compute
-        the result of this table.
+        Returns the AST of this table and the execution plan.
 
         :param extra_details: The extra explain details which the explain result should include,
-                              e.g. estimated cost, change log trait for streaming
+                              e.g. estimated cost, changelog mode for streaming
         :type extra_details: tuple[ExplainDetail] (variable-length arguments of ExplainDetail)
         :return: The statement for which the AST and execution plan will be returned.
         :rtype: str

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -21,6 +21,7 @@ from pyflink.java_gateway import get_gateway
 from pyflink.table.table_schema import TableSchema
 
 from pyflink.util.utils import to_jarray
+from pyflink.util.utils import to_j_explain_detail_arr
 
 __all__ = ['Table', 'GroupedTable', 'GroupWindowedTable', 'OverWindowedTable', 'WindowGroupedTable']
 
@@ -717,6 +718,20 @@ class Table(object):
         :return: The table result.
         """
         self._j_table.executeInsert(table_path, overwrite)
+
+    def explain(self, *extra_details):
+        """
+        Returns the AST of this table and the execution plan to compute
+        the result of this table.
+
+        :param extra_details: The extra explain details which the explain result should include,
+                              e.g. estimated cost, change log trait for streaming
+        :type extra_details: tuple[ExplainDetail] (variable-length arguments of ExplainDetail)
+        :return: The statement for which the AST and execution plan will be returned.
+        :rtype: str
+        """
+        j_extra_details = to_j_explain_detail_arr(extra_details)
+        return self._j_table.explain(j_extra_details)
 
     def __str__(self):
         return self._j_table.toString()

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -36,7 +36,8 @@ from pyflink.table import Table
 from pyflink.table.types import _to_java_type, _create_type_verifier, RowType, DataType, \
     _infer_schema_from_data, _create_converter, from_arrow_type, RowField, create_arrow_schema
 from pyflink.util import utils
-from pyflink.util.utils import get_j_env_configuration, is_local_deployment, load_java_class
+from pyflink.util.utils import get_j_env_configuration, is_local_deployment, load_java_class, \
+    to_j_explain_detail_arr
 
 __all__ = [
     'BatchTableEnvironment',
@@ -467,6 +468,23 @@ class TableEnvironment(object):
             return self._j_tenv.explain(extended)
         else:
             return self._j_tenv.explain(table._j_table, extended)
+
+    def explain_sql(self, stmt, *extra_details):
+        """
+        Returns the AST of the specified statement and the execution plan to compute
+        the result of the given statement.
+
+        :param stmt: The statement for which the AST and execution plan will be returned.
+        :type stmt: str
+        :param extra_details: The extra explain details which the explain result should include,
+                              e.g. estimated cost, change log trait for streaming
+        :type extra_details: tuple[ExplainDetail] (variable-length arguments of ExplainDetail)
+        :return: The statement for which the AST and execution plan will be returned.
+        :rtype: str
+        """
+
+        j_extra_details = to_j_explain_detail_arr(extra_details)
+        return self._j_tenv.explainSql(stmt, j_extra_details)
 
     def sql_query(self, query):
         """

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -471,13 +471,12 @@ class TableEnvironment(object):
 
     def explain_sql(self, stmt, *extra_details):
         """
-        Returns the AST of the specified statement and the execution plan to compute
-        the result of the given statement.
+        Returns the AST of the specified statement and the execution plan.
 
         :param stmt: The statement for which the AST and execution plan will be returned.
         :type stmt: str
         :param extra_details: The extra explain details which the explain result should include,
-                              e.g. estimated cost, change log trait for streaming
+                              e.g. estimated cost, changelog mode for streaming
         :type extra_details: tuple[ExplainDetail] (variable-length arguments of ExplainDetail)
         :return: The statement for which the AST and execution plan will be returned.
         :rtype: str

--- a/flink-python/pyflink/table/tests/test_explain.py
+++ b/flink-python/pyflink/table/tests/test_explain.py
@@ -1,0 +1,40 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase
+from pyflink.table.explain_detail import ExplainDetail
+
+
+class StreamTableExplainTests(PyFlinkStreamTableTestCase):
+
+    def test_explain(self):
+        t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
+        result = t.group_by("c").select("a.sum, c as b").explain(ExplainDetail.CHANGELOG_TRAITS)
+
+        assert isinstance(result, str)
+
+
+if __name__ == '__main__':
+    import unittest
+
+    try:
+        import xmlrunner
+        testRunner = xmlrunner.XMLTestRunner(output='target/test-reports')
+    except ImportError:
+        testRunner = None
+    unittest.main(testRunner=testRunner, verbosity=2)

--- a/flink-python/pyflink/table/tests/test_explain.py
+++ b/flink-python/pyflink/table/tests/test_explain.py
@@ -24,7 +24,7 @@ class StreamTableExplainTests(PyFlinkStreamTableTestCase):
 
     def test_explain(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
-        result = t.group_by("c").select("a.sum, c as b").explain(ExplainDetail.CHANGELOG_TRAITS)
+        result = t.group_by("c").select("a.sum, c as b").explain(ExplainDetail.CHANGELOG_MODE)
 
         assert isinstance(result, str)
 

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -265,7 +265,7 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
             source_sink_utils.TestAppendSink(field_names, field_types))
 
         result = t_env.explain_sql(
-            "select a + 1, b, c from %s" % source, ExplainDetail.ESTIMATED_COST)
+            "select a + 1, b, c from %s" % source, ExplainDetail.CHANGELOG_MODE)
 
         assert isinstance(result, str)
 

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -400,8 +400,9 @@ class BatchTableEnvironmentTests(TableEnvironmentTest, PyFlinkBatchTableTestCase
         t_env.sql_update("insert into sink1 select * from %s where a > 100" % source)
         t_env.sql_update("insert into sink2 select * from %s where a < 100" % source)
 
-        with self.assertRaises(TableException):
-            t_env.explain(extended=True)
+        actual = t_env.explain(extended=True)
+
+        assert isinstance(actual, str)
 
     def test_create_table_environment(self):
         table_config = TableConfig()

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -35,8 +35,8 @@ from pyflink.table.types import RowType
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, PyFlinkBatchTableTestCase, \
     PyFlinkBlinkBatchTableTestCase
-from pyflink.util.exceptions import TableException
 from pyflink.util.utils import get_j_env_configuration
+from pyflink.table.explain_detail import ExplainDetail
 
 
 class TableEnvironmentTest(object):
@@ -241,6 +241,33 @@ class StreamTableEnvironmentTests(TableEnvironmentTest, PyFlinkStreamTableTestCa
 
         actual = t_env.explain(extended=True)
         assert isinstance(actual, str)
+
+    def test_explain_sql_without_explain_detail(self):
+        t_env = self.t_env
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env.register_table_sink(
+            "sinks",
+            source_sink_utils.TestAppendSink(field_names, field_types))
+
+        result = t_env.explain_sql("select a + 1, b, c from %s" % source)
+
+        assert isinstance(result, str)
+
+    def test_explain_sql_with_explain_detail(self):
+        t_env = self.t_env
+        source = t_env.from_elements([(1, "Hi", "Hello"), (2, "Hello", "Hello")], ["a", "b", "c"])
+        field_names = ["a", "b", "c"]
+        field_types = [DataTypes.BIGINT(), DataTypes.STRING(), DataTypes.STRING()]
+        t_env.register_table_sink(
+            "sinks",
+            source_sink_utils.TestAppendSink(field_names, field_types))
+
+        result = t_env.explain_sql(
+            "select a + 1, b, c from %s" % source, ExplainDetail.ESTIMATED_COST)
+
+        assert isinstance(result, str)
 
     def test_create_table_environment(self):
         table_config = TableConfig()

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -134,8 +134,8 @@ def to_j_explain_detail_arr(p_extra_details):
     gateway = get_gateway()
 
     def to_j_explain_detail(p_extra_detail):
-        if p_extra_detail == ExplainDetail.CHANGELOG_TRAITS:
-            return gateway.jvm.org.apache.flink.table.api.ExplainDetail.CHANGELOG_TRAITS
+        if p_extra_detail == ExplainDetail.CHANGELOG_MODE:
+            return gateway.jvm.org.apache.flink.table.api.ExplainDetail.CHANGELOG_MODE
         else:
             return gateway.jvm.org.apache.flink.table.api.ExplainDetail.ESTIMATED_COST
 

--- a/flink-python/pyflink/util/utils.py
+++ b/flink-python/pyflink/util/utils.py
@@ -125,3 +125,23 @@ def add_jars_to_context_class_loader(jar_urls):
     new_classloader = gateway.jvm.java.net.URLClassLoader(
         to_jarray(gateway.jvm.java.net.URL, j_urls), context_classloader)
     gateway.jvm.Thread.currentThread().setContextClassLoader(new_classloader)
+
+
+def to_j_explain_detail_arr(p_extra_details):
+    # sphinx will check "import loop" when generating doc,
+    # use local import to avoid above error
+    from pyflink.table.explain_detail import ExplainDetail
+    gateway = get_gateway()
+
+    def to_j_explain_detail(p_extra_detail):
+        if p_extra_detail == ExplainDetail.CHANGELOG_TRAITS:
+            return gateway.jvm.org.apache.flink.table.api.ExplainDetail.CHANGELOG_TRAITS
+        else:
+            return gateway.jvm.org.apache.flink.table.api.ExplainDetail.ESTIMATED_COST
+
+    _len = len(p_extra_details) if p_extra_details else 0
+    j_arr = gateway.new_array(gateway.jvm.org.apache.flink.table.api.ExplainDetail, _len)
+    for i in range(0, _len):
+        j_arr[i] = to_j_explain_detail(p_extra_details[i])
+
+    return j_arr

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+/**
+ * ExplainDetail defines the types of details for explain result.
+ */
+public enum ExplainDetail {
+	/**
+	 * The cost information on physical rel node estimated by optimizer.
+	 * e.g. TableSourceScan(..., cumulative cost = {1.0E8 rows, 1.0E8 cpu, 2.4E9 io, 0.0 network, 0.0 memory}
+	 */
+	ESTIMATED_COST,
+
+	/**
+	 * The changelog traits produced by a physical rel node.
+	 * e.g. GroupAggregate(..., changelogMode=[I,UA,D])
+	 */
+	CHANGELOG_TRAITS
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/ExplainDetail.java
@@ -29,8 +29,8 @@ public enum ExplainDetail {
 	ESTIMATED_COST,
 
 	/**
-	 * The changelog traits produced by a physical rel node.
+	 * The changelog mode produced by a physical rel node.
 	 * e.g. GroupAggregate(..., changelogMode=[I,UA,D])
 	 */
-	CHANGELOG_TRAITS
+	CHANGELOG_MODE
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -1473,4 +1473,14 @@ public interface Table {
 	 * @return The insert operation execution result.
 	 */
 	TableResult executeInsert(String tablePath, boolean overwrite);
+
+	/**
+	 * Returns the AST of this table and the execution plan to compute
+	 * the result of this table.
+	 *
+	 * @param extraDetails The extra explain details which the explain result should include,
+	 *   e.g. estimated cost, change log trait for streaming
+	 * @return AST and the execution plan.
+	 */
+	String explain(ExplainDetail... extraDetails);
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -828,7 +828,7 @@ public interface TableEnvironment {
 	 * the result of the given {@link Table}.
 	 *
 	 * @param table The table for which the AST and execution plan will be returned.
-	 * @param extended if the plan should contain additional properties such as
+	 * @param extended if the plan should contain additional properties,
 	 * e.g. estimated cost, traits
 	 */
 	String explain(Table table, boolean extended);
@@ -837,10 +837,21 @@ public interface TableEnvironment {
 	 * Returns the AST of the specified Table API and SQL queries and the execution plan to compute
 	 * the result of multiple-sinks plan.
 	 *
-	 * @param extended if the plan should contain additional properties such as
+	 * @param extended if the plan should contain additional properties,
 	 * e.g. estimated cost, traits
 	 */
 	String explain(boolean extended);
+
+	/**
+	 * Returns the AST of the specified statement and the execution plan to compute
+	 * the result of the given statement.
+	 *
+	 * @param statement The statement for which the AST and execution plan will be returned.
+	 * @param extraDetails The extra explain details which the explain result should include,
+	 *   e.g. estimated cost, change log trait for streaming
+	 * @return AST and the execution plan.
+	 */
+	String explainSql(String statement, ExplainDetail... extraDetails);
 
 	/**
 	 * Returns completion hints for the given statement at the given cursor position.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -614,6 +614,11 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	@Override
+	public String explain(List<Operation> operations, ExplainDetail... extraDetails) {
+		return planner.explain(operations, extraDetails);
+	}
+
+	@Override
 	public String[] getCompletionHints(String statement, int position) {
 		return planner.getCompletionHints(statement, position);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -614,7 +614,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	@Override
-	public String explain(List<Operation> operations, ExplainDetail... extraDetails) {
+	public String explainInternal(List<Operation> operations, ExplainDetail... extraDetails) {
 		return planner.explain(operations, extraDetails);
 	}
 
@@ -1002,7 +1002,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	protected ExplainDetail[] getExplainDetails(boolean extended) {
 		if (extended) {
 			if (isStreamingMode) {
-				return new ExplainDetail[] { ExplainDetail.ESTIMATED_COST, ExplainDetail.CHANGELOG_TRAITS };
+				return new ExplainDetail[] { ExplainDetail.ESTIMATED_COST, ExplainDetail.CHANGELOG_MODE };
 			} else {
 				return new ExplainDetail[] { ExplainDetail.ESTIMATED_COST };
 			}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -878,6 +878,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
 					.tableSchema(TableSchema.builder().field("result", DataTypes.STRING()).build())
 					.data(Collections.singletonList(Row.of(explanation)))
+					.setPrintStyle(TableResultImpl.PrintStyle.RAW_CONTENT)
 					.build();
 
 		} else {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -72,6 +72,7 @@ import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CatalogQueryOperation;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
+import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
@@ -852,6 +853,14 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 			return buildShowResult(listFunctions());
 		} else if (operation instanceof ShowViewsOperation) {
 			return buildShowResult(listViews());
+		} else if (operation instanceof ExplainOperation) {
+			String explanation = planner.explain(Collections.singletonList(((ExplainOperation) operation).getChild()), false);
+			return TableResultImpl.builder()
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.tableSchema(TableSchema.builder().field("result", DataTypes.STRING()).build())
+					.data(Collections.singletonList(Row.of(explanation)))
+					.build();
+
 		} else {
 			throw new TableException(UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG);
 		}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -19,11 +19,13 @@
 package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.Operation;
 
 import java.util.List;
 
@@ -56,4 +58,16 @@ interface TableEnvironmentInternal extends TableEnvironment {
 	 * @return the affected row counts (-1 means unknown).
 	 */
 	TableResult executeInternal(List<ModifyOperation> operations);
+
+	/**
+	 * Returns the AST of this table and the execution plan to compute
+	 * the result of this table.
+	 *
+	 * @param operations The operations to be explained.
+	 * @param extraDetails The extra explain details which the explain result should include,
+	 *   e.g. estimated cost, changelog mode for streaming
+	 * @return AST and the execution plan.
+	 */
+	String explain(List<Operation> operations, ExplainDetail... extraDetails);
+
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentInternal.java
@@ -68,6 +68,6 @@ interface TableEnvironmentInternal extends TableEnvironment {
 	 *   e.g. estimated cost, changelog mode for streaming
 	 * @return AST and the execution plan.
 	 */
-	String explain(List<Operation> operations, ExplainDetail... extraDetails);
+	String explainInternal(List<Operation> operations, ExplainDetail... extraDetails);
 
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -567,7 +567,7 @@ public class TableImpl implements Table {
 
 	@Override
 	public String explain(ExplainDetail... extraDetails) {
-		return tableEnvironment.explain(Collections.singletonList(getQueryOperation()), extraDetails);
+		return tableEnvironment.explainInternal(Collections.singletonList(getQueryOperation()), extraDetails);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.api.internal;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.AggregatedTable;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.FlatAggregateTable;
 import org.apache.flink.table.api.GroupWindow;
 import org.apache.flink.table.api.GroupWindowedTable;
@@ -562,6 +563,11 @@ public class TableImpl implements Table {
 				Collections.emptyMap());
 
 		return tableEnvironment.executeInternal(Collections.singletonList(operation));
+	}
+
+	@Override
+	public String explain(ExplainDetail... extraDetails) {
+		return tableEnvironment.explain(Collections.singletonList(getQueryOperation()), extraDetails);
 	}
 
 	@Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableResultImpl.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.utils.PrintUtils;
@@ -51,16 +52,19 @@ class TableResultImpl implements TableResult {
 	private final TableSchema tableSchema;
 	private final ResultKind resultKind;
 	private final Iterator<Row> data;
+	private final PrintStyle printStyle;
 
 	private TableResultImpl(
 			@Nullable JobClient jobClient,
 			TableSchema tableSchema,
 			ResultKind resultKind,
-			Iterator<Row> data) {
+			Iterator<Row> data,
+			PrintStyle printStyle) {
 		this.jobClient = jobClient;
 		this.tableSchema = Preconditions.checkNotNull(tableSchema, "tableSchema should not be null");
 		this.resultKind = Preconditions.checkNotNull(resultKind, "resultKind should not be null");
 		this.data = Preconditions.checkNotNull(data, "data should not be null");
+		this.printStyle = Preconditions.checkNotNull(printStyle, "printStyle should not be null");
 	}
 
 	@Override
@@ -86,7 +90,18 @@ class TableResultImpl implements TableResult {
 	@Override
 	public void print() {
 		Iterator<Row> it = collect();
-		PrintUtils.printAsTableauForm(getTableSchema(), it, new PrintWriter(System.out));
+		switch (printStyle) {
+			case TABLEAU:
+				PrintUtils.printAsTableauForm(getTableSchema(), it, new PrintWriter(System.out));
+				break;
+			case RAW_CONTENT:
+				while (it.hasNext()) {
+					System.out.println(String.join(",", PrintUtils.rowToString(it.next())));
+				}
+				break;
+			default:
+				throw new TableException("Unsupported print style: " + printStyle);
+		}
 	}
 
 	public static Builder builder() {
@@ -101,6 +116,7 @@ class TableResultImpl implements TableResult {
 		private TableSchema tableSchema = null;
 		private ResultKind resultKind = null;
 		private Iterator<Row> data = null;
+		private PrintStyle printStyle = PrintStyle.TABLEAU;
 
 		private Builder() {
 		}
@@ -138,7 +154,7 @@ class TableResultImpl implements TableResult {
 		}
 
 		/**
-		 * Specifies an row iterator as the execution result .
+		 * Specifies an row iterator as the execution result.
 		 *
 		 * @param rowIterator a row iterator as the execution result.
 		 */
@@ -149,7 +165,7 @@ class TableResultImpl implements TableResult {
 		}
 
 		/**
-		 * Specifies an row list as the execution result .
+		 * Specifies an row list as the execution result.
 		 *
 		 * @param rowList a row list as the execution result.
 		 */
@@ -160,11 +176,36 @@ class TableResultImpl implements TableResult {
 		}
 
 		/**
+		 * Specifies print style. Default is {@link PrintStyle#TABLEAU}.
+		 */
+		public Builder setPrintStyle(PrintStyle printStyle) {
+			Preconditions.checkNotNull(printStyle, "printStyle should not be null");
+			this.printStyle = printStyle;
+			return this;
+		}
+
+		/**
 		 * Returns a {@link TableResult} instance.
 		 */
 		public TableResult build() {
-			return new TableResultImpl(jobClient, tableSchema, resultKind, data);
+			return new TableResultImpl(jobClient, tableSchema, resultKind, data, printStyle);
 		}
+	}
+
+	/**
+	 * PrintStyle defines the styles of printing.
+	 */
+	public enum PrintStyle {
+		/**
+		 * print the result schema and content as tableau form.
+		 */
+		TABLEAU,
+
+		/**
+		 * only print the result content as raw form.
+		 * column delimiter is ",", row delimiter is "\n".
+		 */
+		RAW_CONTENT
 	}
 
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/delegation/Planner.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.delegation;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.QueryOperation;
@@ -79,10 +80,10 @@ public interface Planner {
 	 *
 	 * @param operations The collection of relational queries for which the AST
 	 * and execution plan will be returned.
-	 * @param extended if the plan should contain additional properties such as
-	 * e.g. estimated cost, traits
+	 * @param extraDetails The extra explain details which the explain result should include,
+	 *   e.g. estimated cost, change log trait for streaming
 	 */
-	String explain(List<Operation> operations, boolean extended);
+	String explain(List<Operation> operations, ExplainDetail... extraDetails);
 
 	/**
 	 * Returns completion hints for the given statement at the given cursor position.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExplainOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExplainOperation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import java.util.Collections;
+
+/**
+ * Operation to describe an EXPLAIN statement.
+ * NOTES: currently, only default behavior(EXPLAIN PLAN FOR xx) is supported.
+ */
+public class ExplainOperation implements Operation {
+	private final Operation child;
+
+	public ExplainOperation(Operation child) {
+		this.child = child;
+	}
+
+	public Operation getChild() {
+		return child;
+	}
+
+	@Override
+	public String asSummaryString() {
+		return OperationUtils.formatWithChildren(
+				"EXPLAIN PLAN FOR",
+				Collections.emptyMap(),
+				Collections.singletonList(child),
+				Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/PlannerMock.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.utils;
 
 import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.operations.ModifyOperation;
@@ -42,7 +43,7 @@ public class PlannerMock implements Planner {
 	}
 
 	@Override
-	public String explain(List<Operation> operations, boolean extended) {
+	public String explain(List<Operation> operations, ExplainDetail... extraDetails) {
 		return null;
 	}
 

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -30,7 +30,7 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.{RelFieldCollation, RelRoot}
 import org.apache.calcite.sql.advise.{SqlAdvisor, SqlAdvisorValidator}
-import org.apache.calcite.sql.{SqlKind, SqlNode, SqlOperatorTable}
+import org.apache.calcite.sql.{SqlExplain, SqlKind, SqlNode, SqlOperatorTable}
 import org.apache.calcite.sql2rel.{SqlRexConvertletTable, SqlToRelConverter}
 import org.apache.calcite.tools.{FrameworkConfig, RelConversionException}
 import java.lang.{Boolean => JBoolean}
@@ -129,7 +129,14 @@ class FlinkPlannerImpl(
         || sqlNode.isInstanceOf[SqlShowViews]) {
         return sqlNode
       }
-      validator.validate(sqlNode)
+      sqlNode match {
+        case explain: SqlExplain =>
+          val validated = validator.validate(explain.getExplicandum)
+          explain.setOperand(0, validated)
+          explain
+        case _ =>
+          validator.validate(sqlNode)
+      }
     }
     catch {
       case e: RuntimeException =>

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -20,9 +20,10 @@ package org.apache.flink.table.planner.delegation
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.api.{TableConfig, TableException}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
-import org.apache.flink.table.operations.{ModifyOperation, Operation, QueryOperation}
+import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
+import org.apache.flink.table.planner.operations.PlannerQueryOperation
 import org.apache.flink.table.planner.plan.`trait`.FlinkRelDistributionTraitDef
 import org.apache.flink.table.planner.plan.nodes.exec.{BatchExecNode, ExecNode}
 import org.apache.flink.table.planner.plan.nodes.process.DAGProcessContext
@@ -32,6 +33,7 @@ import org.apache.flink.table.planner.plan.utils.{ExecNodePlanDumper, FlinkRelOp
 import org.apache.flink.table.planner.utils.{DummyStreamExecutionEnvironment, ExecutorUtils, PlanUtil}
 
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
+import org.apache.calcite.rel.logical.LogicalTableModify
 import org.apache.calcite.rel.{RelCollationTraitDef, RelNode}
 import org.apache.calcite.sql.SqlExplainLevel
 
@@ -80,7 +82,21 @@ class BatchPlanner(
     require(operations.nonEmpty, "operations should not be empty")
     val sinkRelNodes = operations.map {
       case queryOperation: QueryOperation =>
-        getRelBuilder.queryOperation(queryOperation).build()
+        val relNode = getRelBuilder.queryOperation(queryOperation).build()
+        relNode match {
+          // SQL: explain plan for insert into xx
+          case modify: LogicalTableModify =>
+            // convert LogicalTableModify to CatalogSinkModifyOperation
+            val qualifiedName = modify.getTable.getQualifiedName
+            require(qualifiedName.size() == 3, "the length of qualified name should be 3.")
+            val modifyOperation = new CatalogSinkModifyOperation(
+              ObjectIdentifier.of(qualifiedName.get(0), qualifiedName.get(1), qualifiedName.get(2)),
+              new PlannerQueryOperation(modify.getInput)
+            )
+            translateToRel(modifyOperation)
+          case _ =>
+            relNode
+        }
       case modifyOperation: ModifyOperation =>
         translateToRel(modifyOperation)
       case o => throw new TableException(s"Unsupported operation: ${o.getClass.getCanonicalName}")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/BatchPlanner.scala
@@ -19,7 +19,7 @@
 package org.apache.flink.table.planner.delegation
 
 import org.apache.flink.api.dag.Transformation
-import org.apache.flink.table.api.{TableConfig, TableException}
+import org.apache.flink.table.api.{ExplainDetail, TableConfig, TableException}
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
 import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
@@ -78,7 +78,7 @@ class BatchPlanner(
     }
   }
 
-  override def explain(operations: util.List[Operation], extended: Boolean): String = {
+  override def explain(operations: util.List[Operation], extraDetails: ExplainDetail*): String = {
     require(operations.nonEmpty, "operations should not be empty")
     val sinkRelNodes = operations.map {
       case queryOperation: QueryOperation =>
@@ -122,10 +122,10 @@ class BatchPlanner(
 
     sb.append("== Optimized Logical Plan ==")
     sb.append(System.lineSeparator)
-    val explainLevel = if (extended) {
+    val explainLevel = if (extraDetails.contains(ExplainDetail.ESTIMATED_COST)) {
       SqlExplainLevel.ALL_ATTRIBUTES
     } else {
-      SqlExplainLevel.DIGEST_ATTRIBUTES
+      SqlExplainLevel.EXPPLAN_ATTRIBUTES
     }
     sb.append(ExecNodePlanDumper.dagToString(execNodes, explainLevel))
     sb.append(System.lineSeparator)

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -20,9 +20,10 @@ package org.apache.flink.table.planner.delegation
 
 import org.apache.flink.api.dag.Transformation
 import org.apache.flink.table.api.{TableConfig, TableException}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
+import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, ObjectIdentifier}
 import org.apache.flink.table.delegation.Executor
-import org.apache.flink.table.operations.{ModifyOperation, Operation, QueryOperation}
+import org.apache.flink.table.operations.{CatalogSinkModifyOperation, ModifyOperation, Operation, QueryOperation}
+import org.apache.flink.table.planner.operations.PlannerQueryOperation
 import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, StreamExecNode}
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}
@@ -30,6 +31,7 @@ import org.apache.flink.table.planner.plan.utils.{ExecNodePlanDumper, FlinkRelOp
 import org.apache.flink.table.planner.utils.{DummyStreamExecutionEnvironment, ExecutorUtils, PlanUtil}
 
 import org.apache.calcite.plan.{ConventionTraitDef, RelTrait, RelTraitDef}
+import org.apache.calcite.rel.logical.LogicalTableModify
 import org.apache.calcite.sql.SqlExplainLevel
 
 import java.util
@@ -71,7 +73,21 @@ class StreamPlanner(
     require(operations.nonEmpty, "operations should not be empty")
     val sinkRelNodes = operations.map {
       case queryOperation: QueryOperation =>
-        getRelBuilder.queryOperation(queryOperation).build()
+        val relNode = getRelBuilder.queryOperation(queryOperation).build()
+        relNode match {
+          // SQL: explain plan for insert into xx
+          case modify: LogicalTableModify =>
+            // convert LogicalTableModify to CatalogSinkModifyOperation
+            val qualifiedName = modify.getTable.getQualifiedName
+            require(qualifiedName.size() == 3, "the length of qualified name should be 3.")
+            val modifyOperation = new CatalogSinkModifyOperation(
+              ObjectIdentifier.of(qualifiedName.get(0), qualifiedName.get(1), qualifiedName.get(2)),
+              new PlannerQueryOperation(modify.getInput)
+            )
+            translateToRel(modifyOperation)
+          case _ =>
+            relNode
+        }
       case modifyOperation: ModifyOperation =>
         translateToRel(modifyOperation)
       case o => throw new TableException(s"Unsupported operation: ${o.getClass.getCanonicalName}")

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -114,7 +114,7 @@ class StreamPlanner(
     } else {
       SqlExplainLevel.DIGEST_ATTRIBUTES
     }
-    val withChangelogTraits = extraDetails.contains(ExplainDetail.CHANGELOG_TRAITS)
+    val withChangelogTraits = extraDetails.contains(ExplainDetail.CHANGELOG_MODE)
     sb.append(ExecNodePlanDumper.dagToString(
       execNodes,
       explainLevel,

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExecuteSqlWithExplainInsert.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExecuteSqlWithExplainInsert.out
@@ -1,0 +1,31 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- LogicalProject(d=[$0], e=[$1])
+   +- LogicalFilter(condition=[>($0, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
+
+== Optimized Logical Plan ==
+Sink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- Calc(select=[a, b], where=[>(a, 10)])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Custom Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CollectionTableSource(a, b, c)]], fields=[a, b, c])
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : Calc(select=[a, b], where=[(a > 10)])
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : SinkConversionToRow
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: Unnamed
+					ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExecuteSqlWithExplainSelect.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExecuteSqlWithExplainSelect.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[>($0, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
+
+== Optimized Logical Plan ==
+Calc(select=[a, b, c], where=[>(a, 10)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Custom Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CollectionTableSource(a, b, c)]], fields=[a, b, c])
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : Calc(select=[a, b, c], where=[(a > 10)])
+			ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainSqlWithInsert.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainSqlWithInsert.out
@@ -1,0 +1,31 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[>($0, 10)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
+
+== Optimized Logical Plan ==
+Sink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
++- Calc(select=[a, b], where=[>(a, 10)])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Custom Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CollectionTableSource(a, b, c)]], fields=[a, b, c])
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : Calc(select=[a, b], where=[(a > 10)])
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : SinkConversionToRow
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: Unnamed
+					ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainSqlWithSelect.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testExplainSqlWithSelect.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
++- LogicalFilter(condition=[>($0, 10)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]])
+
+== Optimized Logical Plan ==
+Calc(select=[a, b, c], where=[>(a, 10)], changelogMode=[I])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CollectionTableSource(a, b, c)]]], fields=[a, b, c], changelogMode=[I])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Custom Source
+
+	 : Operator
+		content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CollectionTableSource(a, b, c)]], fields=[a, b, c])
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : Calc(select=[a, b, c], where=[(a > 10)])
+			ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -911,7 +911,7 @@ class TableEnvironmentTest {
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
 
     val actual = tableEnv.explainSql(
-      "select * from MyTable where a > 10", ExplainDetail.CHANGELOG_TRAITS)
+      "select * from MyTable where a > 10", ExplainDetail.CHANGELOG_MODE)
     val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithSelect.out")
     assertEquals(replaceStageId(expected), replaceStageId(actual))
   }
@@ -968,7 +968,7 @@ class TableEnvironmentTest {
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
 
     val actual = tableEnv.sqlQuery("select * from MyTable where a > 10")
-      .explain(ExplainDetail.CHANGELOG_TRAITS)
+      .explain(ExplainDetail.CHANGELOG_MODE)
     val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithSelect.out")
     assertEquals(replaceStageId(expected), replaceStageId(actual))
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.api
 
-import org.apache.calcite.plan.RelOptUtil
-import org.apache.calcite.sql.SqlExplainLevel
 import org.apache.flink.api.common.typeinfo.Types.STRING
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.environment.LocalStreamEnvironment
@@ -29,10 +27,14 @@ import org.apache.flink.table.catalog.{GenericInMemoryCatalog, ObjectPath}
 import org.apache.flink.table.planner.operations.SqlConversionException
 import org.apache.flink.table.planner.runtime.stream.sql.FunctionITCase.TestUDF
 import org.apache.flink.table.planner.runtime.stream.table.FunctionITCase.SimpleScalarFunction
+import org.apache.flink.table.planner.utils.TableTestUtil.replaceStageId
 import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
 import org.apache.flink.types.Row
+
+import org.apache.calcite.plan.RelOptUtil
+import org.apache.calcite.sql.SqlExplainLevel
 import org.hamcrest.Matchers.containsString
-import org.junit.Assert.{assertEquals, assertFalse, assertTrue}
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.rules.ExpectedException
 import org.junit.{Rule, Test}
 
@@ -795,6 +797,113 @@ class TableEnvironmentTest {
     checkData(
       util.Arrays.asList(Row.of("view1"), Row.of("view2")).iterator(),
       tableResult5.collect())
+  }
+
+  @Test
+  def testExecuteSqlWithExplainSelect(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val tableResult2 = tableEnv.executeSql("explain plan for select * from MyTable where a > 10")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    val it = tableResult2.collect()
+    assertTrue(it.hasNext)
+    val row = it.next()
+    assertEquals(1, row.getArity)
+    val actual = row.getField(0).toString
+    val expected = TableTestUtil.readFromResource("/explain/testExecuteSqlWithExplainSelect.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+    assertFalse(it.hasNext)
+  }
+
+  @Test
+  def testExecuteSqlWithExplainInsert(): Unit = {
+    val createTableStmt1 =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt1)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val createTableStmt2 =
+      """
+        |CREATE TABLE MySink (
+        |  d bigint,
+        |  e int
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult2 = tableEnv.executeSql(createTableStmt2)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    val tableResult3 = tableEnv.executeSql(
+      "explain plan for insert into MySink select a, b from MyTable where a > 10")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
+    val it = tableResult3.collect()
+    assertTrue(it.hasNext)
+    val row = it.next()
+    assertEquals(1, row.getArity)
+    val actual = row.getField(0).toString
+    val expected = TableTestUtil.readFromResource("/explain/testExecuteSqlWithExplainInsert.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+    assertFalse(it.hasNext)
+  }
+
+  @Test
+  def testExecuteSqlWithUnsupportedExplain(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    // TODO we can support them later
+    testUnsupportedExplain("explain plan excluding attributes for select * from MyTable")
+    testUnsupportedExplain("explain plan including all attributes for select * from MyTable")
+    testUnsupportedExplain("explain plan with type for select * from MyTable")
+    testUnsupportedExplain("explain plan without implementation for select * from MyTable")
+    testUnsupportedExplain("explain plan as xml for select * from MyTable")
+    testUnsupportedExplain("explain plan as json for select * from MyTable")
+  }
+
+  private def testUnsupportedExplain(explain: String): Unit = {
+    try {
+      tableEnv.executeSql(explain)
+      fail("This should not happen")
+    } catch {
+      case e: TableException =>
+        assertTrue(e.getMessage.contains("Only default behavior is supported now"))
+      case e =>
+        fail("This should not happen, " + e.getMessage)
+    }
   }
 
   private def checkData(expected: util.Iterator[Row], actual: util.Iterator[Row]): Unit = {

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -951,6 +951,28 @@ class TableEnvironmentTest {
     assertEquals(replaceStageId(expected), replaceStageId(actual))
   }
 
+  @Test
+  def testTableExplain(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val actual = tableEnv.sqlQuery("select * from MyTable where a > 10")
+      .explain(ExplainDetail.CHANGELOG_TRAITS)
+    val expected = TableTestUtil.readFromResource("/explain/testExplainSqlWithSelect.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+  }
+
   private def testUnsupportedExplain(explain: String): Unit = {
     try {
       tableEnv.executeSql(explain)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -1091,7 +1091,7 @@ class TestingTableEnvironment private(
   }
 
   override def explain(extended: Boolean): String = {
-    planner.explain(bufferedOperations.toList, extended)
+    planner.explain(bufferedOperations.toList, getExplainDetails(extended): _*)
   }
 
   @throws[Exception]

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.operations.CatalogSinkModifyOperation;
+import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.PlannerQueryOperation;
 import org.apache.flink.table.operations.ShowCatalogsOperation;
@@ -91,6 +92,9 @@ import org.apache.flink.util.StringUtils;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlExplain;
+import org.apache.calcite.sql.SqlExplainFormat;
+import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
@@ -187,6 +191,8 @@ public class SqlToOperationConverter {
 			return Optional.of(converter.convertDropView((SqlDropView) validated));
 		} else if (validated instanceof SqlShowViews) {
 			return Optional.of(converter.convertShowViews((SqlShowViews) validated));
+		} else if (validated instanceof SqlExplain) {
+			return Optional.of(converter.convertExplain((SqlExplain) validated));
 		} else if (validated.getKind().belongsTo(SqlKind.QUERY)) {
 			return Optional.of(converter.convertSqlQuery(validated));
 		} else {
@@ -532,6 +538,19 @@ public class SqlToOperationConverter {
 	/** Convert SHOW VIEWS statement. */
 	private Operation convertShowViews(SqlShowViews sqlShowViews) {
 		return new ShowViewsOperation();
+	}
+
+	/** Convert EXPLAIN statement. */
+	private Operation convertExplain(SqlExplain sqlExplain) {
+		Operation operation = convertSqlQuery(sqlExplain.getExplicandum());
+
+		if (sqlExplain.getDetailLevel() != SqlExplainLevel.EXPPLAN_ATTRIBUTES ||
+				sqlExplain.getDepth() != SqlExplain.Depth.PHYSICAL ||
+				sqlExplain.getFormat() != SqlExplainFormat.TEXT) {
+			throw new TableException("Only default behavior is supported now, EXPLAIN PLAN FOR xx");
+		}
+
+		return new ExplainOperation(operation);
 	}
 
 	/**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/BatchTableEnvImpl.scala
@@ -217,7 +217,7 @@ abstract class BatchTableEnvImpl(
     * @param extended Flag to include detailed optimizer estimates.
     */
   private[flink] def explain(table: Table, extended: Boolean): String = {
-    explain(
+    explainInternal(
       JCollections.singletonList(table.getQueryOperation.asInstanceOf[Operation]),
       getExplainDetails(extended): _*)
   }
@@ -225,12 +225,14 @@ abstract class BatchTableEnvImpl(
   override def explain(table: Table): String = explain(table: Table, extended = false)
 
   override def explain(extended: Boolean): String = {
-    explain(
+    explainInternal(
       bufferedModifyOperations.asScala.map(_.asInstanceOf[Operation]).asJava,
       getExplainDetails(extended): _*)
   }
 
-  protected def explain(operations: JList[Operation], extraDetails: ExplainDetail*): String = {
+  protected override def explainInternal(
+      operations: JList[Operation],
+      extraDetails: ExplainDetail*): String = {
     require(operations.asScala.nonEmpty, "operations should not be empty")
     val astList = operations.asScala.map {
       case queryOperation: QueryOperation =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -24,6 +24,7 @@ import org.apache.flink.api.java.DataSet
 import org.apache.flink.api.java.operators.DataSink
 import org.apache.flink.core.execution.JobClient
 import org.apache.flink.table.api._
+import org.apache.flink.table.api.internal.TableResultImpl.PrintStyle
 import org.apache.flink.table.calcite.{CalciteParser, FlinkPlannerImpl, FlinkRelBuilder}
 import org.apache.flink.table.catalog._
 import org.apache.flink.table.catalog.exceptions.{TableNotExistException => _, _}
@@ -767,6 +768,7 @@ abstract class TableEnvImpl(
           resultKind(ResultKind.SUCCESS_WITH_CONTENT)
           .tableSchema(TableSchema.builder.field("result", DataTypes.STRING).build)
           .data(JCollections.singletonList(Row.of(explanation)))
+          .setPrintStyle(PrintStyle.RAW_CONTENT)
           .build
 
       case _ => throw new TableException(UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -762,7 +762,7 @@ abstract class TableEnvImpl(
       case _: ShowViewsOperation =>
         buildShowResult(listViews())
       case explainOperation: ExplainOperation =>
-        val explanation = explain(JCollections.singletonList(explainOperation.getChild))
+        val explanation = explainInternal(JCollections.singletonList(explainOperation.getChild))
         TableResultImpl.builder.
           resultKind(ResultKind.SUCCESS_WITH_CONTENT)
           .tableSchema(TableSchema.builder.field("result", DataTypes.STRING).build)
@@ -1142,10 +1142,10 @@ abstract class TableEnvImpl(
         "Unsupported SQL query! explainSql() only accepts a single SQL query.")
     }
 
-    explain(operations, extraDetails: _*)
+    explainInternal(operations, extraDetails: _*)
   }
 
-  protected def explain(operations: JList[Operation], extraDetails: ExplainDetail*): String
+  protected def explainInternal(operations: JList[Operation], extraDetails: ExplainDetail*): String
 
   override def fromValues(values: Expression*): Table = {
     createTable(operationTreeBuilder.values(values: _*))

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/LogicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/LogicalSink.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes
+
+import org.apache.flink.table.sinks.TableSink
+
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Sub-class of [[Sink]] that is a relational expression
+  * which writes out data of input node into a [[TableSink]].
+  * This class corresponds to Calcite logical rel.
+  */
+final class LogicalSink(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    sink: TableSink[_],
+    sinkName: String)
+  extends Sink(cluster, traitSet, input, sink, sinkName) {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new LogicalSink(cluster, traitSet, inputs.head, sink, sinkName)
+  }
+
+}
+
+object LogicalSink {
+
+  def create(input: RelNode, sink: TableSink[_], sinkName: String): LogicalSink = {
+    val traits = input.getCluster.traitSetOf(Convention.NONE)
+    new LogicalSink(input.getCluster, traits, input, sink, sinkName)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/Sink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/Sink.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes
+
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.sinks.TableSink
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+
+/**
+  * Relational expression that writes out data of input node into a [[TableSink]].
+  *
+  * @param cluster  cluster that this relational expression belongs to
+  * @param traitSet the traits of this rel
+  * @param input    input relational expression
+  * @param sink     Table sink to write into
+  * @param sinkName Name of tableSink, which is not required property, that is, it could be null
+  */
+abstract class Sink(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    val sink: TableSink[_],
+    val sinkName: String)
+  extends SingleRel(cluster, traitSet, input) {
+
+  override def deriveRowType(): RelDataType = {
+    val typeFactory = getCluster.getTypeFactory.asInstanceOf[FlinkTypeFactory]
+    val tableSchema = sink.getTableSchema
+    typeFactory.buildLogicalRowType(tableSchema.getFieldNames, tableSchema.getFieldTypes)
+  }
+
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super.explainTerms(pw)
+      .itemIf("name", sinkName, sinkName != null)
+      .item("fields", sink.getTableSchema.getFieldNames.mkString(", "))
+  }
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/dataset/DataSetSink.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.dataset
+
+import org.apache.flink.api.java.DataSet
+import org.apache.flink.api.java.operators.DataSink
+import org.apache.flink.table.api.internal.BatchTableEnvImpl
+import org.apache.flink.table.plan.nodes.Sink
+import org.apache.flink.table.sinks.{BatchTableSink, TableSink}
+import org.apache.flink.types.Row
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+
+/**
+  * A special [[DataSetRel]] which make explain result more pretty.
+  *
+  * <p>NOTES: We can't move the [[BatchTableSink#consumeDataSet]]/[[DataSet#output]] logic
+  * from [[BatchTableEnvImpl]] to this node, because the return types of
+  * [[DataSetRel#translateToPlan]] (which returns [[DataSet]]) and
+  * [[BatchTableSink#consumeDataSet]]/[[DataSet#output]] (which returns [[DataSink]]) are
+  * different. [[DataSetSink#translateToPlan]] just returns the input's translated result.
+  */
+class DataSetSink(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    sink: TableSink[_],
+    sinkName: String)
+  extends Sink(cluster, traitSet, inputRel, sink, sinkName)
+    with DataSetRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new DataSetSink(cluster, traitSet, inputs.get(0), sink, sinkName)
+  }
+
+  override def translateToPlan(tableEnv: BatchTableEnvImpl): DataSet[Row] = {
+    getInput.asInstanceOf[DataSetRel].translateToPlan(tableEnv)
+  }
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/datastream/DataStreamSink.scala
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.datastream
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.dag.Transformation
+import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink => StreamingDataStreamSink}
+import org.apache.flink.table.api.{TableException, TableSchema, ValidationException}
+import org.apache.flink.table.calcite.FlinkTypeFactory
+import org.apache.flink.table.plan.nodes.Sink
+import org.apache.flink.table.plan.util.UpdatingPlanChecker
+import org.apache.flink.table.planner.{DataStreamConversions, StreamPlanner}
+import org.apache.flink.table.runtime.types.CRow
+import org.apache.flink.table.sinks.{AppendStreamTableSink, DataStreamTableSink, RetractStreamTableSink, TableSink, UpsertStreamTableSink}
+import org.apache.flink.table.types.utils.TypeConversions
+
+import org.apache.calcite.plan._
+import org.apache.calcite.rel.RelNode
+
+import _root_.java.lang.{Boolean => JBool}
+
+import _root_.scala.collection.JavaConverters._
+
+
+/**
+  * Stream physical RelNode to to write data into an external sink defined by a [[TableSink]].
+  */
+class DataStreamSink(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    sink: TableSink[_],
+    sinkName: String)
+  extends Sink(cluster, traitSet, inputRel, sink, sinkName)
+  with DataStreamRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
+    new DataStreamSink(cluster, traitSet, inputs.get(0), sink, sinkName)
+  }
+
+  override def translateToPlan(planner: StreamPlanner): DataStream[CRow] = {
+    val inputTransform = writeToSink(planner).asInstanceOf[Transformation[CRow]]
+    new DataStream(planner.getExecutionEnvironment, inputTransform)
+  }
+
+  private def writeToSink[T](planner: StreamPlanner): Transformation[_] = {
+    sink match {
+      case retractSink: RetractStreamTableSink[T] =>
+        val resultSink = writeToRetractSink(retractSink, planner)
+        resultSink.getTransformation
+
+      case upsertSink: UpsertStreamTableSink[T] =>
+        val resultSink = writeToUpsertSink(upsertSink, planner)
+        resultSink.getTransformation
+
+      case appendSink: AppendStreamTableSink[T] =>
+        val resultSink = writeToAppendSink(appendSink, planner)
+        resultSink.getTransformation
+
+      case dataStreamTableSink: DataStreamTableSink[_] =>
+        // if no change flags are requested, verify table is an insert-only (append-only) table.
+        if (!dataStreamTableSink.withChangeFlag && !UpdatingPlanChecker.isAppendOnly(getInput)) {
+          throw new ValidationException(
+            "Table is not an append-only table. " +
+              "Use the toRetractStream() in order to handle add and retract messages.")
+        }
+        val dataStream = translateInput(
+          planner,
+          getTableSchema,
+          dataStreamTableSink.getOutputType,
+          dataStreamTableSink.withChangeFlag)
+        dataStream.getTransformation
+
+      case _ =>
+        throw new ValidationException("Stream Tables can only be emitted by AppendStreamTableSink, "
+          + "RetractStreamTableSink, or UpsertStreamTableSink.")
+    }
+  }
+
+  private def writeToRetractSink[T](
+      sink: RetractStreamTableSink[T],
+      planner: StreamPlanner): StreamingDataStreamSink[_]= {
+    // retraction sink can always be used
+    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
+      .asInstanceOf[TypeInformation[JTuple2[JBool, T]]]
+    // translate the Table into a DataStream and provide the type that the TableSink expects.
+    val result: DataStream[JTuple2[JBool, T]] =
+      translateToType(
+        planner,
+        withChangeFlag = true,
+        outputType)
+    // Give the DataStream to the TableSink to emit it.
+    sink.consumeDataStream(result)
+  }
+
+  private def writeToAppendSink[T](
+      sink: AppendStreamTableSink[T],
+      planner: StreamPlanner): StreamingDataStreamSink[_]= {
+    // verify table is an insert-only (append-only) table
+    if (!UpdatingPlanChecker.isAppendOnly(getInput)) {
+      throw new TableException(
+        "AppendStreamTableSink requires that Table has only insert changes.")
+    }
+    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
+      .asInstanceOf[TypeInformation[T]]
+    val resultType = getTableSchema
+    // translate the Table into a DataStream and provide the type that the TableSink expects.
+    val result: DataStream[T] =
+      translateInput(
+        planner,
+        resultType,
+        outputType,
+        withChangeFlag = false)
+    // Give the DataStream to the TableSink to emit it.
+    sink.consumeDataStream(result)
+  }
+
+  private def writeToUpsertSink[T](
+      sink: UpsertStreamTableSink[T],
+      planner: StreamPlanner): StreamingDataStreamSink[_] = {
+    // optimize plan
+    // check for append only table
+    val isAppendOnlyTable = UpdatingPlanChecker.isAppendOnly(getInput)
+    sink.setIsAppendOnly(isAppendOnlyTable)
+    // extract unique key fields
+    val sinkFieldNames = sink.getTableSchema.getFieldNames
+    val tableKeys: Option[Array[String]] = UpdatingPlanChecker
+      .getUniqueKeyFields(getInput, sinkFieldNames)
+    // check that we have keys if the table has changes (is not append-only)
+    tableKeys match {
+      case Some(keys) => sink.setKeyFields(keys)
+      case None if isAppendOnlyTable => sink.setKeyFields(null)
+      case None if !isAppendOnlyTable => throw new TableException(
+        "UpsertStreamTableSink requires that Table has full primary keys if it is updated.")
+    }
+    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
+      .asInstanceOf[TypeInformation[JTuple2[JBool, T]]]
+    val resultType = getTableSchema
+    // translate the Table into a DataStream and provide the type that the TableSink expects.
+    val result: DataStream[JTuple2[JBool, T]] =
+      translateInput(
+        planner,
+        resultType,
+        outputType,
+        withChangeFlag = true)
+    // Give the DataStream to the TableSink to emit it.
+    sink.consumeDataStream(result)
+  }
+
+  private def translateToType[A](
+      planner: StreamPlanner,
+      withChangeFlag: Boolean,
+      tpe: TypeInformation[A]): DataStream[A] = {
+    val rowType = getTableSchema
+
+    // if no change flags are requested, verify table is an insert-only (append-only) table.
+    if (!withChangeFlag && !UpdatingPlanChecker.isAppendOnly(input)) {
+      throw new ValidationException(
+        "Table is not an append-only table. " +
+          "Use the toRetractStream() in order to handle add and retract messages.")
+    }
+
+    // get CRow plan
+    translateInput(planner, rowType, tpe, withChangeFlag)
+  }
+
+  private def translateInput[A](
+      planner: StreamPlanner,
+      logicalSchema: TableSchema,
+      tpe: TypeInformation[A],
+      withChangeFlag: Boolean): DataStream[A] = {
+    val dataStream = getInput().asInstanceOf[DataStreamRel].translateToPlan(planner)
+    DataStreamConversions.convert(dataStream, logicalSchema, withChangeFlag, tpe, planner.getConfig)
+  }
+
+  /**
+    * Returns the record type of the optimized plan with field names of the logical plan.
+    */
+  private def getTableSchema: TableSchema = {
+    val fieldTypes = getInput.getRowType.getFieldList.asScala.map(_.getType)
+      .map(FlinkTypeFactory.toTypeInfo)
+      .map(TypeConversions.fromLegacyInfoToDataType)
+      .toArray
+    TableSchema.builder().fields(sink.getTableSchema.getFieldNames, fieldTypes).build()
+  }
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/logical/FlinkLogicalSink.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.nodes.logical
+
+import org.apache.flink.table.plan.nodes.{FlinkConventions, LogicalSink, Sink}
+import org.apache.flink.table.sinks.TableSink
+
+import org.apache.calcite.plan.{Convention, RelOptCluster, RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+import java.util
+
+import scala.collection.JavaConversions._
+
+/**
+  * Sub-class of [[Sink]] that is a relational expression
+  * which writes out data of input node into a [[TableSink]].
+  */
+class FlinkLogicalSink(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    input: RelNode,
+    sink: TableSink[_],
+    sinkName: String)
+  extends Sink(cluster, traitSet, input, sink, sinkName)
+  with FlinkLogicalRel {
+
+  override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {
+    new FlinkLogicalSink(cluster, traitSet, inputs.head, sink, sinkName)
+  }
+
+}
+
+private class FlinkLogicalSinkConverter
+  extends ConverterRule(
+    classOf[LogicalSink],
+    Convention.NONE,
+    FlinkConventions.LOGICAL,
+    "FlinkLogicalSinkConverter") {
+
+  override def convert(rel: RelNode): RelNode = {
+    val sink = rel.asInstanceOf[LogicalSink]
+    val newInput = RelOptRule.convert(sink.getInput, FlinkConventions.LOGICAL)
+    FlinkLogicalSink.create(newInput, sink.sink, sink.sinkName)
+  }
+}
+
+object FlinkLogicalSink {
+  val CONVERTER: ConverterRule = new FlinkLogicalSinkConverter()
+
+  def create(input: RelNode, sink: TableSink[_], sinkName: String): FlinkLogicalSink = {
+    val cluster = input.getCluster
+    val traitSet = cluster.traitSetOf(FlinkConventions.LOGICAL).simplify()
+    new FlinkLogicalSink(cluster, traitSet, input, sink, sinkName)
+  }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -146,7 +146,8 @@ object FlinkRuleSets {
     FlinkLogicalTableFunctionScan.CONVERTER,
     FlinkLogicalMatch.CONVERTER,
     FlinkLogicalTableAggregate.CONVERTER,
-    FlinkLogicalWindowTableAggregate.CONVERTER
+    FlinkLogicalWindowTableAggregate.CONVERTER,
+    FlinkLogicalSink.CONVERTER
   )
 
   /**
@@ -265,7 +266,8 @@ object FlinkRuleSets {
     DataStreamTableAggregateRule.INSTANCE,
     DataStreamGroupWindowTableAggregateRule.INSTANCE,
     DataStreamPythonCalcRule.INSTANCE,
-    DataStreamPythonCorrelateRule.INSTANCE
+    DataStreamPythonCorrelateRule.INSTANCE,
+    DataStreamSinkRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/FlinkRuleSets.scala
@@ -220,7 +220,8 @@ object FlinkRuleSets {
     DataSetValuesRule.INSTANCE,
     DataSetCorrelateRule.INSTANCE,
     DataSetPythonCorrelateRule.INSTANCE,
-    BatchTableSourceScanRule.INSTANCE
+    BatchTableSourceScanRule.INSTANCE,
+    DataSetSinkRule.INSTANCE
   )
 
   /**

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetSinkRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/dataSet/DataSetSinkRule.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.dataSet
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.dataset.DataSetSink
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalSink
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+class DataSetSinkRule
+  extends ConverterRule(
+    classOf[FlinkLogicalSink],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASET,
+    "DataSetSinkRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val sink: FlinkLogicalSink = rel.asInstanceOf[FlinkLogicalSink]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASET)
+    val convInput: RelNode = RelOptRule.convert(sink.getInput(0), FlinkConventions.DATASET)
+
+    new DataSetSink(
+      rel.getCluster,
+      traitSet,
+      convInput,
+      sink.sink,
+      sink.sinkName
+    )
+  }
+}
+
+object DataSetSinkRule {
+  val INSTANCE = new DataSetSinkRule
+}
+
+

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamSinkRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/rules/datastream/DataStreamSinkRule.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.plan.rules.datastream
+
+import org.apache.flink.table.plan.nodes.FlinkConventions
+import org.apache.flink.table.plan.nodes.datastream.DataStreamSink
+import org.apache.flink.table.plan.nodes.logical.FlinkLogicalSink
+
+import org.apache.calcite.plan.{RelOptRule, RelTraitSet}
+import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.convert.ConverterRule
+
+class DataStreamSinkRule
+  extends ConverterRule(
+    classOf[FlinkLogicalSink],
+    FlinkConventions.LOGICAL,
+    FlinkConventions.DATASTREAM,
+    "DataStreamSinkRule") {
+
+  def convert(rel: RelNode): RelNode = {
+    val sink: FlinkLogicalSink = rel.asInstanceOf[FlinkLogicalSink]
+    val traitSet: RelTraitSet = rel.getTraitSet.replace(FlinkConventions.DATASTREAM)
+    val convInput: RelNode = RelOptRule.convert(sink.getInput(0), FlinkConventions.DATASTREAM)
+
+    new DataStreamSink(
+      rel.getCluster,
+      traitSet,
+      convInput,
+      sink.sink,
+      sink.sinkName
+    )
+  }
+}
+
+object DataStreamSinkRule {
+  val INSTANCE = new DataStreamSinkRule
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -120,7 +120,7 @@ class StreamPlanner(
     }.filter(Objects.nonNull).asJava
   }
 
-  override def explain(operations: util.List[Operation], extended: Boolean): String = {
+  override def explain(operations: util.List[Operation], extraDetails: ExplainDetail*): String = {
     require(operations.asScala.nonEmpty, "operations should not be empty")
     val astWithUpdatesAsRetractionTuples = operations.asScala.map {
       case queryOperation: QueryOperation =>

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/StreamPlanner.scala
@@ -18,10 +18,8 @@
 
 package org.apache.flink.table.planner
 import org.apache.flink.annotation.VisibleForTesting
-import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.dag.Transformation
-import org.apache.flink.api.java.tuple.{Tuple2 => JTuple2}
-import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api._
 import org.apache.flink.table.calcite._
@@ -34,8 +32,8 @@ import org.apache.flink.table.factories.{TableFactoryUtil, TableSinkFactoryConte
 import org.apache.flink.table.operations.OutputConversionModifyOperation.UpdateMode
 import org.apache.flink.table.operations._
 import org.apache.flink.table.plan.StreamOptimizer
+import org.apache.flink.table.plan.nodes.LogicalSink
 import org.apache.flink.table.plan.nodes.datastream.DataStreamRel
-import org.apache.flink.table.plan.util.UpdatingPlanChecker
 import org.apache.flink.table.runtime.types.CRow
 import org.apache.flink.table.sinks._
 import org.apache.flink.table.types.utils.TypeConversions
@@ -46,7 +44,6 @@ import org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema
 import org.apache.calcite.plan.RelOptUtil
 import org.apache.calcite.rel.RelNode
 
-import _root_.java.lang.{Boolean => JBool}
 import _root_.java.util
 import _root_.java.util.Objects
 import _root_.java.util.function.{Supplier => JSupplier}
@@ -111,20 +108,55 @@ class StreamPlanner(
 
   override def getParser: Parser = parser
 
-  override def translate(tableOperations: util.List[ModifyOperation])
-    : util.List[Transformation[_]] = {
-    tableOperations.asScala.map(translate).filter(Objects.nonNull).asJava
+  override def translate(
+      tableOperations: util.List[ModifyOperation]): util.List[Transformation[_]] = {
+    val planner = createDummyPlanner()
+    tableOperations.asScala.map { operation =>
+      val (ast, updatesAsRetraction) = translateToRel(operation)
+      val optimizedPlan = optimizer.optimize(ast, updatesAsRetraction, getRelBuilder)
+      val dataStream = translateToCRow(planner, optimizedPlan)
+      dataStream.getTransformation.asInstanceOf[Transformation[_]]
+    }.filter(Objects.nonNull).asJava
   }
 
   override def explain(operations: util.List[Operation], extended: Boolean): String = {
-    operations.asScala.map {
+    require(operations.asScala.nonEmpty, "operations should not be empty")
+    val astWithUpdatesAsRetractionTuples = operations.asScala.map {
       case queryOperation: QueryOperation =>
-        explain(queryOperation)
+        (getRelBuilder.tableOperation(queryOperation).build(), false)
       case modifyOperation: ModifyOperation =>
-        explain(modifyOperation.getChild)
-      case operation =>
-        throw new TableException(s"${operation.getClass.getCanonicalName} is not supported")
-    }.mkString(s"${System.lineSeparator}${System.lineSeparator}")
+        translateToRel(modifyOperation)
+      case o => throw new TableException(s"Unsupported operation: ${o.getClass.getCanonicalName}")
+    }
+
+    val optimizedNodes = astWithUpdatesAsRetractionTuples.map {
+      case (ast, updatesAsRetraction) =>
+        optimizer.optimize(ast, updatesAsRetraction, getRelBuilder)
+    }
+
+    val planner = createDummyPlanner()
+    val dataStreams = optimizedNodes.map(p => translateToCRow(planner, p))
+
+    val astPlan = astWithUpdatesAsRetractionTuples.map {
+      p => RelOptUtil.toString(p._1)
+    }.mkString(System.lineSeparator)
+    val optimizedPlan = optimizedNodes.map(RelOptUtil.toString).mkString(System.lineSeparator)
+
+    val env = dataStreams.head.getExecutionEnvironment
+    val jsonSqlPlan = env.getExecutionPlan
+    val sqlPlan = PlanJsonParser.getSqlExecutionPlan(jsonSqlPlan, false)
+
+    s"== Abstract Syntax Tree ==" +
+      System.lineSeparator +
+      s"$astPlan" +
+      System.lineSeparator +
+      s"== Optimized Logical Plan ==" +
+      System.lineSeparator +
+      s"$optimizedPlan" +
+      System.lineSeparator +
+      s"== Physical Execution Plan ==" +
+      System.lineSeparator +
+      s"$sqlPlan"
   }
 
   override def getCompletionHints(
@@ -135,11 +167,10 @@ class StreamPlanner(
     planner.getCompletionHints(statement, position)
   }
 
-  private def translate(tableOperation: ModifyOperation)
-    : Transformation[_] = {
-    tableOperation match {
-      case s : UnregisteredSinkModifyOperation[_] =>
-        writeToSink(s.getChild, s.getSink)
+  private def translateToRel(modifyOperation: ModifyOperation): (RelNode, Boolean) = {
+    modifyOperation match {
+      case s: UnregisteredSinkModifyOperation[_] =>
+        writeToSink(s.getChild, s.getSink, "UnregisteredSink")
 
       case catalogSink: CatalogSinkModifyOperation =>
         getTableSink(catalogSink.getTableIdentifier)
@@ -164,7 +195,10 @@ class StreamPlanner(
                   s"${classOf[OverwritableTableSink].getSimpleName} but actually got " +
                   sink.getClass.getName)
             }
-            writeToSink(catalogSink.getChild, sink)
+            writeToSink(
+              catalogSink.getChild,
+              sink,
+              catalogSink.getTableIdentifier.asSummaryString())
           }) match {
           case Some(t) => t
           case None =>
@@ -178,39 +212,17 @@ class StreamPlanner(
           case UpdateMode.UPSERT => (false, true)
         }
 
-        translateToType(
-          tableOperation.getChild,
-          isRetract,
-          withChangeFlag,
-          TypeConversions.fromDataTypeToLegacyInfo(outputConversion.getType)).getTransformation
+        val tableSink = new DataStreamTableSink(
+          outputConversion.getChild.getTableSchema,
+          TypeConversions.fromDataTypeToLegacyInfo(outputConversion.getType),
+          withChangeFlag)
+        val input = getRelBuilder.tableOperation(modifyOperation.getChild).build()
+        val sink = LogicalSink.create(input, tableSink, "DataStreamTableSink")
+        (sink, isRetract)
 
       case _ =>
-        throw new TableException(s"Unsupported ModifyOperation: $tableOperation")
+        throw new TableException(s"Unsupported ModifyOperation: $modifyOperation")
     }
-  }
-
-  private def explain(tableOperation: QueryOperation) = {
-    val ast = getRelBuilder.tableOperation(tableOperation).build()
-    val optimizedPlan = optimizer
-      .optimize(ast, updatesAsRetraction = false, getRelBuilder)
-    val dataStream = translateToCRow(optimizedPlan)
-
-    val env = dataStream.getExecutionEnvironment
-    val jsonSqlPlan = env.getExecutionPlan
-
-    val sqlPlan = PlanJsonParser.getSqlExecutionPlan(jsonSqlPlan, false)
-
-    s"== Abstract Syntax Tree ==" +
-      System.lineSeparator +
-      s"${RelOptUtil.toString(ast)}" +
-      System.lineSeparator +
-      s"== Optimized Logical Plan ==" +
-      System.lineSeparator +
-      s"${RelOptUtil.toString(optimizedPlan)}" +
-      System.lineSeparator +
-      s"== Physical Execution Plan ==" +
-      System.lineSeparator +
-      s"$sqlPlan"
   }
 
   private def getFlinkPlanner: FlinkPlannerImpl = {
@@ -232,9 +244,7 @@ class StreamPlanner(
   private[flink] def getExecutionEnvironment: StreamExecutionEnvironment =
     executor.asInstanceOf[StreamExecutor].getExecutionEnvironment
 
-  private def translateToCRow(logicalPlan: RelNode): DataStream[CRow] = {
-    val planner = createDummyPlanner()
-
+  private def translateToCRow(planner: StreamPlanner, logicalPlan: RelNode): DataStream[CRow] = {
     logicalPlan match {
       case node: DataStreamRel =>
         getExecutionEnvironment.configure(
@@ -249,163 +259,38 @@ class StreamPlanner(
 
   private def writeToSink[T](
       tableOperation: QueryOperation,
-      sink: TableSink[T])
-    : Transformation[_] = {
+      sink: TableSink[T],
+      sinkName: String): (RelNode, Boolean) = {
 
-    val resultSink = sink match {
+    val updatesAsRetraction = sink match {
       case retractSink: RetractStreamTableSink[T] =>
         retractSink match {
           case _: PartitionableTableSink =>
             throw new TableException("Partitionable sink in retract stream mode " +
               "is not supported yet!")
-          case _ =>
+          case _ => // do nothing
         }
-        writeToRetractSink(retractSink, tableOperation)
+        true
 
       case upsertSink: UpsertStreamTableSink[T] =>
         upsertSink match {
           case _: PartitionableTableSink =>
             throw new TableException("Partitionable sink in upsert stream mode " +
               "is not supported yet!")
-          case _ =>
+          case _ => // do nothing
         }
-        writeToUpsertSink(upsertSink, tableOperation)
+        false
 
-      case appendSink: AppendStreamTableSink[T] =>
-        writeToAppendSink(appendSink, tableOperation)
+      case _: AppendStreamTableSink[T] =>
+        false
 
       case _ =>
         throw new ValidationException("Stream Tables can only be emitted by AppendStreamTableSink, "
           + "RetractStreamTableSink, or UpsertStreamTableSink.")
     }
 
-    if (resultSink != null) {
-      resultSink.getTransformation
-    } else {
-      null
-    }
-  }
-
-  private def writeToRetractSink[T](
-      sink: RetractStreamTableSink[T],
-      tableOperation: QueryOperation)
-    : DataStreamSink[_]= {
-    // retraction sink can always be used
-    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
-      .asInstanceOf[TypeInformation[JTuple2[JBool, T]]]
-    // translate the Table into a DataStream and provide the type that the TableSink expects.
-    val result: DataStream[JTuple2[JBool, T]] =
-      translateToType(
-        tableOperation,
-        updatesAsRetraction = true,
-        withChangeFlag = true,
-        outputType)
-    // Give the DataStream to the TableSink to emit it.
-    sink.consumeDataStream(result)
-  }
-
-  private def writeToAppendSink[T](
-      sink: AppendStreamTableSink[T],
-      tableOperation: QueryOperation)
-    : DataStreamSink[_]= {
-    // optimize plan
-    val relNode = getRelBuilder.tableOperation(tableOperation).build()
-    val optimizedPlan = optimizer.optimize(relNode, updatesAsRetraction = false, getRelBuilder)
-    // verify table is an insert-only (append-only) table
-    if (!UpdatingPlanChecker.isAppendOnly(optimizedPlan)) {
-      throw new TableException(
-        "AppendStreamTableSink requires that Table has only insert changes.")
-    }
-    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
-      .asInstanceOf[TypeInformation[T]]
-    val resultType = getTableSchema(tableOperation.getTableSchema.getFieldNames, optimizedPlan)
-    // translate the Table into a DataStream and provide the type that the TableSink expects.
-    val result: DataStream[T] =
-      translateOptimized(
-        optimizedPlan,
-        resultType,
-        outputType,
-        withChangeFlag = false)
-    // Give the DataStream to the TableSink to emit it.
-    sink.consumeDataStream(result)
-  }
-
-  private def writeToUpsertSink[T](
-      sink: UpsertStreamTableSink[T],
-      tableOperation: QueryOperation)
-    : DataStreamSink[_] = {
-    // optimize plan
-    val relNode = getRelBuilder.tableOperation(tableOperation).build()
-    val optimizedPlan = optimizer.optimize(relNode, updatesAsRetraction = false, getRelBuilder)
-    // check for append only table
-    val isAppendOnlyTable = UpdatingPlanChecker.isAppendOnly(optimizedPlan)
-    sink.setIsAppendOnly(isAppendOnlyTable)
-    // extract unique key fields
-    val sinkFieldNames = sink.getTableSchema.getFieldNames
-    val tableKeys: Option[Array[String]] = UpdatingPlanChecker
-      .getUniqueKeyFields(optimizedPlan, sinkFieldNames)
-    // check that we have keys if the table has changes (is not append-only)
-    tableKeys match {
-      case Some(keys) => sink.setKeyFields(keys)
-      case None if isAppendOnlyTable => sink.setKeyFields(null)
-      case None if !isAppendOnlyTable => throw new TableException(
-        "UpsertStreamTableSink requires that Table has full primary keys if it is updated.")
-    }
-    val outputType = TypeConversions.fromDataTypeToLegacyInfo(sink.getConsumedDataType)
-      .asInstanceOf[TypeInformation[JTuple2[JBool, T]]]
-    val resultType = getTableSchema(tableOperation.getTableSchema.getFieldNames, optimizedPlan)
-    // translate the Table into a DataStream and provide the type that the TableSink expects.
-    val result: DataStream[JTuple2[JBool, T]] =
-      translateOptimized(
-        optimizedPlan,
-        resultType,
-        outputType,
-        withChangeFlag = true)
-    // Give the DataStream to the TableSink to emit it.
-    sink.consumeDataStream(result)
-  }
-
-  private def translateToType[A](
-      table: QueryOperation,
-      updatesAsRetraction: Boolean,
-      withChangeFlag: Boolean,
-      tpe: TypeInformation[A])
-    : DataStream[A] = {
-    val relNode = getRelBuilder.tableOperation(table).build()
-    val dataStreamPlan = optimizer.optimize(relNode, updatesAsRetraction, getRelBuilder)
-    val rowType = getTableSchema(table.getTableSchema.getFieldNames, dataStreamPlan)
-
-    // if no change flags are requested, verify table is an insert-only (append-only) table.
-    if (!withChangeFlag && !UpdatingPlanChecker.isAppendOnly(dataStreamPlan)) {
-      throw new ValidationException(
-        "Table is not an append-only table. " +
-          "Use the toRetractStream() in order to handle add and retract messages.")
-    }
-
-    // get CRow plan
-    translateOptimized(dataStreamPlan, rowType, tpe, withChangeFlag)
-  }
-
-  private def translateOptimized[A](
-      optimizedPlan: RelNode,
-      logicalSchema: TableSchema,
-      tpe: TypeInformation[A],
-      withChangeFlag: Boolean)
-    : DataStream[A] = {
-    val dataStream = translateToCRow(optimizedPlan)
-    DataStreamConversions.convert(dataStream, logicalSchema, withChangeFlag, tpe, config)
-  }
-
-  /**
-    * Returns the record type of the optimized plan with field names of the logical plan.
-    */
-  private def getTableSchema(originalNames: Array[String], optimizedPlan: RelNode): TableSchema = {
-    val fieldTypes = optimizedPlan.getRowType.getFieldList.asScala.map(_.getType)
-      .map(FlinkTypeFactory.toTypeInfo)
-      .map(TypeConversions.fromLegacyInfoToDataType)
-      .toArray
-
-    TableSchema.builder().fields(originalNames, fieldTypes).build()
+    val input = getRelBuilder.tableOperation(tableOperation).build()
+    (LogicalSink.create(input, sink, sinkName), updatesAsRetraction)
   }
 
   private def getTableSink(objectIdentifier: ObjectIdentifier): Option[TableSink[_]] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/DataStreamTableSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/sinks/DataStreamTableSink.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.sinks
+
+import org.apache.flink.annotation.Internal
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.table.api.{TableException, TableSchema}
+import org.apache.flink.table.operations.OutputConversionModifyOperation
+
+/**
+  * A special [[TableSink]] that represents information of [[OutputConversionModifyOperation]].
+  *
+  * @param outputType The [[TypeInformation]] that specifies the type of the [[DataStream]].
+  * @param withChangeFlag Set to true to emit records with change flags.
+  * @tparam T The type of the resulting [[DataStream]].
+  */
+@Internal
+class DataStreamTableSink[T](
+    tableSchema: TableSchema,
+    outputType: TypeInformation[T],
+    val withChangeFlag: Boolean)
+  extends TableSink[T] {
+
+  /**
+    * Return the type expected by this [[TableSink]].
+    *
+    * This type should depend on the types returned by [[getTableSchema]].
+    *
+    * @return The type expected by this [[TableSink]].
+    */
+  override def getOutputType: TypeInformation[T] = outputType
+
+  override def getTableSchema: TableSchema = tableSchema
+
+  override def configure(
+      fieldNames: Array[String],
+      fieldTypes: Array[TypeInformation[_]]): TableSink[T] = {
+    throw new TableException(s"configure is not supported.")
+  }
+
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -24,13 +24,14 @@ import org.apache.flink.api.scala._
 import org.apache.flink.core.fs.FileSystem.WriteMode
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecutionEnvironment}
-import org.apache.flink.table.api.TableEnvironmentITCase.{getPersonCsvTableSource, getPersonData, readFromResource, replaceStageId}
+import org.apache.flink.table.api.TableEnvironmentITCase.{getPersonCsvTableSource, getPersonData}
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.java.StreamTableEnvironment
 import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment, _}
 import org.apache.flink.table.runtime.utils.StreamITCase
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.table.sources.CsvTableSource
+import org.apache.flink.table.utils.TableTestUtil.{readFromResource, replaceStageId}
 import org.apache.flink.table.utils.TestingOverwritableTableSink
 import org.apache.flink.types.Row
 import org.apache.flink.util.FileUtils
@@ -46,7 +47,6 @@ import _root_.java.lang.{Long => JLong}
 import _root_.java.util
 
 import _root_.scala.collection.mutable
-import _root_.scala.io.Source
 
 
 @RunWith(classOf[Parameterized])
@@ -450,15 +450,6 @@ object TableEnvironmentITCase {
       Array("TableEnvironment"),
       Array("StreamTableEnvironment")
     )
-  }
-
-  def readFromResource(file: String): String = {
-    val source = s"${getClass.getResource("/").getFile}../../src/test/scala/resources/$file"
-    Source.fromFile(source).mkString
-  }
-
-  def replaceStageId(s: String): String = {
-    s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
   }
 
   def getPersonCsvTableSource: CsvTableSource = {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -221,9 +221,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     }
     val streamEnv = ScalaStreamExecutionEnvironment.getExecutionEnvironment
     val streamTableEnv = ScalaStreamTableEnvironment.create(streamEnv, settings)
-    val t = streamEnv.fromCollection(getPersonData)
-      .toTable(streamTableEnv, 'first, 'id, 'score, 'last)
-    streamTableEnv.registerTable("MyTable", t)
+    streamTableEnv.registerTableSource("MyTable", getPersonCsvTableSource)
     val sink1Path = registerCsvTableSink(streamTableEnv, Array("first"), Array(STRING), "MySink1")
     checkEmptyFile(sink1Path)
     StreamITCase.clear

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -504,6 +504,28 @@ class BatchTableEnvironmentTest extends TableTestBase {
     assertEquals(replaceStageId(expected), replaceStageId(actual))
   }
 
+  @Test
+  def testTableExplain(): Unit = {
+    val util = batchTestUtil()
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val actual = util.tableEnv.sqlQuery("select * from MyTable where a > 10").explain()
+    val expected = readFromResource("testExplainSqlWithSelect1.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+  }
+
   private def testUnsupportedExplain(tableEnv: BatchTableEnvironment, explain: String): Unit = {
     try {
       tableEnv.executeSql(explain)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
@@ -18,19 +18,21 @@
 
 package org.apache.flink.table.api.batch
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
-import org.apache.flink.table.api.Table
 import org.apache.flink.table.api.scala._
 import org.apache.flink.table.api.scala.internal.BatchTableEnvironmentImpl
-import org.apache.flink.table.utils.TableTestUtil.batchTableNode
+import org.apache.flink.table.api.{Table, Types}
+import org.apache.flink.table.runtime.utils.CommonTestData
+import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
+import org.apache.flink.table.utils.TableTestUtil.{batchTableNode, readFromResource, replaceStageId}
 import org.apache.flink.test.util.MultipleProgramsTestBase
+
 import org.junit.Assert.assertEquals
 import org.junit._
 
 class ExplainTest
   extends MultipleProgramsTestBase(MultipleProgramsTestBase.TestExecutionMode.CLUSTER) {
-
-  private val testFilePath = ExplainTest.this.getClass.getResource("/").getFile
 
   @Test
   def testFilterWithoutExtended(): Unit = {
@@ -41,8 +43,7 @@ class ExplainTest
     val table = scan.filter($"a" % 2 === 0)
 
     val result = tEnv.explain(table).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testFilter0.out").mkString
+    val source = readFromResource("testFilter0.out")
 
     val expected = replaceString(source, scan)
     assertEquals(expected, result)
@@ -58,8 +59,7 @@ class ExplainTest
 
     val result = tEnv.asInstanceOf[BatchTableEnvironmentImpl]
       .explain(table, extended = true).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testFilter1.out").mkString
+    val source = readFromResource("testFilter1.out")
 
     val expected = replaceString(source, scan)
     assertEquals(expected, result)
@@ -75,8 +75,7 @@ class ExplainTest
     val table = table1.join(table2).where($"b" === $"d").select($"a", $"c")
 
     val result = tEnv.explain(table).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testJoin0.out").mkString
+    val source = readFromResource("testJoin0.out")
 
     val expected = replaceString(source, table1, table2)
     assertEquals(expected, result)
@@ -93,8 +92,7 @@ class ExplainTest
 
     val result = tEnv.asInstanceOf[BatchTableEnvironmentImpl]
       .explain(table, extended = true).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testJoin1.out").mkString
+    val source = readFromResource("testJoin1.out")
 
     val expected = replaceString(source, table1, table2)
     assertEquals(expected, result)
@@ -110,8 +108,7 @@ class ExplainTest
     val table = table1.unionAll(table2)
 
     val result = tEnv.explain(table).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testUnion0.out").mkString
+    val source = readFromResource("testUnion0.out")
 
     val expected = replaceString(source, table1, table2)
     assertEquals(expected, result)
@@ -128,13 +125,51 @@ class ExplainTest
 
     val result = tEnv.asInstanceOf[BatchTableEnvironmentImpl]
       .explain(table, extended = true).replaceAll("\\r\\n", "\n")
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testUnion1.out").mkString
+    val source = readFromResource("testUnion1.out")
 
     val expected = replaceString(source, table1, table2)
     assertEquals(expected, result)
   }
 
+  @Test
+  def testInsert(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env)
+
+    tEnv.registerTableSource("sourceTable", CommonTestData.getCsvTableSource)
+
+    val fieldNames = Array("d", "e")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING(), Types.INT())
+    val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
+    tEnv.registerTableSink("targetTable", sink.configure(fieldNames, fieldTypes))
+
+    tEnv.sqlUpdate("insert into targetTable select first, id from sourceTable")
+
+    val result = tEnv.explain(false)
+    val expected = readFromResource("testInsert1.out")
+    assertEquals(replaceStageId(expected), replaceStageId(result))
+  }
+
+  @Test
+  def testMultipleInserts(): Unit = {
+    val env = ExecutionEnvironment.getExecutionEnvironment
+    val tEnv = BatchTableEnvironment.create(env)
+
+    tEnv.registerTableSource("sourceTable", CommonTestData.getCsvTableSource)
+
+    val fieldNames = Array("d", "e")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING(), Types.INT())
+    val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
+    tEnv.registerTableSink("targetTable1", sink.configure(fieldNames, fieldTypes))
+    tEnv.registerTableSink("targetTable2", sink.configure(fieldNames, fieldTypes))
+
+    tEnv.sqlUpdate("insert into targetTable1 select first, id from sourceTable")
+    tEnv.sqlUpdate("insert into targetTable2 select last, id from sourceTable")
+
+    val result = tEnv.explain(false)
+    val expected = readFromResource("testMultipleInserts1.out")
+    assertEquals(replaceStageId(expected), replaceStageId(result))
+  }
 
   def replaceString(s: String, t1: Table, t2: Table): String = {
     replaceSourceNode(replaceSourceNode(replaceString(s), t1, 0), t2, 1)
@@ -144,14 +179,14 @@ class ExplainTest
     replaceSourceNode(replaceString(s), t, 0)
   }
 
-  private def replaceSourceNode(s: String, t: Table, idx: Int) = {
+  private def replaceSourceNode(s: String, t: Table, idx: Int): String = {
     s.replace(
       s"%logicalSourceNode$idx%", batchTableNode(t)
         .replace("DataSetScan", "FlinkLogicalDataSetScan"))
       .replace(s"%sourceNode$idx%", batchTableNode(t))
   }
 
-  def replaceString(s: String) = {
+  def replaceString(s: String): String = {
     s.replaceAll("\\r\\n", "\n")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/sql/validation/InsertIntoValidationTest.scala
@@ -41,6 +41,8 @@ class InsertIntoValidationTest extends TableTestBase {
 
     // must fail because table sink schema has too few fields
     util.tableEnv.sqlUpdate(sql)
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -57,6 +59,8 @@ class InsertIntoValidationTest extends TableTestBase {
 
     // must fail because types of table sink do not match query result
     util.tableEnv.sqlUpdate(sql)
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -73,6 +77,8 @@ class InsertIntoValidationTest extends TableTestBase {
 
     // must fail because partial insert is not supported yet.
     util.tableEnv.sqlUpdate(sql)
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 
   @Test
@@ -92,5 +98,7 @@ class InsertIntoValidationTest extends TableTestBase {
     val sql = "INSERT INTO targetTable SELECT a, b FROM sourceTable"
 
     util.tableEnv.sqlUpdate(sql)
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/InsertIntoValidationTest.scala
@@ -41,6 +41,8 @@ class InsertIntoValidationTest extends TableTestBase {
     util.tableEnv.scan("sourceTable")
       .select('a, 'b, 'c)
       .insertInto("targetTable")
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -57,5 +59,7 @@ class InsertIntoValidationTest extends TableTestBase {
     util.tableEnv.scan("sourceTable")
       .select('a, 'b, 'c)
       .insertInto("targetTable")
+    // trigger validation
+    util.tableEnv.execute("test")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
@@ -18,19 +18,20 @@
 
 package org.apache.flink.table.api.stream
 
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.scala._
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
-import org.apache.flink.table.api.{EnvironmentSettings, Table}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.utils.TableTestUtil.streamTableNode
+import org.apache.flink.table.api.{EnvironmentSettings, Table, Types}
+import org.apache.flink.table.runtime.utils.CommonTestData
+import org.apache.flink.table.utils.MemoryTableSourceSinkUtil
+import org.apache.flink.table.utils.TableTestUtil.{readFromResource, replaceStageId, streamTableNode}
 import org.apache.flink.test.util.AbstractTestBase
 
 import org.junit.Assert.assertEquals
 import org.junit._
 
 class ExplainTest extends AbstractTestBase {
-
-  private val testFilePath = this.getClass.getResource("/").getFile
 
   @Test
   def testFilter(): Unit = {
@@ -41,10 +42,9 @@ class ExplainTest extends AbstractTestBase {
     val scan = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
     val table = scan.filter($"a" % 2 === 0)
 
-    val result = replaceString(tEnv.explain(table))
+    val result = replaceStageId(tEnv.explain(table))
 
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testFilterStream0.out").mkString
+    val source = readFromResource("testFilterStream0.out")
     val expect = replaceString(source, scan)
     assertEquals(expect, result)
   }
@@ -59,34 +59,69 @@ class ExplainTest extends AbstractTestBase {
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'count, 'word)
     val table = table1.unionAll(table2)
 
-    val result = replaceString(tEnv.explain(table))
+    val result = replaceStageId(tEnv.explain(table))
 
-    val source = scala.io.Source.fromFile(testFilePath +
-      "../../src/test/scala/resources/testUnionStream0.out").mkString
+    val source = readFromResource("testUnionStream0.out")
     val expect = replaceString(source, table1, table2)
     assertEquals(expect, result)
   }
 
+  @Test
+  def testInsert(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
+    val tEnv = StreamTableEnvironment.create(env, settings)
+
+    tEnv.registerTableSource("sourceTable", CommonTestData.getCsvTableSource)
+
+    val fieldNames = Array("d", "e")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING(), Types.INT())
+    val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
+    tEnv.registerTableSink("targetTable", sink.configure(fieldNames, fieldTypes))
+
+    tEnv.sqlUpdate("INSERT INTO targetTable SELECT first, id FROM sourceTable")
+
+    val result = tEnv.explain(false)
+    val source = readFromResource("testInsert.out")
+    assertEquals(replaceStageId(source), replaceStageId(result))
+  }
+
+  @Test
+  def testMultipleInserts(): Unit = {
+    val env = StreamExecutionEnvironment.getExecutionEnvironment
+    val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
+    val tEnv = StreamTableEnvironment.create(env, settings)
+
+    tEnv.registerTableSource("sourceTable", CommonTestData.getCsvTableSource)
+
+    val fieldNames = Array("d", "e")
+    val fieldTypes: Array[TypeInformation[_]] = Array(Types.STRING(), Types.INT())
+    val sink = new MemoryTableSourceSinkUtil.UnsafeMemoryAppendTableSink
+    tEnv.registerTableSink("targetTable1", sink.configure(fieldNames, fieldTypes))
+    tEnv.registerTableSink("targetTable2", sink.configure(fieldNames, fieldTypes))
+
+    tEnv.sqlUpdate("INSERT INTO targetTable1 SELECT first, id FROM sourceTable")
+    tEnv.sqlUpdate("INSERT INTO targetTable2 SELECT last, id FROM sourceTable")
+
+    val result = tEnv.explain(false)
+    val source = readFromResource("testMultipleInserts.out")
+    assertEquals(replaceStageId(source), replaceStageId(result))
+  }
+
   def replaceString(s: String, t1: Table, t2: Table): String = {
-    replaceSourceNode(replaceSourceNode(replaceString(s), t1, 0), t2, 1)
+    replaceSourceNode(replaceSourceNode(replaceStageId(s), t1, 0), t2, 1)
   }
 
   def replaceString(s: String, t: Table): String = {
-    replaceSourceNode(replaceString(s), t, 0)
+    replaceSourceNode(replaceStageId(s), t, 0)
   }
 
-  private def replaceSourceNode(s: String, t: Table, idx: Int) = {
-    replaceString(s)
+  private def replaceSourceNode(s: String, t: Table, idx: Int): String = {
+    replaceStageId(s)
       .replace(
         s"%logicalSourceNode$idx%", streamTableNode(t)
           .replace("DataStreamScan", "FlinkLogicalDataStreamScan"))
       .replace(s"%sourceNode$idx%", streamTableNode(t))
   }
 
-  def replaceString(s: String) = {
-    /* Stage {id} is ignored, because id keeps incrementing in test class
-     * while StreamExecutionEnvironment is up
-     */
-    s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
-  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -29,20 +29,21 @@ import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.java.internal.{StreamTableEnvironmentImpl => JStreamTableEnvironmentImpl}
 import org.apache.flink.table.api.java.{StreamTableEnvironment => JStreamTableEnv}
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{EnvironmentSettings, Expressions, TableConfig, Types, ValidationException}
-import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog, GenericInMemoryCatalog}
+import org.apache.flink.table.api.{EnvironmentSettings, ResultKind, TableConfig, TableException, Types, ValidationException}
+import org.apache.flink.table.catalog.FunctionCatalog
 import org.apache.flink.table.executor.StreamExecutor
+import org.apache.flink.table.module.ModuleManager
 import org.apache.flink.table.planner.StreamPlanner
 import org.apache.flink.table.runtime.utils.StreamTestData
+import org.apache.flink.table.utils.TableTestUtil.{binaryNode, readFromResource, replaceStageId, streamTableNode, term, unaryNode}
 import org.apache.flink.table.utils.{CatalogManagerMocks, TableTestBase}
-import org.apache.flink.table.utils.TableTestUtil.{binaryNode, streamTableNode, term, unaryNode}
 import org.apache.flink.types.Row
 
+import org.junit.Assert.{assertEquals, assertFalse, assertTrue, fail}
 import org.junit.Test
 import org.mockito.Mockito.{mock, when}
 
 import java.lang.{Integer => JInt, Long => JLong}
-import org.apache.flink.table.module.ModuleManager
 
 class StreamTableEnvironmentTest extends TableTestBase {
 
@@ -206,6 +207,123 @@ class StreamTableEnvironmentTest extends TableTestBase {
   def testRowtimeAndProctimeAttributeParsed2(): Unit = {
     val (jTEnv, ds) = prepareSchemaExpressionParser
     jTEnv.fromDataStream(ds, $("rt").rowtime(), $("b"), $("c"), $("d"), $("e"), $("pt").proctime())
+  }
+
+  @Test
+  def testExecuteSqlWithExplainSelect(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val tableResult2 = util.tableEnv.executeSql(
+      "explain plan for select * from MyTable where a > 10")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    val it = tableResult2.collect()
+    assertTrue(it.hasNext)
+    val row = it.next()
+    assertEquals(1, row.getArity)
+    val actual = row.getField(0).toString
+    val expected = readFromResource("testExecuteSqlWithExplainSelect0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+    assertFalse(it.hasNext)
+  }
+
+  @Test
+  def testExecuteSqlWithExplainInsert(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt1 =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt1)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val createTableStmt2 =
+      """
+        |CREATE TABLE MySink (
+        |  d bigint,
+        |  e int
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult2 = util.tableEnv.executeSql(createTableStmt2)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    val tableResult3 = util.tableEnv.executeSql(
+      "explain plan for insert into MySink select a, b from MyTable where a > 10")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult3.getResultKind)
+    val it = tableResult3.collect()
+    assertTrue(it.hasNext)
+    val row = it.next()
+    assertEquals(1, row.getArity)
+    val actual = row.getField(0).toString
+    val expected = readFromResource("testExecuteSqlWithExplainInsert0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+    assertFalse(it.hasNext)
+  }
+
+  @Test
+  def testExecuteSqlWithUnsupportedExplain(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    // TODO we can support them later
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan excluding attributes for select * from MyTable")
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan including all attributes for select * from MyTable")
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan with type for select * from MyTable")
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan without implementation for select * from MyTable")
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan as xml for select * from MyTable")
+    testUnsupportedExplain(util.tableEnv,
+      "explain plan as json for select * from MyTable")
+  }
+
+  private def testUnsupportedExplain(tableEnv: StreamTableEnvironment, explain: String): Unit = {
+    try {
+      tableEnv.executeSql(explain)
+      fail("This should not happen")
+    } catch {
+      case e: TableException =>
+        assertTrue(e.getMessage.contains("Only default behavior is supported now"))
+      case e =>
+        fail("This should not happen, " + e.getMessage)
+    }
   }
 
   private def prepareSchemaExpressionParser:

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -326,6 +326,64 @@ class StreamTableEnvironmentTest extends TableTestBase {
     }
   }
 
+  @Test
+  def testExplainSqlWithSelect(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val actual = util.tableEnv.explainSql("select * from MyTable where a > 10")
+    val expected = readFromResource("testExplainSqlWithSelect0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+  }
+
+  @Test
+  def testExplainSqlWithInsert(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt1 =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt1)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val createTableStmt2 =
+      """
+        |CREATE TABLE MySink (
+        |  d bigint,
+        |  e int
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult2 = util.tableEnv.executeSql(createTableStmt2)
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+
+    val actual = util.tableEnv.explainSql(
+      "insert into MySink select a, b from MyTable where a > 10")
+    val expected = readFromResource("testExplainSqlWithInsert0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+  }
+
   private def prepareSchemaExpressionParser:
     (JStreamTableEnv, DataStream[JTuple5[JLong, JInt, String, JInt, JLong]]) = {
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/StreamTableEnvironmentTest.scala
@@ -384,6 +384,28 @@ class StreamTableEnvironmentTest extends TableTestBase {
     assertEquals(replaceStageId(expected), replaceStageId(actual))
   }
 
+  @Test
+  def testTableExplain(): Unit = {
+    val util = streamTestUtil()
+    val createTableStmt =
+      """
+        |CREATE TABLE MyTable (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+
+    val actual = util.tableEnv.sqlQuery("select * from MyTable where a > 10").explain()
+    val expected = readFromResource("testExplainSqlWithSelect0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+  }
+
   private def prepareSchemaExpressionParser:
     (JStreamTableEnv, DataStream[JTuple5[JLong, JInt, String, JInt, JLong]]) = {
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.utils
 
 import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.{Table, TableConfig, TableEnvironment, TableResult}
+import org.apache.flink.table.api.{ExplainDetail, Table, TableConfig, TableEnvironment, TableResult}
 import org.apache.flink.table.catalog.Catalog
 import org.apache.flink.table.descriptors.{ConnectTableDescriptor, ConnectorDescriptor}
 import org.apache.flink.table.expressions.Expression
@@ -73,6 +73,8 @@ class MockTableEnvironment extends TableEnvironment {
   override def explain(table: Table, extended: Boolean): String = ???
 
   override def explain(extended: Boolean): String = ???
+
+  override def explainSql(statement: String, extraDetails: ExplainDetail*): String = ???
 
   override def getCompletionHints(statement: String, position: Int): Array[String] = ???
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/TableTestBase.scala
@@ -46,6 +46,7 @@ import org.junit.{ComparisonFailure, Rule}
 import org.mockito.Mockito.{mock, when}
 
 import _root_.scala.util.control.Breaks._
+import scala.io.Source
 
 /**
   * Test base for testing Table API / SQL plans.
@@ -213,6 +214,15 @@ object TableTestUtil {
     }
 
     s"DataStreamScan(id=[$id], fields=[${fieldNames.mkString(", ")}])"
+  }
+
+  def readFromResource(file: String): String = {
+    val source = s"${getClass.getResource("/").getFile}../../src/test/scala/resources/$file"
+    Source.fromFile(source).mkString
+  }
+
+  def replaceStageId(s: String): String = {
+    s.replaceAll("\\r\\n", "\n").replaceAll("Stage \\d+", "")
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainInsert0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainInsert0.out
@@ -1,0 +1,31 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[default_catalog.default_database.MySink], fields=[d, e])
+  LogicalProject(d=[$0], e=[$1])
+    LogicalFilter(condition=[>($0, 10)])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataStreamSink(name=[default_catalog.default_database.MySink], fields=[d, e])
+  DataStreamCalc(select=[a, b], where=[>(a, 10)])
+    StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : from: (a, b)
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : where: (>(a, 10)), select: (a, b)
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: Unnamed
+					ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainInsert1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainInsert1.out
@@ -1,0 +1,36 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
+  LogicalProject(d=[$0], e=[$1])
+    LogicalFilter(condition=[>($0, 10)])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataSetSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
+  DataSetCalc(select=[a, b], where=[>(a, 10)])
+    BatchTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : from: (a, b)
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : FlatMap
+			content : where: (>(a, 10)), select: (a, b)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			driver_strategy : FlatMap
+			Partitioning : RANDOM_PARTITIONED
+
+			 : Data Sink
+				content : org.apache.flink.api.java.io.DiscardingOutputFormat
+				ship_strategy : Forward
+				exchange_mode : PIPELINED
+				Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainSelect0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainSelect0.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataStreamCalc(select=[a, b, c], where=[>(a, 10)])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : Map
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : where: (>(a, 10)), select: (a, b, c)
+			ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainSelect1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExecuteSqlWithExplainSelect1.out
@@ -1,0 +1,27 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataSetCalc(select=[a, b, c], where=[>(a, 10)])
+  BatchTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : FlatMap
+		content : where: (>(a, 10)), select: (a, b, c)
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : FlatMap
+		Partitioning : RANDOM_PARTITIONED
+
+		 : Data Sink
+			content : org.apache.flink.api.java.io.DiscardingOutputFormat
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithInsert0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithInsert0.out
@@ -1,0 +1,31 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[default_catalog.default_database.MySink], fields=[d, e])
+  LogicalProject(a=[$0], b=[$1])
+    LogicalFilter(condition=[>($0, 10)])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataStreamSink(name=[default_catalog.default_database.MySink], fields=[d, e])
+  DataStreamCalc(select=[a, b], where=[>(a, 10)])
+    StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : from: (a, b)
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : where: (>(a, 10)), select: (a, b)
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: Unnamed
+					ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithInsert1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithInsert1.out
@@ -1,0 +1,43 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
+  LogicalProject(a=[$0], b=[$1])
+    LogicalFilter(condition=[>($0, 10)])
+      LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataSetSink(name=[`default_catalog`.`default_database`.`MySink`], fields=[d, e])
+  DataSetCalc(select=[a, b], where=[>(a, 10)])
+    BatchTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : from: (a, b)
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : FlatMap
+			content : where: (>(a, 10)), select: (a, b)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			driver_strategy : FlatMap
+			Partitioning : RANDOM_PARTITIONED
+
+			 : Map
+				content : to: Row
+				ship_strategy : Forward
+				exchange_mode : PIPELINED
+				driver_strategy : Map
+				Partitioning : RANDOM_PARTITIONED
+
+				 : Data Sink
+					content : org.apache.flink.api.java.io.LocalCollectionOutputFormat
+					ship_strategy : Forward
+					exchange_mode : PIPELINED
+					Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithSelect0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithSelect0.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataStreamCalc(select=[a, b, c], where=[>(a, 10)])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : Map
+		ship_strategy : FORWARD
+
+		 : Operator
+			content : where: (>(a, 10)), select: (a, b, c)
+			ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithSelect1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testExplainSqlWithSelect1.out
@@ -1,0 +1,27 @@
+== Abstract Syntax Tree ==
+LogicalProject(a=[$0], b=[$1], c=[$2])
+  LogicalFilter(condition=[>($0, 10)])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataSetCalc(select=[a, b, c], where=[>(a, 10)])
+  BatchTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c], source=[CollectionTableSource(a, b, c)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : FlatMap
+		content : where: (>(a, 10)), select: (a, b, c)
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : FlatMap
+		Partitioning : RANDOM_PARTITIONED
+
+		 : Data Sink
+			content : org.apache.flink.api.java.io.DiscardingOutputFormat
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testFromToDataStreamAndSqlUpdate.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testFromToDataStreamAndSqlUpdate.out
@@ -1,21 +1,22 @@
 == Abstract Syntax Tree ==
-LogicalProject(first=[$0])
-  FlinkLogicalDataStreamScan(fields=[first, id, score, last])
+LogicalSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  LogicalProject(first=[$0])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Logical Plan ==
-DataStreamCalc(select=[first])
-  DataStreamScan(fields=[first, id, score, last])
+DataStreamSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[first], source=[CsvTableSource(read fields: first)])
 
 == Physical Execution Plan ==
  : Data Source
 	content : collect elements with CollectionInputFormat
 
 	 : Operator
-		content : from: (first, id, score, last)
+		content : CsvTableSource(read fields: first)
 		ship_strategy : REBALANCE
 
 		 : Operator
-			content : where: (>(id, 0)), select: (last)
+			content : Map
 			ship_strategy : FORWARD
 
 			 : Operator
@@ -23,14 +24,10 @@ DataStreamCalc(select=[first])
 				ship_strategy : FORWARD
 
 				 : Operator
-					content : from: (first, id, score, last)
+					content : Map
 					ship_strategy : REBALANCE
 
-					 : Operator
-						content : select: (first)
+					 : Data Sink
+						content : Sink: CsvTableSink(first)
 						ship_strategy : FORWARD
-
-						 : Data Sink
-							content : Sink: Unnamed
-							ship_strategy : FORWARD
 

--- a/flink-table/flink-table-planner/src/test/scala/resources/testInsert.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testInsert.out
@@ -1,0 +1,29 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[default_catalog.default_database.targetTable], fields=[d, e])
+  LogicalProject(first=[$0], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+== Optimized Logical Plan ==
+DataStreamSink(name=[default_catalog.default_database.targetTable], fields=[d, e])
+  StreamTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[first, id], source=[CsvTableSource(read fields: first, id)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : CsvTableSource(read fields: first, id)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : Map
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: UnsafeMemoryAppendTableSink(d, e)
+					ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testInsert1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testInsert1.out
@@ -1,0 +1,27 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`targetTable`], fields=[d, e])
+  LogicalProject(first=[$0], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+== Optimized Logical Plan ==
+DataSetSink(name=[`default_catalog`.`default_database`.`targetTable`], fields=[d, e])
+  BatchTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[first, id], source=[CsvTableSource(read fields: first, id)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : to: Row
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : Data Sink
+			content : UnsafeMemoryAppendTableSink(d, e)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testMultipleInserts.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testMultipleInserts.out
@@ -1,0 +1,55 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[default_catalog.default_database.targetTable1], fields=[d, e])
+  LogicalProject(first=[$0], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+LogicalSink(name=[default_catalog.default_database.targetTable2], fields=[d, e])
+  LogicalProject(last=[$3], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+== Optimized Logical Plan ==
+DataStreamSink(name=[default_catalog.default_database.targetTable1], fields=[d, e])
+  StreamTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[first, id], source=[CsvTableSource(read fields: first, id)])
+
+DataStreamSink(name=[default_catalog.default_database.targetTable2], fields=[d, e])
+  StreamTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[last, id], source=[CsvTableSource(read fields: last, id)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : CsvTableSource(read fields: first, id)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : Map
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : CsvTableSource(read fields: last, id)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : Map
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Data Sink
+					content : Sink: UnsafeMemoryAppendTableSink(d, e)
+					ship_strategy : FORWARD
+
+					 : Data Sink
+						content : Sink: UnsafeMemoryAppendTableSink(d, e)
+						ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testMultipleInserts1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testMultipleInserts1.out
@@ -1,0 +1,51 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`targetTable1`], fields=[d, e])
+  LogicalProject(first=[$0], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+LogicalSink(name=[`default_catalog`.`default_database`.`targetTable2`], fields=[d, e])
+  LogicalProject(last=[$3], id=[$1])
+    LogicalTableScan(table=[[default_catalog, default_database, sourceTable]])
+
+== Optimized Logical Plan ==
+DataSetSink(name=[`default_catalog`.`default_database`.`targetTable1`], fields=[d, e])
+  BatchTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[first, id], source=[CsvTableSource(read fields: first, id)])
+
+DataSetSink(name=[`default_catalog`.`default_database`.`targetTable2`], fields=[d, e])
+  BatchTableSourceScan(table=[[default_catalog, default_database, sourceTable]], fields=[last, id], source=[CsvTableSource(read fields: last, id)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : to: Row
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : Data Sink
+			content : UnsafeMemoryAppendTableSink(d, e)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			Partitioning : RANDOM_PARTITIONED
+
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : to: Row
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : Data Sink
+			content : UnsafeMemoryAppendTableSink(d, e)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			Partitioning : RANDOM_PARTITIONED
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testSqlUpdateAndToDataStream.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testSqlUpdateAndToDataStream.out
@@ -1,9 +1,11 @@
 == Abstract Syntax Tree ==
-LogicalProject(first=[$0])
-  LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+LogicalSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  LogicalProject(first=[$0])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Logical Plan ==
-StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[first], source=[CsvTableSource(read fields: first)])
+DataStreamSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[first], source=[CsvTableSource(read fields: first)])
 
 == Physical Execution Plan ==
  : Data Source
@@ -16,4 +18,16 @@ StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fiel
 		 : Operator
 			content : Map
 			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Map
+					ship_strategy : REBALANCE
+
+					 : Data Sink
+						content : Sink: CsvTableSink(first)
+						ship_strategy : FORWARD
 


### PR DESCRIPTION

## What is the purpose of the change

*For TableEnvironment#explain() method, legacy batch planner throws exception directly and legacy stream planner does not handle sink node. This pr fixes them problems first. And then, this pr aim to supports the following features: TableEnvironment#explainSql supports EXPLAIN statement; Introduce TableEnvironment#explainSql api, Introduce Table#explain api*


## Brief change log

  - *legacy stream planner supports explain insert operation*
  - *legacy batch planner supports explain insert operation*
  - *TableEnvironment#explainSql supports EXPLAIN statement*
  - *Introduce TableEnvironment#explainSql api*
  - *Introduce Table#explain api*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended TableEnvironmentTest/BatchTableEnvironmentTest/StreamTableEnvironmentTest to verify the features*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
