### PR TITLE
[FLINK-17030] Add primary key syntax to DDL

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -29,6 +29,8 @@
     "org.apache.flink.sql.parser.ddl.SqlAlterDatabase"
     "org.apache.flink.sql.parser.ddl.SqlAlterFunction"
     "org.apache.flink.sql.parser.ddl.SqlAlterTable"
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableAddConstraint"
+    "org.apache.flink.sql.parser.ddl.SqlAlterTableDropConstraint"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableProperties"
     "org.apache.flink.sql.parser.ddl.SqlAlterTableRename"
     "org.apache.flink.sql.parser.ddl.SqlCreateCatalog"

--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -23,6 +23,9 @@
   # Example. "org.apache.calcite.sql.*", "java.util.List".
   # Please keep the import classes in alphabetical order if new class is added.
   imports: [
+    "org.apache.flink.sql.parser.ddl.constraint.SqlConstraintEnforcement"
+    "org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint"
+    "org.apache.flink.sql.parser.ddl.constraint.SqlUniqueSpec"
     "org.apache.flink.sql.parser.ddl.SqlAlterDatabase"
     "org.apache.flink.sql.parser.ddl.SqlAlterFunction"
     "org.apache.flink.sql.parser.ddl.SqlAlterTable"
@@ -79,6 +82,7 @@
     "CATALOGS"
     "COMMENT"
     "DATABASES"
+    "ENFORCED"
     "EXTENDED"
     "FUNCTIONS"
     "IF"
@@ -413,9 +417,11 @@
   ]
 
   # List of non-reserved keywords to add;
-  # items in this list become non-reserved
+  # items in this list become non-reserved.
+  # Please keep the keyword in alphabetical order if new keyword is added.
   nonReservedKeywordsToAdd: [
     # not in core, added in Flink
+    "ENFORCED"
     "IF"
     "OVERWRITE"
     "OVERWRITING"

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -378,6 +378,8 @@ SqlAlterTable SqlAlterTable() :
     SqlIdentifier tableIdentifier;
     SqlIdentifier newTableIdentifier = null;
     SqlNodeList propertyList = SqlNodeList.EMPTY;
+    SqlIdentifier constraintName;
+    SqlTableConstraint constraint;
 }
 {
     <ALTER> <TABLE> { startPos = getPos(); }
@@ -399,6 +401,21 @@ SqlAlterTable SqlAlterTable() :
                         startPos.plus(getPos()),
                         tableIdentifier,
                         propertyList);
