### PR TITLE
[FLINK-17440][network] Resolve potential buffer leak in output unspilling for unaligned checkpoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriter.java
@@ -45,10 +45,10 @@ public interface ResultPartitionWriter extends AutoCloseable, AvailabilityProvid
 	void setup() throws IOException;
 
 	/**
-	 * Loads the previous output states with the given reader for unaligned checkpoint.
+	 * Reads the previous output states with the given reader for unaligned checkpoint.
 	 * It should be done before task processing the inputs.
 	 */
-	void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException;
+	void readRecoveredState(ChannelStateReader stateReader) throws IOException, InterruptedException;
 
 	ResultPartitionID getPartitionId();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -102,7 +102,7 @@ public class PipelinedSubpartition extends ResultSubpartition {
 	}
 
 	@Override
-	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+	public void readRecoveredState(ChannelStateReader stateReader) throws IOException, InterruptedException {
 		for (ReadResult readResult = ReadResult.HAS_MORE_DATA; readResult == ReadResult.HAS_MORE_DATA;) {
 			BufferBuilder bufferBuilder = parent.getBufferPool().requestBufferBuilderBlocking();
 			BufferConsumer bufferConsumer = bufferBuilder.createBufferConsumer();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -152,9 +152,9 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 	}
 
 	@Override
-	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+	public void readRecoveredState(ChannelStateReader stateReader) throws IOException, InterruptedException {
 		for (ResultSubpartition subpartition : subpartitions) {
-			subpartition.initializeState(stateReader);
+			subpartition.readRecoveredState(stateReader);
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultSubpartition.java
@@ -77,7 +77,7 @@ public abstract class ResultSubpartition {
 		parent.onConsumedSubpartition(getSubPartitionIndex());
 	}
 
-	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+	public void readRecoveredState(ChannelStateReader stateReader) throws IOException, InterruptedException {
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/ConsumableNotifyingResultPartitionWriterDecorator.java
@@ -101,8 +101,8 @@ public class ConsumableNotifyingResultPartitionWriterDecorator implements Result
 	}
 
 	@Override
-	public void initializeState(ChannelStateReader stateReader) throws IOException, InterruptedException {
-		partitionWriter.initializeState(stateReader);
+	public void readRecoveredState(ChannelStateReader stateReader) throws IOException, InterruptedException {
+		partitionWriter.readRecoveredState(stateReader);
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/RecordWriterTest.java
@@ -463,7 +463,7 @@ public class RecordWriterTest {
 
 		try {
 			partition.setup();
-			partition.initializeState(stateReader);
+			partition.readRecoveredState(stateReader);
 
 			for (int record: records) {
 				// the record length 4 is also written into buffer for every emit

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/MockResultPartitionWriter.java
@@ -40,7 +40,7 @@ public class MockResultPartitionWriter implements ResultPartitionWriter {
 	}
 
 	@Override
-	public void initializeState(ChannelStateReader stateReader) {
+	public void readRecoveredState(ChannelStateReader stateReader) {
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -427,7 +427,7 @@ public class ResultPartitionTest {
 		final ChannelStateReader stateReader = ChannelStateReader.NO_OP;
 		try {
 			partition.setup();
-			partition.initializeState(stateReader);
+			partition.readRecoveredState(stateReader);
 
 			for (ResultSubpartition subpartition : partition.getAllPartitions()) {
 				// no buffers are added into the queue for empty states
@@ -483,7 +483,7 @@ public class ResultPartitionTest {
 			Future<Void> result = executor.submit(partitionConsumeTask);
 
 			partition.setup();
-			partition.initializeState(stateReader);
+			partition.readRecoveredState(stateReader);
 
 			// wait the partition consume task finish
 			result.get(20, TimeUnit.SECONDS);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.checkpoint.channel.ChannelStateReader;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.CancelTaskException;
@@ -461,9 +460,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 
 			ResultPartitionWriter[] writers = getEnvironment().getAllWriters();
 			if (writers != null) {
-				//TODO we should get proper state reader from getEnvironment().getTaskStateManager().getChannelStateReader()
 				for (ResultPartitionWriter writer : writers) {
-					writer.readRecoveredState(ChannelStateReader.NO_OP);
+					writer.readRecoveredState(getEnvironment().getTaskStateManager().getChannelStateReader());
 				}
 			}
 		});

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -463,7 +463,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			if (writers != null) {
 				//TODO we should get proper state reader from getEnvironment().getTaskStateManager().getChannelStateReader()
 				for (ResultPartitionWriter writer : writers) {
-					writer.initializeState(ChannelStateReader.NO_OP);
+					writer.readRecoveredState(ChannelStateReader.NO_OP);
 				}
 			}
 		});

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -1776,7 +1776,7 @@ public class StreamTaskTest extends TestLogger {
 		}
 
 		@Override
-		public void initializeState(ChannelStateReader stateReader) {
+		public void readRecoveredState(ChannelStateReader stateReader) {
 			isStateInitialized = true;
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

If there are any exceptions thrown while interacting with `ChannelStateReader#readOutputData`, we should close the respective `BufferConsumer` to avoid leak.

## Brief change log

- Close the respective `BufferConsumer` when exception is thrown from `ChannelStateReader#readOutputData`

## Verifying this change

- Add new unit test `ResultPartitionTest#testReadRecoveredStateWithException`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
