### PR TITLE
[FLINK-15591][table] Support create/drop temporary table in Flink SQL

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -564,7 +564,7 @@ SqlNodeList TableProperties():
     {  return new SqlNodeList(proList, span.end(this)); }
 }
 
-SqlCreate SqlCreateTable(Span s, boolean replace) :
+SqlCreate SqlCreateTable(Span s, boolean replace, boolean isTemporary) :
 {
     final SqlParserPos startPos = s.pos();
     SqlIdentifier tableName;
@@ -624,7 +624,8 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
                 partitionColumns,
                 watermark,
                 comment,
-                tableLike);
+                tableLike,
+                isTemporary);
     }
 }
 
@@ -685,7 +686,7 @@ SqlTableLikeOption SqlTableLikeOption():
     }
 }
 
-SqlDrop SqlDropTable(Span s, boolean replace) :
+SqlDrop SqlDropTable(Span s, boolean replace, boolean isTemporary) :
 {
     SqlIdentifier tableName = null;
     boolean ifExists = false;
@@ -702,7 +703,7 @@ SqlDrop SqlDropTable(Span s, boolean replace) :
     tableName = CompoundIdentifier()
 
     {
-         return new SqlDropTable(s.pos(), tableName, ifExists);
+         return new SqlDropTable(s.pos(), tableName, ifExists, isTemporary);
     }
 }
 
