### PR TITLE
[FLINK-17432][docs-training] Rename Tutorials to Training for better SEO

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -27,13 +27,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The [Hands-on Tutorials]({% link tutorials/index.md %}) explain the basic concepts
-of stateful and timely stream processing that underlie Flink's APIs, and provide examples of how
+The [Hands-on Training]({% link training/index.md %}) explains the basic concepts
+of stateful and timely stream processing that underlie Flink's APIs, and provides examples of how
 these mechanisms are used in applications. Stateful stream processing is introduced in the context
-of [Data Pipelines & ETL]({% link tutorials/etl.md %}#stateful-transformations)
+of [Data Pipelines & ETL]({% link training/etl.md %}#stateful-transformations)
 and is further developed in the section on [Fault Tolerance]({% link
-tutorials/fault_tolerance.md %}). Timely stream processing is introduced in the section on
-[Streaming Analytics]({% link tutorials/streaming_analytics.md %}).
+training/fault_tolerance.md %}). Timely stream processing is introduced in the section on
+[Streaming Analytics]({% link training/streaming_analytics.md %}).
 
 This _Concepts in Depth_ section provides a deeper understanding of how Flink's architecture and runtime 
 implement these concepts.

--- a/docs/concepts/index.zh.md
+++ b/docs/concepts/index.zh.md
@@ -27,13 +27,13 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The [Hands-on Tutorials]({% link tutorials/index.zh.md %}) explain the basic concepts
-of stateful and timely stream processing that underlie Flink's APIs, and provide examples of how
+The [Hands-on Training]({% link training/index.zh.md %}) explains the basic concepts
+of stateful and timely stream processing that underlie Flink's APIs, and provides examples of how
 these mechanisms are used in applications. Stateful stream processing is introduced in the context
-of [Data Pipelines & ETL]({% link tutorials/etl.zh.md %}#stateful-transformations)
+of [Data Pipelines & ETL]({% link training/etl.zh.md %}#stateful-transformations)
 and is further developed in the section on [Fault Tolerance]({% link
-tutorials/fault_tolerance.zh.md %}). Timely stream processing is introduced in the section on
-[Streaming Analytics]({% link tutorials/streaming_analytics.zh.md %}).
+training/fault_tolerance.zh.md %}). Timely stream processing is introduced in the section on
+[Streaming Analytics]({% link training/streaming_analytics.zh.md %}).
 
 This _Concepts in Depth_ section provides a deeper understanding of how Flink's architecture and runtime 
 implement these concepts.

--- a/docs/redirects/tutorials_overview.md
+++ b/docs/redirects/tutorials_overview.md
@@ -1,0 +1,24 @@
+---
+title: "Hands-on Tutorials"
+layout: redirect
+redirect: /training/
+permalink: /tutorials/
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/training/datastream_api.md
+++ b/docs/training/datastream_api.md
@@ -24,8 +24,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The focus of this tutorial is to broadly cover the DataStream API well enough that you will be
-able to get started writing streaming applications. 
+The focus of this training is to broadly cover the DataStream API well enough that you will be able
+to get started writing streaming applications.
 
 * This will be replaced by the TOC
 {:toc}

--- a/docs/training/datastream_api.md
+++ b/docs/training/datastream_api.md
@@ -3,8 +3,7 @@ title: Intro to the DataStream API
 nav-id: datastream-api
 nav-pos: 2
 nav-title: Intro to the DataStream API
-nav-parent_id: tutorials
-permalink: /tutorials/datastream_api.html
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/datastream_api.zh.md
+++ b/docs/training/datastream_api.zh.md
@@ -24,8 +24,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-The focus of this tutorial is to broadly cover the DataStream API well enough that you will be
-able to get started writing streaming applications. 
+The focus of this training is to broadly cover the DataStream API well enough that you will be able
+to get started writing streaming applications.
 
 * This will be replaced by the TOC
 {:toc}

