### PR TITLE
[FLINK-17497][e2e] Properly switch to Scala 2.12 in quickstart test

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -68,6 +68,13 @@ sed -i -e ''$(($position + 1))'i\
 
 sed -i -e "s/org.apache.flink.quickstart.StreamingJob/org.apache.flink.quickstart.$TEST_CLASS_NAME/" pom.xml
 
+if [[ $PROFILE == *"scala-2.12"* ]]; then
+  echo "Changing scala version"
+  sed -i -e "s/scala.binary.version>2.11<\/scala.binary/scala.binary.version>2.12<\/scala.binary/" pom.xml
+  # for flink-quickstart-scala, also change scala version
+  sed -i -e "s/scala.version>2.11.12<\/scala.ver/scala.version>2.12.7<\/scala.ver/" pom.xml
+fi
+
 run_mvn clean package
 
 cd target

--- a/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
+++ b/flink-end-to-end-tests/test-scripts/test_quickstarts.sh
@@ -68,12 +68,20 @@ sed -i -e ''$(($position + 1))'i\
 
 sed -i -e "s/org.apache.flink.quickstart.StreamingJob/org.apache.flink.quickstart.$TEST_CLASS_NAME/" pom.xml
 
-if [[ $PROFILE == *"scala-2.12"* ]]; then
+case $PROFILE in
+*"scala-2.12"*)
   echo "Changing scala version"
   sed -i -e "s/scala.binary.version>2.11<\/scala.binary/scala.binary.version>2.12<\/scala.binary/" pom.xml
   # for flink-quickstart-scala, also change scala version
   sed -i -e "s/scala.version>2.11.12<\/scala.ver/scala.version>2.12.7<\/scala.ver/" pom.xml
-fi
+  ;;
+*"scala-2.11"*)
+  # all good
+  ;;
+*"scala-"*)
+  echo "UNSUPPORTED SCALA VERSION"
+  exit 1
+esac
 
 run_mvn clean package
 


### PR DESCRIPTION
## What is the purpose of the change

The quickstart test was sometimes failing because the scala 2.11 quickstart was used in the scala 2.12 build.


## Brief change log

- if the scala 2.12 profile is detected, change scala version for both java and scala quickstart test to 2.12.


## Verifying this change

Validated in my personal CI: https://dev.azure.com/rmetzger/Flink/_build/results?buildId=7952&view=results