### PR TITLE
[FLINK-17325][orc] Integrate orc to file system connector

### DIFF
--- a/flink-formats/flink-orc/pom.xml
+++ b/flink-formats/flink-orc/pom.xml
@@ -122,6 +122,21 @@ under the License.
 			<type>test-jar</type>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.orc.vector.RowDataVectorizer;
+import org.apache.flink.orc.writer.OrcBulkWriterFactory;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.FileSystemFormatFactory;
+import org.apache.flink.table.filesystem.PartitionPathUtils;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.apache.flink.table.data.vector.VectorizedColumnBatch.DEFAULT_SIZE;
+import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
+import static org.apache.flink.table.filesystem.RowPartitionComputer.restorePartValueFromType;
+
+/**
+ * Orc {@link FileSystemFormatFactory} for file system.
+ */
+public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
+
+	/**
+	 * Prefix for orc-related properties, besides format, start with "orc".
+	 * See more in {@link org.apache.orc.OrcConf}.
+	 */
+	public static final String ORC_PROPERTIES = "format.orc";
+
+	@Override
+	public Map<String, String> requiredContext() {
+		Map<String, String> context = new HashMap<>();
+		context.put(FORMAT, "orc");
+		return context;
+	}
+
+	@Override
+	public List<String> supportedProperties() {
+		return Collections.singletonList(
+				ORC_PROPERTIES + ".*"
+		);
+	}
+
+	private static Properties getOrcProperties(DescriptorProperties properties) {
+		Properties conf = new Properties();
+		properties.asMap().keySet()
+				.stream()
+				.filter(key -> key.startsWith(ORC_PROPERTIES))
+				.forEach(key -> {
+					String value = properties.getString(key);
+					String subKey = key.substring((FORMAT + '.').length());
+					conf.put(subKey, value);
+				});
+		return conf;
+	}
+
+	@Override
+	public InputFormat<RowData, ?> createReader(ReaderContext context) {
+		DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(context.getFormatProperties());
+
+		return new OrcRowDataInputFormat(
+				context.getPaths(),
+				context.getSchema().getFieldNames(),
+				context.getSchema().getFieldDataTypes(),
+				context.getProjectFields(),
+				context.getDefaultPartName(),
+				context.getPushedDownLimit(),
+				getOrcProperties(properties));
+	}
+
+	@Override
+	public Optional<BulkWriter.Factory<RowData>> createBulkWriterFactory(WriterContext context) {
+		DescriptorProperties properties = new DescriptorProperties();
+		properties.putProperties(context.getFormatProperties());
+
+		LogicalType[] orcTypes = Arrays.stream(context.getFieldTypesWithoutPartKeys())
+				.map(DataType::getLogicalType)
+				.toArray(LogicalType[]::new);
+
+		TypeDescription typeDescription = OrcSplitReaderUtil.logicalTypeToOrcType(
+				RowType.of(orcTypes, context.getFieldNamesWithoutPartKeys()));
+
+		OrcBulkWriterFactory<RowData> factory = new OrcBulkWriterFactory<>(
+				new RowDataVectorizer(typeDescription.toString(), orcTypes),
+				getOrcProperties(properties),
+				new Configuration());
+		return Optional.of(factory);
+	}
+
+	@Override
+	public Optional<Encoder<RowData>> createEncoder(WriterContext context) {
+		return Optional.empty();
+	}
+
+	@Override
+	public boolean supportsSchemaDerivation() {
+		return true;
+	}
+
+	/**
+	 * An implementation of {@link FileInputFormat} to read {@link RowData} records
+	 * from orc files.
+	 */
+	public static class OrcRowDataInputFormat extends FileInputFormat<RowData> {
+
+		private static final long serialVersionUID = 1L;
+
+		private final String[] fullFieldNames;
+		private final DataType[] fullFieldTypes;
+		private final int[] selectedFields;
+		private final String partDefaultName;
+		private final Properties properties;
+		private final long limit;
+
+		private transient OrcColumnarRowSplitReader<VectorizedRowBatch> reader;
+		private transient long currentReadCount;
+
+		public OrcRowDataInputFormat(
+				Path[] paths,
+				String[] fullFieldNames,
+				DataType[] fullFieldTypes,
+				int[] selectedFields,
+				String partDefaultName,
+				long limit,
+				Properties properties) {
+			super.setFilePaths(paths);
+			this.limit = limit;
+			this.partDefaultName = partDefaultName;
+			this.fullFieldNames = fullFieldNames;
+			this.fullFieldTypes = fullFieldTypes;
+			this.selectedFields = selectedFields;
+			this.properties = properties;
+		}
+
+		@Override
+		public void open(FileInputSplit fileSplit) throws IOException {
+			// generate partition specs.
+			List<String> fieldNameList = Arrays.asList(fullFieldNames);
+			LinkedHashMap<String, String> partSpec = PartitionPathUtils.extractPartitionSpecFromPath(
+					fileSplit.getPath());
+			LinkedHashMap<String, Object> partObjects = new LinkedHashMap<>();
+			partSpec.forEach((k, v) -> partObjects.put(k, restorePartValueFromType(
+					partDefaultName.equals(v) ? null : v,
+					fullFieldTypes[fieldNameList.indexOf(k)])));
+
+			Configuration conf = new Configuration();
+			properties.forEach((k, v) -> conf.set(k.toString(), v.toString()));
+
+			this.reader = OrcSplitReaderUtil.genPartColumnarRowReader(
+					"3.1.1", // use the latest hive version
+					conf,
+					fullFieldNames,
+					fullFieldTypes,
+					partObjects,
+					selectedFields,
+					new ArrayList<>(),
+					DEFAULT_SIZE,
+					new Path(fileSplit.getPath().toString()),
+					fileSplit.getStart(),
+					fileSplit.getLength());
+			this.currentReadCount = 0L;
+		}
+
+		@Override
+		public boolean supportsMultiPaths() {
+			return true;
+		}
+
+		@Override
+		public boolean reachedEnd() throws IOException {
+			if (currentReadCount >= limit) {
+				return true;
+			} else {
+				return reader.reachedEnd();
+			}
+		}
+
+		@Override
+		public RowData nextRecord(RowData reuse) {
+			currentReadCount++;
+			return reader.nextRecord(reuse);
+		}
+
+		@Override
+		public void close() throws IOException {
+			if (reader != null) {
+				this.reader.close();
+			}
+			this.reader = null;
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileSystemFormatFactory.java
@@ -62,7 +62,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 	 * Prefix for orc-related properties, besides format, start with "orc".
 	 * See more in {@link org.apache.orc.OrcConf}.
 	 */
-	public static final String ORC_PROPERTIES = "format.orc";
+	public static final String ORC_PROPERTIES_PREFIX = "format.orc";
 
 	@Override
 	public Map<String, String> requiredContext() {
@@ -74,7 +74,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 	@Override
 	public List<String> supportedProperties() {
 		return Collections.singletonList(
-				ORC_PROPERTIES + ".*"
+				ORC_PROPERTIES_PREFIX + ".*"
 		);
 	}
 
@@ -82,7 +82,7 @@ public class OrcFileSystemFormatFactory implements FileSystemFormatFactory {
 		Properties conf = new Properties();
 		properties.asMap().keySet()
 				.stream()
-				.filter(key -> key.startsWith(ORC_PROPERTIES))
+				.filter(key -> key.startsWith(ORC_PROPERTIES_PREFIX))
 				.forEach(key -> {
 					String value = properties.getString(key);
 					String subKey = key.substring((FORMAT + '.').length());

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
@@ -56,8 +56,8 @@ public class RowDataVectorizer extends Vectorizer<RowData> {
 	}
 
 	private static void setColumn(
-			int rowId, ColumnVector column, LogicalType type, RowData row, int i) {
-		if (row.isNullAt(i)) {
+			int rowId, ColumnVector column, LogicalType type, RowData row, int columnId) {
+		if (row.isNullAt(columnId)) {
 			column.noNulls = false;
 			column.isNull[rowId] = true;
 			return;
@@ -67,20 +67,20 @@ public class RowDataVectorizer extends Vectorizer<RowData> {
 			case CHAR:
 			case VARCHAR: {
 				BytesColumnVector vector = (BytesColumnVector) column;
-				byte[] bytes = row.getString(i).toBytes();
+				byte[] bytes = row.getString(columnId).toBytes();
 				vector.setVal(rowId, bytes, 0, bytes.length);
 				break;
 			}
 			case BOOLEAN: {
 				LongColumnVector vector = (LongColumnVector) column;
 				vector.vector[rowId] =
-						row.getBoolean(i) ? 1 : 0;
+						row.getBoolean(columnId) ? 1 : 0;
 				break;
 			}
 			case BINARY:
 			case VARBINARY: {
 				BytesColumnVector vector = (BytesColumnVector) column;
-				byte[] bytes = row.getBinary(i);
+				byte[] bytes = row.getBinary(columnId);
 				vector.setVal(rowId, bytes, 0, bytes.length);
 				break;
 			}
@@ -88,51 +88,51 @@ public class RowDataVectorizer extends Vectorizer<RowData> {
 				DecimalType dt = (DecimalType) type;
 				DecimalColumnVector vector = (DecimalColumnVector) column;
 				vector.set(rowId, HiveDecimal.create(
-						row.getDecimal(i, dt.getPrecision(), dt.getScale()).toBigDecimal()));
+						row.getDecimal(columnId, dt.getPrecision(), dt.getScale()).toBigDecimal()));
 				break;
 			}
 			case TINYINT: {
 				LongColumnVector vector = (LongColumnVector) column;
-				vector.vector[rowId] = row.getByte(i);
+				vector.vector[rowId] = row.getByte(columnId);
 				break;
 			}
 			case SMALLINT: {
 				LongColumnVector vector = (LongColumnVector) column;
-				vector.vector[rowId] = row.getShort(i);
+				vector.vector[rowId] = row.getShort(columnId);
 				break;
 			}
 			case DATE:
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTEGER: {
 				LongColumnVector vector = (LongColumnVector) column;
-				vector.vector[rowId] = row.getInt(i);
+				vector.vector[rowId] = row.getInt(columnId);
 				break;
 			}
 			case BIGINT: {
 				LongColumnVector vector = (LongColumnVector) column;
-				vector.vector[rowId] = row.getLong(i);
+				vector.vector[rowId] = row.getLong(columnId);
 				break;
 			}
 			case FLOAT: {
 				DoubleColumnVector vector = (DoubleColumnVector) column;
-				vector.vector[rowId] = row.getFloat(i);
+				vector.vector[rowId] = row.getFloat(columnId);
 				break;
 			}
 			case DOUBLE: {
 				DoubleColumnVector vector = (DoubleColumnVector) column;
-				vector.vector[rowId] = row.getDouble(i);
+				vector.vector[rowId] = row.getDouble(columnId);
 				break;
 			}
 			case TIMESTAMP_WITHOUT_TIME_ZONE: {
 				TimestampType tt = (TimestampType) type;
-				Timestamp timestamp = row.getTimestamp(i, tt.getPrecision()).toTimestamp();
+				Timestamp timestamp = row.getTimestamp(columnId, tt.getPrecision()).toTimestamp();
 				TimestampColumnVector vector = (TimestampColumnVector) column;
 				vector.set(rowId, timestamp);
 				break;
 			}
 			case TIMESTAMP_WITH_LOCAL_TIME_ZONE: {
 				LocalZonedTimestampType lt = (LocalZonedTimestampType) type;
-				Timestamp timestamp = row.getTimestamp(i, lt.getPrecision()).toTimestamp();
+				Timestamp timestamp = row.getTimestamp(columnId, lt.getPrecision()).toTimestamp();
 				TimestampColumnVector vector = (TimestampColumnVector) column;
 				vector.set(rowId, timestamp);
 				break;

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc.vector;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+import java.sql.Timestamp;
+
+/**
+ * A {@link Vectorizer} of {@link RowData} type element.
+ */
+public class RowDataVectorizer extends Vectorizer<RowData> {
+
+	private final LogicalType[] fieldTypes;
+
+	public RowDataVectorizer(String schema, LogicalType[] fieldTypes) {
+		super(schema);
+		this.fieldTypes = fieldTypes;
+	}
+
+	@Override
+	public void vectorize(RowData row, VectorizedRowBatch batch) {
+		int rowId = batch.size++;
+		for(int i = 0; i < row.getArity(); ++i) {
+			setColumn(rowId, batch.cols[i], fieldTypes[i], row, i);
+		}
+	}
+
+	private static void setColumn(
+			int rowId, ColumnVector column, LogicalType type, RowData row, int i) {
+		if (row.isNullAt(i)) {
+			column.noNulls = false;
+			column.isNull[rowId] = true;
+			return;
+		}
+
+		switch (type.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR: {
+				BytesColumnVector vector = (BytesColumnVector) column;
+				byte[] bytes = row.getString(i).toBytes();
+				vector.setVal(rowId, bytes, 0, bytes.length);
+				break;
+			}
+			case BOOLEAN: {
+				LongColumnVector vector = (LongColumnVector) column;
+				vector.vector[rowId] =
+						row.getBoolean(i) ? 1 : 0;
+				break;
+			}
+			case BINARY:
+			case VARBINARY: {
+				BytesColumnVector vector = (BytesColumnVector) column;
+				byte[] bytes = row.getBinary(i);
+				vector.setVal(rowId, bytes, 0, bytes.length);
+				break;
+			}
+			case DECIMAL: {
+				DecimalType dt = (DecimalType) type;
+				DecimalColumnVector vector = (DecimalColumnVector) column;
+				vector.set(rowId, HiveDecimal.create(
+						row.getDecimal(i, dt.getPrecision(), dt.getScale()).toBigDecimal()));
+				break;
+			}
+			case TINYINT: {
+				LongColumnVector vector = (LongColumnVector) column;
+				vector.vector[rowId] = row.getByte(i);
+				break;
+			}
+			case SMALLINT: {
+				LongColumnVector vector = (LongColumnVector) column;
+				vector.vector[rowId] = row.getShort(i);
+				break;
+			}
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case INTEGER: {
+				LongColumnVector vector = (LongColumnVector) column;
+				vector.vector[rowId] = row.getInt(i);
+				break;
+			}
+			case BIGINT: {
+				LongColumnVector vector = (LongColumnVector) column;
+				vector.vector[rowId] = row.getLong(i);
+				break;
+			}
+			case FLOAT: {
+				DoubleColumnVector vector = (DoubleColumnVector) column;
+				vector.vector[rowId] = row.getFloat(i);
+				break;
+			}
+			case DOUBLE: {
+				DoubleColumnVector vector = (DoubleColumnVector) column;
+				vector.vector[rowId] = row.getDouble(i);
+				break;
+			}
+			case TIMESTAMP_WITHOUT_TIME_ZONE: {
+				TimestampType tt = (TimestampType) type;
+				Timestamp timestamp = row.getTimestamp(i, tt.getPrecision()).toTimestamp();
+				TimestampColumnVector vector = (TimestampColumnVector) column;
+				vector.set(rowId, timestamp);
+				break;
+			}
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE: {
+				LocalZonedTimestampType lt = (LocalZonedTimestampType) type;
+				Timestamp timestamp = row.getTimestamp(i, lt.getPrecision()).toTimestamp();
+				TimestampColumnVector vector = (TimestampColumnVector) column;
+				vector.set(rowId, timestamp);
+				break;
+			}
+			default:
+				throw new UnsupportedOperationException("Unsupported type: " + type);
+		}
+	}
+}

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/RowDataVectorizer.java
@@ -50,7 +50,7 @@ public class RowDataVectorizer extends Vectorizer<RowData> {
 	@Override
 	public void vectorize(RowData row, VectorizedRowBatch batch) {
 		int rowId = batch.size++;
-		for(int i = 0; i < row.getArity(); ++i) {
+		for (int i = 0; i < row.getArity(); ++i) {
 			setColumn(rowId, batch.cols[i], fieldTypes[i], row, i);
 		}
 	}

--- a/flink-formats/flink-orc/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/flink-formats/flink-orc/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.orc.OrcFileSystemFormatFactory

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemITCase.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.table.planner.runtime.batch.sql.BatchFileSystemITCaseBase;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * ITCase for {@link OrcFileSystemFormatFactory}.
+ */
+@RunWith(Parameterized.class)
+public class OrcFileSystemITCase extends BatchFileSystemITCaseBase {
+
+	private final boolean configure;
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Boolean> parameters() {
+		return Arrays.asList(false, true);
+	}
+
+	public OrcFileSystemITCase(boolean configure) {
+		this.configure = configure;
+	}
+
+	@Override
+	public String[] formatProperties() {
+		List<String> ret = new ArrayList<>();
+		ret.add("'format'='orc'");
+		if (configure) {
+			ret.add("'format.orc.compress'='snappy'");
+		}
+		return ret.toArray(new String[0]);
+	}
+}

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFsStreamingSinkITCase.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFsStreamingSinkITCase.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.orc;
+
+import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Checkpoint ITCase for {@link OrcFileSystemFormatFactory}.
+ */
+public class OrcFsStreamingSinkITCase extends FsStreamingSinkITCaseBase {
+
+	@Override
+	public String[] additionalProperties() {
+		List<String> ret = new ArrayList<>();
+		ret.add("'format'='orc'");
+		ret.add("'format.orc.compress'='snappy'");
+		return ret.toArray(new String[0]);
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Integrate orc to file system connector, so in the sql world, users can create file system table with orc format by DDL, do some reading, writing and streaming writing. And the RowData is the sql data format. 

## Brief change log

- Introduce OrcRowDataInputFormat with partition support.
- Introduce RowDataVectorizer.
- Introduce OrcFileSystemFormatFactory.

## Verifying this change

`OrcFsStreamingSinkITCase` and `OrcFileSystemITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (no
  - The runtime per-record code paths (performance sensitive): (no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no
  - The S3 file system connector: (no

## Documentation

  - Does this pull request introduce a new feature? (yes
  - If yes, how is the feature documented? (JavaDocs
