### PR TITLE
[FLINK-17386][Security][hotfix] fix LinkageError not captured

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/SecurityUtils.java
@@ -94,6 +94,8 @@ public class SecurityUtils {
 						break;
 					} catch (SecurityContextInitializeException e) {
 						LOG.error("Cannot instantiate security context with: " + contextFactoryClass, e);
+					} catch (LinkageError le) {
+						LOG.error("Error occur when instantiate security context with: " + contextFactoryClass , le);
 					}
 				} else {
 					LOG.warn("Unable to install incompatible security context factory {}", contextFactoryClass);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/SecurityUtilsTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.security.contexts.AnotherCompatibleTestSecurityContextFactory;
 import org.apache.flink.runtime.security.contexts.HadoopSecurityContextFactory;
 import org.apache.flink.runtime.security.contexts.IncompatibleTestSecurityContextFactory;
+import org.apache.flink.runtime.security.contexts.LinkageErrorSecurityContextFactory;
 import org.apache.flink.runtime.security.contexts.NoOpSecurityContext;
 import org.apache.flink.runtime.security.contexts.NoOpSecurityContextFactory;
 import org.apache.flink.runtime.security.contexts.TestSecurityContextFactory;
@@ -79,6 +80,27 @@ public class SecurityUtilsTest {
 
 		SecurityUtils.install(sc);
 		assertEquals(TestSecurityContextFactory.TestSecurityContext.class, SecurityUtils.getInstalledContext().getClass());
+
+		SecurityUtils.uninstall();
+		assertEquals(NoOpSecurityContext.class, SecurityUtils.getInstalledContext().getClass());
+	}
+
+	@Test
+	public void testLinkageErrorShouldFallbackToSecond() throws Exception {
+		Configuration testFlinkConf = new Configuration();
+
+		testFlinkConf.set(
+			SecurityOptions.SECURITY_CONTEXT_FACTORY_CLASSES,
+			Lists.newArrayList(
+				LinkageErrorSecurityContextFactory.class.getCanonicalName(),
+				TestSecurityContextFactory.class.getCanonicalName()));
+
+		SecurityConfiguration testSecurityConf = new SecurityConfiguration(testFlinkConf);
+
+		SecurityUtils.install(testSecurityConf);
+		assertEquals(
+			TestSecurityContextFactory.TestSecurityContext.class,
+			SecurityUtils.getInstalledContext().getClass());
 
 		SecurityUtils.uninstall();
 		assertEquals(NoOpSecurityContext.class, SecurityUtils.getInstalledContext().getClass());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/contexts/LinkageErrorSecurityContextFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/contexts/LinkageErrorSecurityContextFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.contexts;
+
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.SecurityContextInitializeException;
+
+/**
+ * Test security context factory class to test out linkage error circumstances.
+ */
+public class LinkageErrorSecurityContextFactory implements SecurityContextFactory {
+
+	@Override
+	public boolean isCompatibleWith(SecurityConfiguration securityConfig) {
+		return true;
+	}
+
+	@Override
+	public SecurityContext createContext(SecurityConfiguration securityConfig) throws SecurityContextInitializeException {
+		throw new LinkageError("Incompatible due to dependency missing!");
+	}
+}

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.contexts.SecurityContextFactory
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.contexts.SecurityContextFactory
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.security.contexts.TestSecurityContextFactory
-org.apache.flink.runtime.security.contexts.IncompatibleTestSecurityContextFactory
 org.apache.flink.runtime.security.contexts.AnotherCompatibleTestSecurityContextFactory
+org.apache.flink.runtime.security.contexts.LinkageErrorSecurityContextFactory
+org.apache.flink.runtime.security.contexts.IncompatibleTestSecurityContextFactory
+org.apache.flink.runtime.security.contexts.TestSecurityContextFactory


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes a LinkageError not captured correctly problem. see: https://github.com/apache/flink/pull/10836/files#r416703366


## Brief change log

Added LinkageError back into the hadoop security module factory

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
