### PR TITLE
[FLINK-17307] Add collector to deserialize in KafkaDeserializationSchema

### DIFF
--- a/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.10/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka010ITCase.java
@@ -167,6 +167,11 @@ public class Kafka010ITCase extends KafkaConsumerTestBase {
 		runAutoOffsetRetrievalAndCommitToKafka();
 	}
 
+	@Test(timeout = 60000)
+	public void testCollectingSchema() throws Exception {
+		runCollectingSchemaTest();
+	}
+
 	/**
 	 * Kafka 0.10 specific test, ensuring Timestamps are properly written to and read from Kafka.
 	 */

--- a/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011ITCase.java
+++ b/flink-connectors/flink-connector-kafka-0.11/src/test/java/org/apache/flink/streaming/connectors/kafka/Kafka011ITCase.java
@@ -175,6 +175,11 @@ public class Kafka011ITCase extends KafkaConsumerTestBase {
 		runAutoOffsetRetrievalAndCommitToKafka();
 	}
 
+	@Test(timeout = 60000)
+	public void testCollectingSchema() throws Exception {
+		runCollectingSchemaTest();
+	}
+
 	/**
 	 * Kafka 0.11 specific test, ensuring Timestamps are properly written to and read from Kafka.
 	 */

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaDeserializationSchema.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/KafkaDeserializationSchema.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -64,4 +65,21 @@ public interface KafkaDeserializationSchema<T> extends Serializable, ResultTypeQ
 	 * @return The deserialized message as an object (null if the message cannot be deserialized).
 	 */
 	T deserialize(ConsumerRecord<byte[], byte[]> record) throws Exception;
