### PR TITLE
[FLINK-17554] Allow to register release hooks for the user code class loader

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/RuntimeContext.java
@@ -124,6 +124,14 @@ public interface RuntimeContext {
 	 */
 	ClassLoader getUserCodeClassLoader();
 
+	/**
+	 * Registers a release hook for the user code class loader which is executed just before the
+	 * user code class loader is being released.
+	 *
+	 * @param releaseHook releaseHook which is executed just before the user code class loader is being released
+	 */
+	void registerUserCodeClassLoaderReleaseHook(Runnable releaseHook);
+
 	// --------------------------------------------------------------------------------------------
 
 	/**

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/AbstractRuntimeUDFContext.java
@@ -45,6 +45,7 @@ import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.Serializable;
 import java.util.Collections;
@@ -61,7 +62,7 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 
 	private final TaskInfo taskInfo;
 
-	private final ClassLoader userCodeClassLoader;
+	private final UserCodeClassLoader userCodeClassLoader;
 
 	private final ExecutionConfig executionConfig;
 
@@ -71,12 +72,13 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 
 	private final MetricGroup metrics;
 
-	public AbstractRuntimeUDFContext(TaskInfo taskInfo,
-										ClassLoader userCodeClassLoader,
-										ExecutionConfig executionConfig,
-										Map<String, Accumulator<?, ?>> accumulators,
-										Map<String, Future<Path>> cpTasks,
-										MetricGroup metrics) {
+	public AbstractRuntimeUDFContext(
+			TaskInfo taskInfo,
+			UserCodeClassLoader userCodeClassLoader,
+			ExecutionConfig executionConfig,
+			Map<String, Accumulator<?, ?>> accumulators,
+			Map<String, Future<Path>> cpTasks,
+			MetricGroup metrics) {
 		this.taskInfo = checkNotNull(taskInfo);
 		this.userCodeClassLoader = userCodeClassLoader;
 		this.executionConfig = executionConfig;
@@ -167,7 +169,12 @@ public abstract class AbstractRuntimeUDFContext implements RuntimeContext {
 
 	@Override
 	public ClassLoader getUserCodeClassLoader() {
-		return this.userCodeClassLoader;
+		return this.userCodeClassLoader.asClassLoader();
+	}
+
+	@Override
+	public void registerUserCodeClassLoaderReleaseHook(Runnable releaseHook) {
+		userCodeClassLoader.registerReleaseHook(releaseHook);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/functions/util/RuntimeUDFContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
 
 import java.util.HashMap;
 import java.util.List;
@@ -42,10 +43,14 @@ public class RuntimeUDFContext extends AbstractRuntimeUDFContext {
 
 	private final HashMap<String, List<?>> uninitializedBroadcastVars = new HashMap<>();
 
-	public RuntimeUDFContext(TaskInfo taskInfo, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
-								Map<String, Future<Path>> cpTasks, Map<String, Accumulator<?, ?>> accumulators,
-								MetricGroup metrics) {
-		super(taskInfo, userCodeClassLoader, executionConfig, accumulators, cpTasks, metrics);
+	public RuntimeUDFContext(
+			TaskInfo taskInfo,
+			ClassLoader userCodeClassLoader,
+			ExecutionConfig executionConfig,
+			Map<String, Future<Path>> cpTasks,
+			Map<String, Accumulator<?, ?>> accumulators,
+			MetricGroup metrics) {
+		super(taskInfo, SimpleUserCodeClassLoader.create(userCodeClassLoader), executionConfig, accumulators, cpTasks, metrics);
 	}
 
 	@Override

--- a/flink-core/src/main/java/org/apache/flink/util/SimpleUserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/SimpleUserCodeClassLoader.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,20 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmaster.factories;
-
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.OnCompletionActions;
-import org.apache.flink.runtime.jobmaster.JobMasterService;
-import org.apache.flink.util.UserCodeClassLoader;
+package org.apache.flink.util;
 
 /**
- * Factory for a {@link JobMasterService}.
+ * Simple {@link UserCodeClassLoader} implementation which assumes that the provided class
+ * loader will never be released and, hence, will never execute the release hooks.
  */
-public interface JobMasterServiceFactory {
+public class SimpleUserCodeClassLoader implements UserCodeClassLoader {
 
-	JobMasterService createJobMasterService(
-		JobGraph jobGraph,
-		OnCompletionActions jobCompletionActions,
-		UserCodeClassLoader userCodeClassloader) throws Exception;
+	private final ClassLoader classLoader;
+
+	private SimpleUserCodeClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	public ClassLoader asClassLoader() {
+		return classLoader;
+	}
+
+	@Override
+	public void registerReleaseHook(Runnable releaseHook) {}
+
+	public static SimpleUserCodeClassLoader create(ClassLoader classLoader) {
+		return new SimpleUserCodeClassLoader(classLoader);
+	}
 }

--- a/flink-core/src/main/java/org/apache/flink/util/UserCodeClassLoader.java
+++ b/flink-core/src/main/java/org/apache/flink/util/UserCodeClassLoader.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,20 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.jobmaster.factories;
-
-import org.apache.flink.runtime.jobgraph.JobGraph;
-import org.apache.flink.runtime.jobmanager.OnCompletionActions;
-import org.apache.flink.runtime.jobmaster.JobMasterService;
-import org.apache.flink.util.UserCodeClassLoader;
+package org.apache.flink.util;
 
 /**
- * Factory for a {@link JobMasterService}.
+ * UserCodeClassLoader allows to register release hooks for a user code class loader.
+ * These release hooks are being executed just before the user code class loader is
+ * being released.
  */
-public interface JobMasterServiceFactory {
+public interface UserCodeClassLoader {
 
-	JobMasterService createJobMasterService(
-		JobGraph jobGraph,
-		OnCompletionActions jobCompletionActions,
-		UserCodeClassLoader userCodeClassloader) throws Exception;
+	/**
+	 * Obtains the actual class loader.
+	 *
+	 * @return actual class loader
+	 */
+	ClassLoader asClassLoader();
+
+	/**
+	 * Registers a release hook which is being executed before the user code class
+	 * loader is being released.
+	 *
+	 * @param releaseHook releaseHook which is executed before the user code class loader is being released.
+	 */
+	void registerReleaseHook(Runnable releaseHook);
 }

--- a/flink-core/src/test/java/org/apache/flink/util/TestingUserCodeClassLoader.java
+++ b/flink-core/src/test/java/org/apache/flink/util/TestingUserCodeClassLoader.java
@@ -16,14 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.execution.librarycache;
+package org.apache.flink.util;
 
 import java.util.function.Consumer;
 
 /**
- * Testing implementation of {@link LibraryCacheManager.UserCodeClassLoader}.
+ * Testing implementation of {@link UserCodeClassLoader}.
  */
-public class TestingUserCodeClassLoader implements LibraryCacheManager.UserCodeClassLoader {
+public class TestingUserCodeClassLoader implements UserCodeClassLoader {
 
 	private final ClassLoader classLoader;
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepRuntimeContext.java
@@ -111,6 +111,11 @@ class CepRuntimeContext implements RuntimeContext {
 	}
 
 	@Override
+	public void registerUserCodeClassLoaderReleaseHook(Runnable releaseHook) {
+		runtimeContext.getUserCodeClassLoader();
+	}
+
+	@Override
 	public DistributedCache getDistributedCache() {
 		return runtimeContext.getDistributedCache();
 	}

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -31,7 +31,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.PrioritizedOperatorSubtaskState;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -54,6 +53,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Collections;
 import java.util.Map;
@@ -91,7 +91,7 @@ public class SavepointEnvironment implements Environment {
 
 	private final AccumulatorRegistry accumulatorRegistry;
 
-	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
+	private final UserCodeClassLoader userCodeClassLoader;
 
 	private SavepointEnvironment(RuntimeContext ctx, Configuration configuration, int maxParallelism, int indexOfSubtask, PrioritizedOperatorSubtaskState prioritizedOperatorSubtaskState) {
 		this.jobID = new JobID();
@@ -179,7 +179,7 @@ public class SavepointEnvironment implements Environment {
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserClassLoader() {
 		return userCodeClassLoader;
 	}
 
@@ -313,7 +313,7 @@ public class SavepointEnvironment implements Environment {
 		}
 	}
 
-	private static final class UserCodeClassLoaderRuntimeContextAdapter implements LibraryCacheManager.UserCodeClassLoader {
+	private static final class UserCodeClassLoaderRuntimeContextAdapter implements UserCodeClassLoader {
 
 		private final RuntimeContext runtimeContext;
 
@@ -328,7 +328,7 @@ public class SavepointEnvironment implements Environment {
 
 		@Override
 		public void registerReleaseHook(Runnable releaseHook) {
-			throw new UnsupportedOperationException("Not yet supported");
+			runtimeContext.registerUserCodeClassLoaderReleaseHook(releaseHook);
 		}
 
 		private static UserCodeClassLoaderRuntimeContextAdapter from(RuntimeContext runtimeContext) {

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -179,7 +179,7 @@ public class SavepointEnvironment implements Environment {
 	}
 
 	@Override
-	public UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserCodeClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointRuntimeContext.java
@@ -125,6 +125,11 @@ public final class SavepointRuntimeContext implements RuntimeContext {
 	}
 
 	@Override
+	public void registerUserCodeClassLoaderReleaseHook(Runnable releaseHook) {
+		ctx.registerUserCodeClassLoaderReleaseHook(releaseHook);
+	}
+
+	@Override
 	public <V, A extends Serializable> void addAccumulator(
 		String name, Accumulator<V, A> accumulator) {
 		ctx.addAccumulator(name, accumulator);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -43,6 +42,7 @@ import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.state.internal.InternalKvState;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -148,7 +148,7 @@ public interface Environment {
 	/**
 	 * Returns the user code class loader
 	 */
-	LibraryCacheManager.UserCodeClassLoader getUserClassLoader();
+	UserCodeClassLoader getUserClassLoader();
 
 	Map<String, Future<Path>> getDistributedCacheEntries();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -148,7 +148,7 @@ public interface Environment {
 	/**
 	 * Returns the user code class loader
 	 */
-	UserCodeClassLoader getUserClassLoader();
+	UserCodeClassLoader getUserCodeClassLoader();
 
 	Map<String, Future<Path>> getDistributedCacheEntries();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -147,7 +148,7 @@ public interface Environment {
 	/**
 	 * Returns the user code class loader
 	 */
-	ClassLoader getUserClassLoader();
+	LibraryCacheManager.UserCodeClassLoader getUserClassLoader();
 
 	Map<String, Future<Path>> getDistributedCacheEntries();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManager.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,7 +184,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 			this.isReleased = false;
 		}
 
-		private LibraryCacheManager.UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> libraries, Collection<URL> classPaths) throws IOException {
+		private UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> libraries, Collection<URL> classPaths) throws IOException {
 			synchronized (lockObject) {
 				verifyIsNotReleased();
 
@@ -280,7 +281,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		}
 
 		@Override
-		public LibraryCacheManager.UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
+		public UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
 			verifyIsNotClosed();
 			return libraryCacheEntry.getOrResolveClassLoader(
 				requiredJarFiles,
@@ -307,7 +308,7 @@ public class BlobLibraryCacheManager implements LibraryCacheManager {
 		}
 	}
 
-	private static final class ResolvedClassLoader implements LibraryCacheManager.UserCodeClassLoader {
+	private static final class ResolvedClassLoader implements UserCodeClassLoader {
 		private final URLClassLoader classLoader;
 
 		/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.io.IOException;
 import java.net.URL;
@@ -96,26 +97,4 @@ public interface LibraryCacheManager {
 		void release();
 	}
 
-	/**
-	 * UserCodeClassLoader allows to register release hooks for a user code class loader.
-	 * These release hooks are being executed just before the user code class loader is
-	 * being released.
-	 */
-	interface UserCodeClassLoader {
-
-		/**
-		 * Obtains the actual class loader.
-		 *
-		 * @return actual class loader
-		 */
-		ClassLoader asClassLoader();
-
-		/**
-		 * Registers a release hook which is being executed before the user code class
-		 * loader is being released.
-		 *
-		 * @param releaseHook releaseHook which is executed before the user code class loader is being released.
-		 */
-		void registerReleaseHook(Runnable releaseHook);
-	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/librarycache/LibraryCacheManager.java
@@ -77,7 +77,7 @@ public interface LibraryCacheManager {
 		 * @throws IOException if the required jar files cannot be downloaded
 		 * @throws IllegalStateException if the cached user code class loader does not fulfill the requirements
 		 */
-		ClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException;
+		UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException;
 	}
 
 	/**
@@ -94,5 +94,28 @@ public interface LibraryCacheManager {
 		 * user code class loader.
 		 */
 		void release();
+	}
+
+	/**
+	 * UserCodeClassLoader allows to register release hooks for a user code class loader.
+	 * These release hooks are being executed just before the user code class loader is
+	 * being released.
+	 */
+	interface UserCodeClassLoader {
+
+		/**
+		 * Obtains the actual class loader.
+		 *
+		 * @return actual class loader
+		 */
+		ClassLoader asClassLoader();
+
+		/**
+		 * Registers a release hook which is being executed before the user code class
+		 * loader is being released.
+		 *
+		 * @param releaseHook releaseHook which is executed before the user code class loader is being released.
+		 */
+		void registerReleaseHook(Runnable releaseHook);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -184,7 +184,7 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	@Override
 	public DistributedRuntimeUDFContext createRuntimeContext(MetricGroup metrics) {
 		Environment env = getEnvironment();
-		return new IterativeRuntimeUdfContext(env.getTaskInfo(), env.getUserClassLoader(),
+		return new IterativeRuntimeUdfContext(env.getTaskInfo(), env.getUserCodeClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), this.accumulatorMap, metrics);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/AbstractIterativeTask.java
@@ -52,6 +52,7 @@ import org.apache.flink.types.Value;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,7 +184,7 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 	@Override
 	public DistributedRuntimeUDFContext createRuntimeContext(MetricGroup metrics) {
 		Environment env = getEnvironment();
-		return new IterativeRuntimeUdfContext(env.getTaskInfo(), getUserCodeClassLoader(),
+		return new IterativeRuntimeUdfContext(env.getTaskInfo(), env.getUserClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), this.accumulatorMap, metrics);
 	}
 
@@ -374,8 +375,8 @@ public abstract class AbstractIterativeTask<S extends Function, OT> extends Batc
 
 	private class IterativeRuntimeUdfContext extends DistributedRuntimeUDFContext implements IterationRuntimeContext {
 
-		public IterativeRuntimeUdfContext(TaskInfo taskInfo, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
-											Map<String, Future<Path>> cpTasks, Map<String, Accumulator<?, ?>> accumulatorMap, MetricGroup metrics) {
+		public IterativeRuntimeUdfContext(TaskInfo taskInfo, UserCodeClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
+										  Map<String, Future<Path>> cpTasks, Map<String, Accumulator<?, ?>> accumulatorMap, MetricGroup metrics) {
 			super(taskInfo, userCodeClassLoader, executionConfig, cpTasks, accumulatorMap, metrics);
 		}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
@@ -118,7 +118,7 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 		// set up the event handler
 		int numEventsTillEndOfSuperstep = taskConfig.getNumberOfEventsUntilInterruptInIterativeGate(0);
 		eventHandler = new SyncEventHandler(numEventsTillEndOfSuperstep, aggregators,
-				getEnvironment().getUserClassLoader().asClassLoader());
+				getEnvironment().getUserCodeClassLoader().asClassLoader());
 		headEventReader.registerTaskEventListener(eventHandler, WorkerDoneEvent.class);
 
 		IntValue dummy = new IntValue();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationSynchronizationSinkTask.java
@@ -118,7 +118,7 @@ public class IterationSynchronizationSinkTask extends AbstractInvokable implemen
 		// set up the event handler
 		int numEventsTillEndOfSuperstep = taskConfig.getNumberOfEventsUntilInterruptInIterativeGate(0);
 		eventHandler = new SyncEventHandler(numEventsTillEndOfSuperstep, aggregators,
-				getEnvironment().getUserClassLoader());
+				getEnvironment().getUserClassLoader().asClassLoader());
 		headEventReader.registerTaskEventListener(eventHandler, WorkerDoneEvent.class);
 
 		IntValue dummy = new IntValue();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -150,7 +150,7 @@ public abstract class AbstractInvokable {
 	 * @return user code class loader of this invokable.
 	 */
 	public final ClassLoader getUserCodeClassLoader() {
-		return getEnvironment().getUserClassLoader().asClassLoader();
+		return getEnvironment().getUserCodeClassLoader().asClassLoader();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -150,7 +150,7 @@ public abstract class AbstractInvokable {
 	 * @return user code class loader of this invokable.
 	 */
 	public final ClassLoader getUserCodeClassLoader() {
-		return getEnvironment().getUserClassLoader();
+		return getEnvironment().getUserClassLoader().asClassLoader();
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -36,6 +36,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.function.FunctionUtils;
 
 import org.slf4j.Logger;
@@ -124,7 +125,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 			checkArgument(jobGraph.getNumberOfVertices() > 0, "The given job is empty");
 
 			// libraries and class loader first
-			final LibraryCacheManager.UserCodeClassLoader userCodeLoader;
+			final UserCodeClassLoader userCodeLoader;
 			try {
 				userCodeLoader = classLoaderLease.getOrResolveClassLoader(
 					jobGraph.getUserJarBlobKeys(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImpl.java
@@ -124,7 +124,7 @@ public class JobManagerRunnerImpl implements LeaderContender, OnCompletionAction
 			checkArgument(jobGraph.getNumberOfVertices() > 0, "The given job is empty");
 
 			// libraries and class loader first
-			final ClassLoader userCodeLoader;
+			final LibraryCacheManager.UserCodeClassLoader userCodeLoader;
 			try {
 				userCodeLoader = classLoaderLease.getOrResolveClassLoader(
 					jobGraph.getUserJarBlobKeys(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
@@ -155,7 +156,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final FatalErrorHandler fatalErrorHandler;
 
-	private final ClassLoader userCodeLoader;
+	private final LibraryCacheManager.UserCodeClassLoader userCodeLoader;
 
 	private final SlotPool slotPool;
 
@@ -219,7 +220,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			JobManagerJobMetricGroupFactory jobMetricGroupFactory,
 			OnCompletionActions jobCompletionActions,
 			FatalErrorHandler fatalErrorHandler,
-			ClassLoader userCodeLoader,
+			LibraryCacheManager.UserCodeClassLoader userCodeLoader,
 			SchedulerNGFactory schedulerNGFactory,
 			ShuffleMaster<?> shuffleMaster,
 			PartitionTrackerFactory partitionTrackerFactory) throws Exception {
@@ -287,7 +288,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			jobMasterConfiguration.getConfiguration(),
 			scheduler,
 			scheduledExecutorService,
-			userCodeLoader,
+			userCodeLoader.asClassLoader(),
 			highAvailabilityServices.getCheckpointRecoveryFactory(),
 			rpcTimeout,
 			blobWriter,
@@ -467,7 +468,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			final SerializedValue<OperatorEvent> serializedEvent) {
 
 		try {
-			final OperatorEvent evt = serializedEvent.deserializeValue(userCodeLoader);
+			final OperatorEvent evt = serializedEvent.deserializeValue(userCodeLoader.asClassLoader());
 			schedulerNG.deliverOperatorEventToCoordinator(task, operatorID, evt);
 			return CompletableFuture.completedFuture(Acknowledge.get());
 		} catch (Exception e) {
@@ -703,7 +704,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 		AggregateFunction aggregateFunction = null;
 		try {
-			aggregateFunction = InstantiationUtil.deserializeObject(serializedAggregateFunction, userCodeLoader);
+			aggregateFunction = InstantiationUtil.deserializeObject(serializedAggregateFunction, userCodeLoader.asClassLoader());
 		} catch (Exception e) {
 			log.error("Error while attempting to deserialize user AggregateFunction.");
 			return FutureUtils.completedExceptionally(e);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
@@ -93,6 +92,7 @@ import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 
@@ -156,7 +156,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 
 	private final FatalErrorHandler fatalErrorHandler;
 
-	private final LibraryCacheManager.UserCodeClassLoader userCodeLoader;
+	private final UserCodeClassLoader userCodeLoader;
 
 	private final SlotPool slotPool;
 
@@ -220,7 +220,7 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 			JobManagerJobMetricGroupFactory jobMetricGroupFactory,
 			OnCompletionActions jobCompletionActions,
 			FatalErrorHandler fatalErrorHandler,
-			LibraryCacheManager.UserCodeClassLoader userCodeLoader,
+			UserCodeClassLoader userCodeLoader,
 			SchedulerNGFactory schedulerNGFactory,
 			ShuffleMaster<?> shuffleMaster,
 			PartitionTrackerFactory partitionTrackerFactory) throws Exception {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.jobmaster.factories;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTrackerImpl;
@@ -90,7 +91,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 	public JobMaster createJobMasterService(
 			JobGraph jobGraph,
 			OnCompletionActions jobCompletionActions,
-			ClassLoader userCodeClassloader) throws Exception {
+			LibraryCacheManager.UserCodeClassLoader userCodeClassloader) throws Exception {
 
 		return new JobMaster(
 			rpcService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/DefaultJobMasterServiceFactory.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.jobmaster.factories;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTrackerImpl;
@@ -28,12 +27,13 @@ import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobManagerSharedServices;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterConfiguration;
-import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SchedulerFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.scheduler.SchedulerNGFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.UserCodeClassLoader;
 
 /**
  * Default implementation of the {@link JobMasterServiceFactory}.
@@ -91,7 +91,7 @@ public class DefaultJobMasterServiceFactory implements JobMasterServiceFactory {
 	public JobMaster createJobMasterService(
 			JobGraph jobGraph,
 			OnCompletionActions jobCompletionActions,
-			LibraryCacheManager.UserCodeClassLoader userCodeClassloader) throws Exception {
+			UserCodeClassLoader userCodeClassloader) throws Exception {
 
 		return new JobMaster(
 			rpcService,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/factories/JobMasterServiceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.factories;
 
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobMasterService;
@@ -30,5 +31,5 @@ public interface JobMasterServiceFactory {
 	JobMasterService createJobMasterService(
 		JobGraph jobGraph,
 		OnCompletionActions jobCompletionActions,
-		ClassLoader userCodeClassloader) throws Exception;
+		LibraryCacheManager.UserCodeClassLoader userCodeClassloader) throws Exception;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -1026,14 +1026,14 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 
-		this.output = initOutputs(this, getEnvironment().getUserClassLoader(), this.config, this.chainedTasks, this.eventualOutputs,
+		this.output = initOutputs(this, getEnvironment().getUserCodeClassLoader(), this.config, this.chainedTasks, this.eventualOutputs,
 				this.getExecutionConfig(), this.accumulatorMap);
 	}
 
 	public DistributedRuntimeUDFContext createRuntimeContext(MetricGroup metrics) {
 		Environment env = getEnvironment();
 
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserCodeClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), this.accumulatorMap, metrics);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/BatchTask.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.MutableObjectIterator;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1023,18 +1024,16 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		this.chainedTasks = new ArrayList<ChainedDriver<?, ?>>();
 		this.eventualOutputs = new ArrayList<RecordWriter<?>>();
 
-		ClassLoader userCodeClassLoader = getUserCodeClassLoader();
-
 		this.accumulatorMap = getEnvironment().getAccumulatorRegistry().getUserMap();
 
-		this.output = initOutputs(this, userCodeClassLoader, this.config, this.chainedTasks, this.eventualOutputs,
+		this.output = initOutputs(this, getEnvironment().getUserClassLoader(), this.config, this.chainedTasks, this.eventualOutputs,
 				this.getExecutionConfig(), this.accumulatorMap);
 	}
 
 	public DistributedRuntimeUDFContext createRuntimeContext(MetricGroup metrics) {
 		Environment env = getEnvironment();
 
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), getUserCodeClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), this.accumulatorMap, metrics);
 	}
 
@@ -1051,6 +1050,8 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	public TaskManagerRuntimeInfo getTaskManagerInfo() {
 		return getEnvironment().getTaskManagerInfo();
 	}
+
+
 
 	@Override
 	public MemoryManager getMemoryManager() {
@@ -1272,13 +1273,14 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 	 * The output collector applies the configured shipping strategy.
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> Collector<T> initOutputs(AbstractInvokable containingTask, ClassLoader cl, TaskConfig config,
-										List<ChainedDriver<?, ?>> chainedTasksTarget,
-										List<RecordWriter<?>> eventualOutputs,
-										ExecutionConfig executionConfig,
-										Map<String, Accumulator<?,?>> accumulatorMap)
-	throws Exception
-	{
+	public static <T> Collector<T> initOutputs(
+			AbstractInvokable containingTask,
+			UserCodeClassLoader cl,
+			TaskConfig config,
+			List<ChainedDriver<?, ?>> chainedTasksTarget,
+			List<RecordWriter<?>> eventualOutputs,
+			ExecutionConfig executionConfig,
+			Map<String, Accumulator<?,?>> accumulatorMap) throws Exception {
 		final int numOutputs = config.getNumOutputs();
 
 		// check whether we got any chained tasks
@@ -1310,7 +1312,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 
 				if (i == numChained - 1) {
 					// last in chain, instantiate the output collector for this task
-					previous = getOutputCollector(containingTask, chainedStubConf, cl, eventualOutputs, 0, chainedStubConf.getNumOutputs());
+					previous = getOutputCollector(containingTask, chainedStubConf, cl.asClassLoader(), eventualOutputs, 0, chainedStubConf.getNumOutputs());
 				}
 
 				ct.setup(chainedStubConf, taskName, previous, containingTask, cl, executionConfig, accumulatorMap);
@@ -1328,7 +1330,7 @@ public class BatchTask<S extends Function, OT> extends AbstractInvokable impleme
 		// else
 
 		// instantiate the output collector the default way from this configuration
-		return getOutputCollector(containingTask , config, cl, eventualOutputs, 0, numOutputs);
+		return getOutputCollector(containingTask , config, cl.asClassLoader(), eventualOutputs, 0, numOutputs);
 	}
 	
 	// --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -413,7 +413,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 	public DistributedRuntimeUDFContext createRuntimeContext() {
 		Environment env = getEnvironment();
 
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserCodeClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), env.getAccumulatorRegistry().getUserMap(), 
 				getEnvironment().getMetricGroup().getOrAddOperator(getEnvironment().getTaskInfo().getTaskName()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -413,7 +413,7 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 	public DistributedRuntimeUDFContext createRuntimeContext() {
 		Environment env = getEnvironment();
 
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), getUserCodeClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), env.getAccumulatorRegistry().getUserMap(), 
 				getEnvironment().getMetricGroup().getOrAddOperator(getEnvironment().getTaskInfo().getTaskName()));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.runtime.operators.util.metrics.CountingCollector;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -103,7 +104,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 		LOG.debug(getLogString("Start registering input and output"));
 
 		try {
-			initOutputs(getUserCodeClassLoader());
+			initOutputs(getEnvironment().getUserClassLoader());
 		} catch (Exception ex) {
 			throw new RuntimeException("The initialization of the DataSource's outputs caused an error: " +
 					ex.getMessage(), ex);
@@ -309,7 +310,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 	 * Creates a writer for each output. Creates an OutputCollector which forwards its input to all writers.
 	 * The output collector applies the configured shipping strategy.
 	 */
-	private void initOutputs(ClassLoader cl) throws Exception {
+	private void initOutputs(UserCodeClassLoader cl) throws Exception {
 		this.chainedTasks = new ArrayList<ChainedDriver<?, ?>>();
 		this.eventualOutputs = new ArrayList<RecordWriter<?>>();
 
@@ -404,7 +405,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 
 		String sourceName =  getEnvironment().getTaskInfo().getTaskName().split("->")[0].trim();
 		sourceName = sourceName.startsWith("CHAIN") ? sourceName.substring(6) : sourceName;
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), getUserCodeClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), env.getAccumulatorRegistry().getUserMap(), 
 				getEnvironment().getMetricGroup().getOrAddOperator(sourceName));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSourceTask.java
@@ -104,7 +104,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 		LOG.debug(getLogString("Start registering input and output"));
 
 		try {
-			initOutputs(getEnvironment().getUserClassLoader());
+			initOutputs(getEnvironment().getUserCodeClassLoader());
 		} catch (Exception ex) {
 			throw new RuntimeException("The initialization of the DataSource's outputs caused an error: " +
 					ex.getMessage(), ex);
@@ -405,7 +405,7 @@ public class DataSourceTask<OT> extends AbstractInvokable {
 
 		String sourceName =  getEnvironment().getTaskInfo().getTaskName().split("->")[0].trim();
 		sourceName = sourceName.startsWith("CHAIN") ? sourceName.substring(6) : sourceName;
-		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserClassLoader(),
+		return new DistributedRuntimeUDFContext(env.getTaskInfo(), env.getUserCodeClassLoader(),
 				getExecutionConfig(), env.getDistributedCacheEntries(), env.getAccumulatorRegistry().getUserMap(), 
 				getEnvironment().getMetricGroup().getOrAddOperator(sourceName));
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedAllReduceDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedAllReduceDriver.java
@@ -40,11 +40,11 @@ public class ChainedAllReduceDriver<IT> extends ChainedDriver<IT, IT> {
 	// --------------------------------------------------------------------------------------------
 	@Override
 	public void setup(AbstractInvokable parent) {
-		final ReduceFunction<IT> red = BatchTask.instantiateUserCode(this.config, userCodeClassLoader, ReduceFunction.class);
+		final ReduceFunction<IT> red = BatchTask.instantiateUserCode(this.config, userCodeClassLoader.asClassLoader(), ReduceFunction.class);
 		this.reducer = red;
 		FunctionUtils.setFunctionRuntimeContext(red, getUdfRuntimeContext());
 
-		TypeSerializerFactory<IT> serializerFactory = this.config.getInputSerializer(0, userCodeClassLoader);
+		TypeSerializerFactory<IT> serializerFactory = this.config.getInputSerializer(0, userCodeClassLoader.asClassLoader());
 		this.serializer = serializerFactory.getSerializer();
 
 		if (LOG.isDebugEnabled()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedDriver.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.operators.util.DistributedRuntimeUDFContext;
 import org.apache.flink.runtime.operators.util.TaskConfig;
 import org.apache.flink.runtime.operators.util.metrics.CountingCollector;
 import org.apache.flink.util.Collector;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Map;
 
@@ -47,7 +48,7 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 
 	protected Collector<OT> outputCollector;
 	
-	protected ClassLoader userCodeClassLoader;
+	protected UserCodeClassLoader userCodeClassLoader;
 	
 	private DistributedRuntimeUDFContext udfContext;
 
@@ -63,8 +64,8 @@ public abstract class ChainedDriver<IT, OT> implements Collector<IT> {
 
 	
 	public void setup(TaskConfig config, String taskName, Collector<OT> outputCollector,
-			AbstractInvokable parent, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
-			Map<String, Accumulator<?,?>> accumulatorMap)
+					  AbstractInvokable parent, UserCodeClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
+					  Map<String, Accumulator<?,?>> accumulatorMap)
 	{
 		this.config = config;
 		this.taskName = taskName;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedFlatMapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedFlatMapDriver.java
@@ -36,7 +36,7 @@ public class ChainedFlatMapDriver<IT, OT> extends ChainedDriver<IT, OT> {
 	public void setup(AbstractInvokable parent) {
 		@SuppressWarnings("unchecked")
 		final FlatMapFunction<IT, OT> mapper =
-			BatchTask.instantiateUserCode(this.config, userCodeClassLoader, FlatMapFunction.class);
+			BatchTask.instantiateUserCode(this.config, userCodeClassLoader.asClassLoader(), FlatMapFunction.class);
 		this.mapper = mapper;
 		FunctionUtils.setFunctionRuntimeContext(mapper, getUdfRuntimeContext());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedMapDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedMapDriver.java
@@ -35,7 +35,7 @@ public class ChainedMapDriver<IT, OT> extends ChainedDriver<IT, OT> {
 	@Override
 	public void setup(AbstractInvokable parent) {
 		final MapFunction<IT, OT> mapper =
-			BatchTask.instantiateUserCode(this.config, userCodeClassLoader, MapFunction.class);
+			BatchTask.instantiateUserCode(this.config, userCodeClassLoader.asClassLoader(), MapFunction.class);
 		this.mapper = mapper;
 		FunctionUtils.setFunctionRuntimeContext(mapper, getUdfRuntimeContext());
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/ChainedReduceCombineDriver.java
@@ -96,7 +96,7 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 
 		strategy = config.getDriverStrategy();
 
-		reducer = BatchTask.instantiateUserCode(config, userCodeClassLoader, ReduceFunction.class);
+		reducer = BatchTask.instantiateUserCode(config, userCodeClassLoader.asClassLoader(), ReduceFunction.class);
 		FunctionUtils.setFunctionRuntimeContext(reducer, getUdfRuntimeContext());
 	}
 
@@ -107,8 +107,8 @@ public class ChainedReduceCombineDriver<T> extends ChainedDriver<T, T> {
 		BatchTask.openUserCode(reducer, stubConfig);
 
 		// instantiate the serializer / comparator
-		serializer = config.<T>getInputSerializer(0, userCodeClassLoader).getSerializer();
-		comparator = config.<T>getDriverComparator(0, userCodeClassLoader).createComparator();
+		serializer = config.<T>getInputSerializer(0, userCodeClassLoader.asClassLoader()).getSerializer();
+		comparator = config.<T>getDriverComparator(0, userCodeClassLoader.asClassLoader()).createComparator();
 
 		MemoryManager memManager = parent.getEnvironment().getMemoryManager();
 		final int numMemoryPages = memManager.computeNumberOfPages(config.getRelativeMemoryDriver());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/SynchronousChainedCombineDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/chaining/SynchronousChainedCombineDriver.java
@@ -87,7 +87,7 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 
 		@SuppressWarnings("unchecked")
 		final GroupCombineFunction<IN, OUT> combiner =
-			BatchTask.instantiateUserCode(this.config, userCodeClassLoader, GroupCombineFunction.class);
+			BatchTask.instantiateUserCode(this.config, userCodeClassLoader.asClassLoader(), GroupCombineFunction.class);
 		this.combiner = combiner;
 		FunctionUtils.setFunctionRuntimeContext(combiner, getUdfRuntimeContext());
 	}
@@ -101,9 +101,9 @@ public class SynchronousChainedCombineDriver<IN, OUT> extends ChainedDriver<IN, 
 		// ----------------- Set up the sorter -------------------------
 
 		// instantiate the serializer / comparator
-		final TypeSerializerFactory<IN> serializerFactory = this.config.getInputSerializer(0, this.userCodeClassLoader);
-		final TypeComparatorFactory<IN> sortingComparatorFactory = this.config.getDriverComparator(0, this.userCodeClassLoader);
-		final TypeComparatorFactory<IN> groupingComparatorFactory = this.config.getDriverComparator(1, this.userCodeClassLoader);
+		final TypeSerializerFactory<IN> serializerFactory = this.config.getInputSerializer(0, this.userCodeClassLoader.asClassLoader());
+		final TypeComparatorFactory<IN> sortingComparatorFactory = this.config.getDriverComparator(0, this.userCodeClassLoader.asClassLoader());
+		final TypeComparatorFactory<IN> groupingComparatorFactory = this.config.getDriverComparator(1, this.userCodeClassLoader.asClassLoader());
 		
 		this.serializer = serializerFactory.getSerializer();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/util/DistributedRuntimeUDFContext.java
@@ -18,11 +18,6 @@
 
 package org.apache.flink.runtime.operators.util;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.accumulators.Accumulator;
@@ -34,6 +29,12 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.broadcast.BroadcastVariableMaterialization;
 import org.apache.flink.runtime.broadcast.InitializationTypeConflictException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
 
 /**
  * A standalone implementation of the {@link RuntimeContext}, created by runtime UDF operators.
@@ -42,8 +43,13 @@ public class DistributedRuntimeUDFContext extends AbstractRuntimeUDFContext {
 
 	private final HashMap<String, BroadcastVariableMaterialization<?, ?>> broadcastVars = new HashMap<String, BroadcastVariableMaterialization<?, ?>>();
 	
-	public DistributedRuntimeUDFContext(TaskInfo taskInfo, ClassLoader userCodeClassLoader, ExecutionConfig executionConfig,
-											Map<String, Future<Path>> cpTasks, Map<String, Accumulator<?,?>> accumulators, MetricGroup metrics) {
+	public DistributedRuntimeUDFContext(
+			TaskInfo taskInfo,
+			UserCodeClassLoader userCodeClassLoader,
+			ExecutionConfig executionConfig,
+			Map<String, Future<Path>> cpTasks,
+			Map<String, Accumulator<?,?>> accumulators,
+			MetricGroup metrics) {
 		super(taskInfo, userCodeClassLoader, executionConfig, accumulators, cpTasks, metrics);
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -516,7 +516,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		return new HeapKeyedStateBackendBuilder<>(
 			kvStateRegistry,
 			keySerializer,
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),
@@ -537,7 +537,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		CloseableRegistry cancelStreamRegistry) throws BackendBuildingException {
 
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			isUsingAsynchronousSnapshots(),
 			stateHandles,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/filesystem/FsStateBackend.java
@@ -516,7 +516,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		return new HeapKeyedStateBackendBuilder<>(
 			kvStateRegistry,
 			keySerializer,
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),
@@ -537,7 +537,7 @@ public class FsStateBackend extends AbstractFileStateBackend implements Configur
 		CloseableRegistry cancelStreamRegistry) throws BackendBuildingException {
 
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			isUsingAsynchronousSnapshots(),
 			stateHandles,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -307,7 +307,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 		CloseableRegistry cancelStreamRegistry) throws Exception {
 
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			isUsingAsynchronousSnapshots(),
 			stateHandles,
@@ -334,7 +334,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 		return new HeapKeyedStateBackendBuilder<>(
 			kvStateRegistry,
 			keySerializer,
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/MemoryStateBackend.java
@@ -307,7 +307,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 		CloseableRegistry cancelStreamRegistry) throws Exception {
 
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			isUsingAsynchronousSnapshots(),
 			stateHandles,
@@ -334,7 +334,7 @@ public class MemoryStateBackend extends AbstractFileStateBackend implements Conf
 		return new HeapKeyedStateBackendBuilder<>(
 			kvStateRegistry,
 			keySerializer,
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -195,7 +195,7 @@ public class RuntimeEnvironment implements Environment {
 	}
 
 	@Override
-	public UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserCodeClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -195,8 +195,8 @@ public class RuntimeEnvironment implements Environment {
 	}
 
 	@Override
-	public ClassLoader getUserClassLoader() {
-		return userCodeClassLoader.asClassLoader();
+	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+		return userCodeClassLoader;
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -62,7 +63,7 @@ public class RuntimeEnvironment implements Environment {
 	private final Configuration taskConfiguration;
 	private final ExecutionConfig executionConfig;
 
-	private final ClassLoader userCodeClassLoader;
+	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
 
 	private final MemoryManager memManager;
 	private final IOManager ioManager;
@@ -100,7 +101,7 @@ public class RuntimeEnvironment implements Environment {
 			TaskInfo taskInfo,
 			Configuration jobConfiguration,
 			Configuration taskConfiguration,
-			ClassLoader userCodeClassLoader,
+			LibraryCacheManager.UserCodeClassLoader userCodeClassLoader,
 			MemoryManager memManager,
 			IOManager ioManager,
 			BroadcastVariableManager bcVarManager,
@@ -195,7 +196,7 @@ public class RuntimeEnvironment implements Environment {
 
 	@Override
 	public ClassLoader getUserClassLoader() {
-		return userCodeClassLoader;
+		return userCodeClassLoader.asClassLoader();
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/RuntimeEnvironment.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -42,6 +41,7 @@ import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
 import org.apache.flink.runtime.state.TaskStateManager;
 import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Map;
 import java.util.concurrent.Future;
@@ -63,7 +63,7 @@ public class RuntimeEnvironment implements Environment {
 	private final Configuration taskConfiguration;
 	private final ExecutionConfig executionConfig;
 
-	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
+	private final UserCodeClassLoader userCodeClassLoader;
 
 	private final MemoryManager memManager;
 	private final IOManager ioManager;
@@ -101,7 +101,7 @@ public class RuntimeEnvironment implements Environment {
 			TaskInfo taskInfo,
 			Configuration jobConfiguration,
 			Configuration taskConfiguration,
-			LibraryCacheManager.UserCodeClassLoader userCodeClassLoader,
+			UserCodeClassLoader userCodeClassLoader,
 			MemoryManager memManager,
 			IOManager ioManager,
 			BroadcastVariableManager bcVarManager,
@@ -195,7 +195,7 @@ public class RuntimeEnvironment implements Environment {
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -82,6 +82,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import org.slf4j.Logger;
@@ -272,7 +273,7 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 	private long taskCancellationTimeout;
 
 	/** This class loader should be set as the context class loader for threads that may dynamically load user code. */
-	private LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
+	private UserCodeClassLoader userCodeClassLoader;
 
 	/**
 	 * <p><b>IMPORTANT:</b> This constructor may not start any work that would need to
@@ -914,11 +915,11 @@ public class Task implements Runnable, TaskSlotPayload, TaskActions, PartitionPr
 		}
 	}
 
-	private LibraryCacheManager.UserCodeClassLoader createUserCodeClassloader() throws Exception {
+	private UserCodeClassLoader createUserCodeClassloader() throws Exception {
 		long startDownloadTime = System.currentTimeMillis();
 
 		// triggers the download of all missing jar files from the job manager
-		final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = classLoaderHandle.getOrResolveClassLoader(requiredJarFiles, requiredClasspaths);
+		final UserCodeClassLoader userCodeClassLoader = classLoaderHandle.getOrResolveClassLoader(requiredJarFiles, requiredClasspaths);
 
 		LOG.debug("Getting user code class loader for task {} at library cache manager took {} milliseconds",
 				executionId, System.currentTimeMillis() - startDownloadTime);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/BlobLibraryCacheManagerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.blob.PermanentBlobService;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -108,7 +109,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			checkFileCountForJob(0, jobId2, cache);
 
 			final LibraryCacheManager.ClassLoaderLease classLoaderLeaseJob1 = libCache.registerClassLoaderLease(jobId1);
-			final LibraryCacheManager.UserCodeClassLoader classLoader1 = classLoaderLeaseJob1.getOrResolveClassLoader(keys1, Collections.emptyList());
+			final UserCodeClassLoader classLoader1 = classLoaderLeaseJob1.getOrResolveClassLoader(keys1, Collections.emptyList());
 
 			assertEquals(1, libCache.getNumberOfManagedJobs());
 			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId1));
@@ -121,7 +122,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			checkFileCountForJob(0, jobId2, cache);
 
 			final LibraryCacheManager.ClassLoaderLease classLoaderLeaseJob2 = libCache.registerClassLoaderLease(jobId2);
-			final LibraryCacheManager.UserCodeClassLoader classLoader2 = classLoaderLeaseJob2.getOrResolveClassLoader(keys2, Collections.emptyList());
+			final UserCodeClassLoader classLoader2 = classLoaderLeaseJob2.getOrResolveClassLoader(keys2, Collections.emptyList());
 			assertThat(classLoader1, not(sameInstance(classLoader2)));
 
 			try {
@@ -233,7 +234,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			checkFileCountForJob(0, jobId, cache);
 
 			final LibraryCacheManager.ClassLoaderLease classLoaderLease1 = libCache.registerClassLoaderLease(jobId);
-			LibraryCacheManager.UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(keys, Collections.emptyList());
+			UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(keys, Collections.emptyList());
 
 			assertEquals(1, libCache.getNumberOfManagedJobs());
 			assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
@@ -242,7 +243,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 			checkFileCountForJob(2, jobId, cache);
 
 			final LibraryCacheManager.ClassLoaderLease classLoaderLease2 = libCache.registerClassLoaderLease(jobId);
-			final LibraryCacheManager.UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(keys, Collections.emptyList());
+			final UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(keys, Collections.emptyList());
 			assertThat(classLoader1, sameInstance(classLoader2));
 
 			try {
@@ -344,7 +345,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 
 				cache.registerJob(jobId);
 				final LibraryCacheManager.ClassLoaderLease classLoaderLease1 = libCache.registerClassLoaderLease(jobId);
-				final LibraryCacheManager.UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(keys, Collections.emptyList());
+				final UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(keys, Collections.emptyList());
 				assertEquals(1, libCache.getNumberOfManagedJobs());
 				assertEquals(1, libCache.getNumberOfReferenceHolders(jobId));
 				assertEquals(1, checkFilesExist(jobId, keys, cache, true));
@@ -352,7 +353,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 				checkFileCountForJob(1, jobId, cache);
 
 				final LibraryCacheManager.ClassLoaderLease classLoaderLease2 = libCache.registerClassLoaderLease(jobId);
-				final LibraryCacheManager.UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(keys, Collections.emptyList());
+				final UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(keys, Collections.emptyList());
 				assertThat(classLoader1, sameInstance(classLoader2));
 				assertEquals(1, libCache.getNumberOfManagedJobs());
 				assertEquals(2, libCache.getNumberOfReferenceHolders(jobId));
@@ -473,8 +474,8 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 		final LibraryCacheManager.ClassLoaderLease classLoaderLease1 = libraryCacheManager.registerClassLoaderLease(jobId);
 		final LibraryCacheManager.ClassLoaderLease classLoaderLease2 = libraryCacheManager.registerClassLoaderLease(jobId);
 
-		final LibraryCacheManager.UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
-		final LibraryCacheManager.UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
+		final UserCodeClassLoader classLoader1 = classLoaderLease1.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
+		final UserCodeClassLoader classLoader2 = classLoaderLease2.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
 
 		assertThat(classLoader1, sameInstance(classLoader2));
 	}
@@ -510,7 +511,7 @@ public class BlobLibraryCacheManagerTest extends TestLogger {
 		final BlobLibraryCacheManager libraryCacheManager = new TestingBlobLibraryCacheManagerBuilder().build();
 
 		final LibraryCacheManager.ClassLoaderLease classLoaderLease = libraryCacheManager.registerClassLoaderLease(new JobID());
-		final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = classLoaderLease.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
+		final UserCodeClassLoader userCodeClassLoader = classLoaderLease.getOrResolveClassLoader(Collections.emptyList(), Collections.emptyList());
 
 		final OneShotLatch releaseHookLatch = new OneShotLatch();
 		userCodeClassLoader.registerReleaseHook(releaseHookLatch::trigger);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingClassLoaderLease.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingClassLoaderLease.java
@@ -30,17 +30,17 @@ import java.util.Collection;
  */
 public class TestingClassLoaderLease implements LibraryCacheManager.ClassLoaderLease {
 
-	private final BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, ClassLoader, IOException> getOrResolveClassLoaderFunction;
+	private final BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction;
 
 	private final Runnable closeRunnable;
 
-	public TestingClassLoaderLease(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, ClassLoader, IOException> getOrResolveClassLoaderFunction, Runnable closeRunnable) {
+	public TestingClassLoaderLease(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction, Runnable closeRunnable) {
 		this.getOrResolveClassLoaderFunction = getOrResolveClassLoaderFunction;
 		this.closeRunnable = closeRunnable;
 	}
 
 	@Override
-	public ClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
+	public LibraryCacheManager.UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
 		return getOrResolveClassLoaderFunction.apply(requiredJarFiles, requiredClasspaths);
 	}
 
@@ -54,12 +54,13 @@ public class TestingClassLoaderLease implements LibraryCacheManager.ClassLoaderL
 	}
 
 	public static final class Builder {
-		private BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, ClassLoader, IOException> getOrResolveClassLoaderFunction = (ignoredA, ignoredB) -> Builder.class.getClassLoader();
+		private final TestingUserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
+		private BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction = (ignoredA, ignoredB) -> userCodeClassLoader;
 		private Runnable closeRunnable = () -> {};
 
 		private Builder() {}
 
-		public Builder setGetOrResolveClassLoaderFunction(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, ClassLoader, IOException> getOrResolveClassLoaderFunction) {
+		public Builder setGetOrResolveClassLoaderFunction(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction) {
 			this.getOrResolveClassLoaderFunction = getOrResolveClassLoaderFunction;
 			return this;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingClassLoaderLease.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingClassLoaderLease.java
@@ -19,6 +19,8 @@
 package org.apache.flink.runtime.execution.librarycache;
 
 import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.util.TestingUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.util.function.BiFunctionWithException;
 
 import java.io.IOException;
@@ -30,17 +32,17 @@ import java.util.Collection;
  */
 public class TestingClassLoaderLease implements LibraryCacheManager.ClassLoaderLease {
 
-	private final BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction;
+	private final BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction;
 
 	private final Runnable closeRunnable;
 
-	public TestingClassLoaderLease(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction, Runnable closeRunnable) {
+	public TestingClassLoaderLease(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction, Runnable closeRunnable) {
 		this.getOrResolveClassLoaderFunction = getOrResolveClassLoaderFunction;
 		this.closeRunnable = closeRunnable;
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
+	public UserCodeClassLoader getOrResolveClassLoader(Collection<PermanentBlobKey> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
 		return getOrResolveClassLoaderFunction.apply(requiredJarFiles, requiredClasspaths);
 	}
 
@@ -55,12 +57,12 @@ public class TestingClassLoaderLease implements LibraryCacheManager.ClassLoaderL
 
 	public static final class Builder {
 		private final TestingUserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
-		private BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction = (ignoredA, ignoredB) -> userCodeClassLoader;
+		private BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction = (ignoredA, ignoredB) -> userCodeClassLoader;
 		private Runnable closeRunnable = () -> {};
 
 		private Builder() {}
 
-		public Builder setGetOrResolveClassLoaderFunction(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, LibraryCacheManager.UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction) {
+		public Builder setGetOrResolveClassLoaderFunction(BiFunctionWithException<Collection<PermanentBlobKey>, Collection<URL>, UserCodeClassLoader, IOException> getOrResolveClassLoaderFunction) {
 			this.getOrResolveClassLoaderFunction = getOrResolveClassLoaderFunction;
 			return this;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingUserCodeClassLoader.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/execution/librarycache/TestingUserCodeClassLoader.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.execution.librarycache;
+
+import java.util.function.Consumer;
+
+/**
+ * Testing implementation of {@link LibraryCacheManager.UserCodeClassLoader}.
+ */
+public class TestingUserCodeClassLoader implements LibraryCacheManager.UserCodeClassLoader {
+
+	private final ClassLoader classLoader;
+
+	private final Consumer<Runnable> registerReleaseHookConsumer;
+
+	public TestingUserCodeClassLoader(ClassLoader classLoader, Consumer<Runnable> registerReleaseHookConsumer) {
+		this.classLoader = classLoader;
+		this.registerReleaseHookConsumer = registerReleaseHookConsumer;
+	}
+
+	@Override
+	public ClassLoader asClassLoader() {
+		return classLoader;
+	}
+
+	@Override
+	public void registerReleaseHook(Runnable releaseHook) {
+		registerReleaseHookConsumer.accept(releaseHook);
+	}
+
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+		private ClassLoader classLoader = Builder.class.getClassLoader();
+		private Consumer<Runnable> registerReleaseHookConsumer = ignored -> {};
+
+		private Builder() {}
+
+		public Builder setClassLoader(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+			return this;
+		}
+
+		public Builder setRegisterReleaseHookConsumer(Consumer<Runnable> registerReleaseHookConsumer) {
+			this.registerReleaseHookConsumer = registerReleaseHookConsumer;
+			return this;
+		}
+
+		public TestingUserCodeClassLoader build() {
+			return new TestingUserCodeClassLoader(classLoader, registerReleaseHookConsumer);
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.TestingClassLoaderLease;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -180,10 +181,11 @@ public class JobManagerRunnerImplTest extends TestLogger {
 	public void testLibraryCacheManagerRegistration() throws Exception {
 		final OneShotLatch registerClassLoaderLatch = new OneShotLatch();
 		final OneShotLatch closeClassLoaderLeaseLatch = new OneShotLatch();
+		final TestingUserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
 		final TestingClassLoaderLease classLoaderLease = TestingClassLoaderLease.newBuilder()
 			.setGetOrResolveClassLoaderFunction((permanentBlobKeys, urls) -> {
 				registerClassLoaderLatch.trigger();
-				return JobManagerRunnerImplTest.class.getClassLoader();
+				return userCodeClassLoader;
 			})
 			.setCloseRunnable(closeClassLoaderLeaseLatch::trigger)
 			.build();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobManagerRunnerImplTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.execution.librarycache.TestingClassLoaderLease;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.highavailability.TestingHighAvailabilityServices;
 import org.apache.flink.runtime.jobgraph.JobGraph;
@@ -39,6 +38,7 @@ import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestingUserCodeClassLoader;
 
 import org.junit.After;
 import org.junit.Before;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -57,7 +57,6 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -138,6 +137,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestingUserCodeClassLoader;
 
 import akka.actor.ActorSystem;
 import org.hamcrest.Matchers;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.deployment.TaskDeploymentDescriptor;
 import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
 import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.AccessExecution;
 import org.apache.flink.runtime.executiongraph.AccessExecutionVertex;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
@@ -316,7 +317,7 @@ public class JobMasterTest extends TestLogger {
 				UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 				new JobMasterBuilder.TestingOnCompletionActions(),
 				testingFatalErrorHandler,
-				JobMasterTest.class.getClassLoader(),
+				TestingUserCodeClassLoader.newBuilder().build(),
 				schedulerNGFactory,
 				NettyShuffleMaster.INSTANCE,
 				NoOpJobMasterPartitionTracker.FACTORY) {
@@ -1656,7 +1657,7 @@ public class JobMasterTest extends TestLogger {
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 			new JobMasterBuilder.TestingOnCompletionActions(),
 			testingFatalErrorHandler,
-			JobMasterTest.class.getClassLoader(),
+			TestingUserCodeClassLoader.newBuilder().build(),
 			schedulerNGFactory,
 			NettyShuffleMaster.INSTANCE,
 			NoOpJobMasterPartitionTracker.FACTORY) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.jobmaster.factories;
 
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobMaster;
@@ -42,7 +43,7 @@ public class TestingJobMasterServiceFactory implements JobMasterServiceFactory {
 	}
 
 	@Override
-	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, ClassLoader userCodeClassloader) {
+	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, LibraryCacheManager.UserCodeClassLoader userCodeClassloader) {
 		return jobMasterServiceSupplier.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/factories/TestingJobMasterServiceFactory.java
@@ -18,12 +18,12 @@
 
 package org.apache.flink.runtime.jobmaster.factories;
 
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.OnCompletionActions;
 import org.apache.flink.runtime.jobmaster.JobMaster;
 import org.apache.flink.runtime.jobmaster.JobMasterService;
 import org.apache.flink.runtime.jobmaster.TestingJobMasterService;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.function.Supplier;
 
@@ -43,7 +43,7 @@ public class TestingJobMasterServiceFactory implements JobMasterServiceFactory {
 	}
 
 	@Override
-	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, LibraryCacheManager.UserCodeClassLoader userCodeClassloader) {
+	public JobMasterService createJobMasterService(JobGraph jobGraph, OnCompletionActions jobCompletionActions, UserCodeClassLoader userCodeClassloader) {
 		return jobMasterServiceSupplier.get();
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -21,7 +21,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -44,6 +43,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.shuffle.NettyShuffleMaster;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
+import org.apache.flink.util.TestingUserCodeClassLoader;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/JobMasterBuilder.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.checkpoint.StandaloneCheckpointRecoveryFactory;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.dispatcher.SchedulerNGFactoryFactory;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
@@ -166,7 +167,7 @@ public class JobMasterBuilder {
 			UnregisteredJobManagerJobMetricGroupFactory.INSTANCE,
 			onCompletionActions,
 			fatalErrorHandler,
-			JobMasterBuilder.class.getClassLoader(),
+			TestingUserCodeClassLoader.newBuilder().build(),
 			SchedulerNGFactoryFactory.createSchedulerNGFactory(configuration, jobManagerSharedServices.getRestartStrategyFactory()),
 			shuffleMaster,
 			partitionTrackerFactory);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -28,8 +28,6 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -50,6 +48,8 @@ import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.util.TestingUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Collections;
 import java.util.Map;
@@ -66,7 +66,7 @@ public class DummyEnvironment implements Environment {
 	private TaskStateManager taskStateManager;
 	private final GlobalAggregateManager aggregateManager;
 	private final AccumulatorRegistry accumulatorRegistry = new AccumulatorRegistry(jobId, executionId);
-	private LibraryCacheManager.UserCodeClassLoader userClassLoader;
+	private UserCodeClassLoader userClassLoader;
 
 	public DummyEnvironment() {
 		this("Test Job", 1, 0, 1);
@@ -156,7 +156,7 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserClassLoader() {
 		if (userClassLoader == null) {
 			return TestingUserCodeClassLoader.newBuilder().build();
 		} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -28,6 +28,8 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -64,7 +66,7 @@ public class DummyEnvironment implements Environment {
 	private TaskStateManager taskStateManager;
 	private final GlobalAggregateManager aggregateManager;
 	private final AccumulatorRegistry accumulatorRegistry = new AccumulatorRegistry(jobId, executionId);
-	private ClassLoader userClassLoader;
+	private LibraryCacheManager.UserCodeClassLoader userClassLoader;
 
 	public DummyEnvironment() {
 		this("Test Job", 1, 0, 1);
@@ -72,7 +74,7 @@ public class DummyEnvironment implements Environment {
 
 	public DummyEnvironment(ClassLoader userClassLoader) {
 		this("Test Job", 1, 0, 1);
-		this.userClassLoader = userClassLoader;
+		this.userClassLoader = TestingUserCodeClassLoader.newBuilder().setClassLoader(userClassLoader).build();
 	}
 
 	public DummyEnvironment(String taskName, int numSubTasks, int subTaskIndex) {
@@ -154,9 +156,9 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
-	public ClassLoader getUserClassLoader() {
+	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
 		if (userClassLoader == null) {
-			return getClass().getClassLoader();
+			return TestingUserCodeClassLoader.newBuilder().build();
 		} else {
 			return userClassLoader;
 		}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyEnvironment.java
@@ -156,7 +156,7 @@ public class DummyEnvironment implements Environment {
 	}
 
 	@Override
-	public UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserCodeClassLoader() {
 		if (userClassLoader == null) {
 			return TestingUserCodeClassLoader.newBuilder().build();
 		} else {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -23,12 +23,12 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
-import org.apache.flink.core.memory.MemoryType;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
 import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -41,7 +41,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.InputSplitProvider;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.memory.MemoryManager;
-import org.apache.flink.runtime.memory.MemoryManagerBuilder;
 import org.apache.flink.runtime.metrics.groups.TaskMetricGroup;
 import org.apache.flink.runtime.query.KvStateRegistry;
 import org.apache.flink.runtime.query.TaskKvStateRegistry;
@@ -108,7 +107,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	private final int bufferSize;
 
-	private final ClassLoader userCodeClassLoader;
+	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
 
 	private final TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
@@ -136,7 +135,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 			int maxParallelism,
 			int parallelism,
 			int subtaskIndex,
-			ClassLoader userCodeClassLoader,
+			LibraryCacheManager.UserCodeClassLoader userCodeClassLoader,
 			TaskMetricGroup taskMetricGroup,
 			TaskManagerRuntimeInfo taskManagerRuntimeInfo,
 			MemoryManager memManager) {
@@ -255,7 +254,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 	}
 
 	@Override
-	public ClassLoader getUserClassLoader() {
+	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.broadcast.BroadcastVariableManager;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.network.TaskEventDispatcher;
@@ -51,6 +50,7 @@ import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.types.Record;
 import org.apache.flink.util.MutableObjectIterator;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import java.util.Collections;
 import java.util.LinkedList;
@@ -107,7 +107,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 
 	private final int bufferSize;
 
-	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader;
+	private final UserCodeClassLoader userCodeClassLoader;
 
 	private final TaskEventDispatcher taskEventDispatcher = new TaskEventDispatcher();
 
@@ -135,7 +135,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 			int maxParallelism,
 			int parallelism,
 			int subtaskIndex,
-			LibraryCacheManager.UserCodeClassLoader userCodeClassLoader,
+			UserCodeClassLoader userCodeClassLoader,
 			TaskMetricGroup taskMetricGroup,
 			TaskManagerRuntimeInfo taskManagerRuntimeInfo,
 			MemoryManager memManager) {
@@ -254,7 +254,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironment.java
@@ -254,7 +254,7 @@ public class MockEnvironment implements Environment, AutoCloseable {
 	}
 
 	@Override
-	public UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserCodeClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -22,8 +22,6 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -37,6 +35,8 @@ import org.apache.flink.runtime.taskexecutor.GlobalAggregateManager;
 import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
+import org.apache.flink.util.TestingUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
 
 public class MockEnvironmentBuilder {
 	private String taskName = "mock-task";
@@ -49,7 +49,7 @@ public class MockEnvironmentBuilder {
 	private int maxParallelism = 1;
 	private int parallelism = 1;
 	private int subtaskIndex = 0;
-	private LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
+	private UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
 	private JobID jobID = new JobID();
 	private JobVertexID jobVertexID = new JobVertexID();
 	private TaskMetricGroup taskMetricGroup = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/MockEnvironmentBuilder.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.MemoryType;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
@@ -47,7 +49,7 @@ public class MockEnvironmentBuilder {
 	private int maxParallelism = 1;
 	private int parallelism = 1;
 	private int subtaskIndex = 0;
-	private ClassLoader userCodeClassLoader = Thread.currentThread().getContextClassLoader();
+	private LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
 	private JobID jobID = new JobID();
 	private JobVertexID jobVertexID = new JobVertexID();
 	private TaskMetricGroup taskMetricGroup = UnregisteredMetricGroups.createUnregisteredTaskMetricGroup();
@@ -115,7 +117,9 @@ public class MockEnvironmentBuilder {
 	}
 
 	public MockEnvironmentBuilder setUserCodeClassLoader(ClassLoader userCodeClassLoader) {
-		this.userCodeClassLoader = userCodeClassLoader;
+		this.userCodeClassLoader = TestingUserCodeClassLoader.newBuilder()
+			.setClassLoader(userCodeClassLoader)
+			.build();
 		return this;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -36,11 +36,13 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.runtime.util.BlockingCheckpointOutputStream;
 import org.apache.flink.util.Preconditions;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -238,7 +240,7 @@ public class OperatorStateBackendTest {
 		OperatorStateBackend operatorStateBackend = abstractStateBackend.createOperatorStateBackend(env, "test-op-name", emptyStateHandles, cancelStreamRegistry);
 
 		AtomicInteger copyCounter = new AtomicInteger(0);
-		TypeSerializer<Integer> serializer = new VerifyingIntSerializer(env.getUserClassLoader(), copyCounter);
+		TypeSerializer<Integer> serializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), copyCounter);
 
 		// write some state
 		ListStateDescriptor<Integer> stateDescriptor = new ListStateDescriptor<>("test", serializer);
@@ -249,8 +251,8 @@ public class OperatorStateBackendTest {
 		AtomicInteger keyCopyCounter = new AtomicInteger(0);
 		AtomicInteger valueCopyCounter = new AtomicInteger(0);
 
-		TypeSerializer<Integer> keySerializer = new VerifyingIntSerializer(env.getUserClassLoader(), keyCopyCounter);
-		TypeSerializer<Integer> valueSerializer = new VerifyingIntSerializer(env.getUserClassLoader(), valueCopyCounter);
+		TypeSerializer<Integer> keySerializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), keyCopyCounter);
+		TypeSerializer<Integer> valueSerializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), valueCopyCounter);
 
 		MapStateDescriptor<Integer, Integer> broadcastStateDesc = new MapStateDescriptor<>(
 				"test-broadcast", keySerializer, valueSerializer);
@@ -936,7 +938,7 @@ public class OperatorStateBackendTest {
 	private static Environment createMockEnvironment() {
 		Environment env = mock(Environment.class);
 		when(env.getExecutionConfig()).thenReturn(new ExecutionConfig());
-		when(env.getUserClassLoader()).thenReturn(OperatorStateBackendTest.class.getClassLoader());
+		when(env.getUserClassLoader()).thenReturn(TestingUserCodeClassLoader.newBuilder().build());
 		return env;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -36,12 +36,12 @@ import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.StateObjectCollection;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.util.BlockerCheckpointStreamFactory;
 import org.apache.flink.runtime.util.BlockingCheckpointOutputStream;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestingUserCodeClassLoader;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -240,7 +240,7 @@ public class OperatorStateBackendTest {
 		OperatorStateBackend operatorStateBackend = abstractStateBackend.createOperatorStateBackend(env, "test-op-name", emptyStateHandles, cancelStreamRegistry);
 
 		AtomicInteger copyCounter = new AtomicInteger(0);
-		TypeSerializer<Integer> serializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), copyCounter);
+		TypeSerializer<Integer> serializer = new VerifyingIntSerializer(env.getUserCodeClassLoader().asClassLoader(), copyCounter);
 
 		// write some state
 		ListStateDescriptor<Integer> stateDescriptor = new ListStateDescriptor<>("test", serializer);
@@ -251,8 +251,8 @@ public class OperatorStateBackendTest {
 		AtomicInteger keyCopyCounter = new AtomicInteger(0);
 		AtomicInteger valueCopyCounter = new AtomicInteger(0);
 
-		TypeSerializer<Integer> keySerializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), keyCopyCounter);
-		TypeSerializer<Integer> valueSerializer = new VerifyingIntSerializer(env.getUserClassLoader().asClassLoader(), valueCopyCounter);
+		TypeSerializer<Integer> keySerializer = new VerifyingIntSerializer(env.getUserCodeClassLoader().asClassLoader(), keyCopyCounter);
+		TypeSerializer<Integer> valueSerializer = new VerifyingIntSerializer(env.getUserCodeClassLoader().asClassLoader(), valueCopyCounter);
 
 		MapStateDescriptor<Integer, Integer> broadcastStateDesc = new MapStateDescriptor<>(
 				"test-broadcast", keySerializer, valueSerializer);
@@ -938,7 +938,7 @@ public class OperatorStateBackendTest {
 	private static Environment createMockEnvironment() {
 		Environment env = mock(Environment.class);
 		when(env.getExecutionConfig()).thenReturn(new ExecutionConfig());
-		when(env.getUserClassLoader()).thenReturn(TestingUserCodeClassLoader.newBuilder().build());
+		when(env.getUserCodeClassLoader()).thenReturn(TestingUserCodeClassLoader.newBuilder().build());
 		return env;
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -137,7 +137,7 @@ public class MockStateBackend extends AbstractStateBackend {
 		return new MockKeyedStateBackendBuilder<>(
 			new KvStateRegistry().createTaskRegistry(jobID, new JobVertexID()),
 			keySerializer,
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/mock/MockStateBackend.java
@@ -137,7 +137,7 @@ public class MockStateBackend extends AbstractStateBackend {
 		return new MockKeyedStateBackendBuilder<>(
 			new KvStateRegistry().createTaskRegistry(jobID, new JobVertexID()),
 			keySerializer,
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			numberOfKeyGroups,
 			keyGroupRange,
 			env.getExecutionConfig(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -207,7 +207,7 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
 
 		@Override
 		public void invoke() throws Exception {
-			userCodeClassLoaders.put(getEnvironment().getUserClassLoader().asClassLoader());
+			userCodeClassLoaders.put(getEnvironment().getUserCodeClassLoader().asClassLoader());
 		}
 
 		private static void clearQueue() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -207,7 +207,7 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
 
 		@Override
 		public void invoke() throws Exception {
-			userCodeClassLoaders.put(getEnvironment().getUserClassLoader());
+			userCodeClassLoaders.put(getEnvironment().getUserClassLoader().asClassLoader());
 		}
 
 		private static void clearQueue() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.TestingClassLoaderLease;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
@@ -57,6 +56,7 @@ import org.apache.flink.runtime.taskexecutor.TestGlobalAggregateManager;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestingUserCodeClassLoader;
 
 import org.junit.After;
 import org.junit.Before;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskAsyncCallTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.deployment.ResultPartitionDeploymentDescriptor;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.execution.librarycache.TestingClassLoaderLease;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.JobInformation;
 import org.apache.flink.runtime.executiongraph.TaskInformation;
@@ -158,7 +159,9 @@ public class TaskAsyncCallTest extends TestLogger {
 
 	private Task createTask(Class<? extends AbstractInvokable> invokableClass) throws Exception {
 		final TestingClassLoaderLease classLoaderHandle = TestingClassLoaderLease.newBuilder()
-			.setGetOrResolveClassLoaderFunction((permanentBlobKeys, urls) -> new TestUserCodeClassLoader())
+			.setGetOrResolveClassLoaderFunction((permanentBlobKeys, urls) -> TestingUserCodeClassLoader.newBuilder()
+				.setClassLoader(new TestUserCodeClassLoader())
+				.build())
 			.build();
 
 		ResultPartitionConsumableNotifier consumableNotifier = new NoOpResultPartitionConsumableNotifier();

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -523,7 +523,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		StreamCompressionDecorator keyGroupCompressionDecorator = getCompressionDecorator(executionConfig);
 		RocksDBKeyedStateBackendBuilder<K> builder = new RocksDBKeyedStateBackendBuilder<>(
 			operatorIdentifier,
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			instanceBasePath,
 			resourceContainer,
 			stateName -> resourceContainer.getColumnOptions(),
@@ -558,7 +558,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		//the default for RocksDB; eventually there can be a operator state backend based on RocksDB, too.
 		final boolean asyncSnapshots = true;
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader().asClassLoader(),
+			env.getUserCodeClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			asyncSnapshots,
 			stateHandles,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBStateBackend.java
@@ -523,7 +523,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		StreamCompressionDecorator keyGroupCompressionDecorator = getCompressionDecorator(executionConfig);
 		RocksDBKeyedStateBackendBuilder<K> builder = new RocksDBKeyedStateBackendBuilder<>(
 			operatorIdentifier,
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			instanceBasePath,
 			resourceContainer,
 			stateName -> resourceContainer.getColumnOptions(),
@@ -558,7 +558,7 @@ public class RocksDBStateBackend extends AbstractStateBackend implements Configu
 		//the default for RocksDB; eventually there can be a operator state backend based on RocksDB, too.
 		final boolean asyncSnapshots = true;
 		return new DefaultOperatorStateBackendBuilder(
-			env.getUserClassLoader(),
+			env.getUserClassLoader().asClassLoader(),
 			env.getExecutionConfig(),
 			asyncSnapshots,
 			stateHandles,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/async/RichAsyncFunction.java
@@ -149,6 +149,11 @@ public abstract class RichAsyncFunction<IN, OUT> extends AbstractRichFunction im
 			return runtimeContext.getUserCodeClassLoader();
 		}
 
+		@Override
+		public void registerUserCodeClassLoaderReleaseHook(Runnable releaseHook) {
+			runtimeContext.registerUserCodeClassLoaderReleaseHook(releaseHook);
+		}
+
 		// -----------------------------------------------------------------------------------
 		// Unsupported operations
 		// -----------------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -233,7 +233,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 			timeServiceManager.restoreStateForKeyGroup(
 				streamProvider.getStream(),
-				keyGroupIdx, environment.getUserClassLoader());
+				keyGroupIdx, environment.getUserClassLoader().asClassLoader());
 		}
 
 		return timeServiceManager;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImpl.java
@@ -233,7 +233,7 @@ public class StreamTaskStateInitializerImpl implements StreamTaskStateInitialize
 
 			timeServiceManager.restoreStateForKeyGroup(
 				streamProvider.getStream(),
-				keyGroupIdx, environment.getUserClassLoader().asClassLoader());
+				keyGroupIdx, environment.getUserCodeClassLoader().asClassLoader());
 		}
 
 		return timeServiceManager;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -89,7 +89,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 			ProcessingTimeService processingTimeService,
 			@Nullable KeyedStateStore keyedStateStore) {
 		super(checkNotNull(env).getTaskInfo(),
-				env.getUserClassLoader(),
+				env.getUserClassLoader().asClassLoader(),
 				env.getExecutionConfig(),
 				accumulators,
 				env.getDistributedCacheEntries(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -89,7 +89,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 			ProcessingTimeService processingTimeService,
 			@Nullable KeyedStateStore keyedStateStore) {
 		super(checkNotNull(env).getTaskInfo(),
-				env.getUserClassLoader(),
+				env.getUserCodeClassLoader(),
 				env.getExecutionConfig(),
 				accumulators,
 				env.getDistributedCacheEntries(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/StreamingRuntimeContext.java
@@ -89,7 +89,7 @@ public class StreamingRuntimeContext extends AbstractRuntimeUDFContext {
 			ProcessingTimeService processingTimeService,
 			@Nullable KeyedStateStore keyedStateStore) {
 		super(checkNotNull(env).getTaskInfo(),
-				env.getUserClassLoader().asClassLoader(),
+				env.getUserClassLoader(),
 				env.getExecutionConfig(),
 				accumulators,
 				env.getDistributedCacheEntries(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -117,7 +117,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
 
 		this.operatorEventDispatcher = new OperatorEventDispatcherImpl(
-				containingTask.getEnvironment().getUserClassLoader(),
+				containingTask.getEnvironment().getUserClassLoader().asClassLoader(),
 				containingTask.getEnvironment().getOperatorCoordinatorEventGateway());
 
 		final ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
@@ -501,10 +501,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		if (edge.getOutputTag() != null) {
 			// side output
 			outSerializer = upStreamConfig.getTypeSerializerSideOut(
-					edge.getOutputTag(), taskEnvironment.getUserClassLoader());
+					edge.getOutputTag(), taskEnvironment.getUserClassLoader().asClassLoader());
 		} else {
 			// main output
-			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader());
+			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader().asClassLoader());
 		}
 
 		return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -117,7 +117,7 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 			RecordWriterDelegate<SerializationDelegate<StreamRecord<OUT>>> recordWriterDelegate) {
 
 		this.operatorEventDispatcher = new OperatorEventDispatcherImpl(
-				containingTask.getEnvironment().getUserClassLoader().asClassLoader(),
+				containingTask.getEnvironment().getUserCodeClassLoader().asClassLoader(),
 				containingTask.getEnvironment().getOperatorCoordinatorEventGateway());
 
 		final ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
@@ -501,10 +501,10 @@ public class OperatorChain<OUT, OP extends StreamOperator<OUT>> implements Strea
 		if (edge.getOutputTag() != null) {
 			// side output
 			outSerializer = upStreamConfig.getTypeSerializerSideOut(
-					edge.getOutputTag(), taskEnvironment.getUserClassLoader().asClassLoader());
+					edge.getOutputTag(), taskEnvironment.getUserCodeClassLoader().asClassLoader());
 		} else {
 			// main output
-			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserClassLoader().asClassLoader());
+			outSerializer = upStreamConfig.getTypeSerializerOut(taskEnvironment.getUserCodeClassLoader().asClassLoader());
 		}
 
 		return new RecordWriterOutput<>(recordWriter, outSerializer, sideOutputTag, this);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1034,8 +1034,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			StreamConfig configuration,
 			Environment environment) {
 		List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWriters = new ArrayList<>();
-		List<StreamEdge> outEdgesInOrder = configuration.getOutEdgesInOrder(environment.getUserClassLoader());
-		Map<Integer, StreamConfig> chainedConfigs = configuration.getTransitiveChainedTaskConfigsWithSelf(environment.getUserClassLoader());
+		List<StreamEdge> outEdgesInOrder = configuration.getOutEdgesInOrder(environment.getUserClassLoader().asClassLoader());
+		Map<Integer, StreamConfig> chainedConfigs = configuration.getTransitiveChainedTaskConfigsWithSelf(environment.getUserClassLoader().asClassLoader());
 
 		for (int i = 0; i < outEdgesInOrder.size(); i++) {
 			StreamEdge edge = outEdgesInOrder.get(i);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1034,8 +1034,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
 			StreamConfig configuration,
 			Environment environment) {
 		List<RecordWriter<SerializationDelegate<StreamRecord<OUT>>>> recordWriters = new ArrayList<>();
-		List<StreamEdge> outEdgesInOrder = configuration.getOutEdgesInOrder(environment.getUserClassLoader().asClassLoader());
-		Map<Integer, StreamConfig> chainedConfigs = configuration.getTransitiveChainedTaskConfigsWithSelf(environment.getUserClassLoader().asClassLoader());
+		List<StreamEdge> outEdgesInOrder = configuration.getOutEdgesInOrder(environment.getUserCodeClassLoader().asClassLoader());
+		Map<Integer, StreamConfig> chainedConfigs = configuration.getTransitiveChainedTaskConfigsWithSelf(environment.getUserCodeClassLoader().asClassLoader());
 
 		for (int i = 0; i < outEdgesInOrder.size(); i++) {
 			StreamEdge edge = outEdgesInOrder.get(i);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -31,6 +31,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
+import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -108,6 +110,8 @@ public class StreamMockEnvironment implements Environment {
 	private final TaskStateManager taskStateManager;
 
 	private final GlobalAggregateManager aggregateManager;
+
+	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
 
 	@Nullable
 	private Consumer<Throwable> externalExceptionHandler;
@@ -250,8 +254,8 @@ public class StreamMockEnvironment implements Environment {
 	}
 
 	@Override
-	public ClassLoader getUserClassLoader() {
-		return getClass().getClassLoader();
+	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+		return userCodeClassLoader;
 	}
 
 	@Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -254,7 +254,7 @@ public class StreamMockEnvironment implements Environment {
 	}
 
 	@Override
-	public UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserCodeClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -31,8 +31,6 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointMetrics;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.execution.Environment;
-import org.apache.flink.runtime.execution.librarycache.LibraryCacheManager;
-import org.apache.flink.runtime.execution.librarycache.TestingUserCodeClassLoader;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
@@ -58,6 +56,8 @@ import org.apache.flink.runtime.taskmanager.NoOpTaskOperatorEventGateway;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.TestingUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
 
 import javax.annotation.Nullable;
 
@@ -111,7 +111,7 @@ public class StreamMockEnvironment implements Environment {
 
 	private final GlobalAggregateManager aggregateManager;
 
-	private final LibraryCacheManager.UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
+	private final UserCodeClassLoader userCodeClassLoader = TestingUserCodeClassLoader.newBuilder().build();
 
 	@Nullable
 	private Consumer<Throwable> externalExceptionHandler;
@@ -254,7 +254,7 @@ public class StreamMockEnvironment implements Environment {
 	}
 
 	@Override
-	public LibraryCacheManager.UserCodeClassLoader getUserClassLoader() {
+	public UserCodeClassLoader getUserClassLoader() {
 		return userCodeClassLoader;
 	}
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -274,7 +274,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			@Nonnull Collection<OperatorStateHandle> stateHandles,
 			CloseableRegistry cancelStreamRegistry) throws Exception {
 			return new DefaultOperatorStateBackendBuilder(
-				env.getUserClassLoader(),
+				env.getUserClassLoader().asClassLoader(),
 				env.getExecutionConfig(),
 				true,
 				stateHandles,
@@ -324,7 +324,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			@Nonnull Collection<OperatorStateHandle> stateHandles,
 			CloseableRegistry cancelStreamRegistry) throws Exception {
 			return new DefaultOperatorStateBackendBuilder(
-				env.getUserClassLoader(),
+				env.getUserClassLoader().asClassLoader(),
 				env.getExecutionConfig(),
 				true,
 				stateHandles,

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TaskCheckpointingBehaviourTest.java
@@ -274,7 +274,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			@Nonnull Collection<OperatorStateHandle> stateHandles,
 			CloseableRegistry cancelStreamRegistry) throws Exception {
 			return new DefaultOperatorStateBackendBuilder(
-				env.getUserClassLoader().asClassLoader(),
+				env.getUserCodeClassLoader().asClassLoader(),
 				env.getExecutionConfig(),
 				true,
 				stateHandles,
@@ -324,7 +324,7 @@ public class TaskCheckpointingBehaviourTest extends TestLogger {
 			@Nonnull Collection<OperatorStateHandle> stateHandles,
 			CloseableRegistry cancelStreamRegistry) throws Exception {
 			return new DefaultOperatorStateBackendBuilder(
-				env.getUserClassLoader().asClassLoader(),
+				env.getUserCodeClassLoader().asClassLoader(),
 				env.getExecutionConfig(),
 				true,
 				stateHandles,


### PR DESCRIPTION
cc @StephanEwen would this help for the `FlinkKinesisConsumer` to release its classes? It is basically what you mentioned in our sync.

## What is the purpose of the change

TBF

## Brief change log

TBF

## Verifying this change

TBF

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
