### PR TITLE
[FLINK-17017] Implement Bulk Slot Allocation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/SlotInfo.java
@@ -55,4 +55,11 @@ public interface SlotInfo {
 	 * @return the resource profile of the slot.
 	 */
 	ResourceProfile getResourceProfile();
+
+	/**
+	 * Returns whether the slot will be occupied indefinitely.
+	 *
+	 * @return true if the slot will be occupied indefinitely, otherwise false.
+	 */
+	boolean willBeOccupiedIndefinitely();
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/AllocatedSlot.java
@@ -108,6 +108,11 @@ class AllocatedSlot implements PhysicalSlot {
 	}
 
 	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return isUsed() && payloadReference.get().willOccupySlotIndefinitely();
+	}
+
+	@Override
 	public TaskManagerLocation getTaskManagerLocation() {
 		return taskManagerLocation;
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LogicalSlotRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/LogicalSlotRequest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+/**
+ * Represents a request for a logical slot.
+ */
+class LogicalSlotRequest {
+
+	private final SlotRequestId slotRequestId;
+
+	private final ScheduledUnit scheduledUnit;
+
+	private final SlotProfile slotProfile;
+
+	private final boolean slotWillBeOccupiedIndefinitely;
+
+	LogicalSlotRequest(
+			final SlotRequestId slotRequestId,
+			final ScheduledUnit scheduledUnit,
+			final SlotProfile slotProfile,
+			final boolean slotWillBeOccupiedIndefinitely) {
+
+		this.slotRequestId = slotRequestId;
+		this.scheduledUnit = scheduledUnit;
+		this.slotProfile = slotProfile;
+		this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+	}
+
+	SlotRequestId getSlotRequestId() {
+		return slotRequestId;
+	}
+
+	ScheduledUnit getScheduledUnit() {
+		return scheduledUnit;
+	}
+
+	SlotProfile getSlotProfile() {
+		return slotProfile;
+	}
+
+	boolean getSlotWillBeOccupiedIndefinitely() {
+		return slotWillBeOccupiedIndefinitely;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlot.java
@@ -41,10 +41,17 @@ public interface PhysicalSlot extends SlotContext {
 	interface Payload {
 
 		/**
-		 * Releases the payload
+		 * Releases the payload.
 		 *
 		 * @param cause of the payload release
 		 */
 		void release(Throwable cause);
+
+		/**
+		 * Returns whether the payload will occupy a physical slot indefinitely.
+		 *
+		 * @return true if the payload will occupy a slot indefinitely, otherwise false
+		 */
+		boolean willOccupySlotIndefinitely();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/PhysicalSlotRequest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+
+/**
+ * Represents a request for a physical slot.
+ */
+public class PhysicalSlotRequest {
+
+	private final SlotRequestId slotRequestId;
+
+	private final ResourceProfile resourceProfile;
+
+	private final boolean slotWillBeOccupiedIndefinitely;
+
+	private final long bulkId;
+
+	private PhysicalSlotRequest(
+		final SlotRequestId slotRequestId,
+		final ResourceProfile resourceProfile,
+		final boolean slotWillBeOccupiedIndefinitely,
+		final long bulkId) {
+
+		this.slotRequestId = slotRequestId;
+		this.resourceProfile = resourceProfile;
+		this.slotWillBeOccupiedIndefinitely = slotWillBeOccupiedIndefinitely;
+		this.bulkId = bulkId;
+	}
+
+	SlotRequestId getSlotRequestId() {
+		return slotRequestId;
+	}
+
+	ResourceProfile getResourceProfile() {
+		return resourceProfile;
+	}
+
+	boolean getSlotWillBeOccupiedIndefinitely() {
+		return slotWillBeOccupiedIndefinitely;
+	}
+
+	long getBulkId() {
+		return bulkId;
+	}
+
+	static PhysicalSlotRequest createPhysicalSlotRequest(
+			final SlotRequestId slotRequestId,
+			final ResourceProfile resourceProfile,
+			final boolean slotWillBeOccupiedIndefinitely,
+			final long bulkId) {
+
+		return new PhysicalSlotRequest(slotRequestId, resourceProfile, slotWillBeOccupiedIndefinitely, bulkId);
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotInfoWithUtilization.java
@@ -59,6 +59,11 @@ public final class SlotInfoWithUtilization implements SlotInfo {
 		return slotInfoDelegate.getResourceProfile();
 	}
 
+	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return slotInfoDelegate.willBeOccupiedIndefinitely();
+	}
+
 	public static SlotInfoWithUtilization from(SlotInfo slotInfo, double taskExecutorUtilization) {
 		return new SlotInfoWithUtilization(slotInfo, taskExecutorUtilization);
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPool.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.jobmaster.slotpool;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.jobmanager.slots.TaskManagerGateway;
 import org.apache.flink.runtime.jobmaster.AllocatedSlotReport;
@@ -32,6 +31,7 @@ import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -152,30 +152,13 @@ public interface SlotPool extends AllocatedSlotActions, AutoCloseable {
 	 * already available slots from the pool, but instead will add a new slot to that pool that is immediately allocated
 	 * and returned.
 	 *
-	 * @param slotRequestId identifying the requested slot
-	 * @param resourceProfile resource profile that specifies the resource requirements for the requested slot
+	 * @param request for a physical slot
 	 * @param timeout timeout for the allocation procedure
 	 * @return a newly allocated slot that was previously not available.
 	 */
-	@Nonnull
 	CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
-		@Nonnull SlotRequestId slotRequestId,
-		@Nonnull ResourceProfile resourceProfile,
-		Time timeout);
-
-	/**
-	 * Requests the allocation of a new batch slot from the resource manager. Unlike the normal slot, a batch
-	 * slot will only time out if the slot pool does not contain a suitable slot. Moreover, it won't react to
-	 * failure signals from the resource manager.
-	 *
-	 * @param slotRequestId identifying the requested slot
-	 * @param resourceProfile resource profile that specifies the resource requirements for the requested batch slot
-	 * @return a future which is completed with newly allocated batch slot
-	 */
-	@Nonnull
-	CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(
-		@Nonnull SlotRequestId slotRequestId,
-		@Nonnull ResourceProfile resourceProfile);
+		PhysicalSlotRequest request,
+		@Nullable Time timeout);
 
 	/**
 	 * Create report about the allocated slots belonging to the specified task manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotProvider.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -89,6 +90,20 @@ public interface SlotProvider {
 			scheduledUnit,
 			slotProfile,
 			allocationTimeout);
+	}
+
+	/**
+	 * Allocates a bulk of slots.
+	 *
+	 * @param slotRequests a bulk of slot requests
+	 * @param allocationTimeout after which the allocation fails with a timeout exception
+	 * @return future of the allocation which will be completed normally only when all the requests succeed.
+	 *         The slot and its corresponding request are in the same order.
+	 */
+	default CompletableFuture<List<LogicalSlot>> allocateSlots(
+		List<LogicalSlotRequest> slotRequests,
+		Time allocationTimeout) {
+		throw new UnsupportedOperationException("Not properly implemented.");
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotRequestBulkManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/SlotRequestBulkManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.util.clock.Clock;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Manages slot request bulks.
+ */
+class SlotRequestBulkManager {
+
+	private final Clock clock;
+
+	private final HashMap<Long, Set<SlotPoolImpl.PendingRequest>> slotRequestBulks;
+
+	/** Timestamps indicate when bulks become unfulfillable. */
+	private final HashMap<Long, Long> bulkUnfulfillableTimestamps;
+
+	SlotRequestBulkManager(final Clock clock) {
+		this.clock = clock;
+		this.slotRequestBulks = new HashMap<>();
+		this.bulkUnfulfillableTimestamps = new HashMap<>();
+	}
+
+	HashMap<Long, Set<SlotPoolImpl.PendingRequest>> getSlotRequestBulks() {
+		return slotRequestBulks;
+	}
+
+	Set<SlotPoolImpl.PendingRequest> getSlotRequestBulk(final long bulkId) {
+		return slotRequestBulks.get(bulkId);
+	}
+
+	boolean hasBulk(final long bulkId) {
+		return slotRequestBulks.containsKey(bulkId);
+	}
+
+	void addRequestToBulk(final SlotPoolImpl.PendingRequest request, final long bulkId) {
+		final Set<SlotPoolImpl.PendingRequest> requestBulk = slotRequestBulks.computeIfAbsent(bulkId, k -> new HashSet<>());
+
+		if (requestBulk.isEmpty()) {
+			markBulkUnfulfillable(bulkId, clock.relativeTimeMillis());
+		}
+
+		requestBulk.add(request);
+		request.getAllocatedSlotFuture().whenComplete((ignored, failure) -> {
+			requestBulk.remove(request);
+			if (requestBulk.isEmpty()) {
+				slotRequestBulks.remove(bulkId);
+			}
+		});
+	}
+
+	void markBulkFulfillable(final long bulkId) {
+		bulkUnfulfillableTimestamps.put(bulkId, Long.MAX_VALUE);
+	}
+
+	void markBulkUnfulfillable(final long bulkId, final long currentTimestamp) {
+		if (isBulkFulfillable(bulkId)) {
+			bulkUnfulfillableTimestamps.put(bulkId, currentTimestamp);
+		}
+	}
+
+	private boolean isBulkFulfillable(final long bulkId) {
+		return getBulkUnfulfillableSince(bulkId) == Long.MAX_VALUE;
+	}
+
+	long getBulkUnfulfillableSince(final long bulkId) {
+		return bulkUnfulfillableTimestamps.getOrDefault(bulkId, Long.MAX_VALUE);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/instance/SimpleSlotContext.java
@@ -85,4 +85,9 @@ public class SimpleSlotContext implements SlotContext {
 	public ResourceProfile getResourceProfile() {
 		return resourceProfile;
 	}
+
+	@Override
+	public boolean willBeOccupiedIndefinitely() {
+		return true;
+	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobMasterTest.java
@@ -89,6 +89,7 @@ import org.apache.flink.runtime.jobmaster.factories.UnregisteredJobManagerJobMet
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultSchedulerFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.DefaultSlotPoolFactory;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlot;
+import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotRequest;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotInfoWithUtilization;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPool;
 import org.apache.flink.runtime.jobmaster.slotpool.SlotPoolFactory;
@@ -593,13 +594,7 @@ public class JobMasterTest extends TestLogger {
 
 		@Nonnull
 		@Override
-		public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile, Time timeout) {
-			return new CompletableFuture<>();
-		}
-
-		@Nonnull
-		@Override
-		public CompletableFuture<PhysicalSlot> requestNewAllocatedBatchSlot(@Nonnull SlotRequestId slotRequestId, @Nonnull ResourceProfile resourceProfile) {
+		public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(PhysicalSlotRequest request, Time timeout) {
 			return new CompletableFuture<>();
 		}
 
@@ -1074,7 +1069,6 @@ public class JobMasterTest extends TestLogger {
 		configuration.setInteger(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, 1);
 		configuration.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofSeconds(0));
 		configuration.setString(JobManagerOptions.EXECUTION_FAILOVER_STRATEGY, "full");
-
 
 		final Function<List<List<InputSplit>>, Collection<InputSplit>> expectAllRemainingInputSplits = this::flattenCollection;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotAllocationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/BulkSlotAllocationTest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.jobmanager.scheduler.DummyScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.util.clock.ManualClock;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests whether bulk slot allocation works correctly.
+ */
+public class BulkSlotAllocationTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.milliseconds(1L);
+
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	private TestingSlotPoolImpl slotPool;
+
+	private Scheduler scheduler;
+
+	private ManualClock clock;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		clock = new ManualClock();
+
+		slotPool = new SlotPoolBuilder(mainThreadExecutor).setClock(clock).build();
+
+		scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
+		scheduler.start(mainThreadExecutor);
+	}
+
+	@After
+	public void teardown() {
+		CompletableFuture.runAsync(() -> slotPool.close(), mainThreadExecutor).join();
+	}
+
+	@Test
+	public void testFulfilledBulkSlotAllocation() {
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		assertThat(slotFutures.isDone(), is(false));
+
+		addSlotToSlotPool();
+
+		assertThat(slotFutures.isDone(), is(true));
+		assertThat(slotFutures.isCompletedExceptionally(), is(false));
+	}
+
+	@Test
+	public void testFulfillableBulkSlotAllocation() {
+		final LogicalSlot occupyingSlot = addTemporarilyOccupiedSlotToSlotPool();
+
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		triggerSlotRequestTimeoutCheck();
+
+		assertThat(slotFutures.isDone(), is(false));
+
+		releaseSlot(occupyingSlot);
+
+		// requests become fulfilled once the occupied slot has its payload released
+		assertThat(slotFutures.isDone(), is(true));
+	}
+
+	@Test
+	public void testUnfulfillableBulkSlotAllocationDueToInsufficientSlots() {
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		triggerSlotRequestTimeoutCheck();
+
+		assertThat(slotFutures.isCompletedExceptionally(), is(true));
+
+		try {
+			slotFutures.get();
+			fail("Expected that the slot futures time out.");
+		} catch (Exception e) {
+			final Throwable cause = ExceptionUtils.stripExecutionException(e);
+			assertThat(cause, instanceOf(FlinkException.class));
+			assertThat(cause.getMessage(), containsString("Bulk slot allocation failed."));
+		}
+	}
+
+	@Test
+	public void testUnfulfillableBulkSlotAllocationDueToOccupiedSlots() {
+		addIndefinitelyOccupiedSlotToSlotPool();
+
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		triggerSlotRequestTimeoutCheck();
+
+		assertThat(slotFutures.isCompletedExceptionally(), is(true));
+
+		try {
+			slotFutures.get();
+			fail("Expected that the slot futures time out.");
+		} catch (Exception e) {
+			final Throwable cause = ExceptionUtils.stripExecutionException(e);
+			assertThat(cause, instanceOf(FlinkException.class));
+			assertThat(cause.getMessage(), containsString("Bulk slot allocation failed."));
+		}
+	}
+
+	@Test
+	public void testFailedBulkSlotAllocationReleasesAllocatedSlot() {
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		assertThat(slotPool.getAllocatedSlots().listSlotInfo(), hasSize(1));
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		triggerSlotRequestTimeoutCheck();
+
+		assertThat(slotPool.getAllocatedSlots().listSlotInfo(), hasSize(0));
+	}
+
+	@Test
+	public void testFailedBulkSlotAllocationClearsPendingRequests() {
+		final List<LogicalSlotRequest> requests = Arrays.asList(
+			createLogicalSlotRequest(),
+			createLogicalSlotRequest());
+		allocateSlots(requests);
+
+		addSlotToSlotPool();
+
+		assertThat(slotPool.getPendingRequests().values(), hasSize(1));
+
+		clock.advanceTime(TIMEOUT.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
+		triggerSlotRequestTimeoutCheck();
+
+		assertThat(slotPool.getPendingRequests().values(), hasSize(0));
+	}
+
+	private LogicalSlot addTemporarilyOccupiedSlotToSlotPool() {
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(Arrays.asList(createLogicalSlotRequest(false)));
+		addSlotToSlotPool();
+
+		return slotFutures.getNow(null).get(0);
+	}
+
+	private LogicalSlot addIndefinitelyOccupiedSlotToSlotPool() {
+		final CompletableFuture<List<LogicalSlot>> slotFutures = allocateSlots(Arrays.asList(createLogicalSlotRequest()));
+		addSlotToSlotPool();
+
+		return slotFutures.getNow(null).get(0);
+	}
+
+	private void addSlotToSlotPool() {
+		SlotPoolUtils.offerSlots(slotPool, mainThreadExecutor, Collections.singletonList(ResourceProfile.ANY));
+	}
+
+	private CompletableFuture<List<LogicalSlot>> allocateSlots(final List<LogicalSlotRequest> requests) {
+		return CompletableFuture
+			.supplyAsync(
+				() -> scheduler.allocateSlots(
+					requests,
+					TIMEOUT),
+				mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+
+	private static void releaseSlot(final LogicalSlot slot) {
+		CompletableFuture.runAsync(
+			() -> slot.releaseSlot(new Exception("Force releasing slot")),
+			mainThreadExecutor).join();
+	}
+
+	private static LogicalSlotRequest createLogicalSlotRequest() {
+		return createLogicalSlotRequest(true);
+	}
+
+	private static LogicalSlotRequest createLogicalSlotRequest(final boolean slotWillBeOccupiedIndefinitely) {
+		return new LogicalSlotRequest(
+			new SlotRequestId(),
+			new DummyScheduledUnit(),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
+			slotWillBeOccupiedIndefinitely);
+	}
+
+	private void triggerSlotRequestTimeoutCheck() {
+		slotPool.triggerAndWaitForPendingRequestsTimeoutCheck(TIMEOUT, mainThreadExecutor);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotOccupationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotOccupationTest.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotProfile;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
+import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
+import org.apache.flink.runtime.instance.SlotSharingGroupId;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobmanager.scheduler.DummyScheduledUnit;
+import org.apache.flink.runtime.jobmanager.scheduler.ScheduledUnit;
+import org.apache.flink.runtime.jobmaster.LogicalSlot;
+import org.apache.flink.runtime.jobmaster.SlotInfo;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.util.TestLogger;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Iterables;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests whether the slot occupation works correctly.
+ */
+public class SlotOccupationTest extends TestLogger {
+
+	private static final Time TIMEOUT = Time.milliseconds(1L);
+
+	private static ScheduledExecutorService singleThreadScheduledExecutorService;
+
+	private static ComponentMainThreadExecutor mainThreadExecutor;
+
+	private SlotPoolImpl slotPool;
+
+	private Scheduler scheduler;
+
+	@BeforeClass
+	public static void setupClass() {
+		singleThreadScheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+		mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(singleThreadScheduledExecutorService);
+	}
+
+	@AfterClass
+	public static void teardownClass() {
+		if (singleThreadScheduledExecutorService != null) {
+			singleThreadScheduledExecutorService.shutdownNow();
+		}
+	}
+
+	@Before
+	public void setup() throws Exception {
+		slotPool = new SlotPoolBuilder(mainThreadExecutor).build();
+		SlotPoolUtils.offerSlots(slotPool, mainThreadExecutor, Collections.singletonList(ResourceProfile.ANY));
+
+		scheduler = new SchedulerImpl(LocationPreferenceSlotSelectionStrategy.createDefault(), slotPool);
+		scheduler.start(mainThreadExecutor);
+	}
+
+	@After
+	public void teardown() {
+		CompletableFuture.runAsync(() -> slotPool.close(), mainThreadExecutor).join();
+	}
+
+	@Test
+	public void testSingleStreamingTaskSlotRequestWillOccupySlotIndefinitely() throws Exception {
+		final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(
+			getSingleStreamingTaskSlotAllocationSupplier(scheduler),
+			mainThreadExecutor);
+		slotFuture.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+		assertTrue(slot.willBeOccupiedIndefinitely());
+	}
+
+	@Test
+	public void testSingleBatchTaskSlotRequestWillNotOccupySlotIndefinitely() throws Exception {
+		final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(
+			getSingleBatchTaskSlotAllocationSupplier(scheduler),
+			mainThreadExecutor);
+		slotFuture.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+		assertFalse(slot.willBeOccupiedIndefinitely());
+	}
+
+	@Test
+	public void testSharedStreamingTaskSlotRequestWillOccupySlotIndefinitely() throws Exception {
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+		final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(
+			getSharedStreamingTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		slotFuture.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+		assertTrue(slot.willBeOccupiedIndefinitely());
+	}
+
+	@Test
+	public void testSharedBatchTaskSlotRequestWillNotOccupySlotIndefinitely() throws Exception {
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+		final CompletableFuture<LogicalSlot> slotFuture = allocateSlot(
+			getSharedBatchTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		slotFuture.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+		assertFalse(slot.willBeOccupiedIndefinitely());
+	}
+
+	@Test
+	public void testSharedMixedTaskSlotRequestWillOccupySlotIndefinitely() throws Exception {
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+
+		final CompletableFuture<LogicalSlot> slotFuture1 = allocateSlot(
+			getSharedStreamingTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		slotFuture1.get();
+
+		final CompletableFuture<LogicalSlot> slotFuture2 = allocateSlot(
+			getSharedBatchTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		slotFuture2.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+		assertTrue(slot.willBeOccupiedIndefinitely());
+	}
+
+	@Test
+	public void testSharedSlotNotOccupiedOnAllHostedStreamingTaskSlotReleased() throws Exception {
+		final SlotSharingGroupId slotSharingGroupId = new SlotSharingGroupId();
+
+		final CompletableFuture<LogicalSlot> slotFuture1 = allocateSlot(
+			getSharedStreamingTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		final LogicalSlot streamingTaskSlot1 = slotFuture1.get();
+
+		final CompletableFuture<LogicalSlot> slotFuture2 = allocateSlot(
+			getSharedStreamingTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		final LogicalSlot streamingTaskSlot2 = slotFuture2.get();
+
+		final CompletableFuture<LogicalSlot> slotFuture3 = allocateSlot(
+			getSharedBatchTaskSlotAllocationSupplier(scheduler, slotSharingGroupId),
+			mainThreadExecutor);
+		slotFuture3.get();
+
+		final SlotInfo slot = Iterables.getOnlyElement(slotPool.getAllocatedSlots().listSlotInfo());
+
+		CompletableFuture.runAsync(
+			() -> streamingTaskSlot1.releaseSlot(new Exception("Force releasing slot")),
+			mainThreadExecutor).join();
+		assertTrue(slot.willBeOccupiedIndefinitely());
+
+		CompletableFuture.runAsync(
+			() -> streamingTaskSlot2.releaseSlot(new Exception("Force releasing slot")),
+			mainThreadExecutor).join();
+		assertFalse(slot.willBeOccupiedIndefinitely());
+	}
+
+	private static Supplier<CompletableFuture<LogicalSlot>> getSingleStreamingTaskSlotAllocationSupplier(
+			final Scheduler scheduler) {
+		return () -> scheduler.allocateSlot(
+			new SlotRequestId(),
+			new DummyScheduledUnit(),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
+			TIMEOUT);
+	}
+
+	private static Supplier<CompletableFuture<LogicalSlot>> getSingleBatchTaskSlotAllocationSupplier(
+			final Scheduler scheduler) {
+		return () -> scheduler.allocateBatchSlot(
+			new SlotRequestId(),
+			new DummyScheduledUnit(),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN));
+	}
+
+	private static Supplier<CompletableFuture<LogicalSlot>> getSharedStreamingTaskSlotAllocationSupplier(
+			final Scheduler scheduler,
+			final SlotSharingGroupId slotSharingGroupId) {
+		return () -> scheduler.allocateSlot(
+			new SlotRequestId(),
+			new ScheduledUnit(new JobVertexID(), slotSharingGroupId, null),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN),
+			TIMEOUT);
+	}
+
+	private static Supplier<CompletableFuture<LogicalSlot>> getSharedBatchTaskSlotAllocationSupplier(
+			final Scheduler scheduler,
+			final SlotSharingGroupId slotSharingGroupId) {
+		return () -> scheduler.allocateBatchSlot(
+			new SlotRequestId(),
+			new ScheduledUnit(new JobVertexID(), slotSharingGroupId, null),
+			SlotProfile.noLocality(ResourceProfile.UNKNOWN));
+	}
+
+	private static CompletableFuture<LogicalSlot> allocateSlot(
+			final Supplier<CompletableFuture<LogicalSlot>> slotAllocationSupplier,
+			final ComponentMainThreadExecutor mainThreadExecutor) {
+		return CompletableFuture
+			.supplyAsync(slotAllocationSupplier, mainThreadExecutor)
+			.thenCompose(Function.identity());
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolBatchSlotRequestTest.java
@@ -268,12 +268,12 @@ public class SlotPoolBatchSlotRequestTest extends TestLogger {
 
 	private void advanceTimeAndTriggerCheckBatchSlotTimeout(TestingSlotPoolImpl slotPool, ManualClock clock, Time batchSlotTimeout) {
 		// trigger batch slot timeout check which marks unfulfillable slots
-		slotPool.triggerCheckBatchSlotTimeout();
+		slotPool.triggerCheckPendingRequestsTimeout(batchSlotTimeout);
 
 		// advance clock behind timeout
 		clock.advanceTime(batchSlotTimeout.toMilliseconds() + 1L, TimeUnit.MILLISECONDS);
 
 		// timeout all as unfulfillable marked slots
-		slotPool.triggerCheckBatchSlotTimeout();
+		slotPool.triggerCheckPendingRequestsTimeout(batchSlotTimeout);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolPendingRequestFailureTest.java
@@ -62,6 +62,8 @@ public class SlotPoolPendingRequestFailureTest extends TestLogger {
 	private static final ComponentMainThreadExecutor mainThreadExecutor = ComponentMainThreadExecutorServiceAdapter.forMainThread();
 	public static final Time TIMEOUT = Time.seconds(10L);
 
+	private static long requestBulkCounter = 0;
+
 	private TestingResourceManagerGateway resourceManagerGateway;
 
 	@Before
@@ -167,7 +169,9 @@ public class SlotPoolPendingRequestFailureTest extends TestLogger {
 	}
 
 	private CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(SlotPoolImpl slotPool, SlotRequestId slotRequestId, Time timeout) {
-		return slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, timeout);
+		return slotPool.requestNewAllocatedSlot(
+			PhysicalSlotRequest.createPhysicalSlotRequest(slotRequestId, ResourceProfile.UNKNOWN, true, requestBulkCounter++),
+			timeout);
 	}
 
 	private SlotPoolImpl setUpSlotPool() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolRequestCompletionTest.java
@@ -85,7 +85,9 @@ public class SlotPoolRequestCompletionTest extends TestLogger {
 
 			final List<CompletableFuture<PhysicalSlot>> slotRequests = slotRequestIds
 				.stream()
-				.map(slotRequestId -> slotPool.requestNewAllocatedSlot(slotRequestId, ResourceProfile.UNKNOWN, TIMEOUT))
+				.map(slotRequestId -> slotPool.requestNewAllocatedSlot(
+					PhysicalSlotRequest.createPhysicalSlotRequest(slotRequestId, ResourceProfile.UNKNOWN, true, 0),
+					TIMEOUT))
 				.collect(Collectors.toList());
 
 			actionAfterSlotRequest.accept(slotPool);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotPoolUtils.java
@@ -45,6 +45,8 @@ import static org.hamcrest.Matchers.is;
  */
 public class SlotPoolUtils {
 
+	private static long requestBulkCounter = 0;
+
 	private SlotPoolUtils() {
 		throw new UnsupportedOperationException("Cannot instantiate this class.");
 	}
@@ -54,7 +56,10 @@ public class SlotPoolUtils {
 		ComponentMainThreadExecutor mainThreadExecutor,
 		ResourceProfile resourceProfile) {
 		return CompletableFuture
-			.supplyAsync(() -> slotPool.requestNewAllocatedBatchSlot(new SlotRequestId(), resourceProfile), mainThreadExecutor)
+			.supplyAsync(() -> slotPool.requestNewAllocatedSlot(
+					PhysicalSlotRequest.createPhysicalSlotRequest(new SlotRequestId(), resourceProfile, false, requestBulkCounter++),
+					null),
+				mainThreadExecutor)
 			.thenCompose(Function.identity());
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotRequestBulkManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/SlotRequestBulkManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobmaster.slotpool;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.jobmaster.SlotRequestId;
+import org.apache.flink.runtime.util.clock.ManualClock;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * Tests for {@link SlotRequestBulkManager}.
+ */
+public class SlotRequestBulkManagerTest extends TestLogger {
+
+	private ManualClock clock = new ManualClock();
+
+	private SlotRequestBulkManager bulkManager;
+
+	@Before
+	public void setup() throws Exception {
+		bulkManager = new SlotRequestBulkManager(clock);
+	}
+
+	@Test
+	public void testAddRequestToBulk() {
+		final SlotPoolImpl.PendingRequest request = createPendingRequest();
+		final long bulkId = 123;
+		bulkManager.addRequestToBulk(request, bulkId);
+
+		assertThat(bulkManager.hasBulk(bulkId), is(true));
+		assertThat(bulkManager.getSlotRequestBulk(bulkId), contains(request));
+		assertThat(bulkManager.getBulkUnfulfillableSince(bulkId), is(clock.relativeTimeMillis()));
+	}
+
+	@Test
+	public void testRequestWillBeRemovedWhenCompleted() {
+		final SlotPoolImpl.PendingRequest request1 = createPendingRequest();
+		final SlotPoolImpl.PendingRequest request2 = createPendingRequest();
+		final long bulkId = 123;
+		bulkManager.addRequestToBulk(request1, bulkId);
+		bulkManager.addRequestToBulk(request2, bulkId);
+
+		assertThat(bulkManager.getSlotRequestBulk(bulkId), containsInAnyOrder(request1, request2));
+
+		request1.getAllocatedSlotFuture().completeExceptionally(new Exception("Forced failure"));
+
+		assertThat(bulkManager.getSlotRequestBulk(bulkId), containsInAnyOrder(request2));
+
+		request2.getAllocatedSlotFuture().completeExceptionally(new Exception("Forced failure"));
+
+		assertThat(bulkManager.getSlotRequestBulk(bulkId), is(nullValue()));
+	}
+
+	@Test
+	public void testUnfulfillableTimestampWillNotBeOverriddenByFollowingUnfulfillableTimestamp() {
+		final SlotPoolImpl.PendingRequest request = createPendingRequest();
+		final long bulkId = 123;
+		bulkManager.addRequestToBulk(request, bulkId);
+
+		final long unfulfillableSince = clock.relativeTimeMillis();
+
+		assertThat(bulkManager.getBulkUnfulfillableSince(bulkId), is(unfulfillableSince));
+
+		clock.advanceTime(456, TimeUnit.MILLISECONDS);
+		bulkManager.markBulkUnfulfillable(bulkId, clock.relativeTimeMillis());
+
+		assertThat(bulkManager.getBulkUnfulfillableSince(bulkId), is(unfulfillableSince));
+
+		bulkManager.markBulkFulfillable(bulkId);
+		bulkManager.markBulkUnfulfillable(bulkId, clock.relativeTimeMillis());
+
+		assertThat(bulkManager.getBulkUnfulfillableSince(bulkId), is(clock.relativeTimeMillis()));
+	}
+
+	private static SlotPoolImpl.PendingRequest createPendingRequest() {
+		return SlotPoolImpl.PendingRequest.createStreamingRequest(
+			new SlotRequestId(),
+			ResourceProfile.UNKNOWN);
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.util.clock.Clock;
 import org.apache.flink.runtime.util.clock.SystemClock;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -59,8 +61,11 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 		runAsync(this::checkIdleSlot);
 	}
 
-	void triggerCheckBatchSlotTimeout() {
-		runAsync(this::checkBatchSlotTimeout);
+	void triggerCheckPendingRequestsTimeout(final Time timeout) {
+		runAsync(() -> {
+			final Set<PendingRequest> pendingRequests = new HashSet<>(getPendingRequests().values());
+			pendingRequests.forEach(request -> checkPendingRequestTimeout(request, timeout));
+		});
 	}
 
 	@Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/slotpool/TestingSlotPoolImpl.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.akka.AkkaUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
-import org.apache.flink.runtime.jobmaster.SlotRequestId;
 import org.apache.flink.runtime.util.clock.Clock;
 import org.apache.flink.runtime.util.clock.SystemClock;
 
@@ -70,13 +69,12 @@ public class TestingSlotPoolImpl extends SlotPoolImpl {
 
 	@Override
 	public CompletableFuture<PhysicalSlot> requestNewAllocatedSlot(
-			final SlotRequestId slotRequestId,
-			final ResourceProfile resourceProfile,
+			final PhysicalSlotRequest request,
 			final Time timeout) {
 
-		this.lastRequestedSlotResourceProfile = resourceProfile;
+		this.lastRequestedSlotResourceProfile = request.getResourceProfile();
 
-		return super.requestNewAllocatedSlot(slotRequestId, resourceProfile, timeout);
+		return super.requestNewAllocatedSlot(request, timeout);
 	}
 
 	public ResourceProfile getLastRequestedSlotResourceProfile() {


### PR DESCRIPTION
## What is the purpose of the change

SlotProvider should support bulk slot allocation so that we can check to see if the resource requirements of a slot request bulk can be fulfilled at the same time.
More details see [FLIP-119#Bulk Slot Allocation](https://cwiki.apache.org/confluence/display/FLINK/FLIP-119+Pipelined+Region+Scheduling#FLIP-119PipelinedRegionScheduling-BulkSlotAllocation)

This PR is based on #12011.

## Brief change log

  - *SchedulerImpl implements bulk slot allocation interface*
  - *SchedulerImpl exposes slot request bulk ID to SlotPool*
  - *SlotPoolImpl checks request timeout in bulk level*

## Verifying this change

  - *Added unit tests SlotRequestBulkManagerTest*
  - *Added unit tests BulkSlotAllocationTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
