### PR TITLE
[FLINK-12675][Connectors/Kafka] Event time synchronization in Kafka consumer

### DIFF
--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -436,6 +436,20 @@ public abstract class AbstractFetcher<T, KPH> {
 			sourceContext.collectWithTimestamp(record, timestamp);
 			partitionState.setOffset(offset);
 		}
+
+		// Need not be synchronized with checkpointLock as
+		// event time alignment is a transient operation
+		onEmitWithPeriodicWatermark(partitionState, timestamp);
+	}
+
+	/**
+	 * To be used by various implementations for event time alignment.
+	 * @param partitionState
+	 * @param timestamp
+	 */
+	protected void onEmitWithPeriodicWatermark(
+			KafkaTopicPartitionState<KPH> partitionState, long timestamp) {
+		// Hack for event time alignment
 	}
 
 	/**

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/AlignmentTimestampAggregateFunction.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/AlignmentTimestampAggregateFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internal;
+
+import org.apache.flink.api.common.functions.AggregateFunction;
+
+import javafx.util.Pair;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Used to compute the global minimum of current event time across all kafka partitions.
+ * <p/>Maintains a Map of subtaskId to subtask minimum. Computes the minimum
+ * of all subtask in the getResult function.
+ */
+public class AlignmentTimestampAggregateFunction
+	implements AggregateFunction<Pair<Integer, Long>, Map<Integer, Long>, Long> {
+
+	@Override
+	public Map<Integer, Long> createAccumulator() {
+		return new HashMap<>();
+	}
+
+	@Override
+	public Map<Integer, Long> add(Pair<Integer, Long> subtaskTs, Map<Integer, Long> accumulator) {
+		accumulator.put(subtaskTs.getKey(), subtaskTs.getValue());
+		return accumulator;
+	}
+
+	@Override
+	public Long getResult(Map<Integer, Long> accumulator) {
+		return accumulator.values().stream().min(Long::compareTo).get();
+	}
+
+	@Override
+	public Map<Integer, Long> merge(Map<Integer, Long> a, Map<Integer, Long> b) {
+		// not required
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/EventTimeAlignmentHandover.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/EventTimeAlignmentHandover.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka.internal;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.List;
+
+/**
+ * The interface for KafkaFetcher and KafkaConsumerThread
+ * to co-ordinate event time alignment.
+ */
+public class EventTimeAlignmentHandover {
+
+	private final Object lock = new Object();
+
+	/** The list of partitions to be paused for realignment, null if alignment is inactive. */
+	private List<TopicPartition> partitionsToPause;
+
+	public List<TopicPartition> getPartitionsToPause() {
+		synchronized (lock) {
+			return this.partitionsToPause;
+		}
+	}
+
+	public void activate(List<TopicPartition> partitionsToPause) {
+		synchronized (lock) {
+			this.partitionsToPause = partitionsToPause;
+		}
+	}
+
+	public void deactivate() {
+		synchronized (lock) {
+			this.partitionsToPause = null;
+		}
+	}
+
+}

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/AlignmentTimestampAggregateFunctionTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/AlignmentTimestampAggregateFunctionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kafka;
+
+import org.apache.flink.streaming.connectors.kafka.internal.AlignmentTimestampAggregateFunction;
+
+import javafx.util.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * Tests for the {@link AlignmentTimestampAggregateFunction}.
+ */
+public class AlignmentTimestampAggregateFunctionTest {
+
+	@Test
+	public void alignmentTsAggregatorTest() {
+		AlignmentTimestampAggregateFunction aggregator = new AlignmentTimestampAggregateFunction();
+		Map<Integer, Long> accumulator = aggregator.createAccumulator();
+
+		accumulator = aggregator.add(new Pair<>(1, 10L), accumulator);
+		accumulator = aggregator.add(new Pair<>(2, 20L), accumulator);
+		accumulator = aggregator.add(new Pair<>(3, 30L), accumulator);
+
+		Assert.assertEquals("Aggregator result should be min of all tasks",
+			10L, (long) aggregator.getResult(accumulator));
+
+		accumulator = aggregator.add(new Pair<>(1, 25L), accumulator);
+		Assert.assertEquals("Aggregator result should be updated to min of all tasks",
+			20L, (long) aggregator.getResult(accumulator));
+	}
+
+	@Test(expected = NoSuchElementException.class)
+	public void emptyAccumulatorTest() {
+		// We haven't handled empty accumulator because globalAggregateManager.updateGlobalAggregate
+		// always does a aggregator.add before aggregator.getResult
+		AlignmentTimestampAggregateFunction aggregator = new AlignmentTimestampAggregateFunction();
+		aggregator.getResult(aggregator.createAccumulator());
+	}
+
+}


### PR DESCRIPTION
## What is the purpose of the change
This change enables event time alignment for FlinkKafkaConsumer. 

Since this is only an initial draft, I've implemented the change only in FlinkKafkaConsumer, and not pushed it down to AbstractFetcher.

## Brief change log
- Takes 2 new configurations eventTimeAlignmentIntervalMillis (the interval in which sync should occur) and eventTimeAlignmentThresholdMillis (the threshold value for unalignment beyond which the partition will be paused)
- When periodic watermarks are used, and above parameters are set it will start a new thread to check the alignment in KafkaFetcher 
- We keep track of the watermark timestamp at a partition level and then compute the global mininum using GlobalAggregateManager, and the list of partitionsToPause
- Since KafkaFetcher and KafkaConsumerThread are 2 threads, we make use of a EventTimeAlignmentHandover to pass the partitionsToPause to the consumer
- In KafkaConsumerThread run loop, we check if there are any updates in the EventTimeAlignmentHandover pausedPartitions and apply the changes to the KafkaConsumer


## Verifying this change
This change added tests and can be verified as follows:

  - Manually verfied the change by running a local Flink job with parallelism 2, and which listens to 2 kafka topics.   
  - Will add more tests once I get some feedback, total rework might be required so holding it off

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
