### PR TITLE
[FLINK-16529][python]Add ignore_parse_errors() method to Json format …

### DIFF
--- a/flink-python/pyflink/table/descriptors.py
+++ b/flink-python/pyflink/table/descriptors.py
@@ -18,9 +18,9 @@
 from abc import ABCMeta
 
 from py4j.java_gateway import get_method
-from pyflink.table.types import _to_java_type
 
 from pyflink.java_gateway import get_gateway
+from pyflink.table.types import _to_java_type
 
 __all__ = [
     'Rowtime',
@@ -565,6 +565,19 @@ class Json(FormatDescriptor):
         if not isinstance(fail_on_missing_field, bool):
             raise TypeError("Only bool value is supported!")
         self._j_json = self._j_json.failOnMissingField(fail_on_missing_field)
+        return self
+
+    def ignore_parse_errors(self, ignore_parse_errors):
+        """
+        Sets flag whether to fail when parsing json fails.
+
+        :param ignore_parse_errors: If set to true, the operation will ignore parse errors.
+                                    If set to false, the operation fails when parsing json fails.
+        :return: This object.
+        """
+        if not isinstance(ignore_parse_errors, bool):
+            raise TypeError("Only bool value is supported!")
+        self._j_json = self._j_json.ignoreParseErrors(ignore_parse_errors)
         return self
 
     def json_schema(self, json_schema):

--- a/flink-python/pyflink/table/tests/test_descriptor.py
+++ b/flink-python/pyflink/table/tests/test_descriptor.py
@@ -706,6 +706,16 @@ class JsonDescriptorTests(PyFlinkTestCase):
         properties = json.to_properties()
         self.assertEqual(expected, properties)
 
+    def test_ignore_parse_errors(self):
+        json = Json().ignore_parse_errors(True)
+
+        expected = {'format.ignore-parse-errors': 'true',
+                    'format.property-version': '1',
+                    'format.type': 'json'}
+
+        properties = json.to_properties()
+        self.assertEqual(expected, properties)
+
     def test_json_schema(self):
         json = Json().json_schema(
             "{"


### PR DESCRIPTION
## What is the purpose of the change

*JSON format currently support 'format.ignore-parse-errors' to skip dirty records in Java, which should consistent with Java in Python API.*


## Brief change log

  - *Add `ignore_parse_errors` method in `Json` class to support 'format.ignore-parse-errors'.*


## Verifying this change

  - *Add `test_ignore_parse_errors` method in `JsonDescriptorTests` to verify whether to support 'format.ignore-parse-errors'.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
