### PR TITLE
[FLINK-17204][connectors/rabbitmq] Make RMQ queue declaration consistent between source and sink

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -121,7 +121,7 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 	 */
 	protected void setupQueue() throws IOException {
 		if (queueName != null) {
-			channel.queueDeclare(queueName, true, false, false, null);
+			Util.declareQueueDefaults(channel, queueName);
 		}
 	}
 

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -121,7 +121,7 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 	 */
 	protected void setupQueue() throws IOException {
 		if (queueName != null) {
-			channel.queueDeclare(queueName, false, false, false, null);
+			channel.queueDeclare(queueName, true, false, false, null);
 		}
 	}
 

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -138,7 +138,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * defining custom queue parameters)
 	 */
 	protected void setupQueue() throws IOException {
-		channel.queueDeclare(queueName, true, false, false, null);
+		Util.declareQueueDefaults(channel, queueName);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/Util.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/Util.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+
+import java.io.IOException;
+
+class Util {
+	/**
+	 * Declares a queue with sensible defaults: durable, non-exclusive, non-autoDelete, and no arguments.
+	 * @param channel the open RMQ channel.
+	 * @param queueName the name of the queue.
+	 * @throws IOException if an error is encountered setting up the queue.
+	 */
+	static void declareQueueDefaults(Channel channel, String queueName) throws IOException {
+		channel.queueDeclare(queueName, true, false, false, null);
+	}
+}

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
@@ -87,14 +87,14 @@ public class RMQSinkTest {
 	public void openCallDeclaresQueueInStandardMode() throws Exception {
 		createRMQSink();
 
-		verify(channel).queueDeclare(QUEUE_NAME, false, false, false, null);
+		verify(channel).queueDeclare(QUEUE_NAME, true, false, false, null);
 	}
 
 	@Test
 	public void openCallDontDeclaresQueueInWithOptionsMode() throws Exception {
 		createRMQSinkWithOptions(false, false);
 
-		verify(channel, never()).queueDeclare(null, false, false, false, null);
+		verify(channel, never()).queueDeclare(null, true, false, false, null);
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes the queue declaration in the RabbitMQ Source and Sink consistent. Previously, the Source asserted a durable queue while the Sink asserted a transient queue. This made using the same queue for input and output impossible (as described in the ticket FLINK-17204). The rationale for setting queues to durable by default is taken from the RabbitMQ UI defaults, shown here:

![rmq-add-new-queue](https://user-images.githubusercontent.com/4655775/81102687-f787a500-8edd-11ea-86ec-4e98551843c4.png)

The classes can still be overridden if end users want different default semantics.

## Brief change log

  - The `RMQSink` asserts durable queues

## Verifying this change

This change added tests and can be verified as follows:

  - Added a unit test `RMQSourceTest.testOpenCallDeclaresQueueInStandardMode()`, similar to the existing tests in `RMQSinkTest`, which confirm that the queue is asserted with consistent parameters
- Updated the existing unit tests in `RMQSinkTest` to assert that durable queues are created

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)

I couldn't find any mention of the current configuration in the JavaDocs [[RMQSink]](https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.html) [[RMQSource]](https://ci.apache.org/projects/flink/flink-docs-release-1.10/api/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.html), though I'm happy to add docs around this if that would be helpful.
