### PR TITLE
[FLINK-17434][core][hive] Hive partitioned source support streaming read

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartition.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartition.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -64,5 +65,33 @@ public class HiveTablePartition implements Serializable {
 
 	public Properties getTableProps() {
 		return tableProps;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		HiveTablePartition that = (HiveTablePartition) o;
+		return Objects.equals(storageDescriptor, that.storageDescriptor) &&
+				Objects.equals(partitionSpec, that.partitionSpec) &&
+				Objects.equals(tableProps, that.tableProps);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(storageDescriptor, partitionSpec, tableProps);
+	}
+
+	@Override
+	public String toString() {
+		return "HiveTablePartition{" +
+				"storageDescriptor=" + storageDescriptor +
+				", partitionSpec=" + partitionSpec +
+				", tableProps=" + tableProps +
+				'}';
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -79,7 +79,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
-import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TYPE;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_KIND;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_ORDER;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_START_OFFSET;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_ENABLE;
@@ -226,9 +226,9 @@ public class HiveTableSource implements
 		String consumeOffset = properties.getOrDefault(
 				STREAMING_SOURCE_CONSUME_START_OFFSET.key(),
 				STREAMING_SOURCE_CONSUME_START_OFFSET.defaultValue());
-		String extractorType = properties.getOrDefault(
-				PARTITION_TIME_EXTRACTOR_TYPE.key(),
-				PARTITION_TIME_EXTRACTOR_TYPE.defaultValue());
+		String extractorKind = properties.getOrDefault(
+				PARTITION_TIME_EXTRACTOR_KIND.key(),
+				PARTITION_TIME_EXTRACTOR_KIND.defaultValue());
 		String extractorClass = properties.get(PARTITION_TIME_EXTRACTOR_CLASS.key());
 		String extractorPattern = properties.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key());
 
@@ -245,7 +245,7 @@ public class HiveTableSource implements
 				execEnv.getParallelism(),
 				consumeOrder,
 				consumeOffset,
-				extractorType,
+				extractorKind,
 				extractorClass,
 				extractorPattern,
 				monitorInterval.toMillis());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -78,8 +78,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
-import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
 import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_ORDER;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_START_OFFSET;
 import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_ENABLE;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -22,10 +22,14 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connectors.hive.read.HiveContinuousMonitoringFunction;
 import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
