### PR TITLE
[FLINK-17328][rest]Expose network metric for job vertex in rest api

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -1211,7 +1211,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "metrics" : {
             "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:JobVertexIOMetricsInfo",
             "properties" : {
               "read-bytes" : {
                 "type" : "integer"
@@ -1235,6 +1235,30 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
                 "type" : "integer"
               },
               "write-records-complete" : {
+                "type" : "boolean"
+              },
+              "input-exclusive-buffers-usage-avg" : {
+                "type" : "number"
+              },
+              "input-exclusive-buffers-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "input-floating-buffers-usage-avg" : {
+                "type" : "number"
+              },
+              "input-floating-buffers-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "out-pool-usage-avg" : {
+                "type" : "number"
+              },
+              "out-pool-usage-avg-complete" : {
+                "type" : "boolean"
+              },
+              "is-backpressed" : {
+                "type" : "boolean"
+              },
+              "is-backpressed-complete" : {
                 "type" : "boolean"
               }
             }

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -753,7 +753,7 @@
               },
               "metrics" : {
                 "type" : "object",
-                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:IOMetricsInfo",
+                "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:metrics:JobVertexIOMetricsInfo",
                 "properties" : {
                   "read-bytes" : {
                     "type" : "integer"
@@ -777,6 +777,30 @@
                     "type" : "integer"
                   },
                   "write-records-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-exclusive-buffers-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "input-exclusive-buffers-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "input-floating-buffers-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "input-floating-buffers-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "out-pool-usage-avg" : {
+                    "type" : "number"
+                  },
+                  "out-pool-usage-avg-complete" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed" : {
+                    "type" : "boolean"
+                  },
+                  "is-backpressed-complete" : {
                     "type" : "boolean"
                   }
                 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/IOMetrics.java
@@ -35,6 +35,11 @@ public class IOMetrics implements Serializable {
 	protected long numBytesIn;
 	protected long numBytesOut;
 
+	protected float usageInputFloatingBuffers;
+	protected float usageInputExclusiveBuffers;
+	protected float usageOutPool;
+	protected boolean isBackPressured;
+
 	public IOMetrics(Meter recordsIn, Meter recordsOut, Meter bytesIn, Meter bytesOut) {
 		this.numRecordsIn = recordsIn.getCount();
 		this.numRecordsOut = recordsOut.getCount();
@@ -51,6 +56,25 @@ public class IOMetrics implements Serializable {
 		this.numBytesOut = numBytesOut;
 		this.numRecordsIn = numRecordsIn;
 		this.numRecordsOut = numRecordsOut;
+		}
+
+	public IOMetrics(
+			long numBytesIn,
+			long numBytesOut,
+			long numRecordsIn,
+			long numRecordsOut,
+			float usageInputFloatingBuffers,
+			float usageInputExclusiveBuffers,
+			float usageOutPool,
+			boolean isBackPressured) {
+		this.numBytesIn = numBytesIn;
+		this.numBytesOut = numBytesOut;
+		this.numRecordsIn = numRecordsIn;
+		this.numRecordsOut = numRecordsOut;
+		this.usageInputFloatingBuffers = usageInputFloatingBuffers;
+		this.usageInputExclusiveBuffers = usageInputExclusiveBuffers;
+		this.usageOutPool = usageOutPool;
+		this.isBackPressured = isBackPressured;
 	}
 
 	public long getNumRecordsIn() {
@@ -67,5 +91,21 @@ public class IOMetrics implements Serializable {
 
 	public long getNumBytesOut() {
 		return numBytesOut;
+	}
+
+	public float getUsageInputFloatingBuffers() {
+		return usageInputFloatingBuffers;
+	}
+
+	public float getUsageInputExclusiveBuffers() {
+		return usageInputExclusiveBuffers;
+	}
+
+	public float getUsageOutPool() {
+		return usageOutPool;
+	}
+
+	public boolean isBackPressured() {
+		return isBackPressured;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/NettyShuffleMetricFactory.java
@@ -51,23 +51,23 @@ public class NettyShuffleMetricFactory {
 
 	// task level metric group structure: Shuffle.Netty.<Input|Output>.Buffers
 
-	private static final String METRIC_GROUP_SHUFFLE = "Shuffle";
-	private static final String METRIC_GROUP_NETTY = "Netty";
+	public static final String METRIC_GROUP_SHUFFLE = "Shuffle";
+	public static final String METRIC_GROUP_NETTY = "Netty";
 	public static final String METRIC_GROUP_OUTPUT = "Output";
 	public static final String METRIC_GROUP_INPUT = "Input";
-	private static final String METRIC_GROUP_BUFFERS = "Buffers";
+	public static final String METRIC_GROUP_BUFFERS = "Buffers";
 
 	// task level output metrics: Shuffle.Netty.Output.*
 
 	private static final String METRIC_OUTPUT_QUEUE_LENGTH = "outputQueueLength";
-	private static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
+	public static final String METRIC_OUTPUT_POOL_USAGE = "outPoolUsage";
 
 	// task level input metrics: Shuffle.Netty.Input.*
 
 	private static final String METRIC_INPUT_QUEUE_LENGTH = "inputQueueLength";
 	private static final String METRIC_INPUT_POOL_USAGE = "inPoolUsage";
-	private static final String METRIC_INPUT_FLOATING_BUFFERS_USAGE = "inputFloatingBuffersUsage";
-	private static final String METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE = "inputExclusiveBuffersUsage";
+	public static final String METRIC_INPUT_FLOATING_BUFFERS_USAGE = "inputFloatingBuffersUsage";
+	public static final String METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE = "inputExclusiveBuffersUsage";
 
 	private NettyShuffleMetricFactory() {
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.runtime.metrics;
 
+import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
+import org.apache.flink.runtime.metrics.scope.OperatorScopeFormat;
+
+import java.util.StringJoiner;
+
 /**
  * Collection of metric names.
  */
@@ -48,6 +53,27 @@ public class MetricNames {
 	public static final String IO_CURRENT_INPUT_2_WATERMARK = "currentInput2Watermark";
 	public static final String IO_CURRENT_INPUT_WATERMARK_PATERN = "currentInput%dWatermark";
 	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
+
+	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY).toString();
+	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
+	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT)
+		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_INPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_INPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE).toString();
+	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
+		.add(SHUFFLE_NETTY_OUPUT_GROUP)
+		.add(NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE).toString();
 
 	public static final String NUM_RUNNING_JOBS = "numRunningJobs";
 	public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -21,8 +21,6 @@ package org.apache.flink.runtime.metrics;
 import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
 import org.apache.flink.runtime.metrics.scope.OperatorScopeFormat;
 
-import java.util.StringJoiner;
-
 /**
  * Collection of metric names.
  */
@@ -54,26 +52,32 @@ public class MetricNames {
 	public static final String IO_CURRENT_INPUT_WATERMARK_PATERN = "currentInput%dWatermark";
 	public static final String IO_CURRENT_OUTPUT_WATERMARK = "currentOutputWatermark";
 
-	private static final String  SHUFFLE_NETTY_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_NETTY).toString();
-	private static final String SHUFFLE_NETTY_INPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(SHUFFLE_NETTY_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_INPUT)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
-	private static final String SHUFFLE_NETTY_OUPUT_GROUP = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(SHUFFLE_NETTY_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT)
-		.add(NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS).toString();
-	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(SHUFFLE_NETTY_INPUT_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE).toString();
-	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(SHUFFLE_NETTY_INPUT_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE).toString();
-	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = new StringJoiner(OperatorScopeFormat.SCOPE_SEPARATOR)
-		.add(SHUFFLE_NETTY_OUPUT_GROUP)
-		.add(NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE).toString();
+	private static final String  SHUFFLE_NETTY_GROUP = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		NettyShuffleMetricFactory.METRIC_GROUP_SHUFFLE,
+		NettyShuffleMetricFactory.METRIC_GROUP_NETTY);
+	private static final String SHUFFLE_NETTY_INPUT_GROUP = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_GROUP,
+		NettyShuffleMetricFactory.METRIC_GROUP_INPUT,
+		NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS);
+	private static final String SHUFFLE_NETTY_OUPUT_GROUP = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_GROUP,
+		NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT,
+		NettyShuffleMetricFactory.METRIC_GROUP_BUFFERS);
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_INPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_INPUT_FLOATING_BUFFERS_USAGE);
+	public static final String USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_INPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_INPUT_EXCLUSIVE_BUFFERS_USAGE);
+	public static final String USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE = String.join(
+		OperatorScopeFormat.SCOPE_SEPARATOR,
+		SHUFFLE_NETTY_OUPUT_GROUP,
+		NettyShuffleMetricFactory.METRIC_OUTPUT_POOL_USAGE);
 
 	public static final String NUM_RUNNING_JOBS = "numRunningJobs";
 	public static final String TASK_SLOTS_AVAILABLE = "taskSlotsAvailable";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandler.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.rest.messages.JobMessageParameters;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
@@ -201,8 +201,11 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 				jobId.toString(),
 				ejv.getJobVertexId().toString());
 		}