--- a/docs/training/datastream_api.zh.md
+++ b/docs/training/datastream_api.zh.md
@@ -3,8 +3,7 @@ title: Intro to the DataStream API
 nav-id: datastream-api
 nav-pos: 2
 nav-title: Intro to the DataStream API
-nav-parent_id: tutorials
-permalink: /tutorials/datastream_api.html
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/etl.md
+++ b/docs/training/etl.md
@@ -3,7 +3,7 @@ title: Data Pipelines & ETL
 nav-id: etl
 nav-pos: 3
 nav-title: Data Pipelines & ETL
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -29,7 +29,7 @@ that take data from one or more sources, perform some transformations and/or enr
 then store the results somewhere. In this tutorial we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
-Note that Flink's [Table and SQL APIs]({% link dev/table/index.zh.md %})
+Note that Flink's [Table and SQL APIs]({% link dev/table/index.md %})
 are well suited for many ETL use cases. But regardless of whether you ultimately use
 the DataStream API directly, or not, having a solid understanding the basics presented here will
 prove valuable.
@@ -293,7 +293,7 @@ Your applications are certainly capable of using state without getting Flink inv
 * **durable**: Flink state is fault-tolerant, i.e., it is automatically checkpointed at regular intervals, and is restored upon failure
 * **vertically scalable**: Flink state can be kept in embedded RocksDB instances that scale by adding more local disk
 * **horizontally scalable**: Flink state is redistributed as your cluster grows and shrinks
-* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.zh.md %}).
+* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.md %}).
 
 In this section you will learn how to work with Flink's APIs that manage keyed state.
 
@@ -413,14 +413,14 @@ You might want to do this, for example, after a period of inactivity for a given
 to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
 applications.
 
-There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.zh.md
+There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.md
 %}#state-time-to-live-ttl) option that you can configure with the state descriptor that specifies
 when you want the state for stale keys to be automatically cleared.
 
 ### Non-keyed State
 
 It is also possible to work with managed state in non-keyed contexts. This is sometimes called
-[operator state]({% link dev/stream/state/state.zh.md %}#operator-state). The
+[operator state]({% link dev/stream/state/state.md %}#operator-state). The
 interfaces involved are somewhat different, and since it is unusual for user-defined functions to
 need non-keyed state, it is not covered here. This feature is most often used in the implementation
 of sources and sinks. 
@@ -530,7 +530,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [DataStream Transformations]({% link dev/stream/operators/index.zh.md %}#datastream-transformations)
-- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.zh.md %})
+- [DataStream Transformations]({% link dev/stream/operators/index.md %}#datastream-transformations)
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.md %})
 
 {% top %}

--- a/docs/training/etl.md
+++ b/docs/training/etl.md
@@ -26,7 +26,7 @@ under the License.
 
 One very common use case for Apache Flink is to implement ETL (extract, transform, load) pipelines
 that take data from one or more sources, perform some transformations and/or enrichments, and
-then store the results somewhere. In this tutorial we are going to look at how to use Flink's
+then store the results somewhere. In this section we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
 Note that Flink's [Table and SQL APIs]({% link dev/table/index.md %})
@@ -264,7 +264,7 @@ The output stream now contains a record for each key every time the duration rea
 
 ### (Implicit) State
 
-This is the first example in these tutorials that involves stateful streaming. Though the state is
+This is the first example in this training that involves stateful streaming. Though the state is
 being handled transparently, Flink has to keep track of the maximum duration for each distinct
 key.
 
@@ -410,7 +410,7 @@ keyHasBeenSeen.clear()
 {% endhighlight %}
 
 You might want to do this, for example, after a period of inactivity for a given key. You'll see how
-to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
+to use Timers to do this when you learn about `ProcessFunction`s in the section on event-driven
 applications.
 
 There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.md

--- a/docs/training/etl.zh.md
+++ b/docs/training/etl.zh.md
@@ -3,7 +3,7 @@ title: Data Pipelines & ETL
 nav-id: etl
 nav-pos: 3
 nav-title: Data Pipelines & ETL
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -29,7 +29,7 @@ that take data from one or more sources, perform some transformations and/or enr
 then store the results somewhere. In this tutorial we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
