### PR TITLE
[FLINK-17570] Fix recursive call in BatchTableEnvironment#fromValues

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -1091,14 +1091,14 @@ abstract class TableEnvImpl(
     val exprs = values.asScala
       .map(ApiExpressionUtils.objectToExpression)
       .toArray
-    fromValues(exprs)
+    fromValues(exprs: _*)
   }
 
   override def fromValues(rowType: DataType, values: JIterable[_]): Table = {
     val exprs = values.asScala
       .map(ApiExpressionUtils.objectToExpression)
       .toArray
-    fromValues(rowType, exprs)
+    fromValues(rowType, exprs: _*)
   }
 
   /** Returns the [[FlinkRelBuilder]] of this TableEnvironment. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/runtime/batch/table/JavaTableEnvironmentITCase.java
@@ -470,6 +470,19 @@ public class JavaTableEnvironmentITCase extends TableProgramsCollectionTestBase 
 		compareResultAsText(results, expected);
 	}
 
+	@Test
+	public void testFromValues() throws Exception {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		BatchTableEnvironment tableEnv = BatchTableEnvironment.create(env, config());
+
+		Table table = tableEnv.fromValues(1L, 2L, 3L)
+			.select($("*"));
+
+		List<Row> results = tableEnv.toDataSet(table, Row.class).collect();
+		String expected = "1\n2\n3\n";
+		compareResultAsText(results, expected);
+	}
+
 	@Test(expected = ValidationException.class)
 	public void testGenericRow() throws Exception {
 		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();


### PR DESCRIPTION
## What is the purpose of the change

Fix recursive call in BatchTableEnvironment#fromValues

## Verifying this change

Added test `org.apache.flink.table.runtime.batch.table.JavaTableEnvironmentITCase#testFromValues`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