-
-		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+		final int taskSize = ejv.getTaskVertices().length;
+		final float outPoolUsageAvg = counts.getUsageOutPool() / (taskSize * 1.0f);
+		final float inputExclusiveBuffersUsageAvg = counts.getUsageInputExclusiveBuffers() / (taskSize * 1.0f);
+		final float inputFloatingBuffersUsageAvg = counts.getUsageInputFloatingBuffers() / (taskSize * 1.0f);
+		final JobVertexIOMetricsInfo jobVertexMetrics = new JobVertexIOMetricsInfo(
 			counts.getNumBytesIn(),
 			counts.isNumBytesInComplete(),
 			counts.getNumBytesOut(),
@@ -210,7 +213,16 @@ public class JobDetailsHandler extends AbstractExecutionGraphHandler<JobDetailsI
 			counts.getNumRecordsIn(),
 			counts.isNumRecordsInComplete(),
 			counts.getNumRecordsOut(),
-			counts.isNumRecordsOutComplete());
+			counts.isNumRecordsOutComplete(),
+			inputExclusiveBuffersUsageAvg,
+			counts.isUsageInputExclusiveBuffersComplete(),
+			inputFloatingBuffersUsageAvg,
+			counts.isUsageInputFloatingBuffersComplete(),
+			outPoolUsageAvg,
+			counts.isUsageOutPoolComplete(),
+			counts.isBackPressured(),
+			counts.isBackPressuredComplete()
+		);
 
 		return new JobDetailsInfo.JobVertexDetailsInfo(
 			ejv.getJobVertexId(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
 
 import javax.annotation.Nullable;
 
+import java.util.function.Consumer;
+
 /**
  * This class is a mutable version of the {@link IOMetrics} class that allows adding up IO-related metrics.
  *
@@ -44,9 +46,13 @@ public class MutableIOMetrics extends IOMetrics {
 	private boolean numBytesOutComplete = true;
 	private boolean numRecordsInComplete = true;
 	private boolean numRecordsOutComplete = true;
+	private boolean usageInputFloatingBuffersComplete = true;
+	private boolean usageInputExclusiveBuffersComplete = true;
+	private boolean usageOutPoolComplete = true;
+	private boolean isBackPressuredComplete = true;
 
 	public MutableIOMetrics() {
-		super(0, 0, 0, 0);
+		super(0, 0, 0, 0, 0.0f, 0.0f, 0.0f, false);
 	}
 
 	public boolean isNumBytesInComplete() {
@@ -63,6 +69,22 @@ public class MutableIOMetrics extends IOMetrics {
 
 	public boolean isNumRecordsOutComplete() {
 		return numRecordsOutComplete;
+	}
+
+	public boolean isUsageInputFloatingBuffersComplete() {
+		return usageInputFloatingBuffersComplete;
+	}
+
+	public boolean isUsageInputExclusiveBuffersComplete() {
+		return usageInputExclusiveBuffersComplete;
+	}
+
+	public boolean isUsageOutPoolComplete() {
+		return usageOutPoolComplete;
+	}
+
+	public boolean isBackPressuredComplete() {
+		return isBackPressuredComplete;
 	}
 
 	/**
@@ -83,6 +105,10 @@ public class MutableIOMetrics extends IOMetrics {
 				this.numBytesOut += ioMetrics.getNumBytesOut();
 				this.numRecordsIn += ioMetrics.getNumRecordsIn();
 				this.numRecordsOut += ioMetrics.getNumRecordsOut();
+				this.usageInputExclusiveBuffers += ioMetrics.getUsageInputExclusiveBuffers();
+				this.usageInputFloatingBuffers += ioMetrics.getUsageInputFloatingBuffers();
+				this.usageOutPool += ioMetrics.getUsageOutPool();
+				this.isBackPressured |= ioMetrics.isBackPressured();
 			}
 		} else { // execAttempt is still running, use MetricQueryService instead
 			if (fetcher != null) {
@@ -96,41 +122,67 @@ public class MutableIOMetrics extends IOMetrics {
 					 * In case a metric is missing for a parallel instance of a task, we set the complete flag as
 					 * false.
 					 */
-					if (metrics.getMetric(MetricNames.IO_NUM_BYTES_IN) == null){
-						this.numBytesInComplete = false;
-					}
-					else {
-						this.numBytesIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_IN));
-					}
+					update(metrics, MetricNames.IO_NUM_BYTES_IN,
+						(String value) -> this.numBytesInComplete = false,
+						(String value) -> this.numBytesIn += Long.valueOf(value)
+					);
 
