### PR TITLE
[FLINK-16346][runtime][tests] Use BlockingNoOpInvokable

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmanager/BlobsCleanupITCase.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.testtasks.BlockingNoOpInvokable;
 import org.apache.flink.runtime.testtasks.FailingBlockingInvokable;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
@@ -237,8 +238,10 @@ public class BlobsCleanupITCase extends TestLogger {
 	@Nonnull
 	private JobGraph createJobGraph(TestCase testCase, int numTasks) {
 		JobVertex source = new JobVertex("Source");
-		if (testCase == TestCase.JOB_FAILS || testCase == TestCase.JOB_IS_CANCELLED) {
+		if (testCase == TestCase.JOB_FAILS) {
 			source.setInvokableClass(FailingBlockingInvokable.class);
+		} else if (testCase == TestCase.JOB_IS_CANCELLED) {
+			source.setInvokableClass(BlockingNoOpInvokable.class);
 		} else {
 			source.setInvokableClass(NoOpInvokable.class);
 		}


### PR DESCRIPTION
There are 2 problems in this test:
    The Job to be canceled also uses the FailingBlockingInvokable, but we never actually want the Invokable to throw an exception. It should just use a BlockingNoOpInvokable.
    The FailingBlockingInvokable uses static state to control the behavior; if you don't fork the JVM this can result in unexpected behavior in subsequent tests. I believe this is what is happening here; the failing test runs first, sets the blocking flag to false, then the cancel test runs and goes straight to throwing the exception instead of blocking.

This PR is a quick fix, but long-term we should find a safe pattern for such stateful Invokables, possibly using factories (similarly to how me changed the setup of reporters).
