### PR TITLE
[FLINK-17401] Add Labels to the mesos task info 

### DIFF
--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -236,6 +236,19 @@ public class LaunchableMesosWorker implements LaunchableTask {
 		//configure task manager hostname property if hostname override property is supplied
 		Option<String> taskManagerHostnameOption = params.getTaskManagerHostname();
 
+		//configure task manager labels
+		Option<Map<String, String>> taskManagerLabels = params.getTaskManagerLabels();
+		if (taskManagerLabels.isDefined()) {
+			Protos.Labels.Builder labelsBuilder = Protos.Labels.newBuilder();
+			for (Map.Entry<String, String> entry: taskManagerLabels.get().entrySet()) {
+				Protos.Label.Builder labelBuilder = Protos.Label.newBuilder();
+				labelBuilder.setKey(entry.getKey());
+				labelBuilder.setValue(entry.getValue());
+				labelsBuilder.addLabels(labelBuilder);
+			}
+			taskInfo.setLabels(labelsBuilder);
+		}
+
 		if (taskManagerHostnameOption.isDefined()) {
 			// replace the TASK_ID pattern by the actual task id value of the Mesos task
 			final String taskManagerHostname = MesosTaskManagerParameters.TASK_ID_PATTERN

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosTaskManagerParameters.java
@@ -35,6 +35,7 @@ import org.apache.mesos.Protos;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import scala.Option;
@@ -131,6 +132,13 @@ public class MesosTaskManagerParameters {
 				"Example: az:eu-west-1a,series:t2")
 			.build());
 
+	public static final ConfigOption<Map<String, String>> MESOS_RM_TASKS_LABELS =
+		key("mesos.resourcemanager.tasks.labels")
+			.mapType()
+			.noDefaultValue()
+			.withDescription("The labels to be set for TaskManager. Specified as key:value pairs separated by commas. " +
+				"For example, key1:value1,key2:value2.");
+
 	/**
 	 * Value for {@code MESOS_RESOURCEMANAGER_TASKS_CONTAINER_TYPE} setting. Tells to use the Mesos containerizer.
 	 */
@@ -166,6 +174,8 @@ public class MesosTaskManagerParameters {
 
 	private final List<String> uris;
 
+	private final Option<Map<String, String>> taskManagerLabels;
+
 	public MesosTaskManagerParameters(
 			int gpus,
 			int disk,
@@ -179,6 +189,7 @@ public class MesosTaskManagerParameters {
 			String command,
 			Option<String> bootstrapCommand,
 			Option<String> taskManagerHostname,
+			Option<Map<String, String>> taskManagerLabels,
 			List<String> uris) {
 
 		this.gpus = gpus;
@@ -193,6 +204,7 @@ public class MesosTaskManagerParameters {
 		this.command = Preconditions.checkNotNull(command);
 		this.bootstrapCommand = Preconditions.checkNotNull(bootstrapCommand);
 		this.taskManagerHostname = Preconditions.checkNotNull(taskManagerHostname);
+		this.taskManagerLabels = Preconditions.checkNotNull(taskManagerLabels);
 		this.uris = Preconditions.checkNotNull(uris);
 	}
 
@@ -290,6 +302,13 @@ public class MesosTaskManagerParameters {
 	}
 
 	/**
+	 * Get the taskManager labels.
+	 */
+	public Option<Map<String, String>> getTaskManagerLabels() {
+		return taskManagerLabels;
+	}
+
+	/**
 	 * Get custom artifact URIs.
 	 */
 	public List<String> uris() {
@@ -373,6 +392,9 @@ public class MesosTaskManagerParameters {
 		//obtain Task Manager Host Name from the configuration
 		Option<String> taskManagerHostname = Option.apply(flinkConfig.getString(MESOS_TM_HOSTNAME));
 
+		//obtain Task Manager labels from the configuration
+		Option<Map<String, String>> taskManagerLabels = Option.apply(flinkConfig.getOptional(MESOS_RM_TASKS_LABELS).orElse(Collections.emptyMap()));
+
 		//obtain command-line from the configuration
 		String tmCommand = flinkConfig.getString(MESOS_TM_CMD);
 		Option<String> tmBootstrapCommand = Option.apply(flinkConfig.getString(MESOS_TM_BOOTSTRAP_CMD));
@@ -390,6 +412,7 @@ public class MesosTaskManagerParameters {
 			tmCommand,
 			tmBootstrapCommand,
 			taskManagerHostname,
+			taskManagerLabels,
 			uris);
 	}
 

--- a/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
+++ b/flink-mesos/src/test/java/org/apache/flink/mesos/runtime/clusterframework/MesosResourceManagerTest.java
@@ -288,7 +288,7 @@ public class MesosResourceManagerTest extends TestLogger {
 				1, 0, MesosTaskManagerParameters.ContainerType.MESOS, Option.<String>empty(), containeredParams,
 				Collections.<Protos.Volume>emptyList(), Collections.<Protos.Parameter>emptyList(), false,
 				Collections.<ConstraintEvaluator>emptyList(), "", Option.<String>empty(),
-				Option.<String>empty(), Collections.<String>emptyList());
+				Option.<String>empty(), Option.apply(Collections.emptyMap()), Collections.<String>emptyList());
 
 			// resource manager
 			rmResourceID = ResourceID.generate();


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-17401]  Currently labels are not set in the task info object. A lot of companies can have logic specific to labels on TM. For example in criteo, based on labels we set kerberos env variables and mesos debug capabilities. It is critical for us to be able to pass these label values to the task manager.

## Brief change log

Reading the labels as map structure from flink config and pass it to mesos task parameters. TaskInfo object is populated with the labels by LaunchableMesosWorker.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:  don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs 