-					if (metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT) == null){
-						this.numBytesOutComplete = false;
-					}
-					else {
-						this.numBytesOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_BYTES_OUT));
-					}
+					update(metrics, MetricNames.IO_NUM_BYTES_OUT,
+						(String value) -> this.numBytesOutComplete = false,
+						(String value) -> this.numBytesOut += Long.valueOf(value)
+					);
 
-					if (metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN) == null){
-						this.numRecordsInComplete = false;
-					}
-					else {
-						this.numRecordsIn += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_IN));
-					}
+					update(metrics, MetricNames.IO_NUM_RECORDS_IN,
+						(String value) -> this.numRecordsInComplete = false,
+						(String value) -> this.numRecordsIn += Long.valueOf(value)
+					);
 
-					if (metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT) == null){
-						this.numRecordsOutComplete = false;
-					}
-					else {
-						this.numRecordsOut += Long.valueOf(metrics.getMetric(MetricNames.IO_NUM_RECORDS_OUT));
-					}
+					update(metrics, MetricNames.IO_NUM_RECORDS_OUT,
+						(String value) -> this.numRecordsOutComplete = false,
+						(String value) -> this.numRecordsOut += Long.valueOf(value)
+					);
+
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS,
+						(String value) -> this.usageInputFloatingBuffersComplete = false,
+						(String value) -> this.usageInputFloatingBuffers += Float.valueOf(value)
+					);
+
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS,
+						(String value) -> this.usageInputExclusiveBuffersComplete = false,
+						(String value) -> this.usageInputExclusiveBuffers += Float.valueOf(value)
+					);
+
+					update(metrics, MetricNames.USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE,
+						(String value) -> this.usageOutPoolComplete = false,
+						(String value) -> this.usageOutPool += Float.valueOf(value)
+					);
+
+					update(metrics, MetricNames.IS_BACKPRESSURED,
+						(String value) -> this.isBackPressuredComplete = false,
+						(String value) -> this.isBackPressured |= Boolean.valueOf(value)
+					);
 				}
 				else {
 					this.numBytesInComplete = false;
 					this.numBytesOutComplete = false;
 					this.numRecordsInComplete = false;
 					this.numRecordsOutComplete = false;
+					this.usageInputFloatingBuffersComplete = false;
+					this.usageInputExclusiveBuffersComplete = false;
+					this.usageOutPoolComplete = false;
+					this.isBackPressuredComplete = false;
 				}
 			}