-Note that Flink's [Table and SQL APIs]({% link dev/table/index.md %})
+Note that Flink's [Table and SQL APIs]({% link dev/table/index.zh.md %})
 are well suited for many ETL use cases. But regardless of whether you ultimately use
 the DataStream API directly, or not, having a solid understanding the basics presented here will
 prove valuable.
@@ -293,7 +293,7 @@ Your applications are certainly capable of using state without getting Flink inv
 * **durable**: Flink state is fault-tolerant, i.e., it is automatically checkpointed at regular intervals, and is restored upon failure
 * **vertically scalable**: Flink state can be kept in embedded RocksDB instances that scale by adding more local disk
 * **horizontally scalable**: Flink state is redistributed as your cluster grows and shrinks
-* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.md %}).
+* **queryable**: Flink state can be queried externally via the [Queryable State API]({% link dev/stream/state/queryable_state.zh.md %}).
 
 In this section you will learn how to work with Flink's APIs that manage keyed state.
 
@@ -413,14 +413,14 @@ You might want to do this, for example, after a period of inactivity for a given
 to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
 applications.
 
-There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.md
+There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.zh.md
 %}#state-time-to-live-ttl) option that you can configure with the state descriptor that specifies
 when you want the state for stale keys to be automatically cleared.
 
 ### Non-keyed State
 
 It is also possible to work with managed state in non-keyed contexts. This is sometimes called
