### PR TITLE
[FLINK-10934] Support application mode for kubernetes

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/ExecutionConfigAccessor.java
@@ -55,14 +55,14 @@ public class ExecutionConfigAccessor {
 	/**
 	 * Creates an {@link ExecutionConfigAccessor} based on the provided {@link ProgramOptions} as provided by the user through the CLI.
 	 */
-	public static ExecutionConfigAccessor fromProgramOptions(final ProgramOptions options, final List<URL> jobJars) {
+	public static <T> ExecutionConfigAccessor fromProgramOptions(final ProgramOptions options, final List<T> jobJars) {
 		checkNotNull(options);
 		checkNotNull(jobJars);
 
 		final Configuration configuration = new Configuration();
 
 		options.applyToConfiguration(configuration);
-		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jobJars, URL::toString);
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, jobJars, Object::toString);
 
 		return new ExecutionConfigAccessor(configuration);
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PackagedProgramUtils.java
@@ -29,9 +29,12 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -209,6 +212,14 @@ public enum PackagedProgramUtils {
 		} catch (MalformedURLException e) {
 			throw new RuntimeException("URL is invalid. This should not happen.", e);
 		}
+	}
+
+	public static URI resolveURI(String path) throws URISyntaxException {
+		final URI uri = new URI(path);
+		if (uri.getScheme() != null) {
+			return uri;
+		}
+		return new File(path).getAbsoluteFile().toURI();
 	}
 
 	private static ProgramInvocationException generateException(

--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ClassPathPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ClassPathPackagedProgramRetrieverTest.java
@@ -299,6 +299,35 @@ public class ClassPathPackagedProgramRetrieverTest extends TestLogger {
 				containsInAnyOrder(expectedURLs.stream().map(URL::toString).toArray()));
 	}
 