+		}
+	}
+
+	private void update(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<String> noEmptyFunction) {
+		String value = metrics.getMetric(metricKey);
+		if (value == null){
+			emptyFunction.accept(value);
+		}
+		else {
+			noEmptyFunction.accept(value);
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/util/MutableIOMetrics.java
@@ -176,13 +176,9 @@ public class MutableIOMetrics extends IOMetrics {
 		}
 	}
 
-	private void update(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<String> noEmptyFunction) {
+	private void update(MetricStore.ComponentMetricStore metrics, String metricKey, Consumer<String> emptyFunction, Consumer<String> nonEmptyFunction) {
 		String value = metrics.getMetric(metricKey);
-		if (value == null){
-			emptyFunction.accept(value);
-		}
-		else {
-			noEmptyFunction.accept(value);
-		}
+		Consumer<String> updateFunction = value == null ? emptyFunction : nonEmptyFunction;
+		updateFunction.accept(value);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfo.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.ResponseBody;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 import org.apache.flink.runtime.rest.messages.json.JobIDDeserializer;
 import org.apache.flink.runtime.rest.messages.json.JobIDSerializer;
 import org.apache.flink.runtime.rest.messages.json.JobVertexIDDeserializer;
@@ -279,7 +279,7 @@ public class JobDetailsInfo implements ResponseBody {
 		private final Map<ExecutionState, Integer> tasksPerState;
 
 		@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS)
-		private final IOMetricsInfo jobVertexMetrics;
+		private final JobVertexIOMetricsInfo jobVertexMetrics;
 
 		@JsonCreator
 		public JobVertexDetailsInfo(
@@ -291,7 +291,7 @@ public class JobDetailsInfo implements ResponseBody {
 				@JsonProperty(FIELD_NAME_JOB_VERTEX_END_TIME) long endTime,
 				@JsonProperty(FIELD_NAME_JOB_VERTEX_DURATION) long duration,
 				@JsonProperty(FIELD_NAME_TASKS_PER_STATE) Map<ExecutionState, Integer> tasksPerState,
-				@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) IOMetricsInfo jobVertexMetrics) {
+				@JsonProperty(FIELD_NAME_JOB_VERTEX_METRICS) JobVertexIOMetricsInfo jobVertexMetrics) {
 			this.jobVertexID = Preconditions.checkNotNull(jobVertexID);
 			this.name = Preconditions.checkNotNull(name);
 			this.parallelism = parallelism;
@@ -344,7 +344,7 @@ public class JobDetailsInfo implements ResponseBody {
 		}
 
 		@JsonIgnore
-		public IOMetricsInfo getJobVertexMetrics() {
+		public JobVertexIOMetricsInfo getJobVertexMetrics() {
 			return jobVertexMetrics;
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
@@ -26,23 +26,23 @@ import java.util.Objects;
 /**
  * IO metrics information.
  */
-public final class IOMetricsInfo {
+public class IOMetricsInfo {
 
-	private static final String FIELD_NAME_BYTES_READ = "read-bytes";
+	protected static final String FIELD_NAME_BYTES_READ = "read-bytes";
 
-	private static final String FIELD_NAME_BYTES_READ_COMPLETE = "read-bytes-complete";
+	protected static final String FIELD_NAME_BYTES_READ_COMPLETE = "read-bytes-complete";
 
-	private static final String FIELD_NAME_BYTES_WRITTEN = "write-bytes";
+	protected static final String FIELD_NAME_BYTES_WRITTEN = "write-bytes";
 
-	private static final String FIELD_NAME_BYTES_WRITTEN_COMPLETE = "write-bytes-complete";
+	protected static final String FIELD_NAME_BYTES_WRITTEN_COMPLETE = "write-bytes-complete";
 
-	private static final String FIELD_NAME_RECORDS_READ = "read-records";
+	protected static final String FIELD_NAME_RECORDS_READ = "read-records";
 
-	private static final String FIELD_NAME_RECORDS_READ_COMPLETE = "read-records-complete";
+	protected static final String FIELD_NAME_RECORDS_READ_COMPLETE = "read-records-complete";
 
-	private static final String FIELD_NAME_RECORDS_WRITTEN = "write-records";
+	protected static final String FIELD_NAME_RECORDS_WRITTEN = "write-records";
 
-	private static final String FIELD_NAME_RECORDS_WRITTEN_COMPLETE = "write-records-complete";
+	protected static final String FIELD_NAME_RECORDS_WRITTEN_COMPLETE = "write-records-complete";
 
 	@JsonProperty(FIELD_NAME_BYTES_READ)
 	private final long bytesRead;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -168,11 +168,23 @@ public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
-			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
-			this.getInputExclusiveBuffersUsageAvg(), this.isInputExclusiveBuffersUsageAvgComplete(), this.getInputFloatingBuffersUsageAvg(),
-			this.isInputFloatingBuffersUsageAvgComplete(), this.getOutPoolUsageAvg(), this.isOutPoolUsageAvgComplete(),
-			this.isBackPressured(), this.isBackPressuredComplete());
+		return Objects.hash(
+			this.getBytesRead(),
+			this.isBytesReadComplete(),
+			this.getBytesWritten(),
+			this.isBytesWrittenComplete(),
+			this.getRecordsRead(),
+			this.isRecordsReadComplete(),
+			this.getRecordsWritten(),
+			this.isRecordsWrittenComplete(),
+			this.getInputExclusiveBuffersUsageAvg(),
+			this.isInputExclusiveBuffersUsageAvgComplete(),
+			this.getInputFloatingBuffersUsageAvg(),
+			this.isInputFloatingBuffersUsageAvgComplete(),
+			this.getOutPoolUsageAvg(),
+			this.isOutPoolUsageAvgComplete(),
+			this.isBackPressured(),
+			this.isBackPressuredComplete());
 	}
 
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/JobVertexIOMetricsInfo.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.metrics;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * JobVertex IO metrics information.
+ */
+public final class JobVertexIOMetricsInfo extends IOMetricsInfo {
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG = "input-exclusive-buffers-usage-avg";
+
+	private static final String FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE = "input-exclusive-buffers-usage-avg-complete";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE = "input-floating-buffers-usage-avg";
+
+	private static final String FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE = "input-floating-buffers-usage-avg-complete";
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG = "out-pool-usage-avg";
+
+	private static final String FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE = "out-pool-usage-avg-complete";
+
+	private static final String FIELD_NAME_IS_BACKPRESSED = "is-backpressed";
+
+	private static final String FIELD_NAME_IS_BACKPRESSED_COMPLETE = "is-backpressed-complete";
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG)
+	private final float inputExclusiveBuffersUsageAvg;
+
+	@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE)
+	private final boolean inputExclusiveBuffersUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE)
+	private final float inputFloatingBuffersUsageAvg;
+
+	@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE)
+	private final boolean inputFloatingBuffersUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG)
+	private final float outPoolUsageAvg;
+
+	@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE)
+	private final boolean outPoolUsageAvgComplete;
+
+	@JsonProperty(FIELD_NAME_IS_BACKPRESSED)
+	private final boolean isBackPressured;
+
+	@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE)
+	private final boolean isBackPressuredComplete;
+
+	@JsonCreator
+	public JobVertexIOMetricsInfo(
+		@JsonProperty(FIELD_NAME_BYTES_READ) long bytesRead,
+		@JsonProperty(FIELD_NAME_BYTES_READ_COMPLETE) boolean bytesReadComplete,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN) long bytesWritten,
+		@JsonProperty(FIELD_NAME_BYTES_WRITTEN_COMPLETE) boolean bytesWrittenComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_READ) long recordsRead,
+		@JsonProperty(FIELD_NAME_RECORDS_READ_COMPLETE) boolean recordsReadComplete,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN) long recordsWritten,
+		@JsonProperty(FIELD_NAME_RECORDS_WRITTEN_COMPLETE) boolean recordsWrittenComplete,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG) float inputExclusiveBuffersUsageAvg,
+		@JsonProperty(FIELD_NAME_INPUT_EXCLUSIVE_BUFFERS_USAGE_AVG_COMPLETE) boolean inputExclusiveBuffersUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_AVG_USAGE) float inputFloatingBuffersUsageAvg,
+		@JsonProperty(FIELD_NAME_INPUT_FLOATING_BUFFERS_USAGE_AVG_COMPLETE) boolean inputFloatingBuffersUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG) float outPoolUsageAvg,
+		@JsonProperty(FIELD_NAME_OUT_POOL_USAGE_AVG_COMPLETE) boolean outPoolUsageAvgComplete,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED) boolean isBackPressured,
+		@JsonProperty(FIELD_NAME_IS_BACKPRESSED_COMPLETE) boolean isBackPressuredComplete) {
+		super(bytesRead, bytesReadComplete, bytesWritten, bytesWrittenComplete, recordsRead, recordsReadComplete,
+			recordsWritten, recordsWrittenComplete);
+		this.outPoolUsageAvg = outPoolUsageAvg;
+		this.outPoolUsageAvgComplete = outPoolUsageAvgComplete;
+		this.inputExclusiveBuffersUsageAvg = inputExclusiveBuffersUsageAvg;
+		this.inputExclusiveBuffersUsageAvgComplete = inputExclusiveBuffersUsageAvgComplete;
+		this.inputFloatingBuffersUsageAvg = inputFloatingBuffersUsageAvg;
+		this.inputFloatingBuffersUsageAvgComplete = inputFloatingBuffersUsageAvgComplete;
+		this.isBackPressured = isBackPressured;
+		this.isBackPressuredComplete = isBackPressuredComplete;
+	}
+
+	@JsonIgnore
+	public float getInputExclusiveBuffersUsageAvg() {
+		return inputExclusiveBuffersUsageAvg;
+	}
+
+	@JsonIgnore
+	public boolean isInputExclusiveBuffersUsageAvgComplete() {
+		return inputExclusiveBuffersUsageAvgComplete;
+	}
+
+	@JsonIgnore
+	public float getInputFloatingBuffersUsageAvg() {
+		return inputFloatingBuffersUsageAvg;
+	}
+
+	@JsonIgnore
+	public boolean isInputFloatingBuffersUsageAvgComplete() {
+		return inputFloatingBuffersUsageAvgComplete;
+	}
+
+	@JsonIgnore
+	public float getOutPoolUsageAvg() {
+		return outPoolUsageAvg;
+	}
+
+	@JsonIgnore
+	public boolean isOutPoolUsageAvgComplete() {
+		return outPoolUsageAvgComplete;
+	}
+
+	@JsonIgnore
+	public boolean isBackPressured() {
+		return isBackPressured;
+	}
+
+	@JsonIgnore
+	public boolean isBackPressuredComplete() {
+		return isBackPressuredComplete;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		JobVertexIOMetricsInfo that = (JobVertexIOMetricsInfo) o;
+		return this.getBytesRead() == that.getBytesRead() &&
+			this.isBytesReadComplete() == that.isBytesReadComplete() &&
+			this.getBytesWritten() == that.getBytesWritten() &&
+			this.isBytesWrittenComplete() == that.isBytesWrittenComplete() &&
+			this.getRecordsRead() == that.getRecordsRead() &&
+			this.isRecordsReadComplete() == that.isRecordsReadComplete() &&
+			this.getRecordsWritten() == that.getRecordsWritten() &&
+			this.isRecordsWrittenComplete() == that.isRecordsWrittenComplete() &&
+			this.getInputExclusiveBuffersUsageAvg() == that.getInputExclusiveBuffersUsageAvg() &&
+			this.isInputExclusiveBuffersUsageAvgComplete() == that.isInputExclusiveBuffersUsageAvgComplete() &&
+			this.getInputFloatingBuffersUsageAvg() == that.getInputFloatingBuffersUsageAvg() &&
+			this.isInputFloatingBuffersUsageAvgComplete() == that.isInputFloatingBuffersUsageAvgComplete() &&
+			this.getOutPoolUsageAvg() == that.getOutPoolUsageAvg() &&
+			this.isOutPoolUsageAvgComplete() == that.isOutPoolUsageAvgComplete() &&
+			this.isBackPressured() == that.isBackPressured() &&
+			this.isBackPressuredComplete() == that.isBackPressuredComplete();
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.getBytesRead(), this.isBytesReadComplete(), this.getBytesWritten(), this.isBytesWrittenComplete(),
+			this.getRecordsRead(), this.isRecordsReadComplete(), this.getRecordsWritten(), this.isRecordsWrittenComplete(),
+			this.getInputExclusiveBuffersUsageAvg(), this.isInputExclusiveBuffersUsageAvgComplete(), this.getInputFloatingBuffersUsageAvg(),
+			this.isInputFloatingBuffersUsageAvgComplete(), this.getOutPoolUsageAvg(), this.isOutPoolUsageAvgComplete(),
+			this.isBackPressured(), this.isBackPressuredComplete());
+	}
+
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobDetailsHandlerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.concurrent.Executors;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.dump.MetricDump;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcher;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricFetcherImpl;
+import org.apache.flink.runtime.rest.handler.legacy.metrics.MetricStore;
+import org.apache.flink.runtime.rest.handler.legacy.utils.ArchivedExecutionGraphBuilder;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
+import org.apache.flink.runtime.rest.messages.job.JobExceptionsMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
+import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
+import org.apache.flink.runtime.testingUtils.TestingUtils;
+import org.apache.flink.runtime.util.EvictingBoundedList;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.TestingRestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.runtime.webmonitor.retriever.MetricQueryServiceRetriever;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ * Test for the {@link JobDetailsHandler}.
+ */
+public class JobDetailsHandlerTest extends TestLogger {
+
+	private static JobDetailsHandler jobDetailsHandler;
+
+	private static IOMetrics ioMetrics;
+	private static JobVertexIOMetricsInfo jobVertexMetrics;
+
+	private static final JobID JOB_ID = JobID.generate();
+	private static final JobVertexID VERTEX_ID = new JobVertexID();
+
+	@Before
+	public void setup() {
+		final long bytesIn = 1L;
+		final long bytesOut = 10L;
+		final long recordsIn = 20L;
+		final long recordsOut = 30L;
+		final float usageInputFloatingBuffers = 0.1f;
+		final float usageInputExclusiveBuffers = 0.1f;
+		final float usageOutPool = 0.1f;
+		final boolean isBackPressured = false;
+
+		ioMetrics = new IOMetrics(
+			bytesIn,
+			bytesOut,
+			recordsIn,
+			recordsOut,
+			usageInputFloatingBuffers,
+			usageInputExclusiveBuffers,
+			usageOutPool,
+			isBackPressured);
+
+		jobVertexMetrics = new JobVertexIOMetricsInfo(
+			ioMetrics.getNumBytesIn(),
+			true,
+			ioMetrics.getNumBytesOut(),
+			true,
+			ioMetrics.getNumRecordsIn(),
+			true,
+			ioMetrics.getNumRecordsOut(),
+			true,
+			ioMetrics.getUsageInputExclusiveBuffers(),
+			true,
+			ioMetrics.getUsageInputFloatingBuffers(),
+			true,
+			ioMetrics.getUsageOutPool(),
+			true,
+			ioMetrics.isBackPressured(),
+			true
+		);
+
+		MetricFetcher fetcher = new MetricFetcherImpl<RestfulGateway>(
+			mock(GatewayRetriever.class),
+			mock(MetricQueryServiceRetriever.class),
+			Executors.directExecutor(),
+			TestingUtils.TIMEOUT(),
+			MetricOptions.METRIC_FETCHER_UPDATE_INTERVAL.defaultValue());
+		MetricStore store = fetcher.getMetricStore();
+
+		Collection<MetricDump> metricDumps = getMetricDumps();
+		for (MetricDump dump : metricDumps) {
+			store.add(dump);
+		}
+
+		jobDetailsHandler = new JobDetailsHandler(
+			() -> null,
+			TestingUtils.TIMEOUT(),
+			Collections.emptyMap(),
+			JobDetailsHeaders.getInstance(),
+			new DefaultExecutionGraphCache(TestingUtils.TIMEOUT(), TestingUtils.TIMEOUT()),
+			TestingUtils.defaultExecutor(),
+			fetcher);
+	}
+
+	@Test
+	public void testGetJobDetailsInfo() throws Exception {
+
+		final ArchivedExecutionGraph archivedExecutionGraph = createArchivedExecutionGraph(JOB_ID, ioMetrics);
+		final TestingRestfulGateway restfulGateway = new TestingRestfulGateway.Builder()
+			.setRequestJobFunction(jobId -> CompletableFuture.completedFuture(archivedExecutionGraph)).build();
+		final HandlerRequest<EmptyRequestBody, JobMessageParameters> request = createRequest(
+			archivedExecutionGraph.getJobID());
+		final JobDetailsInfo jobDetailsInfo = jobDetailsHandler.handleRequest(request, restfulGateway).get();
+		jobDetailsInfo
+			.getJobVertexInfos()
+			.forEach(jobVertexDetailsInfo ->
+				assertThat(jobVertexDetailsInfo.getJobVertexMetrics(), is(equalTo(jobVertexMetrics)))
+			);
+	}
+
+	private static ArchivedExecutionGraph createArchivedExecutionGraph(JobID jobID, IOMetrics ioMetrics) {
+		Map<JobVertexID, ArchivedExecutionJobVertex> tasks = new HashMap<>();
+		tasks.put(VERTEX_ID, createArchivedExecutionJobVertex(VERTEX_ID, ioMetrics));
+		return new ArchivedExecutionGraphBuilder()
+			.setTasks(tasks)
+			.setJobID(jobID)
+			.build();
+	}
+
+	private static ArchivedExecutionJobVertex createArchivedExecutionJobVertex(JobVertexID jobVertexID, IOMetrics ioMetrics) {
+		final StringifiedAccumulatorResult[] emptyAccumulators = new StringifiedAccumulatorResult[0];
+		final long[] timestamps = new long[ExecutionState.values().length];
+		final ExecutionState expectedState = ExecutionState.RUNNING;
+
+		final LocalTaskManagerLocation assignedResourceLocation = new LocalTaskManagerLocation();
+		final AllocationID allocationID = new AllocationID();
+
+		final int subtaskIndex = 0;
+		final int attempt = 0;
+		return new ArchivedExecutionJobVertex(
+			new ArchivedExecutionVertex[]{
+				new ArchivedExecutionVertex(
+					subtaskIndex,
+					"test task",
+					new ArchivedExecution(
+						new StringifiedAccumulatorResult[0],
+						ioMetrics,
+						new ExecutionAttemptID(),
+						attempt,
+						expectedState,
+						null,
+						assignedResourceLocation,
+						allocationID,
+						subtaskIndex,
+						timestamps),
+					new EvictingBoundedList<>(0)
+				)
+			},
+			jobVertexID,
+			jobVertexID.toString(),
+			1,
+			1,
+			ResourceProfile.UNKNOWN,
+			emptyAccumulators);
+	}
+
+	private static HandlerRequest<EmptyRequestBody, JobMessageParameters> createRequest(JobID jobId) throws HandlerRequestException {
+		final Map<String, String> pathParameters = new HashMap<>();
+		pathParameters.put(JobIDPathParameter.KEY, jobId.toString());
+
+		return new HandlerRequest<>(
+			EmptyRequestBody.getInstance(),
+			new JobExceptionsMessageParameters(),
+			pathParameters,
+			Collections.emptyMap());
+	}
+
+	protected static Collection<MetricDump> getMetricDumps() {
+		Collection<MetricDump> dumps = new ArrayList<>(8);
+		QueryScopeInfo.TaskQueryScopeInfo task1 = new QueryScopeInfo.TaskQueryScopeInfo(JOB_ID.toString(), VERTEX_ID.toString(), 0);
+		MetricDump.CounterDump cd1 = new MetricDump.CounterDump(task1, MetricNames.IO_NUM_BYTES_IN, ioMetrics.getNumBytesIn());
+		MetricDump.CounterDump cd2 = new MetricDump.CounterDump(task1, MetricNames.IO_NUM_BYTES_OUT, ioMetrics.getNumBytesOut());
+		MetricDump.CounterDump cd3 = new MetricDump.CounterDump(task1, MetricNames.IO_NUM_RECORDS_IN, ioMetrics.getNumRecordsIn());
+		MetricDump.CounterDump cd4 = new MetricDump.CounterDump(task1, MetricNames.IO_NUM_RECORDS_OUT, ioMetrics.getNumRecordsOut());
+		MetricDump.GaugeDump cd5 = new MetricDump.GaugeDump(task1, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_FLOATING_BUFFERS, "" + ioMetrics.getUsageInputFloatingBuffers());
+		MetricDump.GaugeDump cd6 = new MetricDump.GaugeDump(task1, MetricNames.USAGE_SHUFFLE_NETTY_INPUT_EXCLUSIVE_BUFFERS, "" + ioMetrics.getUsageInputExclusiveBuffers());
+		MetricDump.GaugeDump cd7 = new MetricDump.GaugeDump(task1, MetricNames.USAGE_SHUFFLE_NETTY_OUTPUT_POOL_USAGE, "" + ioMetrics.getUsageOutPool());
+		MetricDump.GaugeDump cd8 = new MetricDump.GaugeDump(task1, MetricNames.IS_BACKPRESSURED, "" + ioMetrics.isBackPressured());
+		dumps.add(cd1);
+		dumps.add(cd2);
+		dumps.add(cd3);
+		dumps.add(cd4);
+		dumps.add(cd5);
+		dumps.add(cd6);
+		dumps.add(cd7);
+		dumps.add(cd8);
+		return dumps;
+	}
+}
+

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/job/JobDetailsInfoTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.RestResponseMarshallingTestBase;
-import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+import org.apache.flink.runtime.rest.messages.job.metrics.JobVertexIOMetricsInfo;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,7 +80,7 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 
 	private JobDetailsInfo.JobVertexDetailsInfo createJobVertexDetailsInfo(Random random) {
 		final Map<ExecutionState, Integer> tasksPerState = new HashMap<>(ExecutionState.values().length);
-		final IOMetricsInfo jobVertexMetrics = new IOMetricsInfo(
+		final JobVertexIOMetricsInfo jobVertexMetrics = new JobVertexIOMetricsInfo(
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextLong(),
@@ -88,7 +88,16 @@ public class JobDetailsInfoTest extends RestResponseMarshallingTestBase<JobDetai
 			random.nextLong(),
 			random.nextBoolean(),
 			random.nextLong(),
-			random.nextBoolean());
+			random.nextBoolean(),
+			random.nextFloat(),
+			random.nextBoolean(),
+			random.nextFloat(),
+			random.nextBoolean(),
+			random.nextFloat(),
+			random.nextBoolean(),
+			random.nextBoolean(),
+			random.nextBoolean()
+		);
 
 		for (ExecutionState executionState : ExecutionState.values()) {
 			tasksPerState.put(executionState, random.nextInt());


### PR DESCRIPTION
## What is the purpose of the change
This pull request makes JobDetailsHandler show metrics of network pool usage and back-pressured.
## Brief change log
- pool usage: outPoolUsageAvg, inputExclusiveBuffersUsageAvg, inputFloatingBuffersUsageAvg
- back-pressured for show whether it is back pressured(merge all its subtasks)


## Verifying this change

This change added tests and can be verified as follows:
- JobDetailsInfoTest
- JobDetailsHandlerTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
