### PR TITLE
[FLINK-17390][yarn] Fix Hadoop 2.10+ compatibility for WorkerSpecContainerResourceAdapter.

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/WorkerSpecContainerResourceAdapter.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -71,21 +70,18 @@ public class WorkerSpecContainerResourceAdapter {
 		containerMemoryToContainerResource = new HashMap<>();
 	}
 
-	@VisibleForTesting
 	Optional<Resource> tryComputeContainerResource(final WorkerResourceSpec workerResourceSpec) {
 		return Optional.ofNullable(workerSpecToContainerResource.computeIfAbsent(
 			Preconditions.checkNotNull(workerResourceSpec),
 			this::createAndMapContainerResource));
 	}
 
-	@VisibleForTesting
 	Set<WorkerResourceSpec> getWorkerSpecs(final Resource containerResource, final MatchingStrategy matchingStrategy) {
 		return getEquivalentContainerResource(containerResource, matchingStrategy).stream()
 			.flatMap(resource -> containerResourceToWorkerSpecs.getOrDefault(resource, Collections.emptySet()).stream())
 			.collect(Collectors.toSet());
 	}
 
-	@VisibleForTesting
 	Set<Resource> getEquivalentContainerResource(final Resource containerResource, final MatchingStrategy matchingStrategy) {
 		// Yarn might ignore the requested vcores, depending on its configurations.
 		// In such cases, we should also not matching vcores.


### PR DESCRIPTION
## What is the purpose of the change

This PR fix the problem that requested/allocated containers cannot be matched on Hadoop 2.10+.

The problem is due to relying on the hash code of the Hadoop abstract class `Resource` for mapping, which is calculated inconsistently by different `Resource` implementations.

## Verifying this change

- Add `WorkerSpecContainerResourceAdapterTest#testMatchResourceWithDifferentImplementation`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
