### PR TITLE
[FLINK-17552][network] Do not cache InputChannels in UnionInputGate

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -156,6 +156,7 @@ public class ResultPartition implements ResultPartitionWriter, BufferPoolOwner {
 		for (ResultSubpartition subpartition : subpartitions) {
 			subpartition.readRecoveredState(stateReader);
 		}
+		LOG.debug("{}: Finished reading recovered state.", this);
 	}
 
 	public String getOwningTaskName() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGate.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -79,8 +78,7 @@ public class UnionInputGate extends InputGate {
 	 */
 	private final LinkedHashSet<IndexedInputGate> inputGatesWithData = new LinkedHashSet<>();
 
-	/** Input channels across all unioned input gates. */
-	private final InputChannel[] inputChannels;
+	private final int[] inputChannelToInputGateIndex;
 
 	/**
 	 * A mapping from input gate index to (logical) channel index offset. Valid channel indexes go from 0
@@ -101,14 +99,16 @@ public class UnionInputGate extends InputGate {
 
 		final int maxGateIndex = Arrays.stream(inputGates).mapToInt(IndexedInputGate::getGateIndex).max().orElse(0);
 		inputGateChannelIndexOffsets = new int[maxGateIndex + 1];
+		int totalNumberOfInputChannels = Arrays.stream(inputGates).mapToInt(IndexedInputGate::getNumberOfInputChannels).sum();
+		inputChannelToInputGateIndex = new int[totalNumberOfInputChannels];
+
 		int currentNumberOfInputChannels = 0;
 		for (final IndexedInputGate inputGate : inputGates) {
 			inputGateChannelIndexOffsets[inputGate.getGateIndex()] = currentNumberOfInputChannels;
+			int previousNumberOfInputChannels = currentNumberOfInputChannels;
 			currentNumberOfInputChannels += inputGate.getNumberOfInputChannels();
+			Arrays.fill(inputChannelToInputGateIndex, previousNumberOfInputChannels, currentNumberOfInputChannels, inputGate.getGateIndex());
 		}
-		inputChannels = Arrays.stream(inputGates)
-			.flatMap(gate -> IntStream.range(0, gate.getNumberOfInputChannels()).mapToObj(gate::getChannel))
-			.toArray(InputChannel[]::new);
 
 		synchronized (inputGatesWithData) {
 			for (IndexedInputGate inputGate : inputGates) {
@@ -134,12 +134,13 @@ public class UnionInputGate extends InputGate {
 	 */
 	@Override
 	public int getNumberOfInputChannels() {
-		return inputChannels.length;
+		return inputChannelToInputGateIndex.length;
 	}
 
 	@Override
 	public InputChannel getChannel(int channelIndex) {
-		return inputChannels[channelIndex];
+		int gateIndex = this.inputChannelToInputGateIndex[channelIndex];
+		return inputGates[gateIndex].getChannel(channelIndex - inputGateChannelIndexOffsets[gateIndex]);
 	}
 
 	@Override
@@ -260,7 +261,7 @@ public class UnionInputGate extends InputGate {
 		// BEWARE: consumption resumption only happens for streaming jobs in which all
 		// slots are allocated together so there should be no UnknownInputChannel. We
 		// will refactor the code to not rely on this assumption in the future.
-		inputChannels[channelIndex].resumeConsumption();
+		getChannel(channelIndex).resumeConsumption();
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/UnionInputGateTest.java
@@ -18,11 +18,19 @@
 
 package org.apache.flink.runtime.io.network.partition.consumer;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.network.partition.NoOpResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.TestingResultPartitionManager;
+
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.apache.flink.runtime.io.network.partition.consumer.SingleInputGateTest.verifyBufferOrEvent;
+import static org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder.createRemoteWithIdAndLocation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -132,5 +140,28 @@ public class UnionInputGateTest extends InputGateTestBase {
 				inputGate1.notifyChannelNonEmpty(inputChannel1);
 				inputGate2.notifyChannelNonEmpty(inputChannel2);
 			});
+	}
+
+	@Test
+	public void testUpdateInputChannel() throws Exception {
+		final SingleInputGate inputGate1 = createInputGate(1);
+		TestInputChannel inputChannel1 = new TestInputChannel(inputGate1, 0);
+		inputGate1.setInputChannels(inputChannel1);
+
+		final SingleInputGate inputGate2 = createInputGate(1);
+		TestingResultPartitionManager partitionManager = new TestingResultPartitionManager(new NoOpResultSubpartitionView());
+		InputChannel unknownInputChannel2 = InputChannelBuilder.newBuilder()
+			.setPartitionManager(partitionManager)
+			.buildUnknownChannel(inputGate2);
+		inputGate2.setInputChannels(unknownInputChannel2);
+
+		UnionInputGate unionInputGate = new UnionInputGate(inputGate1, inputGate2);
+		ResultPartitionID resultPartitionID = unknownInputChannel2.getPartitionId();
+		ResourceID location = ResourceID.generate();
+		inputGate2.updateInputChannel(location, createRemoteWithIdAndLocation(resultPartitionID.getPartitionId(), location));
+
+		assertThat(unionInputGate.getChannel(0), Matchers.is(inputChannel1));
+		// Check that updated input channel is visible via UnionInputGate
+		assertThat(unionInputGate.getChannel(1), Matchers.is(inputGate2.getChannel(0)));
 	}
 }


### PR DESCRIPTION
This is a simple fix for a bug on the master branch that is not visible currently in anyway, but which is causing an inconsistent state with `UnionInputGate`  if underlying channels are changing.

## Verifying this change

This change added a new unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
