### PR TITLE
[FLINK-17471][python] move the LICENSE and NOTICE file to the package root of the PyFlink source distribution.

### DIFF
--- a/flink-python/MANIFEST.in
+++ b/flink-python/MANIFEST.in
@@ -26,8 +26,8 @@ graft deps/log
 recursive-include deps/examples *.py
 graft deps/licenses
 include README.md
-include pyflink/LICENSE
-include pyflink/NOTICE
+include LICENSE
+include NOTICE
 include pyflink/README.txt
 recursive-exclude deps/opt/python *
 recursive-include pyflink/fn_execution *.pxd

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -99,8 +99,8 @@ LICENSES_TEMP_PATH = os.path.join(TEMP_PATH, "licenses")
 PLUGINS_TEMP_PATH = os.path.join(TEMP_PATH, "plugins")
 SCRIPTS_TEMP_PATH = os.path.join(TEMP_PATH, "bin")
 
-LICENSE_FILE_TEMP_PATH = os.path.join("pyflink", "LICENSE")
-NOTICE_FILE_TEMP_PATH = os.path.join("pyflink", "NOTICE")
+LICENSE_FILE_TEMP_PATH = os.path.join(this_directory, "LICENSE")
+NOTICE_FILE_TEMP_PATH = os.path.join(this_directory, "NOTICE")
 README_FILE_TEMP_PATH = os.path.join("pyflink", "README.txt")
 
 in_flink_source = os.path.isfile("../flink-java/src/main/java/org/apache/flink/api/java/"
@@ -233,7 +233,7 @@ run sdist.
         'pyflink.bin': TEMP_PATH + '/bin'}
 
     PACKAGE_DATA = {
-        'pyflink': ['LICENSE', 'README.txt'],
+        'pyflink': ['README.txt'],
         'pyflink.lib': ['*.jar'],
         'pyflink.opt': ['*.*', '*/*'],
         'pyflink.conf': ['*'],
@@ -246,9 +246,6 @@ run sdist.
         PACKAGES.append('pyflink.licenses')
         PACKAGE_DIR['pyflink.licenses'] = TEMP_PATH + '/licenses'
         PACKAGE_DATA['pyflink.licenses'] = ['*']
-
-    if exist_notice:
-        PACKAGE_DATA['pyflink'].append('NOTICE')
 
     setup(
         name='apache-flink',


### PR DESCRIPTION
## What is the purpose of the change

*This pull request moves the LICENSE and NOTICE file to the package root of the PyFlink source distribution.*


## Brief change log

  - *Change the `setup.py` to copy the LICENSE and NOTICE file to the root of flink-python project dir.*
  - *Change the `manifest.in` to inlcude the LICENSE and NOTICE file in the flink-python project dir.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
