### PR TITLE
[FLINK-17385][jdbc][postgres] Handled problem of numeric with 0 precision

### DIFF
--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -103,6 +103,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 				"[5.5, 6.6, 7.7]," +
 				"[6.6, 7.7, 8.8]," +
 				"[7.70000, 8.80000, 9.90000]," +
+				"[8.800000000000000000, 9.900000000000000000, 10.100000000000000000]," +
 				"[true, false, true]," +
 				"[a, b, c]," +
 				"[b, c, d]," +

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogITCase.java
@@ -85,7 +85,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		List<Row> results = TableUtils.collectToList(
 			tEnv.sqlQuery(String.format("select * from %s", TABLE_PRIMITIVE_TYPE)));
 
-		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03]", results.toString());
+		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03,500.000000000000000000]", results.toString());
 	}
 
 	@Test

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -225,6 +225,7 @@ public class PostgresCatalogTestBase {
 				.field("real_arr", DataTypes.ARRAY(DataTypes.FLOAT()))
 				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
 				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
+				.field("numeric_arr_default", DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18)))
 				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
 				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
 				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
@@ -243,6 +244,7 @@ public class PostgresCatalogTestBase {
 				"real_arr real[], " +
 				"double_precision_arr double precision[], " +
 				"numeric_arr numeric(10, 5)[], " +
+				"numeric_arr_default numeric[], " +
 				"boolean_arr boolean[], " +
 				"text_arr text[], " +
 				"char_arr char[], " +
@@ -260,6 +262,7 @@ public class PostgresCatalogTestBase {
 					"'{5.5,6.6,7.7}'," +
 					"'{6.6,7.7,8.8}'," +
 					"'{7.7,8.8,9.9}'," +
+					"'{8.8,9.9,10.10}'," +
 					"'{true,false,true}'," +
 					"'{a,b,c}'," +
 					"'{b,c,d}'," +

--- a/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-jdbc/src/test/java/org/apache/flink/api/java/io/jdbc/catalog/PostgresCatalogTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.java.io.jdbc.catalog;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.logical.DecimalType;
 
 import com.opentable.db.postgres.junit.EmbeddedPostgresRules;
 import com.opentable.db.postgres.junit.SingleInstancePostgresRule;
@@ -174,6 +175,7 @@ public class PostgresCatalogTestBase {
 //				.field("timestamptz", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(4))
 				.field("date", DataTypes.DATE())
 				.field("time", DataTypes.TIME(0))
+				.field("default_numeric", DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18))
 				.build(),
 			"int integer, " +
 				"bytea bytea, " +
@@ -190,7 +192,8 @@ public class PostgresCatalogTestBase {
 				"timestamp timestamp(5), " +
 //				"timestamptz timestamptz(4), " +
 				"date date," +
-				"time time(0)",
+				"time time(0), " +
+				"default_numeric numeric ",
 			"1," +
 				"'2'," +
 				"3," +
@@ -206,7 +209,8 @@ public class PostgresCatalogTestBase {
 				"'2016-06-22 19:10:25'," +
 //				"'2006-06-22 19:10:25'," +
 				"'2015-01-01'," +
-				"'00:51:02.746572'"
+				"'00:51:02.746572', " +
+				"500"
 		);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Fix error when handling numeric field types with precision 0, such as:

```sql
CREATE TABLE orders(
    ord_no integer PRIMARY KEY,
    ord_date date,
    item_name character(35),
    item_grade character(1),
    ord_qty numeric,
    ord_amount numeric,
    CONSTRAINT unq_ordno_itname UNIQUE(ord_qty,ord_amount)
);
```

This address the same problem of SPARK-26538 (https://github.com/apache/spark/pull/23456), using the same fix.

## Brief change log

In the PostgresCatalog.fromJDBCType, handle Decimal and Numeric types as follow:

```java
if (precision > 0) {
	return DataTypes.DECIMAL(precision, metadata.getScale(colIndex));
}
return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
```

## Verifying this change

This change is already covered by existing tests, such as *PostgresCatalogITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  **no**
  - The serializers:  **no**
  - The runtime per-record code paths (performance sensitive):  **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  **no**
  - The S3 file system connector:  **no**

## Documentation

  - Does this pull request introduce a new feature?  **no**
  - If yes, how is the feature documented? not documented
