### PR TITLE
[FLINK-16804] Deprecate all Table methods that accept expressions as a String

### DIFF
--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountSQL.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountSQL.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Simple example that shows how the Batch SQL API is used in Java.
  *
@@ -49,7 +51,7 @@ public class WordCountSQL {
 			new WC("Hello", 1));
 
 		// register the DataSet as a view "WordCount"
-		tEnv.createTemporaryView("WordCount", input, "word, frequency");
+		tEnv.createTemporaryView("WordCount", input, $("word"), $("frequency"));
 
 		// run a SQL query on the Table and retrieve the result as a new Table
 		Table table = tEnv.sqlQuery(

--- a/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountTable.java
+++ b/flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/WordCountTable.java
@@ -23,6 +23,8 @@ import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Simple example for demonstrating the use of the Table API for a Word Count in Java.
  *
@@ -48,9 +50,9 @@ public class WordCountTable {
 		Table table = tEnv.fromDataSet(input);
 
 		Table filtered = table
-				.groupBy("word")
-				.select("word, frequency.sum as frequency")
-				.filter("frequency = 2");
+				.groupBy($("word"))
+				.select($("word"), $("frequency").sum().as("frequency"))
+				.filter($("frequency").isEqual(2));
 
 		DataSet<WC> result = tEnv.toDataSet(filtered, WC.class);
 

--- a/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountSQL.scala
+++ b/flink-examples/flink-examples-table/src/main/scala/org/apache/flink/table/examples/scala/WordCountSQL.scala
@@ -44,7 +44,7 @@ object WordCountSQL {
     val input = env.fromElements(WC("hello", 1), WC("hello", 1), WC("ciao", 1))
 
     // register the DataSet as a view "WordCount"
-    tEnv.createTemporaryView("WordCount", input, 'word, 'frequency)
+    tEnv.createTemporaryView("WordCount", input, $"word", $"frequency")
 
     // run a SQL query on the Table and retrieve the result as a new Table
     val table = tEnv.sqlQuery("SELECT word, SUM(frequency) FROM WordCount GROUP BY word")

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import static org.apache.flink.table.api.Expressions.$;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -152,7 +153,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
-		Table result = t.select("*");
+		Table result = t.select($("*"));
 
 		List<Row> results = tEnv.toDataSet(result, Row.class).collect();
 		String expected =
@@ -179,7 +180,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
-		Table result = t.select("name");
+		Table result = t.select($("name"));
 		List<Utf8> results = tEnv.toDataSet(result, Types.GENERIC(Utf8.class)).collect();
 		String expected = "Charlie\n" +
 				"Terminator\n" +
@@ -194,8 +195,9 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 
 		Table t = tEnv.fromDataSet(testData(env));
 		Table result = t
-				.filter("type_nested.isNotNull")
-				.select("type_nested.flatten()").as("city, num, state, street, zip");
+				.filter($("type_nested").isNotNull())
+				.select($("type_nested").flatten())
+				.as("city", "num", "state", "street", "zip");
 
 		List<Address> results = tEnv.toDataSet(result, Types.POJO(Address.class)).collect();
 		String expected = USER_1.getTypeNested().toString();
@@ -208,7 +210,7 @@ public class AvroTypesITCase extends TableProgramsClusterTestBase {
 		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env, config());
 
 		Table t = tEnv.fromDataSet(testData(env));
-		Table result = t.select("*");
+		Table result = t.select($("*"));
 
 		List<User> results = tEnv.toDataSet(result, Types.POJO(User.class)).collect();
 		List<User> expected = Arrays.asList(USER_1, USER_2, USER_3);

--- a/flink-ml-parent/flink-ml-lib/src/test/java/org/apache/flink/ml/pipeline/UserDefinedPipelineStages.java
+++ b/flink-ml-parent/flink-ml-lib/src/test/java/org/apache/flink/ml/pipeline/UserDefinedPipelineStages.java
@@ -21,8 +21,12 @@ package org.apache.flink.ml.pipeline;
 import org.apache.flink.ml.api.core.Transformer;
 import org.apache.flink.ml.api.misc.param.Params;
 import org.apache.flink.ml.params.shared.colname.HasSelectedCols;
+import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.expressions.Expression;
+
+import java.util.Arrays;
 
 /**
  * Util class for testing {@link org.apache.flink.ml.api.core.PipelineStage}.
@@ -43,7 +47,7 @@ public class UserDefinedPipelineStages {
 
 		@Override
 		public Table transform(TableEnvironment tEnv, Table input) {
-			return input.select(String.join(", ", this.getSelectedCols()));
+			return input.select(Arrays.stream(this.getSelectedCols()).map(Expressions::$).toArray(Expression[]::new));
 		}
 
 		@Override

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonFunctionFactoryTest.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.flink.python.PythonOptions.PYTHON_FILES;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
 
 /**
  * Tests for PythonFunctionFactory. This test will be executed from Python side. Because the maven test environment
@@ -85,35 +87,35 @@ public class PythonFunctionFactoryTest {
 	public static void testPythonFunctionFactory() {
 		// flink catalog
 		flinkTableEnv.sqlUpdate("create function func1 as 'test1.func1' language python");
-		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+		verifyPlan(flinkSourceTable.select(call("func1", $("str"))), flinkTableEnv);
 
 		// flink catalog
 		flinkTableEnv.sqlUpdate("alter function func1 as 'test1.func1' language python");
-		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+		verifyPlan(flinkSourceTable.select(call("func1", $("str"))), flinkTableEnv);
 
 		// flink temporary catalog
 		flinkTableEnv.sqlUpdate("create temporary function func1 as 'test1.func1' language python");
-		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+		verifyPlan(flinkSourceTable.select(call("func1", $("str"))), flinkTableEnv);
 
 		// flink temporary system
 		flinkTableEnv.sqlUpdate("create temporary system function func1 as 'test1.func1' language python");
-		verifyPlan(flinkSourceTable.select("func1(str)"), flinkTableEnv);
+		verifyPlan(flinkSourceTable.select(call("func1", $("str"))), flinkTableEnv);
 
 		// blink catalog
 		blinkTableEnv.sqlUpdate("create function func1 as 'test1.func1' language python");
-		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
+		verifyPlan(blinkSourceTable.select(call("func1", $("str"))), blinkTableEnv);
 
 		// blink catalog
 		blinkTableEnv.sqlUpdate("alter function func1 as 'test1.func1' language python");
-		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
+		verifyPlan(blinkSourceTable.select(call("func1", $("str"))), blinkTableEnv);
 
 		// blink temporary catalog
 		blinkTableEnv.sqlUpdate("create temporary function func1 as 'test1.func1' language python");
-		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
+		verifyPlan(blinkSourceTable.select(call("func1", $("str"))), blinkTableEnv);
 
 		// blink temporary system
 		blinkTableEnv.sqlUpdate("create temporary system function func1 as 'test1.func1' language python");
-		verifyPlan(blinkSourceTable.select("func1(str)"), blinkTableEnv);
+		verifyPlan(blinkSourceTable.select(call("func1", $("str"))), blinkTableEnv);
 	}
 
 	private static void verifyPlan(Table table, TableEnvironment tableEnvironment) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/operators/python/scalar/PythonScalarFunctionOperatorTestBase.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
 
 /**
  * Base class for Python scalar function operator test. These test that:
@@ -203,7 +204,7 @@ public abstract class PythonScalarFunctionOperatorTestBase<IN, OUT, UDFIN> {
 		StreamTableEnvironment tEnv = createTableEnvironment(env);
 		tEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"));
 		DataStream<Tuple2<Integer, Integer>> ds = env.fromElements(new Tuple2<>(1, 2));
-		Table t = tEnv.fromDataStream(ds, $("a"), $("b")).select("pyFunc(a, b)");
+		Table t = tEnv.fromDataStream(ds, $("a"), $("b")).select(call("pyFunc", $("a"), $("b")));
 		// force generating the physical plan for the given table
 		tEnv.toAppendStream(t, BasicTypeInfo.INT_TYPE_INFO);
 		JobGraph jobGraph = env.getStreamGraph().getJobGraph();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/ExecutionContext.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.java.BatchTableEnvironment;
 import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.api.java.internal.BatchTableEnvironmentImpl;
@@ -108,6 +109,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -692,9 +694,13 @@ public class ExecutionContext<ClusterID> {
 	private void registerTemporalTable(TemporalTableEntry temporalTableEntry) {
 		try {
 			final Table table = tableEnv.scan(temporalTableEntry.getHistoryTable());
+			List<String> primaryKeyFields = temporalTableEntry.getPrimaryKeyFields();
+			if (primaryKeyFields.size() > 1) {
+				throw new ValidationException("Temporal tables over a composite primary key are not supported yet.");
+			}
 			final TableFunction<?> function = table.createTemporalTableFunction(
-				temporalTableEntry.getTimeAttribute(),
-				String.join(",", temporalTableEntry.getPrimaryKeyFields()));
+				$(temporalTableEntry.getTimeAttribute()),
+				$(primaryKeyFields.get(0)));
 			if (tableEnv instanceof StreamTableEnvironment) {
 				StreamTableEnvironment streamTableEnvironment = (StreamTableEnvironment) tableEnv;
 				streamTableEnvironment.registerFunction(temporalTableEntry.getName(), function);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/AggregatedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/AggregatedTable.java
@@ -35,28 +35,42 @@ public interface AggregatedTable {
 	 *
 	 * <pre>
 	 * {@code
-	 *   AggregateFunction aggFunc = new MyAggregateFunction()
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
 	 *   tableEnv.registerFunction("aggFunc", aggFunc);
 	 *   table.groupBy("key")
 	 *     .aggregate("aggFunc(a, b) as (f0, f1, f2)")
-	 *     .select("key, f0, f1")
+	 *     .select("key, f0, f1");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
 	 * Performs a selection operation after an aggregate operation. The field expressions
 	 * cannot contain table functions and aggregations.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
+	 *   tableEnv.registerFunction("aggFunc", aggFunc);
+	 *   table.groupBy($("key"))
+	 *     .aggregate(call("aggFunc", $("a"), $("b")).as("f0", "f1", "f2"))
+	 *     .select($("key"), $("f0"), $("f1"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   val aggFunc = new MyAggregateFunction
-	 *   table.groupBy('key)
-	 *     .aggregate(aggFunc('a, 'b) as ('f0, 'f1, 'f2))
-	 *     .select('key, 'f0, 'f1)
+	 *   table.groupBy($"key")
+	 *     .aggregate(aggFunc($"a", $"b") as ("f0", "f1", "f2"))
+	 *     .select($"key", $"f0", $"f1")
 	 * }
 	 * </pre>
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FlatAggregateTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/FlatAggregateTable.java
@@ -39,14 +39,16 @@ public interface FlatAggregateTable {
 	 *
 	 * <pre>
 	 * {@code
-	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
 	 *   tableEnv.registerFunction("tableAggFunc", tableAggFunc);
 	 *   tab.groupBy("key")
 	 *     .flatAggregate("tableAggFunc(a, b) as (x, y, z)")
 	 *     .select("key, x, y, z")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
@@ -56,14 +58,26 @@ public interface FlatAggregateTable {
 	 * <p><b>Note</b>: You have to close the flatAggregate with a select statement. And the select
 	 * statement does not support aggregate functions.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
+	 *   tableEnv.registerFunction("tableAggFunc", tableAggFunc);
+	 *   tab.groupBy($("key"))
+	 *     .flatAggregate(call("tableAggFunc", $("a"), $("b")).as("x", "y", "z"))
+	 *     .select($("key"), $("x"), $("y"), $("z"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   val tableAggFunc = new MyTableAggregateFunction
-	 *   tab.groupBy('key)
-	 *     .flatAggregate(tableAggFunc('a, 'b) as ('x, 'y, 'z))
-	 *     .select('key, 'x, 'y, 'z)
+	 *   val tableAggFunc: TableAggregateFunction = new MyTableAggregateFunction
+	 *   tab.groupBy($"key")
+	 *     .flatAggregate(tableAggFunc($"a", $"b") as ("x", "y", "z"))
+	 *     .select($"key", $"x", $"y", $"z")
 	 * }
 	 * </pre>
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupWindowedTable.java
@@ -40,11 +40,13 @@ public interface GroupWindowedTable {
 	 * <p>Example:
 	 *
 	 * <pre>
-	 * {code
+	 * {@code
 	 *   tab.window([groupWindow].as("w")).groupBy("w, key").select("key, value.avg")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #groupBy(Expression...)}
 	 */
+	@Deprecated
 	WindowGroupedTable groupBy(String fields);
 
 	/**
@@ -57,10 +59,18 @@ public interface GroupWindowedTable {
 	 * <p>Aggregations are performed per group and defined by a subsequent {@code select(...)}
 	 * clause similar to SQL SELECT-GROUP-BY query.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.window([groupWindow].as("w")).groupBy($("w"), $("key")).select($("key"), $("value").avg());
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
-	 * {code
+	 * {@code
 	 *   tab.window([groupWindow] as 'w)).groupBy('w, 'key).select('key, 'value.avg)
 	 * }
 	 * </pre>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/GroupedTable.java
@@ -38,18 +38,28 @@ public interface GroupedTable {
 	 *   tab.groupBy("key").select("key, value.avg + ' The average' as average")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
 	 * Performs a selection operation on a grouped table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy($("key")).select($("key"), $("value").avg().plus(" The average").as("average"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.groupBy('key).select('key, 'value.avg + " The average" as 'average)
+	 *   tab.groupBy($"key").select($"key", $"value".avg + " The average" as "average")
 	 * }
 	 * </pre>
 	 */
@@ -64,14 +74,16 @@ public interface GroupedTable {
 	 *
 	 * <pre>
 	 * {@code
-	 *   AggregateFunction aggFunc = new MyAggregateFunction()
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
 	 *   tableEnv.registerFunction("aggFunc", aggFunc);
 	 *   table.groupBy("key")
 	 *     .aggregate("aggFunc(a, b) as (f0, f1, f2)")
 	 *     .select("key, f0, f1")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #aggregate(Expression)}
 	 */
+	@Deprecated
 	AggregatedTable aggregate(String aggregateFunction);
 
 	/**
@@ -79,14 +91,26 @@ public interface GroupedTable {
 	 * {@link #aggregate(Expression)} with a select statement. The output will be flattened if the
 	 * output type is a composite type.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
+	 *   tableEnv.registerFunction("aggFunc", aggFunc);
+	 *   tab.groupBy($("key"))
+	 *     .aggregate(call("aggFunc", $("a"), $("b")).as("f0", "f1", "f2"))
+	 *     .select($("key"), $("f0"), $("f1"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   val aggFunc = new MyAggregateFunction
-	 *   table.groupBy('key)
-	 *     .aggregate(aggFunc('a, 'b) as ('f0, 'f1, 'f2))
-	 *     .select('key, 'f0, 'f1)
+	 *   table.groupBy($"key")
+	 *     .aggregate(aggFunc($"a", $"b") as ("f0", "f1", "f2"))
+	 *     .select($"key", $"f0", $"f1")
 	 * }
 	 * </pre>
 	 */
@@ -107,21 +131,35 @@ public interface GroupedTable {
 	 *     .select("key, x, y, z")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #flatAggregate(Expression)}
 	 */
+	@Deprecated
 	FlatAggregateTable flatAggregate(String tableAggFunction);
 
 	/**
 	 * Performs a flatAggregate operation on a grouped table. FlatAggregate takes a
 	 * TableAggregateFunction which returns multiple rows. Use a selection after flatAggregate.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
+	 *   tableEnv.registerFunction("tableAggFunc", tableAggFunc);
+	 *   tab.groupBy($("key"))
+	 *     .flatAggregate(call("tableAggFunc", $("a"), $("b")).as("x", "y", "z"))
+	 *     .select($("key"), $("x"), $("y"), $("z"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   val tableAggFunc: TableAggregateFunction = new MyTableAggregateFunction
-	 *   tab.groupBy('key)
-	 *     .flatAggregate(tableAggFunc('a, 'b) as ('x, 'y, 'z))
-	 *     .select('key, 'x, 'y, 'z)
+	 *   tab.groupBy($"key")
+	 *     .flatAggregate(tableAggFunc($"a", $"b") as ("x", "y", "z"))
+	 *     .select($"key", $"x", $"y", $"z")
 	 * }
 	 * </pre>
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Over.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Over.java
@@ -83,7 +83,9 @@ public final class Over {
 	 *
 	 * @param orderBy field reference
 	 * @return an over window with defined order
+	 * @deprecated use {@link #orderBy(Expression)}
 	 */
+	@Deprecated
 	public static OverWindowPartitionedOrdered orderBy(String orderBy) {
 		return partitionBy().orderBy(orderBy);
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitioned.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitioned.java
@@ -47,7 +47,9 @@ public final class OverWindowPartitioned {
 	 *
 	 * @param orderBy field reference
 	 * @return an over window with defined order
+	 * @deprecated use {@link #orderBy(Expression)}
 	 */
+	@Deprecated
 	public OverWindowPartitionedOrdered orderBy(String orderBy) {
 		return this.orderBy(ExpressionParser.parseExpression(orderBy));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrdered.java
@@ -47,7 +47,9 @@ public final class OverWindowPartitionedOrdered {
 	 *
 	 * @param preceding preceding offset relative to the current row.
 	 * @return an over window with defined preceding
+	 * @deprecated use {@link #preceding(Expression)}
 	 */
+	@Deprecated
 	public OverWindowPartitionedOrderedPreceding preceding(String preceding) {
 		return this.preceding(ExpressionParser.parseExpression(preceding));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrderedPreceding.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowPartitionedOrderedPreceding.java
@@ -70,7 +70,9 @@ public final class OverWindowPartitionedOrderedPreceding {
 	 *
 	 * @param following following offset that relative to the current row.
 	 * @return an over window with defined following
+	 * @deprecated use {@link #following(Expression)}
 	 */
+	@Deprecated
 	public OverWindowPartitionedOrderedPreceding following(String following) {
 		return this.following(ExpressionParser.parseExpression(following));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/OverWindowedTable.java
@@ -42,12 +42,26 @@ public interface OverWindowedTable {
 	 *   overWindowedTable.select("c, b.count over ow, e.sum over ow")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
 	 * Performs a selection operation on a over windowed table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   overWindowedTable.select(
+	 *      $("c"),
+	 *      $("b").count().over($("ow")),
+	 *      $("e").sum().over($("ow"))
+	 *   );
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Session.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Session.java
@@ -54,7 +54,9 @@ public final class Session {
 	 * @param gap specifies how long (as interval of milliseconds) to wait for new data before
 	 *            closing the session window.
 	 * @return a partially defined session window
+	 * @deprecated use {@link #withGap(Expression)}
 	 */
+	@Deprecated
 	public static SessionWithGap withGap(String gap) {
 		return withGap(ExpressionParser.parseExpression(gap));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SessionWithGap.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SessionWithGap.java
@@ -50,7 +50,9 @@ public final class SessionWithGap {
 	 *
 	 * @param timeField time attribute for streaming and batch tables
 	 * @return a tumbling window on event-time
+	 * @deprecated use {@link #on(Expression)}
 	 */
+	@Deprecated
 	public SessionWithGapOnTime on(String timeField) {
 		return on(ExpressionParser.parseExpression(timeField));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Slide.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Slide.java
@@ -61,7 +61,9 @@ public final class Slide {
 	 *
 	 * @param size the size of the window as time or row-count interval
 	 * @return a partially specified sliding window
+	 * @deprecated use {@link #over(Expression)}
 	 */
+	@Deprecated
 	public static SlideWithSize over(String size) {
 		return over(ExpressionParser.parseExpression(size));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SlideWithSize.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SlideWithSize.java
@@ -48,7 +48,9 @@ public final class SlideWithSize {
 	 *
 	 * @param slide the slide of the window either as time or row-count interval.
 	 * @return a sliding window
+	 * @deprecated use {@link #every(Expression)}
 	 */
+	@Deprecated
 	public SlideWithSizeAndSlide every(String slide) {
 		return every(ExpressionParser.parseExpression(slide));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SlideWithSizeAndSlide.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/SlideWithSizeAndSlide.java
@@ -52,7 +52,9 @@ public final class SlideWithSizeAndSlide {
 	 *
 	 * @param timeField time attribute for streaming and batch tables
 	 * @return a tumbling window on event-time
+	 * @deprecated use {@link #on(Expression)}
 	 */
+	@Deprecated
 	public SlideWithSizeAndSlideOnTime on(String timeField) {
 		return on(ExpressionParser.parseExpression(timeField));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Table.java
@@ -100,7 +100,9 @@ public interface Table {
 	 *   tab.select("key, value.avg + ' The average' as average")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
@@ -111,7 +113,15 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.select('key, 'value.avg + " The average" as 'average)
+	 *   tab.select($("key"), $("value").avg().plus(" The average").as("average"));
+	 * }
+	 * </pre>
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.select($"key", $"value".avg + " The average" as "average")
 	 * }
 	 * </pre>
 	 */
@@ -135,7 +145,9 @@ public interface Table {
 	 *        It takes one single argument, the {@code timeAttribute}, for which it returns
 	 *        matching version of the {@link Table}, from which {@link TemporalTableFunction}
 	 *        was created.
+	 * @deprecated use {@link #createTemporalTableFunction(Expression, Expression)}
 	 */
+	@Deprecated
 	TemporalTableFunction createTemporalTableFunction(String timeAttribute, String primaryKey);
 
 	/**
@@ -167,24 +179,34 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.as("a, b")
+	 *   tab.as("a", "b")
 	 * }
 	 * </pre>
 	 */
-	Table as(String fields);
+	Table as(String field, String... fields);
 
 	/**
 	 * Renames the fields of the expression result. Use this to disambiguate fields before
 	 * joining to operations.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.as($("a"), $("b"))
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.as('a, 'b)
+	 *   tab.as($"a", $"b")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #as(String, String...)}
 	 */
+	@Deprecated
 	Table as(Expression... fields);
 
 	/**
@@ -198,18 +220,28 @@ public interface Table {
 	 *   tab.filter("name = 'Fred'")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #filter(Expression)}
 	 */
+	@Deprecated
 	Table filter(String predicate);
 
 	/**
 	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
 	 * clause.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.filter($("name").isEqual("Fred"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.filter('name === "Fred")
+	 *   tab.filter($"name" === "Fred")
 	 * }
 	 * </pre>
 	 */
@@ -226,18 +258,28 @@ public interface Table {
 	 *   tab.where("name = 'Fred'")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #where(Expression)}
 	 */
+	@Deprecated
 	Table where(String predicate);
 
 	/**
 	 * Filters out elements that don't pass the filter predicate. Similar to a SQL WHERE
 	 * clause.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.where($("name").isEqual("Fred"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.where('name === "Fred")
+	 *   tab.where($"name" === "Fred")
 	 * }
 	 * </pre>
 	 */
@@ -254,7 +296,9 @@ public interface Table {
 	 *   tab.groupBy("key").select("key, value.avg")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #groupBy(Expression...)}
 	 */
+	@Deprecated
 	GroupedTable groupBy(String fields);
 
 	/**
@@ -265,7 +309,15 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.groupBy('key).select('key, 'value.avg)
+	 *   tab.groupBy($("key")).select($("key"), $("value").avg());
+	 * }
+	 * </pre>
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.groupBy($"key").select($"key", $"value".avg)
 	 * }
 	 * </pre>
 	 */
@@ -278,7 +330,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.select("key, value").distinct()
+	 *   tab.select($("key"), $("value")).distinct();
 	 * }
 	 * </pre>
 	 */
@@ -295,7 +347,9 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.join(right).where("a = b && c > 3").select("a, b, d")
+	 *   left.join(right)
+	 *       .where($("a").isEqual($("b")).and($("c").isGreater(3))
+	 *       .select($("a"), $("b"), $("d"));
 	 * }
 	 * </pre>
 	 */
@@ -314,7 +368,9 @@ public interface Table {
 	 *   left.join(right, "a = b")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #join(Table, Expression)}
 	 */
+	@Deprecated
 	Table join(Table right, String joinPredicate);
 
 	/**
@@ -323,11 +379,21 @@ public interface Table {
 	 *
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} .
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.join(right, $("a").isEqual($("b")))
+	 *       .select($("a"), $("b"), $("d"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.join(right, 'a === 'b).select('a, 'b, 'd)
+	 *   left.join(right, $"a" === $"b")
+	 *       .select($"a", $"b", $"d")
 	 * }
 	 * </pre>
 	 */
@@ -344,7 +410,8 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.leftOuterJoin(right).select("a, b, d")
+	 *   left.leftOuterJoin(right)
+	 *       .select($("a"), $("b"), $("d"));
 	 * }
 	 * </pre>
 	 */
@@ -364,7 +431,9 @@ public interface Table {
 	 *   left.leftOuterJoin(right, "a = b").select("a, b, d")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #leftOuterJoin(Table, Expression)}
 	 */
+	@Deprecated
 	Table leftOuterJoin(Table right, String joinPredicate);
 
 	/**
@@ -374,11 +443,21 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.leftOuterJoin(right, $("a").isEqual($("b")))
+	 *       .select($("a"), $("b"), $("d"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.leftOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 *   left.leftOuterJoin(right, $"a" === $"b")
+	 *       .select($"a", $"b", $"d")
 	 * }
 	 * </pre>
 	 */
@@ -398,7 +477,9 @@ public interface Table {
 	 *   left.rightOuterJoin(right, "a = b").select("a, b, d")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #rightOuterJoin(Table, Expression)}
 	 */
+	@Deprecated
 	Table rightOuterJoin(Table right, String joinPredicate);
 
 	/**
@@ -408,11 +489,21 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.rightOuterJoin(right, $("a").isEqual($("b")))
+	 *       .select($("a"), $("b"), $("d"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.rightOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 *   left.rightOuterJoin(right, $"a" === $"b")
+	 *       .select($"a", $"b", $"d")
 	 * }
 	 * </pre>
 	 */
@@ -432,7 +523,9 @@ public interface Table {
 	 *   left.fullOuterJoin(right, "a = b").select("a, b, d")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #fullOuterJoin(Table, Expression)}
 	 */
+	@Deprecated
 	Table fullOuterJoin(Table right, String joinPredicate);
 
 	/**
@@ -442,11 +535,21 @@ public interface Table {
 	 * <p>Note: Both tables must be bound to the same {@code TableEnvironment} and its
 	 * {@code TableConfig} must have null check enabled (default).
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   left.fullOuterJoin(right, $("a").isEqual($("b")))
+	 *       .select($("a"), $("b"), $("d"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.fullOuterJoin(right, 'a === 'b).select('a, 'b, 'd)
+	 *   left.fullOuterJoin(right, $"a" === $"b")
+	 *       .select($"a", $"b", $"d")
 	 * }
 	 * </pre>
 	 */
@@ -472,13 +575,31 @@ public interface Table {
 	 *   table.joinLateral("split(c) as (s)").select("a, b, c, s");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #joinLateral(Expression)}
 	 */
+	@Deprecated
 	Table joinLateral(String tableFunctionCall);
 
 	/**
 	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
 	 * a SQL inner join with ON TRUE predicate but works with a table function. Each row of the
 	 * table is joined with all rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   table.joinLateral(call(split, $("c")).as("s"))
+	 *        .select($("a"), $("b"), $("c"), $("s"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -491,7 +612,8 @@ public interface Table {
 	 *   }
 	 *
 	 *   val split = new MySplitUDTF()
-	 *   table.joinLateral(split('c) as ('s)).select('a, 'b, 'c, 's)
+	 *   table.joinLateral(split($"c") as "s")
+	 *        .select($"a", $"b", $"c", $"s")
 	 * }
 	 * </pre>
 	 */
@@ -517,13 +639,31 @@ public interface Table {
 	 *   table.joinLateral("split(c) as (s)", "a = s").select("a, b, c, s");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #joinLateral(Expression, Expression)}
 	 */
+	@Deprecated
 	Table joinLateral(String tableFunctionCall, String joinPredicate);
 
 	/**
 	 * Joins this {@link Table} with an user-defined {@link TableFunction}. This join is similar to
 	 * a SQL inner join but works with a table function. Each row of the table is joined with all
 	 * rows produced by the table function.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   table.joinLateral(call(split, $("c")).as("s"), $("a").isEqual($("s")))
+	 *        .select($("a"), $("b"), $("c"), $("s"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -536,7 +676,8 @@ public interface Table {
 	 *   }
 	 *
 	 *   val split = new MySplitUDTF()
-	 *   table.joinLateral(split('c) as ('s), 'a === 's).select('a, 'b, 'c, 's)
+	 *   table.joinLateral(split($"c") as "s", $"a" === $"s")
+	 *        .select($"a", $"b", $"c", $"s")
 	 * }
 	 * </pre>
 	 */
@@ -563,7 +704,9 @@ public interface Table {
 	 *   table.leftOuterJoinLateral("split(c) as (s)").select("a, b, c, s");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #leftOuterJoinLateral(Expression)}
 	 */
+	@Deprecated
 	Table leftOuterJoinLateral(String tableFunctionCall);
 
 	/**
@@ -571,6 +714,22 @@ public interface Table {
 	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
 	 * the table is joined with all rows produced by the table function. If the table function does
 	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   table.leftOuterJoinLateral(call(split, $("c")).as("s"))
+	 *        .select($("a"), $("b"), $("c"), $("s"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -583,7 +742,8 @@ public interface Table {
 	 *   }
 	 *
 	 *   val split = new MySplitUDTF()
-	 *   table.leftOuterJoinLateral(split('c) as ('s)).select('a, 'b, 'c, 's)
+	 *   table.leftOuterJoinLateral(split($"c") as "s")
+	 *        .select($"a", $"b", $"c", $"s")
 	 * }
 	 * </pre>
 	 */
@@ -610,7 +770,9 @@ public interface Table {
 	 *   table.leftOuterJoinLateral("split(c) as (s)", "a = s").select("a, b, c, s");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #leftOuterJoinLateral(Expression, Expression)}
 	 */
+	@Deprecated
 	Table leftOuterJoinLateral(String tableFunctionCall, String joinPredicate);
 
 	/**
@@ -618,6 +780,22 @@ public interface Table {
 	 * a SQL left outer join with ON TRUE predicate but works with a table function. Each row of
 	 * the table is joined with all rows produced by the table function. If the table function does
 	 * not produce any row, the outer row is padded with nulls.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   class MySplitUDTF extends TableFunction<String> {
+	 *     public void eval(String str) {
+	 *       str.split("#").forEach(this::collect);
+	 *     }
+	 *   }
+	 *
+	 *   TableFunction<String> split = new MySplitUDTF();
+	 *   table.leftOuterJoinLateral(call(split, $("c")).as("s"), $("a").isEqual($("s")))
+	 *        .select($("a"), $("b"), $("c"), $("s"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -630,7 +808,8 @@ public interface Table {
 	 *   }
 	 *
 	 *   val split = new MySplitUDTF()
-	 *   table.leftOuterJoinLateral(split('c) as ('s), 'a === 's).select('a, 'b, 'c, 's)
+	 *   table.leftOuterJoinLateral(split($"c") as "s", $"a" === $"s")
+	 *        .select($"a", $"b", $"c", $"s")
 	 * }
 	 * </pre>
 	 */
@@ -648,7 +827,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.minus(right)
+	 *   left.minus(right);
 	 * }
 	 * </pre>
 	 */
@@ -667,7 +846,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.minusAll(right)
+	 *   left.minusAll(right);
 	 * }
 	 * </pre>
 	 */
@@ -683,7 +862,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.union(right)
+	 *   left.union(right);
 	 * }
 	 * </pre>
 	 */
@@ -699,7 +878,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.unionAll(right)
+	 *   left.unionAll(right);
 	 * }
 	 * </pre>
 	 */
@@ -717,7 +896,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.intersect(right)
+	 *   left.intersect(right);
 	 * }
 	 * </pre>
 	 */
@@ -735,7 +914,7 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   left.intersectAll(right)
+	 *   left.intersectAll(right);
 	 * }
 	 * </pre>
 	 */
@@ -752,7 +931,9 @@ public interface Table {
 	 *   tab.orderBy("name.desc")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #orderBy(Expression...)}
 	 */
+	@Deprecated
 	Table orderBy(String fields);
 
 	/**
@@ -763,7 +944,15 @@ public interface Table {
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.orderBy('name.desc)
+	 *   tab.orderBy($("name").desc());
+	 * }
+	 * </pre>
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.orderBy($"name".desc)
 	 * }
 	 * </pre>
 	 */
@@ -780,9 +969,9 @@ public interface Table {
 	 * <pre>
 	 * {@code
 	 *   // skips the first 3 rows and returns all following rows.
-	 *   tab.orderBy("name.desc").offset(3)
+	 *   tab.orderBy($("name").desc()).offset(3);
 	 *   // skips the first 10 rows and returns the next 5 rows.
-	 *   tab.orderBy("name.desc").offset(10).fetch(5)
+	 *   tab.orderBy($("name").desc()).offset(10).fetch(5);
 	 * }
 	 * </pre>
 	 *
@@ -801,9 +990,9 @@ public interface Table {
 	 * <pre>
 	 * {@code
 	 *   // returns the first 3 records.
-	 *   tab.orderBy("name.desc").fetch(3)
+	 *   tab.orderBy($("name").desc()).fetch(3);
 	 *   // skips the first 10 rows and returns the next 5 rows.
-	 *   tab.orderBy("name.desc").offset(10).fetch(5)
+	 *   tab.orderBy($("name").desc()).offset(10).fetch(5);
 	 * }
 	 * </pre>
 	 *
@@ -856,8 +1045,18 @@ public interface Table {
 	 * <pre>
 	 * {@code
 	 *   table
-	 *     .window(Over partitionBy 'c orderBy 'rowTime preceding 10.seconds as 'ow)
-	 *     .select('c, 'b.count over 'ow, 'e.sum over 'ow)
+	 *     .window(Over.partitionBy($("c")).orderBy($("rowTime")).preceding(lit(10).seconds()).as("ow")
+	 *     .select($("c"), $("b").count().over($("ow")), $("e").sum().over($("ow")));
+	 * }
+	 * </pre>
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   table
+	 *     .window(Over partitionBy $"c" orderBy $"rowTime" preceding 10.seconds as "ow")
+	 *     .select($"c", $"b".count over $"ow", $"e".sum over $"ow")
 	 * }
 	 * </pre>
 	 *
@@ -884,7 +1083,9 @@ public interface Table {
 	 *   tab.addColumns("a + 1 as a1, concat(b, 'sunny') as b1")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #addColumns(Expression...)}
 	 */
+	@Deprecated
 	Table addColumns(String fields);
 
 	/**
@@ -892,11 +1093,25 @@ public interface Table {
 	 * can contain complex expressions, but can not contain aggregations. It will throw an exception
 	 * if the added fields already exist.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.addColumns(
+	 *      $("a").plus(1).as("a1"),
+	 *      concat($("b"), "sunny").as("b1")
+	 *   );
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.addColumns('a + 1 as 'a1, concat('b, "sunny") as 'b1)
+	 *   tab.addColumns(
+	 *      $"a" + 1 as "a1",
+	 *      concat($"b", "sunny") as "b1"
+	 *   )
 	 * }
 	 * </pre>
 	 */
@@ -914,7 +1129,9 @@ public interface Table {
 	 *   tab.addOrReplaceColumns("a + 1 as a1, concat(b, 'sunny') as b1")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #addOrReplaceColumns(Expression...)}
 	 */
+	@Deprecated
 	Table addOrReplaceColumns(String fields);
 
 	/**
@@ -922,10 +1139,25 @@ public interface Table {
 	 * can contain complex expressions, but can not contain aggregations. Existing fields will be
 	 * replaced. If the added fields have duplicate field name, then the last one is used.
 	 *
-	 * <p>Scala Example:
+	 * <p>Example:
+	 *
 	 * <pre>
 	 * {@code
-	 *   tab.addOrReplaceColumns('a + 1 as 'a1, concat('b, "sunny") as 'b1)
+	 *   tab.addOrReplaceColumns(
+	 *      $("a").plus(1).as("a1"),
+	 *      concat($("b"), "sunny").as("b1")
+	 *   );
+	 * }
+	 * </pre>
+	 *
+	 * <p>Scala Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.addOrReplaceColumns(
+	 *      $"a" + 1 as "a1",
+	 *      concat($"b", "sunny") as "b1"
+	 *   )
 	 * }
 	 * </pre>
 	 */
@@ -942,18 +1174,34 @@ public interface Table {
 	 *   tab.renameColumns("a as a1, b as b1")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #renameColumns(Expression...)}
 	 */
+	@Deprecated
 	Table renameColumns(String fields);
 
 	/**
 	 * Renames existing columns. Similar to a field alias statement. The field expressions
 	 * should be alias expressions, and only the existing fields can be renamed.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   tab.renameColumns(
+	 *      $("a").as($("a1")),
+	 *      $("b").as($("b1"))
+	 *   );
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   tab.renameColumns('a as 'a1, 'b as 'b1)
+	 *   tab.renameColumns(
+	 *      $"a" as $"a1",
+	 *      $"b" as $"b1"
+	 *   )
 	 * }
 	 * </pre>
 	 */
@@ -969,16 +1217,25 @@ public interface Table {
 	 *   tab.dropColumns("a, b")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #dropColumns(Expression...)}
 	 */
+	@Deprecated
 	Table dropColumns(String fields);
 
 	/**
 	 * Drops existing columns. The field expressions should be field reference expressions.
 	 *
+	 * <p>Example:
+	 * <pre>
+	 * {@code
+	 *   tab.dropColumns($("a"), $("b"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 * <pre>
 	 * {@code
-	 *   tab.dropColumns('a, 'b)
+	 *   tab.dropColumns($"a", $"b")
 	 * }
 	 * </pre>
 	 */
@@ -997,19 +1254,30 @@ public interface Table {
 	 *   tab.map("func(c)");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #map(Expression)}
 	 */
+	@Deprecated
 	Table map(String mapFunction);
 
 	/**
 	 * Performs a map operation with an user-defined scalar function or built-in scalar function.
 	 * The output will be flattened if the output type is a composite type.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   ScalarFunction func = new MyMapFunction();
+	 *   tab.map(call(func, $("c")))
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   val func = new MyMapFunction()
-	 *   tab.map(func('c))
+	 *   tab.map(func($"c"))
 	 * }
 	 * </pre>
 	 */
@@ -1028,19 +1296,30 @@ public interface Table {
 	 *   table.flatMap("func(c)");
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #flatMap(Expression)}
 	 */
+	@Deprecated
 	Table flatMap(String tableFunction);
 
 	/**
 	 * Performs a flatMap operation with an user-defined table function or built-in table function.
 	 * The output will be flattened if the output type is a composite type.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableFunction func = new MyFlatMapFunction();
+	 *   tab.flatMap(call(func, $("c")))
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   val func = new MyFlatMapFunction
-	 *   table.flatMap(func('c))
+	 *   val func = new MyFlatMapFunction()
+	 *   tab.flatMap(func($"c"))
 	 * }
 	 * </pre>
 	 */
@@ -1061,7 +1340,9 @@ public interface Table {
 	 *     .select("f0, f1")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #aggregate(Expression)}
 	 */
+	@Deprecated
 	AggregatedTable aggregate(String aggregateFunction);
 
 	/**
@@ -1069,13 +1350,23 @@ public interface Table {
 	 * {@link #aggregate(Expression)} with a select statement. The output will be flattened if the
 	 * output type is a composite type.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
+	 *   tab.aggregate(call(aggFunc, $("a"), $("b")).as("f0", "f1", "f2"))
+	 *     .select($("f0"), $("f1"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
 	 *   val aggFunc = new MyAggregateFunction
-	 *   table.aggregate(aggFunc('a, 'b) as ('f0, 'f1, 'f2))
-	 *     .select('f0, 'f1)
+	 *   table.aggregate(aggFunc($"a", $"b") as ("f0", "f1", "f2"))
+	 *     .select($"f0", $"f1")
 	 * }
 	 * </pre>
 	 */
@@ -1095,20 +1386,32 @@ public interface Table {
 	 *     .select("x, y, z")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #flatAggregate(Expression)}
 	 */
+	@Deprecated
 	FlatAggregateTable flatAggregate(String tableAggregateFunction);
 
 	/**
 	 * Perform a global flatAggregate without groupBy. FlatAggregate takes a TableAggregateFunction
 	 * which returns multiple rows. Use a selection after the flatAggregate.
 	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
+	 *   tab.flatAggregate(call(tableAggFunc, $("a"), $("b")).as("x", "y", "z"))
+	 *     .select($("x"), $("y"), $("z"));
+	 * }
+	 * </pre>
+	 *
 	 * <p>Scala Example:
 	 *
 	 * <pre>
 	 * {@code
-	 *   val tableAggFunc = new MyTableAggregateFunction
-	 *   tab.flatAggregate(tableAggFunc('a, 'b) as ('x, 'y, 'z))
-	 *     .select('x, 'y, 'z)
+	 *   val tableAggFunc: TableAggregateFunction = new MyTableAggregateFunction
+	 *   tab.flatAggregate(tableAggFunc($"a", $"b") as ("x", "y", "z"))
+	 *     .select($"x", $"y", $"z")
 	 * }
 	 * </pre>
 	 */

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Tumble.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Tumble.java
@@ -53,7 +53,9 @@ public final class Tumble {
 	 *
 	 * @param size the size of the window as time or row-count interval.
 	 * @return a partially defined tumbling window
+	 * @deprecated use {@link #over(Expression)}
 	 */
+	@Deprecated
 	public static TumbleWithSize over(String size) {
 		return over(ExpressionParser.parseExpression(size));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TumbleWithSize.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TumbleWithSize.java
@@ -65,7 +65,9 @@ public final class TumbleWithSize {
 	 *
 	 * @param timeField time attribute for streaming and batch tables
 	 * @return a tumbling window on event-time
+	 * @deprecated use {@link #on(Expression)}
 	 */
+	@Deprecated
 	public TumbleWithSizeOnTime on(String timeField) {
 		return on(ExpressionParser.parseExpression(timeField));
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/WindowGroupedTable.java
@@ -38,12 +38,22 @@ public interface WindowGroupedTable {
 	 *   windowGroupedTable.select("key, window.start, value.avg as valavg")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #select(Expression...)}
 	 */
+	@Deprecated
 	Table select(String fields);
 
 	/**
 	 * Performs a selection operation on a window grouped table. Similar to an SQL SELECT statement.
 	 * The field expressions can contain complex expressions and aggregations.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   windowGroupedTable.select($("key"), $("window").start(), $("value").avg().as("valavg"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -71,13 +81,25 @@ public interface WindowGroupedTable {
 	 *     .select("key, window.start, x, y, z")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #aggregate(Expression)}
 	 */
+	@Deprecated
 	AggregatedTable aggregate(String aggregateFunction);
 
 	/**
 	 * Performs an aggregate operation on a window grouped table. You have to close the
 	 * {@link #aggregate(Expression)} with a select statement. The output will be flattened if the
 	 * output type is a composite type.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   AggregateFunction aggFunc = new MyAggregateFunction();
+	 *   windowGroupedTable.aggregate(call(aggFunc, $("a"), $("b")).as("x", "y", "z"))
+	 *     .select($("key"), $("window").start(), $("x"), $("y"), $("z"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *
@@ -107,12 +129,24 @@ public interface WindowGroupedTable {
 	 *     .select("key, window.start, x, y, z")
 	 * }
 	 * </pre>
+	 * @deprecated use {@link #flatAggregate(Expression)}
 	 */
+	@Deprecated
 	FlatAggregateTable flatAggregate(String tableAggregateFunction);
 
 	/**
 	 * Performs a flatAggregate operation on a window grouped table. FlatAggregate takes a
 	 * TableAggregateFunction which returns multiple rows. Use a selection after flatAggregate.
+	 *
+	 * <p>Example:
+	 *
+	 * <pre>
+	 * {@code
+	 *   TableAggregateFunction tableAggFunc = new MyTableAggregateFunction();
+	 *   windowGroupedTable.flatAggregate(call(tableAggFunc, $("a"), $("b")).as("x", "y", "z"))
+	 *     .select($("key"), $("window").start(), $("x"), $("y"), $("z"));
+	 * }
+	 * </pre>
 	 *
 	 * <p>Scala Example:
 	 *

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableImpl.java
@@ -45,12 +45,15 @@ import org.apache.flink.table.operations.utils.OperationExpressionsUtils;
 import org.apache.flink.table.operations.utils.OperationExpressionsUtils.CategorizedExpressions;
 import org.apache.flink.table.operations.utils.OperationTreeBuilder;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.table.api.Expressions.lit;
 
 /**
  * Implementation for {@link Table}.
@@ -156,8 +159,17 @@ public class TableImpl implements Table {
 	}
 
 	@Override
-	public Table as(String fields) {
-		List<Expression> fieldsExprs = ExpressionParser.parseExpressionList(fields);
+	public Table as(String field, String... fields) {
+		final List<Expression> fieldsExprs;
+		if (fields.length == 0 && operationTree.getTableSchema().getFieldCount() > 1) {
+			fieldsExprs = ExpressionParser.parseExpressionList(field);
+		} else {
+			fieldsExprs = new ArrayList<>();
+			fieldsExprs.add(lit(field));
+			for (String extraField : fields) {
+				fieldsExprs.add(lit(extraField));
+			}
+		}
 		return createTable(operationTreeBuilder.alias(fieldsExprs, operationTree));
 	}
 

--- a/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
+++ b/flink-table/flink-table-planner-blink/src/test/java/org/apache/flink/table/planner/runtime/stream/table/ValuesITCase.java
@@ -43,6 +43,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.apache.flink.table.api.Expressions.call;
+import static org.apache.flink.table.api.Expressions.range;
+import static org.apache.flink.table.api.Expressions.withColumns;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -291,7 +294,7 @@ public class ValuesITCase extends StreamingTestBase {
 
 		tEnv().createTemporaryFunction("func", new CustomScalarFunction());
 		Table t = tEnv().fromValues(data)
-			.select("func(f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, f13, f14, f15)");
+			.select(call("func", withColumns(range("f0", "f15"))));
 
 		TestCollectionTableFactory.reset();
 		tEnv().sqlUpdate(

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/join/TemporalJoinTest.scala
@@ -39,7 +39,7 @@ class TemporalJoinTest extends TableTestBase {
 
   val rates = util.addFunction(
     "Rates",
-    ratesHistory.createTemporalTableFunction("rowtime", "currency"))
+    ratesHistory.createTemporalTableFunction($"rowtime", $"currency"))
 
   @Test
   def testSimpleJoin(): Unit = {
@@ -69,7 +69,7 @@ class TemporalJoinTest extends TableTestBase {
 
     val ratesHistory = util.addDataStream[(Timestamp, String, String, Int, Int)](
       "RatesHistory", 'rowtime, 'comment, 'currency, 'rate, 'secondary_key)
-    val rates = ratesHistory.createTemporalTableFunction("rowtime", "currency")
+    val rates = ratesHistory.createTemporalTableFunction($"rowtime", $"currency")
     util.addFunction("Rates", rates)
 
     val sqlQuery =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/CalcTest.scala
@@ -104,7 +104,7 @@ class CalcTest extends TableTestBase {
 
     util.tableEnv.registerFunction("hashCode", MyHashCode)
 
-    val resultTable = sourceTable.select("hashCode(c), b")
+    val resultTable = sourceTable.select(call("hashCode", $"c"), $"b")
 
     util.verifyPlan(resultTable)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/SetOperatorsTest.scala
@@ -37,7 +37,7 @@ class SetOperatorsTest extends TableTestBase {
     val t = util.addTableSource[((Int, Int), String, (Int, Int))]("A", 'a, 'b, 'c)
 
     val elements = t.where('b === "two").select('a).as("a1")
-    val in = t.select("*").where('c.in(elements))
+    val in = t.select($"*").where('c.in(elements))
 
     util.verifyPlan(in)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/TemporalTableJoinTest.scala
@@ -46,9 +46,9 @@ class TemporalTableJoinTest extends TableTestBase {
     expectedException.expectMessage("Cannot generate a valid execution plan for the given query")
 
     val result = orders
-      .as('o_amount, 'o_currency, 'o_rowtime)
+      .as("o_amount", "o_currency", "o_rowtime")
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyPlan(result)
   }
@@ -60,11 +60,11 @@ class TemporalTableJoinTest extends TableTestBase {
       containsString("Cannot generate a valid execution plan"))
 
     val result = orders
-      .as('o_amount, 'o_currency, 'o_rowtime)
+      .as("o_amount", "o_currency", "o_rowtime")
       .joinLateral(
         rates(java.sql.Timestamp.valueOf("2016-06-27 10:10:42.123")),
         'o_currency === 'currency)
-      .select("o_amount * rate")
+      .select($"o_amount" * $"rate")
 
     util.verifyPlan(result)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/stringexpr/CalcStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/stringexpr/CalcStringExpressionTest.scala
@@ -177,7 +177,7 @@ class CalcStringExpressionTest extends TableTestBase {
   def testFilterOnCustomType(): Unit = {
     val util = batchTestUtil()
     val t = util.addTableSource[CustomType]("Table3",'myInt, 'myLong, 'myString)
-      .as('i, 'l, 's)
+      .as("i", "l", "s")
 
     val t1 = t.filter( 's.like("%a%") )
     val t2 = t.filter("s.like('%a%')")

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/stringexpr/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/stringexpr/SetOperatorsTest.scala
@@ -33,8 +33,8 @@ class SetOperatorsTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[((Int, Int), String, (Int, Int))]("A", 'a, 'b, 'c)
 
-    val elements = t.where("b === 'two'").select("a").as("a1")
-    val in = t.select("*").where('c.in(elements))
+    val elements = t.where("b === 'two'").select($"a").as("a1")
+    val in = t.select($"*").where('c.in(elements))
 
     util.verifyPlan(in)
   }
@@ -44,7 +44,7 @@ class SetOperatorsTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Timestamp, String)]("A", 'a, 'b, 'c)
 
-    val in = t.select("b.in('1972-02-22 07:12:00.333'.toTimestamp)").as("b2")
+    val in = t.select($"b" in ("1972-02-22 07:12:00.333".toTimestamp)).as("b2")
 
     util.verifyPlan(in)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/AggregateValidationTest.scala
@@ -119,7 +119,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.select("foo.avg")
+    t.select($"foo".avg)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -128,7 +128,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2",'b, 'c)
     // Must fail. Cannot compute SUM aggregate on String field.
-    t.select("c.sum")
+    t.select($"c".sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -137,7 +137,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2",'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
-    t.select("b.sum.sum")
+    t.select($"b".sum.sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -146,7 +146,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Long, String)]("Table2",'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
-    t.select("(b.sum + 1).sum")
+    t.select(($"b".sum + 1).sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -156,8 +156,8 @@ class AggregateValidationTest extends TableTestBase {
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
     // must fail. Field foo is not in input
-    t.groupBy("foo")
-    .select("a.avg")
+    t.groupBy($"foo")
+    .select($"a".avg)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -166,9 +166,9 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.groupBy("a, b")
+    t.groupBy($"a", $"b")
     // must fail. Field c is not a grouping key or aggregation
-    .select("c")
+    .select($"c")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -178,7 +178,7 @@ class AggregateValidationTest extends TableTestBase {
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
     // must fail. unknown is not known
-    t.select("unknown(c)")
+    t.select(call("unknown", $"c"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -187,9 +187,9 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTableSource[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.groupBy("a, b")
+    t.groupBy($"a", $"b")
     // must fail. unknown is not known
-    .select("unknown(c)")
+      .select(call("unknown", $"c"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -202,7 +202,7 @@ class AggregateValidationTest extends TableTestBase {
    util.addFunction("myWeightedAvg", myWeightedAvg)
 
     // must fail. UDAGG does not accept String type
-    t.select("myWeightedAvg(c, a)")
+    t.select(call("myWeightedAvg", $"c", $"a"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -214,8 +214,8 @@ class AggregateValidationTest extends TableTestBase {
     val myWeightedAvg = new WeightedAvgWithMergeAndReset
    util.addFunction("myWeightedAvg", myWeightedAvg)
 
-    t.groupBy("b")
+    t.groupBy($"b")
     // must fail. UDAGG does not accept String type
-    .select("myWeightedAvg(c, a)")
+    .select(call("myWeightedAvg", $"c", $"a"))
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/CalcValidationTest.scala
@@ -53,7 +53,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTableSource[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist
-    t.select("a + 1, foo + 2")
+    t.select($"a" + 1, $"foo" + 2)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -62,7 +62,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTableSource[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist
-    t.select("a + 1 as foo, b + 2 as foo")
+    t.select($"a" + 1 as "foo", $"b" + 2 as "foo")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -71,7 +71,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTableSource[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist.
-    t.filter("foo = 17")
+    t.filter($"foo" === 17)
   }
 
   @Test
@@ -94,7 +94,7 @@ class CalcValidationTest extends TableTestBase {
     }
 
     try {
-      util.addTableSource[(Int, Long, String)]("Table3").as('*, 'b, 'c)
+      util.addTableSource[(Int, Long, String)]("Table3").as("*", "b", "c")
       fail("ValidationException expected")
     } catch {
       case _: ValidationException => //ignore

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/batch/table/validation/JoinValidationTest.scala
@@ -114,7 +114,7 @@ class JoinValidationTest extends TableTestBase {
     val ds1 = CollectionBatchExecTable.getSmall3TupleDataSet(tEnv1, "a, b, c")
     val ds2 = CollectionBatchExecTable.get5TupleDataSet(tEnv2, "d, e, f, g, c")
     // Must fail. Tables are bound to different TableEnvironments.
-    ds1.join(ds2).where("a === d").select("g.count")
+    ds1.join(ds2).where($"a" === $"d").select($"g".count)
   }
 
   @Test(expected = classOf[TableException])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MiniBatchIntervalInferTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/MiniBatchIntervalInferTest.scala
@@ -160,7 +160,7 @@ class MiniBatchIntervalInferTest extends TableTestBase {
 
     util.addFunction(
       "Rates",
-      util.tableEnv.scan("RatesHistory").createTemporalTableFunction("rowtime", "b"))
+      util.tableEnv.scan("RatesHistory").createTemporalTableFunction($"rowtime", $"b"))
 
     val sqlQuery =
       """

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.scala
@@ -39,7 +39,7 @@ class TemporalJoinTest extends TableTestBase {
 
   util.addFunction(
     "Rates",
-    ratesHistory.createTemporalTableFunction("rowtime", "currency"))
+    ratesHistory.createTemporalTableFunction($"rowtime", $"currency"))
 
   private val proctimeOrders = util.addDataStream[(Long, String)](
     "ProctimeOrders", 'o_amount, 'o_currency, 'o_proctime.proctime)
@@ -49,7 +49,7 @@ class TemporalJoinTest extends TableTestBase {
 
   util.addFunction(
     "ProctimeRates",
-    proctimeRatesHistory.createTemporalTableFunction("proctime", "currency"))
+    proctimeRatesHistory.createTemporalTableFunction($"proctime", $"currency"))
 
   @Test
   def testSimpleJoin(): Unit = {
@@ -103,7 +103,7 @@ class TemporalJoinTest extends TableTestBase {
       "RatesHistory", 'rowtime.rowtime, 'comment, 'currency, 'rate, 'secondary_key)
     val rates = util.tableEnv
       .sqlQuery("SELECT * FROM RatesHistory WHERE rate > 110")
-      .createTemporalTableFunction("rowtime", "currency")
+      .createTemporalTableFunction($"rowtime", $"currency")
     util.addTemporarySystemFunction("Rates", rates)
 
     val sqlQuery =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CalcTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/CalcTest.scala
@@ -78,7 +78,7 @@ class CalcTest extends TableTestBase {
     val util = streamTestUtil()
     val sourceTable = util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val resultTable = sourceTable.select('a, 'b, 'c)
-      .where(s"${(1 to 30).map("b = " + _).mkString(" || ")} && c = 'xx'")
+      .where((1 to 30).map($"b" === _).reduce((ex1, ex2) => ex1 || ex2) && ($"c" === "xx"))
 
     util.verifyPlan(resultTable)
   }
@@ -88,7 +88,7 @@ class CalcTest extends TableTestBase {
     val util = streamTestUtil()
     val sourceTable = util.addTableSource[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val resultTable = sourceTable.select('a, 'b, 'c)
-      .where(s"${(1 to 30).map("b != " + _).mkString(" && ")} || c != 'xx'")
+      .where((1 to 30).map($"b" !== _).reduce((ex1, ex2) => ex1 && ex2) || ($"c" !== "xx"))
 
     util.verifyPlan(resultTable)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/ColumnFunctionsTest.scala
@@ -140,7 +140,7 @@ class ColumnFunctionsTest extends TableTestBase {
   @Test
   def testWindowGroupBy(): Unit = {
     val t = util.addDataStream[(Int, Long, String, Int)]("T1",'a, 'rowtime.rowtime, 'c, 'd)
-      .as('a, 'b, 'c, 'd)
+      .as("a", "b", "c", "d")
 
     val tab1 = t
       .window(Slide over 3.milli every 10.milli on withColumns('b) as 'w)

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableAggregateTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableAggregateTest.scala
@@ -64,7 +64,7 @@ class TableAggregateTest extends TableTestBase {
 
     val resultTable = table
       .flatAggregate(emptyFunc('b))
-      .select("*")
+      .select($"*")
 
     util.verifyPlan(resultTable)
   }
@@ -103,9 +103,9 @@ class TableAggregateTest extends TableTestBase {
     util.addFunction("func", func)
 
     val resultTable = table
-      .groupBy("c")
+      .groupBy($"c")
       .flatAggregate("func(a)")
-      .select("*")
+      .select($"*")
 
     util.verifyPlan(resultTable)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
@@ -46,7 +46,7 @@ class TableSourceTest extends TableTestBase {
       new TestTableSourceWithTime[Row](
         false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
-    val t = util.tableEnv.scan("rowTimeT").select("rowtime, id, name, val")
+    val t = util.tableEnv.scan("rowTimeT").select($"rowtime", $"id", $"name", $"val")
     util.verifyPlan(t)
   }
 
@@ -67,7 +67,7 @@ class TableSourceTest extends TableTestBase {
       new TestTableSourceWithTime[Row](
         false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
-    val t = util.tableEnv.scan("rowTimeT").select("rowtime, id, name, val")
+    val t = util.tableEnv.scan("rowTimeT").select($"rowtime", $"id", $"name", $"val")
     util.verifyPlan(t)
   }
 
@@ -89,7 +89,7 @@ class TableSourceTest extends TableTestBase {
         false, tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
     val t = util.tableEnv.scan("rowTimeT")
-      .filter("val > 100")
+      .where($"val" > 100)
       .window(Tumble over 10.minutes on 'rowtime as 'w)
       .groupBy('name, 'w)
       .select('name, 'w.end, 'val.avg)
@@ -112,7 +112,7 @@ class TableSourceTest extends TableTestBase {
       new TestTableSourceWithTime[Row](
         false, tableSchema, returnType, Seq(), proctime = "proctime"))
 
-    val t = util.tableEnv.scan("procTimeT").select("proctime, id, name, val")
+    val t = util.tableEnv.scan("procTimeT").select($"proctime", $"id", $"name", $"val")
     util.verifyPlan(t)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -54,17 +54,17 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaUtil.addFunction("func1", func1)
 
     var scalaTable = sTab.joinLateral(call("func1", 'c) as 's).select('c, 's)
-    var javaTable = jTab.joinLateral("func1(c).as(s)").select("c, s")
+    var javaTable = jTab.joinLateral(call("func1", $("c")).as("s")).select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test left outer join
     scalaTable = sTab.leftOuterJoinLateral(call("func1", 'c) as 's).select('c, 's)
-    javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select("c, s")
+    javaTable = jTab.leftOuterJoinLateral(call("func1", $("c")).as("s")).select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test overloading
     scalaTable = sTab.joinLateral(call("func1", 'c, "$") as 's).select('c, 's)
-    javaTable = jTab.joinLateral("func1(c, '$') as (s)").select("c, s")
+    javaTable = jTab.joinLateral(call("func1", $("c"), "$").as("s")).select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test custom result type
@@ -72,8 +72,9 @@ class CorrelateStringExpressionTest extends TableTestBase {
     javaUtil.addFunction("func2", func2)
     scalaUtil.addFunction("func2", func2)
     scalaTable = sTab.joinLateral(call("func2", 'c) as ('name, 'len)).select('c, 'name, 'len)
-    javaTable = jTab.joinLateral(
-      "func2(c).as(name, len)").select("c, name, len")
+    javaTable = jTab
+      .joinLateral(call("func2", $("c")).as("name", "len"))
+      .select($("c"), $("name"), $("len"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test hierarchy generic type
@@ -82,8 +83,9 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaUtil.addFunction("hierarchy", hierarchy)
     scalaTable = sTab.joinLateral(
       call("hierarchy", 'c) as ('name, 'adult, 'len)).select('c, 'name, 'len, 'adult)
-    javaTable = jTab.joinLateral("AS(hierarchy(c), name, adult, len)")
-      .select("c, name, len, adult")
+    javaTable = jTab
+      .joinLateral(call("hierarchy", $("c")).as("name", "adult", "len"))
+      .select($("c"), $("name"), $("len"), $("adult"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test pojo type
@@ -91,14 +93,14 @@ class CorrelateStringExpressionTest extends TableTestBase {
     javaUtil.addFunction("pojo", pojo)
     scalaUtil.addFunction("pojo", pojo)
     scalaTable = sTab.joinLateral(call("pojo", 'c)).select('c, 'name, 'age)
-    javaTable = jTab.joinLateral("pojo(c)").select("c, name, age")
+    javaTable = jTab.joinLateral(call("pojo", $("c"))).select($("c"), $("name"), $("age"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
     scalaTable = sTab.joinLateral(
       call("func2", 'c) as ('name, 'len)).select('c, 'name, 'len).filter('len > 2)
-    javaTable = jTab.joinLateral("func2(c) as (name, len)")
-      .select("c, name, len").filter("len > 2")
+    javaTable = jTab.joinLateral(call("func2", $("c")).as("name", "len"))
+      .select($("c"), $("name"), $("len")).filter($("len").isGreater(Int.box(2)))
     verifyTableEquals(scalaTable, javaTable)
   }
 
@@ -120,16 +122,16 @@ class CorrelateStringExpressionTest extends TableTestBase {
     val func1 = new TableFunc1
     scalaUtil.addFunction("func1", func1)
     javaUtil.addFunction("func1", func1)
-    var scalaTable = sTab.flatMap(call("func1", 'c)).as('s).select('s)
-    var javaTable = jTab.flatMap("func1(c)").as("s").select("s")
+    var scalaTable = sTab.flatMap(call("func1", 'c)).as("s").select('s)
+    var javaTable = jTab.flatMap(call("func1", $("c"))).as("s").select($("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test custom result type
     val func2 = new TableFunc2
     scalaUtil.addFunction("func2", func2)
     javaUtil.addFunction("func2", func2)
-    scalaTable = sTab.flatMap(call("func2", 'c)).as('name, 'len).select('name, 'len)
-    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len")
+    scalaTable = sTab.flatMap(call("func2", 'c)).as("name", "len").select('name, 'len)
+    javaTable = jTab.flatMap(call("func2", $("c"))).as("name, len").select($("name"), $("len"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test hierarchy generic type
@@ -137,9 +139,12 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaUtil.addFunction("hierarchy", hierarchy)
     javaUtil.addFunction("hierarchy", hierarchy)
     scalaTable = sTab.flatMap(call("hierarchy", 'c))
-      .as('name, 'adult, 'len)
+      .as("name", "adult", "len")
       .select('name, 'len, 'adult)
-    javaTable = jTab.flatMap("hierarchy(c)").as("name, adult, len").select("name, len, adult")
+    javaTable = jTab
+      .flatMap(call("hierarchy", $("c")))
+      .as("name", "adult", "len")
+      .select($("name"), $("len"), $("adult"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test pojo type
@@ -147,20 +152,24 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaUtil.addFunction("pojo", pojo)
     javaUtil.addFunction("pojo", pojo)
     scalaTable = sTab.flatMap(call("pojo", 'c)).select('name, 'age)
-    javaTable = jTab.flatMap("pojo(c)").select("name, age")
+    javaTable = jTab.flatMap(call("pojo", $("c"))).select($("name"), $("age"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
     scalaTable = sTab.flatMap(call("func2", 'c))
-      .as('name, 'len)
+      .as("name", "len")
       .select('name, 'len)
       .filter('len > 2)
-    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len").filter("len > 2")
+    javaTable = jTab
+      .flatMap(call("func2", $("c")))
+      .as("name", "len")
+      .select($("name"), $("len"))
+      .filter($("len").isGreater(Int.box(2)))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with scalar function
-    scalaTable = sTab.flatMap(call("func1", 'c.substring(2))).as('s).select('s)
-    javaTable = jTab.flatMap("func1(substring(c, 2))").as("s").select("s")
+    scalaTable = sTab.flatMap(call("func1", 'c.substring(2))).as("s").select('s)
+    javaTable = jTab.flatMap(call("func1", $("c").substring(Int.box(2)))).as("s").select($("s"))
     verifyTableEquals(scalaTable, javaTable)
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
@@ -89,7 +89,7 @@ class TableAggregateStringExpressionTest extends TableTestBase {
     // String / Java API
     val resJava = t
       .flatAggregate("top3(a) as (d, e)")
-      .select("*")
+      .select($"*")
 
     verifyTableEquals(resJava, resScala)
   }
@@ -113,7 +113,7 @@ class TableAggregateStringExpressionTest extends TableTestBase {
     val resJava = t
       .groupBy("b")
       .flatAggregate("top3(a) as (d, e)")
-      .select("*")
+      .select($"*")
 
     verifyTableEquals(resJava, resScala)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/AggregateValidationTest.scala
@@ -105,7 +105,7 @@ class AggregateValidationTest extends TableTestBase {
     table
       .groupBy('a)
       // must fail. Only AggregateFunction can be used in aggregate
-      .aggregate("func(c) as d")
+      .aggregate(call("func", $"c") as "d")
       .select('a, 'd)
   }
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CalcValidationTest.scala
@@ -137,7 +137,7 @@ class CalcValidationTest extends TableTestBase {
     util.addFunction("weightedAvg", new WeightedAvg)
     util.addTableSource[(Int)](
       "MyTable", 'int)
-      .map("weightedAvg(int, int)") // do not support AggregateFunction as input
+      .map(call("weightedAvg", $"int", $"int")) // do not support AggregateFunction as input
   }
 
   @Test(expected = classOf[ValidationException])
@@ -147,6 +147,6 @@ class CalcValidationTest extends TableTestBase {
     util.addFunction("func", new TableFunc0)
     util.addTableSource[(String)](
       "MyTable", 'string)
-      .map("func(string) as a") // do not support TableFunction as input
+      .map(call("func", $"string") as "a") // do not support TableFunction as input
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/CorrelateValidationTest.scala
@@ -58,7 +58,7 @@ class CorrelateValidationTest extends TableTestBase {
     //============ throw exception when table function is not registered =========
     // Java Table API call
     expectExceptionThrown(
-      t.joinLateral("nonexist(a)"), "Undefined function: nonexist")
+      t.joinLateral(call("nonexist", $"a")), "Undefined function: nonexist")
     // SQL API call
     expectExceptionThrown(
       util.tableEnv.sqlQuery("SELECT * FROM MyTable, LATERAL TABLE(nonexist(a))"),
@@ -79,7 +79,7 @@ class CorrelateValidationTest extends TableTestBase {
     // Java Table API call
     util.addFunction("func2", new TableFunc2)
     expectExceptionThrown(
-      t.joinLateral("func2(c, c)"),
+      t.joinLateral(call("func2", $"c", $"c")),
       "Given parameters of function 'func2' do not match any signature")
     // SQL API call
     expectExceptionThrown(
@@ -130,7 +130,7 @@ class CorrelateValidationTest extends TableTestBase {
     util.addFunction("weightedAvg", new WeightedAvg)
     util.addTableSource[(Int)](
       "MyTable", 'int)
-      .flatMap("weightedAvg(int, int)") // do not support AggregateFunction as input
+      .flatMap(call("weightedAvg", $"int", $"int")) // do not support AggregateFunction as input
   }
 
   @Test(expected = classOf[ValidationException])

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TemporalTableJoinValidationTest.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/plan/stream/table/validation/TemporalTableJoinValidationTest.scala
@@ -59,7 +59,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage("Cannot resolve field [foobar]")
 
-    ratesHistory.createTemporalTableFunction("rowtime", "foobar")
+    ratesHistory.createTemporalTableFunction($"rowtime", $"foobar")
   }
 
   @Test
@@ -72,7 +72,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = orders
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyExplain(result)
   }
@@ -87,7 +87,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = ordersWithoutTimeAttribute
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyExplain(result)
   }
@@ -103,7 +103,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = ordersProctime
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyExplain(result)
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/CorrelateITCase.scala
@@ -38,7 +38,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testCrossJoin(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val func1 = new TableFunc1
     val result = in.joinLateral(func1('c) as 's).select('c, 's)
@@ -57,7 +57,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testLeftOuterJoinWithoutPredicates(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in.leftOuterJoinLateral(func2('c) as ('s, 'l)).select('c, 's, 'l)
@@ -70,7 +70,7 @@ class CorrelateITCase extends BatchTestBase {
   @Test
   def testLeftOuterJoinWithSplit(): Unit = {
     tEnv.getConfig.setMaxGeneratedCodeLength(1) // split every field
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in.leftOuterJoinLateral(func2('c) as ('s, 'l)).select('c, 's, 'l)
@@ -85,7 +85,7 @@ class CorrelateITCase extends BatchTestBase {
     */
   @Test (expected = classOf[ValidationException])
   def testLeftOuterJoinWithPredicates(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in
@@ -98,7 +98,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testWithFilter(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -114,7 +114,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testCustomReturnType(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func2 = new TableFunc2
 
     val result = in
@@ -130,7 +130,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testHierarchyType(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val hierarchy = new HierarchyTableFunction
     val result = in
@@ -146,7 +146,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testPojoType(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
 
     val pojo = new PojoTableFunc()
     val result = in
@@ -162,7 +162,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func1 = new TableFunc1
 
     val result = in
@@ -178,7 +178,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testUserDefinedTableFunctionWithScalarFunctionInCondition(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -194,7 +194,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testLongAndTemporalTypes(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func0 = new JavaTableFunc0
 
     val result = in
@@ -212,7 +212,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testByteShortFloatArguments(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val tFunc = new TableFunc4
 
     val result = in.select(
@@ -266,7 +266,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
     val func32 = new TableFunc3("TwoConf_")
@@ -322,7 +322,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testCountStarOnCorrelate(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -336,7 +336,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testCountStarOnLeftCorrelate(): Unit = {
-    val in = testData.as('a, 'b, 'c)
+    val in = testData.as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -350,7 +350,7 @@ class CorrelateITCase extends BatchTestBase {
 
   @Test
   def testTableFunctionCollectorOpenClose(): Unit = {
-    val t = testData.as('a, 'b, 'c)
+    val t = testData.as("a", "b", "c")
     val func0 = new TableFunc0
     val func = new FuncWithOpen
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
@@ -204,7 +204,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('a === 'f0).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('a === 'f0).select(1.count),
       Seq(LONG),
       s1r(1L))
   }
@@ -217,7 +217,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('a === 'f1).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('a === 'f1).select(1.count),
       Seq(LONG),
       s1r(1L))
   }
@@ -230,7 +230,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('b === 'f0).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('b === 'f0).select(1.count),
       Seq(LONG),
       s1r(1L))
 
@@ -244,7 +244,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('a === 'f2).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('a === 'f2).select(1.count),
       Seq(LONG),
       s1r(1L))
   }
@@ -257,7 +257,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('c === 'f0).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('c === 'f0).select(1.count),
       Seq(LONG),
       s1r(1L))
   }
@@ -270,7 +270,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('a === 'f3).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('a === 'f3).select(1.count),
       Seq(LONG),
       s1r(1L))
   }
@@ -282,7 +282,7 @@ class DecimalITCase extends BatchTestBase {
     checkQuery(
       Seq(DECIMAL(8, 2), DECIMAL(8, 4), INT, DOUBLE),
       s1r(d"1", d"1", 1, 1.0),
-      table => table.as('a, 'b, 'c, 'd).join(table).where('a === 'f3).select(1.count),
+      table => table.as("a", "b", "c", "d").join(table).where('a === 'f3).select(1.count),
       Seq(LONG),
       s1r(1L))
   }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/JoinITCase.scala
@@ -73,8 +73,8 @@ class JoinITCase extends BatchTestBase {
 
   @Test
   def testJoinWithFilter(): Unit = {
-    val ds1 = CollectionBatchExecTable.getSmall3TupleDataSet(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionBatchExecTable.get5TupleDataSet(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionBatchExecTable.getSmall3TupleDataSet(tEnv).as("a", "b", "c")
+    val ds2 = CollectionBatchExecTable.get5TupleDataSet(tEnv).as("d", "e", "f", "g", "h")
 
     val joinT = ds1.join(ds2).where('b === 'e && 'b < 2).select('c, 'g)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AggregateITCase.scala
@@ -608,7 +608,7 @@ class AggregateITCase(
     data.+=((8, 4L, null))
     val sqlQuery = "SELECT b, LISTAGG(DISTINCT c, '#') FROM MyTable GROUP BY b"
     tEnv.registerTable("MyTable",
-      failingDataSource(data).toTable(tEnv).as('a, 'b, 'c))
+      failingDataSource(data).toTable(tEnv).as("a", "b", "c"))
     val sink = new TestingRetractSink
     tEnv.sqlQuery(sqlQuery).toRetractStream[Row].addSink(sink).setParallelism(1)
     env.execute()
@@ -1164,7 +1164,7 @@ class AggregateITCase(
 
   @Test
   def testDistinctWithMultiFilter(): Unit = {
-    val t = failingDataSource(TestData.tupleData3).toTable(tEnv).as('a, 'b, 'c)
+    val t = failingDataSource(TestData.tupleData3).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery =

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -88,7 +88,7 @@ class TemporalJoinITCase(state: StateBackendMode)
     tEnv.registerTable("RatesHistory", ratesHistory)
     tEnv.registerFunction(
       "Rates",
-      ratesHistory.createTemporalTableFunction("proctime", "currency"))
+      ratesHistory.createTemporalTableFunction($"proctime", $"currency"))
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
     result.addSink(new TestingAppendSink)
@@ -146,7 +146,7 @@ class TemporalJoinITCase(state: StateBackendMode)
       "Rates",
       tEnv
         .scan("FilteredRatesHistory")
-        .createTemporalTableFunction("rowtime", "currency"))
+        .createTemporalTableFunction($"rowtime", $"currency"))
     tEnv.registerTable("TemporalJoinResult", tEnv.sqlQuery(sqlQuery))
 
     // Scan from registered table to test for interplay between
@@ -215,10 +215,10 @@ class TemporalJoinITCase(state: StateBackendMode)
     tEnv.createTemporaryView("RatesHistory", ratesHistory)
     tEnv.createTemporarySystemFunction(
       "Rates",
-      ratesHistory.createTemporalTableFunction("rowtime", "currency"))
+      ratesHistory.createTemporalTableFunction($"rowtime", $"currency"))
     tEnv.registerFunction(
       "Prices",
-      pricesHistory.createTemporalTableFunction("rowtime", "productId"))
+      pricesHistory.createTemporalTableFunction($"rowtime", $"productId"))
 
     tEnv.createTemporaryView("TemporalJoinResult", tEnv.sqlQuery(sqlQuery))
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/CorrelateITCase.scala
@@ -42,7 +42,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testCrossJoin(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
     val pojoFunc0 = new PojoTableFunc()
 
@@ -64,7 +64,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testLeftOuterJoinWithoutPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -87,7 +87,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     */
   @Test (expected = classOf[ValidationException])
   def testLeftOuterJoinWithPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -106,7 +106,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -173,7 +173,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val config = Map("key1" -> "value1", "key2" -> "value2")
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
@@ -273,7 +273,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     )
 
     val rowType = Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
-    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as('a, 'b, 'c)
+    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as("a", "b", "c")
 
     val tableFunc = new TableFunc6()
     val result = in
@@ -292,7 +292,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testTableFunctionCollectorOpenClose(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
     val func26 = new FuncWithOpen
     tEnv.registerFunction("func26", func26)
@@ -317,7 +317,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testTableFunctionCollectorInit(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     // this case will generate 'timestamp' member field and 'DateFormatter'
@@ -343,7 +343,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
       .select('f0, 'f1)
       // test the output field name of flatMap is the same as the field name of the input table
       .flatMap(func2(concat('f0, "#")))
-      .as ('f0, 'f1)
+      .as ("f0", "f1")
       .select('f0, 'f1)
 
     val sink = new TestingAppendSink
@@ -372,7 +372,7 @@ class CorrelateITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     )
 
     val rowType = Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
-    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as('a, 'b, 'c)
+    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as("a", "b", "c")
     val result = in.select(rf('a) as 'd).joinLateral(tf('d) as 'e)
 
     val sink = new TestingAppendSink

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverWindowITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/OverWindowITCase.scala
@@ -19,8 +19,9 @@
 package org.apache.flink.table.planner.runtime.stream.table
 
 import org.apache.flink.api.scala._
+import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.scala._
-import org.apache.flink.table.api.{DataTypes, Over}
+import org.apache.flink.table.api.{DataTypes, Expressions, Over}
 import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions.{CountDistinct, CountDistinctWithRetractAndReset, WeightedAvg}
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions.JavaFunc0
 import org.apache.flink.table.planner.runtime.utils.StreamingWithStateTestBase.StateBackendMode
@@ -261,12 +262,12 @@ class OverWindowITCase(mode: StateBackendMode) extends StreamingWithStateTestBas
     val stream = failingDataSource(data)
     val table = stream.toTable(tEnv, 'a, 'b, 'c, 'd, 'e, 'proctime.proctime)
 
-    val windowedTable = table.select("a, b, c, d, e, proctime")
+    val windowedTable = table.select($"a", $"b", $"c", $"d", $"e", $"proctime")
       .window(Over
-        .partitionBy("a")
-        .orderBy("proctime")
-        .preceding("4.rows")
-        .following("CURRENT_ROW")
+        .partitionBy($("a"))
+        .orderBy($("proctime"))
+        .preceding(Expressions.rowInterval(4L))
+        .following(Expressions.CURRENT_ROW)
         .as("w"))
       .select('a, 'c.sum over 'w, 'c.min over 'w, countDist('e) over 'w)
 

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/table/TableAggregateITCase.scala
@@ -52,7 +52,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .flatAggregate(top3('a))
       .select('b, 'f0, 'f1)
-      .as('category, 'v1, 'v2)
+      .as("category", "v1", "v2")
 
     val sink = new TestingRetractSink()
     resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
@@ -86,7 +86,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
     val resultTable = source
       .flatAggregate(top3('a))
       .select('f0, 'f1)
-      .as('v1, 'v2)
+      .as("v1", "v2")
 
     val sink = new TestingRetractSink()
     resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)
@@ -108,7 +108,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .flatAggregate(top3('a))
       .select('b, 'f0, 'f1)
-      .as('category, 'v1, 'v2)
+      .as("category", "v1", "v2")
       .groupBy('category)
       .select('category, 'v1.max)
 
@@ -135,7 +135,7 @@ class TableAggregateITCase(mode: StateBackendMode) extends StreamingWithStateTes
       .groupBy('b)
       .flatAggregate(top3('a))
       .select('b, 'f0, 'f1)
-      .as('category, 'v1, 'v2)
+      .as("category", "v1", "v2")
 
     val sink = new TestingRetractSink()
     resultTable.toRetractStream[Row].addSink(sink).setParallelism(1)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/ViewExpansionTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/catalog/ViewExpansionTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.ExpectedException;
 
 import scala.Some;
 
+import static org.apache.flink.table.api.Expressions.$;
 import static org.apache.flink.table.catalog.CatalogStructureBuilder.database;
 import static org.apache.flink.table.catalog.CatalogStructureBuilder.root;
 import static org.apache.flink.table.catalog.CatalogStructureBuilder.table;
@@ -106,7 +107,7 @@ public class ViewExpansionTest {
 			).build();
 
 		StreamTableTestUtil util = new StreamTableTestUtil(new Some<>(catalogManager));
-		Table tab = util.javaTableEnv().scan("builtin", "default", "view").select("*");
+		Table tab = util.javaTableEnv().scan("builtin", "default", "view").select($("*"));
 		util.verifyJavaTable(
 			tab,
 			source("builtin", "default", "tab1"));
@@ -138,7 +139,7 @@ public class ViewExpansionTest {
 			).build();
 
 		StreamTableTestUtil util = new StreamTableTestUtil(new Some<>(catalogManager));
-		Table tab = util.javaTableEnv().scan("builtin", "default", "view").select("*");
+		Table tab = util.javaTableEnv().scan("builtin", "default", "view").select($("*"));
 		final String expected = "DataStreamCalc(select=[a, b, CAST(EXPR$2) AS c])\n"
 			+ "DataStreamGroupAggregate(groupBy=[a, b], select=[a, b, COUNT(c) AS EXPR$2])\n"
 			+ "StreamTableSourceScan(table=[[builtin, default, tab1]], fields=[a, b, c], source=[isTemporary=[false]])";
@@ -195,7 +196,7 @@ public class ViewExpansionTest {
 
 		tableEnv.useCatalog("builtin");
 		tableEnv.useDatabase("default");
-		Table tab = tableEnv.scan("builtin", "different", "view").select("*");
+		Table tab = tableEnv.scan("builtin", "different", "view").select($("*"));
 
 		//Note: even though default path is set to builtin.default, the default path for view expansion
 		//is the path of the view.
@@ -235,7 +236,7 @@ public class ViewExpansionTest {
 
 		tableEnv.useCatalog("builtin");
 		tableEnv.useDatabase("default");
-		Table tab = tableEnv.scan("different_cat", "different_db", "view").select("*");
+		Table tab = tableEnv.scan("different_cat", "different_db", "view").select($("*"));
 
 		//Note: even though default path is set to builtin.default, the default catalog for the view expansion
 		//is the catalog of the view.

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/JavaTableSourceITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/JavaTableSourceITCase.java
@@ -33,6 +33,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.List;
 
+import static org.apache.flink.table.api.Expressions.$;
+
 /**
  * Integration tests for {@link BatchTableSource}.
  */
@@ -53,7 +55,7 @@ public class JavaTableSourceITCase extends TableProgramsCollectionTestBase {
 		tableEnv.registerTableSource("persons", csvTable);
 
 		Table result = tableEnv.scan("persons")
-			.select("id, first, last, score");
+			.select($("id"), $("first"), $("last"), $("score"));
 
 		DataSet<Row> resultSet = tableEnv.toDataSet(result, Row.class);
 		List<Row> results = resultSet.collect();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
@@ -322,7 +322,7 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 					TypeInformation.of(new TypeHint<Either<String, Integer>>() { })
 				),
 				$("either"))
-			.select("either");
+			.select($("either"));
 
 		DataSet<Row> ds = tableEnv.toDataSet(table, Row.class);
 		List<Row> results = ds.collect();

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableSourceTest.scala
@@ -50,8 +50,8 @@ class TableSourceTest extends TableTestBase {
     tableEnv.registerTableSource("table1", tableSource1)
     tableEnv.registerTableSource("table2", tableSource2)
 
-    val table1 = tableEnv.scan("table1").where("amount > 2")
-    val table2 = tableEnv.scan("table2").where("amount > 2")
+    val table1 = tableEnv.scan("table1").where($"amount" > 2)
+    val table2 = tableEnv.scan("table2").where($"amount" > 2)
     val result = table1.unionAll(table2)
 
     val expected = binaryNode(
@@ -163,7 +163,7 @@ class TableSourceTest extends TableTestBase {
     val result = tableEnv
         .scan(tableName)
         .select('price, 'id, 'amount)
-        .where("price * 2 < 32")
+        .where($"price" * 2 < 32)
 
     val expected = unaryNode(
       "DataSetCalc",
@@ -189,7 +189,7 @@ class TableSourceTest extends TableTestBase {
 
     val result = tableEnv
       .scan(tableName)
-      .where("amount > 2 && price * 2 < 32")
+      .where($"amount" > 2 && $"price" * 2 < 32)
       .select('price, 'name.lowerCase(), 'amount)
 
     val expected = unaryNode(
@@ -216,7 +216,7 @@ class TableSourceTest extends TableTestBase {
     val result = tableEnv
         .scan(tableName)
         .select('price, 'id, 'amount)
-        .where("amount > 2 && amount < 32")
+        .where($"amount" > 2 && $"amount" < 32)
 
     val expected = batchFilterableSourceTableNode(
       tableName,
@@ -237,8 +237,8 @@ class TableSourceTest extends TableTestBase {
     val result = tableEnv
         .scan(tableName)
         .select('price, 'id, 'amount)
-        .where("amount > 2 && id < 1.2 && " +
-          "(amount < 32 || amount.cast(LONG) > 10)") // cast can not be converted
+        .where($"amount" > 2 && $"id" < 1.2 &&
+          ($"amount" < 32 || $"amount".cast(Types.LONG) > 10)) // cast can not be converted
 
     val expected = unaryNode(
       "DataSetCalc",
@@ -266,7 +266,7 @@ class TableSourceTest extends TableTestBase {
     val result = tableEnv
         .scan(tableName)
         .select('price, 'id, 'amount)
-        .where("amount > 2 && func0(amount) < 32")
+        .where($"amount" > 2 && call("func0", $"amount") < 32)
 
     val expected = unaryNode(
       "DataSetCalc",
@@ -350,7 +350,7 @@ class TableSourceTest extends TableTestBase {
     val result = tableEnv
       .scan(tableName)
       .select('price, 'id, 'amount)
-      .where("amount > 2 && price * 2 < 32")
+      .where($"amount" > 2 && $"price" * 2 < 32)
 
     val expected = unaryNode(
       "DataStreamCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/ExplainTest.scala
@@ -38,7 +38,7 @@ class ExplainTest
     val tEnv = BatchTableEnvironment.create(env)
 
     val scan = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
-    val table = scan.filter("a % 2 = 0")
+    val table = scan.filter($"a" % 2 === 0)
 
     val result = tEnv.explain(table).replaceAll("\\r\\n", "\n")
     val source = scala.io.Source.fromFile(testFilePath +
@@ -54,7 +54,7 @@ class ExplainTest
     val tEnv = BatchTableEnvironment.create(env)
 
     val scan = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
-    val table = scan.filter("a % 2 = 0")
+    val table = scan.filter($"a" % 2 === 0)
 
     val result = tEnv.asInstanceOf[BatchTableEnvironmentImpl]
       .explain(table, extended = true).replaceAll("\\r\\n", "\n")
@@ -72,7 +72,7 @@ class ExplainTest
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'c, 'd)
-    val table = table1.join(table2).where("b = d").select("a, c")
+    val table = table1.join(table2).where($"b" === $"d").select($"a", $"c")
 
     val result = tEnv.explain(table).replaceAll("\\r\\n", "\n")
     val source = scala.io.Source.fromFile(testFilePath +
@@ -89,7 +89,7 @@ class ExplainTest
 
     val table1 = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
     val table2 = env.fromElements((1, "hello")).toTable(tEnv, 'c, 'd)
-    val table = table1.join(table2).where("b = d").select("a, c")
+    val table = table1.join(table2).where($"b" === $"d").select($"a", $"c")
 
     val result = tEnv.asInstanceOf[BatchTableEnvironmentImpl]
       .explain(table, extended = true).replaceAll("\\r\\n", "\n")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/CalcTest.scala
@@ -202,7 +202,7 @@ class CalcTest extends TableTestBase {
 
     util.tableEnv.registerFunction("hashCode", MyHashCode)
 
-    val resultTable = sourceTable.select("hashCode(c), b")
+    val resultTable = sourceTable.select(call("hashCode", $"c"), $"b")
 
     val expected = unaryNode(
       "DataSetCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/SetOperatorsTest.scala
@@ -39,7 +39,7 @@ class SetOperatorsTest extends TableTestBase {
     val t = util.addTable[((Int, Int), String, (Int, Int))]("A", 'a, 'b, 'c)
 
     val elements = t.where('b === "two").select('a).as("a1")
-    val in = t.select("*").where('c.in(elements))
+    val in = t.select($"*").where('c.in(elements))
 
     val expected = unaryNode(
       "DataSetCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/TemporalTableJoinTest.scala
@@ -47,7 +47,7 @@ class TemporalTableJoinTest extends TableTestBase {
 
     val result = orders
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.printTable(result)
   }
@@ -61,7 +61,7 @@ class TemporalTableJoinTest extends TableTestBase {
       .joinLateral(
         rates(java.sql.Timestamp.valueOf("2016-06-27 10:10:42.123")),
         'o_currency === 'currency)
-      .select("o_amount * rate")
+      .select($"o_amount" * $"rate")
 
     util.printTable(result)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -56,12 +56,12 @@ class CorrelateStringExpressionTest extends TableTestBase {
 
     // test left outer join
     scalaTable = sTab.leftOuterJoinLateral(func1('c) as 's).select('c, 's)
-    javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select("c, s")
+    javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test overloading
     scalaTable = sTab.joinLateral(func1('c, "$") as 's).select('c, 's)
-    javaTable = jTab.joinLateral("func1(c, '$') as (s)").select("c, s")
+    javaTable = jTab.joinLateral("func1(c, '$') as (s)").select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test custom result type
@@ -69,7 +69,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     util.javaTableEnv.registerFunction("func2", func2)
     scalaTable = sTab.joinLateral(func2('c) as('name, 'len)).select('c, 'name, 'len)
     javaTable = jTab.joinLateral(
-      "func2(c).as(name, len)").select("c, name, len")
+      "func2(c).as(name, len)").select($("c"), $("name"), $("len"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test hierarchy generic type
@@ -78,27 +78,27 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaTable = sTab.joinLateral(
       hierarchy('c) as('name, 'adult, 'len)).select('c, 'name, 'len, 'adult)
     javaTable = jTab.joinLateral("AS(hierarchy(c), name, adult, len)")
-      .select("c, name, len, adult")
+      .select($("c"), $("name"), $("len"), $("adult"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test pojo type
     val pojo = new PojoTableFunc
     util.javaTableEnv.registerFunction("pojo", pojo)
     scalaTable = sTab.joinLateral(pojo('c)).select('c, 'name, 'age)
-    javaTable = jTab.joinLateral("pojo(c)").select("c, name, age")
+    javaTable = jTab.joinLateral("pojo(c)").select($("c"), $("name"), $("age"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
     scalaTable = sTab.joinLateral(
       func2('c) as('name, 'len)).select('c, 'name, 'len).filter('len > 2)
     javaTable = jTab.joinLateral("func2(c) as (name, len)")
-      .select("c, name, len").filter("len > 2")
+      .select($("c"), $("name"), $("len")).filter($("len").isGreater(Int.box(2)))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with scalar function
     scalaTable = sTab.joinLateral(func1('c.substring(2)) as 's).select('a, 'c, 's)
     javaTable = jTab.joinLateral(
-      "func1(substring(c, 2)) as (s)").select("a, c, s")
+      "func1(substring(c, 2)) as (s)").select($("a"), $("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/stringexpr/SetOperatorsTest.scala
@@ -34,7 +34,7 @@ class SetOperatorsTest extends TableTestBase {
     val t = util.addTable[((Int, Int), String, (Int, Int))]("A", 'a, 'b, 'c)
 
     val elements = t.where("b === 'two'").select("a").as("a1")
-    val in = t.select("*").where(s"c.in($elements)")
+    val in = t.select($"*").where(s"c.in($elements)")
 
     val expected = unaryNode(
       "DataSetCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/AggregateValidationTest.scala
@@ -118,7 +118,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.select("foo.avg")
+    t.select($"foo".avg)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -127,7 +127,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Long, String)]("Table2",'b, 'c)
     // Must fail. Cannot compute SUM aggregate on String field.
-    t.select("c.sum")
+    t.select($"c".sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -136,7 +136,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Long, String)]("Table2",'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
-    t.select("b.sum.sum")
+    t.select($"b".sum.sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -145,7 +145,7 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Long, String)]("Table2",'b, 'c)
     // Must fail. Aggregation on aggregation not allowed.
-    t.select("(b.sum + 1).sum")
+    t.select(($"b".sum + 1).sum)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -155,8 +155,8 @@ class AggregateValidationTest extends TableTestBase {
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
     // must fail. Field foo is not in input
-    t.groupBy("foo")
-    .select("a.avg")
+    t.groupBy($"foo")
+    .select($"a".avg)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -165,9 +165,9 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.groupBy("a, b")
+    t.groupBy($"a", $"b")
     // must fail. Field c is not a grouping key or aggregation
-    .select("c")
+    .select($"c")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -177,7 +177,7 @@ class AggregateValidationTest extends TableTestBase {
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
     // must fail. unknown is not known
-    t.select("unknown(c)")
+    .select(call("unknown", $"c"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -186,9 +186,9 @@ class AggregateValidationTest extends TableTestBase {
     val util = batchTestUtil()
     val t = util.addTable[(Int, Long, String)]("Table3", 'a, 'b, 'c)
 
-    t.groupBy("a, b")
+    t.groupBy($"a", $"b")
     // must fail. unknown is not known
-    .select("unknown(c)")
+    .select(call("unknown", $"c"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -201,7 +201,7 @@ class AggregateValidationTest extends TableTestBase {
     util.tableEnv.registerFunction("myWeightedAvg", myWeightedAvg)
 
     // must fail. UDAGG does not accept String type
-    t.select("myWeightedAvg(c, a)")
+    t.select(call("myWeightedAvg", $"c", $"a"))
   }
 
   @Test(expected = classOf[ValidationException])
@@ -213,8 +213,8 @@ class AggregateValidationTest extends TableTestBase {
     val myWeightedAvg = new WeightedAvgWithMergeAndReset
     util.tableEnv.registerFunction("myWeightedAvg", myWeightedAvg)
 
-    t.groupBy("b")
+    t.groupBy($"b")
     // must fail. UDAGG does not accept String type
-    .select("myWeightedAvg(c, a)")
+    t.select(call("myWeightedAvg", $"c", $"a"))
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/CalcValidationTest.scala
@@ -69,7 +69,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist
-    t.select("a + 1, foo + 2")
+    t.select($"a" + 1, $"foo" + 2)
   }
 
   @Test(expected = classOf[ValidationException])
@@ -78,7 +78,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist
-    t.select("a + 1 as foo, b + 2 as foo")
+    t.select($"a" + 1 as "foo", $"b" + 2 as "foo")
   }
 
   @Test(expected = classOf[ValidationException])
@@ -87,7 +87,7 @@ class CalcValidationTest extends TableTestBase {
     val t = util.addTable[(Int, Long, String)]("Table3",'a, 'b, 'c)
 
     // Must fail. Field foo does not exist.
-    t.filter("foo = 17")
+    t.filter($"foo" === 17)
   }
 
   @Test
@@ -110,7 +110,7 @@ class CalcValidationTest extends TableTestBase {
     }
 
     try {
-      util.addTable[(Int, Long, String)]("Table3").as('*, 'b, 'c)
+      util.addTable[(Int, Long, String)]("Table3").as("*", "b", "c")
       fail("ValidationException expected")
     } catch {
       case _: ValidationException => //ignore

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/batch/table/validation/JoinValidationTest.scala
@@ -142,6 +142,6 @@ class JoinValidationTest extends TableTestBase {
     val in1 = tEnv1.fromDataSet(ds1, 'a, 'b, 'c)
     val in2 = tEnv2.fromDataSet(ds2, 'd, 'e, 'f, 'g, 'c)
     // Must fail. Tables are bound to different TableEnvironments.
-    in1.join(in2).where("a === d").select("g.count")
+    in1.join(in2).where($"a" === $"d").select($"g".count)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/ExplainTest.scala
@@ -39,7 +39,7 @@ class ExplainTest extends AbstractTestBase {
     val tEnv = StreamTableEnvironment.create(env, settings)
 
     val scan = env.fromElements((1, "hello")).toTable(tEnv, 'a, 'b)
-    val table = scan.filter("a % 2 = 0")
+    val table = scan.filter($"a" % 2 === 0)
 
     val result = replaceString(tEnv.explain(table))
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/InsertIntoValidationTest.scala
@@ -35,7 +35,7 @@ class InsertIntoValidationTest {
 
   @Test(expected = classOf[ValidationException])
   def testInconsistentLengthInsert(): Unit = {
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e")
@@ -53,7 +53,7 @@ class InsertIntoValidationTest {
 
   @Test(expected = classOf[ValidationException])
   def testUnmatchedTypesInsert(): Unit = {
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")
@@ -71,7 +71,7 @@ class InsertIntoValidationTest {
 
   @Test(expected = classOf[ValidationException])
   def testUnsupportedPartialInsert(): Unit = {
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/sql/validation/JoinValidationTest.scala
@@ -179,7 +179,7 @@ class JoinValidationTest extends TableTestBase {
 
     val left = util.tableEnv.sqlQuery(sql1)
     val right = util.tableEnv.sqlQuery(sql2)
-    val result = left.join(right).where("id === r_id && t1 === t2").select("id, t1")
+    val result = left.join(right).where($"id" === $"r_id" && $"t1" === $"t2").select($"id", $"t1")
 
     util.verifyTable(result, "n/a")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CalcTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/CalcTest.scala
@@ -111,7 +111,7 @@ class CalcTest extends TableTestBase {
     val util = streamTestUtil()
     val sourceTable = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val resultTable = sourceTable.select('a, 'b, 'c)
-      .where(s"${(1 to 30).map("b = " + _).mkString(" || ")} && c = 'xx'")
+      .where((1 to 30).map($"b" === _).reduce((ex1, ex2) => ex1 || ex2) && ($"c" === "xx"))
 
     val expected = unaryNode(
       "DataStreamCalc",
@@ -128,7 +128,7 @@ class CalcTest extends TableTestBase {
     val util = streamTestUtil()
     val sourceTable = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val resultTable = sourceTable.select('a, 'b, 'c)
-      .where(s"${(1 to 30).map("b != " + _).mkString(" && ")} || c != 'xx'")
+      .where((1 to 30).map($"b" !== _).reduce((ex1, ex2) => ex1 && ex2) || ($"c" !== "xx"))
 
     val expected = unaryNode(
       "DataStreamCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableAggregateTest.scala
@@ -111,7 +111,7 @@ class TableAggregateTest extends TableTestBase {
 
     val resultTable = table
       .flatAggregate(emptyFunc('b))
-      .select("*")
+      .select($"*")
 
     val expected =
       unaryNode(
@@ -160,9 +160,9 @@ class TableAggregateTest extends TableTestBase {
     util.javaTableEnv.registerFunction("func", func)
 
     val resultTable = table
-      .groupBy("c")
+      .groupBy($"c")
       .flatAggregate("func(a)")
-      .select("*")
+      .select($"*")
 
     val expected =
       unaryNode(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TableSourceTest.scala
@@ -45,7 +45,7 @@ class TableSourceTest extends TableTestBase {
       "rowTimeT",
       new TestTableSourceWithTime[Row](tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
-    val t = util.tableEnv.scan("rowTimeT").select("rowtime, id, name, val")
+    val t = util.tableEnv.scan("rowTimeT").select($"rowtime", $"id", $"name", $"val")
 
     val expected = "StreamTableSourceScan(table=[[default_catalog, default_database, rowTimeT]], " +
       "fields=[rowtime, id, name, val], " +
@@ -69,7 +69,7 @@ class TableSourceTest extends TableTestBase {
       "rowTimeT",
       new TestTableSourceWithTime[Row](tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
-    val t = util.tableEnv.scan("rowTimeT").select("rowtime, id, name, val")
+    val t = util.tableEnv.scan("rowTimeT").select($"rowtime", $"id", $"name", $"val")
 
     val expected = "StreamTableSourceScan(table=[[default_catalog, default_database, rowTimeT]], " +
       "fields=[rowtime, id, name, val], " +
@@ -94,7 +94,7 @@ class TableSourceTest extends TableTestBase {
       new TestTableSourceWithTime[Row](tableSchema, returnType, Seq(), rowtime = "rowtime"))
 
     val t = util.tableEnv.scan("rowTimeT")
-      .filter("val > 100")
+      .filter($"val" > 100)
       .window(Tumble over 10.minutes on 'rowtime as 'w)
       .groupBy('name, 'w)
       .select('name, 'w.end, 'val.avg)
@@ -136,7 +136,7 @@ class TableSourceTest extends TableTestBase {
       "procTimeT",
       new TestTableSourceWithTime[Row](tableSchema, returnType, Seq(), proctime = "proctime"))
 
-    val t = util.tableEnv.scan("procTimeT").select("proctime, id, name, val")
+    val t = util.tableEnv.scan("procTimeT").select($"proctime", $"id", $"name", $"val")
 
     val expected =
       unaryNode(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/TemporalTableJoinTest.scala
@@ -60,13 +60,13 @@ class TemporalTableJoinTest extends TableTestBase {
   def testSimpleJoin(): Unit = {
     val result = orders
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyTable(result, getExpectedSimpleJoinPlan())
 
     val resultJava = orders
-      .joinLateral("Rates(o_rowtime)", "currency = o_currency")
-      .select("o_amount * rate").as("rate")
+      .joinLateral(call("Rates", $"o_rowtime"), $"currency" === $"o_currency")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyTable(resultJava, getExpectedSimpleJoinPlan())
   }
@@ -75,7 +75,7 @@ class TemporalTableJoinTest extends TableTestBase {
   def testSimpleProctimeJoin(): Unit = {
     val result = proctimeOrders
       .joinLateral(proctimeRates('o_proctime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.verifyTable(result, getExpectedSimpleProctimeJoinPlan())
   }
@@ -102,7 +102,7 @@ class TemporalTableJoinTest extends TableTestBase {
     val result = orders
       .joinLateral(rates('o_rowtime))
       .filter('currency === 'o_currency || 'secondary_key === 'o_secondary_key)
-      .select('o_amount * 'rate, 'secondary_key).as('rate, 'secondary_key)
+      .select('o_amount * 'rate, 'secondary_key).as("rate", "secondary_key")
       .join(thirdTable, 't3_secondary_key === 'secondary_key)
 
     util.verifyTable(result, binaryNode(
@@ -151,7 +151,7 @@ class TemporalTableJoinTest extends TableTestBase {
     val filteredRatesHistory = ratesHistory
       .filter('rate > 100)
       .select('currency, 'rate * 2, 'rowtime)
-      .as('currency, 'rate, 'rowtime)
+      .as("currency", "rate", "rowtime")
 
     val filteredRates = util.addFunction(
       "FilteredRates",
@@ -159,8 +159,8 @@ class TemporalTableJoinTest extends TableTestBase {
 
     val result = orders
       .joinLateral(filteredRates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate")
-      .as('rate)
+      .select($"o_amount" * $"rate")
+      .as("rate")
 
     util.verifyTable(result, getExpectedTemporalTableFunctionOnTopOfQueryPlan())
   }
@@ -174,7 +174,7 @@ class TemporalTableJoinTest extends TableTestBase {
       .joinLateral(rates(
         java.sql.Timestamp.valueOf("2016-06-27 10:10:42.123")),
         'o_currency === 'currency)
-      .select("o_amount * rate")
+      .select($"o_amount" * $"rate")
 
     util.printTable(result)
   }
@@ -186,7 +186,7 @@ class TemporalTableJoinTest extends TableTestBase {
 
   @Test
   def testValidStringFieldReference(): Unit = {
-    val rates = ratesHistory.createTemporalTableFunction("rowtime", "currency")
+    val rates = ratesHistory.createTemporalTableFunction($"rowtime", $"currency")
     assertRatesFunction(ratesHistory.getSchema, rates)
   }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/CorrelateStringExpressionTest.scala
@@ -56,12 +56,12 @@ class CorrelateStringExpressionTest extends TableTestBase {
 
     // test left outer join
     scalaTable = sTab.leftOuterJoinLateral(func1('c) as 's).select('c, 's)
-    javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select("c, s")
+    javaTable = jTab.leftOuterJoinLateral("as(func1(c), s)").select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test overloading
     scalaTable = sTab.joinLateral(func1('c, "$") as 's).select('c, 's)
-    javaTable = jTab.joinLateral("func1(c, '$') as (s)").select("c, s")
+    javaTable = jTab.joinLateral("func1(c, '$') as (s)").select($("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test custom result type
@@ -69,7 +69,7 @@ class CorrelateStringExpressionTest extends TableTestBase {
     util.javaTableEnv.registerFunction("func2", func2)
     scalaTable = sTab.joinLateral(func2('c) as ('name, 'len)).select('c, 'name, 'len)
     javaTable = jTab.joinLateral(
-      "func2(c).as(name, len)").select("c, name, len")
+      "func2(c).as(name, len)").select($("c"), $("name"), $("len"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test hierarchy generic type
@@ -78,27 +78,27 @@ class CorrelateStringExpressionTest extends TableTestBase {
     scalaTable = sTab.joinLateral(
       hierarchy('c) as ('name, 'adult, 'len)).select('c, 'name, 'len, 'adult)
     javaTable = jTab.joinLateral("AS(hierarchy(c), name, adult, len)")
-      .select("c, name, len, adult")
+      .select($("c"), $("name"), $("len"), $("adult"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test pojo type
     val pojo = new PojoTableFunc
     util.javaTableEnv.registerFunction("pojo", pojo)
     scalaTable = sTab.joinLateral(pojo('c)).select('c, 'name, 'age)
-    javaTable = jTab.joinLateral("pojo(c)").select("c, name, age")
+    javaTable = jTab.joinLateral("pojo(c)").select($("c"), $("name"), $("age"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
     scalaTable = sTab.joinLateral(
       func2('c) as ('name, 'len)).select('c, 'name, 'len).filter('len > 2)
     javaTable = jTab.joinLateral("func2(c) as (name, len)")
-      .select("c, name, len").filter("len > 2")
+      .select($("c"), $("name"), $("len")).filter($("len").isGreater(Int.box(2)))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with scalar function
     scalaTable = sTab.joinLateral(func1('c.substring(2)) as 's).select('a, 'c, 's)
     javaTable = jTab.joinLateral(
-      "func1(substring(c, 2)) as (s)").select("a, c, s")
+      "func1(substring(c, 2)) as (s)").select($("a"), $("c"), $("s"))
     verifyTableEquals(scalaTable, javaTable)
   }
 
@@ -119,39 +119,44 @@ class CorrelateStringExpressionTest extends TableTestBase {
     // test flatMap
     val func1 = new TableFunc1
     util.javaTableEnv.registerFunction("func1", func1)
-    var scalaTable = sTab.flatMap(func1('c)).as('s).select('s)
-    var javaTable = jTab.flatMap("func1(c)").as("s").select("s")
+    var scalaTable = sTab.flatMap(func1('c)).as("s").select('s)
+    var javaTable = jTab.flatMap("func1(c)").as("s").select($("s"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test custom result type
     val func2 = new TableFunc2
     util.javaTableEnv.registerFunction("func2", func2)
-    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len)
-    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len")
+    scalaTable = sTab.flatMap(func2('c)).as("name", "len").select('name, 'len)
+    javaTable = jTab.flatMap("func2(c)").as("name, len").select($("name"), $("len"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test hierarchy generic type
     val hierarchy = new HierarchyTableFunction
     util.javaTableEnv.registerFunction("hierarchy", hierarchy)
-    scalaTable = sTab.flatMap(hierarchy('c)).as('name, 'adult, 'len).select('name, 'len, 'adult)
-    javaTable = jTab.flatMap("hierarchy(c)").as("name, adult, len").select("name, len, adult")
+    scalaTable = sTab.flatMap(hierarchy('c)).as("name", "adult", "len").select('name, 'len, 'adult)
+    javaTable = jTab.flatMap("hierarchy(c)")
+      .as("name, adult, len")
+      .select($("name"), $("len"), $("adult"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test pojo type
     val pojo = new PojoTableFunc
     util.javaTableEnv.registerFunction("pojo", pojo)
     scalaTable = sTab.flatMap(pojo('c)).select('name, 'age)
-    javaTable = jTab.flatMap("pojo(c)").select("name, age")
+    javaTable = jTab.flatMap("pojo(c)").select($("name"), $("age"))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with filter
-    scalaTable = sTab.flatMap(func2('c)).as('name, 'len).select('name, 'len).filter('len > 2)
-    javaTable = jTab.flatMap("func2(c)").as("name, len").select("name, len").filter("len > 2")
+    scalaTable = sTab.flatMap(func2('c)).as("name", "len").select('name, 'len).filter('len > 2)
+    javaTable = jTab.flatMap("func2(c)")
+      .as("name, len")
+      .select($("name"), $("len"))
+      .filter($("len").isGreater(Int.box(2)))
     verifyTableEquals(scalaTable, javaTable)
 
     // test with scalar function
-    scalaTable = sTab.flatMap(func1('c.substring(2))).as('s).select('s)
-    javaTable = jTab.flatMap("func1(substring(c, 2))").as("s").select("s")
+    scalaTable = sTab.flatMap(func1('c.substring(2))).as("s").select('s)
+    javaTable = jTab.flatMap("func1(substring(c, 2))").as("s").select($("s"))
     verifyTableEquals(scalaTable, javaTable)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/stringexpr/TableAggregateStringExpressionTest.scala
@@ -89,7 +89,7 @@ class TableAggregateStringExpressionTest extends TableTestBase {
     // String / Java API
     val resJava = t
       .flatAggregate("top3(a) as (d, e)")
-      .select("*")
+      .select($"*")
 
     verifyTableEquals(resJava, resScala)
   }
@@ -113,7 +113,7 @@ class TableAggregateStringExpressionTest extends TableTestBase {
     val resJava = t
       .groupBy("b")
       .flatAggregate("top3(a) as (d, e)")
-      .select("*")
+      .select($"*")
 
     verifyTableEquals(resJava, resScala)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/AggregateValidationTest.scala
@@ -108,7 +108,7 @@ class AggregateValidationTest extends TableTestBase {
     table
       .groupBy('a)
       // must fail. Only AggregateFunction can be used in aggregate
-      .aggregate("func(c) as d")
+      .aggregate(call("func", $"c") as "d")
       .select('a, 'd)
   }
 
@@ -139,7 +139,7 @@ class AggregateValidationTest extends TableTestBase {
     table
       .groupBy('a)
       // must fail. Invalid alias length
-      .aggregate("minMax(b) as (x, y)")
+      .aggregate(call("minMax", $"b") as ("x", "y"))
       .select("x, y")
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CalcValidationTest.scala
@@ -136,7 +136,7 @@ class CalcValidationTest extends TableTestBase {
     util.tableEnv.registerFunction("weightedAvg", new WeightedAvg)
     util.addTable[(Int)](
       "MyTable", 'int)
-      .map("weightedAvg(int, int)") // do not support AggregateFunction as input
+      .map(call("weightedAvg", $"int", $"int")) // do not support AggregateFunction as input
   }
 
   @Test(expected = classOf[ValidationException])
@@ -146,6 +146,6 @@ class CalcValidationTest extends TableTestBase {
     util.tableEnv.registerFunction("func", new TableFunc0)
     util.addTable[(String)](
       "MyTable", 'string)
-      .map("func(string) as a") // do not support TableFunction as input
+      .map(call("func", $"string") as "a") // do not support TableFunction as input
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/CorrelateValidationTest.scala
@@ -60,7 +60,7 @@ class CorrelateValidationTest extends TableTestBase {
     //============ throw exception when table function is not registered =========
     // Java Table API call
     expectExceptionThrown(
-      t.joinLateral("nonexist(a)"), "Undefined function: nonexist")
+      t.joinLateral(call("nonexist", $"a")), "Undefined function: nonexist")
     // SQL API call
     expectExceptionThrown(
       util.tableEnv.sqlQuery("SELECT * FROM MyTable, LATERAL TABLE(nonexist(a))"),
@@ -81,7 +81,7 @@ class CorrelateValidationTest extends TableTestBase {
     // Java Table API call
     util.addFunction("func2", new TableFunc2)
     expectExceptionThrown(
-      t.joinLateral("func2(c, c)"),
+      t.joinLateral(call("func2", $"c", $"c")),
       "Given parameters of function 'func2' do not match any signature")
     // SQL API call
     expectExceptionThrown(
@@ -131,7 +131,7 @@ class CorrelateValidationTest extends TableTestBase {
     util.tableEnv.registerFunction("weightedAvg", new WeightedAvg)
     util.addTable[(Int)](
       "MyTable", 'int)
-      .flatMap("weightedAvg(int, int)") // do not support AggregateFunction as input
+      .flatMap(call("weightedAvg", $"int", $"int")) // do not support AggregateFunction as input
   }
 
   @Test(expected = classOf[ValidationException])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/InsertIntoValidationTest.scala
@@ -35,7 +35,7 @@ class InsertIntoValidationTest {
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "f")
@@ -58,7 +58,7 @@ class InsertIntoValidationTest {
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/JoinValidationTest.scala
@@ -232,7 +232,7 @@ class JoinValidationTest extends TableTestBase {
     val in1 = tEnv1.fromDataStream(ds1, 'a, 'b, 'c)
     val in2 = tEnv2.fromDataStream(ds2, 'd, 'e, 'f, 'g, 'c)
     // Must fail. Tables are bound to different TableEnvironments.
-    in1.join(in2).where("a === d").select("g.count")
+    in1.join(in2).where($"a" === $"d").select($"g".count)
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSourceValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TableSourceValidationTest.scala
@@ -64,7 +64,7 @@ class TableSourceValidationTest extends TableTestBase {
     val t = util.tableEnv
       .scan("T")
       .select('price, 'id, 'amount)
-      .where("price * 2 < 32")
+      .where($"price" * 2 < 32)
 
     // must fail since pushed filter is not explained in source
     util.explain(t)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TemporalTableJoinValidationTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/stream/table/validation/TemporalTableJoinValidationTest.scala
@@ -58,7 +58,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
     expectedException.expect(classOf[ValidationException])
     expectedException.expectMessage("Cannot resolve field [foobar]")
 
-    ratesHistory.createTemporalTableFunction("rowtime", "foobar")
+    ratesHistory.createTemporalTableFunction($"rowtime", $"foobar")
   }
 
   @Test
@@ -71,7 +71,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = orders
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.explain(result)
   }
@@ -86,7 +86,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = ordersWithoutTimeAttribute
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.explain(result)
   }
@@ -102,7 +102,7 @@ class TemporalTableJoinValidationTest extends TableTestBase {
 
     val result = ordersProctime
       .joinLateral(rates('o_rowtime), 'currency === 'o_currency)
-      .select("o_amount * rate").as("rate")
+      .select($"o_amount" * $"rate").as("rate")
 
     util.explain(result)
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/ExpressionReductionRulesTest.scala
@@ -473,7 +473,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
     val table = util.addTable[(Int, Long, String)]("MyTable", 'a, 'b, 'c)
     val result = table
       .select('a, 'b, 'c, DeterministicNullFunc() as 'd)
-      .where("d.isNull")
+      .where($"d".isNull)
       .select('a, 'b, 'c)
 
     val expected: String = unaryNode("DataStreamCalc",
@@ -492,7 +492,7 @@ class ExpressionReductionRulesTest extends TableTestBase {
 
     val result = table
       .select('a, 'b, 'c, NonDeterministicNullFunc() as 'd)
-      .where("d.isNull")
+      .where($"d".isNull)
       .select('a, 'b, 'c)
 
     val expected = unaryNode(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCorrelateSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/PythonCorrelateSplitRuleTest.scala
@@ -102,7 +102,7 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
     val pyFunc = new PythonScalarFunction("pyFunc")
     util.addFunction("pyFunc", pyFunc)
     val resultTable = table.select('a, 'b, 'c, 'd.flatten())
-      .joinLateral("tableFunc(a * d$_1, pyFunc(d$_2, c))")
+      .joinLateral(call("tableFunc", $"a" * $"d$$_1", call("pyFunc", $"d$$_2", $"c")))
 
     val expected = unaryNode(
       "DataStreamCalc",
@@ -139,7 +139,7 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
     val pyFunc = new PythonScalarFunction("pyFunc")
     util.addFunction("pyFunc", pyFunc)
     val result = table.select('a, 'b, 'c, 'd.flatten())
-      .joinLateral("tableFunc(pyFunc(d$_1))")
+      .joinLateral(call("tableFunc", call("pyFunc", $"d$$_1")))
 
     val expected = unaryNode(
       "DataStreamCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromJoinRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/SplitPythonConditionFromJoinRuleTest.scala
@@ -35,8 +35,8 @@ class SplitPythonConditionFromJoinRuleTest extends TableTestBase {
     util.tableEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"))
 
     val result = left
-      .join(right, "a === d && pyFunc(a, d) === b")
-      .select("a, b, d")
+      .join(right, $"a" === $"d" && call("pyFunc", $"a", $"d") === $"b")
+      .select($"a", $"b", $"d")
 
     val expected = unaryNode(
       "DataStreamCalc",
@@ -74,10 +74,10 @@ class SplitPythonConditionFromJoinRuleTest extends TableTestBase {
     util.tableEnv.registerFunction("pyFunc", new PythonScalarFunction("pyFunc"))
 
     val result = left
-      .join(right, "a === d && pyFunc(a, d) = a + b")
-      .select("a, b, d")
-      .filter("pyFunc(a, b) = b * d")
-      .select("a + 1, b, d")
+      .join(right, $"a" === $"d" && call("pyFunc", $"a", $"d") === ($"a" + $"b"))
+      .select($"a", $"b", $"d")
+      .filter(call("pyFunc", $"a", $"b") === ($"b" * $"d"))
+      .select($"a" + 1, $"b", $"d")
 
     val expected = unaryNode(
       "DataStreamCalc",

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/plan/TimeIndicatorConversionTest.scala
@@ -383,7 +383,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val result = proctimeOrders
       .joinLateral(proctimeRates('o_proctime), 'currency === 'o_currency)
-      .select("o_amount * rate, currency, proctime").as("converted_amount")
+      .select($"o_amount" * $"rate", $"currency", $"proctime").as("converted_amount")
       .window(Tumble over 1.second on 'proctime as 'w)
       .groupBy('w, 'currency)
       .select('converted_amount.sum)
@@ -420,7 +420,7 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val result = proctimeOrders
       .joinLateral(proctimeRates('o_proctime), 'currency === 'o_currency)
-      .select("o_amount * rate, currency, o_proctime").as("converted_amount")
+      .select($"o_amount" * $"rate", $"currency", $"o_proctime").as("converted_amount")
       .window(Tumble over 1.second on 'o_proctime as 'w)
       .groupBy('w, 'currency)
       .select('converted_amount.sum)
@@ -457,7 +457,8 @@ class TimeIndicatorConversionTest extends TableTestBase {
 
     val result = proctimeOrders
       .joinLateral(proctimeRates('o_proctime), 'currency === 'o_currency)
-      .select("o_amount * rate, currency, o_proctime, o_rowtime").as("converted_amount")
+      .select($"o_amount" * $"rate", $"currency", $"o_proctime", $"o_rowtime")
+      .as("converted_amount")
       .window(Tumble over 1.second on 'o_rowtime as 'w)
       .groupBy('w, 'currency)
       .select('converted_amount.sum)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/AggregateITCase.scala
@@ -592,7 +592,7 @@ class AggregateITCase(
       ") GROUP BY b " +
       "ORDER BY b"
 
-    val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toDataSet[Row].collect()

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/CalcITCase.scala
@@ -52,7 +52,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -76,7 +76,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable"
 
-    val ds = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv).as('a, 'b)
+    val ds = CollectionDataSets.getSmallNestedTupleDataSet(env).toTable(tEnv)as("a", "b")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -119,7 +119,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT a, b, c FROM MyTable"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -164,7 +164,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT a, foo FROM MyTable"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     tEnv.sqlQuery(sqlQuery)
@@ -219,7 +219,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable WHERE c LIKE '%world%'"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -237,7 +237,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable WHERE MOD(a,2)=0"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -258,7 +258,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a < 2 OR a > 20 OR a IN(3,4,5)"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -277,7 +277,7 @@ class CalcITCase(
 
     val sqlQuery = "SELECT * FROM MyTable WHERE MOD(a,2)<>0 AND MOD(b,2)=0 AND b NOT IN(1,2,3)"
 
-    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/JoinITCase.scala
@@ -47,8 +47,8 @@ class JoinITCase(
     val tEnv = BatchTableEnvironment.create(env, config)
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -67,8 +67,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND b < 2"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -87,8 +87,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE b = e AND a < 6 AND h < b"
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -107,8 +107,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3, Table5 WHERE a = d AND b = h"
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -130,8 +130,8 @@ class JoinITCase(
       "SELECT Table5.c, T.`1-_./Ü` FROM (SELECT a, b, c AS `1-_./Ü` FROM Table3) AS T, Table5 " +
       "WHERE a = d AND a < 4"
 
-    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'c)
+    val ds1 = CollectionDataSets.get3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "c")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -191,8 +191,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 FULL OUTER JOIN Table5 ON b = e"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -214,8 +214,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table5 LEFT OUTER JOIN Table3 ON b = e"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -236,8 +236,8 @@ class JoinITCase(
 
     val sqlQuery = "SELECT c, g FROM Table3 RIGHT OUTER JOIN Table5 ON b = e"
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -254,7 +254,7 @@ class JoinITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
+    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a1", "a2", "a3")
     tEnv.registerTable("A", table)
 
     val sqlQuery2 = "SELECT * FROM (SELECT count(*) FROM A) CROSS JOIN A"
@@ -271,7 +271,7 @@ class JoinITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
+    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a1", "a2", "a3")
     tEnv.registerTable("A", table)
 
     val sqlQuery1 = "SELECT * FROM A CROSS JOIN (SELECT count(*) FROM A)"
@@ -288,7 +288,7 @@ class JoinITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a1, 'a2, 'a3)
+    val table = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a1", "a2", "a3")
     tEnv.registerTable("A", table)
 
     val sqlQuery1 = "SELECT * FROM A CROSS JOIN (SELECT count(*) FROM A HAVING count(*) < 0)"
@@ -304,7 +304,7 @@ class JoinITCase(
       "SELECT a, cnt " +
       "FROM (SELECT cnt FROM (SELECT COUNT(*) AS cnt FROM B) WHERE cnt < 0) RIGHT JOIN A ON a < cnt"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
@@ -331,7 +331,7 @@ class JoinITCase(
     val sqlQuery =
       "SELECT a, cnt FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt = a"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
@@ -355,7 +355,7 @@ class JoinITCase(
     val sqlQuery =
       "SELECT a, cnt FROM (SELECT COUNT(*) AS cnt FROM B) RIGHT JOIN A ON cnt > a"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
@@ -381,7 +381,7 @@ class JoinITCase(
       "FROM A LEFT JOIN (SELECT cnt FROM (SELECT COUNT(*) AS cnt FROM B) WHERE cnt < 0) ON cnt > a"
 
     val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv)
-    val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("A", ds2)
     tEnv.registerTable("B", ds1)
 
@@ -402,7 +402,7 @@ class JoinITCase(
     val sqlQuery =
       "SELECT a, cnt FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) ON cnt = a"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
@@ -427,7 +427,7 @@ class JoinITCase(
     val sqlQuery =
       "SELECT a, cnt FROM A LEFT JOIN (SELECT COUNT(*) AS cnt FROM B) ON cnt < a"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("A", ds1)
     tEnv.registerTable("B", ds2)
@@ -453,7 +453,7 @@ class JoinITCase(
       "SELECT a, cnt, cnt2 " +
       "FROM t1 LEFT JOIN (SELECT COUNT(*) AS cnt,COUNT(*) AS cnt2 FROM t2 ) AS x ON a = cnt"
 
-    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c, 'd, 'e)
+    val ds1 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("a", "b", "c", "d", "e")
     val ds2 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv)
     tEnv.registerTable("t1", ds1)
     tEnv.registerTable("t2", ds2)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/SetOperatorsITCase.scala
@@ -279,8 +279,8 @@ class SetOperatorsITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 
@@ -296,8 +296,8 @@ class SetOperatorsITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
     tEnv.registerTable("Table3", ds1)
     tEnv.registerTable("Table5", ds2)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/sql/TableEnvironmentITCase.scala
@@ -114,7 +114,7 @@ class TableEnvironmentITCase(
 
     val sqlQuery = "SELECT MyTable.a2, MyTable.a1._2 FROM MyTable"
 
-    val ds = env.fromElements(((12, true), "Hello")).toTable(tEnv).as('a1, 'a2)
+    val ds = env.fromElements(((12, true), "Hello")).toTable(tEnv).as("a1", "a2")
     tEnv.registerTable("MyTable", ds)
 
     val result = tEnv.sqlQuery(sqlQuery)
@@ -131,7 +131,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
-    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")
@@ -153,7 +153,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
-    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")
@@ -236,7 +236,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
-    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CalcITCase.scala
@@ -530,7 +530,7 @@ class CalcITCase(
     data.+=((2, 2L, "John#19"))
     data.+=((3, 2L, "Anna#44"))
     data.+=((4, 3L, "nosharp"))
-    val in = env.fromCollection(data).toTable(tableEnv).as('a, 'b, 'c)
+    val in = env.fromCollection(data).toTable(tableEnv).as("a", "b", "c")
 
     val func0 = new Func13("default")
     val func1 = new Func13("Sunny")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/CorrelateITCase.scala
@@ -50,7 +50,7 @@ class CorrelateITCase(
   def testCrossJoin(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val func1 = new TableFunc1
     val result = in.joinLateral(func1('c) as 's).select('c, 's).toDataSet[Row]
@@ -71,7 +71,7 @@ class CorrelateITCase(
   def testLeftOuterJoinWithoutPredicates(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in.leftOuterJoinLateral(func2('c) as ('s, 'l)).select('c, 's, 'l).toDataSet[Row]
@@ -86,7 +86,7 @@ class CorrelateITCase(
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
     tableEnv.getConfig.setMaxGeneratedCodeLength(1) // split every field
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in.leftOuterJoinLateral(func2('c) as ('s, 'l)).select('c, 's, 'l).toDataSet[Row]
@@ -103,7 +103,7 @@ class CorrelateITCase(
   def testLeftOuterJoinWithPredicates(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val func2 = new TableFunc2
     val result = in
@@ -119,7 +119,7 @@ class CorrelateITCase(
   def testWithFilter(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -137,7 +137,7 @@ class CorrelateITCase(
   def testCustomReturnType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func2 = new TableFunc2
 
     val result = in
@@ -155,7 +155,7 @@ class CorrelateITCase(
   def testHierarchyType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val hierarchy = new HierarchyTableFunction
     val result = in
@@ -173,7 +173,7 @@ class CorrelateITCase(
   def testPojoType(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
 
     val pojo = new PojoTableFunc()
     val result = in
@@ -191,7 +191,7 @@ class CorrelateITCase(
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func1 = new TableFunc1
 
     val result = in
@@ -209,7 +209,7 @@ class CorrelateITCase(
   def testUserDefinedTableFunctionWithScalarFunctionInCondition(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = in
@@ -227,7 +227,7 @@ class CorrelateITCase(
   def testLongAndTemporalTypes(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func0 = new JavaTableFunc0
 
     val result = in
@@ -248,7 +248,7 @@ class CorrelateITCase(
   def testByteShortFloatArguments(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val tFunc = new TableFunc4
 
     val result = in
@@ -309,7 +309,7 @@ class CorrelateITCase(
   def testTableFunctionConstructorWithParams(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val in = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val in = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
     val func32 = new TableFunc3("TwoConf_")
@@ -371,7 +371,7 @@ class CorrelateITCase(
   def testTableFunctionCollectorOpenClose(): Unit = {
     val env = ExecutionEnvironment.getExecutionEnvironment
     val tableEnv = BatchTableEnvironment.create(env, config)
-    val t = testData(env).toTable(tableEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tableEnv).as("a", "b", "c")
     val func0 = new TableFunc0
     val func20 = new Func20
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/JoinITCase.scala
@@ -71,8 +71,8 @@ class JoinITCase(
     val env: ExecutionEnvironment = ExecutionEnvironment.getExecutionEnvironment
     val tEnv = BatchTableEnvironment.create(env, config)
 
-    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
-    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as('d, 'e, 'f, 'g, 'h)
+    val ds1 = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
+    val ds2 = CollectionDataSets.get5TupleDataSet(env).toTable(tEnv).as("d", "e", "f", "g", "h")
 
     val joinT = ds1.join(ds2).where('b === 'e && 'b < 2).select('c, 'g)
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableEnvironmentITCase.scala
@@ -187,7 +187,7 @@ class TableEnvironmentITCase(
     val tEnv = BatchTableEnvironment.create(env)
     MemoryTableSourceSinkUtil.clear()
 
-    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = CollectionDataSets.getSmall3TupleDataSet(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("sourceTable", t)
 
     val fieldNames = Array("d", "e", "f")

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/batch/table/TableSourceITCase.scala
@@ -137,8 +137,8 @@ class TableSourceITCase(
     tableEnv.registerTableSource(tableName, TestFilterableTableSource())
     val results = tableEnv
       .scan(tableName)
-      .where("amount > 4 && price < 9")
-      .select("id, name")
+      .where($"amount" > 4 && $"price" < 9)
+      .select($"id", $"name")
       .collect()
 
     val expected = Seq(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SetOperatorsITCase.scala
@@ -61,10 +61,10 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTable(tEnv).as("a", "b", "c"))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTable(tEnv).as("x", "y"))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)
@@ -108,13 +108,13 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTable(tEnv).as("a", "b", "c"))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTable(tEnv).as("x", "y"))
 
     tEnv.registerTable("tableC",
-      env.fromCollection(dataC).toTable(tEnv).as('w, 'z))
+      env.fromCollection(dataC).toTable(tEnv).as("w", "z"))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)
@@ -151,10 +151,10 @@ class SetOperatorsITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("tableA",
-      env.fromCollection(dataA).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(dataA).toTable(tEnv).as("a", "b", "c"))
 
     tEnv.registerTable("tableB",
-      env.fromCollection(dataB).toTable(tEnv).as('x, 'y))
+      env.fromCollection(dataB).toTable(tEnv).as("x", "y"))
 
     val results = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/SqlITCase.scala
@@ -212,7 +212,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     
     val ds = env.fromCollection(data)
     
-    val t = ds.toTable(tEnv).as('a, 'b, 'c)
+    val t = ds.toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTableRow", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -232,7 +232,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT b, COUNT(a) FROM MyTable GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -257,7 +257,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       "FROM MyTable " +
       "GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -286,7 +286,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     data.+=((4, 1L, "Hi World"))
     data.+=((4, 1L, "Test"))
 
-    val t = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+    val t = env.fromCollection(data).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     // "1,1,3", "2,1,2", "3,1,1", "4,1,2"
@@ -314,7 +314,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT b, COLLECT(a) FROM MyTable GROUP BY b"
 
-    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.get3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
@@ -349,7 +349,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     )
 
     tEnv.registerTable("MyTable",
-      env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c))
+      env.fromCollection(data).toTable(tEnv).as("a", "b", "c"))
 
     val result = tEnv.sqlQuery(sqlQuery).toRetractStream[Row]
     result.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -371,7 +371,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT * FROM MyTable"
 
-    val t = StreamTestData.getSmallNestedTupleDataStream(env).toTable(tEnv).as('a, 'b)
+    val t = StreamTestData.getSmallNestedTupleDataStream(env).toTable(tEnv).as("a", "b")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -391,7 +391,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT a * 2, b - 1 FROM MyTable"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -411,7 +411,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT a * 2, b - 1 FROM MyTable"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -431,7 +431,7 @@ class SqlITCase extends StreamingWithStateTestBase {
 
     val sqlQuery = "SELECT * FROM MyTable WHERE a = 3"
 
-    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -473,9 +473,9 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT * FROM T2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T1", t1)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -500,9 +500,9 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT * FROM T2 WHERE a = 2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T1", t1)
-    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t2 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T2", t2)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -526,7 +526,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       "UNION ALL " +
       "SELECT c FROM T2 WHERE a = 2"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T1", t1)
     val t2 = StreamTestData.get3TupleDataStream(env)
     tEnv.createTemporaryView("T2", t2, 'a, 'b, 'c)
@@ -638,7 +638,7 @@ class SqlITCase extends StreamingWithStateTestBase {
       (3, 2, (13, "41.6")),
       (4, 3, (14, "45.2136")),
       (5, 3, (18, "42.6")))
-    tEnv.registerTable("t1", env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c))
+    tEnv.registerTable("t1", env.fromCollection(data).toTable(tEnv).as("a", "b", "c"))
 
     val t2 = tEnv.sqlQuery("SELECT b, COLLECT(c) as `set` FROM t1 GROUP BY b")
     tEnv.registerTable("t2", t2)
@@ -674,7 +674,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val settings = EnvironmentSettings.newInstance().useOldPlanner().build()
     val tEnv = StreamTableEnvironment.create(env, settings)
 
-    val t1 = env.fromCollection(data).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = env.fromCollection(data).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("t1", t1)
 
     val t2 = tEnv.sqlQuery("SELECT a, COLLECT(b) as `set` FROM t1 GROUP BY a")
@@ -798,7 +798,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val parameters = "c," + (0 until 300).map(_ => "a").mkString(",")
     val sqlQuery = s"SELECT func15($parameters) FROM T1"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -824,7 +824,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val sqlQuery = s"SELECT T1.a, T2.x FROM T1 " +
       s"JOIN LATERAL TABLE(udtf($parameters)) as T2(x) ON TRUE"
 
-    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t1 = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("T1", t1)
 
     val result = tEnv.sqlQuery(sqlQuery).toAppendStream[Row]
@@ -844,7 +844,7 @@ class SqlITCase extends StreamingWithStateTestBase {
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     val tEnv = StreamTableEnvironment.create(env, settings)
 
-    val t = StreamTestData.getSingletonDataStream(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = StreamTestData.getSingletonDataStream(env).toTable(tEnv).as("a", "b", "c")
     tEnv.registerTable("MyTable", t)
 
     val sqlQuery = new StringBuilder

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/sql/TemporalJoinITCase.scala
@@ -218,10 +218,10 @@ class TemporalJoinITCase extends StreamingWithStateTestBase {
     tEnv.createTemporaryView("RatesHistory", ratesHistory)
     tEnv.registerFunction(
       "Rates",
-      ratesHistory.createTemporalTableFunction("rowtime", "currency"))
+      ratesHistory.createTemporalTableFunction($"rowtime", $"currency"))
     tEnv.registerFunction(
       "Prices",
-      pricesHistory.createTemporalTableFunction("rowtime", "productId"))
+      pricesHistory.createTemporalTableFunction($"rowtime", $"productId"))
 
     tEnv.createTemporaryView("TemporalJoinResult", tEnv.sqlQuery(sqlQuery))
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CalcITCase.scala
@@ -60,7 +60,7 @@ class CalcITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv)
       .select()
-      .select("count(1)")
+      .select(1.count)
 
     val results = ds.toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -182,7 +182,7 @@ class CalcITCase extends AbstractTestBase {
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( 'a % 2 === 0 )
-      .where("b = 3 || b = 4 || b = 5")
+      .where($"b" === 3 || $"b" === 4 || $"b" === 5)
     val results = filterDs.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
@@ -199,7 +199,7 @@ class CalcITCase extends AbstractTestBase {
     val ds = StreamTestData.get3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
 
     val filterDs = ds.filter( 'a % 2 !== 0)
-      .where("b != 1 && b != 2 && b != 3")
+      .where(($"b" !== 1) && ($"b" !== 2) && ($"b" !== 3))
     val results = filterDs.toAppendStream[Row]
     results.addSink(new StreamITCase.StringSink[Row])
     env.execute()
@@ -219,7 +219,7 @@ class CalcITCase extends AbstractTestBase {
 
     val result = StreamTestData.get3TupleDataStream(env)
       .toTable(tEnv, 'a, 'b, 'c)
-      .where("RichFunc2(c)='ABC#Hello'")
+      .where(call("RichFunc2", $"c") === "ABC#Hello")
       .select('c)
 
     val results = result.toAppendStream[Row]
@@ -240,7 +240,9 @@ class CalcITCase extends AbstractTestBase {
 
     val result = StreamTestData.get3TupleDataStream(env)
       .toTable(tEnv, 'a, 'b, 'c)
-      .where("RichFunc2(c)='Abc#Hello' || RichFunc1(a)=3 && b=2")
+      .where(call("RichFunc2", $"c") === "Abc#Hello" ||
+             (call("RichFunc1", $"a") === 3) &&
+             ($"b" === 2))
       .select('c)
 
     val results = result.toAppendStream[Row]
@@ -261,7 +263,7 @@ class CalcITCase extends AbstractTestBase {
     testData.+=((3, 2L, "Anna#44"))
     testData.+=((4, 3L, "nosharp"))
 
-    val t = env.fromCollection(testData).toTable(tEnv).as('a, 'b, 'c)
+    val t = env.fromCollection(testData).toTable(tEnv).as("a", "b", "c")
     val func0 = new Func13("default")
     val func1 = new Func13("Sunny")
     val func2 = new Func13("kevin2")
@@ -284,7 +286,7 @@ class CalcITCase extends AbstractTestBase {
   def testInlineScalarFunction(): Unit = {
     StreamITCase.testResults = mutable.MutableList()
 
-    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as('a)
+    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as("a")
 
     val result = t.select(
       (new ScalarFunction() {
@@ -309,7 +311,7 @@ class CalcITCase extends AbstractTestBase {
   def testNonStaticObjectScalarFunction(): Unit = {
     StreamITCase.testResults = mutable.MutableList()
 
-    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as('a)
+    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as("a")
 
     val result = t.select(NonStaticObjectScalarFunction('a, ">>"))
 
@@ -335,7 +337,7 @@ class CalcITCase extends AbstractTestBase {
   def testNonStaticClassScalarFunction(): Unit = {
     StreamITCase.testResults = mutable.MutableList()
 
-    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as('a)
+    val t = env.fromElements(1, 2, 3, 4).toTable(tEnv).as("a")
 
     val result = t.select(new NonStaticClassScalarFunction()('a, ">>"))
 
@@ -401,7 +403,7 @@ class CalcITCase extends AbstractTestBase {
     testData.+=((1, 1L, "Kevin"))
     testData.+=((2, 2L, "Sunny"))
 
-    val t = env.fromCollection(testData).toTable(tEnv).as('a, 'b, 'c)
+    val t = env.fromCollection(testData).toTable(tEnv).as("a", "b", "c")
 
     val result = t
       // Adds simple column
@@ -438,8 +440,8 @@ class CalcITCase extends AbstractTestBase {
     StreamITCase.testResults = mutable.MutableList()
 
     val ds = StreamTestData.getSmall3TupleDataStream(env).toTable(tEnv, 'a, 'b, 'c)
-      .map(Func23('a, 'b, 'c)).as("a, b, c, d")
-      .map(Func24('a, 'b, 'c, 'd)).as("a, b, c, d")
+      .map(Func23('a, 'b, 'c)).as("a", "b", "c", "d")
+      .map(Func24('a, 'b, 'c, 'd)).as("a", "b", "c", "d")
       .map(Func1('b))
 
     val results = ds.toAppendStream[Row]

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/CorrelateITCase.scala
@@ -46,7 +46,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testCrossJoin(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
     val pojoFunc0 = new PojoTableFunc()
 
@@ -67,7 +67,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testLeftOuterJoinWithoutPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -89,7 +89,7 @@ class CorrelateITCase extends AbstractTestBase {
     */
   @Test (expected = classOf[ValidationException])
   def testLeftOuterJoinWithPredicates(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -107,7 +107,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testUserDefinedTableFunctionWithScalarFunction(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     val result = t
@@ -175,7 +175,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionConstructorWithParams(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val config = Map("key1" -> "value1", "key2" -> "value2")
     val func30 = new TableFunc3(null)
     val func31 = new TableFunc3("OneConf_")
@@ -242,7 +242,7 @@ class CorrelateITCase extends AbstractTestBase {
     )
 
     val rowType = Types.ROW(Types.INT, Types.BOOLEAN, Types.ROW(Types.INT, Types.INT, Types.INT))
-    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as('a, 'b, 'c)
+    val in = env.fromElements(row, row)(rowType).toTable(tEnv).as("a", "b", "c")
 
     val tableFunc5 = new TableFunc5()
     val result = in
@@ -260,7 +260,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionCollectorOpenClose(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
     val func20 = new Func20
 
@@ -287,7 +287,7 @@ class CorrelateITCase extends AbstractTestBase {
 
   @Test
   def testTableFunctionCollectorInit(): Unit = {
-    val t = testData(env).toTable(tEnv).as('a, 'b, 'c)
+    val t = testData(env).toTable(tEnv).as("a", "b", "c")
     val func0 = new TableFunc0
 
     // this case will generate 'timestamp' member field and 'DateFormatter'
@@ -315,7 +315,7 @@ class CorrelateITCase extends AbstractTestBase {
       .select('f0, 'f1)
       // test the output field name of flatMap is the same as the field name of the input table
       .flatMap(func2(concat('f0, "#")))
-      .as ('f0, 'f1)
+      .as ("f0", "f1")
       .select('f0, 'f1)
 
     val results = ds.toAppendStream[Row]

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableAggregateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableAggregateITCase.scala
@@ -51,7 +51,7 @@ class TableAggregateITCase extends StreamingWithStateTestBase {
     val resultTable = source.groupBy('b)
       .flatAggregate(top3('a))
       .select('b, 'f0, 'f1)
-      .as('category, 'v1, 'v2)
+      .as("category", "v1", "v2")
 
     val results = resultTable.toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -89,7 +89,7 @@ class TableAggregateITCase extends StreamingWithStateTestBase {
     val resultTable = source.groupBy('b)
       .flatAggregate(top3('a))
       .select('b, 'f0, 'f1)
-      .as('category, 'v1, 'v2)
+      .as("category", "v1", "v2")
 
     val results = resultTable.toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)
@@ -127,7 +127,7 @@ class TableAggregateITCase extends StreamingWithStateTestBase {
     val resultTable = source
       .flatAggregate(top3('a))
       .select('f0, 'f1)
-      .as('v1, 'v2)
+      .as("v1", "v2")
 
     val results = resultTable.toRetractStream[Row]
     results.addSink(new StreamITCase.RetractingSink).setParallelism(1)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/runtime/stream/table/TableSourceITCase.scala
@@ -136,8 +136,8 @@ class TableSourceITCase extends AbstractTestBase {
 
     tEnv.registerTableSource(tableName, TestFilterableTableSource())
     tEnv.scan(tableName)
-      .where("amount > 4 && price < 9")
-      .select("id, name")
+      .where($"amount" > 4 && $"price" < 9)
+      .select($"id", $"name")
       .addSink(new StreamITCase.StringSink[Row])
 
     env.execute()


### PR DESCRIPTION
## What is the purpose of the change

All methods of Table (and related classes like e.g. GroupedTable) that
expect expressions as a String were deprecated in favor of the
Expression DSL counterparts. This commit also removes majority of the
usages of the deprecated methods. The remaining methods explicitly test
the behavior of parsing/converting the String DSL.

## Verifying this change
All existing tests should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
