### PR TITLE
[FLINK-17361] [jdbc] Added custom query on JDBC tables

### DIFF
--- a/docs/dev/table/connect.md
+++ b/docs/dev/table/connect.md
@@ -1307,7 +1307,11 @@ CREATE TABLE MyUserTable (
   'connector.username' = 'name',
   'connector.password' = 'password',
   
-  -- **followings are scan options, optional, used when reading from table**
+  -- **followings are scan options, optional, used when reading from a table**
+
+  -- optional: SQL query / prepared statement.
+  -- If set, this will take precedence over the 'connector.table' setting
+  'connector.read.query' = 'SELECT * FROM sometable',
 
   -- These options must all be specified if any of them is specified. In addition,
   -- partition.num must be specified. They describe how to partition the table when

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/options/JdbcReadOptions.java
@@ -27,6 +27,7 @@ import java.util.Optional;
  */
 public class JdbcReadOptions implements Serializable {
 
+	private final String query;
 	private final String partitionColumnName;
 	private final Long partitionLowerBound;
 	private final Long partitionUpperBound;
@@ -35,17 +36,23 @@ public class JdbcReadOptions implements Serializable {
 	private final int fetchSize;
 
 	private JdbcReadOptions(
+			String query,
 			String partitionColumnName,
 			Long partitionLowerBound,
 			Long partitionUpperBound,
 			Integer numPartitions,
 			int fetchSize) {
+		this.query = query;
 		this.partitionColumnName = partitionColumnName;
 		this.partitionLowerBound = partitionLowerBound;
 		this.partitionUpperBound = partitionUpperBound;
 		this.numPartitions = numPartitions;
 
 		this.fetchSize = fetchSize;
+	}
+
+	public Optional<String> getQuery() {
+		return Optional.ofNullable(query);
 	}
 
 	public Optional<String> getPartitionColumnName() {
@@ -76,11 +83,12 @@ public class JdbcReadOptions implements Serializable {
 	public boolean equals(Object o) {
 		if (o instanceof JdbcReadOptions) {
 			JdbcReadOptions options = (JdbcReadOptions) o;
-			return Objects.equals(partitionColumnName, options.partitionColumnName) &&
-				Objects.equals(partitionLowerBound, options.partitionLowerBound) &&
-				Objects.equals(partitionUpperBound, options.partitionUpperBound) &&
-				Objects.equals(numPartitions, options.numPartitions) &&
-				Objects.equals(fetchSize, options.fetchSize);
+			return Objects.equals(query, options.query) &&
+					Objects.equals(partitionColumnName, options.partitionColumnName) &&
+					Objects.equals(partitionLowerBound, options.partitionLowerBound) &&
+					Objects.equals(partitionUpperBound, options.partitionUpperBound) &&
+					Objects.equals(numPartitions, options.numPartitions) &&
+					Objects.equals(fetchSize, options.fetchSize);
 		} else {
 			return false;
 		}
@@ -90,12 +98,21 @@ public class JdbcReadOptions implements Serializable {
 	 * Builder of {@link JdbcReadOptions}.
 	 */
 	public static class Builder {
+		protected String query;
 		protected String partitionColumnName;
 		protected Long partitionLowerBound;
 		protected Long partitionUpperBound;
 		protected Integer numPartitions;
 
 		protected int fetchSize = 0;
+
+		/**
+		 * optional, SQL query statement for this JDBC source.
+		 */
+		public Builder setQuery(String query) {
+			this.query = query;
+			return this;
+		}
 
 		/**
 		 * optional, name of the column used for partitioning the input.
@@ -140,7 +157,7 @@ public class JdbcReadOptions implements Serializable {
 
 		public JdbcReadOptions build() {
 			return new JdbcReadOptions(
-				partitionColumnName, partitionLowerBound, partitionUpperBound, numPartitions, fetchSize);
+				query, partitionColumnName, partitionLowerBound, partitionUpperBound, numPartitions, fetchSize);
 		}
 	}
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSource.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSource.java
@@ -168,8 +168,7 @@ public class JdbcTableSource implements
 		}
 
 		final JdbcDialect dialect = options.getDialect();
-		String query = dialect.getSelectFromStatement(
-			options.getTableName(), rowTypeInfo.getFieldNames(), new String[0]);
+		String query = getBaseQueryStatement(rowTypeInfo);
 		if (readOptions.getPartitionColumnName().isPresent()) {
 			long lowerBound = readOptions.getPartitionLowerBound().get();
 			long upperBound = readOptions.getPartitionUpperBound().get();
@@ -183,6 +182,12 @@ public class JdbcTableSource implements
 		builder.setQuery(query);
 
 		return builder.finish();
+	}
+
+	private String getBaseQueryStatement(RowTypeInfo rowTypeInfo) {
+		return readOptions.getQuery().orElseGet(() ->
+			options.getDialect().getSelectFromStatement(
+				options.getTableName(), rowTypeInfo.getFieldNames(), new String[0]));
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactory.java
@@ -57,6 +57,7 @@ import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_READ_PA
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_READ_PARTITION_LOWER_BOUND;
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_READ_PARTITION_NUM;
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_READ_PARTITION_UPPER_BOUND;
+import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_READ_QUERY;
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_TABLE;
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_TYPE_VALUE_JDBC;
 import static org.apache.flink.table.descriptors.JdbcValidator.CONNECTOR_URL;
@@ -96,6 +97,7 @@ public class JdbcTableSourceSinkFactory implements
 		properties.add(CONNECTOR_PASSWORD);
 
 		// scan options
+		properties.add(CONNECTOR_READ_QUERY);
 		properties.add(CONNECTOR_READ_PARTITION_COLUMN);
 		properties.add(CONNECTOR_READ_PARTITION_NUM);
 		properties.add(CONNECTOR_READ_PARTITION_LOWER_BOUND);
@@ -184,6 +186,7 @@ public class JdbcTableSourceSinkFactory implements
 	}
 
 	private JdbcReadOptions getJdbcReadOptions(DescriptorProperties descriptorProperties) {
+		final Optional<String> query = descriptorProperties.getOptionalString(CONNECTOR_READ_QUERY);
 		final Optional<String> partitionColumnName =
 			descriptorProperties.getOptionalString(CONNECTOR_READ_PARTITION_COLUMN);
 		final Optional<Long> partitionLower = descriptorProperties.getOptionalLong(CONNECTOR_READ_PARTITION_LOWER_BOUND);
@@ -191,6 +194,9 @@ public class JdbcTableSourceSinkFactory implements
 		final Optional<Integer> numPartitions = descriptorProperties.getOptionalInt(CONNECTOR_READ_PARTITION_NUM);
 
 		final JdbcReadOptions.Builder builder = JdbcReadOptions.builder();
+		if (query.isPresent()) {
+			builder.setQuery(query.get());
+		}
 		if (partitionColumnName.isPresent()) {
 			builder.setPartitionColumnName(partitionColumnName.get());
 			builder.setPartitionLowerBound(partitionLower.get());

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/table/descriptors/JdbcValidator.java
@@ -43,6 +43,7 @@ public class JdbcValidator extends ConnectorDescriptorValidator {
 	public static final String CONNECTOR_USERNAME = "connector.username";
 	public static final String CONNECTOR_PASSWORD = "connector.password";
 
+	public static final String CONNECTOR_READ_QUERY = "connector.read.query";
 	public static final String CONNECTOR_READ_PARTITION_COLUMN = "connector.read.partition.column";
 	public static final String CONNECTOR_READ_PARTITION_LOWER_BOUND = "connector.read.partition.lower-bound";
 	public static final String CONNECTOR_READ_PARTITION_UPPER_BOUND = "connector.read.partition.upper-bound";
@@ -89,6 +90,7 @@ public class JdbcValidator extends ConnectorDescriptorValidator {
 	}
 
 	private void validateReadProperties(DescriptorProperties properties) {
+		properties.validateString(CONNECTOR_READ_QUERY, true);
 		properties.validateString(CONNECTOR_READ_PARTITION_COLUMN, true);
 		properties.validateLong(CONNECTOR_READ_PARTITION_LOWER_BOUND, true);
 		properties.validateLong(CONNECTOR_READ_PARTITION_UPPER_BOUND, true);

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceITCase.java
@@ -21,8 +21,8 @@ package org.apache.flink.connector.jdbc.table;
 import org.apache.flink.connector.jdbc.JdbcTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
-import org.apache.flink.table.runtime.utils.StreamITCase;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 
@@ -34,8 +34,15 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
 
 
 /**
@@ -107,20 +114,19 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
 				")"
 		);
 
-		StreamITCase.clear();
-		tEnv.toAppendStream(tEnv.sqlQuery("SELECT * FROM " + INPUT_TABLE), Row.class)
-			.addSink(new StreamITCase.StringSink<>());
-		env.execute();
+		TableResult tableResult = tEnv.executeSql("SELECT * FROM " + INPUT_TABLE);
 
-		List<String> expected =
-			Arrays.asList(
-				"1,2020-01-01T15:35:00.123456,2020-01-01T15:35:00.123456789,15:35,1.175E-37,1.79769E308,100.1234",
-				"2,2020-01-01T15:36:01.123456,2020-01-01T15:36:01.123456789,15:36:01,-1.175E-37,-1.79769E308,101.1234");
-		StreamITCase.compareWithList(expected);
+		List<String> results = manifestResults(tableResult);
+
+		assertThat(
+				results,
+				containsInAnyOrder(
+						"1,2020-01-01T15:35:00.123456,2020-01-01T15:35:00.123456789,15:35,1.175E-37,1.79769E308,100.1234",
+						"2,2020-01-01T15:36:01.123456,2020-01-01T15:36:01.123456789,15:36:01,-1.175E-37,-1.79769E308,101.1234"));
 	}
 
 	@Test
-	public void testProjectableJdbcSource() throws Exception {
+	public void testProjectableJdbcSource() {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
 				.useBlinkPlanner()
@@ -143,20 +149,19 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
 				")"
 		);
 
-		StreamITCase.clear();
-		tEnv.toAppendStream(tEnv.sqlQuery("SELECT timestamp6_col, decimal_col FROM " + INPUT_TABLE), Row.class)
-				.addSink(new StreamITCase.StringSink<>());
-		env.execute();
+		TableResult tableResult = tEnv.executeSql("SELECT timestamp6_col, decimal_col FROM " + INPUT_TABLE);
 
-		List<String> expected =
-			Arrays.asList(
-				"2020-01-01T15:35:00.123456,100.1234",
-				"2020-01-01T15:36:01.123456,101.1234");
-		StreamITCase.compareWithList(expected);
+		List<String> results = manifestResults(tableResult);
+
+		assertThat(
+				results,
+				containsInAnyOrder(
+						"2020-01-01T15:35:00.123456,100.1234",
+						"2020-01-01T15:36:01.123456,101.1234"));
 	}
 
 	@Test
-	public void testScanQueryJDBCSource() throws Exception {
+	public void testScanQueryJDBCSource() {
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 		EnvironmentSettings envSettings = EnvironmentSettings.newInstance()
 			.useBlinkPlanner()
@@ -165,23 +170,29 @@ public class JdbcTableSourceITCase extends AbstractTestBase {
 		StreamTableEnvironment tEnv = StreamTableEnvironment.create(env, envSettings);
 
 		final String testQuery = "SELECT id FROM " + INPUT_TABLE;
-		tEnv.sqlUpdate(
-			"CREATE TABLE test(" +
-				"id BIGINT" +
-				") WITH (" +
-				"  'connector.type'='jdbc'," +
-				"  'connector.url'='" + DB_URL + "'," +
-				"  'connector.table'='whatever'," +
-				"  'connector.read.query'='" + testQuery + "'" +
-				")"
+		tEnv.executeSql(
+				"CREATE TABLE test(" +
+						"id BIGINT" +
+						") WITH (" +
+						"  'connector.type'='jdbc'," +
+						"  'connector.url'='" + DB_URL + "'," +
+						"  'connector.table'='whatever'," +
+						"  'connector.read.query'='" + testQuery + "'" +
+						")"
 		);
 
-		StreamITCase.clear();
-		tEnv.toAppendStream(tEnv.sqlQuery("SELECT id FROM test"), Row.class)
-			.addSink(new StreamITCase.StringSink<>());
-		env.execute();
+		TableResult tableResult = tEnv.executeSql("SELECT id FROM test");
 
-		List<String> expected =	Arrays.asList("1", "2");
-		StreamITCase.compareWithList(expected);
+		List<String> results = manifestResults(tableResult);
+
+		assertThat(results, containsInAnyOrder("1", "2"));
+	}
+
+	private static List<String> manifestResults(TableResult result) {
+		Iterator<Row> resultIterator = result.collect();
+		return StreamSupport
+				.stream(Spliterators.spliteratorUnknownSize(resultIterator, Spliterator.ORDERED), false)
+				.map(Row::toString)
+				.collect(Collectors.toList());
 	}
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcTableSourceSinkFactoryTest.java
@@ -88,6 +88,7 @@ public class JdbcTableSourceSinkFactoryTest {
 	@Test
 	public void testJdbcReadProperties() {
 		Map<String, String> properties = getBasicProperties();
+		properties.put("connector.read.query", "SELECT aaa FROM mytable");
 		properties.put("connector.read.partition.column", "aaa");
 		properties.put("connector.read.partition.lower-bound", "-10");
 		properties.put("connector.read.partition.upper-bound", "100");
@@ -102,6 +103,7 @@ public class JdbcTableSourceSinkFactoryTest {
 			.setTableName("mytable")
 			.build();
 		final JdbcReadOptions readOptions = JdbcReadOptions.builder()
+			.setQuery("SELECT aaa FROM mytable")
 			.setPartitionColumnName("aaa")
 			.setPartitionLowerBound(-10)
 			.setPartitionUpperBound(100)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Enable users to create a JDBC source table using a custom query / prepared statement.


## Brief change log

- Managed 'connector.read.query' to create a (read-only) source table using a custom query.
- Currently a read-only Table cannot be created. When a final decision will be taken on that we should set such a flag for tables having such a property
- When a final decision will be made for renaming of connector properties this property could probably become simply 'scan.query', but I decided to left the renaming of those properties to another specific PR


## Verifying this change

This change is already covered by existing tests, such as *JDBCTableSourceSinkFactoryTest* and *JDBCTableSourceITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper:*no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs