### PR TITLE
[FLINK-17391][filesystem] rolling-policy interval default value should be bigger

### DIFF
--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -78,8 +78,9 @@ public class FileSystemTableFactory implements
 
 	public static final ConfigOption<Long> SINK_ROLLING_POLICY_TIME_INTERVAL = key("sink.rolling-policy.time.interval")
 			.longType()
-			.defaultValue(60L * 1000L)
-			.withDescription("The maximum time duration a part file can stay open before rolling (by default 60 sec).");
+			.defaultValue(30L * 60 * 1000L)
+			.withDescription("The maximum time duration a part file can stay open before rolling" +
+					" (by default 30 min to avoid to many small files).");
 
 	public static final ConfigOption<Boolean> SINK_SHUFFLE_BY_PARTITION = key("sink.shuffle-by-partition.enable")
 			.booleanType()


### PR DESCRIPTION

## What is the purpose of the change

by default 30 min to avoid to many small files.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? (no