### PR TITLE
[FLINK-17436][python] Fix the IllegalAccessError caused by package-private access control when submitting Python job via "flink run".

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CliFrontendParser.java
@@ -79,7 +79,7 @@ public class CliFrontendParser {
 	public static final Option YARN_DETACHED_OPTION = new Option("yd", "yarndetached", false, "If present, runs " +
 		"the job in detached mode (deprecated; use non-YARN specific option instead)");
 
-	static final Option ARGS_OPTION = new Option("a", "arguments", true,
+	public static final Option ARGS_OPTION = new Option("a", "arguments", true,
 			"Program arguments. Arguments can also be added without -a, simply as trailing parameters.");
 
 	public static final Option ADDRESS_OPTION = new Option("m", "jobmanager", true,

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptions.java
@@ -67,7 +67,7 @@ public class ProgramOptions extends CommandLineOptions {
 
 	private final SavepointRestoreSettings savepointSettings;
 
-	ProgramOptions(CommandLine line) throws CliArgsException {
+	protected ProgramOptions(CommandLine line) throws CliArgsException {
 		super(line);
 
 		this.entryPointClass = line.hasOption(CLASS_OPTION.getOpt()) ?

--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ProgramOptionsUtils.java
@@ -40,7 +40,7 @@ import static org.apache.flink.client.cli.CliFrontendParser.PY_OPTION;
 /**
  * Utility class for {@link ProgramOptions}.
  */
-enum ProgramOptionsUtils {
+public enum ProgramOptionsUtils {
 	;
 
 	private static final Logger LOG = LoggerFactory.getLogger(ProgramOptionsUtils.class);
@@ -48,7 +48,7 @@ enum ProgramOptionsUtils {
 	/**
 	 * @return True if the commandline contains "-py" or "-pym" options or comes from PyFlink shell, false otherwise.
 	 */
-	static boolean isPythonEntryPoint(CommandLine line) {
+	public static boolean isPythonEntryPoint(CommandLine line) {
 		return line.hasOption(PY_OPTION.getOpt()) ||
 			line.hasOption(PYMODULE_OPTION.getOpt()) ||
 			"org.apache.flink.client.python.PythonGatewayServer".equals(line.getOptionValue(CLASS_OPTION.getOpt()));
@@ -57,14 +57,14 @@ enum ProgramOptionsUtils {
 	/**
 	 * @return True if the commandline contains "-pyfs", "-pyarch", "-pyreq", "-pyexec" options, false otherwise.
 	 */
-	static boolean containsPythonDependencyOptions(CommandLine line) {
+	public static boolean containsPythonDependencyOptions(CommandLine line) {
 		return line.hasOption(PYFILES_OPTION.getOpt()) ||
 			line.hasOption(PYREQUIREMENTS_OPTION.getOpt()) ||
 			line.hasOption(PYARCHIVE_OPTION.getOpt()) ||
 			line.hasOption(PYEXEC_OPTION.getOpt());
 	}
 
-	static ProgramOptions createPythonProgramOptions(CommandLine line) throws CliArgsException {
+	public static ProgramOptions createPythonProgramOptions(CommandLine line) throws CliArgsException {
 		try {
 			ClassLoader classLoader;
 			try {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes the IllegalAccessError caused by package-private access control when submitting Python job via "flink run".*


## Brief change log

  - *Change access control of relevant members and methods to "public" or "protected".*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