@@ -1180,7 +1181,7 @@ SqlCreate SqlCreateExtended(Span s, boolean replace) :
     (
         create = SqlCreateCatalog(s, replace)
         |
-        create = SqlCreateTable(s, replace)
+        create = SqlCreateTable(s, replace, isTemporary)
         |
         create = SqlCreateView(s, replace, isTemporary)
         |
@@ -1203,7 +1204,7 @@ SqlDrop SqlDropExtended(Span s, boolean replace) :
         <TEMPORARY> { isTemporary = true; }
     ]
     (
-        drop = SqlDropTable(s, replace)
+        drop = SqlDropTable(s, replace, isTemporary)
         |
         drop = SqlDropView(s, replace, isTemporary)
         |

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlCreateTable.java
@@ -75,6 +75,8 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 
 	private final SqlTableLike tableLike;
 
+	private final boolean isTemporary;
+
 	public SqlCreateTable(
 			SqlParserPos pos,
 			SqlIdentifier tableName,
@@ -85,7 +87,8 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			SqlNodeList partitionKeyList,
 			@Nullable SqlWatermark watermark,
 			@Nullable SqlCharStringLiteral comment,
-			@Nullable SqlTableLike tableLike) {
+			@Nullable SqlTableLike tableLike,
+			boolean isTemporary) {
 		super(OPERATOR, pos, false, false);
 		this.tableName = requireNonNull(tableName, "tableName should not be null");
 		this.columnList = requireNonNull(columnList, "columnList should not be null");
@@ -96,6 +99,7 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 		this.watermark = watermark;
 		this.comment = comment;
 		this.tableLike = tableLike;
+		this.isTemporary = isTemporary;
 	}
 
 	@Override
@@ -147,6 +151,10 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 
 	public boolean isIfNotExists() {
 		return ifNotExists;
+	}
+
+	public boolean isTemporary() {
+		return isTemporary;
 	}
 
 	@Override
@@ -255,7 +263,11 @@ public class SqlCreateTable extends SqlCreate implements ExtendedSqlNode {
 			SqlWriter writer,
 			int leftPrec,
 			int rightPrec) {
-		writer.keyword("CREATE TABLE");
+		writer.keyword("CREATE");
+		if (isTemporary()) {
+			writer.keyword("TEMPORARY");
+		}
+		writer.keyword("TABLE");
 		tableName.unparse(writer, leftPrec, rightPrec);
 		SqlWriter.Frame frame = writer.startList(SqlWriter.FrameTypeEnum.create("sds"), "(", ")");
 		for (SqlNode column : columnList) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlDropTable.java
@@ -39,11 +39,17 @@ public class SqlDropTable extends SqlDrop {
 
 	private SqlIdentifier tableName;
 	private boolean ifExists;
+	private final boolean isTemporary;
 
-	public SqlDropTable(SqlParserPos pos, SqlIdentifier tableName, boolean ifExists) {
+	public SqlDropTable(
+			SqlParserPos pos,
+			SqlIdentifier tableName,
+			boolean ifExists,
+			boolean isTemporary) {
 		super(OPERATOR, pos, ifExists);
 		this.tableName = tableName;
 		this.ifExists = ifExists;
+		this.isTemporary = isTemporary;
 	}
 
 	@Override
@@ -67,9 +73,16 @@ public class SqlDropTable extends SqlDrop {
 		this.ifExists = ifExists;
 	}
 
+	public boolean isTemporary() {
+		return this.isTemporary;
+	}
+
 	@Override
 	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
 		writer.keyword("DROP");
+		if (isTemporary) {
+			writer.keyword("TEMPORARY");
+		}
 		writer.keyword("TABLE");
 		if (ifExists) {
 			writer.keyword("IF EXISTS");

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -606,6 +606,27 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
+	public void testCreateTemporaryTable() {
+		final String sql = "create temporary table source_table(\n" +
+			"  a int,\n" +
+			"  b bigint,\n" +
+			"  c string\n" +
+			") with (\n" +
+			"  'x' = 'y',\n" +
+			"  'abc' = 'def'\n" +
+			")";
+		final String expected = "CREATE TEMPORARY TABLE `SOURCE_TABLE` (\n" +
+			"  `A`  INTEGER,\n" +
+			"  `B`  BIGINT,\n" +
+			"  `C`  STRING\n" +
+			") WITH (\n" +
+			"  'x' = 'y',\n" +
+			"  'abc' = 'def'\n" +
+			")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
 	public void testDropTable() {
 		final String sql = "DROP table catalog1.db1.tbl1";
 		final String expected = "DROP TABLE `CATALOG1`.`DB1`.`TBL1`";
@@ -616,6 +637,20 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	public void testDropIfExists() {
 		final String sql = "DROP table IF EXISTS catalog1.db1.tbl1";
 		final String expected = "DROP TABLE IF EXISTS `CATALOG1`.`DB1`.`TBL1`";
+		sql(sql).ok(expected);
+	}
+
+	@Test
+	public void testTemporaryDropTable() {
+		final String sql = "DROP temporary table catalog1.db1.tbl1";
+		final String expected = "DROP TEMPORARY TABLE `CATALOG1`.`DB1`.`TBL1`";
+		sql(sql).ok(expected);
+	}
+
+	@Test
+	public void testDropTemporaryIfExists() {
+		final String sql = "DROP temporary table IF EXISTS catalog1.db1.tbl1";
+		final String expected = "DROP TEMPORARY TABLE IF EXISTS `CATALOG1`.`DB1`.`TBL1`";
 		sql(sql).ok(expected);
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/CatalogManager.java
@@ -548,34 +548,42 @@ public final class CatalogManager {
 	}
 
 	/**
-	 * Drop a temporary table in a given fully qualified path if it exists.
+	 * Drop a temporary table in a given fully qualified path.
 	 *
-	 * @param objectIdentifier The fully qualified path of the table to drop
-	 * @return true if a table with a given identifier existed and was removed, false otherwise
+	 * @param objectIdentifier The fully qualified path of the table to drop.
+	 * @param ignoreIfNotExists If false exception will be thrown if the table to be dropped does not exist.
 	 */
-	public boolean dropTemporaryTable(ObjectIdentifier objectIdentifier) {
-		return dropTemporaryTableInternal(objectIdentifier, (table) -> table instanceof CatalogTable);
+	public void dropTemporaryTable(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+		dropTemporaryTableInternal(
+				objectIdentifier,
+				(table) -> table instanceof CatalogTable,
+				ignoreIfNotExists);
 	}
 
 	/**
-	 * Drop a temporary view in a given fully qualified path if it exists.
+	 * Drop a temporary view in a given fully qualified path.
 	 *
-	 * @param objectIdentifier potentially unresolved identifier
-	 * @return true if a view with a given identifier existed and was removed, false otherwise
+	 * @param objectIdentifier The fully qualified path of the view to drop.
+	 * @param ignoreIfNotExists If false exception will be thrown if the view to be dropped does not exist.
 	 */
-	public boolean dropTemporaryView(ObjectIdentifier objectIdentifier) {
-		return dropTemporaryTableInternal(objectIdentifier, (table) -> table instanceof CatalogView);
+	public void dropTemporaryView(ObjectIdentifier objectIdentifier, boolean ignoreIfNotExists) {
+		dropTemporaryTableInternal(
+				objectIdentifier,
+				(table) -> table instanceof CatalogView,
+				ignoreIfNotExists);
 	}
 
-	private boolean dropTemporaryTableInternal(
+	private void dropTemporaryTableInternal(
 			ObjectIdentifier objectIdentifier,
-			Predicate<CatalogBaseTable> filter) {
+			Predicate<CatalogBaseTable> filter,
+			boolean ignoreIfNotExists) {
 		CatalogBaseTable catalogBaseTable = temporaryTables.get(objectIdentifier);
 		if (filter.test(catalogBaseTable)) {
 			temporaryTables.remove(objectIdentifier);
-			return true;
-		} else {
-			return false;
+		} else if (!ignoreIfNotExists) {
+			throw new ValidationException(String.format(
+				"Temporary table or view with identifier '%s' does not exist.",
+				objectIdentifier.asSummaryString()));
 		}
 	}
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/CreateTableOperation.java
@@ -34,14 +34,17 @@ public class CreateTableOperation implements CreateOperation {
 	private final ObjectIdentifier tableIdentifier;
 	private CatalogTable catalogTable;
 	private boolean ignoreIfExists;
+	private boolean isTemporary;
 
 	public CreateTableOperation(
 			ObjectIdentifier tableIdentifier,
 			CatalogTable catalogTable,
-			boolean ignoreIfExists) {
+			boolean ignoreIfExists,
+			boolean isTemporary) {
 		this.tableIdentifier = tableIdentifier;
 		this.catalogTable = catalogTable;
 		this.ignoreIfExists = ignoreIfExists;
+		this.isTemporary = isTemporary;
 	}
 
 	public CatalogTable getCatalogTable() {
@@ -56,12 +59,17 @@ public class CreateTableOperation implements CreateOperation {
 		return ignoreIfExists;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("catalogTable", catalogTable.toProperties());
 		params.put("identifier", tableIdentifier);
 		params.put("ignoreIfExists", ignoreIfExists);
+		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
 			"CREATE TABLE",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/DropTableOperation.java
@@ -32,10 +32,15 @@ import java.util.Map;
 public class DropTableOperation implements DropOperation {
 	private final ObjectIdentifier tableIdentifier;
 	private final boolean ifExists;
+	private final boolean isTemporary;
 
-	public DropTableOperation(ObjectIdentifier tableIdentifier, boolean ifExists) {
+	public DropTableOperation(
+			ObjectIdentifier tableIdentifier,
+			boolean ifExists,
+			boolean isTemporary) {
 		this.tableIdentifier = tableIdentifier;
 		this.ifExists = ifExists;
+		this.isTemporary = isTemporary;
 	}
 
 	public ObjectIdentifier getTableIdentifier() {
@@ -46,11 +51,16 @@ public class DropTableOperation implements DropOperation {
 		return this.ifExists;
 	}
 
+	public boolean isTemporary() {
+		return isTemporary;
+	}
+
 	@Override
 	public String asSummaryString() {
 		Map<String, Object> params = new LinkedHashMap<>();
 		params.put("identifier", tableIdentifier);
 		params.put("IfExists", ifExists);
+		params.put("isTemporary", isTemporary);
 
 		return OperationUtils.formatWithChildren(
 			"DROP TABLE",

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -236,7 +236,8 @@ public class SqlToOperationConverter {
 		return new CreateTableOperation(
 			identifier,
 			catalogTable,
-			sqlCreateTable.isIfNotExists());
+			sqlCreateTable.isIfNotExists(),
+			sqlCreateTable.isTemporary());
 	}
 
 	/** Convert DROP TABLE statement. */
@@ -244,7 +245,7 @@ public class SqlToOperationConverter {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlDropTable.fullTableName());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-		return new DropTableOperation(identifier, sqlDropTable.getIfExists());
+		return new DropTableOperation(identifier, sqlDropTable.getIfExists(), sqlDropTable.isTemporary());
 	}
 
 	/** convert ALTER TABLE statement. */

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -138,6 +138,28 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testExecuteSqlWithCreateDropTemporaryTable(): Unit = {
+    val createTableStmt =
+      """
+        |CREATE TEMPORARY TABLE tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'false'
+        |)
+      """.stripMargin
+    val tableResult1 = tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+    assert(tableEnv.listTables().sameElements(Array[String]("tbl1")))
+
+    val tableResult2 = tableEnv.executeSql("DROP TEMPORARY TABLE tbl1")
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+    assert(tableEnv.listTables().sameElements(Array.empty[String]))
+  }
+
+  @Test
   def testExecuteSqlWithCreateAlterDropDatabase(): Unit = {
     val tableResult1 = tableEnv.executeSql("CREATE DATABASE db1 COMMENT 'db1_comment'")
     assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -233,7 +233,8 @@ public class SqlToOperationConverter {
 		return new CreateTableOperation(
 			identifier,
 			catalogTable,
-			sqlCreateTable.isIfNotExists());
+			sqlCreateTable.isIfNotExists(),
+			sqlCreateTable.isTemporary());
 	}
 
 	/** Convert DROP TABLE statement. */
@@ -241,7 +242,7 @@ public class SqlToOperationConverter {
 		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlDropTable.fullTableName());
 		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
-		return new DropTableOperation(identifier, sqlDropTable.getIfExists());
+		return new DropTableOperation(identifier, sqlDropTable.getIfExists(), sqlDropTable.isTemporary());
 	}
 
 	/** convert ALTER TABLE statement. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -597,15 +597,32 @@ abstract class TableEnvImpl(
   private def executeOperation(operation: Operation): TableResult = {
     operation match {
       case createTableOperation: CreateTableOperation =>
-        catalogManager.createTable(
-          createTableOperation.getCatalogTable,
-          createTableOperation.getTableIdentifier,
-          createTableOperation.isIgnoreIfExists)
+        if (createTableOperation.isTemporary) {
+          catalogManager.createTemporaryTable(
+            createTableOperation.getCatalogTable,
+            createTableOperation.getTableIdentifier,
+            createTableOperation.isIgnoreIfExists
+          )
+        } else {
+          catalogManager.createTable(
+            createTableOperation.getCatalogTable,
+            createTableOperation.getTableIdentifier,
+            createTableOperation.isIgnoreIfExists)
+        }
         TableResultImpl.TABLE_RESULT_OK
       case dropTableOperation: DropTableOperation =>
-        catalogManager.dropTable(
-          dropTableOperation.getTableIdentifier,
-          dropTableOperation.isIfExists)
+        if (dropTableOperation.isTemporary) {
+          val dropped = catalogManager.dropTemporaryTable(dropTableOperation.getTableIdentifier)
+          if (!dropped && !dropTableOperation.isIfExists) {
+            throw new ValidationException(String.format(
+              "Temporary table with identifier '%s' doesn't exist",
+              dropTableOperation.getTableIdentifier.asSummaryString()))
+          }
+        } else {
+          catalogManager.dropTable(
+            dropTableOperation.getTableIdentifier,
+            dropTableOperation.isIfExists)
+        }
         TableResultImpl.TABLE_RESULT_OK
       case alterTableOperation: AlterTableOperation =>
         val catalog = getCatalogOrThrowException(

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -35,7 +35,6 @@ import static org.apache.flink.table.catalog.CatalogStructureBuilder.database;
 import static org.apache.flink.table.catalog.CatalogStructureBuilder.root;
 import static org.apache.flink.table.catalog.CatalogStructureBuilder.table;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/CatalogManagerTest.java
@@ -153,16 +153,14 @@ public class CatalogManagerTest extends TestLogger {
 
 	}
 
-	@Test
+	@Test(expected = ValidationException.class)
 	public void testDropTemporaryNonExistingTable() throws Exception {
 		CatalogManager manager = root()
 			.builtin(
 				database(BUILTIN_DEFAULT_DATABASE_NAME, table("test")))
 			.build();
 
-		boolean dropped = manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")));
-
-		assertThat(dropped, is(false));
+		manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")), false);
 	}
 
 	@Test
@@ -174,9 +172,7 @@ public class CatalogManagerTest extends TestLogger {
 			.temporaryTable(identifier)
 			.build();
 
-		boolean dropped = manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")));
-
-		assertThat(dropped, is(true));
+		manager.dropTemporaryTable(manager.qualifyIdentifier(UnresolvedIdentifier.of("test")), false);
 	}
 
 	@Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/BatchTableEnvironmentTest.scala
@@ -75,7 +75,6 @@ class BatchTableEnvironmentTest extends TableTestBase {
     util.verifyTable(sqlTable2, expected2)
   }
 
-
   @Test
   def testExecuteSqlWithCreateDropTable(): Unit = {
     val util = batchTestUtil()
@@ -107,6 +106,30 @@ class BatchTableEnvironmentTest extends TableTestBase {
     assertEquals(ResultKind.SUCCESS, tableResult3.getResultKind)
     assertFalse(util.tableEnv.getCatalog(util.tableEnv.getCurrentCatalog).get()
       .tableExists(ObjectPath.fromString(s"${util.tableEnv.getCurrentDatabase}.tbl1")))
+  }
+
+  @Test
+  def testExecuteSqlWithCreateDropTemporaryTable(): Unit = {
+    val util = batchTestUtil()
+
+    val createTableStmt =
+      """
+        |CREATE TEMPORARY TABLE tbl1 (
+        |  a bigint,
+        |  b int,
+        |  c varchar
+        |) with (
+        |  'connector' = 'COLLECTION',
+        |  'is-bounded' = 'true'
+        |)
+      """.stripMargin
+    val tableResult1 = util.tableEnv.executeSql(createTableStmt)
+    assertEquals(ResultKind.SUCCESS, tableResult1.getResultKind)
+    assert(util.tableEnv.listTables().sameElements(Array[String]("tbl1")))
+
+    val tableResult2 = util.tableEnv.executeSql("DROP TEMPORARY TABLE tbl1")
+    assertEquals(ResultKind.SUCCESS, tableResult2.getResultKind)
+    assert(util.tableEnv.listTables().sameElements(Array.empty[String]))
   }
 
   @Test


### PR DESCRIPTION

## What is the purpose of the change

This PR supports create/drop temporary table in Flink SQL

## Brief change log

- e172a38 support parsing TEMPORARY in table definition in sql parser
- 74191ef support create/drop temporary table in blink planner
- 487163f support create/drop temporary table in legacy planner

## Verifying this change

This change added tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
