### PR TITLE
[FLINK-17002] Support CREATE TABLE ... LIKE clause

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -101,6 +101,7 @@
     "USE"
     "VIEWS"
     "WATERMARK"
+    "WATERMARKS"
   ]
 
   # List of keywords from "keywords" section that are not reserved.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -775,6 +775,8 @@ SqlTableLikeOption SqlTableLikeOption():
         <OPTIONS> { featureOption = FeatureOption.OPTIONS;}
     |
         <PARTITIONS> { featureOption = FeatureOption.PARTITIONS;}
+    |
+        <WATERMARKS> { featureOption = FeatureOption.WATERMARKS;}
     )
 
     {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
@@ -114,6 +114,7 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
 	 *     <li>ALL - a shortcut to change the default merging strategy if none provided</li>
 	 *     <li>CONSTRAINTS - constraints such as primary and unique keys</li>
 	 *     <li>GENERATED - computed columns</li>
+	 *     <li>WATERMARKS - watermark declarations</li>
 	 *     <li>PARTITIONS - partition of the tables</li>
 	 *     <li>OPTIONS - connector options that decribed connector and format properties</li>
 	 * </ul>
@@ -140,8 +141,9 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
 		ALL,
 		CONSTRAINTS,
 		GENERATED,
+		OPTIONS,
 		PARTITIONS,
-		OPTIONS
+		WATERMARKS
 	}
 
 	private final SqlIdentifier sourceTable;

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlTableLike.java
@@ -32,6 +32,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -196,7 +197,8 @@ public class SqlTableLike extends SqlCall implements ExtendedSqlNode {
 		}
 
 		for (SqlTableLikeOption option : options) {
-			if (invalidCombinations.get(option.featureOption).contains(option.mergingStrategy)) {
+			if (invalidCombinations.getOrDefault(option.featureOption, Collections.emptyList())
+				.contains(option.mergingStrategy)) {
 				throw new SqlValidateException(
 					pos,
 					String.format(

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -80,6 +80,8 @@ public class CreateTableLikeTest {
 			")\n" +
 			"LIKE b (\n" +
 			"   EXCLUDING PARTITIONS\n" +
+			"   EXCLUDING CONSTRAINTS\n" +
+			"   EXCLUDING WATERMARKS\n" +
 			"   OVERWRITING GENERATED\n" +
 			"   OVERWRITING OPTIONS\n" +
 			")")
@@ -92,6 +94,8 @@ public class CreateTableLikeTest {
 					pointsTo("b"),
 					hasOptions(
 						option(MergingStrategy.EXCLUDING, FeatureOption.PARTITIONS),
+						option(MergingStrategy.EXCLUDING, FeatureOption.CONSTRAINTS),
+						option(MergingStrategy.EXCLUDING, FeatureOption.WATERMARKS),
 						option(MergingStrategy.OVERWRITING, FeatureOption.GENERATED),
 						option(MergingStrategy.OVERWRITING, FeatureOption.OPTIONS)
 					)

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -28,6 +28,7 @@ import org.apache.calcite.sql.parser.SqlParserImplFactory;
 import org.apache.calcite.sql.parser.SqlParserTest;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -271,76 +272,98 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 	@Test
 	public void testTableConstraints() {
-		final String sql0 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint,\n" +
-				"  h varchar, \n" +
-				"  g as 2 * (a + 1),\n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  b varchar,\n" +
-				"  proc as PROCTIME(),\n" +
-				"  PRIMARY KEY (a, b),\n" +
-				"  UNIQUE (h, g)\n" +
-				") with (\n" +
-				"  'connector' = 'kafka',\n" +
-				"  'kafka.topic' = 'log.test'\n" +
-				")\n";
-		final String expected0 = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  BIGINT,\n" +
-				"  `H`  VARCHAR,\n" +
-				"  `G` AS (2 * (`A` + 1)),\n" +
-				"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  `B`  VARCHAR,\n" +
-				"  `PROC` AS `PROCTIME`(),\n" +
-				"  PRIMARY KEY (`A`, `B`),\n" +
-				"  UNIQUE (`H`, `G`)\n" +
-				") WITH (\n" +
-				"  'connector' = 'kafka',\n" +
-				"  'kafka.topic' = 'log.test'\n" +
-				")";
-		sql(sql0).ok(expected0);
-		// Test with enforcement specification.
-		final String sql1 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint primary key enforced comment 'test column comment AAA.',\n" +
-				"  h varchar constraint ct1 unique not enforced,\n" +
-				"  g as 2 * (a + 1), \n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  b varchar constraint ct2 unique,\n" +
-				"  proc as PROCTIME(),\n" +
-				"  unique (g, ts) not enforced" +
-				") with (\n" +
-				"    'connector' = 'kafka',\n" +
-				"    'kafka.topic' = 'log.test'\n" +
-				")\n";
-		final String expected1 = "CREATE TABLE `TBL1` (\n" +
-				"  `A`  BIGINT PRIMARY KEY ENFORCED  COMMENT 'test column comment AAA.',\n" +
-				"  `H`  VARCHAR CONSTRAINT `CT1` UNIQUE NOT ENFORCED,\n" +
-				"  `G` AS (2 * (`A` + 1)),\n" +
-				"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  `B`  VARCHAR CONSTRAINT `CT2` UNIQUE,\n" +
-				"  `PROC` AS `PROCTIME`(),\n" +
-				"  UNIQUE (`G`, `TS`) NOT ENFORCED\n" +
-				") WITH (\n" +
-				"  'connector' = 'kafka',\n" +
-				"  'kafka.topic' = 'log.test'\n" +
-				")";
-		sql(sql1).ok(expected1);
-		// Test duplicate constraint name.
-		final String sql2 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint comment 'test column comment AAA.',\n" +
-				"  h varchar constraint ct1 unique,\n" +
-				"  g as 2 * (a + 1), \n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'), \n" +
-				"  b varchar constraint ct2 unique,\n" +
-				"  proc as PROCTIME(),\n" +
-				"  constraint ct1 unique (b, h)" +
-				") with (\n" +
-				"    'connector' = 'kafka',\n" +
-				"    'kafka.topic' = 'log.test'\n" +
-				")\n";
-		sql(sql2).node(new ValidationMatcher()
-				.fails("Duplicate definition for constraint [CT1]"));
-		// Test duplicate PK definitions.
-		final String sql3 = "CREATE TABLE tbl1 (\n" +
+		final String sql = "CREATE TABLE tbl1 (\n" +
+			"  a bigint,\n" +
+			"  h varchar, \n" +
+			"  g as 2 * (a + 1),\n" +
+			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  b varchar,\n" +
+			"  proc as PROCTIME(),\n" +
+			"  PRIMARY KEY (a, b),\n" +
+			"  UNIQUE (h, g)\n" +
+			") with (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")\n";
+		final String expected = "CREATE TABLE `TBL1` (\n" +
+			"  `A`  BIGINT,\n" +
+			"  `H`  VARCHAR,\n" +
+			"  `G` AS (2 * (`A` + 1)),\n" +
+			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  `B`  VARCHAR,\n" +
+			"  `PROC` AS `PROCTIME`(),\n" +
+			"  PRIMARY KEY (`A`, `B`),\n" +
+			"  UNIQUE (`H`, `G`)\n" +
+			") WITH (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
+	public void testTableConstraintsValidated() {
+		final String sql = "CREATE TABLE tbl1 (\n" +
+			"  a bigint,\n" +
+			"  h varchar, \n" +
+			"  g as 2 * (a + 1),\n" +
+			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  b varchar,\n" +
+			"  proc as PROCTIME(),\n" +
+			"  PRIMARY KEY (a, b),\n" +
+			"  UNIQUE (h, g)\n" +
+			") with (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")\n";
+		final String expected = "CREATE TABLE `TBL1` (\n" +
+			"  `A`  BIGINT NOT NULL,\n" +
+			"  `H`  VARCHAR,\n" +
+			"  `G` AS (2 * (`A` + 1)),\n" +
+			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  `B`  VARCHAR NOT NULL,\n" +
+			"  `PROC` AS `PROCTIME`(),\n" +
+			"  PRIMARY KEY (`A`, `B`),\n" +
+			"  UNIQUE (`H`, `G`)\n" +
+			") WITH (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")";
+		sql(sql).node(validated(expected));
+	}
+
+	@Test
+	public void testTableConstraintsWithEnforcement() {
+		final String sql = "CREATE TABLE tbl1 (\n" +
+			"  a bigint primary key enforced comment 'test column comment AAA.',\n" +
+			"  h varchar constraint ct1 unique not enforced,\n" +
+			"  g as 2 * (a + 1), \n" +
+			"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  b varchar constraint ct2 unique,\n" +
+			"  proc as PROCTIME(),\n" +
+			"  unique (g, ts) not enforced" +
+			") with (\n" +
+			"    'connector' = 'kafka',\n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+		final String expected = "CREATE TABLE `TBL1` (\n" +
+			"  `A`  BIGINT PRIMARY KEY ENFORCED  COMMENT 'test column comment AAA.',\n" +
+			"  `H`  VARCHAR CONSTRAINT `CT1` UNIQUE NOT ENFORCED,\n" +
+			"  `G` AS (2 * (`A` + 1)),\n" +
+			"  `TS` AS `TOTIMESTAMP`(`B`, 'yyyy-MM-dd HH:mm:ss'),\n" +
+			"  `B`  VARCHAR CONSTRAINT `CT2` UNIQUE,\n" +
+			"  `PROC` AS `PROCTIME`(),\n" +
+			"  UNIQUE (`G`, `TS`) NOT ENFORCED\n" +
+			") WITH (\n" +
+			"  'connector' = 'kafka',\n" +
+			"  'kafka.topic' = 'log.test'\n" +
+			")";
+		sql(sql).ok(expected);
+	}
+
+	@Test
+	public void testDuplicatePk() {
+		final String sql = "CREATE TABLE tbl1 (\n" +
 				"  a bigint comment 'test column comment AAA.',\n" +
 				"  h varchar constraint ct1 primary key,\n" +
 				"  g as 2 * (a + 1), \n" +
@@ -352,51 +375,8 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 				"    'connector' = 'kafka', \n" +
 				"    'kafka.topic' = 'log.test'\n" +
 				")\n";
-		sql(sql3).node(new ValidationMatcher()
+		sql(sql).node(new ValidationMatcher()
 				.fails("Duplicate primary key definition"));
-		// Test unique constraint on non-exist column.
-		final String sql4 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint comment 'test column comment AAA.',\n" +
-				"  h varchar constraint ct1 primary key,\n" +
-				"  g as 2 * (a + 1), \n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  b varchar,\n" +
-				"  proc as PROCTIME(),\n" +
-				"  constraint ct2 unique (c, d)" +
-				") with (\n" +
-				"    'connector' = 'kafka', \n" +
-				"    'kafka.topic' = 'log.test'\n" +
-				")\n";
-		sql(sql4).node(new ValidationMatcher()
-				.fails("Unique key column [C] not defined"));
-		// Test PK constraint on non-exist column.
-		final String sql5 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint comment 'test column comment AAA.',\n" +
-				"  h varchar,\n" +
-				"  g as 2 * (a + 1), \n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  b varchar,\n" +
-				"  proc as PROCTIME(),\n" +
-				"  constraint ct2 primary key (c, d)" +
-				") with (\n" +
-				"    'connector' = 'kafka', \n" +
-				"    'kafka.topic' = 'log.test'\n" +
-				")\n";
-		sql(sql5).node(new ValidationMatcher()
-				.fails("Primary key column [C] not defined"));
-		// Test constraint on computed column.
-		final String sql6 = "CREATE TABLE tbl1 (\n" +
-				"  a bigint comment 'test column comment AAA.',\n" +
-				"  h varchar,\n" +
-				"  g as 2 * (a + 1) ^primary^ key, \n" +
-				"  ts as toTimestamp(b, 'yyyy-MM-dd HH:mm:ss'),\n" +
-				"  b varchar,\n" +
-				"  proc as PROCTIME()\n" +
-				") with (\n" +
-				"    'connector' = 'kafka', \n" +
-				"    'kafka.topic' = 'log.test'\n" +
-				")\n";
-		sql(sql6).fails("(?s).*Encountered \"primary\" at.*");
 	}
 
 	@Test
@@ -995,6 +975,33 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 
 		sql("drop temporary system function if exists catalog1.db1.function1")
 				.ok("DROP TEMPORARY SYSTEM FUNCTION IF EXISTS `CATALOG1`.`DB1`.`FUNCTION1`");
+	}
+
+	public static BaseMatcher<SqlNode> validated(String validatedSql) {
+		return new TypeSafeDiagnosingMatcher<SqlNode>() {
+			@Override
+			protected boolean matchesSafely(SqlNode item, Description mismatchDescription) {
+				if (item instanceof ExtendedSqlNode) {
+					try {
+						((ExtendedSqlNode) item).validate();
+					} catch (SqlValidateException e) {
+						mismatchDescription.appendText("Could not validate the node. Exception: \n");
+						mismatchDescription.appendValue(e);
+					}
+
+					String actual = item.toSqlString(null, true).getSql();
+					return actual.equals(validatedSql);
+				}
+				mismatchDescription.appendText("This matcher can be applied only to ExtendedSqlNode.");
+				return false;
+			}
+
+			@Override
+			public void describeTo(Description description) {
+				description.appendText("The validated node string representation should be equal to: \n");
+				description.appendText(validatedSql);
+			}
+		};
 	}
 
 	/** Matcher that invokes the #validate() of the {@link ExtendedSqlNode} instance. **/

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -464,21 +464,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 	}
 
 	@Test
-	public void testCreateTableWithInvalidWatermark() {
-		String sql = "CREATE TABLE tbl1 (\n" +
-			"  f1 row<q1 bigint, q2 varchar, q3 boolean>,\n" +
-			"  WATERMARK FOR f1.q0 AS NOW()\n" +
-			")\n" +
-			"  with (\n" +
-			"    'connector' = 'kafka', \n" +
-			"    'kafka.topic' = 'log.test'\n" +
-			")\n";
-		sql(sql).node(new ValidationMatcher()
-			.fails("The rowtime attribute field \"F1.Q0\" is not defined in columns, at line 3, column 17"));
-
-	}
-
-	@Test
 	public void testCreateTableWithMultipleWatermark() {
 		String sql = "CREATE TABLE tbl1 (\n" +
 			"  f0 bigint,\n" +
@@ -630,20 +615,6 @@ public class FlinkSqlParserImplTest extends SqlParserTest {
 			+ "`PROCTIME`() AS `PROC`, `C`";
 		sql(sql).node(new ValidationMatcher()
 			.expectColumnSql(expected));
-	}
-
-	@Test
-	public void testCreateInvalidPartitionedTable() {
-		final String sql = "create table sls_stream1(\n" +
-			"  a bigint,\n" +
-			"  b VARCHAR,\n" +
-			"  PRIMARY KEY(a, b)\n" +
-			") PARTITIONED BY (\n" +
-			"  c,\n" +
-			"  d\n" +
-			") with ( 'x' = 'y', 'asd' = 'dada')";
-		sql(sql).node(new ValidationMatcher()
-			.fails("Partition column [C] not defined in columns, at line 6, column 3"));
 	}
 
 	@Test

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -553,6 +553,16 @@ public class TableSchema {
 		}
 
 		/**
+		 * Adds a {@link TableColumn} to this builder.
+		 *
+		 * <p>The call order of this method determines the order of fields in the schema.
+		 */
+		public Builder field(TableColumn column) {
+			columns.add(column);
+			return this;
+		}
+
+		/**
 		 * Add an array of fields with names and data types.
 		 *
 		 * <p>The call order of this method determines the order of fields in the schema.
@@ -605,6 +615,17 @@ public class TableSchema {
 				rowtimeAttribute,
 				watermarkExpressionString,
 				watermarkExprOutputType));
+			return this;
+		}
+
+		/**
+		 * Adds the given {@link WatermarkSpec} to this builder.
+		 */
+		public Builder watermark(WatermarkSpec watermarkSpec) {
+			if (!this.watermarkSpecs.isEmpty()) {
+				throw new IllegalStateException("Multiple watermark definition is not supported yet.");
+			}
+			this.watermarkSpecs.add(watermarkSpec);
 			return this;
 		}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -557,7 +557,7 @@ public class TableSchema {
 		 *
 		 * <p>The call order of this method determines the order of fields in the schema.
 		 */
-		public Builder field(TableColumn column) {
+		public Builder add(TableColumn column) {
 			columns.add(column);
 			return this;
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -272,13 +272,23 @@ class MergeTableLikeUtil {
 					String primaryKey = ((SqlIdentifier) primaryKeyNode).getSimple();
 					if (!columns.containsKey(primaryKey)) {
 						throw new ValidationException(
-							"Primary key column '%s' is not defined in the schema, at " +
-								primaryKeyNode.getParserPosition());
+							String.format("Primary key column '%s' is not defined in the schema, at %s",
+								primaryKey,
+								primaryKeyNode.getParserPosition()));
+					}
+					if (columns.get(primaryKey).isGenerated()) {
+						throw new ValidationException(
+							String.format(
+								"Could not create a PRIMARY KEY with a generated column '%s', at %s.\n" +
+									"PRIMARY KEY constraint is not allowed on computed columns.",
+								primaryKey,
+								primaryKeyNode.getParserPosition()));
 					}
 					primaryKeyColumns.add(primaryKey);
 				}
 				primaryKey = UniqueConstraint.primaryKey(
-					derivedPrimaryKey.getConstraintName().orElseGet(() -> "PK_" + primaryKeyColumns.hashCode()),
+					derivedPrimaryKey.getConstraintName()
+						.orElseGet(() -> "PK_" + primaryKeyColumns.hashCode()),
 					primaryKeyColumns);
 			}
 		}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -417,7 +417,7 @@ class MergeTableLikeUtil {
 		public TableSchema build() {
 			TableSchema.Builder resultBuilder = TableSchema.builder();
 			for (TableColumn column : columns.values()) {
-				resultBuilder.field(column);
+				resultBuilder.add(column);
 			}
 			for (WatermarkSpec watermarkSpec : watermarkSpecs.values()) {
 				resultBuilder.watermark(watermarkSpec);

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/MergeTableLikeUtil.java
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableLike;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
+import org.apache.flink.sql.parser.ddl.SqlWatermark;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.WatermarkSpec;
+import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.utils.TypeConversions;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.table.planner.calcite.FlinkTypeFactory.toLogicalType;
+import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
+
+/**
+ * A utility class with logic for handling the {@code CREATE TABLE ... LIKE} clause.
+ */
+class MergeTableLikeUtil {
+	/**
+	 * Default merging strategy if given option was not provided explicitly by the user.
+	 */
+	private static final HashMap<FeatureOption, MergingStrategy> defaultMergingStrategies = new HashMap<>();
+
+	static {
+		defaultMergingStrategies.put(FeatureOption.OPTIONS, MergingStrategy.OVERWRITING);
+		defaultMergingStrategies.put(FeatureOption.WATERMARKS, MergingStrategy.INCLUDING);
+		defaultMergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.INCLUDING);
+		defaultMergingStrategies.put(FeatureOption.CONSTRAINTS, MergingStrategy.INCLUDING);
+		defaultMergingStrategies.put(FeatureOption.PARTITIONS, MergingStrategy.INCLUDING);
+	}
+
+	private final SqlValidator validator;
+	private final Function<SqlNode, String> escapeExpression;
+
+	MergeTableLikeUtil(
+			SqlValidator validator,
+			Function<SqlNode, String> escapeExpression) {
+		this.validator = validator;
+		this.escapeExpression = escapeExpression;
+	}
+
+	/**
+	 * Calculates merging strategies for all options. It applies options given by a user to the
+	 * {@link #defaultMergingStrategies}. The {@link MergingStrategy} specified for {@link FeatureOption#ALL}
+	 * overwrites all the default options. Those can be further changed with a specific {@link FeatureOption}.
+	 */
+	public Map<FeatureOption, MergingStrategy> computeMergingStrategies(
+			List<SqlTableLike.SqlTableLikeOption> mergingOptions) {
+
+		Map<FeatureOption, MergingStrategy> result = new HashMap<>(defaultMergingStrategies);
+
+		Optional<SqlTableLike.SqlTableLikeOption> maybeAllOption = mergingOptions.stream()
+				.filter(option -> option.getFeatureOption() == FeatureOption.ALL)
+				.findFirst();
+
+		maybeAllOption.ifPresent((allOption) -> {
+			MergingStrategy strategy = allOption.getMergingStrategy();
+			for (FeatureOption featureOption : FeatureOption.values()) {
+				if (featureOption != FeatureOption.ALL) {
+					result.put(featureOption, strategy);
+				}
+			}
+		});
+
+		for (SqlTableLike.SqlTableLikeOption mergingOption : mergingOptions) {
+			result.put(mergingOption.getFeatureOption(), mergingOption.getMergingStrategy());
+		}
+
+		return result;
+	}
+
+	/**
+	 * Merges the schema part of {@code CREATE TABLE} statement. It merges
+	 * <ul>
+	 *     <li>columns</li>
+	 *     <li>computed columns</li>
+	 *     <li>watermarks</li>
+	 *     <li>primary key</li>
+	 * </ul>
+	 *
+	 * <p>Additionally it performs validation of the features of the derived table. This
+	 * is not done in the {@link SqlCreateTable#validate()} anymore because the validation should
+	 * be done on top of the merged properties. E.g. Some of the columns used in computed columns
+	 * of the derived table can be defined in the source table.
+	 */
+	public TableSchema mergeTables(
+			Map<FeatureOption, MergingStrategy> mergingStrategies,
+			TableSchema sourceSchema,
+			List<SqlNode> derivedColumns,
+			List<SqlWatermark> derivedWatermarkSpecs,
+			List<SqlNode> derivedPrimaryKey) {
+
+		SchemaBuilder schemaBuilder = new SchemaBuilder(
+			mergingStrategies,
+			sourceSchema,
+			(FlinkTypeFactory) validator.getTypeFactory(),
+			validator,
+			escapeExpression);
+		schemaBuilder.appendDerivedColumns(mergingStrategies, derivedColumns);
+		schemaBuilder.appendDerivedWatermarks(mergingStrategies, derivedWatermarkSpecs);
+		schemaBuilder.appendDerivedPrimaryKey(derivedPrimaryKey);
+
+		return schemaBuilder.build();
+	}
+
+	/**
+	 * Merges the partitions part of {@code CREATE TABLE} statement.
+	 *
+	 * <p>Partitioning is a single property of a Table, thus there can be at most a single instance of partitioning.
+	 * Therefore it is not possible to use {@link MergingStrategy#INCLUDING} with partitioning defined in both source
+	 * and derived table.
+	 */
+	public List<String> mergePartitions(
+			MergingStrategy mergingStrategy,
+			List<String> sourcePartitions,
+			List<String> derivedPartitions) {
+
+		if (!derivedPartitions.isEmpty() &&
+				!sourcePartitions.isEmpty() &&
+				mergingStrategy != MergingStrategy.EXCLUDING) {
+			throw new ValidationException("The base table already has partitions defined. You might want to specify " +
+				"EXCLUDING PARTITIONS.");
+		}
+
+		if (!derivedPartitions.isEmpty()) {
+			return derivedPartitions;
+		}
+		return sourcePartitions;
+	}
+
+	/**
+	 * Merges the options part of {@code CREATE TABLE} statement.
+	 */
+	public Map<String, String> mergeOptions(
+			MergingStrategy mergingStrategy,
+			Map<String, String> sourceOptions,
+			Map<String, String> derivedOptions) {
+		Map<String, String> options = new HashMap<>();
+		if (mergingStrategy != MergingStrategy.EXCLUDING) {
+			options.putAll(sourceOptions);
+		}
+
+		derivedOptions.forEach((key, value) -> {
+			if (mergingStrategy != MergingStrategy.OVERWRITING && options.containsKey(key)) {
+				throw new ValidationException(String.format(
+					"There already exists an option ['%s' -> '%s']  in the " +
+						"base table. You might want to specify EXCLUDING OPTIONS or OVERWRITING OPTIONS.",
+					key,
+					options.get(key)));
+			}
+
+			options.put(key, value);
+		});
+		return options;
+	}
+
+	private static class SchemaBuilder {
+
+			Map<String, TableColumn> columns = new LinkedHashMap<>();
+			Map<String, WatermarkSpec> watermarkSpecs = new HashMap<>();
+			UniqueConstraint primaryKey = null;
+
+			// Intermediate state
+			Map<String, RelDataType> physicalFieldNamesToTypes = new LinkedHashMap<>();
+			Map<String, RelDataType> computedFieldNamesToTypes = new LinkedHashMap<>();
+
+			Function<SqlNode, String> escapeExpressions;
+			FlinkTypeFactory typeFactory;
+			SqlValidator sqlValidator;
+
+			SchemaBuilder(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				TableSchema sourceSchema,
+				FlinkTypeFactory typeFactory,
+				SqlValidator sqlValidator,
+				Function<SqlNode, String> escapeExpressions) {
+			this.typeFactory = typeFactory;
+			this.sqlValidator = sqlValidator;
+			this.escapeExpressions = escapeExpressions;
+			populateColumnsFromSourceTable(mergingStrategies, sourceSchema);
+			populateWatermarksFromSourceTable(mergingStrategies, sourceSchema);
+			populatePrimaryKeyFromSourceTable(mergingStrategies, sourceSchema);
+		}
+
+		private void populateColumnsFromSourceTable(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				TableSchema sourceSchema) {
+			for (TableColumn sourceColumn : sourceSchema.getTableColumns()) {
+				if (sourceColumn.getExpr().isPresent()) {
+					if (mergingStrategies.get(FeatureOption.GENERATED) != MergingStrategy.EXCLUDING) {
+						columns.put(sourceColumn.getName(), sourceColumn);
+					}
+				} else {
+					physicalFieldNamesToTypes.put(
+						sourceColumn.getName(),
+						typeFactory.createFieldTypeFromLogicalType(sourceColumn.getType().getLogicalType()));
+					columns.put(sourceColumn.getName(), sourceColumn);
+				}
+			}
+		}
+
+		private void populateWatermarksFromSourceTable(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				TableSchema sourceSchema) {
+			for (WatermarkSpec sourceWatermarkSpec : sourceSchema.getWatermarkSpecs()) {
+				if (mergingStrategies.get(FeatureOption.WATERMARKS) != MergingStrategy.EXCLUDING) {
+					watermarkSpecs.put(sourceWatermarkSpec.getRowtimeAttribute(), sourceWatermarkSpec);
+				}
+			}
+		}
+
+		private void populatePrimaryKeyFromSourceTable(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				TableSchema sourceSchema) {
+			if (sourceSchema.getPrimaryKey().isPresent() &&
+				mergingStrategies.get(FeatureOption.CONSTRAINTS) == MergingStrategy.INCLUDING) {
+				primaryKey = sourceSchema.getPrimaryKey().get();
+			}
+		}
+
+		private void appendDerivedPrimaryKey(List<SqlNode> derivedPrimaryKey) {
+			if (!derivedPrimaryKey.isEmpty() && primaryKey != null) {
+				throw new ValidationException("The base table already has a primary key. You might " +
+					"want to specify EXCLUDING CONSTRAINTS.");
+			} else if (!derivedPrimaryKey.isEmpty()) {
+				List<String> primaryKeyColumns = new ArrayList<>();
+				for (SqlNode primaryKeyNode : derivedPrimaryKey) {
+					String primaryKey = ((SqlIdentifier) primaryKeyNode).getSimple();
+					if (!columns.containsKey(primaryKey)) {
+						throw new ValidationException(
+							"Primary key [" + primaryKey + "] not defined in columns, at " +
+								primaryKeyNode.getParserPosition());
+					}
+					primaryKeyColumns.add(primaryKey);
+				}
+				primaryKey = UniqueConstraint.primaryKey("PK_" + primaryKeyColumns.hashCode(), primaryKeyColumns);
+			}
+		}
+
+		private void appendDerivedWatermarks(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				List<SqlWatermark> derivedWatermarkSpecs) {
+			for (SqlWatermark derivedWatermarkSpec : derivedWatermarkSpecs) {
+				SqlIdentifier eventTimeColumnName = derivedWatermarkSpec.getEventTimeColumnName();
+
+				HashMap<String, RelDataType> nameToTypeMap = new LinkedHashMap<>(physicalFieldNamesToTypes);
+				nameToTypeMap.putAll(computedFieldNamesToTypes);
+				verifyRowtimeAttribute(mergingStrategies, eventTimeColumnName, nameToTypeMap);
+				String rowtimeAttribute = eventTimeColumnName.toString();
+
+				SqlNode expression = derivedWatermarkSpec.getWatermarkStrategy();
+
+				// this will validate and expand function identifiers.
+				SqlNode validated = sqlValidator.validateParameterizedExpression(expression, nameToTypeMap);
+				RelDataType validatedType = sqlValidator.getValidatedNodeType(validated);
+				DataType exprDataType = fromLogicalToDataType(toLogicalType(validatedType));
+
+				watermarkSpecs.put(rowtimeAttribute, new WatermarkSpec(
+					rowtimeAttribute,
+					escapeExpressions.apply(validated),
+					exprDataType));
+			}
+		}
+
+		private void verifyRowtimeAttribute(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				SqlIdentifier eventTimeColumnName,
+				Map<String, RelDataType> allFieldsTypes) {
+			String fullRowtimeExpression = eventTimeColumnName.toString();
+			boolean specAlreadyExists = watermarkSpecs.containsKey(fullRowtimeExpression);
+
+			if (specAlreadyExists &&
+				mergingStrategies.get(FeatureOption.WATERMARKS) != MergingStrategy.OVERWRITING) {
+				throw new ValidationException(String.format(
+					"There already exists a watermark spec for column '%s' in the base table. You " +
+						"might want to specify EXCLUDING WATERMARKS or OVERWRITING WATERMARKS.",
+					fullRowtimeExpression));
+			}
+
+			List<String> components = eventTimeColumnName.names;
+			if (!allFieldsTypes.containsKey(components.get(0))) {
+				throw new ValidationException(
+					String.format(
+						"The rowtime attribute field '%s' is not defined in the table schema, at %s\n" +
+							"Available fields: [%s]",
+						fullRowtimeExpression,
+						eventTimeColumnName.getParserPosition(),
+						allFieldsTypes.keySet().stream().collect(Collectors.joining("', '", "'", "'"))
+					));
+			}
+
+			if (components.size() > 1) {
+				RelDataType componentType = allFieldsTypes.get(components.get(0));
+				for (int i = 1; i < components.size(); i++) {
+					RelDataTypeField field = componentType.getField(components.get(i), true, false);
+					if (field == null) {
+						throw new ValidationException(
+							String.format(
+								"The rowtime attribute field '%s' is not defined in the table schema, at %s\n" +
+									"Nested field '%s' was not found in a composite type: %s.",
+								fullRowtimeExpression,
+								eventTimeColumnName.getComponent(i).getParserPosition(),
+								components.get(i),
+								FlinkTypeFactory.toLogicalType(allFieldsTypes.get(components.get(0))))
+							);
+					}
+					componentType = field.getType();
+				}
+			}
+		}
+
+		private void appendDerivedColumns(
+				Map<FeatureOption, MergingStrategy> mergingStrategies,
+				List<SqlNode> derivedColumns) {
+
+			collectPhysicalFieldsTypes(derivedColumns);
+
+			for (SqlNode derivedColumn : derivedColumns) {
+
+				boolean isComputed = !(derivedColumn instanceof SqlTableColumn);
+				final TableColumn column;
+				if (isComputed) {
+					SqlBasicCall call = (SqlBasicCall) derivedColumn;
+					String fieldName = call.operand(1).toString();
+					if (columns.containsKey(fieldName)) {
+						if (!columns.get(fieldName).isGenerated()) {
+							throw new ValidationException(String.format(
+								"A physical column named '%s' already exists in the base table. Computed columns can" +
+									"not overwrite physical fields.",
+								fieldName));
+						}
+
+						if (mergingStrategies.get(FeatureOption.GENERATED) != MergingStrategy.OVERWRITING) {
+							throw new ValidationException(String.format(
+								"A generated column named '%s' already exists in the base table. You " +
+									"might want to specify EXCLUDING GENERATED or OVERWRITING GENERATED.",
+								fieldName));
+						}
+					}
+
+					SqlNode validatedExpr = sqlValidator.validateParameterizedExpression(
+						call.operand(0),
+						physicalFieldNamesToTypes);
+					final RelDataType validatedType = sqlValidator.getValidatedNodeType(validatedExpr);
+					column = TableColumn.of(
+						fieldName,
+						fromLogicalToDataType(toLogicalType(validatedType)),
+						escapeExpressions.apply(validatedExpr));
+					computedFieldNamesToTypes.put(fieldName, validatedType);
+				} else {
+					String name = ((SqlTableColumn) derivedColumn).getName().getSimple();
+					LogicalType logicalType = FlinkTypeFactory.toLogicalType(physicalFieldNamesToTypes.get(name));
+					column = TableColumn.of(name, TypeConversions.fromLogicalToDataType(logicalType));
+				}
+				columns.put(column.getName(), column);
+			}
+		}
+
+		private void collectPhysicalFieldsTypes(List<SqlNode> derivedColumns) {
+			for (SqlNode derivedColumn : derivedColumns) {
+				if (derivedColumn instanceof SqlTableColumn) {
+					SqlTableColumn column = (SqlTableColumn) derivedColumn;
+					String name = column.getName().getSimple();
+					if (columns.containsKey(name)) {
+						throw new ValidationException(String.format(
+							"A column named '%s' already exists in the base table.",
+							name));
+					}
+					RelDataType relType = column.getType().deriveType(sqlValidator, column.getType().getNullable());
+					// add field name and field type to physical field list
+					physicalFieldNamesToTypes.put(name, relType);
+				}
+			}
+		}
+
+		public TableSchema build() {
+			TableSchema.Builder resultBuilder = TableSchema.builder();
+			for (TableColumn column : columns.values()) {
+				resultBuilder.field(column);
+			}
+			for (WatermarkSpec watermarkSpec : watermarkSpecs.values()) {
+				resultBuilder.watermark(watermarkSpec);
+			}
+			if (primaryKey != null) {
+				resultBuilder.primaryKey(
+					primaryKey.getName(),
+					primaryKey.getColumns().toArray(new String[0]));
+			}
+			return resultBuilder.build();
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner-blink/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlTableLike;
+import org.apache.flink.sql.parser.ddl.SqlTableOption;
+import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateTableOperation;
+import org.apache.flink.table.planner.calcite.FlinkCalciteSqlValidator;
+
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class for converting {@link SqlCreateTable} to {@link CreateTableOperation}.
+ */
+class SqlCreateTableConverter {
+
+	private final MergeTableLikeUtil mergeTableLikeUtil;
+	private final CatalogManager catalogManager;
+	private final Consumer<SqlTableConstraint> validateTableConstraint;
+
+	SqlCreateTableConverter(
+			FlinkCalciteSqlValidator sqlValidator,
+			CatalogManager catalogManager,
+			Function<SqlNode, String> escapeExpression,
+			Consumer<SqlTableConstraint> validateTableConstraint) {
+		this.mergeTableLikeUtil = new MergeTableLikeUtil(
+			sqlValidator,
+			escapeExpression);
+		this.catalogManager = catalogManager;
+		this.validateTableConstraint = validateTableConstraint;
+	}
+
+	/**
+	 * Convert the {@link SqlCreateTable} node.
+	 */
+	Operation convertCreateTable(SqlCreateTable sqlCreateTable) {
+		sqlCreateTable.getTableConstraints().forEach(validateTableConstraint);
+		CatalogTable catalogTable = createCatalogTable(sqlCreateTable);
+
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlCreateTable.fullTableName());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+
+		return new CreateTableOperation(
+			identifier,
+			catalogTable,
+			sqlCreateTable.isIfNotExists(),
+			sqlCreateTable.isTemporary());
+	}
+
+	private CatalogTable createCatalogTable(SqlCreateTable sqlCreateTable) {
+
+		final TableSchema sourceTableSchema;
+		final List<String> sourcePartitionKeys;
+		final List<SqlTableLike.SqlTableLikeOption> likeOptions;
+		final Map<String, String> sourceProperties;
+		if (sqlCreateTable.getTableLike().isPresent()) {
+			SqlTableLike sqlTableLike = sqlCreateTable.getTableLike().get();
+			CatalogTable table = lookupLikeSourceTable(sqlTableLike);
+			sourceTableSchema = table.getSchema();
+			sourcePartitionKeys = table.getPartitionKeys();
+			likeOptions = sqlTableLike.getOptions();
+			sourceProperties = table.getProperties();
+		} else {
+			sourceTableSchema = TableSchema.builder().build();
+			sourcePartitionKeys = Collections.emptyList();
+			likeOptions = Collections.emptyList();
+			sourceProperties = Collections.emptyMap();
+		}
+
+		Map<SqlTableLike.FeatureOption, SqlTableLike.MergingStrategy> mergingStrategies =
+			mergeTableLikeUtil.computeMergingStrategies(likeOptions);
+
+		Map<String, String> mergedOptions = mergeOptions(sqlCreateTable, sourceProperties, mergingStrategies);
+
+		Optional<SqlTableConstraint> primaryKey = sqlCreateTable.getFullConstraints()
+			.stream()
+			.filter(SqlTableConstraint::isPrimaryKey)
+			.findAny();
+		TableSchema mergedSchema = mergeTableLikeUtil.mergeTables(
+			mergingStrategies,
+			sourceTableSchema,
+			sqlCreateTable.getColumnList().getList(),
+			sqlCreateTable.getWatermark().map(Collections::singletonList).orElseGet(Collections::emptyList),
+			primaryKey.orElse(null)
+		);
+
+		List<String> partitionKeys = mergePartitions(
+			sourcePartitionKeys,
+			sqlCreateTable.getPartitionKeyList(),
+			mergingStrategies
+		);
+		verifyPartitioningColumnsExist(mergedSchema, partitionKeys);
+
+		String tableComment = sqlCreateTable.getComment()
+			.map(comment -> comment.getNlsString().getValue())
+			.orElse(null);
+
+		return new CatalogTableImpl(mergedSchema,
+			partitionKeys,
+			mergedOptions,
+			tableComment);
+	}
+
+	private CatalogTable lookupLikeSourceTable(SqlTableLike sqlTableLike) {
+		UnresolvedIdentifier unresolvedIdentifier = UnresolvedIdentifier.of(sqlTableLike.getSourceTable()
+			.toString());
+		ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
+		CatalogManager.TableLookupResult lookupResult = catalogManager.getTable(identifier)
+			.orElseThrow(() -> new ValidationException(String.format(
+				"Source table '%s' of the LIKE clause not found in the catalog, at %s",
+				identifier,
+				sqlTableLike.getSourceTable().getParserPosition())));
+		if (!(lookupResult.getTable() instanceof CatalogTable)) {
+			throw new ValidationException(String.format(
+				"Source table '%s' of the LIKE clause can not be a VIEW, at %s",
+				identifier,
+				sqlTableLike.getSourceTable().getParserPosition()));
+		}
+		return (CatalogTable) lookupResult.getTable();
+	}
+
+	private void verifyPartitioningColumnsExist(TableSchema mergedSchema, List<String> partitionKeys) {
+		for (String partitionKey : partitionKeys) {
+			if (!mergedSchema.getTableColumn(partitionKey).isPresent()) {
+				throw new ValidationException(
+					String.format(
+						"Partition column '%s' not defined in the table schema. Available columns: [%s]",
+						partitionKey,
+						Arrays.stream(mergedSchema.getFieldNames()).collect(Collectors.joining("', '", "'", "'"))
+					));
+			}
+		}
+	}
+
+	private List<String> mergePartitions(
+		List<String> sourcePartitionKeys,
+		SqlNodeList derivedPartitionKeys,
+		Map<SqlTableLike.FeatureOption, SqlTableLike.MergingStrategy> mergingStrategies) {
+		// set partition key
+		return mergeTableLikeUtil.mergePartitions(
+			mergingStrategies.get(SqlTableLike.FeatureOption.PARTITIONS),
+			sourcePartitionKeys,
+			derivedPartitionKeys
+				.getList()
+				.stream()
+				.map(p -> ((SqlIdentifier) p).getSimple())
+				.collect(Collectors.toList()));
+	}
+
+	private Map<String, String> mergeOptions(
+		SqlCreateTable sqlCreateTable,
+		Map<String, String> sourceProperties,
+		Map<SqlTableLike.FeatureOption, SqlTableLike.MergingStrategy> mergingStrategies) {
+		// set with properties
+		Map<String, String> properties = new HashMap<>();
+		sqlCreateTable.getPropertyList().getList().forEach(p ->
+			properties.put(((SqlTableOption) p).getKeyString(), ((SqlTableOption) p).getValueString()));
+		return mergeTableLikeUtil.mergeOptions(
+			mergingStrategies.get(SqlTableLike.FeatureOption.OPTIONS),
+			sourceProperties,
+			properties
+		);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
@@ -1,0 +1,771 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.sql.parser.ddl.SqlTableColumn;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.FeatureOption;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
+import org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption;
+import org.apache.flink.sql.parser.ddl.SqlWatermark;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.planner.calcite.FlinkCalciteSqlValidator;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
+import org.apache.flink.table.planner.delegation.PlannerContext;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.utils.CatalogManagerMocks;
+
+import org.apache.calcite.avatica.util.TimeUnit;
+import org.apache.calcite.sql.SqlAsOperator;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link MergeTableLikeUtil}.
+ */
+public class MergeTableLikeUtilTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(new FlinkTypeSystem());
+	private final TableConfig tableConfig = new TableConfig();
+	private final CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
+	private final ModuleManager moduleManager = new ModuleManager();
+	private final FunctionCatalog functionCatalog = new FunctionCatalog(
+		tableConfig,
+		catalogManager,
+		moduleManager);
+	private final PlannerContext plannerContext =
+		new PlannerContext(
+			tableConfig,
+			functionCatalog,
+			catalogManager,
+			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
+			new ArrayList<>());
+	private final FlinkCalciteSqlValidator sqlValidator = plannerContext.createFlinkPlanner(
+		catalogManager.getCurrentCatalog(),
+		catalogManager.getCurrentDatabase())
+		.getOrCreateSqlValidator();
+	private final MergeTableLikeUtil util = new MergeTableLikeUtil(
+		sqlValidator,
+		SqlNode::toString
+	);
+
+	@Test
+	public void mergeBasicColumns() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.STRING())
+				.build();
+
+		List<SqlNode> derivedColumns = Arrays.asList(
+				tableColumn("three", DataTypes.INT()),
+				tableColumn("four", DataTypes.STRING()));
+
+		TableSchema mergedSchema = util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.STRING())
+				.field("three", DataTypes.INT())
+				.field("four", DataTypes.STRING())
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeWithIncludeFailsOnDuplicateColumn() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.build();
+
+		List<SqlNode> derivedColumns = Arrays.asList(
+				tableColumn("one", DataTypes.INT()),
+				tableColumn("four", DataTypes.STRING()));
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("A column named 'one' already exists in the base table.");
+		util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+	}
+
+	@Test
+	public void mergeGeneratedColumns() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.build();
+
+		List<SqlNode> derivedColumns = Arrays.asList(
+				tableColumn("three", DataTypes.INT()),
+				tableColumn("four", plus("one", "3")));
+
+		TableSchema mergedSchema = util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.field("three", DataTypes.INT())
+				.field("four", DataTypes.INT(), "`one` + 3")
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeIncludingGeneratedColumnsFailsOnDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.build();
+
+		List<SqlNode> derivedColumns = Collections.singletonList(
+				tableColumn("two", plus("one", "3")));
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("A generated column named 'two' already exists in the base table. You " +
+				"might want to specify EXCLUDING GENERATED or OVERWRITING GENERATED");
+		util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+	}
+
+	@Test
+	public void mergeExcludingGeneratedColumnsDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.build();
+
+		List<SqlNode> derivedColumns = Collections.singletonList(
+				tableColumn("two", plus("one", "3")));
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.EXCLUDING);
+
+		TableSchema mergedSchema = util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "`one` + 3")
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeOverwritingGeneratedColumnsDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.build();
+
+		List<SqlNode> derivedColumns = Collections.singletonList(
+				tableColumn("two", plus("one", "3")));
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.OVERWRITING);
+
+		TableSchema mergedSchema = util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "`one` + 3")
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeOverwritingPhysicalFieldWithGeneratedColumn() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT())
+				.build();
+
+		List<SqlNode> derivedColumns = Collections.singletonList(
+				tableColumn("two", plus("one", "3")));
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.GENERATED, MergingStrategy.OVERWRITING);
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("A physical column named 'two' already exists in the base table." +
+			" Computed columns cannot overwrite physical fields");
+		util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+	}
+
+	@Test
+	public void mergeWatermarks() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"timestamp - INTERVAL '5' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		List<SqlNode> derivedColumns = Arrays.asList(
+				tableColumn("three", DataTypes.INT()),
+				tableColumn("four", plus("one", "3")));
+
+		TableSchema mergedSchema = util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				derivedColumns,
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("two", DataTypes.INT(), "one + 1")
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"timestamp - INTERVAL '5' SECOND",
+						DataTypes.TIMESTAMP())
+				.field("three", DataTypes.INT())
+				.field("four", DataTypes.INT(), "`one` + 3")
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeIncludingWatermarksFailsOnDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"timestamp - INTERVAL '5' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		List<SqlWatermark> derivedWatermarkSpecs = Collections.singletonList(
+				new SqlWatermark(
+					SqlParserPos.ZERO,
+						identifier("timestamp"),
+						boundedStrategy("timestamp", "10"))
+		);
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("There already exists a watermark spec for column 'timestamp' in the " +
+				"base table. You might want to specify EXCLUDING WATERMARKS or OVERWRITING WATERMARKS.");
+		util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				Collections.emptyList(),
+				derivedWatermarkSpecs,
+				Collections.emptyList());
+	}
+
+	@Test
+	public void mergeExcludingWatermarksDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"timestamp - INTERVAL '5' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		List<SqlWatermark> derivedWatermarkSpecs = Collections.singletonList(
+			new SqlWatermark(
+				SqlParserPos.ZERO,
+				identifier("timestamp"),
+				boundedStrategy("timestamp", "10"))
+		);
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.WATERMARKS, MergingStrategy.EXCLUDING);
+
+		TableSchema mergedSchema = util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				Collections.emptyList(),
+				derivedWatermarkSpecs,
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"`timestamp` - INTERVAL '10' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeOverwritingWatermarksDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"timestamp - INTERVAL '5' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		List<SqlWatermark> derivedWatermarkSpecs = Collections.singletonList(
+			new SqlWatermark(
+				SqlParserPos.ZERO,
+				identifier("timestamp"),
+				boundedStrategy("timestamp", "10"))
+		);
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.WATERMARKS, MergingStrategy.OVERWRITING);
+
+		TableSchema mergedSchema = util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				Collections.emptyList(),
+				derivedWatermarkSpecs,
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT())
+				.field("timestamp", DataTypes.TIMESTAMP())
+				.watermark(
+						"timestamp",
+						"`timestamp` - INTERVAL '10' SECOND",
+						DataTypes.TIMESTAMP())
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeConstraintsFromBaseTable() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT())
+				.primaryKey("constraint-42", new String[]{"one", "two"})
+				.build();
+
+		TableSchema mergedSchema = util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Collections.emptyList());
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT())
+				.primaryKey("constraint-42", new String[]{"one", "two"})
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeConstraintsFromDerivedTable() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT())
+				.build();
+
+		TableSchema mergedSchema = util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Arrays.asList(identifier("one"), identifier("two")));
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT())
+				.primaryKey("PK_3531879", new String[]{"one", "two"})
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergeIncludingConstraintsFailsOnDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT())
+				.primaryKey("constraint-42", new String[]{"one", "two"})
+				.build();
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("The base table already has a primary key. You might want to specify " +
+				"EXCLUDING CONSTRAINTS.");
+		util.mergeTables(
+				getDefaultMergingStrategies(),
+				sourceSchema,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Arrays.asList(identifier("one"), identifier("two")));
+	}
+
+	@Test
+	public void mergeExcludingConstraintsOnDuplicate() {
+		TableSchema sourceSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT().notNull())
+				.primaryKey("constraint-42", new String[]{"one", "two", "three"})
+				.build();
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies = getDefaultMergingStrategies();
+		mergingStrategies.put(FeatureOption.CONSTRAINTS, MergingStrategy.EXCLUDING);
+
+		TableSchema mergedSchema = util.mergeTables(
+				mergingStrategies,
+				sourceSchema,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				Arrays.asList(identifier("one"), identifier("two")));
+
+		TableSchema expectedSchema = TableSchema.builder()
+				.field("one", DataTypes.INT().notNull())
+				.field("two", DataTypes.STRING().notNull())
+				.field("three", DataTypes.FLOAT().notNull())
+				.primaryKey("PK_3531879", new String[]{"one", "two"})
+				.build();
+
+		assertThat(mergedSchema, equalTo(expectedSchema));
+	}
+
+	@Test
+	public void mergePartitionsFromBaseTable() {
+		List<String> sourcePartitions = Arrays.asList("col1", "col2");
+		List<String> mergePartitions = util.mergePartitions(
+			getDefaultMergingStrategies().get(FeatureOption.PARTITIONS),
+			sourcePartitions,
+			Collections.emptyList());
+
+		assertThat(mergePartitions, equalTo(sourcePartitions));
+	}
+
+	@Test
+	public void mergePartitionsFromDerivedTable() {
+		List<String> derivedPartitions = Arrays.asList("col1", "col2");
+		List<String> mergePartitions = util.mergePartitions(
+			getDefaultMergingStrategies().get(FeatureOption.PARTITIONS),
+			Collections.emptyList(),
+			derivedPartitions);
+
+		assertThat(mergePartitions, equalTo(derivedPartitions));
+	}
+
+	@Test
+	public void mergeIncludingPartitionsFailsOnDuplicate() {
+		List<String> sourcePartitions = Arrays.asList("col3", "col4");
+		List<String> derivedPartitions = Arrays.asList("col1", "col2");
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage(
+			"The base table already has partitions defined. You might want to specify EXCLUDING PARTITIONS");
+		util.mergePartitions(
+			MergingStrategy.INCLUDING,
+			sourcePartitions,
+			derivedPartitions);
+	}
+
+	@Test
+	public void mergeExcludingPartitionsOnDuplicate() {
+		List<String> sourcePartitions = Arrays.asList("col3", "col4");
+		List<String> derivedPartitions = Arrays.asList("col1", "col2");
+
+		List<String> mergedPartitions = util.mergePartitions(
+			MergingStrategy.EXCLUDING,
+			sourcePartitions,
+			derivedPartitions);
+
+		assertThat(mergedPartitions, equalTo(derivedPartitions));
+	}
+
+	@Test
+	public void mergeOptions() {
+		Map<String, String> sourceOptions = new HashMap<>();
+		sourceOptions.put("offset", "1");
+		sourceOptions.put("format", "json");
+
+		Map<String, String> derivedOptions = new HashMap<>();
+		derivedOptions.put("format.ignore-errors", "true");
+
+		Map<String, String> mergedOptions = util.mergeOptions(
+			getDefaultMergingStrategies().get(FeatureOption.OPTIONS),
+			sourceOptions,
+			derivedOptions);
+
+		Map<String, String> expectedOptions = new HashMap<>();
+		expectedOptions.put("offset", "1");
+		expectedOptions.put("format", "json");
+		expectedOptions.put("format.ignore-errors", "true");
+
+		assertThat(mergedOptions, equalTo(expectedOptions));
+	}
+
+	@Test
+	public void mergeIncludingOptionsFailsOnDuplicate() {
+		Map<String, String> sourceOptions = new HashMap<>();
+		sourceOptions.put("offset", "1");
+
+		Map<String, String> derivedOptions = new HashMap<>();
+		derivedOptions.put("offset", "2");
+
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("There already exists an option ['offset' -> '1']  in the base table. You might want" +
+			" to specify EXCLUDING OPTIONS or OVERWRITING OPTIONS.");
+		util.mergeOptions(
+			MergingStrategy.INCLUDING,
+			sourceOptions,
+			derivedOptions);
+	}
+
+	@Test
+	public void mergeExcludingOptionsDuplicate() {
+		Map<String, String> sourceOptions = new HashMap<>();
+		sourceOptions.put("offset", "1");
+		sourceOptions.put("format", "json");
+
+		Map<String, String> derivedOptions = new HashMap<>();
+		derivedOptions.put("format", "csv");
+		derivedOptions.put("format.ignore-errors", "true");
+
+		Map<String, String> mergedOptions = util.mergeOptions(
+			MergingStrategy.EXCLUDING,
+			sourceOptions,
+			derivedOptions);
+
+		Map<String, String> expectedOptions = new HashMap<>();
+		expectedOptions.put("format", "csv");
+		expectedOptions.put("format.ignore-errors", "true");
+
+		assertThat(mergedOptions, equalTo(expectedOptions));
+	}
+
+	@Test
+	public void mergeOverwritingOptionsDuplicate() {
+		Map<String, String> sourceOptions = new HashMap<>();
+		sourceOptions.put("offset", "1");
+		sourceOptions.put("format", "json");
+
+		Map<String, String> derivedOptions = new HashMap<>();
+		derivedOptions.put("offset", "2");
+		derivedOptions.put("format.ignore-errors", "true");
+
+		Map<String, String> mergedOptions = util.mergeOptions(
+			MergingStrategy.OVERWRITING,
+			sourceOptions,
+			derivedOptions);
+
+		Map<String, String> expectedOptions = new HashMap<>();
+		expectedOptions.put("offset", "2");
+		expectedOptions.put("format", "json");
+		expectedOptions.put("format.ignore-errors", "true");
+
+		assertThat(mergedOptions, equalTo(expectedOptions));
+	}
+
+	@Test
+	public void defaultMergeStrategies() {
+		Map<FeatureOption, MergingStrategy> mergingStrategies =
+				util.computeMergingStrategies(Collections.emptyList());
+
+		assertThat(mergingStrategies.get(FeatureOption.OPTIONS), is(MergingStrategy.OVERWRITING));
+		assertThat(mergingStrategies.get(FeatureOption.PARTITIONS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.CONSTRAINTS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.GENERATED), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.WATERMARKS), is(MergingStrategy.INCLUDING));
+	}
+
+	@Test
+	public void includingAllMergeStrategyExpansion() {
+		List<SqlTableLikeOption> inputOptions = Collections.singletonList(
+				new SqlTableLikeOption(MergingStrategy.INCLUDING, FeatureOption.ALL)
+		);
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies =
+				util.computeMergingStrategies(inputOptions);
+
+		assertThat(mergingStrategies.get(FeatureOption.OPTIONS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.PARTITIONS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.CONSTRAINTS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.GENERATED), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.WATERMARKS), is(MergingStrategy.INCLUDING));
+	}
+
+	@Test
+	public void excludingAllMergeStrategyExpansion() {
+		List<SqlTableLikeOption> inputOptions = Collections.singletonList(
+				new SqlTableLikeOption(MergingStrategy.EXCLUDING, FeatureOption.ALL)
+		);
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies =
+				util.computeMergingStrategies(inputOptions);
+
+		assertThat(mergingStrategies.get(FeatureOption.OPTIONS), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.PARTITIONS), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.CONSTRAINTS), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.GENERATED), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.WATERMARKS), is(MergingStrategy.EXCLUDING));
+	}
+
+	@Test
+	public void includingAllOverwriteOptionsMergeStrategyExpansion() {
+		List<SqlTableLikeOption> inputOptions = Arrays.asList(
+				new SqlTableLikeOption(MergingStrategy.EXCLUDING, FeatureOption.ALL),
+				new SqlTableLikeOption(MergingStrategy.INCLUDING, FeatureOption.CONSTRAINTS)
+		);
+
+		Map<FeatureOption, MergingStrategy> mergingStrategies =
+				util.computeMergingStrategies(inputOptions);
+
+		assertThat(mergingStrategies.get(FeatureOption.OPTIONS), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.PARTITIONS), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.CONSTRAINTS), is(MergingStrategy.INCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.GENERATED), is(MergingStrategy.EXCLUDING));
+		assertThat(mergingStrategies.get(FeatureOption.WATERMARKS), is(MergingStrategy.EXCLUDING));
+	}
+
+	private Map<FeatureOption, MergingStrategy> getDefaultMergingStrategies() {
+		return util.computeMergingStrategies(Collections.emptyList());
+	}
+
+	private SqlNode tableColumn(String name, DataType type) {
+		LogicalType logicalType = type.getLogicalType();
+		return new SqlTableColumn(
+			new SqlIdentifier(name, SqlParserPos.ZERO),
+			SqlTypeUtil.convertTypeToSpec(typeFactory.createFieldTypeFromLogicalType(logicalType))
+				.withNullable(logicalType.isNullable()),
+			null,
+			SqlParserPos.ZERO
+		);
+	}
+
+	private SqlNode tableColumn(String name, SqlNode expression) {
+		return new SqlBasicCall(
+			new SqlAsOperator(),
+			new SqlNode[]{expression, identifier(name)},
+			SqlParserPos.ZERO
+		);
+	}
+
+	private SqlNode plus(String column, String value) {
+		return new SqlBasicCall(
+			SqlStdOperatorTable.PLUS,
+			new SqlNode[]{
+				identifier(column), SqlLiteral.createExactNumeric(value, SqlParserPos.ZERO)},
+			SqlParserPos.ZERO
+		);
+	}
+
+	private SqlNode boundedStrategy(String rowtimeColumn, String delay) {
+		return new SqlBasicCall(
+			SqlStdOperatorTable.MINUS,
+			new SqlNode[]{
+				identifier(rowtimeColumn),
+				SqlLiteral.createInterval(
+					1,
+					delay,
+					new SqlIntervalQualifier(TimeUnit.SECOND, TimeUnit.SECOND, SqlParserPos.ZERO),
+					SqlParserPos.ZERO)
+			},
+			SqlParserPos.ZERO
+		);
+	}
+
+	private SqlIdentifier identifier(String name) {
+		return new SqlIdentifier(
+			name,
+			SqlParserPos.ZERO
+		);
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/MergeTableLikeUtilTest.java
@@ -24,20 +24,13 @@ import org.apache.flink.sql.parser.ddl.SqlTableLike.MergingStrategy;
 import org.apache.flink.sql.parser.ddl.SqlTableLike.SqlTableLikeOption;
 import org.apache.flink.sql.parser.ddl.SqlWatermark;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.FunctionCatalog;
-import org.apache.flink.table.module.ModuleManager;
-import org.apache.flink.table.planner.calcite.FlinkCalciteSqlValidator;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
-import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
-import org.apache.flink.table.planner.delegation.PlannerContext;
+import org.apache.flink.table.planner.utils.PlannerMocks;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.utils.CatalogManagerMocks;
 
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.sql.SqlAsOperator;
@@ -49,18 +42,17 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.validate.SqlValidator;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -74,24 +66,7 @@ public class MergeTableLikeUtilTest {
 	public ExpectedException thrown = ExpectedException.none();
 
 	private final FlinkTypeFactory typeFactory = new FlinkTypeFactory(new FlinkTypeSystem());
-	private final TableConfig tableConfig = new TableConfig();
-	private final CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
-	private final ModuleManager moduleManager = new ModuleManager();
-	private final FunctionCatalog functionCatalog = new FunctionCatalog(
-		tableConfig,
-		catalogManager,
-		moduleManager);
-	private final PlannerContext plannerContext =
-		new PlannerContext(
-			tableConfig,
-			functionCatalog,
-			catalogManager,
-			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
-			new ArrayList<>());
-	private final FlinkCalciteSqlValidator sqlValidator = plannerContext.createFlinkPlanner(
-		catalogManager.getCurrentCatalog(),
-		catalogManager.getCurrentDatabase())
-		.getOrCreateSqlValidator();
+	private final SqlValidator sqlValidator = PlannerMocks.createDefaultPlanner().getOrCreateSqlValidator();
 	private final MergeTableLikeUtil util = new MergeTableLikeUtil(
 		sqlValidator,
 		SqlNode::toString

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -361,6 +361,40 @@ public class SqlToOperationConverterTest {
 	}
 
 	@Test
+	public void testPrimaryKeyOnGeneratedColumn() {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage(
+			"Could not create a PRIMARY KEY with a generated column 'c', at line 5, column 34.\n" +
+				"PRIMARY KEY constraint is not allowed on computed columns.");
+		final String sql2 = "CREATE TABLE tbl1 (\n" +
+			"  a bigint not null,\n" +
+			"  b varchar not null,\n" +
+			"  c as 2 * (a + 1),\n" +
+			"  constraint ct1 primary key (b, c) not enforced" +
+			") with (\n" +
+			"    'connector' = 'kafka',\n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+		parseAndConvert(sql2);
+	}
+
+	@Test
+	public void testPrimaryKeyNonExistentColumn() {
+		thrown.expect(ValidationException.class);
+		thrown.expectMessage("Primary key column 'd' is not defined in the schema, at line 5, column 34");
+		final String sql2 = "CREATE TABLE tbl1 (\n" +
+			"  a bigint not null,\n" +
+			"  b varchar not null,\n" +
+			"  c as 2 * (a + 1),\n" +
+			"  constraint ct1 primary key (b, d) not enforced" +
+			") with (\n" +
+			"    'connector' = 'kafka',\n" +
+			"    'kafka.topic' = 'log.test'\n" +
+			")\n";
+		parseAndConvert(sql2);
+	}
+
+	@Test
 	public void testCreateTableWithMinusInOptionKey() {
 		final String sql = "create table source_table(\n" +
 			"  a int,\n" +

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/OperationMatchers.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.operations.ddl.CreateTableOperation;
+
+import org.hamcrest.Description;
+import org.hamcrest.FeatureMatcher;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+
+/**
+ * {@link Matcher Matchers} for asserting {@link Operation}.
+ */
+public class OperationMatchers {
+	/**
+	 * Checks for a {@link CreateTableOperation}. You can provide additional matchers as parameters.
+	 * All of the provided nested matchers must match.
+	 *
+	 * <p>Example:
+	 * <pre>{@code
+	 * assertThat(
+	 * 	operation,
+	 * 	createTableOperation(
+	 * 		hasSchema(
+	 * 			TableSchema.builder()
+	 * 				.field("f0", DataTypes.INT().notNull())
+	 * 				.field("f1", DataTypes.TIMESTAMP(3))
+	 * 				.field("a", DataTypes.INT())
+	 * 				.watermark("f1", "`f1` - INTERVAL '5' SECOND", DataTypes.TIMESTAMP(3))
+	 * 				.build()
+	 * 		),
+	 * 		hasOptions(
+	 * 			entry("connector.type", "kafka"),
+	 * 			entry("format.type", "json")
+	 * 		),
+	 * 		hasPartition(
+	 * 			"a", "f0"
+	 * 		)
+	 * 	)
+	 * );
+	 * }</pre>
+	 *
+	 * @param nestedMatchers additional matchers that must match
+	 * @see #withOptions(MapEntry[])
+	 * @see #withSchema(TableSchema)
+	 * @see #partitionedBy(String...)
+	 */
+	@SafeVarargs
+	public static Matcher<Operation> isCreateTableOperation(Matcher<CreateTableOperation>... nestedMatchers) {
+		return new CreateTableOperationMatcher(nestedMatchers);
+	}
+
+	/**
+	 * Checks that the {@link CreateTableOperation} has all given connector options.
+	 *
+	 * @param entries Connector options to check.
+	 * @see #entry(String, String)
+	 */
+	@SafeVarargs
+	public static Matcher<CreateTableOperation> withOptions(MapEntry<String, String>... entries) {
+		return new FeatureMatcher<CreateTableOperation, Map<String, String>>(
+			equalTo(mapOf(entries)),
+			"options of the derived table",
+			"options"
+		) {
+			@Override
+			protected Map<String, String> featureValueOf(CreateTableOperation actual) {
+				return actual.getCatalogTable().getProperties();
+			}
+		};
+	}
+
+	/**
+	 * Helper method for easier creating maps in matchers.
+	 */
+	public static MapEntry<String, String> entry(String key, String value) {
+		return new MapEntry<>(key, value);
+	}
+
+	/**
+	 * Checks that the {@link CreateTableOperation} is partitioned by given fields.
+	 *
+	 * @param fields Fields on which the Table should be partitioned.
+	 * @see #isCreateTableOperation(Matcher[])
+	 */
+	public static Matcher<CreateTableOperation> partitionedBy(String... fields) {
+		return new FeatureMatcher<CreateTableOperation, List<String>>(
+			equalTo(Arrays.asList(fields)),
+			"partitions of the derived table",
+			"partitions"
+		) {
+			@Override
+			protected List<String> featureValueOf(CreateTableOperation actual) {
+				return actual.getCatalogTable().getPartitionKeys();
+			}
+		};
+	}
+
+	/**
+	 * Checks that the schema of {@link CreateTableOperation} is equal to the given {@link TableSchema}.
+	 *
+	 * @param schema TableSchema that the {@link CreateTableOperation} should have
+	 * @see #isCreateTableOperation(Matcher[])
+	 */
+	public static Matcher<CreateTableOperation> withSchema(TableSchema schema) {
+		return new FeatureMatcher<CreateTableOperation, TableSchema>(
+			equalTo(schema),
+			"table schema of the derived table",
+			"table schema") {
+			@Override
+			protected TableSchema featureValueOf(CreateTableOperation actual) {
+				return actual.getCatalogTable().getSchema();
+			}
+		};
+	}
+
+	/**
+	 * Helper class for easier creating maps in matchers.
+	 */
+	public static class MapEntry<K, V> {
+		private final K key;
+		private final V value;
+
+		public MapEntry(K key, V value) {
+			this.key = key;
+			this.value = value;
+		}
+	}
+
+	@SafeVarargs
+	private static Map<String, String> mapOf(MapEntry<String, String>... entries) {
+		Map<String, String> map = new HashMap<>();
+		for (MapEntry<String, String> entry : entries) {
+			map.put(entry.key, entry.value);
+		}
+
+		return map;
+	}
+
+	private static class CreateTableOperationMatcher extends TypeSafeDiagnosingMatcher<Operation> {
+		private final Matcher<CreateTableOperation>[] nestedMatchers;
+
+		public CreateTableOperationMatcher(Matcher<CreateTableOperation>[] nestedMatchers) {
+			this.nestedMatchers = nestedMatchers;
+		}
+
+		@Override
+		protected boolean matchesSafely(Operation item, Description mismatchDescription) {
+			if (!(item instanceof CreateTableOperation)) {
+
+				return false;
+			}
+
+			for (Matcher<CreateTableOperation> nestedMatcher : nestedMatchers) {
+				if (!nestedMatcher.matches(item)) {
+					nestedMatcher.describeMismatch(item, mismatchDescription);
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText("\n");
+			Arrays.stream(nestedMatchers).forEach(matcher -> {
+				matcher.describeTo(description);
+				description.appendText("\n");
+			});
+		}
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/utils/PlannerMocks.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
+import org.apache.flink.table.planner.delegation.PlannerContext;
+import org.apache.flink.table.utils.CatalogManagerMocks;
+
+import java.util.ArrayList;
+
+import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
+
+/**
+ * A utility class for creating an instance of {@link FlinkPlannerImpl} for testing.
+ */
+public class PlannerMocks {
+	public static FlinkPlannerImpl createDefaultPlanner() {
+		TableConfig tableConfig = new TableConfig();
+		CatalogManager catalogManager = CatalogManagerMocks.createEmptyCatalogManager();
+		ModuleManager moduleManager = new ModuleManager();
+		FunctionCatalog functionCatalog = new FunctionCatalog(
+			tableConfig,
+			catalogManager,
+			moduleManager);
+		PlannerContext plannerContext = new PlannerContext(
+			tableConfig,
+			functionCatalog,
+			catalogManager,
+			asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)),
+			new ArrayList<>());
+		return plannerContext.createFlinkPlanner(
+			catalogManager.getCurrentCatalog(),
+			catalogManager.getCurrentDatabase());
+	}
+
+	private PlannerMocks() {
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR implements the logic behind `CREATE TABLE ... LIKE` clause. It does not add a specific option/parameters to the `Operation` stack. The clause is evaluated into a plain `CreateTableOperation` when converting from `SqlCreateTable`.

## Brief change log

  - Added `INCLUDING/EXCLUDING/OVERWRITING WATERMARKS` option.
    
    The reason to separate the watermarks from generated columns is because we support only a single watermark in a table. This becomes troublesome when user wants to have a watermark on a different column than the source table. The only way this can be achieved without watermarks is to `EXCLUDE GENERATED`. That approach results in dropping the generated columns which might not be intended. I think having a separate WATERMARKS option gives a more fine grained control over the end table.

  - Moved the validation from `SqlCreateTable#validate` to `SqlToOperationConverter`.

   With the `LIKE` clause `SqlCreateTable` is not self contained any more. `SqlCreateTable` can e.g. define computed columns on columns inherited from the source table. The validation can be performed only after merging valid features which happens in the `SqlToOperationConverter`.

  - Throw exception in the legacy planner if the CREATE TABLE ... LIKE is present.

  We do not support majority of the features that the CREATE TABLE ... LIKE applies to. Therefore in order not to duplicate too much of the code I decided not to support this clause in the old planner.


## Verifying this change

Added tests:
* MergeTableLikeUtilTest - tests the merging logic
* Tests in SqlToOperationConverterTest - tests supporting the like clause in `SqlToOperationConverter`
* Added validation tests in `SqlToOperationConverterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented) -> docs to be done FLINK-17004
