### PR TITLE
[FLINK-17015]Fix NPE from NullAwareMapIterator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/HeapMapState.java
@@ -28,6 +28,7 @@ import org.apache.flink.queryablestate.client.state.serialization.KvStateSeriali
 import org.apache.flink.runtime.state.internal.InternalMapState;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -158,7 +159,7 @@ class HeapMapState<K, N, UK, UV>
 	@Override
 	public Iterator<Map.Entry<UK, UV>> iterator() {
 		Map<UK, UV> userMap = stateTable.get(currentNamespace);
-		return userMap == null ? null : userMap.entrySet().iterator();
+		return userMap == null ? Collections.<UK, UV>emptyMap().entrySet().iterator() : userMap.entrySet().iterator();
 	}
 
 	@Override


### PR DESCRIPTION
## What is the purpose of the change

*`HeapMapState#iterator` could return a null iterator when using Heap statebackend, it should better return empty map for ` NullAwareMapIterator`.*


## Brief change log

  - *`HeapMapState#iterator` return empty map when stateTable doesn't contain current namespace table.*

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