+	@Test
+	public void testRetrieveFromJarFileWithoutUserLib() throws IOException, FlinkException, ProgramInvocationException {
+		final File testJar = TestJob.getTestJobJar();
+		final ClassPathPackagedProgramRetriever retrieverUnderTest =
+			ClassPathPackagedProgramRetriever.newBuilder(PROGRAM_ARGUMENTS)
+				.setJarFile(testJar)
+				.build();
+		final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, new Configuration());
+
+		assertThat(jobGraph.getUserJars(), containsInAnyOrder(new org.apache.flink.core.fs.Path(testJar.toURI())));
+		assertThat(jobGraph.getClasspaths().isEmpty(), is(true));
+	}
+
+	@Test
+	public void testRetrieveFromJarFileWithUserLib() throws IOException, FlinkException, ProgramInvocationException {
+		final File testJar = TestJob.getTestJobJar();
+		final ClassPathPackagedProgramRetriever retrieverUnderTest =
+			ClassPathPackagedProgramRetriever.newBuilder(PROGRAM_ARGUMENTS)
+				.setJarFile(testJar)
+				.setUserLibDirectory(userDirHasEntryClass)
+				.build();
+		final JobGraph jobGraph = retrieveJobGraph(retrieverUnderTest, new Configuration());
+
+		assertThat(jobGraph.getUserJars(), containsInAnyOrder(new org.apache.flink.core.fs.Path(testJar.toURI())));
+		assertThat(
+			jobGraph.getClasspaths().stream().map(URL::toString).collect(Collectors.toList()),
+			containsInAnyOrder(expectedURLs.stream().map(URL::toString).toArray()));
+	}
+
 	private JobGraph retrieveJobGraph(ClassPathPackagedProgramRetriever retrieverUnderTest, Configuration configuration) throws FlinkException, ProgramInvocationException {
 		final PackagedProgram packagedProgram = retrieverUnderTest.getPackagedProgram();
 

--- a/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramUtilsTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/PackagedProgramUtilsTest.java
@@ -29,6 +29,10 @@ import org.apache.flink.streaming.api.graph.StreamGraph;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.net.URISyntaxException;
+
+import static org.apache.flink.client.program.PackagedProgramUtils.resolveURI;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -85,6 +89,27 @@ public class PackagedProgramUtilsTest {
 		ExecutionConfig executionConfig = ((StreamGraph) pipeline).getExecutionConfig();
 
 		assertExpectedOption(executionConfig);
+	}
+
+	@Test
+	public void testResolveURI() throws URISyntaxException {
+		final String relativeFile = "path/of/user.jar";
+		assertThat(resolveURI(relativeFile).getScheme(), is("file"));
+		assertThat(
+			resolveURI(relativeFile).getPath(),
+			is(new File(System.getProperty("user.dir"), relativeFile).getAbsolutePath()));
+
+		final String absoluteFile = "/path/of/user.jar";
+		assertThat(resolveURI(relativeFile).getScheme(), is("file"));
+		assertThat(resolveURI(absoluteFile).getPath(), is(absoluteFile));
+
+		final String fileSchemaFile = "file:///path/of/user.jar";
+		assertThat(resolveURI(fileSchemaFile).getScheme(), is("file"));
+		assertThat(resolveURI(fileSchemaFile).toString(), is(fileSchemaFile));
+
+		final String localSchemaFile = "local:///path/of/user.jar";
+		assertThat(resolveURI(localSchemaFile).getScheme(), is("local"));
+		assertThat(resolveURI(localSchemaFile).toString(), is(localSchemaFile));
 	}
 
 	private static void assertPrecondition(ExecutionConfig executionConfig) {

--- a/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-cli.properties
@@ -39,6 +39,11 @@ logger.hadoop.name = org.apache.hadoop
 logger.hadoop.level = INFO
 logger.hadoop.appenderRef.console.ref = ConsoleAppender
 
+# Log output from org.apache.flink.kubernetes to the console.
+logger.kubernetes.name = org.apache.flink.kubernetes
+logger.kubernetes.level = INFO
+logger.kubernetes.appenderRef.console.ref = ConsoleAppender
+
 appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -126,6 +126,7 @@ if [[ ${PROFILE} != *"jdk11"* ]]; then
 
 	run_test "Run Kubernetes test" "$END_TO_END_DIR/test-scripts/test_kubernetes_embedded_job.sh"
 	run_test "Run kubernetes session test" "$END_TO_END_DIR/test-scripts/test_kubernetes_session.sh"
+	run_test "Run kubernetes application test" "$END_TO_END_DIR/test-scripts/test_kubernetes_application.sh"
 
 	run_test "Running Flink over NAT end-to-end test" "$END_TO_END_DIR/test-scripts/test_nat.sh" "skip_check_exceptions"
 

--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -157,4 +157,25 @@ function wait_rest_endpoint_up_k8s {
   exit 1
 }
 
+function cleanup {
+    if [ $TRAPPED_EXIT_CODE != 0 ];then
+      debug_and_show_logs
+    fi
+    internal_cleanup
+    kubectl wait --for=delete pod --all=true
+    stop_kubernetes
+}
+
+function setConsoleLogging {
+    cat >> $FLINK_DIR/conf/log4j.properties <<END
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+# Log all infos to the console
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %-60c %x - %m%n
+END
+}
+
 on_exit cleanup

--- a/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
+++ b/flink-end-to-end-tests/test-scripts/test_kubernetes_embedded_job.sh
@@ -26,16 +26,10 @@ export OUTPUT_FILE=kubernetes_wc_out
 export FLINK_JOB_PARALLELISM=1
 export FLINK_JOB_ARGUMENTS='"--output", "/cache/kubernetes_wc_out"'
 
-SUCCEEDED=1
-
-function cleanup {
-    if [ $SUCCEEDED != 0 ];then
-      debug_and_show_logs
-    fi
+function internal_cleanup {
     kubectl delete job flink-job-cluster
     kubectl delete service flink-job-cluster
     kubectl delete deployment flink-task-manager
-    stop_kubernetes
 }
 
 start_kubernetes
@@ -54,4 +48,3 @@ kubectl wait --for=condition=complete job/flink-job-cluster --timeout=1h
 kubectl cp `kubectl get pods | awk '/task-manager/ {print $1}'`:/cache/${OUTPUT_FILE} ${OUTPUT_VOLUME}/${OUTPUT_FILE}
 
 check_result_hash "WordCount" ${OUTPUT_VOLUME}/${OUTPUT_FILE} "${RESULT_HASH}"
-SUCCEEDED=$?

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterClientFactory.java
@@ -24,7 +24,7 @@ import org.apache.flink.client.deployment.ClusterClientFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
-import org.apache.flink.kubernetes.executors.KubernetesSessionClusterExecutor;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.kubeclient.KubeClientFactory;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.AbstractID;
@@ -45,7 +45,7 @@ public class KubernetesClusterClientFactory extends AbstractContainerizedCluster
 	public boolean isCompatibleWith(Configuration configuration) {
 		checkNotNull(configuration);
 		final String deploymentTarget = configuration.getString(DeploymentOptions.TARGET);
-		return KubernetesSessionClusterExecutor.NAME.equalsIgnoreCase(deploymentTarget);
+		return KubernetesDeploymentTarget.isValidKubernetesTarget(deploymentTarget);
 	}
 
 	@Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -34,6 +34,8 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptionsInternal;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
+import org.apache.flink.kubernetes.entrypoint.KubernetesApplicationClusterEntrypoint;
 import org.apache.flink.kubernetes.entrypoint.KubernetesSessionClusterEntrypoint;
 import org.apache.flink.kubernetes.kubeclient.Endpoint;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
@@ -48,10 +50,13 @@ import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClie
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -146,8 +151,39 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
 	@Override
 	public ClusterClientProvider<String> deployApplicationCluster(
 			final ClusterSpecification clusterSpecification,
-			final ApplicationConfiguration applicationConfiguration) {
-		throw new UnsupportedOperationException("Application Mode not supported by Active Kubernetes deployments.");
+			final ApplicationConfiguration applicationConfiguration) throws ClusterDeploymentException {
+		if (client.getRestService(clusterId).isPresent()) {
+			throw new ClusterDeploymentException("The Flink cluster " + clusterId + " already exists.");
+		}
+
+		checkNotNull(clusterSpecification);
+		checkNotNull(applicationConfiguration);
+
+		final KubernetesDeploymentTarget deploymentTarget = KubernetesDeploymentTarget.fromConfig(flinkConfig);
+		if (KubernetesDeploymentTarget.APPLICATION != deploymentTarget) {
+			throw new ClusterDeploymentException(
+				"Couldn't deploy Kubernetes Application Cluster." +
+					" Expected deployment.target=" + KubernetesDeploymentTarget.APPLICATION.getName() +
+					" but actual one was \"" + deploymentTarget + "\"");
+		}
+
+		applicationConfiguration.applyToConfiguration(flinkConfig);
+
+		final List<File> pipelineJars = KubernetesUtils.checkJarFileForApplicationMode(flinkConfig);
+		Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+
+		final ClusterClientProvider<String> clusterClientProvider = deployClusterInternal(
+			KubernetesApplicationClusterEntrypoint.class.getName(),
+			clusterSpecification,
+			false);
+
+		try (ClusterClient<String> clusterClient = clusterClientProvider.getClusterClient()) {
+			LOG.info(
+				"Create flink application cluster {} successfully, JobManager Web Interface: {}",
+				clusterId,
+				clusterClient.getWebInterfaceURL());
+		}
+		return clusterClientProvider;
 	}
 
 	@Override

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesDeploymentTarget.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesDeploymentTarget.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.configuration;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A class containing all the supported deployment target names for Kubernetes.
+ */
+@Internal
+public enum KubernetesDeploymentTarget {
+
+	SESSION("kubernetes-session"),
+	APPLICATION("kubernetes-application");
+
+	private final String name;
+
+	KubernetesDeploymentTarget(final String name) {
+		this.name = checkNotNull(name);
+	}
+
+	public static KubernetesDeploymentTarget fromConfig(final Configuration configuration) {
+		checkNotNull(configuration);
+
+		final String deploymentTargetStr = configuration.get(DeploymentOptions.TARGET);
+		final KubernetesDeploymentTarget deploymentTarget = getFromName(deploymentTargetStr);
+
+		if (deploymentTarget == null) {
+			throw new IllegalArgumentException(
+					"Unknown Kubernetes deployment target \"" + deploymentTargetStr + "\"." +
+							" The available options are: " + options());
+		}
+		return deploymentTarget;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public static boolean isValidKubernetesTarget(final String configValue) {
+		return configValue != null &&
+				Arrays.stream(KubernetesDeploymentTarget.values())
+						.anyMatch(kubernetesDeploymentTarget -> kubernetesDeploymentTarget.name.equalsIgnoreCase(configValue));
+	}
+
+	private static KubernetesDeploymentTarget getFromName(final String deploymentTarget) {
+		if (deploymentTarget == null) {
+			return null;
+		}
+
+		if (SESSION.name.equalsIgnoreCase(deploymentTarget)) {
+			return SESSION;
+		} else if (APPLICATION.name.equalsIgnoreCase(deploymentTarget)) {
+			return APPLICATION;
+		}
+		return null;
+	}
+
+	private static String options() {
+		return Arrays.stream(KubernetesDeploymentTarget.values())
+				.map(KubernetesDeploymentTarget::getName)
+				.collect(Collectors.joining(","));
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.entrypoint;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.client.deployment.application.ApplicationClusterEntryPoint;
+import org.apache.flink.client.deployment.application.ApplicationConfiguration;
+import org.apache.flink.client.deployment.application.ClassPathPackagedProgramRetriever;
+import org.apache.flink.client.deployment.application.executors.EmbeddedExecutor;
+import org.apache.flink.client.program.PackagedProgram;
+import org.apache.flink.client.program.PackagedProgramRetriever;
+import org.apache.flink.configuration.ConfigUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
+import org.apache.flink.runtime.util.EnvironmentInformation;
+import org.apache.flink.runtime.util.JvmShutdownSafeguard;
+import org.apache.flink.runtime.util.SignalHandler;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+
+import static org.apache.flink.runtime.util.ClusterEntrypointUtils.tryFindUserLibDirectory;
+
+/**
+ * An {@link ApplicationClusterEntryPoint} for Kubernetes.
+ */
+@Internal
+public final class KubernetesApplicationClusterEntrypoint extends ApplicationClusterEntryPoint {
+
+	private KubernetesApplicationClusterEntrypoint(
+			final Configuration configuration,
+			final PackagedProgram program) {
+		super(configuration, program, KubernetesResourceManagerFactory.getInstance());
+	}
+
+	public static void main(final String[] args) {
+		// startup checks and logging
+		EnvironmentInformation.logEnvironmentInfo(LOG, KubernetesApplicationClusterEntrypoint.class.getSimpleName(), args);
+		SignalHandler.register(LOG);
+		JvmShutdownSafeguard.installAsShutdownHook(LOG);
+
+		final Configuration configuration = KubernetesEntrypointUtils.loadConfiguration();
+
+		PackagedProgram program = null;
+		try {
+			program = getPackagedProgram(configuration);
+		} catch (Exception e) {
+			LOG.error("Could not create application program.", e);
+			System.exit(1);
+		}
+
+		configuration.set(DeploymentOptions.TARGET, EmbeddedExecutor.NAME);
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.JARS, program.getJobJarAndDependencies(), URL::toString);
+		ConfigUtils.encodeCollectionToConfig(configuration, PipelineOptions.CLASSPATHS, program.getClasspaths(), URL::toString);
+
+		final KubernetesApplicationClusterEntrypoint kubernetesApplicationClusterEntrypoint =
+			new KubernetesApplicationClusterEntrypoint(configuration, program);
+
+		ClusterEntrypoint.runClusterEntrypoint(kubernetesApplicationClusterEntrypoint);
+	}
+
+	private static PackagedProgram getPackagedProgram(final Configuration configuration) throws IOException, FlinkException {
+
+		final ApplicationConfiguration applicationConfiguration =
+			ApplicationConfiguration.fromConfiguration(configuration);
+
+		final PackagedProgramRetriever programRetriever = getPackagedProgramRetriever(
+			configuration,
+			applicationConfiguration.getProgramArguments(),
+			applicationConfiguration.getApplicationClassName());
+		return programRetriever.getPackagedProgram();
+	}
+
+	private static PackagedProgramRetriever getPackagedProgramRetriever(
+			final Configuration configuration,
+			final String[] programArguments,
+			@Nullable final String jobClassName) throws IOException {
+
+		final List<File> pipelineJars = KubernetesUtils.checkJarFileForApplicationMode(configuration);
+		Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+
+		final ClassPathPackagedProgramRetriever.Builder retrieverBuilder =
+			ClassPathPackagedProgramRetriever
+				.newBuilder(programArguments)
+				.setJarFile(pipelineJars.get(0))
+				.setJobClassName(jobClassName);
+		tryFindUserLibDirectory().ifPresent(retrieverBuilder::setUserLibDirectory);
+		return retrieverBuilder.build();
+	}
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/executors/KubernetesSessionClusterExecutor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.client.deployment.executors.AbstractSessionClusterExecutor;
 import org.apache.flink.core.execution.PipelineExecutor;
 import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 
 /**
  * The {@link PipelineExecutor} to be used when executing a job on an already running cluster.
@@ -29,7 +30,7 @@ import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 @Internal
 public class KubernetesSessionClusterExecutor extends AbstractSessionClusterExecutor<String, KubernetesClusterClientFactory> {
 
-	public static final String NAME = "kubernetes-session";
+	public static final String NAME = KubernetesDeploymentTarget.SESSION.getName();
 
 	public KubernetesSessionClusterExecutor() {
 		super(new KubernetesClusterClientFactory());

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.kubernetes.utils;
 
+import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.function.FunctionUtils;
 
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -33,9 +36,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.File;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -177,6 +184,21 @@ public class KubernetesUtils {
 
 		final String commandTemplate = flinkConfig.getString(KubernetesConfigOptions.CONTAINER_START_COMMAND_TEMPLATE);
 		return BootstrapTools.getStartCommand(commandTemplate, startCommandValues);
+	}
+
+	public static List<File> checkJarFileForApplicationMode(Configuration configuration) {
+		return configuration.get(PipelineOptions.JARS).stream().map(
+			FunctionUtils.uncheckedFunction(
+				uri -> {
+					final URI jarURI = PackagedProgramUtils.resolveURI(uri);
+					if (jarURI.getScheme().equals("local") && jarURI.isAbsolute()) {
+						return new File(jarURI.getPath());
+					}
+					throw new IllegalArgumentException("Only \"local\" is supported as schema for application mode." +
+							" This assumes that the jar is located in the image, not the Flink client." +
+							" An example of such path is: local:///opt/flink/examples/streaming/WindowJoin.jar");
+				})
+		).collect(Collectors.toList());
 	}
 
 	private static String getJavaOpts(Configuration flinkConfig, ConfigOption<String> configOption) {

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -20,24 +20,32 @@ package org.apache.flink.kubernetes;
 
 import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.core.testutils.CommonTestUtils.assertThrows;
 import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_IP_ADDRESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,16 +60,135 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
 	private final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
 		.createClusterSpecification();
 
+	private final Service loadBalancerSvc = buildExternalServiceWithLoadBalancer(MOCK_SERVICE_HOST_NAME, MOCK_SERVICE_IP);
+
+	private final ApplicationConfiguration appConfig = new ApplicationConfiguration(new String[0], null);
+
+	private KubernetesClusterDescriptor descriptor;
+
 	@Before
 	public void setup() throws Exception {
 		super.setup();
 
-		mockExpectedServiceFromServerSide(buildExternalServiceWithLoadBalancer(MOCK_SERVICE_HOST_NAME, MOCK_SERVICE_IP));
+		descriptor = new KubernetesClusterDescriptor(flinkConfig, flinkKubeClient);
 	}
 
 	@Test
 	public void testDeploySessionCluster() throws Exception {
-		final ClusterClient<String> clusterClient = deploySessionCluster();
+		final ClusterClient<String> clusterClient = deploySessionCluster().getClusterClient();
+		checkClusterClient(clusterClient);
+		checkUpdatedConfigAndResourceSetting();
+		clusterClient.close();
+	}
+
+	@Test
+	public void testDeployHighAvailabilitySessionCluster() throws ClusterDeploymentException {
+		flinkConfig.setString(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.toString());
+		final ClusterClient<String> clusterClient = deploySessionCluster().getClusterClient();
+		checkClusterClient(clusterClient);
+
+		final Container jmContainer = kubeClient
+			.apps()
+			.deployments()
+			.list()
+			.getItems()
+			.get(0)
+			.getSpec()
+			.getTemplate()
+			.getSpec()
+			.getContainers()
+			.get(0);
+		assertTrue(
+			"Environment " + ENV_FLINK_POD_IP_ADDRESS + " should be set.",
+			jmContainer.getEnv().stream()
+				.map(EnvVar::getName)
+				.collect(Collectors.toList())
+				.contains(ENV_FLINK_POD_IP_ADDRESS));
+
+		clusterClient.close();
+	}
+
+	@Test
+	public void testKillCluster() throws Exception {
+		deploySessionCluster();
+
+		assertEquals(2, kubeClient.services().list().getItems().size());
+
+		descriptor.killCluster(CLUSTER_ID);
+
+		// Mock kubernetes server do not delete the accompanying resources by gc.
+		assertTrue(kubeClient.apps().deployments().list().getItems().isEmpty());
+		assertEquals(2, kubeClient.services().list().getItems().size());
+		assertEquals(1, kubeClient.configMaps().list().getItems().size());
+	}
+
+	@Test
+	public void testDeployApplicationCluster() {
+		flinkConfig.set(PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
+		flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+		try {
+			descriptor.deployApplicationCluster(clusterSpecification, appConfig);
+		} catch (Exception ignored) {}
+
+		mockExpectedServiceFromServerSide(loadBalancerSvc);
+		final ClusterClient<String> clusterClient = descriptor.retrieve(CLUSTER_ID).getClusterClient();
+		checkClusterClient(clusterClient);
+		checkUpdatedConfigAndResourceSetting();
+	}
+
+	@Test
+	public void testDeployApplicationClusterWithNonLocalSchema() {
+		flinkConfig.set(PipelineOptions.JARS, Collections.singletonList("file:///path/of/user.jar"));
+		flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+		assertThrows(
+			"Only \"local\" is supported as schema for application mode.",
+			IllegalArgumentException.class,
+			() -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+	}
+
+	@Test
+	public void testDeployApplicationClusterWithClusterAlreadyExists() {
+		flinkConfig.set(PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
+		flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+		mockExpectedServiceFromServerSide(loadBalancerSvc);
+		assertThrows(
+			"The Flink cluster " + CLUSTER_ID + " already exists.",
+			ClusterDeploymentException.class,
+			() -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+	}
+
+	@Test
+	public void testDeployApplicationClusterWithDeploymentTargetNotCorrectlySet() {
+		flinkConfig.set(PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
+		flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName());
+		assertThrows(
+			"Expected deployment.target=kubernetes-application",
+			ClusterDeploymentException.class,
+			() -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+	}
+
+	@Test
+	public void testDeployApplicationClusterWithMultipleJarsSet() {
+		flinkConfig.set(PipelineOptions.JARS, Arrays.asList("local:///path/of/user.jar", "local:///user2.jar"));
+		flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+		assertThrows(
+			"Should only have one jar",
+			IllegalArgumentException.class,
+			() -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
+	}
+
+	private ClusterClientProvider<String> deploySessionCluster() throws ClusterDeploymentException {
+		mockExpectedServiceFromServerSide(loadBalancerSvc);
+		return descriptor.deploySessionCluster(clusterSpecification);
+	}
+
+	private void checkClusterClient(ClusterClient<String> clusterClient) {
+		assertEquals(CLUSTER_ID, clusterClient.getClusterId());
+		// Both HA and non-HA mode, the web interface should always be the Kubernetes exposed service address.
+		assertEquals(String.format("http://%s:%d", MOCK_SERVICE_IP, REST_PORT), clusterClient.getWebInterfaceURL());
+	}
+
+	private void checkUpdatedConfigAndResourceSetting() {
 		// Check updated flink config options
 		assertEquals(String.valueOf(Constants.BLOB_SERVER_PORT), flinkConfig.getString(BlobServerOptions.PORT));
 		assertEquals(String.valueOf(Constants.TASK_MANAGER_RPC_PORT), flinkConfig.getString(TaskManagerOptions.RPC_PORT));
@@ -88,68 +215,5 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
 		assertEquals(
 			clusterSpecification.getMasterMemoryMB() + Constants.RESOURCE_UNIT_MB,
 			jmContainer.getResources().getLimits().get(Constants.RESOURCE_NAME_MEMORY).getAmount());
-
-		clusterClient.close();
-	}
-
-	@Test
-	public void testDeployHighAvailabilitySessionCluster() throws ClusterDeploymentException {
-		flinkConfig.setString(HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.toString());
-		final ClusterClient<String> clusterClient = deploySessionCluster();
-
-		final KubernetesClient kubeClient = server.getClient();
-		final Container jmContainer = kubeClient
-			.apps()
-			.deployments()
-			.list()
-			.getItems()
-			.get(0)
-			.getSpec()
-			.getTemplate()
-			.getSpec()
-			.getContainers()
-			.get(0);
-		assertTrue(
-			"Environment " + ENV_FLINK_POD_IP_ADDRESS + " should be set.",
-			jmContainer.getEnv().stream()
-				.map(EnvVar::getName)
-				.collect(Collectors.toList())
-				.contains(ENV_FLINK_POD_IP_ADDRESS));
-
-		clusterClient.close();
-	}
-
-	@Test
-	public void testKillCluster() throws Exception {
-		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(flinkConfig, flinkKubeClient);
-
-		final ClusterSpecification clusterSpecification = new ClusterSpecification.ClusterSpecificationBuilder()
-			.createClusterSpecification();
-
-		descriptor.deploySessionCluster(clusterSpecification);
-
-		final KubernetesClient kubeClient = server.getClient();
-		assertEquals(2, kubeClient.services().list().getItems().size());
-
-		descriptor.killCluster(CLUSTER_ID);
-
-		// Mock kubernetes server do not delete the accompanying resources by gc.
-		assertTrue(kubeClient.apps().deployments().list().getItems().isEmpty());
-		assertEquals(2, kubeClient.services().list().getItems().size());
-		assertEquals(1, kubeClient.configMaps().list().getItems().size());
-	}
-
-	private ClusterClient<String> deploySessionCluster() throws ClusterDeploymentException {
-		final KubernetesClusterDescriptor descriptor = new KubernetesClusterDescriptor(flinkConfig, flinkKubeClient);
-
-		final ClusterClient<String> clusterClient = descriptor
-			.deploySessionCluster(clusterSpecification)
-			.getClusterClient();
-
-		assertEquals(CLUSTER_ID, clusterClient.getClusterId());
-		// Both HA and non-HA mode, the web interface should always be the Kubernetes exposed service address.
-		assertEquals(String.format("http://%s:%d", MOCK_SERVICE_IP, REST_PORT), clusterClient.getWebInterfaceURL());
-
-		return clusterClient;
 	}
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/configuration/KubernetesDeploymentTargetTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/configuration/KubernetesDeploymentTargetTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.configuration;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for the {@link KubernetesDeploymentTarget}.
+ */
+public class KubernetesDeploymentTargetTest {
+
+	@Test
+	public void testCorrectInstantiationFromConfiguration() {
+		for (KubernetesDeploymentTarget t : KubernetesDeploymentTarget.values()) {
+			testCorrectInstantiationFromConfigurationHelper(t);
+		}
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidInstantiationFromConfiguration() {
+		final Configuration configuration = getConfigurationWithTarget("invalid-target");
+		KubernetesDeploymentTarget.fromConfig(configuration);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testNullInstantiationFromConfiguration() {
+		KubernetesDeploymentTarget.fromConfig(new Configuration());
+	}
+
+	@Test
+	public void testThatAValidOptionIsValid() {
+		assertTrue(KubernetesDeploymentTarget.isValidKubernetesTarget(KubernetesDeploymentTarget.APPLICATION.getName()));
+	}
+
+	@Test
+	public void testThatAnInvalidOptionIsInvalid() {
+		assertFalse(KubernetesDeploymentTarget.isValidKubernetesTarget("invalid-target"));
+	}
+
+	private void testCorrectInstantiationFromConfigurationHelper(final KubernetesDeploymentTarget expectedDeploymentTarget) {
+		final Configuration configuration = getConfigurationWithTarget(expectedDeploymentTarget.getName().toUpperCase());
+		final KubernetesDeploymentTarget actualDeploymentTarget = KubernetesDeploymentTarget.fromConfig(configuration);
+
+		assertSame(actualDeploymentTarget, expectedDeploymentTarget);
+	}
+
+	private Configuration getConfigurationWithTarget(final String target) {
+		final Configuration configuration = new Configuration();
+		configuration.set(DeploymentOptions.TARGET,  target);
+		return configuration;
+	}
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The PR is to support application mode for the Kubernetes. The start command is very similar to Yarn integration just like following. Non-ha and HA mode both should work as expected.
```
flink run-application -t kubernetes-application \
    -Dkubernetes.cluster-id=${CLUSTER_ID} \
    -Dkubernetes.container.image=${FLINK_IMAGE_NAME} \
    -Djobmanager.memory.process.size=2048m \
    -Dkubernetes.jobmanager.cpu=1 \
    -Dkubernetes.taskmanager.cpu=1 \
    -Dkubernetes.rest-service.exposed.type=NodePort \
    local:///opt/flink/examples/streaming/WindowJoin.jar
```

**How to specify user jar and classpath?**
In native K8s application, when the jobmanager is launched, all the user jar and dependencies have already existed(e.g. built in the image, or downloaded by init-container). 

The user jar should be specified with schema `local://`, which means it exists in the jobmanager side.

For the dependencies, users could put it in the `$FLINK_HOME/usrlib` directory, the jars located in the usrlib will be automatically added to the user classpath. They could also specify the user classpath via `-C/--classpath` of `flink run-application` command.



## Brief change log

* Make flink run-application could support local schema
* Support application mode for kubernetes
* Add e2e tests for Kubernetes application mode
* Set log4j for Kubernetes cli


## Verifying this change
* The changes is covered by new added UT and e2e test(`test_kubernetes_application.sh`)
* Manually test in a real K8s cluster for the non-HA and HA mode


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (will update the doc in a separate ticket)
