### PR TITLE
[FLINK-17403][test] Fix invalid classpath in BashJavaUtilsITCase

### DIFF
--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -34,9 +34,10 @@ bin=`cd "$bin"; pwd`
 
 FLINK_CONF_DIR=${bin}/../../main/resources
 FLINK_TARGET_DIR=${bin}/../../../target
-FLINK_DIST_JAR=`find $FLINK_TARGET_DIR -name 'flink-dist*.jar'`
+FLINK_DIST_JARS=`find ${FLINK_TARGET_DIR} -name 'flink-dist*.jar' -maxdepth 1`
+FLINK_DIST_CLASSPATH=`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 
-output=$(runBashJavaUtilsCmd ${COMMAND} ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:$FLINK_DIST_JAR}" $DYNAMIC_OPTS)
+output=$(runBashJavaUtilsCmd ${COMMAND} ${FLINK_CONF_DIR} "$FLINK_TARGET_DIR/bash-java-utils.jar:${FLINK_DIST_CLASSPATH}" $DYNAMIC_OPTS)
 extractExecutionResults "${output}" ${EXPECTED_LINES}

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -35,7 +35,7 @@ bin=`cd "$bin"; pwd`
 FLINK_CONF_DIR=${bin}/../../main/resources
 FLINK_TARGET_DIR=${bin}/../../../target
 FLINK_DIST_JARS=`find ${FLINK_TARGET_DIR} -maxdepth 1 -name 'flink-dist*.jar'`
-FLINK_DIST_CLASSPATH=`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`
+FLINK_DIST_CLASSPATH=(`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`)
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -34,8 +34,8 @@ bin=`cd "$bin"; pwd`
 
 FLINK_CONF_DIR=${bin}/../../main/resources
 FLINK_TARGET_DIR=${bin}/../../../target
-FLINK_DIST_JARS=`find ${FLINK_TARGET_DIR} -maxdepth 1 -name 'flink-dist*.jar'`
-FLINK_DIST_CLASSPATH=(`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`)
+FLINK_DIST_JARS=(`find ${FLINK_TARGET_DIR} -maxdepth 1 -name 'flink-dist*.jar'`)
+FLINK_DIST_CLASSPATH=`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null
 

--- a/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
+++ b/flink-dist/src/test/bin/runBashJavaUtilsCmd.sh
@@ -34,7 +34,7 @@ bin=`cd "$bin"; pwd`
 
 FLINK_CONF_DIR=${bin}/../../main/resources
 FLINK_TARGET_DIR=${bin}/../../../target
-FLINK_DIST_JARS=`find ${FLINK_TARGET_DIR} -name 'flink-dist*.jar' -maxdepth 1`
+FLINK_DIST_JARS=`find ${FLINK_TARGET_DIR} -maxdepth 1 -name 'flink-dist*.jar'`
 FLINK_DIST_CLASSPATH=`echo ${FLINK_DIST_JARS[@]} | tr ' ' ':'`
 
 . ${bin}/../../main/flink-bin/bin/config.sh > /dev/null


### PR DESCRIPTION
## What is the purpose of the change

This PR hardens BashJavaUtilsITCase.

In BashJavaUtilsITCase, runBashJavaUtilsCmd.sh locates flink-dist.jar by `find` with pattern `flink-dist*.jar`, but it doesn't filter out the flink-dist*-source.jar built by maven and the flink-dist jar in the original bin directory, so it might get 3 jars as the result, which might break the command depends on it.

For instance, the result of `find` can be:
```
project_dir/flink-dist/src/test/bin/../../../target/flink-dist_2.11-1.10.0-sources.jar
project_dir/flink-dist/src/test/bin/../../../target/flink-1.10.0-bin/flink-1.10.0/lib/flink-dist_2.11-1.10.0.jar
project_dirflink-dist/src/test/bin/../../../target/flink-dist_2.11-1.10.0.jar
```

## Brief change log

Restrict the search scope to `-maxdepth 1` under `target` directory, and join the jars found with `:` before adding them to the classpath.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
