### PR TITLE
[FLINK-17483][legal] Update flink-sql-connector-elasticsearch7 NOTICE file to correctly reflect bundled dependencies

### DIFF
--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.carrotsearch:hppc:0.8.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.1
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.1
+- com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.10
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.4
@@ -34,11 +36,13 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.elasticsearch:elasticsearch:7.5.1
 - org.elasticsearch:elasticsearch-cli:7.5.1
 - org.elasticsearch:elasticsearch-core:7.5.1
+- org.elasticsearch:elasticsearch-geo:7.5.1
 - org.elasticsearch:elasticsearch-secure-sm:7.5.1
 - org.elasticsearch:elasticsearch-x-content:7.5.1
 - org.elasticsearch.client:elasticsearch-rest-client:7.5.1
 - org.elasticsearch.client:elasticsearch-rest-high-level-client:7.5.1
 - org.elasticsearch.plugin:aggs-matrix-stats-client:7.5.1
+- org.elasticsearch.plugin:lang-mustache-client:7.5.1
 - org.elasticsearch.plugin:mapper-extras-client:7.5.1
 - org.elasticsearch.plugin:parent-join-client:7.5.1
 - org.elasticsearch.plugin:rank-eval-client:7.5.1


### PR DESCRIPTION
## What is the purpose of the change

Fix the legal issue in `flink-sql-connector-elasticsearch7` as reported by FLINK-17483, for master branch

## Brief change log

Update flink-sql-connector-elasticsearch7 NOTICE file to correctly reflect bundled dependencies, including:
* com.carrotsearch:hppc:0.8.1
* com.github.spullara.mustache.java:compiler:0.9.6
* org.elasticsearch:elasticsearch-geo:7.5.1
* org.elasticsearch.plugin:lang-mustache-client:7.5.1

(The same dependencies missing but just with different versions as #11965 )

## Verifying this change

Manually compare the output of shaded plugin and the entries in the NOTICE file, make sure they are in accordance.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
