### PR TITLE
[FLINK-17306] Add open method to (De)SerializationSchema

### DIFF
--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
@@ -35,6 +35,11 @@ class DeserializationSchemaWrapper<T> implements PubSubDeserializationSchema<T> 
 	}
 
 	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		this.deserializationSchema.open(context);
+	}
+
+	@Override
 	public boolean isEndOfStream(T t) {
 		return deserializationSchema.isEndOfStream(t);
 	}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSink.java
@@ -94,6 +94,8 @@ public class PubSubSink<IN> extends RichSinkFunction<IN> implements Checkpointed
 
 	@Override
 	public void open(Configuration configuration) throws Exception {
+		serializationSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+
 		Publisher.Builder builder = Publisher
 			.newBuilder(ProjectTopicName.of(projectName, topicName))
 			.setCredentialsProvider(FixedCredentialsProvider.create(credentials));

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
@@ -96,6 +96,7 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 		//convert per-subtask-limit to global rate limit, as FlinkConnectorRateLimiter::setRate expects a global rate limit.
 		rateLimiter.setRate(messagePerSecondRateLimit * getRuntimeContext().getNumberOfParallelSubtasks());
 		rateLimiter.open(getRuntimeContext());
+		deserializationSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 
 		createAndSetPubSubSubscriber();
 		this.isRunning = true;

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/PubSubDeserializationSchema.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/PubSubDeserializationSchema.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.streaming.connectors.gcp.pubsub.common;
 
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 
 import com.google.pubsub.v1.PubsubMessage;
@@ -30,6 +31,18 @@ import java.io.Serializable;
  * @param <T> The type created by the deserialization schema.
  */
 public interface PubSubDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(DeserializationSchema.InitializationContext context) throws Exception {
+	}
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.gcp.pubsub;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.DeserializationSchema.InitializationContext;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import com.google.protobuf.ByteString;
@@ -26,11 +27,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.internal.verification.VerificationModeFactory;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,6 +77,14 @@ public class DeserializationSchemaWrapperTest {
 
 		assertThat(deserializationSchemaWrapper.deserialize(pubSubMessage(inputAsString)), is(inputAsString));
 		verify(deserializationSchema, times(1)).deserialize(inputAsBytes);
+	}
+
+	@Test
+	public void testOpen() throws Exception {
+		InitializationContext initContext = mock(InitializationContext.class);
+		deserializationSchemaWrapper.open(initContext);
+
+		verify(deserializationSchema, VerificationModeFactory.times(1)).open(eq(initContext));
 	}
 
 	private PubsubMessage pubSubMessage(String message) {

--- a/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer011.java
@@ -615,6 +615,11 @@ public class FlinkKafkaProducer011<IN>
 			};
 		}
 
+		if (schema instanceof KeyedSerializationSchemaWrapper) {
+			((KeyedSerializationSchemaWrapper<IN>) schema).getSerializationSchema()
+				.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		}
+
 		super.open(configuration);
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBase.java
@@ -654,6 +654,8 @@ public abstract class FlinkKafkaConsumerBase<T> extends RichParallelSourceFuncti
 				LOG.info("Consumer subtask {} initially has no partitions to read from.",
 					getRuntimeContext().getIndexOfThisSubtask());
 			}
+
+			this.deserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBase.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
+import org.apache.flink.streaming.connectors.kafka.internals.KeyedSerializationSchemaWrapper;
 import org.apache.flink.streaming.connectors.kafka.internals.metrics.KafkaMetricWrapper;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
@@ -211,7 +212,11 @@ public abstract class FlinkKafkaProducerBase<IN> extends RichSinkFunction<IN> im
 	 * Initializes the connection to Kafka.
 	 */
 	@Override
