### PR TITLE
[FLINK-17564][checkpointing] Fix buffer disorder issue of RemoteInputChannel for unaligned checkpoint

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -146,7 +146,12 @@ public interface ChannelStateWriter extends Closeable, CheckpointListener {
 	 */
 	ChannelStateWriteResult getWriteResult(long checkpointId);
 
-	ChannelStateWriter NO_OP = new ChannelStateWriter() {
+	ChannelStateWriter NO_OP = new NoOpChannelStateWriter();
+
+	/**
+	 * No-op implementation of {@link ChannelStateWriter}.
+	 */
+	class NoOpChannelStateWriter implements ChannelStateWriter {
 		@Override
 		public void start(long checkpointId, CheckpointOptions checkpointOptions) {
 		}
@@ -185,5 +190,5 @@ public interface ChannelStateWriter extends Closeable, CheckpointListener {
 		@Override
 		public void notifyCheckpointComplete(long checkpointId) {
 		}
-	};
+	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.event.TaskEvent;
@@ -33,8 +34,6 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -152,8 +151,7 @@ public abstract class InputChannel {
 		inputGate.notifyChannelNonEmpty(this);
 	}
 
-	public List<Buffer> requestInflightBuffers(long checkpointId) throws IOException {
-		return Collections.emptyList();
+	public void spillInflightBuffers(long checkpointId, ChannelStateWriter channelStateWriter) throws IOException {
 	}
 
 	// ------------------------------------------------------------------------

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/CheckpointedInputGate.java
@@ -19,11 +19,11 @@ package org.apache.flink.streaming.runtime.io;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.io.PullingAsyncDataInput;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
-import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.partition.consumer.BufferOrEvent;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputGate;
@@ -34,8 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -137,12 +135,13 @@ public class CheckpointedInputGate implements PullingAsyncDataInput<BufferOrEven
 		}
 	}
 
-	public List<Buffer> requestInflightBuffers(long checkpointId, int channelIndex) throws IOException {
+	public void spillInflightBuffers(
+			long checkpointId,
+			int channelIndex,
+			ChannelStateWriter channelStateWriter) throws IOException {
 		if (((CheckpointBarrierUnaligner) barrierHandler).hasInflightData(checkpointId, channelIndex)) {
-			return inputGate.getChannel(channelIndex).requestInflightBuffers(checkpointId);
+			inputGate.getChannel(channelIndex).spillInflightBuffers(checkpointId, channelStateWriter);
 		}
-
-		return Collections.emptyList();
 	}
 
 	public CompletableFuture<Void> getAllBarriersReceivedFuture(long checkpointId) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -211,11 +211,7 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 					ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
 					buffer));
 
-			channelStateWriter.addInputData(
-				checkpointId,
-				channel.getChannelInfo(),
-				ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
-				checkpointedInputGate.requestInflightBuffers(checkpointId, channelIndex).toArray(new Buffer[0]));
+			checkpointedInputGate.spillInflightBuffers(checkpointId, channelIndex, channelStateWriter);
 		}
 		return checkpointedInputGate.getAllBarriersReceivedFuture(checkpointId);
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/CheckpointBarrierUnalignerTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter.NO_OP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -612,7 +613,7 @@ public class CheckpointBarrierUnalignerTest {
 			nextExpectedCheckpointId = checkpointMetaData.getCheckpointId() + 1;
 
 			for (int index = 0; index < inputGate.getNumberOfInputChannels(); index++) {
-				inputGate.getChannel(index).requestInflightBuffers(checkpointMetaData.getCheckpointId());
+				inputGate.getChannel(index).spillInflightBuffers(checkpointMetaData.getCheckpointId(), NO_OP);
 			}
 		}
 


### PR DESCRIPTION
## What is the purpose of the change

For unaligned checkpoint, when checkpointing the inflight data of incoming channel, both task thread and Netty thread may add data to the channel state writer. More specifically, the task thread will first request inflight buffers from the input channel and add the buffers to the channel state writer, and then the Netty thread will add the following up buffers (if any) to the channel state writer. The buffer adding of task thread and Netty thread is not synchronized so the Netty thread may add buffers before the task thread which leads to disorder of the data and corruption of the data stream.
This PR tries to fix the problem.


## Brief change log

  - Make requesting and adding of  inflight buffer of task thread happen in synchronized block to avoid race condition.


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
