### PR TITLE
[FLINK-17515][yarn] Move file upload functionality out of the YarnClusterDescriptor

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.yarn;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
 import org.apache.flink.runtime.util.HadoopUtils;
@@ -50,7 +49,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -60,7 +58,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.yarn.YarnConfigKeys.ENV_FLINK_CLASSPATH;
 
@@ -80,12 +77,6 @@ public final class Utils {
 	/** Yarn site xml file name populated in YARN container for secure IT run. */
 	public static final String YARN_SITE_FILE_NAME = "yarn-site.xml";
 
-	/** Number of total retries to fetch the remote resources after uploaded in case of FileNotFoundException. */
-	public static final int REMOTE_RESOURCES_FETCH_NUM_RETRY = 3;
-
-	/** Time to wait in milliseconds between each remote resources fetch in case of FileNotFoundException. */
-	public static final int REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI = 100;
-
 	public static void setupYarnClassPath(Configuration conf, Map<String, String> appMasterEnv) {
 		addToEnvironment(
 			appMasterEnv,
@@ -97,85 +88,6 @@ public final class Utils {
 		for (String c : applicationClassPathEntries) {
 			addToEnvironment(appMasterEnv, Environment.CLASSPATH.name(), c.trim());
 		}
-	}
-
-	/**
-	 * Copy a local file to a remote file system.
-	 *
-	 * @param fs
-	 * 		remote filesystem
-	 * @param appId
-	 * 		application ID
-	 * @param localSrcPath
-	 * 		path to the local file
-	 * @param homedir
-	 * 		remote home directory base (will be extended)
-	 * @param relativeTargetPath
-	 * 		relative target path of the file (will be prefixed be the full home directory we set up)
-	 * @param replication
-	 * 	    number of replications of a remote file to be created
-	 *
-	 * @return Path to remote file (usually hdfs)
-	 */
-	static Tuple2<Path, Long> uploadLocalFileToRemote(
-		FileSystem fs,
-		String appId,
-		Path localSrcPath,
-		Path homedir,
-		String relativeTargetPath,
-		int replication) throws IOException {
-
-		File localFile = new File(localSrcPath.toUri().getPath());
-		if (localFile.isDirectory()) {
-			throw new IllegalArgumentException("File to copy must not be a directory: " +
-				localSrcPath);
-		}
-
-		// copy resource to HDFS
-		String suffix =
-			".flink/"
-				+ appId
-				+ (relativeTargetPath.isEmpty() ? "" : "/" + relativeTargetPath)
-				+ "/" + localSrcPath.getName();
-
-		Path dst = new Path(homedir, suffix);
-
-		LOG.debug("Copying from {} to {} with replication number {}", localSrcPath, dst, replication);
-		fs.copyFromLocalFile(false, true, localSrcPath, dst);
-		fs.setReplication(dst, (short) replication);
-
-		// Note: If we directly used registerLocalResource(FileSystem, Path) here, we would access the remote
-		//       file once again which has problems with eventually consistent read-after-write file
-		//       systems. Instead, we decide to wait until the remote file be available.
-
-		FileStatus[] fss = null;
-		int iter = 1;
-		while (iter <= REMOTE_RESOURCES_FETCH_NUM_RETRY + 1) {
-			try {
-				fss = fs.listStatus(dst);
-				break;
-			} catch (FileNotFoundException e) {
-				LOG.debug("Got FileNotFoundException while fetching uploaded remote resources at retry num {}", iter);
-				try {
-					LOG.debug("Sleeping for {}ms", REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI);
-					TimeUnit.MILLISECONDS.sleep(REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI);
-				} catch (InterruptedException ie) {
-					LOG.warn("Failed to sleep for {}ms at retry num {} while fetching uploaded remote resources",
-						REMOTE_RESOURCES_FETCH_WAIT_IN_MILLI, iter, ie);
-				}
-				iter++;
-			}
-		}
-
-		final long dstModificationTime;
-		if (fss != null && fss.length >  0) {
-			dstModificationTime = fss[0].getModificationTime();
-			LOG.debug("Got modification time {} from remote path {}", dstModificationTime, dst);
-		} else {
-			dstModificationTime = localFile.lastModified();
-			LOG.debug("Failed to fetch remote modification time from {}, using local timestamp {}", dst, dstModificationTime);
-		}
-		return new Tuple2<>(dst, dstModificationTime);
 	}
 
 	/**

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/Utils.java
@@ -100,39 +100,6 @@ public final class Utils {
 	}
 
 	/**
-	 * Copy a local file to a remote file system and register as Local Resource.
-	 *
-	 * @param fs
-	 * 		remote filesystem
-	 * @param appId
-	 * 		application ID
-	 * @param localSrcPath
-	 * 		path to the local file
-	 * @param homedir
-	 * 		remote home directory base (will be extended)
-	 * @param relativeTargetPath
-	 * 		relative target path of the file (will be prefixed be the full home directory we set up)
-	 * @param replication
-	 * 	    number of replications of a remote file to be created
-	 *
-	 * @return Path to remote file (usually hdfs)
-	 */
-	static Tuple2<Path, LocalResource> setupLocalResource(
-		FileSystem fs,
-		String appId,
-		Path localSrcPath,
-		Path homedir,
-		String relativeTargetPath,
-		int replication) throws IOException {
-
-		File localFile = new File(localSrcPath.toUri().getPath());
-		Tuple2<Path, Long> remoteFileInfo = uploadLocalFileToRemote(fs, appId, localSrcPath, homedir, relativeTargetPath, replication);
-		// now create the resource instance
-		LocalResource resource = registerLocalResource(remoteFileInfo.f0, localFile.length(), remoteFileInfo.f1);
-		return Tuple2.of(remoteFileInfo.f0, resource);
-	}
-
-	/**
 	 * Copy a local file to a remote file system.
 	 *
 	 * @param fs
@@ -243,7 +210,7 @@ public final class Utils {
 	 *
 	 * @return YARN resource
 	 */
-	private static LocalResource registerLocalResource(
+	static LocalResource registerLocalResource(
 			Path remoteRsrcPath,
 			long resourceSize,
 			long resourceModificationTime) {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -217,7 +217,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
 		return classPaths;
 	}
 
-	static YarnApplicationFileUploader initialize(
+	static YarnApplicationFileUploader from(
 			final FileSystem fileSystem,
 			final Path homeDirectory,
 			final ApplicationId applicationId) throws IOException {

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -255,7 +255,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 	 * Adds the given files to the list of files to ship.
 	 *
 	 * <p>Note that any file matching "<tt>flink-dist*.jar</tt>" will be excluded from the upload by
-	 * {@link YarnFileUploader#uploadAndRegisterFiles(Collection, List, Map, String, StringBuilder, int)}
+	 * {@link YarnApplicationFileUploader#setupMultipleLocalResources(Collection, List, Map, String, StringBuilder, int)}
 	 * since we upload the Flink uber jar ourselves and do not need to deploy it multiple times.
 	 *
 	 * @param shipFiles files to ship
@@ -441,7 +441,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			yarnClient.killApplication(applicationId);
 
 			try (final FileSystem fs = FileSystem.get(yarnConfiguration)) {
-				final Path applicationDir = YarnFileUploader
+				final Path applicationDir = YarnApplicationFileUploader
 						.getApplicationDirPath(fs.getHomeDirectory(), applicationId);
 
 				Utils.deleteApplicationFiles(Collections.singletonMap(
@@ -677,7 +677,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		ApplicationSubmissionContext appContext = yarnApplication.getApplicationSubmissionContext();
 
-		final YarnFileUploader fileUploader = YarnFileUploader.initialize(
+		final YarnApplicationFileUploader fileUploader = YarnApplicationFileUploader.initialize(
 				fs, fs.getHomeDirectory(), appContext.getApplicationId()
 		);
 
@@ -768,7 +768,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 		StringBuilder envShipFileList = new StringBuilder();
 
 		// upload and register ship files, these files will be added to classpath.
-		List<String> systemClassPaths = fileUploader.uploadAndRegisterFiles(
+		List<String> systemClassPaths = fileUploader.setupMultipleLocalResources(
 			systemShipFiles,
 			paths,
 			localResources,
@@ -777,7 +777,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			fileReplication);
 
 		// upload and register ship-only files
-		fileUploader.uploadAndRegisterFiles(
+		fileUploader.setupMultipleLocalResources(
 			shipOnlyFiles,
 			paths,
 			localResources,
@@ -785,7 +785,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			envShipFileList,
 			fileReplication);
 
-		final List<String> userClassPaths = fileUploader.uploadAndRegisterFiles(
+		final List<String> userClassPaths = fileUploader.setupMultipleLocalResources(
 			userJarFiles,
 			paths,
 			localResources,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -677,7 +677,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 
 		ApplicationSubmissionContext appContext = yarnApplication.getApplicationSubmissionContext();
 
-		final YarnApplicationFileUploader fileUploader = YarnApplicationFileUploader.initialize(
+		final YarnApplicationFileUploader fileUploader = YarnApplicationFileUploader.from(
 				fs, fs.getHomeDirectory(), appContext.getApplicationId()
 		);
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnFileUploader.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.util.IOUtils;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.LocalResource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Javadoc.
+ */
+class YarnFileUploader implements AutoCloseable {
+
+	private final FileSystem fileSystem;
+
+	private final ApplicationId applicationId;
+
+	private final Path homeDir;
+
+	private final Path applicationDir;
+
+	private YarnFileUploader(
+			final FileSystem fileSystem,
+			final Path homeDir,
+			final ApplicationId applicationId) throws IOException {
+		this.fileSystem = checkNotNull(fileSystem);
+		this.homeDir = checkNotNull(homeDir);
+		this.applicationId = checkNotNull(applicationId);
+		this.applicationDir = getApplicationDir(applicationId);
+	}
+
+	Path getHomeDir() {
+		return homeDir;
+	}
+
+	Path getApplicationDir() {
+		return applicationDir;
+	}
+
+	private Path getApplicationDir(final ApplicationId applicationId) throws IOException {
+		final Path applicationDir = getApplicationDirPath(homeDir, applicationId);
+		if (!fileSystem.exists(applicationDir)) {
+			final FsPermission permission = new FsPermission(FsAction.ALL, FsAction.NONE, FsAction.NONE);
+			fileSystem.mkdirs(applicationDir, permission);
+		}
+		return applicationDir;
+	}
+
+	@Override
+	public void close() {
+		IOUtils.closeQuietly(fileSystem);
+	}
+
+	static YarnFileUploader initialize(
+			final FileSystem fileSystem,
+			final Path homeDirectory,
+			final ApplicationId applicationId) throws IOException {
+		final FileSystem fs = checkNotNull(fileSystem);
+		final Path homeDir = checkNotNull(homeDirectory);
+		return new YarnFileUploader(fs, homeDir, applicationId);
+	}
+
+	/**
+	 * Uploads and registers a single resource and adds it to <tt>localResources</tt>.
+	 *
+	 * @param key
+	 * 		the key to add the resource under
+	 * @param localSrcPath
+	 * 		local path to the file
+	 * @param localResources
+	 * 		map of resources
+	 * @param replication
+	 * 	    number of replications of a remote file to be created
+	 *
+	 * @return the remote path to the uploaded resource
+	 */
+	Path setupSingleLocalResource(
+			String key,
+			Path localSrcPath,
+			Map<String, LocalResource> localResources,
+			String relativeTargetPath,
+			int replication) throws IOException {
+
+		File localFile = new File(localSrcPath.toUri().getPath());
+		Tuple2<Path, Long> remoteFileInfo = uploadLocalFileToRemote(localSrcPath, relativeTargetPath, replication);
+		LocalResource resource = Utils.registerLocalResource(remoteFileInfo.f0, localFile.length(), remoteFileInfo.f1);
+		localResources.put(key, resource);
+		return remoteFileInfo.f0;
+	}
+
+	Tuple2<Path, Long> uploadLocalFileToRemote(
+			Path localSrcPath,
+			String relativeTargetPath,
+			int replication) throws IOException {
+		return Utils.uploadLocalFileToRemote(fileSystem, applicationId.toString(), localSrcPath, homeDir, relativeTargetPath, replication);
+	}
+
+	/**
+	 * Recursively uploads (and registers) any (user and system) files in <tt>shipFiles</tt> except
+	 * for files matching "<tt>flink-dist*.jar</tt>" which should be uploaded separately.
+	 *
+	 * @param shipFiles
+	 * 		files to upload
+	 * @param remotePaths
+	 * 		paths of the remote resources (uploaded resources will be added)
+	 * @param localResources
+	 * 		map of resources (uploaded resources will be added)
+	 * @param localResourcesDirectory
+	 *		the directory the localResources are uploaded to
+	 * @param envShipFileList
+	 * 		list of shipped files in a format understood by {@link Utils#createTaskExecutorContext}
+	 * @param replication
+	 * 	     number of replications of a remote file to be created
+	 *
+	 * @return list of class paths with the the proper resource keys from the registration
+	 */
+	List<String> uploadAndRegisterFiles(
+			Collection<File> shipFiles,
+			List<Path> remotePaths,
+			Map<String, LocalResource> localResources,
+			String localResourcesDirectory,
+			StringBuilder envShipFileList,
+			int replication) throws IOException {
+
+		checkArgument(replication >= 1);
+		final List<Path> localPaths = new ArrayList<>();
+		final List<Path> relativePaths = new ArrayList<>();
+		for (File shipFile : shipFiles) {
+			if (shipFile.isDirectory()) {
+				// add directories to the classpath
+				final java.nio.file.Path shipPath = shipFile.toPath();
+				final java.nio.file.Path parentPath = shipPath.getParent();
+				Files.walkFileTree(shipPath, new SimpleFileVisitor<java.nio.file.Path>() {
+					@Override
+					public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) {
+						localPaths.add(new Path(file.toUri()));
+						relativePaths.add(new Path(localResourcesDirectory, parentPath.relativize(file).toString()));
+						return FileVisitResult.CONTINUE;
+					}
+				});
+			} else {
+				localPaths.add(new Path(shipFile.toURI()));
+				relativePaths.add(new Path(localResourcesDirectory, shipFile.getName()));
+			}
+		}
+
+		final Set<String> archives = new HashSet<>();
+		final Set<String> resources = new HashSet<>();
+		for (int i = 0; i < localPaths.size(); i++) {
+			final Path localPath = localPaths.get(i);
+			final Path relativePath = relativePaths.get(i);
+			if (!isFlinkDistJar(relativePath.getName())) {
+				final String key = relativePath.toString();
+				final Path remotePath = setupSingleLocalResource(
+						key,
+						localPath,
+						localResources,
+						relativePath.getParent().toString(),
+						replication);
+				remotePaths.add(remotePath);
+				envShipFileList.append(key).append("=").append(remotePath).append(",");
+				// add files to the classpath
+				if (key.endsWith("jar")) {
+					archives.add(relativePath.toString());
+				} else {
+					resources.add(relativePath.getParent().toString());
+				}
+			}
+		}
+
+		// construct classpath, we always want resource directories to go first, we also sort
+		// both resources and archives in order to make classpath deterministic
+		final ArrayList<String> classPaths = new ArrayList<>();
+		resources.stream().sorted().forEach(classPaths::add);
+		archives.stream().sorted().forEach(classPaths::add);
+		return classPaths;
+	}
+
+	private static boolean isFlinkDistJar(String fileName) {
+		return fileName.startsWith("flink-dist") && fileName.endsWith("jar");
+	}
+
+	static Path getApplicationDirPath(final Path homeDir, final ApplicationId applicationId) {
+		return new Path(checkNotNull(homeDir), ".flink/" + checkNotNull(applicationId) + '/');
+	}
+}

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -194,10 +194,10 @@ public class YarnFileStageTest extends TestLogger {
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
-			final YarnFileUploader uploader = YarnFileUploader.initialize(
+			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.initialize(
 					targetFileSystem, targetDir, applicationId);
 
-			final List<String> classpath = uploader.uploadAndRegisterFiles(
+			final List<String> classpath = uploader.setupMultipleLocalResources(
 				Collections.singletonList(new File(srcPath.toUri().getPath())),
 				remotePaths,
 				localResources,
@@ -259,10 +259,10 @@ public class YarnFileStageTest extends TestLogger {
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
-			final YarnFileUploader uploader = YarnFileUploader.initialize(
+			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.initialize(
 					targetFileSystem, targetDir, applicationId);
 
-			final List<String> classpath = uploader.uploadAndRegisterFiles(
+			final List<String> classpath = uploader.setupMultipleLocalResources(
 				Collections.singletonList(new File(srcDir, localFile)),
 				remotePaths,
 				localResources,

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -194,7 +194,7 @@ public class YarnFileStageTest extends TestLogger {
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
-			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.initialize(
+			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.from(
 					targetFileSystem, targetDir, applicationId);
 
 			final List<String> classpath = uploader.setupMultipleLocalResources(
@@ -259,7 +259,7 @@ public class YarnFileStageTest extends TestLogger {
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
 
 			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
-			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.initialize(
+			final YarnApplicationFileUploader uploader = YarnApplicationFileUploader.from(
 					targetFileSystem, targetDir, applicationId);
 
 			final List<String> classpath = uploader.setupMultipleLocalResources(

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/YarnFileStageTest.java
@@ -192,11 +192,13 @@ public class YarnFileStageTest extends TestLogger {
 		try {
 			final List<Path> remotePaths = new ArrayList<>();
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
-			final List<String> classpath = YarnClusterDescriptor.uploadAndRegisterFiles(
+
+			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
+			final YarnFileUploader uploader = YarnFileUploader.initialize(
+					targetFileSystem, targetDir, applicationId);
+
+			final List<String> classpath = uploader.uploadAndRegisterFiles(
 				Collections.singletonList(new File(srcPath.toUri().getPath())),
-				targetFileSystem,
-				targetDir,
-				ApplicationId.newInstance(0, 0),
 				remotePaths,
 				localResources,
 				localResourceDirectory,
@@ -255,11 +257,13 @@ public class YarnFileStageTest extends TestLogger {
 		try {
 			final List<Path> remotePaths = new ArrayList<>();
 			final HashMap<String, LocalResource> localResources = new HashMap<>();
-			final List<String> classpath = YarnClusterDescriptor.uploadAndRegisterFiles(
+
+			final ApplicationId applicationId = ApplicationId.newInstance(0, 0);
+			final YarnFileUploader uploader = YarnFileUploader.initialize(
+					targetFileSystem, targetDir, applicationId);
+
+			final List<String> classpath = uploader.uploadAndRegisterFiles(
 				Collections.singletonList(new File(srcDir, localFile)),
-				targetFileSystem,
-				targetDir,
-				ApplicationId.newInstance(0, 0),
 				remotePaths,
 				localResources,
 				localResourceDirectory,


### PR DESCRIPTION
## What is the purpose of the change

**NOTE TO REVIEWERS:** all commits in this PR are going to get squashed into a single one, when merged. I just left them here in case it is easier to follow the changes.

This PR refactors code out of the `YarnClusterDescriptor` and the `yarn.Utils` and into the `YarnApplicationFileUploader`. The main methods transferred are the:

* `Utils.uploadLocalFileToRemote()`
* `uploadAndRegisterFiles()`
* `setupSingleLocalResource()`

## Verifying this change

This change is a trivial rework / code cleanup and it is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes - YARN** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