-	public void open(Configuration configuration) {
+	public void open(Configuration configuration) throws Exception {
+		if (schema instanceof KeyedSerializationSchemaWrapper) {
+			((KeyedSerializationSchemaWrapper<IN>) schema).getSerializationSchema()
+				.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		}
 		producer = getKafkaProducer(this.producerConfig);
 
 		RuntimeContext ctx = getRuntimeContext();

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaDeserializationSchema.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -32,6 +33,18 @@ import java.io.Serializable;
  */
 @PublicEvolving
 public interface KafkaDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(DeserializationSchema.InitializationContext context) throws Exception {
+	}
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaSerializationSchema.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 
@@ -38,6 +39,18 @@ import java.io.Serializable;
  */
 @PublicEvolving
 public interface KafkaSerializationSchema<T> extends Serializable {
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #serialize(Object, Long)} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link SerializationSchema.InitializationContext} can be used to access additional
+	 * features such as e.g. registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(SerializationSchema.InitializationContext context) throws Exception {
+	}
 
 	/**
 	 * Serializes given element and returns it as a {@link ProducerRecord}.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
@@ -41,6 +41,11 @@ public class KafkaDeserializationSchemaWrapper<T> implements KafkaDeserializatio
 	}
 
 	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		this.deserializationSchema.open(context);
+	}
+
+	@Override
 	public T deserialize(ConsumerRecord<byte[], byte[]> record) throws Exception {
 		return deserializationSchema.deserialize(record.value());
 	}

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KeyedSerializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KeyedSerializationSchemaWrapper.java
@@ -37,6 +37,10 @@ public class KeyedSerializationSchemaWrapper<T> implements KeyedSerializationSch
 		this.serializationSchema = serializationSchema;
 	}
 
+	public SerializationSchema<T> getSerializationSchema() {
+		return serializationSchema;
+	}
+
 	@Override
 	public byte[] serializeKey(T element) {
 		return null;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducer.java
@@ -758,6 +758,10 @@ public class FlinkKafkaProducer<IN>
 			};
 		}
 
+		if (kafkaSchema != null) {
+			kafkaSchema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		}
+
 		super.open(configuration);
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisProducer.java
@@ -119,6 +119,12 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 
 		// create a simple wrapper for the serialization schema
 		this(new KinesisSerializationSchema<OUT>() {
+
+			@Override
+			public void open(SerializationSchema.InitializationContext context) throws Exception {
+				schema.open(context);
+			}
+
 			@Override
 			public ByteBuffer serialize(OUT element) {
 				// wrap into ByteBuffer
@@ -205,6 +211,8 @@ public class FlinkKinesisProducer<OUT> extends RichSinkFunction<OUT> implements 
 	@Override
 	public void open(Configuration parameters) throws Exception {
 		super.open(parameters);
+
+		schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 
 		// check and pass the configuration properties
 		KinesisProducerConfiguration producerConfig = KinesisConfigUtil.getValidatedProducerConfiguration(configProps);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/DynamoDBStreamsDataFetcher.java
@@ -93,11 +93,12 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 	 * @return
 	 */
 	@Override
-	protected ShardConsumer createShardConsumer(
+	protected ShardConsumer<T> createShardConsumer(
 		Integer subscribedShardStateIndex,
 		StreamShardHandle handle,
 		SequenceNumber lastSeqNum,
-		ShardMetricsReporter shardMetricsReporter) {
+		ShardMetricsReporter shardMetricsReporter,
+		KinesisDeserializationSchema<T> shardDeserializer) {
 
 		return new ShardConsumer(
 			this,
@@ -105,6 +106,7 @@ public class DynamoDBStreamsDataFetcher<T> extends KinesisDataFetcher<T> {
 			handle,
 			lastSeqNum,
 			DynamoDBStreamsProxy.create(getConsumerConfiguration()),
-			shardMetricsReporter);
+			shardMetricsReporter,
+			shardDeserializer);
 	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -95,7 +95,8 @@ public class ShardConsumer<T> implements Runnable {
 						StreamShardHandle subscribedShard,
 						SequenceNumber lastSequenceNum,
 						KinesisProxyInterface kinesis,
-						ShardMetricsReporter shardMetricsReporter) {
+						ShardMetricsReporter shardMetricsReporter,
+						KinesisDeserializationSchema<T> shardDeserializer) {
 		this.fetcherRef = checkNotNull(fetcherRef);
 		this.subscribedShardStateIndex = checkNotNull(subscribedShardStateIndex);
 		this.subscribedShard = checkNotNull(subscribedShard);
@@ -107,7 +108,7 @@ public class ShardConsumer<T> implements Runnable {
 			!lastSequenceNum.equals(SentinelSequenceNumber.SENTINEL_SHARD_ENDING_SEQUENCE_NUM.get()),
 			"Should not start a ShardConsumer if the shard has already been completely read.");
 
-		this.deserializer = fetcherRef.getClonedDeserializationSchema();
+		this.deserializer = shardDeserializer;
 
 		Properties consumerConfig = fetcherRef.getConsumerConfiguration();
 		this.kinesis = kinesis;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchema.java
@@ -35,6 +35,18 @@ import java.io.Serializable;
 public interface KinesisDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(DeserializationSchema.InitializationContext context) throws Exception {
+	}
+
+	/**
 	 * Deserializes a Kinesis record's bytes. If the record cannot be deserialized, {@code null}
 	 * may be returned. This informs the Flink Kinesis Consumer to process the Kinesis record
 	 * without producing any output for it, i.e. effectively "skipping" the record.

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
@@ -39,6 +39,11 @@ public class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializ
 	}
 
 	@Override
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+		this.deserializationSchema.open(context);
+	}
+
+	@Override
 	public T deserialize(byte[] recordValue, String partitionKey, String seqNum, long approxArrivalTimestamp, String stream, String shardId)
 		throws IOException {
 		return deserializationSchema.deserialize(recordValue);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisSerializationSchema.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisSerializationSchema.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kinesis.serialization;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema.InitializationContext;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
@@ -29,6 +30,18 @@ import java.nio.ByteBuffer;
  */
 @PublicEvolving
 public interface KinesisSerializationSchema<T> extends Serializable {
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #serialize(Object)} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link InitializationContext} can be used to access additional features such
+	 * as e.g. registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	default void open(InitializationContext context) throws Exception {
+	}
+
 	/**
 	 * Serialize the given element into a ByteBuffer.
 	 *

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumerTest.java
@@ -62,12 +62,14 @@ public class ShardConsumerTest {
 
 		TestSourceContext<String> sourceContext = new TestSourceContext<>();
 
+		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
+			new SimpleStringSchema());
 		TestableKinesisDataFetcher<String> fetcher =
 			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
 				sourceContext,
 				new Properties(),
-				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+				deserializationSchema,
 				10,
 				2,
 				new AtomicReference<>(),
@@ -83,7 +85,9 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9, millisBehindLatest),
-			shardMetricsReporter).run();
+			shardMetricsReporter,
+			deserializationSchema)
+			.run();
 
 		// the millisBehindLatest metric should have been reported
 		assertEquals(millisBehindLatest, shardMetricsReporter.getMillisBehindLatest());
@@ -100,12 +104,14 @@ public class ShardConsumerTest {
 
 		TestSourceContext<String> sourceContext = new TestSourceContext<>();
 
+		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
+			new SimpleStringSchema());
 		TestableKinesisDataFetcher<String> fetcher =
 			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
 				sourceContext,
 				new Properties(),
-				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+				deserializationSchema,
 				10,
 				2,
 				new AtomicReference<>(),
@@ -120,7 +126,9 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getStreamShardHandle(),
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCalls(1000, 9, 500L),
-			new ShardMetricsReporter()).run();
+			new ShardMetricsReporter(),
+			deserializationSchema)
+			.run();
 
 		assertEquals(1000, sourceContext.getCollectedOutputs().size());
 		assertEquals(
@@ -139,12 +147,14 @@ public class ShardConsumerTest {
 
 		TestSourceContext<String> sourceContext = new TestSourceContext<>();
 
+		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
+			new SimpleStringSchema());
 		TestableKinesisDataFetcher<String> fetcher =
 			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
 				sourceContext,
 				new Properties(),
-				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+				deserializationSchema,
 				10,
 				2,
 				new AtomicReference<>(),
@@ -162,7 +172,9 @@ public class ShardConsumerTest {
 			// and the 7th getRecords() call will encounter an unexpected expired shard iterator
 			FakeKinesisBehavioursFactory.totalNumOfRecordsAfterNumOfGetRecordsCallsWithUnexpectedExpiredIterator(
 				1000, 9, 7, 500L),
-			new ShardMetricsReporter()).run();
+			new ShardMetricsReporter(),
+			deserializationSchema)
+			.run();
 
 		assertEquals(1000, sourceContext.getCollectedOutputs().size());
 		assertEquals(
@@ -184,12 +196,14 @@ public class ShardConsumerTest {
 
 		TestSourceContext<String> sourceContext = new TestSourceContext<>();
 
+		KinesisDeserializationSchemaWrapper<String> deserializationSchema = new KinesisDeserializationSchemaWrapper<>(
+			new SimpleStringSchema());
 		TestableKinesisDataFetcher<String> fetcher =
 			new TestableKinesisDataFetcher<>(
 				Collections.singletonList("fakeStream"),
 				sourceContext,
 				consumerProperties,
-				new KinesisDeserializationSchemaWrapper<>(new SimpleStringSchema()),
+				deserializationSchema,
 				10,
 				2,
 				new AtomicReference<>(),
@@ -205,7 +219,9 @@ public class ShardConsumerTest {
 			subscribedShardsStateUnderTest.get(0).getLastProcessedSequenceNum(),
 			// Initial number of records to fetch --> 10
 			FakeKinesisBehavioursFactory.initialNumOfRecordsAfterNumOfGetRecordsCallsWithAdaptiveReads(10, 2, 500L),
-			new ShardMetricsReporter()).run();
+			new ShardMetricsReporter(),
+			deserializationSchema)
+			.run();
 
 		// Avg record size for first batch --> 10 * 10 Kb/10 = 10 Kb
 		// Number of records fetched in second batch --> 2 Mb/10Kb * 5 = 40

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestableKinesisDataFetcherForShardConsumerException.java
@@ -88,9 +88,4 @@ public class TestableKinesisDataFetcherForShardConsumerException<T> extends Test
 			throw e;
 		}
 	}
-
-	@Override
-	protected KinesisDeserializationSchema<T> getClonedDeserializationSchema() {
-		return super.getClonedDeserializationSchema();
-	}
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -140,6 +140,8 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
 	@Override
 	public void open(Configuration config) throws Exception {
 		ConnectionFactory factory = rmqConnectionConfig.getConnectionFactory();
+		schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+
 		try {
 			connection = factory.newConnection();
 			channel = connection.createChannel();

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -171,6 +171,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 			throw new RuntimeException("Cannot create RMQ connection with " + queueName + " at "
 					+ rmqConnectionConfig.getHost(), e);
 		}
+		this.schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 		running = true;
 	}
 

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSinkTest.java
@@ -20,7 +20,10 @@ package org.apache.flink.streaming.connectors.rabbitmq;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.sink.SinkContextUtil;
+import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
+import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.MockSerializationSchema;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
@@ -33,7 +36,9 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Collections;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -100,6 +105,19 @@ public class RMQSinkTest {
 		} catch (RuntimeException ex) {
 			assertEquals("None of RabbitMQ channels are available", ex.getMessage());
 		}
+	}
+
+	@Test
+	public void testOpen() throws Exception {
+		MockSerializationSchema<String> serializationSchema = new MockSerializationSchema<>();
+
+		RMQSink<String> producer = new RMQSink<>(rmqConnectionConfig, serializationSchema, publishOptions);
+		AbstractStreamOperatorTestHarness<Object> testHarness = new AbstractStreamOperatorTestHarness<>(
+			new StreamSink<>(producer), 1, 1, 0
+		);
+
+		testHarness.open();
+		assertThat("Open method was not called", serializationSchema.isOpenCalled(), is(true));
 	}
 
 	private RMQSink<String> createRMQSink() throws Exception {

--- a/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializationSchema.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/serialization/SerializationSchema.java
@@ -18,6 +18,8 @@
 package org.apache.flink.api.common.serialization;
 
 import org.apache.flink.annotation.Public;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.MetricGroup;
 
 import java.io.Serializable;
 
@@ -30,6 +32,18 @@ import java.io.Serializable;
  */
 @Public
 public interface SerializationSchema<T> extends Serializable {
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #serialize(Object)} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	@PublicEvolving
+	default void open(InitializationContext context) throws Exception {
+	}
 
 	/**
 	 * Serializes the incoming element to a specified type.
@@ -39,4 +53,25 @@ public interface SerializationSchema<T> extends Serializable {
 	 * @return The serialized element.
 	 */
 	byte[] serialize(T element);
+
+	/**
+	 * A contextual information provided for {@link #open(InitializationContext)} method. It can be used to:
+	 * <ul>
+	 *     <li>Register user metrics via {@link InitializationContext#getMetricGroup()}</li>
+	 * </ul>
+	 */
+	@PublicEvolving
+	interface InitializationContext {
+		/**
+		 * Returns the metric group for the parallel subtask of the source that runs
+		 * this {@link DeserializationSchema}.
+		 *
+		 * <p>Instances of this class can be used to register new metrics with Flink and to create a nested
+		 * hierarchy based on the group names. See {@link MetricGroup} for more information for the metrics
+		 * system.
+		 *
+		 * @see MetricGroup
+		 */
+		MetricGroup getMetricGroup();
+	}
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockDeserializationSchema.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockDeserializationSchema.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.metrics.MetricGroup;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A mocked {@link DeserializationSchema} that verifies that {@link DeserializationSchema#open(InitializationContext)}
+ * was called at most once. It also checks that the {@link InitializationContext} returns a not
+ * null {@link MetricGroup}.
+ *
+ * <p>It does not implement any of the deserialization methods.
+ */
+public class MockDeserializationSchema<T> implements DeserializationSchema<T> {
+
+	private boolean openCalled = false;
+
+	@Override
+	public void open(InitializationContext context) throws Exception {
+		assertThat("Open was called multiple times", openCalled, is(false));
+		assertThat(context.getMetricGroup(), notNullValue(MetricGroup.class));
+		this.openCalled = true;
+	}
+
+	@Override
+	public T deserialize(byte[] message) throws IOException {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public boolean isEndOfStream(T nextElement) {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	@Override
+	public TypeInformation<T> getProducedType() {
+		throw new UnsupportedOperationException("Not implemented");
+	}
+
+	public boolean isOpenCalled() {
+		return openCalled;
+	}
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockSerializationSchema.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockSerializationSchema.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.metrics.MetricGroup;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * A mocked {@link SerializationSchema} that verifies that {@link SerializationSchema#open(InitializationContext)}
+ * was called at most once. It also checks that the {@link InitializationContext} returns a not
+ * null {@link MetricGroup}.
+ *
+ * <p>It does not implement any of the deserialization methods.
+ */
+public class MockSerializationSchema<T> implements SerializationSchema<T> {
+
+	private boolean openCalled = false;
+
+	@Override
+	public void open(SerializationSchema.InitializationContext context) throws Exception {
+		assertThat("Open was called multiple times", openCalled, is(false));
+		assertThat(context.getMetricGroup(), notNullValue(MetricGroup.class));
+		this.openCalled = true;
+	}
+
+	@Override
+	public byte[] serialize(T element) {
+		return new byte[0];
+	}
+
+	public boolean isOpenCalled() {
+		return openCalled;
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds open method to the `DeserializationSchema` and `SerializationSchema`. It gives users access to metrics. Moreover it adds a well defined step in the lifecycle to perform initialization.

It also updates Kafka, Kinesis, PubSub and GCP connectors to call the method.

## Verifying this change

Check tests in corresponding connectors.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
