### PR TITLE
[FLINK-17496][kinesis] Upgrade amazon-kinesis-producer to 0.14.0

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.11.603</aws.sdk.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.13.1</aws.kinesis-kpl.version>
+		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>
 	</properties>
 

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
 - com.amazonaws:amazon-kinesis-client:1.11.2
-- com.amazonaws:amazon-kinesis-producer:0.13.1
+- com.amazonaws:amazon-kinesis-producer:0.14.0
 - com.amazonaws:aws-java-sdk-core:1.11.603
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.603
 - com.amazonaws:aws-java-sdk-kinesis:1.11.603


### PR DESCRIPTION
## What is the purpose of the change

Kinesis producer 0.13.1 introduced a performance regression that can be addressed with the upgrade to 0.14.0

## Verifying this change

The problem was discovered and the fix verified as part of 1.10.1 release testing in an internal benchmark environment.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
