### PR TITLE
[FLINK-14881] [s3|kinesis] Add support for IAM Roles for Service Accounts on AWS EKS

### DIFF
--- a/docs/dev/connectors/kinesis.md
+++ b/docs/dev/connectors/kinesis.md
@@ -45,7 +45,25 @@ Due to the licensing issue, the `flink-connector-kinesis{{ site.scala_version_su
 
 ## Using the Amazon Kinesis Streams Service
 Follow the instructions from the [Amazon Kinesis Streams Developer Guide](https://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-create-stream.html)
-to setup Kinesis streams. Make sure to create the appropriate IAM policy and user to read / write to the Kinesis streams.
+to setup Kinesis streams.
+
+## Configuring Access to Kinesis with IAM
+Make sure to create the appropriate IAM policy to allow reading / writing to / from the Kinesis streams. See examples [here](https://docs.aws.amazon.com/streams/latest/dev/controlling-access.html).
+
+Depending on your deployment you would choose a different Credentials Provider to allow access to Kinesis.
+By default, the `AUTO` Credentials Provider is used.
+If the access key ID and secret key are set in the configuration, the `BASIC` provider is used.  
+
+A specific Credentials Provider can **optionally** be set by using the `AWSConfigConstants.AWS_CREDENTIALS_PROVIDER` setting.
+ 
+Supported Credential Providers are:
+* `AUTO` - Using the default AWS Credentials Provider chain that searches for credentials in the following order: `ENV_VARS`, `SYS_PROPS`, `WEB_IDENTITY_TOKEN`, `PROFILE` and EC2/ECS credentials provider.
+* `BASIC` - Using access key ID and secret key supplied as configuration. 
+* `ENV_VAR` - Using `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` environment variables.
+* `SYS_PROP` - Using Java system properties aws.accessKeyId and aws.secretKey.
+* `PROFILE` - Use AWS credentials profile file to create the AWS credentials.
+* `ASSUME_ROLE` - Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied.
+* `WEB_IDENTITY_TOKEN` - Create AWS credentials by assuming a role using Web Identity Token. 
 
 ## Kinesis Consumer
 
@@ -91,8 +109,7 @@ The above is a simple example of using the consumer. Configuration for the consu
 instance, the configuration keys for which can be found in `AWSConfigConstants` (AWS-specific parameters) and 
 `ConsumerConfigConstants` (Kinesis consumer parameters). The example
 demonstrates consuming a single Kinesis stream in the AWS region "us-east-1". The AWS credentials are supplied using the basic method in which
-the AWS access key ID and secret access key are directly supplied in the configuration (other options are setting
-`AWSConfigConstants.AWS_CREDENTIALS_PROVIDER` to `ENV_VAR`, `SYS_PROP`, `PROFILE`, `ASSUME_ROLE`, and `AUTO`). Also, data is being consumed
+the AWS access key ID and secret access key are directly supplied in the configuration. Also, data is being consumed
 from the newest position in the Kinesis stream (the other option will be setting `ConsumerConfigConstants.STREAM_INITIAL_POSITION`
 to `TRIM_HORIZON`, which lets the consumer start reading the Kinesis stream from the earliest record possible).
 

--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>flink-connector-kinesis</name>
 	<properties>
-		<aws.sdk.version>1.11.603</aws.sdk.version>
+		<aws.sdk.version>1.11.754</aws.sdk.version>
 		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
 		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.0</aws.dynamodbstreams-kinesis-adapter.version>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/AWSConfigConstants.java
@@ -48,7 +48,10 @@ public class AWSConfigConstants {
 		/** Create AWS credentials by assuming a role. The credentials for assuming the role must be supplied. **/
 		ASSUME_ROLE,
 
-		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, PROFILE in the AWS instance metadata. **/
+		/** Use AWS WebIdentityToken in order to assume a role. A token file and role details can be supplied as configuration or environment variables. **/
+		WEB_IDENTITY_TOKEN,
+
+		/** A credentials provider chain will be used that searches for credentials in this order: ENV_VARS, SYS_PROPS, WEB_IDENTITY_TOKEN, PROFILE in the AWS instance metadata. **/
 		AUTO,
 	}
 
@@ -70,14 +73,17 @@ public class AWSConfigConstants {
 	/** Optional configuration for profile name if credential provider type is set to be PROFILE. */
 	public static final String AWS_PROFILE_NAME = profileName(AWS_CREDENTIALS_PROVIDER);
 
-	/** The role ARN to use when credential provider type is set to ASSUME_ROLE. */
+	/** The role ARN to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN. */
 	public static final String AWS_ROLE_ARN = roleArn(AWS_CREDENTIALS_PROVIDER);
 
-	/** The role session name to use when credential provider type is set to ASSUME_ROLE. */
+	/** The role session name to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN. */
 	public static final String AWS_ROLE_SESSION_NAME = roleSessionName(AWS_CREDENTIALS_PROVIDER);
 
 	/** The external ID to use when credential provider type is set to ASSUME_ROLE. */
 	public static final String AWS_ROLE_EXTERNAL_ID = externalId(AWS_CREDENTIALS_PROVIDER);
+
+	/** The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN. */
+	public static final String AWS_WEB_IDENTITY_TOKEN_FILE = webIdentityTokenFile(AWS_CREDENTIALS_PROVIDER);
 
 	/**
 	 * The credentials provider that provides credentials for assuming the role when credential
@@ -119,5 +125,9 @@ public class AWSConfigConstants {
 
 	public static String roleCredentialsProvider(String prefix) {
 		return prefix + ".role.provider";
+	}
+
+	public static String webIdentityTokenFile(String prefix) {
+		return prefix + ".webIdentityToken.file";
 	}
 }

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -31,6 +31,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
@@ -172,6 +173,13 @@ public class AWSUtil {
 						configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix)))
 						.withExternalId(configProps.getProperty(AWSConfigConstants.externalId(configPrefix)))
 						.withStsClient(baseCredentials)
+						.build();
+
+			case WEB_IDENTITY_TOKEN:
+				return WebIdentityTokenCredentialsProvider.builder()
+						.roleArn(configProps.getProperty(AWSConfigConstants.roleArn(configPrefix), null))
+						.roleSessionName(configProps.getProperty(AWSConfigConstants.roleSessionName(configPrefix), null))
+						.webIdentityTokenFile(configProps.getProperty(AWSConfigConstants.webIdentityTokenFile(configPrefix), null))
 						.build();
 
 			default:

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -8,14 +8,14 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.amazonaws:amazon-kinesis-client:1.11.2
 - com.amazonaws:amazon-kinesis-producer:0.14.0
-- com.amazonaws:aws-java-sdk-core:1.11.603
-- com.amazonaws:aws-java-sdk-dynamodb:1.11.603
-- com.amazonaws:aws-java-sdk-kinesis:1.11.603
-- com.amazonaws:aws-java-sdk-kms:1.11.603
-- com.amazonaws:aws-java-sdk-s3:1.11.603
-- com.amazonaws:aws-java-sdk-sts:1.11.603
+- com.amazonaws:aws-java-sdk-core:1.11.754
+- com.amazonaws:aws-java-sdk-dynamodb:1.11.754
+- com.amazonaws:aws-java-sdk-kinesis:1.11.754
+- com.amazonaws:aws-java-sdk-kms:1.11.754
+- com.amazonaws:aws-java-sdk-s3:1.11.754
+- com.amazonaws:aws-java-sdk-sts:1.11.754
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.0
-- com.amazonaws:jmespath-java:1.11.603
+- com.amazonaws:jmespath-java:1.11.754
 - org.apache.httpcomponents:httpclient:4.5.9
 - org.apache.httpcomponents:httpcore:4.4.6
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.util;
+
+import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for AWSUtil.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AWSUtil.class)
+public class AWSUtilTest {
+	@Rule
+	private final ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void testDefaultCredentialsProvider() {
+		Properties testConfig = new Properties();
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+
+		assertTrue(credentialsProvider instanceof DefaultAWSCredentialsProviderChain);
+	}
+
+	@Test
+	public void testGetCredentialsProvider() {
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "WEB_IDENTITY_TOKEN");
+
+		AWSCredentialsProvider credentialsProvider = AWSUtil.getCredentialsProvider(testConfig);
+		assertTrue(credentialsProvider instanceof WebIdentityTokenCredentialsProvider);
+	}
+
+	@Test
+	public void testInvalidCredentialsProvider() {
+		exception.expect(IllegalArgumentException.class);
+
+		Properties testConfig = new Properties();
+		testConfig.setProperty(AWSConfigConstants.AWS_CREDENTIALS_PROVIDER, "INVALID_PROVIDER");
+
+		AWSUtil.getCredentialsProvider(testConfig);
+	}
+
+	@Test
+	public void testValidRegion() {
+		assertTrue(AWSUtil.isValidRegion("us-east-1"));
+	}
+
+	@Test
+	public void testInvalidRegion() {
+		assertFalse(AWSUtil.isValidRegion("ur-east-1"));
+	}
+}

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<fs.s3.aws.version>1.11.271</fs.s3.aws.version>
+		<fs.s3.aws.version>1.11.754</fs.s3.aws.version>
 	</properties>
 
 	<dependencies>
@@ -202,6 +202,11 @@ under the License.
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-dynamodb</artifactId>
+			<version>${fs.s3.aws.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-sts</artifactId>
 			<version>${fs.s3.aws.version}</version>
 		</dependency>
 

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -76,6 +76,17 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- aws-sdk requires httpclient >= 4.5.9 due to api compatibility breakage -->
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.9</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -7,6 +7,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.754
 - com.amazonaws:aws-java-sdk-kms:1.11.754
 - com.amazonaws:aws-java-sdk-s3:1.11.754
+- com.amazonaws:aws-java-sdk-sts:1.11.754
 - com.amazonaws:jmespath-java:1.11.754
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -3,11 +3,11 @@ Copyright 2014-2020 The Apache Software Foundation
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.amazonaws:aws-java-sdk-core:1.11.271
-- com.amazonaws:aws-java-sdk-dynamodb:1.11.271
-- com.amazonaws:aws-java-sdk-kms:1.11.271
-- com.amazonaws:aws-java-sdk-s3:1.11.271
-- com.amazonaws:jmespath-java:1.11.271
+- com.amazonaws:aws-java-sdk-core:1.11.754
+- com.amazonaws:aws-java-sdk-dynamodb:1.11.754
+- com.amazonaws:aws-java-sdk-kms:1.11.754
+- com.amazonaws:aws-java-sdk-s3:1.11.754
+- com.amazonaws:jmespath-java:1.11.754
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
 - com.fasterxml.jackson.core:jackson-core:2.10.1
 - com.fasterxml.jackson.core:jackson-databind:2.10.1
@@ -29,7 +29,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-common:3.1.0
 - org.apache.htrace:htrace-core4:4.1.0-incubating
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.apache.httpcomponents:httpclient:4.5.3
+- org.apache.httpcomponents:httpclient:4.5.9
 - software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under the CDDL 1.1 license.

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -213,6 +213,18 @@ under the License.
 		</dependency>
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<!-- aws-sdk requires httpclient >= 4.5.9 due to api compatibility breakage -->
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.9</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+
 	<build>
 		<plugins>
 			<plugin>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -16,6 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.754
 - com.amazonaws:aws-java-sdk-kms:1.11.754
 - com.amazonaws:aws-java-sdk-s3:1.11.754
+- com.amazonaws:aws-java-sdk-sts:1.11.754
 - com.amazonaws:jmespath-java:1.11.754
 - com.facebook.presto:presto-hive:0.187
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -12,11 +12,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.4
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
-- com.amazonaws:aws-java-sdk-core:1.11.271
-- com.amazonaws:aws-java-sdk-dynamodb:1.11.271
-- com.amazonaws:aws-java-sdk-kms:1.11.271
-- com.amazonaws:aws-java-sdk-s3:1.11.271
-- com.amazonaws:jmespath-java:1.11.271
+- com.amazonaws:aws-java-sdk-core:1.11.754
+- com.amazonaws:aws-java-sdk-dynamodb:1.11.754
+- com.amazonaws:aws-java-sdk-kms:1.11.754
+- com.amazonaws:aws-java-sdk-s3:1.11.754
+- com.amazonaws:jmespath-java:1.11.754
 - com.facebook.presto:presto-hive:0.187
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.3-1
 - com.fasterxml.jackson.core:jackson-annotations:2.10.1
@@ -39,7 +39,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.hadoop:hadoop-common:3.1.0
 - org.apache.htrace:htrace-core4:4.1.0-incubating
 - org.apache.httpcomponents:httpcore:4.4.6
-- org.apache.httpcomponents:httpclient:4.5.3
+- org.apache.httpcomponents:httpclient:4.5.9
 - org.weakref:jmxutils:1.19
 - software.amazon.ion:ion-java:1.0.2
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

IAM Roles for Service Accounts have many advantages when deploying Flink on AWS EKS.
From AWS documentation:
> With IAM roles for service accounts on Amazon EKS clusters, you can associate an IAM role with a Kubernetes service account. This service account can then provide AWS permissions to the containers in any pod that uses that service account. With this feature, you no longer need to provide extended permissions to the worker node IAM role so that pods on that node can call AWS APIs.
 
In order to support for IAM Roles for Service Accounts we need to add support for a relatively new authentication method in AWS SDK called WebIdentityToken.

This pull request adds support for WebIdentityToken authentication method when using AWS services. This includes S3 and Kinesis.

## Brief change log

S3
  - Bumping AWS SDK dependency to 1.11.754
  - Bumping httpcomponents:httpclient dependency to 4.5.9
  - Added aws-java-sdk-sts dependency

Kinesis
  - Bumping AWS SDK dependency to 1.11.754
  - Added CredentialProvider type for WebIdentityToken

## Verifying this change

It is tricky to verify this change by end-to-end test as Kinesalite doesn't support authentication methods. Minio does support it but requires extra containers to be launched to do the actual token verification that will complicate and lengthen the s3 tests. 

Added configuration unit tests in `AWSUtilTest`

As this change is mainly a dependency change, I verified it manually on an actual EKS cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no**)
  - The runtime per-record code paths (performance sensitive): (yes / **no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (**yes** / no)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)

Currently I could not find the deployment on EKS documented anywhere. If needed i'm willing to add docs if that would be helpful.