+        }
+    |
+        <ADD> constraint = TableConstraint() {
+            return new SqlAlterTableAddConstraint(
+                        tableIdentifier,
+                        constraint,
+                        startPos.plus(getPos()));
+        }
+    |
+        <DROP> <CONSTRAINT>
+        constraintName = SimpleIdentifier() {
+            return new SqlAlterTableDropConstraint(
+                tableIdentifier,
+                constraintName,
+                startPos.plus(getPos()));
         }
     )
 }

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableAddConstraint.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableAddConstraint.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * ALTER TABLE [catalog_name.][db_name.]table_name ADD [CONSTRAINT constraint_name]
+ *  (PRIMARY KEY | UNIQUE) (column, ...)
+ *  [[NOT] ENFORCED].
+ */
+public class SqlAlterTableAddConstraint extends SqlAlterTable {
+	private final SqlTableConstraint constraint;
+
+	/**
+	 * Creates a add table constraint node.
+	 *
+	 * @param tableID    Table ID
+	 * @param constraint Table constraint
+	 * @param pos        Parser position
+	 */
+	public SqlAlterTableAddConstraint(
+			SqlIdentifier tableID,
+			SqlTableConstraint constraint,
+			SqlParserPos pos) {
+		super(pos, tableID);
+		this.constraint = constraint;
+	}
+
+	public SqlTableConstraint getConstraint() {
+		return constraint;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(getTableName(), this.constraint);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		super.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("ADD");
+		this.constraint.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableDropConstraint.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAlterTableDropConstraint.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import java.util.List;
+
+/**
+ * ALTER TABLE [catalog_name.][db_name.]table_name DROP CONSTRAINT constraint_name.
+ */
+public class SqlAlterTableDropConstraint extends SqlAlterTable {
+	private final SqlIdentifier constraintName;
+
+	/**
+	 * Creates an alter table drop constraint node.
+	 *
+	 * @param tableID        Table ID
+	 * @param constraintName Constraint name
+	 * @param pos            Parser position
+	 */
+	public SqlAlterTableDropConstraint(
+			SqlIdentifier tableID,
+			SqlIdentifier constraintName,
+			SqlParserPos pos) {
+		super(pos, tableID);
+		this.constraintName = constraintName;
+	}
+
+	public SqlIdentifier getConstraintName() {
+		return constraintName;
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(getTableName(), this.constraintName);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		super.unparse(writer, leftPrec, rightPrec);
+		writer.keyword("DROP CONSTRAINT");
+		this.constraintName.unparse(writer, leftPrec, rightPrec);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableColumn.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.sql.parser.ddl;
 
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
+
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlDataTypeSpec;
@@ -47,16 +49,19 @@ public class SqlTableColumn extends SqlCall {
 	private SqlIdentifier name;
 	private SqlDataTypeSpec type;
 
-	@Nullable
+	private SqlTableConstraint constraint;
+
 	private SqlCharStringLiteral comment;
 
 	public SqlTableColumn(SqlIdentifier name,
 			SqlDataTypeSpec type,
-			SqlCharStringLiteral comment,
+			@Nullable SqlTableConstraint constraint,
+			@Nullable SqlCharStringLiteral comment,
 			SqlParserPos pos) {
 		super(pos);
 		this.name = requireNonNull(name, "Column name should not be null");
 		this.type = requireNonNull(type, "Column type should not be null");
+		this.constraint = constraint;
 		this.comment = comment;
 	}
 
@@ -79,6 +84,9 @@ public class SqlTableColumn extends SqlCall {
 			// Default is nullable.
 			writer.keyword("NOT NULL");
 		}
+		if (this.constraint != null) {
+			this.constraint.unparse(writer, leftPrec, rightPrec);
+		}
 		if (this.comment != null) {
 			writer.print(" COMMENT ");
 			this.comment.unparse(writer, leftPrec, rightPrec);
@@ -99,6 +107,10 @@ public class SqlTableColumn extends SqlCall {
 
 	public void setType(SqlDataTypeSpec type) {
 		this.type = type;
+	}
+
+	public Optional<SqlTableConstraint> getConstraint() {
+		return Optional.ofNullable(constraint);
 	}
 
 	public Optional<SqlCharStringLiteral> getComment() {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlConstraintEnforcement.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlConstraintEnforcement.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl.constraint;
+
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/** Enumeration of SQL constraint enforcement. */
+public enum SqlConstraintEnforcement {
+	ENFORCED("ENFORCED"),
+	NOT_ENFORCED("NOT ENFORCED");
+
+	private final String digest;
+
+	SqlConstraintEnforcement(String digest) {
+		this.digest = digest;
+	}
+
+	@Override
+	public String toString() {
+		return digest;
+	}
+
+	/**
+	 * Creates a parse-tree node representing an occurrence of this keyword
+	 * at a particular position in the parsed text.
+	 */
+	public SqlLiteral symbol(SqlParserPos pos) {
+		return SqlLiteral.createSymbol(this, pos);
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlTableConstraint.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlTableConstraint.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl.constraint;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Table constraint of a table definition.
+ *
+ * <p>Syntax from
+ * SQL-2011 IWD 9075-2:201?(E) 11.3 &lt;table definition&gt;:
+ *
+ * <pre>
+ * &lt;table constraint definition&gt; ::=
+ *   [ &lt;constraint name definition&gt; ] &lt;table constraint&gt;
+ *       [ &lt;constraint characteristics&gt; ]
+ *
+ * &lt;table constraint&gt; ::=
+ *     &lt;unique constraint definition&gt;
+ *
+ * &lt;unique constraint definition&gt; ::=
+ *     &lt;unique specification&gt; &lt;left paren&gt; &lt;unique column list&gt; &lt;right paren&gt;
+ *
+ * &lt;unique specification&gt; ::=
+ *     UNIQUE
+ *   | PRIMARY KEY
+ * </pre>
+ */
+public class SqlTableConstraint extends SqlCall {
+	/** Use this operator only if you don't have a better one. */
+	private static final SqlOperator OPERATOR =
+			new SqlSpecialOperator("SqlTableConstraint", SqlKind.OTHER);
+
+	private final SqlIdentifier constraintName;
+	private final SqlLiteral uniqueSpec;
+	private final SqlNodeList columns;
+	private final SqlLiteral enforcement;
+	// Whether this is a table constraint, currently it is only used for SQL unparse.
+	private final boolean isTableConstraint;
+
+	/**
+	 * Creates a table constraint node.
+	 *
+	 * @param constraintName Constraint name
+	 * @param uniqueSpec     Unique specification
+	 * @param columns        Column list on which the constraint enforces
+	 *                       or null if this is a column constraint
+	 * @param enforcement    Whether the constraint is enforced
+	 * @param isTableConstraint Whether this is a table constraint
+	 * @param pos            Parser position
+	 */
+	public SqlTableConstraint(
+			@Nullable SqlIdentifier constraintName,
+			SqlLiteral uniqueSpec,
+			SqlNodeList columns,
+			@Nullable SqlLiteral enforcement,
+			boolean isTableConstraint,
+			SqlParserPos pos) {
+		super(pos);
+		this.constraintName = constraintName;
+		this.uniqueSpec = uniqueSpec;
+		this.columns = columns;
+		this.enforcement = enforcement;
+		this.isTableConstraint = isTableConstraint;
+	}
+
+	@Override
+	public SqlOperator getOperator() {
+		return OPERATOR;
+	}
+
+	/** Returns whether the constraint is UNIQUE. */
+	public boolean isUnique() {
+		return this.uniqueSpec.getValueAs(SqlUniqueSpec.class) == SqlUniqueSpec.UNIQUE;
+	}
+
+	/** Returns whether the constraint is PRIMARY KEY. */
+	public boolean isPrimaryKey() {
+		return this.uniqueSpec.getValueAs(SqlUniqueSpec.class) == SqlUniqueSpec.PRIMARY_KEY;
+	}
+
+	/** Returns whether the constraint is enforced. */
+	public boolean isEnforced() {
+		// Default is enforced.
+		return this.enforcement == null
+				|| this.enforcement.getValueAs(SqlConstraintEnforcement.class)
+					== SqlConstraintEnforcement.ENFORCED;
+	}
+
+	public Optional<String> getConstraintName() {
+		String ret = constraintName != null ? constraintName.getSimple() : null;
+		return Optional.ofNullable(ret);
+	}
+
+	public SqlNodeList getColumns() {
+		return columns;
+	}
+
+	public boolean isTableConstraint() {
+		return isTableConstraint;
+	}
+
+	/**
+	 * Returns the columns as a string array.
+	 */
+	public String[] getColumnNames() {
+		return columns.getList()
+				.stream()
+				.map(col -> ((SqlIdentifier) col)
+						.getSimple())
+				.toArray(String[]::new);
+	}
+
+	@Override
+	public List<SqlNode> getOperandList() {
+		return ImmutableNullableList.of(constraintName, uniqueSpec, columns, enforcement);
+	}
+
+	@Override
+	public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+		if (this.constraintName != null) {
+			writer.keyword("CONSTRAINT");
+			this.constraintName.unparse(writer, leftPrec, rightPrec);
+		}
+		this.uniqueSpec.unparse(writer, leftPrec, rightPrec);
+		if (isTableConstraint) {
+			SqlWriter.Frame frame = writer.startList("(", ")");
+			for (SqlNode column : this.columns) {
+				writer.sep(",", false);
+				column.unparse(writer, leftPrec, rightPrec);
+			}
+			writer.endList(frame);
+		}
+		if (this.enforcement != null) {
+			this.enforcement.unparse(writer, leftPrec, rightPrec);
+		}
+	}
+}

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlUniqueSpec.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/constraint/SqlUniqueSpec.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl.constraint;
+
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+/** Enumeration of SQL unique specification. */
+public enum SqlUniqueSpec {
+	PRIMARY_KEY("PRIMARY KEY"),
+	UNIQUE("UNIQUE");
+
+	private final String digest;
+
+	SqlUniqueSpec(String digest) {
+		this.digest = digest;
+	}
+
+	@Override
+	public String toString() {
+		return this.digest;
+	}
+
+	/**
+	 * Creates a parse-tree node representing an occurrence of this keyword
+	 * at a particular position in the parsed text.
+	 */
+	public SqlLiteral symbol(SqlParserPos pos) {
+		return SqlLiteral.createSymbol(this, pos);
+	}
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -181,11 +181,24 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	public void testAlterTable() {
 		sql("alter table t1 rename to t2").ok("ALTER TABLE `T1` RENAME TO `T2`");
 		sql("alter table c1.d1.t1 rename to t2").ok("ALTER TABLE `C1`.`D1`.`T1` RENAME TO `T2`");
-		final String sql = "alter table t1 set ('key1'='value1')";
-		final String expected = "ALTER TABLE `T1` SET (\n"
+		final String sql0 = "alter table t1 set ('key1'='value1')";
+		final String expected0 = "ALTER TABLE `T1` SET (\n"
 				+ "  'key1' = 'value1'\n"
 				+ ")";
-		sql(sql).ok(expected);
+		sql(sql0).ok(expected0);
+		final String sql1 = "alter table t1 "
+				+ "add constraint ct1 primary key(a, b) not enforced";
+		final String expected1 = "ALTER TABLE `T1` "
+				+ "ADD CONSTRAINT `CT1` PRIMARY KEY (`A`, `B`) NOT ENFORCED";
+		sql(sql1).ok(expected1);
+		final String sql2 = "alter table t1 "
+				+ "add unique(a, b)";
+		final String expected2 = "ALTER TABLE `T1` "
+				+ "ADD UNIQUE (`A`, `B`)";
+		sql(sql2).ok(expected2);
+		final String sql3 = "alter table t1 drop constraint ct1";
+		final String expected3 = "ALTER TABLE `T1` DROP CONSTRAINT `CT1`";
+		sql(sql3).ok(expected3);
 	}
 
 	@Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableAddConstraintOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableAddConstraintOperation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.OperationUtils;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Operation of "ALTER TABLE ADD [CONSTRAINT constraintName] ..." clause.
+ *
+ * <p>Note: only primary key is supported now.
+ */
+public class AlterTableAddConstraintOperation extends AlterTableOperation {
+	private final String constraintName;
+	private final String[] columnNames;
+
+	public AlterTableAddConstraintOperation(
+			ObjectIdentifier tableIdentifier,
+			@Nullable String constraintName,
+			String[] columnNames) {
+		super(tableIdentifier);
+		this.constraintName = constraintName;
+		this.columnNames = columnNames;
+	}
+
+	public Optional<String> getConstraintName() {
+		return Optional.ofNullable(constraintName);
+	}
+
+	public String[] getColumnNames() {
+		return columnNames;
+	}
+
+	@Override
+	public String asSummaryString() {
+		Map<String, Object> params = new LinkedHashMap<>();
+		params.put("identifier", tableIdentifier);
+		if (getConstraintName().isPresent()) {
+			params.put("constraintName", this.constraintName);
+		}
+		params.put("columns", this.columnNames);
+
+		return OperationUtils.formatWithChildren(
+				"ALTER TABLE ADD CONSTRAINT",
+				params,
+				Collections.emptyList(),
+				Operation::asSummaryString);
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableDropConstraintOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ddl/AlterTableDropConstraintOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations.ddl;
+
+import org.apache.flink.table.catalog.ObjectIdentifier;
+
+/** Operation of "ALTER TABLE ADD [CONSTRAINT constraintName] ..." clause. **/
+public class AlterTableDropConstraintOperation extends AlterTableOperation {
+	private final String constraintName;
+
+	public AlterTableDropConstraintOperation(
+			ObjectIdentifier tableIdentifier,
+			String constraintName) {
+		super(tableIdentifier);
+		this.constraintName = constraintName;
+	}
+
+	public String getConstraintName() {
+		return constraintName;
+	}
+
+	@Override
+	public String asSummaryString() {
+		return String.format("ALTER TABLE %s DROP CONSTRAINT %s",
+				tableIdentifier, constraintName);
+	}
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -303,11 +303,13 @@ public class TableSchema {
 				sb.append(" |-- ").append("WATERMARK FOR ")
 					.append(watermark.getRowtimeAttribute()).append(" AS ")
 					.append(watermark.getWatermarkExpr());
+				sb.append('\n');
 			}
 		}
 
 		if (primaryKey != null) {
 			sb.append(" |-- ").append(primaryKey.asSummaryString());
+			sb.append('\n');
 		}
 		return sb.toString();
 	}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/api/TableSchemaTest.java
@@ -68,7 +68,7 @@ public class TableSchemaTest {
 			" |-- f1: ROW<`q1` STRING, `q2` TIMESTAMP(3)>\n" +
 			" |-- f2: STRING\n" +
 			" |-- f3: BIGINT AS f0 + 1\n" +
-			" |-- WATERMARK FOR f1.q2 AS now()";
+			" |-- WATERMARK FOR f1.q2 AS now()\n";
 		assertEquals(expected, schema.toString());
 
 		// test getFieldNames and getFieldDataType
@@ -213,7 +213,7 @@ public class TableSchemaTest {
 				" |-- f0: BIGINT NOT NULL\n" +
 				" |-- f1: STRING NOT NULL\n" +
 				" |-- f2: DOUBLE NOT NULL\n" +
-				" |-- CONSTRAINT pk PRIMARY KEY (f0, f2)"
+				" |-- CONSTRAINT pk PRIMARY KEY (f0, f2)\n"
 		));
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/utils/TableSchemaUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for TableSchemaUtils. */
+public class TableSchemaUtilsTest {
+	@Rule
+	public ExpectedException exceptionRule = ExpectedException.none();
+
+	@Test
+	public void testBuilderWithGivenSchema() {
+		TableSchema oriSchema = TableSchema.builder()
+				.field("a", DataTypes.INT().notNull())
+				.field("b", DataTypes.STRING())
+				.field("c", DataTypes.INT(), "a + 1")
+				.field("t", DataTypes.TIMESTAMP(3))
+				.primaryKey("ct1", new String[] {"a"})
+				.watermark("t", "t", DataTypes.TIMESTAMP(3))
+				.build();
+		TableSchema newSchema = TableSchemaUtils.builderWithGivenSchema(oriSchema).build();
+		assertEquals(oriSchema, newSchema);
+	}
+
+	@Test
+	public void testDropConstraint() {
+		TableSchema oriSchema = TableSchema.builder()
+				.field("a", DataTypes.INT().notNull())
+				.field("b", DataTypes.STRING())
+				.field("c", DataTypes.INT(), "a + 1")
+				.field("t", DataTypes.TIMESTAMP(3))
+				.primaryKey("ct1", new String[] {"a"})
+				.watermark("t", "t", DataTypes.TIMESTAMP(3))
+				.build();
+		TableSchema newSchema = TableSchemaUtils.dropConstraint(oriSchema, "ct1");
+		final String expected = "root\n" +
+				" |-- a: INT NOT NULL\n" +
+				" |-- b: STRING\n" +
+				" |-- c: INT AS a + 1\n" +
+				" |-- t: TIMESTAMP(3)\n" +
+				" |-- WATERMARK FOR t AS t\n";
+		assertEquals(expected, newSchema.toString());
+		// Drop non-exist constraint.
+		exceptionRule.expect(ValidationException.class);
+		exceptionRule.expectMessage("Constraint ct2 to drop does not exist");
+		TableSchemaUtils.dropConstraint(oriSchema, "ct2");
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -36,6 +36,7 @@ import org.apache.flink.sql.parser.ddl.SqlTableColumn;
 import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
 import org.apache.flink.sql.parser.dql.SqlShowCatalogs;
 import org.apache.flink.sql.parser.dql.SqlShowDatabases;
@@ -208,11 +209,9 @@ public class SqlToOperationConverter {
 	 * Convert the {@link SqlCreateTable} node.
 	 */
 	private Operation convertCreateTable(SqlCreateTable sqlCreateTable) {
-		// primary key and unique keys are not supported
-		if ((sqlCreateTable.getPrimaryKeyList().size() > 0)
-			|| (sqlCreateTable.getUniqueKeysList().size() > 0)) {
-			throw new SqlConversionException("Primary key and unique key are not supported yet.");
-		}
+		// Unique key and enforced mode are not supported yet.
+		sqlCreateTable.getFullConstraints()
+				.forEach(this::validateTableConstraint);
 
 		// set with properties
 		Map<String, String> properties = new HashMap<>();
@@ -265,8 +264,7 @@ public class SqlToOperationConverter {
 			Optional<CatalogManager.TableLookupResult> optionalCatalogTable = catalogManager.getTable(tableIdentifier);
 			if (optionalCatalogTable.isPresent() && !optionalCatalogTable.get().isTemporary()) {
 				CatalogTable originalCatalogTable = (CatalogTable) optionalCatalogTable.get().getTable();
-				Map<String, String> properties = new HashMap<>();
-				properties.putAll(originalCatalogTable.getProperties());
+				Map<String, String> properties = new HashMap<>(originalCatalogTable.getOptions());
 				((SqlAlterTableProperties) sqlAlterTable).getPropertyList().getList().forEach(p ->
 					properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
 				CatalogTable catalogTable = new CatalogTableImpl(
@@ -477,13 +475,13 @@ public class SqlToOperationConverter {
 		}
 		String catalogName = (fullDatabaseName.length == 1) ? catalogManager.getCurrentCatalog() : fullDatabaseName[0];
 		String databaseName = (fullDatabaseName.length == 1) ? fullDatabaseName[0] : fullDatabaseName[1];
-		Map<String, String> properties = new HashMap<>();
+		final Map<String, String> properties;
 		CatalogDatabase originCatalogDatabase;
 		Optional<Catalog> catalog = catalogManager.getCatalog(catalogName);
 		if (catalog.isPresent()) {
 			try {
 				originCatalogDatabase = catalog.get().getDatabase(databaseName);
-				properties.putAll(originCatalogDatabase.getProperties());
+				properties = new HashMap<>(originCatalogDatabase.getProperties());
 			} catch (DatabaseNotExistException e) {
 				throw new SqlConversionException(String.format("Database %s not exists", databaseName), e);
 			}
@@ -612,10 +610,14 @@ public class SqlToOperationConverter {
 			if (node instanceof SqlTableColumn) {
 				SqlTableColumn column = (SqlTableColumn) node;
 				RelDataType relType = column.getType()
-					.deriveType(validator, column.getType().getNullable());
+					.deriveType(validator);
+				RelDataType colType = validator.getTypeFactory()
+						.createTypeWithNullability(
+								relType,
+								sqlCreateTable.isColumnNullable(column));
 				String name = column.getName().getSimple();
 				// add field name and field type to physical field list
-				physicalFieldNamesToTypes.put(name, relType);
+				physicalFieldNamesToTypes.put(name, colType);
 			}
 		}
 		// Collect all fields types for watermark expression validation
@@ -660,7 +662,31 @@ public class SqlToOperationConverter {
 			builder.watermark(rowtimeAttribute, getQuotedSqlString(validated), exprDataType);
 		});
 
+		// Set up table and column constraints into the schema.
+		for (SqlTableConstraint constraint : sqlCreateTable.getFullConstraints()) {
+			final Optional<String> constraintName = constraint.getConstraintName();
+			if (constraint.isPrimaryKey()) {
+				if (constraintName.isPresent()) {
+					builder.primaryKey(constraintName.get(), constraint.getColumnNames());
+				} else {
+					builder.primaryKey(constraint.getColumnNames());
+				}
+			}
+		}
 		return builder.build();
+	}
+
+	private void validateTableConstraint(SqlTableConstraint constraint) {
+		if (constraint.isUnique()) {
+			throw new UnsupportedOperationException("UNIQUE constraint is not supported yet");
+		}
+		if (constraint.isEnforced()) {
+			throw new ValidationException("Flink doesn't support ENFORCED mode for "
+					+ "PRIMARY KEY constaint. ENFORCED/NOT ENFORCED  controls if the constraint "
+					+ "checks are performed on the incoming/outgoing data. "
+					+ "Flink does not own the data therefore the only supported mode "
+					+ "is the NOT ENFORCED mode");
+		}
 	}
 
 	private String getQuotedSqlString(SqlNode sqlNode) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/sqlexec/SqlToOperationConverter.java
@@ -201,8 +201,7 @@ public class SqlToOperationConverter {
 	 */
 	private Operation convertCreateTable(SqlCreateTable sqlCreateTable) {
 		// primary key and unique keys are not supported
-		if ((sqlCreateTable.getPrimaryKeyList().size() > 0)
-			|| (sqlCreateTable.getUniqueKeysList().size() > 0)) {
+		if (sqlCreateTable.getFullConstraints().size() > 0) {
 			throw new SqlConversionException("Primary key and unique key are not supported yet.");
 		}
 
@@ -276,8 +275,11 @@ public class SqlToOperationConverter {
 				throw new ValidationException(String.format("Table %s doesn't exist or is a temporary table.",
 					tableIdentifier.toString()));
 			}
+		} else {
+			throw new ValidationException(
+					String.format("[%s] needs to implement",
+							sqlAlterTable.toSqlString(CalciteSqlDialect.DEFAULT)));
 		}
-		return null;
 	}
 
 	/** Convert CREATE FUNCTION statement. */


### PR DESCRIPTION
## What is the purpose of the change

Supports primary key and unique key syntax to sql-parser and blink-planner.

## Brief change log

- Add primary key and unique syntax to sql parser
- Add primary key support for CREATE TABLE for blink-planner
- Add primary key support for ALTER TABLE for blink-planner

## Verifying this change

Added UTs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