-[operator state]({% link dev/stream/state/state.md %}#operator-state). The
+[operator state]({% link dev/stream/state/state.zh.md %}#operator-state). The
 interfaces involved are somewhat different, and since it is unusual for user-defined functions to
 need non-keyed state, it is not covered here. This feature is most often used in the implementation
 of sources and sinks. 
@@ -530,7 +530,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [DataStream Transformations]({% link dev/stream/operators/index.md %}#datastream-transformations)
-- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.md %})
+- [DataStream Transformations]({% link dev/stream/operators/index.zh.md %}#datastream-transformations)
+- [Stateful Stream Processing]({% link concepts/stateful-stream-processing.zh.md %})
 
 {% top %}

--- a/docs/training/etl.zh.md
+++ b/docs/training/etl.zh.md
@@ -26,7 +26,7 @@ under the License.
 
 One very common use case for Apache Flink is to implement ETL (extract, transform, load) pipelines
 that take data from one or more sources, perform some transformations and/or enrichments, and
-then store the results somewhere. In this tutorial we are going to look at how to use Flink's
+then store the results somewhere. In this section we are going to look at how to use Flink's
 DataStream API to implement this kind of application.
 
 Note that Flink's [Table and SQL APIs]({% link dev/table/index.zh.md %})
@@ -264,7 +264,7 @@ The output stream now contains a record for each key every time the duration rea
 
 ### (Implicit) State
 
-This is the first example in these tutorials that involves stateful streaming. Though the state is
+This is the first example in this training that involves stateful streaming. Though the state is
 being handled transparently, Flink has to keep track of the maximum duration for each distinct
 key.
 
@@ -410,7 +410,7 @@ keyHasBeenSeen.clear()
 {% endhighlight %}
 
 You might want to do this, for example, after a period of inactivity for a given key. You'll see how
-to use Timers to do this when you learn about `ProcessFunction`s in the tutorial on event-driven
+to use Timers to do this when you learn about `ProcessFunction`s in the section on event-driven
 applications.
 
 There's also a [State Time-to-Live (TTL)]({% link dev/stream/state/state.zh.md

--- a/docs/training/event_driven.md
+++ b/docs/training/event_driven.md
@@ -39,7 +39,7 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 
 If you've done the
 [hands-on exercise]({% link training/streaming_analytics.md %}#hands-on)
-in the [Streaming Analytics tutorial]({% link training/streaming_analytics.md %}),
+in the [Streaming Analytics training]({% link training/streaming_analytics.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 

--- a/docs/training/event_driven.md
+++ b/docs/training/event_driven.md
@@ -3,7 +3,7 @@ title: Event-driven Applications
 nav-id: event-driven
 nav-pos: 5
 nav-title: Event-driven Applications
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -38,8 +38,8 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 ### Example
 
 If you've done the
-[hands-on exercise]({% link tutorials/streaming_analytics.zh.md %}#hands-on)
-in the [Streaming Analytics tutorial]({% link tutorials/streaming_analytics.zh.md %}),
+[hands-on exercise]({% link training/streaming_analytics.md %}#hands-on)
+in the [Streaming Analytics tutorial]({% link training/streaming_analytics.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 
@@ -177,7 +177,7 @@ Things to consider:
 
 * What happens with late events? Events that are behind the watermark (i.e., late) are being
   dropped. If you want to do something better than this, consider using a side output, which is
-  explained in the [next section]({% link tutorials/event_driven.zh.md
+  explained in the [next section]({% link training/event_driven.md
   %}#side-outputs).
 
 * This example uses a `MapState` where the keys are timestamps, and sets a `Timer` for that same
@@ -302,7 +302,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [ProcessFunction]({% link dev/stream/operators/process_function.zh.md %})
-- [Side Outputs]({% link dev/stream/side_output.zh.md %})
+- [ProcessFunction]({% link dev/stream/operators/process_function.md %})
+- [Side Outputs]({% link dev/stream/side_output.md %})
 
 {% top %}

--- a/docs/training/event_driven.zh.md
+++ b/docs/training/event_driven.zh.md
@@ -39,7 +39,7 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 
 If you've done the
 [hands-on exercise]({% link training/streaming_analytics.zh.md %}#hands-on)
-in the [Streaming Analytics tutorial]({% link training/streaming_analytics.zh.md %}),
+in the [Streaming Analytics training]({% link training/streaming_analytics.zh.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 

--- a/docs/training/event_driven.zh.md
+++ b/docs/training/event_driven.zh.md
@@ -3,7 +3,7 @@ title: Event-driven Applications
 nav-id: event-driven
 nav-pos: 5
 nav-title: Event-driven Applications
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -38,8 +38,8 @@ with Flink. It is very similar to a `RichFlatMapFunction`, but with the addition
 ### Example
 
 If you've done the
-[hands-on exercise]({% link tutorials/streaming_analytics.md %}#hands-on)
-in the [Streaming Analytics tutorial]({% link tutorials/streaming_analytics.md %}),
+[hands-on exercise]({% link training/streaming_analytics.zh.md %}#hands-on)
+in the [Streaming Analytics tutorial]({% link training/streaming_analytics.zh.md %}),
 you will recall that it uses a `TumblingEventTimeWindow` to compute the sum of the tips for
 each driver during each hour, like this:
 
@@ -177,7 +177,7 @@ Things to consider:
 
 * What happens with late events? Events that are behind the watermark (i.e., late) are being
   dropped. If you want to do something better than this, consider using a side output, which is
-  explained in the [next section]({% link tutorials/event_driven.md
+  explained in the [next section]({% link training/event_driven.zh.md
   %}#side-outputs).
 
 * This example uses a `MapState` where the keys are timestamps, and sets a `Timer` for that same
@@ -302,7 +302,7 @@ Exercise](https://github.com/apache/flink-training/tree/{% if site.is_stable %}r
 
 ## Further Reading
 
-- [ProcessFunction]({% link dev/stream/operators/process_function.md %})
-- [Side Outputs]({% link dev/stream/side_output.md %})
+- [ProcessFunction]({% link dev/stream/operators/process_function.zh.md %})
+- [Side Outputs]({% link dev/stream/side_output.zh.md %})
 
 {% top %}

--- a/docs/training/fault_tolerance.md
+++ b/docs/training/fault_tolerance.md
@@ -3,7 +3,7 @@ title: Fault Tolerance via State Snapshots
 nav-id: fault-tolerance
 nav-pos: 6
 nav-title: Fault Tolerance
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/fault_tolerance.zh.md
+++ b/docs/training/fault_tolerance.zh.md
@@ -3,7 +3,7 @@ title: Fault Tolerance via State Snapshots
 nav-id: fault-tolerance
 nav-pos: 6
 nav-title: Fault Tolerance
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,8 +1,8 @@
 ---
-title: Hands-on Tutorials
-nav-id: tutorials
+title: Hands-on Training
+nav-id: training
 nav-pos: 2
-nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Tutorials'
+nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Training'
 nav-parent_id: root
 nav-show_overview: true
 always-expand: true
@@ -29,15 +29,15 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-## Goals and Scope of these Tutorials
+## Goals and Scope of this Training
 
-These tutorials present an introduction to Apache Flink that includes just enough to get you started
+This training presents an introduction to Apache Flink that includes just enough to get you started
 writing scalable streaming ETL, analytics, and event-driven applications, while leaving out a lot of
 (ultimately important) details. The focus is on providing straightforward introductions to Flink's
 APIs for managing state and time, with the expectation that having mastered these fundamentals,
 you'll be much better equipped to pick up the rest of what you need to know from the more detailed
-reference documentation. The links at the end of each page will lead you to where you can learn
-more.
+reference documentation. The links at the end of each section will lead you to where you
+can learn more.
 
 Specifically, you will learn:
 
@@ -47,12 +47,12 @@ Specifically, you will learn:
 - how to build event-driven applications on continuous streams
 - how Flink is able to provide fault-tolerant, stateful stream processing with exactly-once semantics
 
-These tutorials focus on four critical concepts: continuous processing of streaming data, event
+This training focuses on four critical concepts: continuous processing of streaming data, event
 time, stateful stream processing, and state snapshots. This page introduces these concepts.
 
-{% info Note %} Accompanying these tutorials are a set of hands-on exercises that will guide you
-through learning how to work with the concepts being presented. A link to the relevant exercise
-is provided at the end of each tutorial.
+{% info Note %} Accompanying this training is a set of hands-on exercises that will
+guide you through learning how to work with the concepts being presented. A link to the relevant
+exercise is provided at the end of each section.
 
 {% top %}
 

--- a/docs/training/index.zh.md
+++ b/docs/training/index.zh.md
@@ -1,8 +1,8 @@
 ---
-title: Hands-on Tutorials
-nav-id: tutorials
+title: Hands-on Training
+nav-id: training
 nav-pos: 2
-nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Tutorials'
+nav-title: '<i class="fa fa-hand-paper-o title appetizer" aria-hidden="true"></i> Hands-on Training'
 nav-parent_id: root
 nav-show_overview: true
 always-expand: true
@@ -29,15 +29,15 @@ under the License.
 * This will be replaced by the TOC
 {:toc}
 
-## Goals and Scope of these Tutorials
+## Goals and Scope of this Training
 
-These tutorials present an introduction to Apache Flink that includes just enough to get you started
+This training presents an introduction to Apache Flink that includes just enough to get you started
 writing scalable streaming ETL, analytics, and event-driven applications, while leaving out a lot of
 (ultimately important) details. The focus is on providing straightforward introductions to Flink's
 APIs for managing state and time, with the expectation that having mastered these fundamentals,
 you'll be much better equipped to pick up the rest of what you need to know from the more detailed
-reference documentation. The links at the end of each page will lead you to where you can learn
-more.
+reference documentation. The links at the end of each section will lead you to where you
+can learn more.
 
 Specifically, you will learn:
 
@@ -47,12 +47,12 @@ Specifically, you will learn:
 - how to build event-driven applications on continuous streams
 - how Flink is able to provide fault-tolerant, stateful stream processing with exactly-once semantics
 
-These tutorials focus on four critical concepts: continuous processing of streaming data, event
+This training focuses on four critical concepts: continuous processing of streaming data, event
 time, stateful stream processing, and state snapshots. This page introduces these concepts.
 
-{% info Note %} Accompanying these tutorials are a set of hands-on exercises that will guide you
-through learning how to work with the concepts being presented. A link to the relevant exercise
-is provided at the end of each tutorial.
+{% info Note %} Accompanying this training is a set of hands-on exercises that will
+guide you through learning how to work with the concepts being presented. A link to the relevant
+exercise is provided at the end of each section.
 
 {% top %}
 

--- a/docs/training/streaming_analytics.md
+++ b/docs/training/streaming_analytics.md
@@ -3,7 +3,7 @@ title: Streaming Analytics
 nav-id: analytics
 nav-pos: 4
 nav-title: Streaming Analytics
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -60,7 +60,7 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark
 Generator that Flink will use to track the progress of event time. This will be covered in the
 section below on [Working with Watermarks]({% link
-tutorials/streaming_analytics.md %}#working-with-watermarks), but first we should explain what
+training/streaming_analytics.md %}#working-with-watermarks), but first we should explain what
 watermarks are.
 
 ### Watermarks
@@ -253,7 +253,7 @@ that behavior yourself with a custom Trigger.
 A global window assigner assigns every event (with the same key) to the same global window. This is
 only useful if you are going to do your own custom windowing, with a custom Trigger. In many cases
 where this might seem useful you will be better off using a `ProcessFunction` as described
-[in another section]({% link tutorials/event_driven.md %}#process-functions).
+[in another section]({% link training/event_driven.md %}#process-functions).
 
 ### Window Functions
 
@@ -365,7 +365,7 @@ the window API that give you more control over this.
 
 You can arrange for the events that would be dropped to be collected to an alternate output stream
 instead, using a mechanism called
-[Side Outputs]({% link tutorials/event_driven.md %}#side-outputs).
+[Side Outputs]({% link training/event_driven.md %}#side-outputs).
 Here is an example of what that might look like:
 
 {% highlight java %}

--- a/docs/training/streaming_analytics.zh.md
+++ b/docs/training/streaming_analytics.zh.md
@@ -3,7 +3,7 @@ title: Streaming Analytics
 nav-id: analytics
 nav-pos: 4
 nav-title: Streaming Analytics
-nav-parent_id: tutorials
+nav-parent_id: training
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
@@ -60,7 +60,7 @@ env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 If you want to use event time, you will also need to supply a Timestamp Extractor and Watermark
 Generator that Flink will use to track the progress of event time. This will be covered in the
 section below on [Working with Watermarks]({% link
-tutorials/streaming_analytics.zh.md %}#working-with-watermarks), but first we should explain what
+training/streaming_analytics.zh.md %}#working-with-watermarks), but first we should explain what
 watermarks are.
 
 ### Watermarks
@@ -253,7 +253,7 @@ that behavior yourself with a custom Trigger.
 A global window assigner assigns every event (with the same key) to the same global window. This is
 only useful if you are going to do your own custom windowing, with a custom Trigger. In many cases
 where this might seem useful you will be better off using a `ProcessFunction` as described
-[in another section]({% link tutorials/event_driven.zh.md %}#process-functions).
+[in another section]({% link training/event_driven.zh.md %}#process-functions).
 
 ### Window Functions
 
@@ -365,7 +365,7 @@ the window API that give you more control over this.
 
 You can arrange for the events that would be dropped to be collected to an alternate output stream
 instead, using a mechanism called
-[Side Outputs]({% link tutorials/event_driven.zh.md %}#side-outputs).
+[Side Outputs]({% link training/event_driven.zh.md %}#side-outputs).
 Here is an example of what that might look like:
 
 {% highlight java %}


### PR DESCRIPTION
## What is the purpose of the change

This pull request renames the new Tutorials section of the documentation.

## Brief change log

* Renamed the tutorials directory to training
* Changed all links
* Reworded a few sentences to talk about training
* Added a redirect from /tutorials to /training
