### PR TITLE
[FLINK-15154][runtime] Change Flink binding addresses in local execution mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blob/BlobServer.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.net.SSLUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FileUtils;
@@ -40,6 +41,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.security.MessageDigest;
@@ -188,8 +190,10 @@ public class BlobServer extends Thread implements BlobService, BlobWriter, Perma
 		}
 
 		final int finalBacklog = backlog;
+		final String bindHost = config.getOptional(JobManagerOptions.BIND_HOST).orElseGet(NetUtils::getWildcardIPAddress);
+
 		this.serverSocket = NetUtils.createSocketFromPorts(ports,
-				(port) -> socketFactory.createServerSocket(port, finalBacklog));
+				(port) -> socketFactory.createServerSocket(port, finalBacklog, InetAddress.getByName(bindHost)));
 
 		if (serverSocket == null) {
 			throw new IOException("Unable to open BLOB Server in specified port range: " + serverPortRange);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -269,7 +269,7 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
 			heartbeatServices = createHeartbeatServices(configuration);
 			metricRegistry = createMetricRegistry(configuration, pluginManager);
 
-			final RpcService metricQueryServiceRpcService = MetricUtils.startMetricsRpcService(configuration, commonRpcService.getAddress());
+			final RpcService metricQueryServiceRpcService = MetricUtils.startRemoteMetricsRpcService(configuration, commonRpcService.getAddress());
 			metricRegistry.startQueryService(metricQueryServiceRpcService, null);
 
 			final String hostname = RpcUtils.getHostname(commonRpcService);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/util/MetricUtils.java
@@ -132,11 +132,21 @@ public class MetricUtils {
 		instantiateCPUMetrics(jvm.addGroup("CPU"));
 	}
 
-	public static RpcService startMetricsRpcService(Configuration configuration, String hostname) throws Exception {
+	public static RpcService startRemoteMetricsRpcService(Configuration configuration, String hostname) throws Exception {
 		final String portRange = configuration.getString(MetricOptions.QUERY_SERVICE_PORT);
+
+		return startMetricRpcService(configuration, AkkaRpcServiceUtils.remoteServiceBuilder(configuration, hostname, portRange));
+	}
+
+	public static RpcService startLocalMetricsRpcService(Configuration configuration) throws Exception {
+		return startMetricRpcService(configuration, AkkaRpcServiceUtils.localServiceBuilder(configuration));
+	}
+
+	private static RpcService startMetricRpcService(
+			Configuration configuration, AkkaRpcServiceUtils.AkkaRpcServiceBuilder rpcServiceBuilder) throws Exception {
 		final int threadPriority = configuration.getInteger(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY);
 
-		return AkkaRpcServiceUtils.remoteServiceBuilder(configuration, hostname, portRange)
+		return rpcServiceBuilder
 			.withActorSystemName(METRICS_ACTOR_SYSTEM_NAME)
 			.withActorSystemExecutorConfiguration(new BootstrapTools.FixedThreadPoolExecutorConfiguration(1, 1, threadPriority))
 			.createAndStart();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -259,6 +259,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 				LOG.info("Starting RPC Service(s)");
 
 				final RpcServiceFactory dispatcherResourceManagreComponentRpcServiceFactory;
+				final RpcService metricQueryServiceRpcService;
 
 				if (useSingleRpcService) {
 					// we always need the 'commonRpcService' for auxiliary calls
@@ -266,6 +267,7 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					final CommonRpcServiceFactory commonRpcServiceFactory = new CommonRpcServiceFactory(commonRpcService);
 					taskManagerRpcServiceFactory = commonRpcServiceFactory;
 					dispatcherResourceManagreComponentRpcServiceFactory = commonRpcServiceFactory;
+					metricQueryServiceRpcService = MetricUtils.startLocalMetricsRpcService(configuration);
 				} else {
 
 					// start a new service per component, possibly with custom bind addresses
@@ -292,11 +294,11 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 					// we always need the 'commonRpcService' for auxiliary calls
 					// bind to the JobManager address with port 0
 					commonRpcService = createRemoteRpcService(configuration, jobManagerBindAddress, 0);
+					metricQueryServiceRpcService = MetricUtils.startRemoteMetricsRpcService(
+						configuration,
+						commonRpcService.getAddress());
 				}
 
-				RpcService metricQueryServiceRpcService = MetricUtils.startMetricsRpcService(
-					configuration,
-					commonRpcService.getAddress());
 				metricRegistry.startQueryService(metricQueryServiceRpcService, null);
 
 				processMetricGroup = MetricUtils.instantiateProcessMetricGroup(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -138,7 +138,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			MetricRegistryConfiguration.fromConfiguration(configuration),
 			ReporterSetup.fromConfiguration(configuration, pluginManager));
 
-		final RpcService metricQueryServiceRpcService = MetricUtils.startMetricsRpcService(configuration, rpcService.getAddress());
+		final RpcService metricQueryServiceRpcService = MetricUtils.startRemoteMetricsRpcService(configuration, rpcService.getAddress());
 		metricRegistry.startQueryService(metricQueryServiceRpcService, resourceId);
 
 		blobCacheService = new BlobCacheService(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -45,7 +45,7 @@ public class MetricUtilsTest extends TestLogger {
 	private static final Logger LOG = LoggerFactory.getLogger(MetricUtilsTest.class);
 
 	/**
-	 * Tests that the {@link MetricUtils#startMetricsRpcService(Configuration, String)} respects
+	 * Tests that the {@link MetricUtils#startRemoteMetricsRpcService(Configuration, String)} respects
 	 * the given {@link MetricOptions#QUERY_SERVICE_THREAD_PRIORITY}.
 	 */
 	@Test
@@ -54,7 +54,7 @@ public class MetricUtilsTest extends TestLogger {
 		final int expectedThreadPriority = 3;
 		configuration.setInteger(MetricOptions.QUERY_SERVICE_THREAD_PRIORITY, expectedThreadPriority);
 
-		final RpcService rpcService = MetricUtils.startMetricsRpcService(configuration, "localhost");
+		final RpcService rpcService = MetricUtils.startRemoteMetricsRpcService(configuration, "localhost");
 		assertThat(rpcService, instanceOf(AkkaRpcService.class));
 
 		final ActorSystem actorSystem = ((AkkaRpcService) rpcService).getActorSystem();


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the problem that Flink's bind address in local execution mode is not configurable.

Currently, Flink listens to 3 ports in local execution mode, for the following purposes.
1. Rest endpoint
2. Blob server
3. Metrics query RPC service

While binding address for 1 can be configure via `rest.bind-address`, those for 2 & 3 cannot be configured.

## Brief change log

- Make blob server respect the configuration option 'jobmanager.bind-host' for its binding address.
- Make metrics query RPC service use akka local actor system in local execution mode, to avoid unnecessary port binding.

## Verifying this change

Manually verified by executing jobs in local mode and checking all the network ports the process binds to.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