+
+	/**
+	 * Deserializes the Kafka record.
+	 *
+	 * <p>Can output multiple records through the {@link Collector}. Note that number and size of the
+	 * produced records should be relatively small. Depending on the source implementation records
+	 * can be buffered in memory or collecting records might delay emitting checkpoint barrier.
+	 *
+	 * @param message The message, as a byte array.
+	 * @param out The collector to put the resulting messages.
+	 */
+	default void deserialize(ConsumerRecord<byte[], byte[]> message, Collector<T> out) throws Exception {
+		T deserialized = deserialize(message);
+		if (deserialized != null) {
+			out.collect(deserialized);
+		}
+	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
@@ -342,93 +343,72 @@ public abstract class AbstractFetcher<T, KPH> {
 
 	/**
 	 * Emits a record attaching a timestamp to it.
-	 *
-	 * <p>Implementation Note: This method is kept brief to be JIT inlining friendly.
-	 * That makes the fast path efficient, the extended paths are called as separate methods.
-	 *
-	 * @param record The record to emit
+	 *  @param records The records to emit
 	 * @param partitionState The state of the Kafka partition from which the record was fetched
-	 * @param offset The offset of the record
+	 * @param offset The offset of the corresponding Kafka record
+	 * @param kafkaEventTimestamp The timestamp of the Kafka record
 	 */
-	protected void emitRecordWithTimestamp(
-			T record, KafkaTopicPartitionState<KPH> partitionState, long offset, long timestamp) throws Exception {
-
-		if (record != null) {
-			if (timestampWatermarkMode == NO_TIMESTAMPS_WATERMARKS) {
-				// fast path logic, in case there are no watermarks generated in the fetcher
-
-				// emit the record, using the checkpoint lock to guarantee
-				// atomicity of record emission and offset state update
-				synchronized (checkpointLock) {
-					sourceContext.collectWithTimestamp(record, timestamp);
-					partitionState.setOffset(offset);
+	protected void emitRecordsWithTimestamps(
+			Queue<T> records,
+			KafkaTopicPartitionState<KPH> partitionState,
+			long offset,
+			long kafkaEventTimestamp) {
+		// emit the records, using the checkpoint lock to guarantee
+		// atomicity of record emission and offset state update
+		synchronized (checkpointLock) {
+			T record;
+			while ((record = records.poll()) != null) {
+				// timestamps will be of the same size as records.
+				long timestamp = getTimestampForRecord(record, partitionState, kafkaEventTimestamp);
+				sourceContext.collectWithTimestamp(record, timestamp);
+				if (timestampWatermarkMode == PUNCTUATED_WATERMARKS) {
+					emitPunctuatedWatermark(record, timestamp, partitionState);
 				}
-			} else if (timestampWatermarkMode == PERIODIC_WATERMARKS) {
-				emitRecordWithTimestampAndPeriodicWatermark(record, partitionState, offset, timestamp);
-			} else {
-				emitRecordWithTimestampAndPunctuatedWatermark(record, partitionState, offset, timestamp);
 			}
-		} else {
-			// if the record is null, simply just update the offset state for partition
-			synchronized (checkpointLock) {
-				partitionState.setOffset(offset);
-			}
-		}
-	}
-
-	/**
-	 * Record emission, if a timestamp will be attached from an assigner that is
-	 * also a periodic watermark generator.
-	 */
-	private void emitRecordWithTimestampAndPeriodicWatermark(
-			T record, KafkaTopicPartitionState<KPH> partitionState, long offset, long kafkaEventTimestamp) {
-		@SuppressWarnings("unchecked")
-		final KafkaTopicPartitionStateWithPeriodicWatermarks<T, KPH> withWatermarksState =
-				(KafkaTopicPartitionStateWithPeriodicWatermarks<T, KPH>) partitionState;
-
-		// extract timestamp - this accesses/modifies the per-partition state inside the
-		// watermark generator instance, so we need to lock the access on the
-		// partition state. concurrent access can happen from the periodic emitter
-		final long timestamp;
-		//noinspection SynchronizationOnLocalVariableOrMethodParameter
-		synchronized (withWatermarksState) {
-			timestamp = withWatermarksState.getTimestampForRecord(record, kafkaEventTimestamp);
-		}
-
-		// emit the record with timestamp, using the usual checkpoint lock to guarantee
-		// atomicity of record emission and offset state update
-		synchronized (checkpointLock) {
-			sourceContext.collectWithTimestamp(record, timestamp);
 			partitionState.setOffset(offset);
 		}
 	}
 
-	/**
-	 * Record emission, if a timestamp will be attached from an assigner that is
-	 * also a punctuated watermark generator.
-	 */
-	private void emitRecordWithTimestampAndPunctuatedWatermark(
-			T record, KafkaTopicPartitionState<KPH> partitionState, long offset, long kafkaEventTimestamp) {
-		@SuppressWarnings("unchecked")
+	private void emitPunctuatedWatermark(
+			T record,
+			long timestamp,
+			KafkaTopicPartitionState<KPH> partitionState) {
 		final KafkaTopicPartitionStateWithPunctuatedWatermarks<T, KPH> withWatermarksState =
-				(KafkaTopicPartitionStateWithPunctuatedWatermarks<T, KPH>) partitionState;
+			(KafkaTopicPartitionStateWithPunctuatedWatermarks<T, KPH>) partitionState;
 
-		// only one thread ever works on accessing timestamps and watermarks
-		// from the punctuated extractor
-		final long timestamp = withWatermarksState.getTimestampForRecord(record, kafkaEventTimestamp);
-		final Watermark newWatermark = withWatermarksState.checkAndGetNewWatermark(record, timestamp);
-
-		// emit the record with timestamp, using the usual checkpoint lock to guarantee
-		// atomicity of record emission and offset state update
-		synchronized (checkpointLock) {
-			sourceContext.collectWithTimestamp(record, timestamp);
-			partitionState.setOffset(offset);
-		}
+		Watermark newWatermark = withWatermarksState.checkAndGetNewWatermark(record, timestamp);
 
 		// if we also have a new per-partition watermark, check if that is also a
 		// new cross-partition watermark
 		if (newWatermark != null) {
 			updateMinPunctuatedWatermark(newWatermark);
+		}
+	}
+
+	protected long getTimestampForRecord(
+			T record,
+			KafkaTopicPartitionState<KPH> partitionState,
+			long kafkaEventTimestamp) {
+		if (timestampWatermarkMode == NO_TIMESTAMPS_WATERMARKS) {
+			return kafkaEventTimestamp;
+		} else if (timestampWatermarkMode == PERIODIC_WATERMARKS) {
+			final KafkaTopicPartitionStateWithPeriodicWatermarks<T, KPH> withWatermarksState =
+				(KafkaTopicPartitionStateWithPeriodicWatermarks<T, KPH>) partitionState;
+
+			// extract timestamp - this accesses/modifies the per-partition state inside the
+			// watermark generator instance, so we need to lock the access on the
+			// partition state. concurrent access can happen from the periodic emitter
+			//noinspection SynchronizationOnLocalVariableOrMethodParameter
+			synchronized (withWatermarksState) {
+				return withWatermarksState.getTimestampForRecord(record, kafkaEventTimestamp);
+			}
+		} else {
+			final KafkaTopicPartitionStateWithPunctuatedWatermarks<T, KPH> withWatermarksState =
+				(KafkaTopicPartitionStateWithPunctuatedWatermarks<T, KPH>) partitionState;
+
+			// only one thread ever works on accessing timestamps and watermarks
+			// from the punctuated extractor
+			return withWatermarksState.getTimestampForRecord(record, kafkaEventTimestamp);
 		}
 	}
 

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -341,41 +341,6 @@ public abstract class AbstractFetcher<T, KPH> {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * Emits a record without attaching an existing timestamp to it.
-	 *
-	 * <p>Implementation Note: This method is kept brief to be JIT inlining friendly.
-	 * That makes the fast path efficient, the extended paths are called as separate methods.
-	 *
-	 * @param record The record to emit
-	 * @param partitionState The state of the Kafka partition from which the record was fetched
-	 * @param offset The offset of the record
-	 */
-	protected void emitRecord(T record, KafkaTopicPartitionState<KPH> partitionState, long offset) throws Exception {
-
-		if (record != null) {
-			if (timestampWatermarkMode == NO_TIMESTAMPS_WATERMARKS) {
-				// fast path logic, in case there are no watermarks
-
-				// emit the record, using the checkpoint lock to guarantee
-				// atomicity of record emission and offset state update
-				synchronized (checkpointLock) {
-					sourceContext.collect(record);
-					partitionState.setOffset(offset);
-				}
-			} else if (timestampWatermarkMode == PERIODIC_WATERMARKS) {
-				emitRecordWithTimestampAndPeriodicWatermark(record, partitionState, offset, Long.MIN_VALUE);
-			} else {
-				emitRecordWithTimestampAndPunctuatedWatermark(record, partitionState, offset, Long.MIN_VALUE);
-			}
-		} else {
-			// if the record is null, simply just update the offset state for partition
-			synchronized (checkpointLock) {
-				partitionState.setOffset(offset);
-			}
-		}
-	}
-
-	/**
 	 * Emits a record attaching a timestamp to it.
 	 *
 	 * <p>Implementation Note: This method is kept brief to be JIT inlining friendly.

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.connectors.kafka.KafkaDeserializationSchema;
+import org.apache.flink.util.Collector;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -47,7 +48,15 @@ public class KafkaDeserializationSchemaWrapper<T> implements KafkaDeserializatio
 
 	@Override
 	public T deserialize(ConsumerRecord<byte[], byte[]> record) throws Exception {
-		return deserializationSchema.deserialize(record.value());
+		throw new UnsupportedOperationException("Should never be called");
+	}
+
+	@Override
+	public void deserialize(ConsumerRecord<byte[], byte[]> message, Collector<T> out) throws Exception {
+		T record = deserializationSchema.deserialize(message.value());
+		if (record != null) {
+			out.collect(record);
+		}
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
+++ b/flink-connectors/flink-connector-kafka-base/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
@@ -108,13 +108,13 @@ public class AbstractFetcherTest {
 
 		final KafkaTopicPartitionState<Object> partitionStateHolder = fetcher.subscribedPartitionStates().get(0);
 
-		fetcher.emitRecord(1L, partitionStateHolder, 1L);
-		fetcher.emitRecord(2L, partitionStateHolder, 2L);
+		emitRecord(fetcher, 1L, partitionStateHolder, 1L);
+		emitRecord(fetcher, 2L, partitionStateHolder, 2L);
 		assertEquals(2L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(2L, partitionStateHolder.getOffset());
 
 		// emit null record
-		fetcher.emitRecord(null, partitionStateHolder, 3L);
+		emitRecord(fetcher, null, partitionStateHolder, 3L);
 		assertEquals(2L, sourceContext.getLatestElement().getValue().longValue()); // the null record should be skipped
 		assertEquals(3L, partitionStateHolder.getOffset()); // the offset in state still should have advanced
 	}
@@ -140,9 +140,9 @@ public class AbstractFetcherTest {
 		final KafkaTopicPartitionState<Object> partitionStateHolder = fetcher.subscribedPartitionStates().get(0);
 
 		// elements generate a watermark if the timestamp is a multiple of three
-		fetcher.emitRecord(1L, partitionStateHolder, 1L);
-		fetcher.emitRecord(2L, partitionStateHolder, 2L);
-		fetcher.emitRecord(3L, partitionStateHolder, 3L);
+		emitRecord(fetcher, 1L, partitionStateHolder, 1L);
+		emitRecord(fetcher, 2L, partitionStateHolder, 2L);
+		emitRecord(fetcher, 3L, partitionStateHolder, 3L);
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(3L, sourceContext.getLatestElement().getTimestamp());
 		assertTrue(sourceContext.hasWatermark());
@@ -150,7 +150,7 @@ public class AbstractFetcherTest {
 		assertEquals(3L, partitionStateHolder.getOffset());
 
 		// emit null record
-		fetcher.emitRecord(null, partitionStateHolder, 4L);
+		emitRecord(fetcher, null, partitionStateHolder, 4L);
 
 		// no elements or watermarks should have been collected
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
@@ -181,9 +181,9 @@ public class AbstractFetcherTest {
 		final KafkaTopicPartitionState<Object> partitionStateHolder = fetcher.subscribedPartitionStates().get(0);
 
 		// elements generate a watermark if the timestamp is a multiple of three
-		fetcher.emitRecord(1L, partitionStateHolder, 1L);
-		fetcher.emitRecord(2L, partitionStateHolder, 2L);
-		fetcher.emitRecord(3L, partitionStateHolder, 3L);
+		emitRecord(fetcher, 1L, partitionStateHolder, 1L);
+		emitRecord(fetcher, 2L, partitionStateHolder, 2L);
+		emitRecord(fetcher, 3L, partitionStateHolder, 3L);
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(3L, sourceContext.getLatestElement().getTimestamp());
 		assertEquals(3L, partitionStateHolder.getOffset());
@@ -194,7 +194,7 @@ public class AbstractFetcherTest {
 		assertEquals(3L, sourceContext.getLatestWatermark().getTimestamp());
 
 		// emit null record
-		fetcher.emitRecord(null, partitionStateHolder, 4L);
+		emitRecord(fetcher, null, partitionStateHolder, 4L);
 
 		// no elements should have been collected
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
@@ -238,22 +238,22 @@ public class AbstractFetcherTest {
 		// elements generate a watermark if the timestamp is a multiple of three
 
 		// elements for partition 1
-		fetcher.emitRecord(1L, part1, 1L);
-		fetcher.emitRecord(2L, part1, 2L);
-		fetcher.emitRecord(3L, part1, 3L);
+		emitRecord(fetcher, 1L, part1, 1L);
+		emitRecord(fetcher, 2L, part1, 2L);
+		emitRecord(fetcher, 3L, part1, 3L);
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(3L, sourceContext.getLatestElement().getTimestamp());
 		assertFalse(sourceContext.hasWatermark());
 
 		// elements for partition 2
-		fetcher.emitRecord(12L, part2, 1L);
+		emitRecord(fetcher, 12L, part2, 1L);
 		assertEquals(12L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(12L, sourceContext.getLatestElement().getTimestamp());
 		assertFalse(sourceContext.hasWatermark());
 
 		// elements for partition 3
-		fetcher.emitRecord(101L, part3, 1L);
-		fetcher.emitRecord(102L, part3, 2L);
+		emitRecord(fetcher, 101L, part3, 1L);
+		emitRecord(fetcher, 102L, part3, 2L);
 		assertEquals(102L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(102L, sourceContext.getLatestElement().getTimestamp());
 
@@ -262,25 +262,25 @@ public class AbstractFetcherTest {
 		assertEquals(3L, sourceContext.getLatestWatermark().getTimestamp());
 
 		// advance partition 3
-		fetcher.emitRecord(1003L, part3, 3L);
-		fetcher.emitRecord(1004L, part3, 4L);
-		fetcher.emitRecord(1005L, part3, 5L);
+		emitRecord(fetcher, 1003L, part3, 3L);
+		emitRecord(fetcher, 1004L, part3, 4L);
+		emitRecord(fetcher, 1005L, part3, 5L);
 		assertEquals(1005L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(1005L, sourceContext.getLatestElement().getTimestamp());
 
 		// advance partition 1 beyond partition 2 - this bumps the watermark
-		fetcher.emitRecord(30L, part1, 4L);
+		emitRecord(fetcher, 30L, part1, 4L);
 		assertEquals(30L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(30L, sourceContext.getLatestElement().getTimestamp());
 		assertTrue(sourceContext.hasWatermark());
 		assertEquals(12L, sourceContext.getLatestWatermark().getTimestamp());
 
 		// advance partition 2 again - this bumps the watermark
-		fetcher.emitRecord(13L, part2, 2L);
+		emitRecord(fetcher, 13L, part2, 2L);
 		assertFalse(sourceContext.hasWatermark());
-		fetcher.emitRecord(14L, part2, 3L);
+		emitRecord(fetcher, 14L, part2, 3L);
 		assertFalse(sourceContext.hasWatermark());
-		fetcher.emitRecord(15L, part2, 3L);
+		emitRecord(fetcher, 15L, part2, 3L);
 		assertTrue(sourceContext.hasWatermark());
 		assertEquals(15L, sourceContext.getLatestWatermark().getTimestamp());
 	}
@@ -312,20 +312,20 @@ public class AbstractFetcherTest {
 		// elements generate a watermark if the timestamp is a multiple of three
 
 		// elements for partition 1
-		fetcher.emitRecord(1L, part1, 1L);
-		fetcher.emitRecord(2L, part1, 2L);
-		fetcher.emitRecord(3L, part1, 3L);
+		emitRecord(fetcher, 1L, part1, 1L);
+		emitRecord(fetcher, 2L, part1, 2L);
+		emitRecord(fetcher, 3L, part1, 3L);
 		assertEquals(3L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(3L, sourceContext.getLatestElement().getTimestamp());
 
 		// elements for partition 2
-		fetcher.emitRecord(12L, part2, 1L);
+		emitRecord(fetcher, 12L, part2, 1L);
 		assertEquals(12L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(12L, sourceContext.getLatestElement().getTimestamp());
 
 		// elements for partition 3
-		fetcher.emitRecord(101L, part3, 1L);
-		fetcher.emitRecord(102L, part3, 2L);
+		emitRecord(fetcher, 101L, part3, 1L);
+		emitRecord(fetcher, 102L, part3, 2L);
 		assertEquals(102L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(102L, sourceContext.getLatestElement().getTimestamp());
 
@@ -335,14 +335,14 @@ public class AbstractFetcherTest {
 		assertEquals(3L, sourceContext.getLatestWatermark().getTimestamp());
 
 		// advance partition 3
-		fetcher.emitRecord(1003L, part3, 3L);
-		fetcher.emitRecord(1004L, part3, 4L);
-		fetcher.emitRecord(1005L, part3, 5L);
+		emitRecord(fetcher, 1003L, part3, 3L);
+		emitRecord(fetcher, 1004L, part3, 4L);
+		emitRecord(fetcher, 1005L, part3, 5L);
 		assertEquals(1005L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(1005L, sourceContext.getLatestElement().getTimestamp());
 
 		// advance partition 1 beyond partition 2 - this bumps the watermark
-		fetcher.emitRecord(30L, part1, 4L);
+		emitRecord(fetcher, 30L, part1, 4L);
 		assertEquals(30L, sourceContext.getLatestElement().getValue().longValue());
 		assertEquals(30L, sourceContext.getLatestElement().getTimestamp());
 
@@ -352,9 +352,9 @@ public class AbstractFetcherTest {
 		assertEquals(12L, sourceContext.getLatestWatermark().getTimestamp());
 
 		// advance partition 2 again - this bumps the watermark
-		fetcher.emitRecord(13L, part2, 2L);
-		fetcher.emitRecord(14L, part2, 3L);
-		fetcher.emitRecord(15L, part2, 3L);
+		emitRecord(fetcher, 13L, part2, 2L);
+		emitRecord(fetcher, 14L, part2, 3L);
+		emitRecord(fetcher, 15L, part2, 3L);
 
 		processingTimeService.setCurrentTime(30);
 		// this blocks until the periodic thread emitted the watermark
@@ -386,7 +386,7 @@ public class AbstractFetcherTest {
 		// counter-test that when the fetcher does actually have partitions,
 		// when the periodic watermark emitter fires again, a watermark really is emitted
 		fetcher.addDiscoveredPartitions(Collections.singletonList(new KafkaTopicPartition(testTopic, 0)));
-		fetcher.emitRecord(100L, fetcher.subscribedPartitionStates().get(0), 3L);
+		emitRecord(fetcher, 100L, fetcher.subscribedPartitionStates().get(0), 3L);
 		processingTimeProvider.setCurrentTime(20);
 		assertEquals(100, sourceContext.getLatestWatermark().getTimestamp());
 	}
@@ -528,6 +528,19 @@ public class AbstractFetcherTest {
 	}
 
 	// ------------------------------------------------------------------------
+
+	private static <T, KPH> void emitRecord(
+			AbstractFetcher<T, KPH> fetcher,
+			T record,
+			KafkaTopicPartitionState<KPH> partitionState,
+			long offset) throws Exception {
+
+		fetcher.emitRecordWithTimestamp(
+			record,
+			partitionState,
+			offset,
+			Long.MIN_VALUE);
+	}
 
 	private static class PeriodicTestExtractor implements AssignerWithPeriodicWatermarks<Long> {
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaFetcher.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internal/KafkaFetcher.java
@@ -28,6 +28,7 @@ import org.apache.flink.streaming.connectors.kafka.internals.KafkaCommitCallback
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartition;
 import org.apache.flink.streaming.connectors.kafka.internals.KafkaTopicPartitionState;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.SerializedValue;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -39,10 +40,12 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Queue;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -117,6 +120,8 @@ public class KafkaFetcher<T> extends AbstractFetcher<T, TopicPartition> {
 	//  Fetcher work methods
 	// ------------------------------------------------------------------------
 
+	private final KafkaCollector kafkaCollector = new KafkaCollector();
+
 	@Override
 	public void runFetchLoop() throws Exception {
 		try {
@@ -137,17 +142,21 @@ public class KafkaFetcher<T> extends AbstractFetcher<T, TopicPartition> {
 						records.records(partition.getKafkaPartitionHandle());
 
 					for (ConsumerRecord<byte[], byte[]> record : partitionRecords) {
-						final T value = deserializer.deserialize(record);
+						deserializer.deserialize(record, kafkaCollector);
 
-						if (deserializer.isEndOfStream(value)) {
+						// emit the actual records. this also updates offset state atomically and emits
+						// watermarks
+						emitRecordsWithTimestamps(
+							kafkaCollector.getRecords(),
+							partition,
+							record.offset(),
+							record.timestamp());
+
+						if (kafkaCollector.isEndOfStreamSignalled()) {
 							// end of stream signaled
 							running = false;
 							break;
 						}
-
-						// emit the actual record. this also updates offset state atomically
-						// and deals with timestamps and watermark generation
-						emitRecord(value, partition, record.offset(), record);
 					}
 				}
 			}
@@ -174,15 +183,6 @@ public class KafkaFetcher<T> extends AbstractFetcher<T, TopicPartition> {
 		running = false;
 		handover.close();
 		consumerThread.shutdown();
-	}
-
-	protected void emitRecord(
-		T record,
-		KafkaTopicPartitionState<TopicPartition> partition,
-		long offset,
-		ConsumerRecord<?, ?> consumerRecord) throws Exception {
-
-		emitRecordWithTimestamp(record, partition, offset, consumerRecord.timestamp());
 	}
 
 	/**
@@ -227,5 +227,34 @@ public class KafkaFetcher<T> extends AbstractFetcher<T, TopicPartition> {
 
 		// record the work to be committed by the main consumer thread and make sure the consumer notices that
 		consumerThread.setOffsetsToCommit(offsetsToCommit, commitCallback);
+	}
+
+	private class KafkaCollector implements Collector<T> {
+		private final Queue<T> records = new ArrayDeque<>();
+
+		private boolean endOfStreamSignalled = false;
+
+		@Override
+		public void collect(T record) {
+			// do not emit subsequent elements if the end of the stream reached
+			if (endOfStreamSignalled || deserializer.isEndOfStream(record)) {
+				endOfStreamSignalled = true;
+				return;
+			}
+			records.add(record);
+		}
+
+		public Queue<T> getRecords() {
+			return records;
+		}
+
+		public boolean isEndOfStreamSignalled() {
+			return endOfStreamSignalled;
+		}
+
+		@Override
+		public void close() {
+
+		}
 	}
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -180,6 +180,11 @@ public class KafkaITCase extends KafkaConsumerTestBase {
 		runAutoOffsetRetrievalAndCommitToKafka();
 	}
 
+	@Test(timeout = 60000)
+	public void testCollectingSchema() throws Exception {
+		runCollectingSchemaTest();
+	}
+
 	/**
 	 * Kafka 20 specific test, ensuring Timestamps are properly written to and read from Kafka.
 	 */


### PR DESCRIPTION

## What is the purpose of the change

This PR adds a way to emit multiple records from
KafkaDeserializationSchema. This is possible through a collector, which
will buffer deserialized records in a queue and then emit all records
atomically. The queue is reused for all incoming Kafka records to
minimize creating new objects on the hot path.


## Verifying this change
All existing kafka tests should pass. 
Added:
* org.apache.flink.streaming.connectors.kafka.KafkaConsumerTestBase#runCollectingSchemaTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
