### PR TITLE
[FLINK-17488] Now JdbcConnectionOptions supports autoCommit control

### DIFF
--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOptions.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JDBCOptions.java
@@ -37,8 +37,8 @@ public class JDBCOptions extends JdbcConnectionOptions {
 	private JDBCDialect dialect;
 
 	private JDBCOptions(String dbURL, String tableName, String driverName, String username,
-			String password, JDBCDialect dialect) {
-		super(dbURL, driverName, username, password);
+			String password, Boolean autoCommit, JDBCDialect dialect) {
+		super(dbURL, driverName, username, password, autoCommit);
 		this.tableName = tableName;
 		this.dialect = dialect;
 	}
@@ -79,6 +79,7 @@ public class JDBCOptions extends JdbcConnectionOptions {
 		private String driverName;
 		private String username;
 		private String password;
+		private Boolean autoCommit;
 		private JDBCDialect dialect;
 
 		/**
@@ -123,6 +124,14 @@ public class JDBCOptions extends JdbcConnectionOptions {
 		}
 
 		/**
+		 * required, autoCommit setting.
+		 */
+		public Builder setAutoCommit(boolean autoCommit) {
+			this.autoCommit = autoCommit;
+			return this;
+		}
+
+		/**
 		 * optional, Handle the SQL dialect of jdbc driver. If not set, it will be infer by
 		 * {@link JDBCDialects#get} from DB url.
 		 */
@@ -147,7 +156,7 @@ public class JDBCOptions extends JdbcConnectionOptions {
 				});
 			}
 
-			return new JDBCOptions(dbURL, tableName, driverName, username, password, dialect);
+			return new JDBCOptions(dbURL, tableName, driverName, username, password, autoCommit, dialect);
 		}
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcConnectionOptions.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/JdbcConnectionOptions.java
@@ -40,11 +40,16 @@ public class JdbcConnectionOptions implements Serializable {
 	@Nullable
 	protected final String password;
 
-	JdbcConnectionOptions(String url, String driverName, String username, String password) {
+	// use Boolean instead of boolean to respect the default settings of the driver
+	@Nullable
+	protected final Boolean autoCommit;
+
+	JdbcConnectionOptions(String url, String driverName, String username, String password, Boolean autoCommit) {
 		this.url = Preconditions.checkNotNull(url, "jdbc url is empty");
 		this.driverName = Preconditions.checkNotNull(driverName, "driver name is empty");
 		this.username = username;
 		this.password = password;
+		this.autoCommit = autoCommit;
 	}
 
 	public String getDbURL() {
@@ -63,6 +68,10 @@ public class JdbcConnectionOptions implements Serializable {
 		return Optional.ofNullable(password);
 	}
 
+	public Optional<Boolean> getAutoCommit() {
+		return Optional.ofNullable(autoCommit);
+	}
+
 	/**
 	 * Builder for {@link JdbcConnectionOptions}.
 	 */
@@ -71,6 +80,7 @@ public class JdbcConnectionOptions implements Serializable {
 		private String driverName;
 		private String username;
 		private String password;
+		private Boolean autoCommit;
 
 		public JdbcConnectionOptionsBuilder withUrl(String url) {
 			this.url = url;
@@ -92,8 +102,13 @@ public class JdbcConnectionOptions implements Serializable {
 			return this;
 		}
 
+		public JdbcConnectionOptionsBuilder withAutoCommit(boolean autoCommit) {
+			this.autoCommit = autoCommit;
+			return this;
+		}
+
 		public JdbcConnectionOptions build() {
-			return new JdbcConnectionOptions(url, driverName, username, password);
+			return new JdbcConnectionOptions(url, driverName, username, password, autoCommit);
 		}
 	}
 }

--- a/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/SimpleJdbcConnectionProvider.java
+++ b/flink-connectors/flink-jdbc/src/main/java/org/apache/flink/api/java/io/jdbc/SimpleJdbcConnectionProvider.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
 /**
  * Simple JDBC connection provider.
@@ -47,6 +48,10 @@ class SimpleJdbcConnectionProvider implements JdbcConnectionProvider, Serializab
 						connection = DriverManager.getConnection(jdbcOptions.getDbURL(), jdbcOptions.getUsername().get(), jdbcOptions.getPassword().orElse(null));
 					} else {
 						connection = DriverManager.getConnection(jdbcOptions.getDbURL());
+					}
+					Optional<Boolean> autoCommit = jdbcOptions.getAutoCommit();
+					if (autoCommit.isPresent()) {
+						connection.setAutoCommit(autoCommit.get());
 					}
 				}
 			}


### PR DESCRIPTION
- Now JdbcConnectionOptions supports autoCommit control
   Default behaviour hasn't changed.
- Added logging information to be able to track batches

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
