### PR TITLE
[FLINK-17435] [hive] Hive non-partitioned source supports streaming read

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+/**
+ * {@link ConsumeOrder} defines the orders to continuously consume stream source.
+ */
+public enum ConsumeOrder {
+
+	/**
+	 * create-time compare partition/file creation time,
+	 * this is not the partition create time in Hive metaStore,
+	 * but the folder/file create time in filesystem.
+	 */
+	CREATE_TIME_ORDER("create-time"),
+
+	/**
+	 * partition-time compare time represented by partition name.
+	 */
+	PARTITION_TIME_ORDER("partition-time");
+
+	private final String order;
+	ConsumeOrder(String order) {
+		this.order = order;
+	}
+
+	@Override
+	public String toString() {
+		return order;
+	}
+
+	/**
+	 * Get {@link ConsumeOrder} from consume order string.
+	 */
+	public static ConsumeOrder getConsumeOrder(String consumeOrderStr) {
+		for (ConsumeOrder consumeOrder : ConsumeOrder.values()) {
+			if (consumeOrder.order.equals(consumeOrderStr)) {
+				return consumeOrder;
+			}
+		}
+		return null;
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ConsumeOrder.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.connectors.hive;
 
+import java.util.Arrays;
+
 /**
  * {@link ConsumeOrder} defines the orders to continuously consume stream source.
  */
@@ -36,6 +38,7 @@ public enum ConsumeOrder {
 	PARTITION_TIME_ORDER("partition-time");
 
 	private final String order;
+
 	ConsumeOrder(String order) {
 		this.order = order;
 	}
@@ -49,11 +52,12 @@ public enum ConsumeOrder {
 	 * Get {@link ConsumeOrder} from consume order string.
 	 */
 	public static ConsumeOrder getConsumeOrder(String consumeOrderStr) {
-		for (ConsumeOrder consumeOrder : ConsumeOrder.values()) {
-			if (consumeOrder.order.equals(consumeOrderStr)) {
+		for (ConsumeOrder consumeOrder : values()) {
+			if (consumeOrder.order.equalsIgnoreCase(consumeOrderStr)) {
 				return consumeOrder;
 			}
 		}
-		return null;
+		throw new IllegalArgumentException(
+				"Illegal value: " + consumeOrderStr + ", only " + Arrays.toString(values()) + " are supported.");
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeutils.base.ListSerializer;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connectors.hive.ConsumeOrder;
 import org.apache.flink.connectors.hive.HiveTablePartition;
 import org.apache.flink.connectors.hive.HiveTableSource;
 import org.apache.flink.connectors.hive.JobConfWrapper;
@@ -87,9 +88,6 @@ public class HiveContinuousMonitoringFunction
 
 	private static final Logger LOG = LoggerFactory.getLogger(HiveContinuousMonitoringFunction.class);
 
-	private static final String CREATE_TIME_ORDER = "create-time";
-	private static final String PARTITION_TIME_ORDER = "partition-time";
-
 	/** The parallelism of the downstream readers. */
 	private final int readerParallelism;
 
@@ -109,7 +107,7 @@ public class HiveContinuousMonitoringFunction
 	private final DataType[] fieldTypes;
 
 	// consumer variables
-	private final String consumeOrder;
+	private final ConsumeOrder consumeOrder;
 	private final String consumeOffset;
 
 	// extractor variables
@@ -146,7 +144,7 @@ public class HiveContinuousMonitoringFunction
 			ObjectPath tablePath,
 			CatalogTable catalogTable,
 			int readerParallelism,
-			String consumeOrder,
+			ConsumeOrder consumeOrder,
 			String consumeOffset,
 			String extractorKind,
 			String extractorClass,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveContinuousMonitoringFunction.java
@@ -252,9 +252,7 @@ public class HiveContinuousMonitoringFunction
 			this.distinctPartitions.addAll(this.distinctPartsState.get().iterator().next());
 		} else {
 			LOG.info("No state to restore for the {}.", getClass().getSimpleName());
-			if (consumeOffset != null) {
-				this.currentReadTime = toMills(consumeOffset);
-			}
+			this.currentReadTime = toMills(consumeOffset);
 		}
 	}
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
@@ -33,17 +33,21 @@ import java.net.URI;
 
 /**
  * A {@link FileInputFormat} that wraps a {@link HiveTableInputFormat}.
+ *
+ * <p>We only use a {@link HiveTableInputFormat} to read the data of a {@link FileInputSplit}.
+ * `createInputSplits`, `getInputSplitAssigner` will use {@link FileInputFormat}'s logic.
  */
 public class HiveTableFileInputFormat extends FileInputFormat<RowData> {
 
-	private HiveTableInputFormat inputFormat;
-	private HiveTablePartition hiveTablePartition;
+	private final HiveTableInputFormat inputFormat;
+	private final HiveTablePartition hiveTablePartition;
 
 	public HiveTableFileInputFormat(
 			HiveTableInputFormat inputFormat,
 			HiveTablePartition hiveTablePartition) {
 		this.inputFormat = inputFormat;
 		this.hiveTablePartition = hiveTablePartition;
+		setFilePath(hiveTablePartition.getStorageDescriptor().getLocation());
 	}
 
 	@Override
@@ -70,31 +74,31 @@ public class HiveTableFileInputFormat extends FileInputFormat<RowData> {
 
 	@Override
 	public void configure(Configuration parameters) {
-		inputFormat.configure(parameters);
 		super.configure(parameters);
+		inputFormat.configure(parameters);
 	}
 
 	@Override
 	public void close() throws IOException {
-		inputFormat.close();
 		super.close();
+		inputFormat.close();
 	}
 
 	@Override
 	public void setRuntimeContext(RuntimeContext t) {
-		inputFormat.setRuntimeContext(t);
 		super.setRuntimeContext(t);
+		inputFormat.setRuntimeContext(t);
 	}
 
 	@Override
 	public void openInputFormat() throws IOException {
-		inputFormat.openInputFormat();
 		super.openInputFormat();
+		inputFormat.openInputFormat();
 	}
 
 	@Override
 	public void closeInputFormat() throws IOException {
-		inputFormat.closeInputFormat();
 		super.closeInputFormat();
+		inputFormat.closeInputFormat();
 	}
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableFileInputFormat.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive.read;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.table.data.RowData;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * A {@link FileInputFormat} that wraps a {@link HiveTableInputFormat}.
+ */
+public class HiveTableFileInputFormat extends FileInputFormat<RowData> {
+
+	private HiveTableInputFormat inputFormat;
+	private HiveTablePartition hiveTablePartition;
+
+	public HiveTableFileInputFormat(
+			HiveTableInputFormat inputFormat,
+			HiveTablePartition hiveTablePartition) {
+		this.inputFormat = inputFormat;
+		this.hiveTablePartition = hiveTablePartition;
+	}
+
+	@Override
+	public void open(FileInputSplit fileSplit) throws IOException {
+		URI uri = fileSplit.getPath().toUri();
+		HiveTableInputSplit split = new HiveTableInputSplit(
+				fileSplit.getSplitNumber(),
+				new FileSplit(new Path(uri), fileSplit.getStart(), fileSplit.getLength(), (String[]) null),
+				inputFormat.getJobConf(),
+				hiveTablePartition
+		);
+		inputFormat.open(split);
+	}
+
+	@Override
+	public boolean reachedEnd() throws IOException {
+		return inputFormat.reachedEnd();
+	}
+
+	@Override
+	public RowData nextRecord(RowData reuse) throws IOException {
+		return inputFormat.nextRecord(reuse);
+	}
+
+	@Override
+	public void configure(Configuration parameters) {
+		inputFormat.configure(parameters);
+		super.configure(parameters);
+	}
+
+	@Override
+	public void close() throws IOException {
+		inputFormat.close();
+		super.close();
+	}
+
+	@Override
+	public void setRuntimeContext(RuntimeContext t) {
+		inputFormat.setRuntimeContext(t);
+		super.setRuntimeContext(t);
+	}
+
+	@Override
+	public void openInputFormat() throws IOException {
+		inputFormat.openInputFormat();
+		super.openInputFormat();
+	}
+
+	@Override
+	public void closeInputFormat() throws IOException {
+		inputFormat.closeInputFormat();
+		super.closeInputFormat();
+	}
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveTableInputFormat.java
@@ -120,6 +120,10 @@ public class HiveTableInputFormat extends HadoopInputFormatCommonBase<RowData, H
 		this.useMapRedReader = useMapRedReader;
 	}
 
+	public JobConf getJobConf() {
+		return jobConf;
+	}
+
 	@Override
 	public void configure(org.apache.flink.configuration.Configuration parameters) {
 	}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -586,7 +586,7 @@ public class HiveTableSourceTest {
 		// Waiting for writing test data to finish
 		thread.join();
 		// Wait up to 20 seconds for all data to be processed
-		for (int i = 0; i < 20; ++ i) {
+		for (int i = 0; i < 20; ++i) {
 			if (sink.getAppendResults().size() == 6) {
 				break;
 			} else {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -47,6 +47,8 @@ import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.runtime.utils.TestingAppendRowDataSink;
+import org.apache.flink.table.planner.runtime.utils.TestingAppendSink;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
 import org.apache.flink.test.util.TestBaseUtils;
@@ -70,6 +72,7 @@ import org.junit.runner.RunWith;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -125,10 +128,10 @@ public class HiveTableSourceTest {
 		final String tblName = "test";
 		hiveShell.execute("CREATE TABLE source_db.test ( a INT, b INT, c STRING, d BIGINT, e DOUBLE)");
 		HiveTestUtils.createTextTableInserter(hiveShell, dbName, tblName)
-				.addRow(new Object[]{1, 1, "a", 1000L, 1.11})
-				.addRow(new Object[]{2, 2, "b", 2000L, 2.22})
-				.addRow(new Object[]{3, 3, "c", 3000L, 3.33})
-				.addRow(new Object[]{4, 4, "d", 4000L, 4.44})
+				.addRow(new Object[] { 1, 1, "a", 1000L, 1.11 })
+				.addRow(new Object[] { 2, 2, "b", 2000L, 2.22 })
+				.addRow(new Object[] { 3, 3, "c", 3000L, 3.33 })
+				.addRow(new Object[] { 4, 4, "d", 4000L, 4.44 })
 				.commit();
 
 		TableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerBatchMode();
@@ -529,6 +532,76 @@ public class HiveTableSourceTest {
 		results.sort(String::compareTo);
 		assertEquals(expected, results);
 		job.cancel();
+	}
+
+	@Test(timeout = 30000)
+	public void testNonPartitionStreamingSourceWithMapredReader() throws Exception {
+		testNonPartitionStreamingSource(true, "test_mapred_reader");
+	}
+
+	@Test(timeout = 30000)
+	public void testNonPartitionStreamingSourceWithVectorizedReader() throws Exception {
+		testNonPartitionStreamingSource(false, "test_vectorized_reader");
+	}
+
+	private void testNonPartitionStreamingSource(Boolean useMapredReader, String tblName) throws Exception {
+		final String catalogName = "hive";
+		final String dbName = "source_db";
+		hiveShell.execute("CREATE TABLE source_db." + tblName + " (" +
+				"  a INT," +
+				"  b CHAR(1) " +
+				") TBLPROPERTIES (" +
+				"  'streaming-source.enable'='true'," +
+				"  'streaming-source.monitor-interval'='100ms'" +
+				")");
+
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		StreamTableEnvironment tEnv = HiveTestUtils.createTableEnvWithBlinkPlannerStreamMode(env);
+		tEnv.getConfig().getConfiguration().setBoolean(
+				HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER, useMapredReader);
+
+		tEnv.registerCatalog(catalogName, hiveCatalog);
+		Table src = tEnv.sqlQuery("select * from hive.source_db." + tblName);
+
+		TestingAppendSink sink = new TestingAppendSink();
+		tEnv.toAppendStream(src, Row.class).addSink(sink);
+		DataStream<RowData> out = tEnv.toAppendStream(src, RowData.class);
+		out.print(); // add print to see streaming reading
+		final JobClient jobClient = env.executeAsync();
+
+		Runnable runnable = () -> {
+			for (int i = 0; i < 3; ++i) {
+				hiveShell.execute("insert into source_db." + tblName + " values (1,'a'), (2,'b')");
+				try {
+					Thread.sleep(2_000);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+					break;
+				}
+			}
+		};
+		Thread thread = new Thread(runnable);
+		thread.setDaemon(true);
+		thread.start();
+		// Waiting for writing test data to finish
+		thread.join();
+		// Wait up to 20 seconds for all data to be processed
+		for (int i = 0; i < 20; ++ i) {
+			if (sink.getAppendResults().size() == 6) {
+				break;
+			} else {
+				Thread.sleep(1000);
+			}
+		}
+
+		// check the result
+		List<String> actual = new ArrayList<>(JavaScalaConversionUtil.toJava(sink.getAppendResults()));
+		actual.sort(String::compareTo);
+		List<String> expected = Arrays.asList("1,a", "1,a", "1,a", "2,b", "2,b", "2,b");
+		expected.sort(String::compareTo);
+		assertEquals(expected, actual);
+		// cancel the job
+		jobClient.cancel();
 	}
 
 	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -550,7 +550,7 @@ public class HiveTableSourceTest {
 		hiveShell.execute("CREATE TABLE source_db." + tblName + " (" +
 				"  a INT," +
 				"  b CHAR(1) " +
-				") TBLPROPERTIES (" +
+				") stored as parquet TBLPROPERTIES (" +
 				"  'streaming-source.enable'='true'," +
 				"  'streaming-source.monitor-interval'='100ms'" +
 				")");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileMonitoringFunction.java
@@ -94,7 +94,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 	private final FileProcessingMode watchType;
 
 	/** The maximum file modification time seen so far. */
-	private volatile long globalModificationTime = Long.MIN_VALUE;
+	private volatile long globalModificationTime;
 
 	private transient Object checkpointLock;
 
@@ -103,10 +103,19 @@ public class ContinuousFileMonitoringFunction<OUT>
 	private transient ListState<Long> checkpointedState;
 
 	public ContinuousFileMonitoringFunction(
+			FileInputFormat<OUT> format,
+			FileProcessingMode watchType,
+			int readerParallelism,
+			long interval) {
+		this(format, watchType, readerParallelism, interval, Long.MIN_VALUE);
+	}
+
+	public ContinuousFileMonitoringFunction(
 		FileInputFormat<OUT> format,
 		FileProcessingMode watchType,
 		int readerParallelism,
-		long interval) {
+		long interval,
+		long globalModificationTime) {
 
 		Preconditions.checkArgument(
 			watchType == FileProcessingMode.PROCESS_ONCE || interval >= MIN_MONITORING_INTERVAL,
@@ -124,7 +133,7 @@ public class ContinuousFileMonitoringFunction<OUT>
 		this.interval = interval;
 		this.watchType = watchType;
 		this.readerParallelism = Math.max(readerParallelism, 1);
-		this.globalModificationTime = Long.MIN_VALUE;
+		this.globalModificationTime = globalModificationTime;
 	}
 
 	@VisibleForTesting

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -33,7 +33,10 @@ public class FileSystemOptions {
 			key("streaming-source.enable")
 					.booleanType()
 					.defaultValue(false)
-					.withDescription("Enable streaming source or not.");
+					.withDescription("Enable streaming source or not.\n" +
+							"NOTES: For non-partition table, please make sure that " +
+							"each file should be put atomically into the target directory, " +
+							"otherwise the reader may get incomplete data.");
 
 	public static final ConfigOption<Duration> STREAMING_SOURCE_MONITOR_INTERVAL =
 			key("streaming-source.monitor-interval")
@@ -50,7 +53,8 @@ public class FileSystemOptions {
 							" create-time compare partition/file creation time, this is not the" +
 							" partition create time in Hive metaStore, but the folder/file create" +
 							" time in filesystem;" +
-							" partition-time compare time represented by partition name.");
+							" partition-time compare time represented by partition name.\n" +
+							"For non-partition table, this value should always be 'create-time'.");
 
 	public static final ConfigOption<String> STREAMING_SOURCE_CONSUME_START_OFFSET =
 			key("streaming-source.consume-start-offset")


### PR DESCRIPTION

## What is the purpose of the change

*for non-partitioned hive source, we can use existing continuous file processing mechanism to read new data. This pr aim let non-partitioned hive source support streaming read.*


## Brief change log
  - *A hive FileInputFormat that wraps HiveTableInputFormat*
  - *create streaming source with PROCESS_CONTINUOUSLY mode*


## Verifying this change


This change added tests and can be verified as follows:

  - *Extended HiveTableSourceTest for streaming read on non-partitioned source*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
