### PR TITLE
[FLINK-17499][state-processor-api] LazyTimerService used to register …

### DIFF
--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/LazyTimerService.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/output/operators/LazyTimerService.java
@@ -59,13 +59,13 @@ public class LazyTimerService implements TimerService {
 	@Override
 	public void registerProcessingTimeTimer(long time) {
 		ensureInitialized();
-		internalTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, time);
+		internalTimerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, time);
 	}
 
 	@Override
 	public void registerEventTimeTimer(long time) {
 		ensureInitialized();
-		internalTimerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, time);
+		internalTimerService.registerEventTimeTimer(VoidNamespace.INSTANCE, time);
 	}
 
 	@Override


### PR DESCRIPTION
…timers via State Processing API incorrectly mixes event time timers with processing time timers

## What is the purpose of the change

Fix registration of timer service in state processor api

## Verifying this change

UT 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
