### PR TITLE
[FLINK-17489][core] Support any kind of array in StringUtils.arrayAwareToString()

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/StringUtils.java
@@ -101,82 +101,14 @@ public final class StringUtils {
 	}
 
 	/**
-	 * This method calls {@link Object#toString()} on the given object, unless the
-	 * object is an array. In that case, it will use the {@link #arrayToString(Object)}
-	 * method to create a string representation of the array that includes all contained
-	 * elements.
+	 * Converts the given object into a string representation by calling {@link Object#toString()}
+	 * and formatting (possibly nested) arrays and {@code null}.
 	 *
-	 * @param o The object for which to create the string representation.
-	 * @return The string representation of the object.
+	 * <p>See {@link Arrays#deepToString(Object[])} for more information about the used format.
 	 */
 	public static String arrayAwareToString(Object o) {
-		if (o == null) {
-			return "null";
-		}
-		if (o.getClass().isArray()) {
-			return arrayToString(o);
-		}
-
-		return o.toString();
-	}
-
-	/**
-	 * Returns a string representation of the given array. This method takes an Object
-	 * to allow also all types of primitive type arrays.
-	 *
-	 * @param array The array to create a string representation for.
-	 * @return The string representation of the array.
-	 * @throws IllegalArgumentException If the given object is no array.
-	 */
-	public static String arrayToString(Object array) {
-		if (array == null) {
-			throw new NullPointerException();
-		}
-
-		if (array instanceof int[]) {
-			return Arrays.toString((int[]) array);
-		}
-		if (array instanceof long[]) {
-			return Arrays.toString((long[]) array);
-		}
-		// for array of byte array
-		if (array instanceof byte[][]) {
-			byte[][] b = (byte[][]) array;
-			String[] strs = new String[b.length];
-
-			for (int i = 0; i < b.length; i++) {
-				strs[i] = Arrays.toString(b[i]);
-			}
-
-			return Arrays.toString(strs);
-		}
-		if (array instanceof byte[]) {
-			return Arrays.toString((byte[]) array);
-		}
-		if (array instanceof double[]) {
-			return Arrays.toString((double[]) array);
-		}
-		if (array instanceof float[]) {
-			return Arrays.toString((float[]) array);
-		}
-		if (array instanceof boolean[]) {
-			return Arrays.toString((boolean[]) array);
-		}
-		if (array instanceof char[]) {
-			return Arrays.toString((char[]) array);
-		}
-		if (array instanceof short[]) {
-			return Arrays.toString((short[]) array);
-		}
-		if (array instanceof Object[]) {
-			return Arrays.toString((Object[]) array);
-		}
-
-		if (array.getClass().isArray()) {
-			return "<unknown array type>";
-		} else {
-			throw new IllegalArgumentException("The given argument is no array.");
-		}
+		final String arrayString = Arrays.deepToString(new Object[]{o});
+		return arrayString.substring(1, arrayString.length() - 1);
 	}
 
 	/**

--- a/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/StringUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.util;
 
 import org.junit.Test;
 
+import java.time.DayOfWeek;
 import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -39,21 +40,26 @@ public class StringUtilsTest extends TestLogger {
 	}
 
 	@Test
-	public void testArrayOfBytesArray() {
-		byte[][] expectedArray = new byte[][]{
-			{1, -97, 49, 74 },
-			{2, -92, 48, 73 }
-		};
+	public void testArrayAwareToString() {
+		assertEquals(
+			"null",
+			StringUtils.arrayAwareToString(null));
 
-		String controlString = StringUtils.arrayToString(expectedArray);
-		assertEquals("[[1, -97, 49, 74], [2, -92, 48, 73]]", controlString);
-	}
+		assertEquals(
+			"MONDAY",
+			StringUtils.arrayAwareToString(DayOfWeek.MONDAY));
 
-	@Test
-	public void testArrayToString() {
-		double[] array = {1.0};
-		String controlString = StringUtils.arrayToString(array);
-		assertEquals("[1.0]", controlString);
+		assertEquals(
+			"[1, 2, 3]",
+			StringUtils.arrayAwareToString(new int[]{1, 2, 3}));
+
+		assertEquals(
+			"[[4, 5, 6], null, []]",
+			StringUtils.arrayAwareToString(new byte[][]{{4, 5, 6}, null, {}}));
+
+		assertEquals(
+			"[[4, 5, 6], null, MONDAY]",
+			StringUtils.arrayAwareToString(new Object[]{new Integer[]{4, 5, 6}, null, DayOfWeek.MONDAY}));
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
@@ -21,8 +21,8 @@ package org.apache.flink.table.data;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
-import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -212,7 +212,7 @@ public final class GenericRowData implements RowData {
 			if (i != 0) {
 				sb.append(",");
 			}
-			sb.append(EncodingUtils.objectToString(fields[i]));
+			sb.append(StringUtils.arrayAwareToString(fields[i]));
 		}
 		sb.append(")");
 		return sb.toString();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -25,8 +25,8 @@ import org.apache.flink.table.types.inference.CallContext;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.utils.ValueDataTypeConverter;
-import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -311,6 +311,6 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 		} else if (value instanceof String) {
 			return "'" + ((String) value).replace("'", "''") + "'";
 		}
-		return EncodingUtils.objectToString(value);
+		return StringUtils.arrayAwareToString(value);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/EncodingUtils.java
@@ -29,7 +29,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Base64;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -143,11 +142,6 @@ public abstract class EncodingUtils {
 			hexChars[j * 2 + 1] = HEX_CHARS[v & 0x0F];
 		}
 		return new String(hexChars);
-	}
-
-	public static String objectToString(Object object) {
-		final String arrayString = Arrays.deepToString(new Object[]{object});
-		return arrayString.substring(1, arrayString.length() - 1);
 	}
 
 	// --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PrintUtils.java
@@ -22,10 +22,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.StringUtils;
 
 import com.ibm.icu.lang.UCharacter;
 import com.ibm.icu.lang.UProperty;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -106,7 +106,7 @@ public class PrintUtils {
 			if (field == null) {
 				fields[i] = NULL_COLUMN;
 			} else {
-				fields[i] = EncodingUtils.objectToString(field);
+				fields[i] = StringUtils.arrayAwareToString(field);
 			}
 		}
 		return fields;
@@ -135,7 +135,7 @@ public class PrintUtils {
 		StringBuilder sb = new StringBuilder();
 		sb.append("+");
 		for (int width : colWidths) {
-			sb.append(StringUtils.repeat('-', width + 1));
+			sb.append(EncodingUtils.repeat('-', width + 1));
 			sb.append("-+");
 		}
 		return sb.toString();
@@ -149,7 +149,7 @@ public class PrintUtils {
 			sb.append(" ");
 			int displayWidth = getStringDisplayWidth(col);
 			if (displayWidth <= colWidths[idx]) {
-				sb.append(StringUtils.repeat(' ', colWidths[idx] - displayWidth));
+				sb.append(EncodingUtils.repeat(' ', colWidths[idx] - displayWidth));
 				sb.append(col);
 			} else {
 				sb.append(truncateString(col, colWidths[idx] - COLUMN_TRUNCATED_FLAG.length()));
@@ -180,7 +180,7 @@ public class PrintUtils {
 		// pad with ' ' before the column
 		int lackedWidth = targetWidth - getStringDisplayWidth(substring);
 		if (lackedWidth > 0) {
-			substring = StringUtils.repeat(' ', lackedWidth) + substring;
+			substring = EncodingUtils.repeat(' ', lackedWidth) + substring;
 		}
 		return substring;
 	}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -39,8 +39,8 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.logical.RawType;
-import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.Row;
+import org.apache.flink.util.StringUtils;
 
 import org.junit.Test;
 
@@ -865,7 +865,7 @@ public class FunctionITCase extends StreamingTestBase {
 	 */
 	public static class ComplexScalarFunction extends ScalarFunction {
 		public String eval(@DataTypeHint(inputGroup = InputGroup.ANY) Object o, java.sql.Timestamp t) {
-			return EncodingUtils.objectToString(o) + "+" + t.toString();
+			return StringUtils.arrayAwareToString(o) + "+" + t.toString();
 		}
 
 		public @DataTypeHint("DECIMAL(5, 2)") BigDecimal eval() {

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/RowDataTestUtil.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/RowDataTestUtil.java
@@ -26,7 +26,7 @@ import org.apache.flink.table.runtime.types.InternalSerializers;
 import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.utils.EncodingUtils;
+import org.apache.flink.util.StringUtils;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -54,7 +54,7 @@ public class RowDataTestUtil {
 			// TODO support after FLINK-11898 is merged
 			throw new UnsupportedOperationException();
 		} else {
-			return EncodingUtils.objectToString(field);
+			return StringUtils.arrayAwareToString(field);
 		}
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/TestSinkUtil.scala
@@ -27,11 +27,11 @@ import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.sinks.TableSink
 import org.apache.flink.table.utils.EncodingUtils
 import org.apache.flink.types.Row
-
 import org.apache.calcite.avatica.util.DateTimeUtils
-
 import java.sql.{Date, Time, Timestamp}
 import java.util.{Calendar, TimeZone}
+
+import org.apache.flink.util.StringUtils
 
 import scala.collection.JavaConverters._
 
@@ -58,7 +58,7 @@ object TestSinkUtil {
     field match {
       case _: Date | _: Time | _: Timestamp =>
         unixDateTimeToString(field, tz)
-      case _ => EncodingUtils.objectToString(field)
+      case _ => StringUtils.arrayAwareToString(field)
     }
   }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/BoxedWrapperRowData.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/BoxedWrapperRowData.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.data;
 
 import org.apache.flink.table.data.binary.TypedSetters;
-import org.apache.flink.table.utils.EncodingUtils;
 import org.apache.flink.types.BooleanValue;
 import org.apache.flink.types.ByteValue;
 import org.apache.flink.types.DoubleValue;
@@ -28,6 +27,7 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.LongValue;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.ShortValue;
+import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -255,7 +255,7 @@ public class BoxedWrapperRowData implements RowData, TypedSetters {
 			if (i != 0) {
 				sb.append(",");
 			}
-			sb.append(EncodingUtils.objectToString(fields[i]));
+			sb.append(StringUtils.arrayAwareToString(fields[i]));
 		}
 		sb.append(")");
 		return sb.toString();


### PR DESCRIPTION
## What is the purpose of the change

Support arbitrary objects in `StringUtils.arrayAwareToString()`.

## Brief change log

Refactors `StringUtils` and ensures consistent usage.

## Verifying this change

This change added tests and can be verified as follows: `StringUtilsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