+import org.apache.flink.connectors.hive.read.TimestampedHiveInputSplit;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.catalog.CatalogTable;
@@ -48,6 +52,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TimeUtils;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -63,6 +68,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -70,6 +76,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TYPE;
+import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_ORDER;
+import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_CONSUME_START_OFFSET;
+import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_ENABLE;
+import static org.apache.flink.table.filesystem.FileSystemOptions.STREAMING_SOURCE_MONITOR_INTERVAL;
 
 /**
  * A TableSource implementation to read data from Hive tables.
@@ -135,7 +149,7 @@ public class HiveTableSource implements
 
 	@Override
 	public boolean isBounded() {
-		return true;
+		return !isStreamingSource();
 	}
 
 	@Override
@@ -150,6 +164,25 @@ public class HiveTableSource implements
 				allHivePartitions,
 				flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER));
 
+		if (isStreamingSource()) {
+			if (catalogTable.getPartitionKeys().isEmpty()) {
+				throw new UnsupportedOperationException(
+						"Non-partition table does not support streaming read now.");
+			}
+			return createStreamSource(execEnv, typeInfo, inputFormat);
+		} else {
+			return createBatchSource(execEnv, typeInfo, inputFormat);
+		}
+	}
+
+	private boolean isStreamingSource() {
+		return Boolean.parseBoolean(catalogTable.getOptions().getOrDefault(
+				STREAMING_SOURCE_ENABLE.key(),
+				STREAMING_SOURCE_ENABLE.defaultValue().toString()));
+	}
+
+	private DataStream<RowData> createBatchSource(StreamExecutionEnvironment execEnv,
+			TypeInformation<RowData> typeInfo, HiveTableInputFormat inputFormat) {
 		DataStreamSource<RowData> source = execEnv.createInput(inputFormat, typeInfo);
 
 		int parallelism = flinkConf.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM);
@@ -179,6 +212,53 @@ public class HiveTableSource implements
 		parallelism = Math.max(1, parallelism);
 		source.setParallelism(parallelism);
 		return source.name(explainSource());
+	}
+
+	private DataStream<RowData> createStreamSource(
+			StreamExecutionEnvironment execEnv,
+			TypeInformation<RowData> typeInfo,
+			HiveTableInputFormat inputFormat) {
+		final Map<String, String> properties = catalogTable.getOptions();
+
+		String consumeOrder = properties.getOrDefault(
+				STREAMING_SOURCE_CONSUME_ORDER.key(),
+				STREAMING_SOURCE_CONSUME_ORDER.defaultValue());
+		String consumeOffset = properties.getOrDefault(
+				STREAMING_SOURCE_CONSUME_START_OFFSET.key(),
+				STREAMING_SOURCE_CONSUME_START_OFFSET.defaultValue());
+		String extractorType = properties.getOrDefault(
+				PARTITION_TIME_EXTRACTOR_TYPE.key(),
+				PARTITION_TIME_EXTRACTOR_TYPE.defaultValue());
+		String extractorClass = properties.get(PARTITION_TIME_EXTRACTOR_CLASS.key());
+		String extractorPattern = properties.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key());
+
+		String monitorIntervalStr = properties.get(STREAMING_SOURCE_MONITOR_INTERVAL.key());
+		Duration monitorInterval = monitorIntervalStr != null ?
+				TimeUtils.parseDuration(monitorIntervalStr) :
+				STREAMING_SOURCE_MONITOR_INTERVAL.defaultValue();
+
+		HiveContinuousMonitoringFunction monitoringFunction = new HiveContinuousMonitoringFunction(
+				hiveShim,
+				jobConf,
+				tablePath,
+				catalogTable,
+				execEnv.getParallelism(),
+				consumeOrder,
+				consumeOffset,
+				extractorType,
+				extractorClass,
+				extractorPattern,
+				monitorInterval.toMillis());
+
+		ContinuousFileReaderOperatorFactory<RowData, TimestampedHiveInputSplit> factory =
+				new ContinuousFileReaderOperatorFactory<>(inputFormat);
+
+		String sourceName = "HiveMonitoringFunction";
+		SingleOutputStreamOperator<RowData> source = execEnv
+				.addSource(monitoringFunction, sourceName)
+				.transform("Split Reader: " + sourceName, typeInfo, factory);
+
+		return new DataStreamSource<>(source);
 	}
 
 	@VisibleForTesting
@@ -298,23 +378,14 @@ public class HiveTableSource implements
 					partitions.addAll(client.listPartitions(dbName, tableName, (short) -1));
 				}
 				for (Partition partition : partitions) {
-					StorageDescriptor sd = partition.getSd();
-					Map<String, Object> partitionColValues = new HashMap<>();
-					for (int i = 0; i < partitionColNames.size(); i++) {
-						String partitionColName = partitionColNames.get(i);
-						String partitionValue = partition.getValues().get(i);
-						DataType type = catalogTable.getSchema().getFieldDataType(partitionColName).get();
-						Object partitionObject;
-						if (defaultPartitionName.equals(partitionValue)) {
-							LogicalTypeRoot typeRoot = type.getLogicalType().getTypeRoot();
-							// while this is inline with Hive, seems it should be null for string columns as well
-							partitionObject = typeRoot == LogicalTypeRoot.CHAR || typeRoot == LogicalTypeRoot.VARCHAR ? defaultPartitionName : null;
-						} else {
-							partitionObject = restorePartitionValueFromFromType(partitionValue, type);
-						}
-						partitionColValues.put(partitionColName, partitionObject);
-					}
-					HiveTablePartition hiveTablePartition = new HiveTablePartition(sd, partitionColValues, tableProps);
+					HiveTablePartition hiveTablePartition = toHiveTablePartition(
+							catalogTable.getPartitionKeys(),
+							catalogTable.getSchema().getFieldNames(),
+							catalogTable.getSchema().getFieldDataTypes(),
+							hiveShim,
+							tableProps,
+							defaultPartitionName,
+							partition);
 					allHivePartitions.add(hiveTablePartition);
 				}
 			} else {
@@ -326,13 +397,41 @@ public class HiveTableSource implements
 		return allHivePartitions;
 	}
 
+	public static HiveTablePartition toHiveTablePartition(
+			List<String> partitionKeys,
+			String[] fieldNames,
+			DataType[] fieldTypes,
+			HiveShim shim,
+			Properties tableProps,
+			String defaultPartitionName,
+			Partition partition) {
+		StorageDescriptor sd = partition.getSd();
+		Map<String, Object> partitionColValues = new HashMap<>();
+		List<String> nameList = Arrays.asList(fieldNames);
+		for (int i = 0; i < partitionKeys.size(); i++) {
+			String partitionColName = partitionKeys.get(i);
+			String partitionValue = partition.getValues().get(i);
+			DataType type = fieldTypes[nameList.indexOf(partitionColName)];
+			Object partitionObject;
+			if (defaultPartitionName.equals(partitionValue)) {
+				LogicalTypeRoot typeRoot = type.getLogicalType().getTypeRoot();
+				// while this is inline with Hive, seems it should be null for string columns as well
+				partitionObject = typeRoot == LogicalTypeRoot.CHAR || typeRoot == LogicalTypeRoot.VARCHAR ? defaultPartitionName : null;
+			} else {
+				partitionObject = restorePartitionValueFromFromType(shim, partitionValue, type);
+			}
+			partitionColValues.put(partitionColName, partitionObject);
+		}
+		return new HiveTablePartition(sd, partitionColValues, tableProps);
+	}
+
 	private static List<String> partitionSpecToValues(Map<String, String> spec, List<String> partitionColNames) {
 		Preconditions.checkArgument(spec.size() == partitionColNames.size() && spec.keySet().containsAll(partitionColNames),
 				"Partition spec (%s) and partition column names (%s) doesn't match", spec, partitionColNames);
 		return partitionColNames.stream().map(spec::get).collect(Collectors.toList());
 	}
 
-	private Object restorePartitionValueFromFromType(String valStr, DataType type) {
+	private static Object restorePartitionValueFromFromType(HiveShim shim, String valStr, DataType type) {
 		LogicalTypeRoot typeRoot = type.getLogicalType().getTypeRoot();
 		//note: it's not a complete list ofr partition key types that Hive support, we may need add more later.
 		switch (typeRoot) {
@@ -356,13 +455,13 @@ public class HiveTableSource implements
 			case DATE:
 				return HiveInspectors.toFlinkObject(
 						HiveInspectors.getObjectInspector(type),
-						hiveShim.toHiveDate(Date.valueOf(valStr)),
-						hiveShim);
+						shim.toHiveDate(Date.valueOf(valStr)),
+						shim);
 			case TIMESTAMP_WITHOUT_TIME_ZONE:
 				return HiveInspectors.toFlinkObject(
 						HiveInspectors.getObjectInspector(type),
-						hiveShim.toHiveTimestamp(Timestamp.valueOf(valStr)),
-						hiveShim);
+						shim.toHiveTimestamp(Timestamp.valueOf(valStr)),
+						shim);
 			default:
 				break;
 		}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/JobConfWrapper.java
@@ -37,7 +37,7 @@ public class JobConfWrapper implements Serializable {
 
 	private JobConf jobConf;
 
-	JobConfWrapper(JobConf jobConf) {
+	public JobConfWrapper(JobConf jobConf) {
 		this.jobConf = jobConf;
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/DirectoryMonitorDiscovery.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/DirectoryMonitorDiscovery.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Partition;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.table.filesystem.PartitionPathUtils.extractPartitionValues;
+
+/**
+ * Directory monitor {@link PartitionDiscovery}.
+ */
+public class DirectoryMonitorDiscovery implements PartitionDiscovery {
+
+	@Override
+	public List<Tuple2<Partition, Long>> fetchPartitions(
+			Context context, long previousTimestamp) throws Exception {
+		FileStatus[] statuses = getFileStatusRecurse(
+				context.tableLocation(), context.partitionKeys().size(), context.fileSystem());
+		List<Tuple2<Partition, Long>> partitions = new ArrayList<>();
+		for (FileStatus status : statuses) {
+			List<String> partValues = extractPartitionValues(
+					new org.apache.flink.core.fs.Path(status.getPath().toString()));
+			long timestamp = context.extractTimestamp(
+					context.partitionKeys(), partValues, status::getModificationTime);
+			if (timestamp >= previousTimestamp) {
+				context.getPartition(partValues).ifPresent(
+						partition -> partitions.add(new Tuple2<>(partition, timestamp)));
+			}
+		}
+		return partitions;
+	}
+
+	private static FileStatus[] getFileStatusRecurse(Path path, int expectLevel, FileSystem fs) {
+		ArrayList<FileStatus> result = new ArrayList<>();
+
+		try {
+			FileStatus fileStatus = fs.getFileStatus(path);
+			listStatusRecursively(fs, fileStatus, 0, expectLevel, result);
+		} catch (IOException ignore) {
+			return new FileStatus[0];
+		}
+
+		return result.toArray(new FileStatus[0]);
+	}
+
+	private static void listStatusRecursively(
+			FileSystem fs,
+			FileStatus fileStatus,
+			int level,
+			int expectLevel,
+			List<FileStatus> results) throws IOException {
+		if (expectLevel == level) {
+			results.add(fileStatus);
+			return;
+		}
+
+		if (fileStatus.isDir()) {
+			for (FileStatus stat : fs.listStatus(fileStatus.getPath())) {
+				listStatusRecursively(fs, stat, level + 1, expectLevel, results);
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/DirectoryMonitorDiscovery.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/DirectoryMonitorDiscovery.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.apache.flink.table.filesystem.PartitionPathUtils.extractPartitionValues;
+import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionValues;
 
 /**
  * Directory monitor {@link PartitionDiscovery}.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -113,7 +113,7 @@ public class HiveContinuousMonitoringFunction
 	private final String consumeOffset;
 
 	// extractor variables
-	private final String extractorType;
+	private final String extractorKind;
 	private final String extractorClass;
 	private final String extractorPattern;
 
@@ -148,7 +148,7 @@ public class HiveContinuousMonitoringFunction
 			int readerParallelism,
 			String consumeOrder,
 			String consumeOffset,
-			String extractorType,
+			String extractorKind,
 			String extractorClass,
 			String extractorPattern,
 			long interval) {
@@ -159,7 +159,7 @@ public class HiveContinuousMonitoringFunction
 		this.fieldNames = catalogTable.getSchema().getFieldNames();
 		this.fieldTypes = catalogTable.getSchema().getFieldDataTypes();
 		this.consumeOrder = consumeOrder;
-		this.extractorType = extractorType;
+		this.extractorKind = extractorKind;
 		this.extractorClass = extractorClass;
 		this.extractorPattern = extractorPattern;
 		this.consumeOffset = consumeOffset;
@@ -193,7 +193,7 @@ public class HiveContinuousMonitoringFunction
 
 		PartitionTimeExtractor extractor = PartitionTimeExtractor.create(
 				getRuntimeContext().getUserCodeClassLoader(),
-				extractorType,
+				extractorKind,
 				extractorClass,
 				extractorPattern);
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.HiveTableSource;
+import org.apache.flink.connectors.hive.JobConfWrapper;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.hive.client.HiveShim;
+import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
+import org.apache.flink.table.filesystem.PartitionTimeExtractor;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static org.apache.flink.table.filesystem.DefaultPartTimeExtractor.toMills;
+
+/**
+ * This is the single (non-parallel) monitoring task which takes a {@link HiveTableInputFormat},
+ * it is responsible for:
+ *
+ * <ol>
+ *     <li>Monitoring partitions of hive meta store.</li>
+ *     <li>Deciding which partitions should be further read and processed.</li>
+ *     <li>Creating the {@link HiveTableInputSplit splits} corresponding to those partitions.</li>
+ *     <li>Assigning them to downstream tasks for further processing.</li>
+ * </ol>
+ *
+ * <p>The splits to be read are forwarded to the downstream {@link ContinuousFileReaderOperator}
+ * which can have parallelism greater than one.
+ *
+ * <p><b>IMPORTANT NOTE: </b> Splits are forwarded downstream for reading in ascending partition time order,
+ * based on the partition time of the partitions they belong to.
+ */
+public class HiveContinuousMonitoringFunction
+		extends RichSourceFunction<TimestampedHiveInputSplit>
+		implements CheckpointedFunction {
+
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOG = LoggerFactory.getLogger(HiveContinuousMonitoringFunction.class);
+
+	private static final String CREATE_TIME_ORDER = "create-time";
+	private static final String PARTITION_TIME_ORDER = "partition-time";
+
+	/** The parallelism of the downstream readers. */
+	private final int readerParallelism;
+
+	/** The interval between consecutive path scans. */
+	private final long interval;
+
+	private final HiveShim hiveShim;
+
+	private final JobConfWrapper conf;
+
+	private final ObjectPath tablePath;
+
+	private final List<String> partitionKeys;
+
+	private final String[] fieldNames;
+
+	private final DataType[] fieldTypes;
+
+	// consumer variables
+	private final String consumeOrder;
+	private final String consumeOffset;
+
+	// extractor variables
+	private final String extractorType;
+	private final String extractorClass;
+	private final String extractorPattern;
+
+	private volatile boolean isRunning = true;
+
+	/** The maximum partition read time seen so far. */
+	private volatile long currentReadTime;
+
+	private transient PartitionDiscovery.Context context;
+
+	private transient PartitionDiscovery fetcher;
+
+	private transient Object checkpointLock;
+
+	private transient ListState<Long> currReadTimeState;
+
+	private transient ListState<List<List<String>>> distinctPartsState;
+
+	private transient IMetaStoreClient client;
+
+	private transient Properties tableProps;
+
+	private transient String defaultPartitionName;
+
+	private transient Set<List<String>> distinctPartitions;
+
+	public HiveContinuousMonitoringFunction(
+			HiveShim hiveShim,
+			JobConf conf,
+			ObjectPath tablePath,
+			CatalogTable catalogTable,
+			int readerParallelism,
+			String consumeOrder,
+			String consumeOffset,
+			String extractorType,
+			String extractorClass,
+			String extractorPattern,
+			long interval) {
+		this.hiveShim = hiveShim;
+		this.conf = new JobConfWrapper(conf);
+		this.tablePath = tablePath;
+		this.partitionKeys = catalogTable.getPartitionKeys();
+		this.fieldNames = catalogTable.getSchema().getFieldNames();
+		this.fieldTypes = catalogTable.getSchema().getFieldDataTypes();
+		this.consumeOrder = consumeOrder;
+		this.extractorType = extractorType;
+		this.extractorClass = extractorClass;
+		this.extractorPattern = extractorPattern;
+		this.consumeOffset = consumeOffset;
+
+		this.interval = interval;
+		this.readerParallelism = Math.max(readerParallelism, 1);
+		this.currentReadTime = 0;
+	}
+
+	@Override
+	public void initializeState(FunctionInitializationContext context) throws Exception {
+		this.currReadTimeState = context.getOperatorStateStore().getListState(
+			new ListStateDescriptor<>(
+				"partition-monitoring-state",
+				LongSerializer.INSTANCE
+			)
+		);
+		this.distinctPartsState = context.getOperatorStateStore().getListState(
+			new ListStateDescriptor<>(
+				"partition-monitoring-state",
+				new ListSerializer<>(new ListSerializer<>(StringSerializer.INSTANCE))
+			)
+		);
+
+		this.client = this.hiveShim.getHiveMetastoreClient(new HiveConf(conf.conf(), HiveConf.class));
+
+		Table hiveTable = client.getTable(tablePath.getDatabaseName(), tablePath.getObjectName());
+		this.tableProps = HiveReflectionUtils.getTableMetadata(hiveShim, hiveTable);
+		this.defaultPartitionName = conf.conf().get(HiveConf.ConfVars.DEFAULTPARTITIONNAME.varname,
+				HiveConf.ConfVars.DEFAULTPARTITIONNAME.defaultStrVal);
+
+		PartitionTimeExtractor extractor = PartitionTimeExtractor.create(
+				getRuntimeContext().getUserCodeClassLoader(),
+				extractorType,
+				extractorClass,
+				extractorPattern);
+
+		this.fetcher = new DirectoryMonitorDiscovery();
+
+		Path location = new Path(hiveTable.getSd().getLocation());
+		FileSystem fs = location.getFileSystem(conf.conf());
+		this.context = new PartitionDiscovery.Context() {
+
+			@Override
+			public List<String> partitionKeys() {
+				return partitionKeys;
+			}
+
+			@Override
+			public Optional<Partition> getPartition(List<String> partValues) throws TException {
+				try {
+					return Optional.of(client.getPartition(
+							tablePath.getDatabaseName(),
+							tablePath.getObjectName(),
+							partValues));
+				} catch (NoSuchObjectException e) {
+					return Optional.empty();
+				}
+			}
+
+			@Override
+			public FileSystem fileSystem() {
+				return fs;
+			}
+
+			@Override
+			public Path tableLocation() {
+				return new Path(hiveTable.getSd().getLocation());
+			}
+
+			@Override
+			public long extractTimestamp(
+					List<String> partKeys,
+					List<String> partValues,
+					Supplier<Long> fileTime) {
+				switch (consumeOrder) {
+					case CREATE_TIME_ORDER:
+						return fileTime.get();
+					case PARTITION_TIME_ORDER:
+						return toMills(extractor.extract(partKeys, partValues));
+					default:
+						throw new UnsupportedOperationException(
+								"Unsupported consumer order: " + consumeOrder);
+				}
+			}
+		};
+
+		this.distinctPartitions = new HashSet<>();
+		if (context.isRestored()) {
+			LOG.info("Restoring state for the {}.", getClass().getSimpleName());
+			this.currentReadTime = this.currReadTimeState.get().iterator().next();
+			this.distinctPartitions.addAll(this.distinctPartsState.get().iterator().next());
+		} else {
+			LOG.info("No state to restore for the {}.", getClass().getSimpleName());
+			if (consumeOffset != null) {
+				this.currentReadTime = toMills(consumeOffset);
+			}
+		}
+	}
+
+	@Override
+	public void run(SourceContext<TimestampedHiveInputSplit> context) throws Exception {
+		checkpointLock = context.getCheckpointLock();
+		while (isRunning) {
+			synchronized (checkpointLock) {
+				monitorAndForwardSplits(context);
+			}
+			Thread.sleep(interval);
+		}
+	}
+
+	private void monitorAndForwardSplits(
+			SourceContext<TimestampedHiveInputSplit> context) throws Exception {
+		assert (Thread.holdsLock(checkpointLock));
+
+		List<Tuple2<Partition, Long>> partitions = fetcher.fetchPartitions(this.context, currentReadTime);
+
+		if (partitions.isEmpty()) {
+			return;
+		}
+
+		partitions.sort((o1, o2) -> (int) (o1.f1 - o2.f1));
+
+		long maxTimestamp = Long.MIN_VALUE;
+		Set<List<String>> nextDistinctParts = new HashSet<>();
+		for (Tuple2<Partition, Long> tuple2 : partitions) {
+			Partition partition = tuple2.f0;
+			List<String> partSpec = partition.getValues();
+			if (!this.distinctPartitions.contains(partSpec)) {
+				this.distinctPartitions.add(partSpec);
+				long timestamp = tuple2.f1;
+				if (timestamp > currentReadTime) {
+					nextDistinctParts.add(partSpec);
+				}
+				if (timestamp > maxTimestamp) {
+					maxTimestamp = timestamp;
+				}
+				HiveTableInputSplit[] splits = HiveTableInputFormat.createInputSplits(
+						this.readerParallelism,
+						Collections.singletonList(toHiveTablePartition(partition)),
+						this.conf.conf());
+				for (HiveTableInputSplit split : splits) {
+					context.collect(new TimestampedHiveInputSplit(timestamp, split));
+				}
+			}
+		}
+
+		if (maxTimestamp > currentReadTime) {
+			currentReadTime = maxTimestamp;
+			distinctPartitions.clear();
+			distinctPartitions.addAll(nextDistinctParts);
+		}
+	}
+
+	private HiveTablePartition toHiveTablePartition(Partition p) {
+		return HiveTableSource.toHiveTablePartition(
+				partitionKeys, fieldNames, fieldTypes, hiveShim, tableProps, defaultPartitionName, p);
+	}
+
+	@Override
+	public void snapshotState(FunctionSnapshotContext context) throws Exception {
+		Preconditions.checkState(this.currReadTimeState != null,
+				"The " + getClass().getSimpleName() + " state has not been properly initialized.");
+
+		this.currReadTimeState.clear();
+		this.currReadTimeState.add(this.currentReadTime);
+
+		this.distinctPartsState.clear();
+		this.distinctPartsState.add(new ArrayList<>(this.distinctPartitions));
+
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("{} checkpointed {}.", getClass().getSimpleName(), currentReadTime);
+		}
+	}
+
+	@Override
+	public void close() {
+		cancel();
+	}
+
+	@Override
+	public void cancel() {
+		// this is to cover the case where cancel() is called before the run()
+		if (checkpointLock != null) {
+			synchronized (checkpointLock) {
+				currentReadTime = Long.MAX_VALUE;
+				isRunning = false;
+			}
+		} else {
+			currentReadTime = Long.MAX_VALUE;
+			isRunning = false;
+		}
+
+		if (this.client != null) {
+			this.client.close();
+			this.client = null;
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -273,6 +273,13 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 	@Override
 	public HiveTableInputSplit[] createInputSplits(int minNumSplits)
 			throws IOException {
+		return createInputSplits(minNumSplits, partitions, jobConf);
+	}
+
+	public static HiveTableInputSplit[] createInputSplits(
+			int minNumSplits,
+			List<HiveTablePartition> partitions,
+			JobConf jobConf) throws IOException {
 		List<HiveTableInputSplit> hiveSplits = new ArrayList<>();
 		int splitNum = 0;
 		for (HiveTablePartition partition : partitions) {
@@ -280,7 +287,7 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 			InputFormat format;
 			try {
 				format = (InputFormat)
-					Class.forName(sd.getInputFormat(), true, Thread.currentThread().getContextClassLoader()).newInstance();
+						Class.forName(sd.getInputFormat(), true, Thread.currentThread().getContextClassLoader()).newInstance();
 			} catch (Exception e) {
 				throw new FlinkHiveException("Unable to instantiate the hadoop input format", e);
 			}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputSplit.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputSplit.java
@@ -24,6 +24,8 @@ import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 
+import java.util.Objects;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -31,7 +33,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * Right now, it contains info about the partition of the split.
  */
 public class HiveTableInputSplit extends HadoopInputSplit {
-	private final HiveTablePartition hiveTablePartition;
+
+	private static final long serialVersionUID = 1L;
+
+	protected final HiveTablePartition hiveTablePartition;
 
 	public HiveTableInputSplit(
 			int splitNumber,
@@ -44,5 +49,32 @@ public class HiveTableInputSplit extends HadoopInputSplit {
 
 	public HiveTablePartition getHiveTablePartition() {
 		return hiveTablePartition;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		HiveTableInputSplit split = (HiveTableInputSplit) o;
+		return Objects.equals(hiveTablePartition, split.hiveTablePartition);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), hiveTablePartition);
+	}
+
+	@Override
+	public String toString() {
+		return "HiveTableInputSplit{" +
+				"hiveTablePartition=" + hiveTablePartition +
+				'}';
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/PartitionDiscovery.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/PartitionDiscovery.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.thrift.TException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Partition strategy for helping fetch hive partitioned table.
+ */
+@Internal
+public interface PartitionDiscovery {
+
+	/**
+	 * Fetch partitions by previous timestamp (Including).
+	 */
+	List<Tuple2<Partition, Long>> fetchPartitions(Context context, long previousTimestamp) throws Exception;
+
+	/**
+	 * Context for fetch partitions, partition information is stored in hive meta store.
+	 */
+	interface Context {
+
+		/**
+		 * Partition keys of this table.
+		 */
+		List<String> partitionKeys();
+
+		/**
+		 * See {@link IMetaStoreClient#getPartition}.
+		 */
+		Optional<Partition> getPartition(List<String> partValues) throws TException;
+
+		/**
+		 * Hadoop filesystem.
+		 */
+		FileSystem fileSystem();
+
+		/**
+		 * Root location of table.
+		 */
+		Path tableLocation();
+
+		/**
+		 * Extract timestamp from partition.
+		 */
+		long extractTimestamp(
+				List<String> partKeys,
+				List<String> partValues,
+				Supplier<Long> fileTime);
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/TimestampedHiveInputSplit.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/TimestampedHiveInputSplit.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInfoFactory;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.SimpleTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.base.TypeSerializerSingleton;
+import org.apache.flink.api.java.typeutils.runtime.DataInputViewStream;
+import org.apache.flink.api.java.typeutils.runtime.DataOutputViewStream;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.streaming.api.functions.source.TimestampedInputSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.InstantiationUtil;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A {@link HiveTableInputSplit} with {@link TimestampedInputSplit}.
+ * Kryo serializer can not deal with hadoop split, need specific type information factory.
+ *
+ * <p>Note: this class has a natural ordering that is inconsistent with equals.
+ */
+@TypeInfo(TimestampedHiveInputSplit.SplitTypeInfoFactory.class)
+public class TimestampedHiveInputSplit extends HiveTableInputSplit implements TimestampedInputSplit {
+
+	private static final long serialVersionUID = 1L;
+
+	/** The modification time of the file this split belongs to. */
+	private final long modificationTime;
+
+	/**
+	 * The state of the split. This information is used when
+	 * restoring from a checkpoint and allows to resume reading the
+	 * underlying file from the point we left off.
+	 * */
+	private Serializable splitState;
+
+	public TimestampedHiveInputSplit(
+			long modificationTime,
+			HiveTableInputSplit split) {
+		super(
+				split.getSplitNumber(),
+				split.getHadoopInputSplit(),
+				split.getJobConf(),
+				split.getHiveTablePartition());
+		this.modificationTime = modificationTime;
+	}
+
+	@Override
+	public void setSplitState(Serializable state) {
+		this.splitState = state;
+	}
+
+	@Override
+	public Serializable getSplitState() {
+		return this.splitState;
+	}
+
+	@Override
+	public long getModificationTime() {
+		return modificationTime;
+	}
+
+	/**
+	 * Note Again: this class has a natural ordering that is inconsistent with equals.
+	 */
+	@Override
+	public int compareTo(TimestampedInputSplit o) {
+		TimestampedHiveInputSplit split = (TimestampedHiveInputSplit) o;
+		int modTimeComp = Long.compare(this.modificationTime, split.modificationTime);
+		if (modTimeComp != 0L) {
+			return modTimeComp;
+		}
+
+		int sdComp = this.hiveTablePartition.getStorageDescriptor().compareTo(
+				split.hiveTablePartition.getStorageDescriptor());
+
+		return sdComp != 0 ? sdComp :
+				this.getSplitNumber() - o.getSplitNumber();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		if (!super.equals(o)) {
+			return false;
+		}
+		TimestampedHiveInputSplit that = (TimestampedHiveInputSplit) o;
+		return modificationTime == that.modificationTime;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), modificationTime);
+	}
+
+	@Override
+	public String toString() {
+		return "TimestampedHiveInputSplit{" +
+				"modificationTime=" + modificationTime +
+				", splitState=" + splitState +
+				", hiveTablePartition=" + hiveTablePartition +
+				'}';
+	}
+
+	/**
+	 * {@link TypeInfoFactory} for {@link TimestampedHiveInputSplit}.
+	 */
+	public static class SplitTypeInfoFactory
+			extends TypeInfoFactory<TimestampedHiveInputSplit>
+			implements Serializable {
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public TypeInformation<TimestampedHiveInputSplit> createTypeInfo(
+				Type t, Map genericParameters) {
+			return new BasicTypeInfo<TimestampedHiveInputSplit>(
+					TimestampedHiveInputSplit.class,
+					new Class<?>[]{},
+					SplitTypeSerializer.INSTANCE,
+					null) {};
+		}
+	}
+
+	private static class SplitTypeSerializer extends TypeSerializerSingleton<TimestampedHiveInputSplit> {
+
+		private static final SplitTypeSerializer INSTANCE = new SplitTypeSerializer();
+
+		private static final long serialVersionUID = 1L;
+
+		@Override
+		public boolean isImmutableType() {
+			return false;
+		}
+
+		@Override
+		public TimestampedHiveInputSplit createInstance() {
+			return null;
+		}
+
+		@Override
+		public TimestampedHiveInputSplit copy(TimestampedHiveInputSplit from) {
+			try {
+				return InstantiationUtil.clone(from, Thread.currentThread().getContextClassLoader());
+			} catch (IOException | ClassNotFoundException e) {
+				throw new FlinkRuntimeException("Could not copy element via serialization: " + from, e);
+			}
+		}
+
+		@Override
+		public TimestampedHiveInputSplit copy(TimestampedHiveInputSplit from, TimestampedHiveInputSplit reuse) {
+			return copy(from);
+		}
+
+		@Override
+		public int getLength() {
+			return -1;
+		}
+
+		@Override
+		public void serialize(TimestampedHiveInputSplit record, DataOutputView target) throws IOException {
+			try (final DataOutputViewStream outViewWrapper = new DataOutputViewStream(target)) {
+				InstantiationUtil.serializeObject(outViewWrapper, record);
+			}
+		}
+
+		@Override
+		public TimestampedHiveInputSplit deserialize(DataInputView source) throws IOException {
+			try (final DataInputViewStream inViewWrapper = new DataInputViewStream(source)) {
+				return InstantiationUtil.deserializeObject(
+						inViewWrapper,
+						Thread.currentThread().getContextClassLoader());
+			} catch (ClassNotFoundException e) {
+				throw new IOException("Could not deserialize object.", e);
+			}
+		}
+
+		@Override
+		public TimestampedHiveInputSplit deserialize(
+				TimestampedHiveInputSplit reuse, DataInputView source) throws IOException {
+			return deserialize(source);
+		}
+
+		@Override
+		public void copy(DataInputView source, DataOutputView target) throws IOException {
+			TimestampedHiveInputSplit tmp = deserialize(source);
+			serialize(tmp, target);
+		}
+
+		@Override
+		public TypeSerializerSnapshot<TimestampedHiveInputSplit> snapshotConfiguration() {
+			return new SplitTypeSerializer.SplitSerializerSnapshot();
+		}
+
+		/**
+		 * Serializer configuration snapshot for compatibility and format evolution.
+		 */
+		@SuppressWarnings("WeakerAccess")
+		public static final class SplitSerializerSnapshot extends
+				SimpleTypeSerializerSnapshot<TimestampedHiveInputSplit> {
+
+			public SplitSerializerSnapshot() {
+				super(SplitTypeSerializer::new);
+			}
+		}
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -21,17 +21,20 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connectors.hive.read.HiveTableInputFormat;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.table.HiveVersionTestUtil;
+import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableUtils;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -44,7 +47,9 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.runtime.utils.TestingAppendRowDataSink;
 import org.apache.flink.table.planner.utils.TableTestUtil;
+import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
 import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 
@@ -64,6 +69,7 @@ import org.junit.runner.RunWith;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -458,6 +464,70 @@ public class HiveTableSourceTest {
 			TestBaseUtils.setEnv(env);
 			hiveShell.execute("drop database db1 cascade");
 		}
+	}
+
+	@Test(timeout = 120000)
+	public void testStreamPartitionRead() throws Exception {
+		final String catalogName = "hive";
+		final String dbName = "source_db";
+		final String tblName = "stream_test";
+		hiveShell.execute("CREATE TABLE source_db.stream_test (" +
+				" a INT," +
+				" b STRING" +
+				") PARTITIONED BY (ts STRING) TBLPROPERTIES (" +
+				"'streaming-source.enable'='true'," +
+				"'streaming-source.monitor-interval'='100ms'," +
+				"'streaming-source.consume-order'='partition-time'" +
+				")");
+
+		HiveTestUtils.createTextTableInserter(hiveShell, dbName, tblName)
+				.addRow(new Object[]{0, "0"})
+				.commit("ts='2020-05-06 00:00:00'");
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+		tEnv.registerCatalog(catalogName, hiveCatalog);
+		Table src = tEnv.from("hive.source_db.stream_test");
+
+		TestingAppendRowDataSink sink = new TestingAppendRowDataSink(new RowDataTypeInfo(
+				DataTypes.INT().getLogicalType(),
+				DataTypes.STRING().getLogicalType(),
+				DataTypes.STRING().getLogicalType()));
+		DataStream<RowData> out = tEnv.toAppendStream(src, RowData.class);
+		out.print(); // add print to see streaming reading
+		out.addSink(sink);
+		JobClient job = env.executeAsync("job");
+
+		Runnable runnable = () -> {
+			for (int i = 1; i < 6; i++) {
+				try {
+					Thread.sleep(5_000);
+				} catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+				HiveTestUtils.createTextTableInserter(hiveShell, dbName, tblName)
+						.addRow(new Object[]{i, String.valueOf(i)})
+						.commit("ts='2020-05-06 00:" + i + "0:00'");
+			}
+		};
+		Thread thread = new Thread(runnable);
+		thread.setDaemon(true);
+		thread.start();
+		thread.join();
+		Thread.sleep(5_000);
+
+		List<String> expected = Arrays.asList(
+				"+I(0,0,2020-05-06 00:00:00)",
+				"+I(1,1,2020-05-06 00:10:00)",
+				"+I(2,2,2020-05-06 00:20:00)",
+				"+I(3,3,2020-05-06 00:30:00)",
+				"+I(4,4,2020-05-06 00:40:00)",
+				"+I(5,5,2020-05-06 00:50:00)"
+		);
+		List<String> results = sink.getJavaAppendResults();
+		results.sort(String::compareTo);
+		assertEquals(expected, results);
+		job.cancel();
 	}
 
 	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveTestUtils.java
@@ -18,8 +18,10 @@
 
 package org.apache.flink.table.catalog.hive;
 
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
 import org.apache.flink.table.catalog.CatalogTest;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
@@ -112,6 +114,14 @@ public class HiveTestUtils {
 	public static TableEnvironment createTableEnvWithBlinkPlannerBatchMode() {
 		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build();
 		TableEnvironment tableEnv = TableEnvironment.create(settings);
+		tableEnv.getConfig().getConfiguration().setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);
+		return tableEnv;
+	}
+
+	public static StreamTableEnvironment createTableEnvWithBlinkPlannerStreamMode(
+			StreamExecutionEnvironment env) {
+		EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build();
+		StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
 		tableEnv.getConfig().getConfiguration().setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);
 		return tableEnv;
 	}

--- a/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
+++ b/flink-connectors/flink-hadoop-compatibility/src/main/java/org/apache/flink/api/java/hadoop/mapred/wrapper/HadoopInputSplit.java
@@ -86,6 +86,10 @@ public class HadoopInputSplit extends LocatableInputSplit {
 		return hadoopInputSplit;
 	}
 
+	public JobConf getJobConf() {
+		return jobConf;
+	}
+
 	// ------------------------------------------------------------------------
 	//  Serialization
 	// ------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/PartitionPathUtils.java
@@ -126,6 +126,16 @@ public class PartitionPathUtils {
 	}
 
 	/**
+	 * Make partition values from path.
+	 *
+	 * @param currPath partition file path.
+	 * @return Sequential partition specs.
+	 */
+	public static List<String> extractPartitionValues(Path currPath) {
+		return new ArrayList<>(extractPartitionSpecFromPath(currPath).values());
+	}
+
+	/**
 	 * Make partition spec from path.
 	 *
 	 * @param currPath partition file path.

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -41,6 +41,7 @@ import org.apache.flink.types.Row
 import _root_.java.lang.{Boolean => JBoolean}
 import _root_.java.util.TimeZone
 import _root_.java.util.concurrent.atomic.AtomicInteger
+import java.util
 
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.collection.mutable
@@ -150,6 +151,8 @@ final class TestingAppendRowDataSink(
     RowDataTestUtil.rowToString(value, rowTypeInfo, tz)
 
   def getAppendResults: List[String] = getResults
+
+  def getJavaAppendResults: java.util.List[String] = new util.ArrayList[String](getResults.asJava)
 
 }
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DefaultPartTimeExtractor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/DefaultPartTimeExtractor.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.table.data.TimestampData;
+
+import javax.annotation.Nullable;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+import java.util.List;
+
+import static java.time.temporal.ChronoField.DAY_OF_MONTH;
+import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.MINUTE_OF_HOUR;
+import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
+import static java.time.temporal.ChronoField.SECOND_OF_MINUTE;
+import static java.time.temporal.ChronoField.YEAR;
+
+/**
+ * Default {@link PartitionTimeExtractor}.
+ * See {@link FileSystemOptions#PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN}.
+ */
+public class DefaultPartTimeExtractor implements PartitionTimeExtractor {
+
+	private static final DateTimeFormatter TIMESTAMP_FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+			.appendLiteral('-')
+			.appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL)
+			.appendLiteral('-')
+			.appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NORMAL)
+			.optionalStart()
+			.appendLiteral(" ")
+			.appendValue(HOUR_OF_DAY, 1, 2, SignStyle.NORMAL)
+			.appendLiteral(':')
+			.appendValue(MINUTE_OF_HOUR, 1, 2, SignStyle.NORMAL)
+			.appendLiteral(':')
+			.appendValue(SECOND_OF_MINUTE, 1, 2, SignStyle.NORMAL)
+			.optionalStart()
+			.appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
+			.optionalEnd()
+			.optionalEnd()
+			.toFormatter()
+			.withResolverStyle(ResolverStyle.LENIENT);
+
+	private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
+			.appendValue(YEAR, 1, 10, SignStyle.NORMAL)
+			.appendLiteral('-')
+			.appendValue(MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL)
+			.appendLiteral('-')
+			.appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NORMAL)
+			.toFormatter()
+			.withResolverStyle(ResolverStyle.LENIENT);
+
+	@Nullable
+	private final String pattern;
+
+	public DefaultPartTimeExtractor(@Nullable String pattern) {
+		this.pattern = pattern;
+	}
+
+	@Override
+	public LocalDateTime extract(List<String> partitionKeys, List<String> partitionValues) {
+		String timestampString;
+		if (pattern == null) {
+			timestampString = partitionValues.get(0);
+		} else {
+			timestampString = pattern;
+			for (int i = 0; i < partitionKeys.size(); i++) {
+				timestampString = timestampString.replaceAll(
+						"\\$" + partitionKeys.get(i),
+						partitionValues.get(i));
+			}
+		}
+		return toLocalDateTime(timestampString);
+	}
+
+	public static LocalDateTime toLocalDateTime(String timestampString) {
+		try {
+			return LocalDateTime.parse(timestampString, TIMESTAMP_FORMATTER);
+		} catch (DateTimeParseException e) {
+			return LocalDateTime.of(
+					LocalDate.parse(timestampString, DATE_FORMATTER),
+					LocalTime.MIDNIGHT);
+		}
+	}
+
+	public static long toMills(LocalDateTime dateTime) {
+		return TimestampData.fromLocalDateTime(dateTime).getMillisecond();
+	}
+
+	public static long toMills(String timestampString) {
+		return toMills(toLocalDateTime(timestampString));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -38,7 +38,7 @@ public class FileSystemOptions {
 	public static final ConfigOption<Duration> STREAMING_SOURCE_MONITOR_INTERVAL =
 			key("streaming-source.monitor-interval")
 					.durationType()
-					.defaultValue(Duration.ofMillis(1))
+					.defaultValue(Duration.ofMinutes(1))
 					.withDescription("Time interval for consecutively monitoring partition/file.");
 
 	public static final ConfigOption<String> STREAMING_SOURCE_CONSUME_ORDER =

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -60,8 +60,8 @@ public class FileSystemOptions {
 							" How to parse and compare offsets depends on your order." +
 							" For create-time and partition-time, should be a timestamp string.");
 
-	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TYPE =
-			key("partition.time-extractor.type")
+	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_KIND =
+			key("partition.time-extractor.kind")
 					.stringType()
 					.defaultValue("default")
 					.withDescription("Time extractor to extract time from partition values. Only be" +

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -58,14 +58,16 @@ public class FileSystemOptions {
 					.defaultValue("1970-00-00")
 					.withDescription("Start offset for streaming consuming." +
 							" How to parse and compare offsets depends on your order." +
-							" For create-time and partition-time, should be a timestamp string.");
+							" For create-time and partition-time, should be a timestamp string." +
+							" For partition-time, will use partition time extractor to" +
+							" extract time from partition.");
 
 	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_KIND =
 			key("partition.time-extractor.kind")
 					.stringType()
 					.defaultValue("default")
-					.withDescription("Time extractor to extract time from partition values. Only be" +
-							" used if order is set to partition-time. Support default and custom." +
+					.withDescription("Time extractor to extract time from partition values." +
+							" Support default and custom." +
 							" For default, can configure timestamp pattern." +
 							" For custom, should configure extractor class.");
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import java.time.Duration;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/**
+ * This class holds configuration constants used by filesystem(Including hive) connector.
+ */
+public class FileSystemOptions {
+
+	public static final ConfigOption<Boolean> STREAMING_SOURCE_ENABLE =
+			key("streaming-source.enable")
+					.booleanType()
+					.defaultValue(false)
+					.withDescription("Enable streaming source or not.");
+
+	public static final ConfigOption<Duration> STREAMING_SOURCE_MONITOR_INTERVAL =
+			key("streaming-source.monitor-interval")
+					.durationType()
+					.defaultValue(Duration.ofMillis(1))
+					.withDescription("Time interval for consecutively monitoring partition/file.");
+
+	public static final ConfigOption<String> STREAMING_SOURCE_CONSUME_ORDER =
+			key("streaming-source.consume-order")
+					.stringType()
+					.defaultValue("create-time")
+					.withDescription("The consume order of streaming source," +
+							" support create-time and partition-time." +
+							" create-time compare partition/file creation time, this is not the" +
+							" partition create time in Hive metaStore, but the folder/file create" +
+							" time in filesystem;" +
+							" partition-time compare time represented by partition name.");
+
+	public static final ConfigOption<String> STREAMING_SOURCE_CONSUME_START_OFFSET =
+			key("streaming-source.consume-start-offset")
+					.stringType()
+					.defaultValue("1970-00-00")
+					.withDescription("Start offset for streaming consuming." +
+							" How to parse and compare offsets depends on your order." +
+							" For create-time and partition-time, should be a timestamp string.");
+
+	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TYPE =
+			key("partition.time-extractor.type")
+					.stringType()
+					.defaultValue("default")
+					.withDescription("Time extractor to extract time from partition values. Only be" +
+							" used if order is set to partition-time. Support default and custom." +
+							" For default, can configure timestamp pattern." +
+							" For custom, should configure extractor class.");
+
+	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_CLASS =
+			key("partition.time-extractor.class")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("The extractor class for implement PartitionTimeExtractor interface.");
+
+	public static final ConfigOption<String> PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN =
+			key("partition.time-extractor.timestamp-pattern")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("The 'default' construction way allows users to use partition" +
+							" fields to get a legal timestamp pattern." +
+							" Default support 'yyyy-mm-dd hh:mm:ss' from first field." +
+							" If timestamp in partition is single field 'dt', can configure: '$dt'." +
+							" If timestamp in partition is year, month, day, hour," +
+							" can configure: '$year-$month-$day $hour:00:00'." +
+							" If timestamp in partition is dt and hour, can configure: '$dt $hour:00:00'.");
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTimeExtractor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTimeExtractor.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Time extractor to extract time from partition values.
+ */
+@Experimental
+public interface PartitionTimeExtractor extends Serializable {
+
+	String DEFAULT = "default";
+	String CUSTOM = "custom";
+
+	/**
+	 * Extract time from partition keys and values.
+	 */
+	LocalDateTime extract(List<String> partitionKeys, List<String> partitionValues);
+
+	static PartitionTimeExtractor create(
+			ClassLoader userClassLoader,
+			String extractorType,
+			String extractorClass,
+			String extractorPattern) {
+		switch (extractorType) {
+			case DEFAULT:
+				return new DefaultPartTimeExtractor(extractorPattern);
+			case CUSTOM:
+				try {
+					return (PartitionTimeExtractor) userClassLoader.loadClass(extractorClass).newInstance();
+				} catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+					throw new RuntimeException(
+							"Can not new instance for custom class from " + extractorClass, e);
+				}
+			default:
+				throw new UnsupportedOperationException(
+						"Unsupported extractor type: " + extractorType);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTimeExtractor.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionTimeExtractor.java
@@ -40,10 +40,10 @@ public interface PartitionTimeExtractor extends Serializable {
 
 	static PartitionTimeExtractor create(
 			ClassLoader userClassLoader,
-			String extractorType,
+			String extractorKind,
 			String extractorClass,
 			String extractorPattern) {
-		switch (extractorType) {
+		switch (extractorKind) {
 			case DEFAULT:
 				return new DefaultPartTimeExtractor(extractorPattern);
 			case CUSTOM:
@@ -55,7 +55,7 @@ public interface PartitionTimeExtractor extends Serializable {
 				}
 			default:
 				throw new UnsupportedOperationException(
-						"Unsupported extractor type: " + extractorType);
+						"Unsupported extractor kind: " + extractorKind);
 		}
 	}
 }


### PR DESCRIPTION

## What is the purpose of the change

Implement a hive streaming source, it monitor partitions of hive meta store. Streaming reading.

## Brief change log

- Refactor ContinuousFileReaderOperator to read generic split to reuse this operator.
- HiveTableInputFormat implements CheckpointableInputFormat for streaming reading
- Support streaming read for hive partitioned source

## Verifying this change

Manually testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented?JavaDocs
