### PR TITLE
[FLINK-17467] Align channels on savepoint in UC mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointOptions.java
@@ -66,6 +66,10 @@ public class CheckpointOptions implements Serializable {
 		this.isUnalignedCheckpoint = isUnalignedCheckpoint;
 	}
 
+	public boolean needsAlignment() {
+		return isExactlyOnceMode() && (getCheckpointType().isSavepoint() || !isUnalignedCheckpoint());
+	}
+
 	// ------------------------------------------------------------------------
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/CheckpointBarrier.java
@@ -113,4 +113,8 @@ public class CheckpointBarrier extends RuntimeEvent {
 	public String toString() {
 		return String.format("CheckpointBarrier %d @ %d Options: %s", id, timestamp, checkpointOptions);
 	}
+
+	public boolean isCheckpoint() {
+		return !checkpointOptions.getCheckpointType().isSavepoint();
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -247,42 +247,41 @@ public interface Buffer {
 		/**
 		 * DATA_BUFFER indicates that this buffer represents a non-event data buffer.
 		 */
-		DATA_BUFFER(true),
+		DATA_BUFFER(true, false),
 
 		/**
 		 * EVENT_BUFFER indicates that this buffer represents serialized data of an event.
 		 * Note that this type can be further divided into more fine-grained event types
 		 * like {@link #ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER} and etc.
 		 */
-		EVENT_BUFFER(false),
+		EVENT_BUFFER(false, false),
 
 		/**
 		 * ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER indicates that this buffer represents a
 		 * serialized checkpoint barrier of aligned exactly-once checkpoint mode.
 		 */
-		ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER(false);
+		ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER(false, true);
 
 		private final boolean isBuffer;
+		private final boolean isBlockingUpstream;
 
-		DataType(boolean isBuffer) {
+		DataType(boolean isBuffer, boolean isBlockingUpstream) {
 			this.isBuffer = isBuffer;
+			this.isBlockingUpstream = isBlockingUpstream;
 		}
 
 		public boolean isBuffer() {
 			return isBuffer;
 		}
 
-		public static boolean isAlignedExactlyOnceCheckpointBarrier(Buffer buffer) {
-			return buffer.getDataType() == ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER;
+		public boolean isBlockingUpstream() {
+			return isBlockingUpstream;
 		}
 
 		public static DataType getDataType(AbstractEvent event) {
-			if (event instanceof CheckpointBarrier &&
-					((CheckpointBarrier) event).getCheckpointOptions().isExactlyOnceMode() &&
-					!((CheckpointBarrier) event).getCheckpointOptions().isUnalignedCheckpoint()) {
-				return ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER;
-			}
-			return EVENT_BUFFER;
+			return event instanceof CheckpointBarrier && ((CheckpointBarrier) event).getCheckpointOptions().needsAlignment() ?
+					ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER :
+					EVENT_BUFFER;
 		}
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -268,7 +268,7 @@ public class PipelinedSubpartition extends ResultSubpartition {
 				return null;
 			}
 
-			if (Buffer.DataType.isAlignedExactlyOnceCheckpointBarrier(buffer)) {
+			if (buffer.getDataType().isBlockingUpstream()) {
 				isBlockedByCheckpoint = true;
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -317,8 +317,9 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			CheckpointBarrier event = parseCheckpointBarrierOrNull(buffer);
 			if (event == null) {
 				throw new IllegalStateException("Currently only checkpoint barriers are known priority events");
+			} else if (event.isCheckpoint()) {
+				inputGate.getBufferReceivedListener().notifyBarrierReceived(event, channelInfo);
 			}
-			inputGate.getBufferReceivedListener().notifyBarrierReceived(event, channelInfo);
 		} finally {
 			buffer.recycleBuffer();
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -469,7 +469,9 @@ public class RemoteInputChannel extends InputChannel {
 
 			if (notifyReceivedBarrier != null) {
 				receivedCheckpointId = notifyReceivedBarrier.getId();
-				listener.notifyBarrierReceived(notifyReceivedBarrier, channelInfo);
+				if (notifyReceivedBarrier.isCheckpoint()) {
+					listener.notifyBarrierReceived(notifyReceivedBarrier, channelInfo);
+				}
 			} else if (notifyReceivedBuffer != null) {
 				listener.notifyBufferReceived(notifyReceivedBuffer, channelInfo);
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointOptionsTest.java
@@ -25,8 +25,11 @@ import org.junit.Test;
 
 import java.util.Random;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -58,5 +61,23 @@ public class CheckpointOptionsTest {
 		final CheckpointOptions copy = CommonTestUtils.createCopySerializable(options);
 		assertEquals(options.getCheckpointType(), copy.getCheckpointType());
 		assertArrayEquals(locationBytes, copy.getTargetLocation().getReferenceBytes());
+	}
+
+	@Test
+	public void testSavepointNeedsAlignment() {
+		CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
+		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, true).needsAlignment());
+		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, true).needsAlignment());
+		assertTrue(new CheckpointOptions(SAVEPOINT, location, true, false).needsAlignment());
+		assertFalse(new CheckpointOptions(SAVEPOINT, location, false, false).needsAlignment());
+	}
+
+	@Test
+	public void testCheckpointNeedsAlignment() {
+		CheckpointStorageLocationReference location = CheckpointStorageLocationReference.getDefault();
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, true, true).needsAlignment());
+		assertTrue(new CheckpointOptions(CHECKPOINT, location, true, false).needsAlignment());
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, true).needsAlignment());
+		assertFalse(new CheckpointOptions(CHECKPOINT, location, false, false).needsAlignment());
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/EventSerializerTest.java
@@ -77,7 +77,7 @@ public class EventSerializerTest {
 			assertFalse(bufferConsumer.isRecycled());
 
 			if (evt instanceof CheckpointBarrier) {
-				assertTrue(Buffer.DataType.isAlignedExactlyOnceCheckpointBarrier(bufferConsumer.build()));
+				assertTrue(bufferConsumer.build().getDataType().isBlockingUpstream());
 			} else {
 				assertEquals(Buffer.DataType.EVENT_BUFFER, bufferConsumer.build().getDataType());
 			}
@@ -94,7 +94,7 @@ public class EventSerializerTest {
 			assertFalse(buffer.isRecycled());
 
 			if (evt instanceof CheckpointBarrier) {
-				assertTrue(Buffer.DataType.isAlignedExactlyOnceCheckpointBarrier(buffer));
+				assertTrue(buffer.getDataType().isBlockingUpstream());
 			} else {
 				assertEquals(Buffer.DataType.EVENT_BUFFER, buffer.getDataType());
 			}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.concurrent.FutureUtils;
@@ -32,6 +33,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferProvider;
 import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
+import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
 import org.apache.flink.runtime.io.network.partition.PartitionNotFoundException;
@@ -47,6 +49,7 @@ import org.apache.flink.runtime.io.network.util.TestBufferFactory;
 import org.apache.flink.runtime.io.network.util.TestPartitionProducer;
 import org.apache.flink.runtime.io.network.util.TestProducerSource;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
@@ -69,6 +72,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT;
+import static org.apache.flink.runtime.io.network.api.serialization.EventSerializer.toBuffer;
+import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType.getDataType;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createLocalInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createSingleInputGate;
 import static org.apache.flink.runtime.io.network.partition.InputGateFairnessTest.setupInputGate;
@@ -454,6 +460,18 @@ public class LocalInputChannelTest {
 
 		localChannel.releaseAllResources();
 		localChannel.resumeConsumption();
+	}
+
+	@Test
+	public void testNoNotifyOnSavepoint() throws IOException {
+		TestBufferReceivedListener listener = new TestBufferReceivedListener();
+		SingleInputGate inputGate = new SingleInputGateBuilder().build();
+		inputGate.registerBufferReceivedListener(listener);
+		LocalInputChannel channel = InputChannelBuilder.newBuilder().buildLocalChannel(inputGate);
+		CheckpointBarrier barrier = new CheckpointBarrier(123L, 123L, new CheckpointOptions(SAVEPOINT, CheckpointStorageLocationReference.getDefault()));
+		channel.notifyPriorityEvent(new BufferConsumer(toBuffer(barrier).getMemorySegment(), FreeingBufferRecycler.INSTANCE, getDataType(barrier)));
+		channel.checkError();
+		assertTrue(listener.notifiedOnBarriers.isEmpty());
 	}
 
 	@Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestBufferReceivedListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/TestBufferReceivedListener.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+class TestBufferReceivedListener implements BufferReceivedListener {
+	private final Map<InputChannelInfo, List<Buffer>> notifiedOnBuffers = new HashMap<>();
+	final Map<InputChannelInfo, List<CheckpointBarrier>> notifiedOnBarriers = new HashMap<>();
+
+	@Override
+	public void notifyBufferReceived(Buffer buffer, InputChannelInfo channelInfo) {
+		notifiedOnBuffers.computeIfAbsent(channelInfo, unused -> new ArrayList<>()).add(buffer);
+	}
+
+	@Override
+	public void notifyBarrierReceived(CheckpointBarrier barrier, InputChannelInfo channelInfo) {
+		notifiedOnBarriers.computeIfAbsent(channelInfo, unused -> new ArrayList<>()).add(barrier);
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandler.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.BufferReceivedListener;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_SUBSUMED;
+
+class AlternatingCheckpointBarrierHandler extends CheckpointBarrierHandler {
+	private final CheckpointBarrierAligner alignedHandler;
+	private final CheckpointBarrierUnaligner unalignedHandler;
+	private CheckpointBarrierHandler activeHandler;
+
+	AlternatingCheckpointBarrierHandler(CheckpointBarrierAligner alignedHandler, CheckpointBarrierUnaligner unalignedHandler, AbstractInvokable invokable) {
+		super(invokable);
+		this.activeHandler = this.alignedHandler = alignedHandler;
+		this.unalignedHandler = unalignedHandler;
+	}
+
+	@Override
+	public void releaseBlocksAndResetBarriers() {
+		activeHandler.releaseBlocksAndResetBarriers();
+	}
+
+	@Override
+	public boolean isBlocked(int channelIndex) {
+		return activeHandler.isBlocked(channelIndex);
+	}
+
+	@Override
+	public void processBarrier(CheckpointBarrier receivedBarrier, int channelIndex) throws Exception {
+		CheckpointBarrierHandler previousHandler = activeHandler;
+		activeHandler = receivedBarrier.isCheckpoint() ? unalignedHandler : alignedHandler;
+		abortPreviousIfNeeded(receivedBarrier, previousHandler);
+		activeHandler.processBarrier(receivedBarrier, channelIndex);
+	}
+
+	private void abortPreviousIfNeeded(CheckpointBarrier barrier, CheckpointBarrierHandler prevHandler) throws IOException {
+		if (prevHandler != activeHandler && prevHandler.isCheckpointPending() && prevHandler.getLatestCheckpointId() < barrier.getId()) {
+			prevHandler.releaseBlocksAndResetBarriers();
+			notifyAbort(
+				prevHandler.getLatestCheckpointId(),
+				new CheckpointException(
+					format("checkpoint %d subsumed by %d", prevHandler.getLatestCheckpointId(), barrier.getId()),
+					CHECKPOINT_DECLINED_SUBSUMED));
+		}
+	}
+
+	@Override
+	public void processCancellationBarrier(CancelCheckpointMarker cancelBarrier) throws Exception {
+		activeHandler.processCancellationBarrier(cancelBarrier);
+	}
+
+	@Override
+	public void processEndOfPartition() throws Exception {
+		alignedHandler.processEndOfPartition();
+		unalignedHandler.processEndOfPartition();
+	}
+
+	@Override
+	public long getLatestCheckpointId() {
+		return activeHandler.getLatestCheckpointId();
+	}
+
+	@Override
+	public long getAlignmentDurationNanos() {
+		return alignedHandler.getAlignmentDurationNanos();
+	}
+
+	@Override
+	public Optional<BufferReceivedListener> getBufferReceivedListener() {
+		return unalignedHandler.getBufferReceivedListener();
+	}
+
+	@Override
+	protected boolean isCheckpointPending() {
+		return activeHandler.isCheckpointPending();
+	}
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
@@ -325,11 +326,21 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 		}
 	}
 
+	@Override
+	protected boolean isCheckpointPending() {
+		return numBarriersReceived > 0;
+	}
+
 	private void resumeConsumption(int channelIndex) {
 		InputGate inputGate = channelIndexToInputGate[channelIndex];
 		checkState(!inputGate.isFinished(), "InputGate already finished.");
 
 		inputGate.resumeConsumption(channelIndex - inputGateToChannelIndexOffset.get(inputGate));
+	}
+
+	@VisibleForTesting
+	public int getNumClosedChannels() {
+		return numClosedChannels;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierAligner.java
@@ -134,7 +134,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 
 		// -- general code path for multiple input channels --
 
-		if (numBarriersReceived > 0) {
+		if (isCheckpointPending()) {
 			// this is only true if some alignment is already progress and was not canceled
 
 			if (barrierId == currentCheckpointId) {
@@ -243,7 +243,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 
 		// -- general code path for multiple input channels --
 
-		if (numBarriersReceived > 0) {
+		if (isCheckpointPending()) {
 			// this is only true if some alignment is in progress and nothing was canceled
 
 			if (barrierId == currentCheckpointId) {
@@ -303,7 +303,7 @@ public class CheckpointBarrierAligner extends CheckpointBarrierHandler {
 	public void processEndOfPartition() throws Exception {
 		numClosedChannels++;
 
-		if (numBarriersReceived > 0) {
+		if (isCheckpointPending()) {
 			// let the task know we skip a checkpoint
 			notifyAbort(currentCheckpointId,
 				new CheckpointException(CheckpointFailureReason.CHECKPOINT_DECLINED_INPUT_END_OF_STREAM));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -131,4 +131,6 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 			Object... descriptionArgs) throws E {
 		toNotifyOnCheckpoint.executeInTaskThread(runnable, descriptionFormat, descriptionArgs);
 	}
+
+	protected abstract boolean isCheckpointPending();
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierHandler.java
@@ -31,6 +31,7 @@ import org.apache.flink.util.function.ThrowingRunnable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -80,6 +81,19 @@ public abstract class CheckpointBarrierHandler implements Closeable {
 
 	public Optional<BufferReceivedListener> getBufferReceivedListener() {
 		return Optional.empty();
+	}
+
+	/**
+	 * Returns true if there is in-flight data in the buffers for the given channel and checkpoint. More specifically,
+	 * this method returns true iff the unaligner still expects the respective barrier to be <i>consumed</i> on the
+	 * that channel.
+	 */
+	public boolean hasInflightData(long checkpointId, int channelIndex) {
+		return false;
+	}
+
+	public CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {
+		return CompletableFuture.completedFuture(null);
 	}
 
 	protected void notifyCheckpoint(CheckpointBarrier checkpointBarrier, long alignmentDurationNanos) throws IOException {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierTracker.java
@@ -226,6 +226,10 @@ public class CheckpointBarrierTracker extends CheckpointBarrierHandler {
 		return 0;
 	}
 
+	public boolean isCheckpointPending() {
+		return !pendingCheckpoints.isEmpty();
+	}
+
 	/**
 	 * Simple class for a checkpoint ID with a barrier counter.
 	 */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -226,11 +226,7 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 		threadSafeUnaligner.close();
 	}
 
-	/**
-	 * Returns true if there is in-flight data in the buffers for the given channel and checkpoint. More specifically,
-	 * this method returns true iff the unaligner still expects the respective barrier to be <i>consumed</i> on the
-	 * that channel.
-	 */
+	@Override
 	public boolean hasInflightData(long checkpointId, int channelIndex) {
 		if (checkpointId < currentConsumedCheckpointId) {
 			return false;
@@ -241,6 +237,7 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 		return hasInflightBuffers[channelIndex];
 	}
 
+	@Override
 	public CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {
 		return threadSafeUnaligner.getAllBarriersReceivedFuture(checkpointId);
 	}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnaligner.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointFailureReason;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
@@ -247,6 +248,11 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 		return Optional.of(threadSafeUnaligner);
 	}
 
+	@Override
+	protected boolean isCheckpointPending() {
+		return numBarrierConsumed > 0;
+	}
+
 	private int getFlattenedChannelIndex(InputChannelInfo channelInfo) {
 		return gateChannelOffsets[channelInfo.getGateIdx()] + channelInfo.getInputChannelIdx();
 	}
@@ -335,9 +341,13 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 			allBarriersReceivedFuture.cancel(false);
 		}
 
+		boolean isCheckpointPending() {
+			return numBarriersReceived > 0;
+		}
+
 		private synchronized void handleNewCheckpoint(CheckpointBarrier barrier) throws IOException {
 			long barrierId = barrier.getId();
-			if (!allBarriersReceivedFuture.isDone()) {
+			if (!allBarriersReceivedFuture.isDone() && isCheckpointPending()) {
 				// we did not complete the current checkpoint, another started before
 				LOG.warn("{}: Received checkpoint barrier for checkpoint {} before completing current checkpoint {}. " +
 						"Skipping current checkpoint.",
@@ -388,5 +398,15 @@ public class CheckpointBarrierUnaligner extends CheckpointBarrierHandler {
 		public synchronized void setCurrentReceivedCheckpointId(long currentReceivedCheckpointId) {
 			this.currentReceivedCheckpointId = Math.max(currentReceivedCheckpointId, this.currentReceivedCheckpointId);
 		}
+
+		@VisibleForTesting
+		public synchronized int getNumOpenChannels() {
+			return numOpenChannels;
+		}
+	}
+
+	@VisibleForTesting
+	public int getNumOpenChannels() {
+		return threadSafeUnaligner.getNumOpenChannels();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -140,13 +140,13 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 			long checkpointId,
 			int channelIndex,
 			ChannelStateWriter channelStateWriter) throws IOException {
-		if (((CheckpointBarrierUnaligner) barrierHandler).hasInflightData(checkpointId, channelIndex)) {
+		if (barrierHandler.hasInflightData(checkpointId, channelIndex)) {
 			inputGate.getChannel(channelIndex).spillInflightBuffers(checkpointId, channelStateWriter);
 		}
 	}
 
 	public CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {
-		return ((CheckpointBarrierUnaligner) barrierHandler).getAllBarriersReceivedFuture(checkpointId);
+		return barrierHandler.getAllBarriersReceivedFuture(checkpointId);
 	}
 
 	private int offsetChannelIndex(int channelIndex) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/InputProcessorUtil.java
@@ -118,10 +118,17 @@ public class InputProcessorUtil {
 		switch (config.getCheckpointMode()) {
 			case EXACTLY_ONCE:
 				if (config.isUnalignedCheckpointsEnabled()) {
-					return new CheckpointBarrierUnaligner(
-						numberOfInputChannelsPerGate.toArray(),
-						channelStateWriter,
-						taskName,
+					return new AlternatingCheckpointBarrierHandler(
+						new CheckpointBarrierAligner(
+							taskName,
+							channelIndexToInputGate,
+							inputGateToChannelIndexOffset,
+							toNotifyOnCheckpoint),
+						new CheckpointBarrierUnaligner(
+							numberOfInputChannelsPerGate.toArray(),
+							channelStateWriter,
+							taskName,
+							toNotifyOnCheckpoint),
 						toNotifyOnCheckpoint);
 				}
 				return new CheckpointBarrierAligner(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandlerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/AlternatingCheckpointBarrierHandlerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io;
+
+import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
+import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.checkpoint.CheckpointType;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
+import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGate;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateBuilder;
+import org.apache.flink.runtime.io.network.partition.consumer.TestInputChannel;
+import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
+import static org.apache.flink.runtime.checkpoint.CheckpointType.SAVEPOINT;
+import static org.apache.flink.runtime.io.network.api.serialization.EventSerializer.toBuffer;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * {@link AlternatingCheckpointBarrierHandler} test.
+ */
+public class AlternatingCheckpointBarrierHandlerTest {
+
+	@Test
+	public void testCheckpointHandling() throws Exception {
+		testBarrierHandling(CHECKPOINT);
+	}
+
+	@Test
+	public void testSavepointHandling() throws Exception {
+		testBarrierHandling(SAVEPOINT);
+	}
+
+	@Test
+	public void testAlternation() throws Exception {
+		int numBarriers = 123;
+		int numChannels = 123;
+		TestInvokable target = new TestInvokable();
+		CheckpointedInputGate gate = buildGate(target, numChannels);
+		List<Long> barriers = new ArrayList<>();
+		for (long barrier = 0; barrier < numBarriers; barrier++) {
+			barriers.add(barrier);
+			CheckpointType type = barrier % 2 == 0 ? CHECKPOINT : SAVEPOINT;
+			for (int channel = 0; channel < numChannels; channel++) {
+				sendBarrier(barrier, type, (TestInputChannel) gate.getChannel(channel), gate);
+			}
+		}
+		assertEquals(barriers, target.triggeredCheckpoints);
+	}
+
+	@Test
+	public void testPreviousHandlerReset() throws Exception {
+		SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(2).build();
+		inputGate.setInputChannels(new TestInputChannel(inputGate, 0), new TestInputChannel(inputGate, 1));
+		TestInvokable target = new TestInvokable();
+		CheckpointBarrierAligner alignedHandler = new CheckpointBarrierAligner("test", new InputGate[]{inputGate, inputGate}, singletonMap(inputGate, 0), target);
+		CheckpointBarrierUnaligner unalignedHandler = new CheckpointBarrierUnaligner(new int[]{inputGate.getNumberOfInputChannels()}, ChannelStateWriter.NO_OP, "test", target);
+		AlternatingCheckpointBarrierHandler barrierHandler = new AlternatingCheckpointBarrierHandler(alignedHandler, unalignedHandler, target);
+
+		for (int i = 0; i < 4; i++) {
+			int channel = i % 2;
+			CheckpointType type = channel == 0 ? CHECKPOINT : SAVEPOINT;
+			barrierHandler.processBarrier(new CheckpointBarrier(i, 0, new CheckpointOptions(type, CheckpointStorageLocationReference.getDefault())), channel);
+			assertEquals(type.isSavepoint(), alignedHandler.isCheckpointPending());
+			assertNotEquals(alignedHandler.isCheckpointPending(), unalignedHandler.isCheckpointPending());
+		}
+	}
+
+	@Test
+	public void testEndOfPartition() throws Exception {
+		int totalChannels = 5;
+		int closedChannels = 2;
+		SingleInputGate inputGate = new SingleInputGateBuilder().setNumberOfChannels(totalChannels).build();
+		TestInvokable target = new TestInvokable();
+		CheckpointBarrierAligner alignedHandler = new CheckpointBarrierAligner("test", new InputGate[]{inputGate}, singletonMap(inputGate, 0), target);
+		CheckpointBarrierUnaligner unalignedHandler = new CheckpointBarrierUnaligner(new int[]{inputGate.getNumberOfInputChannels()}, ChannelStateWriter.NO_OP, "test", target);
+		AlternatingCheckpointBarrierHandler barrierHandler = new AlternatingCheckpointBarrierHandler(alignedHandler, unalignedHandler, target);
+		for (int i = 0; i < closedChannels; i++) {
+			barrierHandler.processEndOfPartition();
+		}
+		assertEquals(closedChannels, alignedHandler.getNumClosedChannels());
+		assertEquals(totalChannels - closedChannels, unalignedHandler.getNumOpenChannels());
+	}
+
+	private void testBarrierHandling(CheckpointType checkpointType) throws Exception {
+		final long barrierId = 123L;
+		TestInvokable target = new TestInvokable();
+		SingleInputGate gate = new SingleInputGateBuilder().setNumberOfChannels(2).build();
+		TestInputChannel fast = new TestInputChannel(gate, 0, false, true);
+		TestInputChannel slow = new TestInputChannel(gate, 1, false, true);
+		gate.setInputChannels(fast, slow);
+		AlternatingCheckpointBarrierHandler barrierHandler = barrierHandler(gate, target);
+		CheckpointedInputGate checkpointedGate = new CheckpointedInputGate(gate, barrierHandler, 0 /* offset */);
+
+		sendBarrier(barrierId, checkpointType, fast, checkpointedGate);
+
+		assertEquals(checkpointType.isSavepoint(), target.triggeredCheckpoints.isEmpty());
+		assertEquals(checkpointType.isSavepoint(), barrierHandler.isBlocked(fast.getChannelIndex()));
+		assertFalse(barrierHandler.isBlocked(slow.getChannelIndex()));
+
+		sendBarrier(barrierId, checkpointType, slow, checkpointedGate);
+
+		assertEquals(singletonList(barrierId), target.triggeredCheckpoints);
+		for (InputChannel channel : gate.getInputChannels().values()) {
+			assertFalse(barrierHandler.isBlocked(channel.getChannelIndex()));
+			assertEquals(
+				String.format("channel %d should be resumed", channel.getChannelIndex()),
+				checkpointType.isSavepoint(),
+				((TestInputChannel) channel).isResumed());
+		}
+	}
+
+	private void sendBarrier(long id, CheckpointType type, TestInputChannel channel, CheckpointedInputGate gate) throws Exception {
+		channel.read(barrier(id, type).retainBuffer());
+		while (gate.pollNext().isPresent()) {
+		}
+	}
+
+	private static AlternatingCheckpointBarrierHandler barrierHandler(SingleInputGate inputGate, AbstractInvokable target) {
+		String taskName = "test";
+		InputGate[] channelIndexToInputGate = new InputGate[inputGate.getNumberOfInputChannels()];
+		Arrays.fill(channelIndexToInputGate, inputGate);
+		return new AlternatingCheckpointBarrierHandler(
+			new CheckpointBarrierAligner(taskName, channelIndexToInputGate, singletonMap(inputGate, 0), target),
+			new CheckpointBarrierUnaligner(new int[]{inputGate.getNumberOfInputChannels()}, ChannelStateWriter.NO_OP, taskName, target),
+			target);
+	}
+
+	private Buffer barrier(long id, CheckpointType checkpointType) throws IOException {
+		return toBuffer(new CheckpointBarrier(
+			id,
+			System.currentTimeMillis(),
+			new CheckpointOptions(checkpointType, CheckpointStorageLocationReference.getDefault(), true, true)));
+	}
+
+	private static class TestInvokable extends AbstractInvokable {
+		private List<Long> triggeredCheckpoints = new ArrayList<>();
+
+		TestInvokable() {
+			super(new DummyEnvironment());
+		}
+
+		@Override
+		public void invoke() {
+		}
+
+		@Override
+		public <E extends Exception> void executeInTaskThread(ThrowingRunnable<E> runnable, String descriptionFormat, Object... descriptionArgs) throws E {
+			runnable.run();
+		}
+
+		@Override
+		public void triggerCheckpointOnBarrier(CheckpointMetaData checkpointMetaData, CheckpointOptions checkpointOptions, CheckpointMetrics checkpointMetrics) {
+			triggeredCheckpoints.add(checkpointMetaData.getCheckpointId());
+		}
+
+		@Override
+		public void abortCheckpointOnBarrier(long checkpointId, Throwable cause) {
+		}
+	}
+
+	private static CheckpointedInputGate buildGate(TestInvokable target, int numChannels) {
+		SingleInputGate gate = new SingleInputGateBuilder().setNumberOfChannels(numChannels).build();
+		TestInputChannel[] channels = new TestInputChannel[numChannels];
+		for (int i = 0; i < numChannels; i++) {
+			channels[i] = new TestInputChannel(gate, i, false, true);
+		}
+		gate.setInputChannels(channels);
+		return new CheckpointedInputGate(gate, barrierHandler(gate, target), 0);
+	}
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/MockSubtaskCheckpointCoordinatorBuilder.java
@@ -46,9 +46,20 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
 	private CloseableRegistry closeableRegistry = new CloseableRegistry();
 	private ExecutorService executorService = Executors.newDirectExecutorService();
 	private BiFunctionWithException<ChannelStateWriter, Long, CompletableFuture<Void>, IOException> prepareInputSnapshot = (channelStateWriter, aLong) -> FutureUtils.completedVoidFuture();
+	private boolean unalignedCheckpointEnabled;
 
 	public MockSubtaskCheckpointCoordinatorBuilder setEnvironment(Environment environment) {
 		this.environment = environment;
+		return this;
+	}
+
+	public MockSubtaskCheckpointCoordinatorBuilder setPrepareInputSnapshot(BiFunctionWithException<ChannelStateWriter, Long, CompletableFuture<Void>, IOException> prepareInputSnapshot) {
+		this.prepareInputSnapshot = prepareInputSnapshot;
+		return this;
+	}
+
+	public MockSubtaskCheckpointCoordinatorBuilder setUnalignedCheckpointEnabled(boolean unalignedCheckpointEnabled) {
+		this.unalignedCheckpointEnabled = unalignedCheckpointEnabled;
 		return this;
 	}
 
@@ -71,7 +82,7 @@ public class MockSubtaskCheckpointCoordinatorBuilder {
 			executorService,
 			environment,
 			asyncExceptionHandler,
-			false,
+			unalignedCheckpointEnabled,
 			prepareInputSnapshot);
 	}
 


### PR DESCRIPTION
## What is the purpose of the change

Perform alignment for savepoints even if UnalignedCheckpoints are enabled.

## Changelog

1. Introduce `AlternatingCheckpointBarrierHandler` which delegates to either Aligned or Unaligned barrier handlers
1. Don't notify barrier listener about savepoints in Input Channels
1. Don't include channel state into savepoint snapshots
1. Block upstream on savepoints in UC mode too

## Verifying this change

Added unit tests:
 - `AlternatingCheckpointBarrierHandlerTest`
 - `CheckpointOptionsTest`
 - `testNoNotifyOnSavepoint` for input channels
 - `SubtaskCheckpointCoordinatorTest.testSkipChannelStateForSavepoints`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
