### PR TITLE
[FLINK-17332][k8s] Fix restart policy not equals to Never for native task manager pods

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -59,6 +59,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
 				.withAnnotations(kubernetesTaskManagerParameters.getAnnotations())
 				.endMetadata()
 			.editOrNewSpec()
+				.withRestartPolicy(Constants.RESTART_POLICY_OF_NEVER)
 				.withImagePullSecrets(kubernetesTaskManagerParameters.getImagePullSecrets())
 				.withNodeSelector(kubernetesTaskManagerParameters.getNodeSelector())
 				.withTolerations(kubernetesTaskManagerParameters.getTolerations().stream()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -78,4 +78,6 @@ public class Constants {
 	public static final String HEADLESS_SERVICE_CLUSTER_IP = "None";
 
 	public static final int MAXIMUM_CHARACTERS_OF_CLUSTER_ID = 45;
+
+	public static final String RESTART_POLICY_OF_NEVER = "Never";
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -163,6 +163,13 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 	}
 
 	@Test
+	public void testRestartPolicy() {
+		final String resultRestartPolicy = this.resultPod.getSpec().getRestartPolicy();
+
+		assertThat(resultRestartPolicy, is(Constants.RESTART_POLICY_OF_NEVER));
+	}
+
+	@Test
 	public void testImagePullSecrets() {
 		final List<String> resultSecrets = this.resultPod.getSpec().getImagePullSecrets()
 			.stream()


### PR DESCRIPTION
## What is the purpose of the change

Currently, we do not explicitly set the `RestartPolicy` for the task manager pods in the native K8s setups so that it is `Always` by default.  From the K8s RM perspective, the task manager pod itself must not restart the failed Container, the decision for how to deal with the failed task manager pod must always be made by the active job manager.

Therefore, this PR proposes to set the `RestartPolicy` to `Never` for the task manager pods.

## Brief change log

  - Set `Pod.Spec.RestartPolicy` to `Never` in `InitTaskManagerDecorator#decorateFlinkPod`


## Verifying this change

This change added a new unit test:
  - `InitTaskManagerDecoratorTest#testRestartPolicy`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
