### PR TITLE
[FLINK-14807][runtime][client] Introduce communication through REST API between the clients and the operator coordinators

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -28,7 +28,7 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
-import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestGateway;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 
 import org.apache.commons.io.IOUtils;
@@ -45,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An implementation of the {@link JobClient} interface that uses a {@link ClusterClient} underneath..
  */
-public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, CoordinationRequester {
+public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, CoordinationRequestGateway {
 
 	private final ClusterClientProvider<ClusterID> clusterClientProvider;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -26,6 +26,10 @@ import org.apache.flink.client.program.ClusterClientProvider;
 import org.apache.flink.client.program.ProgramInvocationException;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 
 import org.apache.commons.io.IOUtils;
 
@@ -41,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /**
  * An implementation of the {@link JobClient} interface that uses a {@link ClusterClient} underneath..
  */
-public class ClusterClientJobClientAdapter<ClusterID> implements JobClient {
+public class ClusterClientJobClientAdapter<ClusterID> implements JobClient, CoordinationRequester {
 
 	private final ClusterClientProvider<ClusterID> clusterClientProvider;
 
@@ -115,6 +119,13 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient {
 					})));
 	}
 
+	@Override
+	public CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request) {
+		return bridgeClientRequest(
+			clusterClientProvider,
+			clusterClient -> clusterClient.sendCoordinationRequest(jobID, operatorId, request));
+	}
+
 	private static <T> CompletableFuture<T> bridgeClientRequest(
 			ClusterClientProvider<?> clusterClientProvider,
 			Function<ClusterClient<?>, CompletableFuture<T>> resultRetriever) {
@@ -132,5 +143,4 @@ public class ClusterClientJobClientAdapter<ClusterID> implements JobClient {
 		return resultFuture.whenCompleteAsync(
 				(jobResult, throwable) -> IOUtils.closeQuietly(clusterClient::close));
 	}
-
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -25,12 +25,19 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.accumulators.AccumulatorHelper;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutor;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -42,7 +49,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * uses directly the {@link DispatcherGateway}.
  */
 @Internal
-public class EmbeddedJobClient implements JobClient {
+public class EmbeddedJobClient implements JobClient, CoordinationRequester {
 
 	private final JobID jobId;
 
@@ -118,5 +125,16 @@ public class EmbeddedJobClient implements JobClient {
 						throw new CompletionException(new Exception("Job " + jobId + " failed", t));
 					}
 				});
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request) {
+		try {
+			SerializedValue<CoordinationRequest> serializedRequest = new SerializedValue<>(request);
+			return dispatcherGateway.deliverCoordinationRequestToCoordinator(
+				jobId, operatorId, serializedRequest, timeout);
+		} catch (IOException e) {
+			return FutureUtils.completedExceptionally(e);
+		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/application/EmbeddedJobClient.java
@@ -31,7 +31,7 @@ import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
-import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestGateway;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.util.SerializedValue;
 
@@ -49,7 +49,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * uses directly the {@link DispatcherGateway}.
  */
 @Internal
-public class EmbeddedJobClient implements JobClient, CoordinationRequester {
+public class EmbeddedJobClient implements JobClient, CoordinationRequestGateway {
 
 	private final JobID jobId;
 

--- a/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/ClusterClient.java
@@ -23,8 +23,11 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.util.FlinkException;
 
 import javax.annotation.Nullable;
@@ -162,4 +165,14 @@ public interface ClusterClient<T> extends AutoCloseable {
 	 * @return path future where the savepoint is located
 	 */
 	CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory);
+
+	/**
+	 * Sends out a request to a specified coordinator and return the response.
+	 *
+	 * @param jobId specifies the job which the coordinator belongs to
+	 * @param operatorId specifies which coordinator to receive the request
+	 * @param request the request to send
+	 * @return the response from the coordinator
+	 */
+	CompletableFuture<CoordinationResponse> sendCoordinationRequest(JobID jobId, OperatorID operatorId, CoordinationRequest request);
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
@@ -34,7 +34,7 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
-import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestGateway;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.util.MathUtils;
 import org.apache.flink.util.SerializedValue;
@@ -134,7 +134,7 @@ public final class PerJobMiniClusterFactory {
 	/**
 	 * A {@link JobClient} for a {@link PerJobMiniClusterFactory}.
 	 */
-	private static final class PerJobMiniClusterJobClient implements JobClient, CoordinationRequester {
+	private static final class PerJobMiniClusterJobClient implements JobClient, CoordinationRequestGateway {
 
 		private final JobID jobID;
 		private final MiniCluster miniCluster;

--- a/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/PerJobMiniClusterFactory.java
@@ -26,18 +26,25 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.MiniClusterConfiguration;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequester;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.util.MathUtils;
+import org.apache.flink.util.SerializedValue;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -127,7 +134,7 @@ public final class PerJobMiniClusterFactory {
 	/**
 	 * A {@link JobClient} for a {@link PerJobMiniClusterFactory}.
 	 */
-	private static final class PerJobMiniClusterJobClient implements JobClient {
+	private static final class PerJobMiniClusterJobClient implements JobClient, CoordinationRequester {
 
 		private final JobID jobID;
 		private final MiniCluster miniCluster;
@@ -181,6 +188,16 @@ public final class PerJobMiniClusterFactory {
 					throw new CompletionException("Failed to convert JobResult to JobExecutionResult.", e);
 				}
 			});
+		}
+
+		@Override
+		public CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request) {
+			try {
+				SerializedValue<CoordinationRequest> serializedRequest = new SerializedValue<>(request);
+				return miniCluster.deliverCoordinationRequestToCoordinator(jobID, operatorId, serializedRequest);
+			} catch (IOException e) {
+				return FutureUtils.completedExceptionally(e);
+			}
 		}
 	}
 }

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -443,7 +443,7 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 						.getSerializedCoordinationResponse()
 						.deserializeValue(getClass().getClassLoader());
 				} catch (IOException | ClassNotFoundException e) {
-					throw new RuntimeException("Failed to deserialize coordination response", e);
+					throw new CompletionException("Failed to deserialize coordination response", e);
 				}
 			});
 	}

--- a/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/rest/RestClusterClient.java
@@ -37,9 +37,12 @@ import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.highavailability.ClientHighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.rest.FileUpload;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationInfo;
@@ -67,6 +70,9 @@ import org.apache.flink.runtime.rest.messages.job.JobExecutionResultHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationHeaders;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationRequestBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalRequest;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusMessageParameters;
@@ -88,6 +94,7 @@ import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.CheckedSupplier;
 
 import org.apache.flink.shaded.netty4.io.netty.channel.ConnectTimeoutException;
@@ -409,6 +416,36 @@ public class RestClusterClient<T> implements ClusterClient<T> {
 			final JobID jobId,
 			final @Nullable String savepointDirectory) {
 		return triggerSavepoint(jobId, savepointDirectory, false);
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
+			JobID jobId,
+			OperatorID operatorId,
+			CoordinationRequest request) {
+		ClientCoordinationHeaders headers = ClientCoordinationHeaders.getInstance();
+		ClientCoordinationMessageParameters params = new ClientCoordinationMessageParameters();
+		params.jobPathParameter.resolve(jobId);
+		params.operatorPathParameter.resolve(operatorId);
+
+		SerializedValue<CoordinationRequest> serializedRequest;
+		try {
+			serializedRequest = new SerializedValue<>(request);
+		} catch (IOException e) {
+			return FutureUtils.completedExceptionally(e);
+		}
+
+		ClientCoordinationRequestBody requestBody = new ClientCoordinationRequestBody(serializedRequest);
+		return sendRequest(headers, params, requestBody).thenApply(
+			responseBody -> {
+				try {
+					return responseBody
+						.getSerializedCoordinationResponse()
+						.deserializeValue(getClass().getClassLoader());
+				} catch (IOException | ClassNotFoundException e) {
+					throw new RuntimeException("Failed to deserialize coordination response", e);
+				}
+			});
 	}
 
 	private CompletableFuture<String> triggerSavepoint(

--- a/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/TestingClusterClient.java
@@ -23,8 +23,11 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.util.function.TriFunction;
 
 import javax.annotation.Nonnull;
@@ -130,6 +133,14 @@ public class TestingClusterClient<T> implements ClusterClient<T> {
 	@Override
 	public CompletableFuture<String> triggerSavepoint(JobID jobId, @Nullable String savepointDirectory) {
 		return triggerSavepointFunction.apply(jobId, savepointDirectory);
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
+			JobID jobId,
+			OperatorID operatorId,
+			CoordinationRequest request) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/rest/RestClusterClientTest.java
@@ -39,10 +39,13 @@ import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.rest.FileUpload;
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.RestClient;
@@ -76,6 +79,10 @@ import org.apache.flink.runtime.rest.messages.job.JobExecutionResultResponseBody
 import org.apache.flink.runtime.rest.messages.job.JobSubmitHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitRequestBody;
 import org.apache.flink.runtime.rest.messages.job.JobSubmitResponseBody;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationHeaders;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationRequestBody;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationResponseBody;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalRequest;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalStatusMessageParameters;
@@ -698,6 +705,74 @@ public class RestClusterClientTest extends TestLogger {
 		@Override
 		public String getTargetRestEndpointURL() {
 			return "/foobar";
+		}
+	}
+
+	@Test
+	public void testSendCoordinationRequest() throws Exception {
+		final TestClientCoordinationHandler handler = new TestClientCoordinationHandler();
+
+		try (TestRestServerEndpoint restServerEndpoint = createRestServerEndpoint(handler)) {
+			RestClusterClient<?> restClusterClient = createRestClusterClient(restServerEndpoint.getServerAddress().getPort());
+
+			String payload = "testing payload";
+			TestCoordinationRequest<String> request  = new TestCoordinationRequest<>(payload);
+			try {
+				CompletableFuture<CoordinationResponse> future =
+					restClusterClient.sendCoordinationRequest(jobId, new OperatorID(), request);
+				TestCoordinationResponse response = (TestCoordinationResponse) future.get();
+
+				assertEquals(payload, response.payload);
+			} finally {
+				restClusterClient.close();
+			}
+		}
+	}
+
+	private class TestClientCoordinationHandler extends TestHandler<ClientCoordinationRequestBody, ClientCoordinationResponseBody, ClientCoordinationMessageParameters> {
+
+		private TestClientCoordinationHandler() {
+			super(ClientCoordinationHeaders.getInstance());
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		protected CompletableFuture<ClientCoordinationResponseBody> handleRequest(@Nonnull HandlerRequest<ClientCoordinationRequestBody, ClientCoordinationMessageParameters> request, @Nonnull DispatcherGateway gateway) throws RestHandlerException {
+			try {
+				TestCoordinationRequest req =
+					(TestCoordinationRequest) request
+						.getRequestBody()
+						.getSerializedCoordinationRequest()
+						.deserializeValue(getClass().getClassLoader());
+				TestCoordinationResponse resp = new TestCoordinationResponse(req.payload);
+				return CompletableFuture.completedFuture(
+					new ClientCoordinationResponseBody(
+						new SerializedValue<>(resp)));
+			} catch (Exception e) {
+				return FutureUtils.completedExceptionally(e);
+			}
+		}
+	}
+
+	private static class TestCoordinationRequest<T> implements CoordinationRequest {
+
+		private static final long serialVersionUID = 1L;
+
+		private final T payload;
+
+		private TestCoordinationRequest(T payload) {
+			this.payload = payload;
+		}
+	}
+
+	private static class TestCoordinationResponse<T> implements CoordinationResponse {
+
+		private static final long serialVersionUID = 1L;
+
+		private final T payload;
+
+		private TestCoordinationResponse(T payload) {
+			this.payload = payload;
 		}
 	}
 

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1430,6 +1430,39 @@
       "type" : "any"
     }
   }, {
+    "url" : "/jobs/:jobid/coordinators/:operatorid",
+    "method" : "POST",
+    "status-code" : "200 OK",
+    "file-upload" : false,
+    "path-parameters" : {
+      "pathParameters" : [ {
+        "key" : "jobid"
+      }, {
+        "key" : "operatorid"
+      } ]
+    },
+    "query-parameters" : {
+      "queryParameters" : [ ]
+    },
+    "request" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:coordination:ClientCoordinationRequestBody",
+      "properties" : {
+        "serializedCoordinationRequest" : {
+          "type" : "any"
+        }
+      }
+    },
+    "response" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:job:coordination:ClientCoordinationResponseBody",
+      "properties" : {
+        "serializedCoordinationResult" : {
+          "type" : "any"
+        }
+      }
+    }
+  }, {
     "url" : "/jobs/:jobid/exceptions",
     "method" : "GET",
     "status-code" : "200 OK",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.highavailability.RunningJobsRegistry;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmanager.JobGraphWriter;
 import org.apache.flink.runtime.jobmaster.JobManagerRunner;
 import org.apache.flink.runtime.jobmaster.JobManagerRunnerImpl;
@@ -55,6 +56,8 @@ import org.apache.flink.runtime.messages.webmonitor.JobsOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.JobManagerMetricGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceOverview;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
@@ -66,6 +69,7 @@ import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.BiConsumerWithException;
 import org.apache.flink.util.function.CheckedSupplier;
 import org.apache.flink.util.function.FunctionUtils;
@@ -623,6 +627,19 @@ public abstract class Dispatcher extends PermanentlyFencedRpcEndpoint<Dispatcher
 	public CompletableFuture<Acknowledge> shutDownCluster(final ApplicationStatus applicationStatus) {
 		shutDownFuture.complete(applicationStatus);
 		return CompletableFuture.completedFuture(Acknowledge.get());
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+			JobID jobId,
+			OperatorID operatorId,
+			SerializedValue<CoordinationRequest> serializedRequest,
+			Time timeout) {
+		final CompletableFuture<JobMasterGateway> jobMasterGatewayFuture = getJobMasterGatewayFuture(jobId);
+
+		return jobMasterGatewayFuture.thenCompose(
+			(JobMasterGateway jobMasterGateway) ->
+				jobMasterGateway.deliverCoordinationRequestToCoordinator(operatorId, serializedRequest, timeout));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -62,6 +62,8 @@ import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateLocation;
 import org.apache.flink.runtime.query.UnknownKvStateLocation;
@@ -716,6 +718,19 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId> implements JobMast
 		accumulator = aggregateFunction.add(aggregand, accumulator);
 		accumulators.put(aggregateName, accumulator);
 		return CompletableFuture.completedFuture(aggregateFunction.getResult(accumulator));
+	}
+
+	@Override
+	public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+			OperatorID operatorId,
+			SerializedValue<CoordinationRequest> serializedRequest,
+			Time timeout) {
+		try {
+			CoordinationRequest request = serializedRequest.deserializeValue(userCodeLoader);
+			return schedulerNG.deliverCoordinationRequestToCoordinator(operatorId, request);
+		} catch (Exception e) {
+			return FutureUtils.completedExceptionally(e);
+		}
 	}
 
 	//----------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -33,8 +33,11 @@ import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
@@ -44,6 +47,7 @@ import org.apache.flink.runtime.taskexecutor.AccumulatorReport;
 import org.apache.flink.runtime.taskexecutor.slot.SlotOffer;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.taskmanager.UnresolvedTaskManagerLocation;
+import org.apache.flink.util.SerializedValue;
 
 import javax.annotation.Nullable;
 
@@ -271,4 +275,17 @@ public interface JobMasterGateway extends
 	 * @return The updated aggregate
 	 */
 	CompletableFuture<Object> updateGlobalAggregate(String aggregateName, Object aggregand, byte[] serializedAggregationFunction);
+
+	/**
+	 * Deliver a coordination request to a specified coordinator and return the response.
+	 *
+	 * @param operatorId identifying the coordinator to receive the request
+	 * @param serializedRequest serialized request to deliver
+	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
+	 *         if the coordinator cannot handle client events.
+	 */
+	CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+		OperatorID operatorId,
+		SerializedValue<CoordinationRequest> serializedRequest,
+		@RpcTimeout Time timeout);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -281,8 +281,10 @@ public interface JobMasterGateway extends
 	 *
 	 * @param operatorId identifying the coordinator to receive the request
 	 * @param serializedRequest serialized request to deliver
-	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
-	 *         if the coordinator cannot handle client events.
+	 * @return A future containing the response.
+	 *         The response will fail with a {@link org.apache.flink.util.FlinkException}
+	 *         if the task is not running, or no operator/coordinator exists for the given ID,
+	 *         or the coordinator cannot handle client events.
 	 */
 	CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
 		OperatorID operatorId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -50,6 +50,7 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.highavailability.HighAvailabilityServicesUtils;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -60,6 +61,8 @@ import org.apache.flink.runtime.metrics.MetricRegistryImpl;
 import org.apache.flink.runtime.metrics.ReporterSetup;
 import org.apache.flink.runtime.metrics.groups.ProcessMetricGroup;
 import org.apache.flink.runtime.metrics.util.MetricUtils;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
 import org.apache.flink.runtime.resourcemanager.StandaloneResourceManagerFactory;
@@ -79,6 +82,7 @@ import org.apache.flink.util.AutoCloseableAsync;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.SerializedValue;
 import org.apache.flink.util.function.FunctionUtils;
 
 import org.slf4j.Logger;
@@ -599,6 +603,16 @@ public class MiniCluster implements JobExecutorService, AutoCloseableAsync {
 
 	public CompletableFuture<? extends AccessExecutionGraph> getExecutionGraph(JobID jobId) {
 		return runDispatcherCommand(dispatcherGateway -> dispatcherGateway.requestJob(jobId, rpcTimeout));
+	}
+
+	public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+			JobID jobId,
+			OperatorID operatorId,
+			SerializedValue<CoordinationRequest> serializedRequest) {
+		return runDispatcherCommand(
+			dispatcherGateway ->
+				dispatcherGateway.deliverCoordinationRequestToCoordinator(
+					jobId, operatorId, serializedRequest, rpcTimeout));
 	}
 
 	private <T> CompletableFuture<T> runDispatcherCommand(Function<DispatcherGateway, CompletableFuture<T>> dispatcherCommand) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequest.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import java.io.Serializable;
+
+/**
+ * Root interface for all requests from the client to a {@link OperatorCoordinator}
+ * which requests for a {@link CoordinationResponse}.
+ */
+public interface CoordinationRequest extends Serializable {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestGateway.java
@@ -18,17 +18,22 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+import java.util.concurrent.CompletableFuture;
+
 /**
- * Coordinator interface which can handle {@link CoordinationRequest}s
- * and response with {@link CoordinationResponse}s to the client.
+ * Client interface which sends out a {@link CoordinationRequest} and
+ * expects for a {@link CoordinationResponse} from a {@link OperatorCoordinator}.
  */
-public interface CoordinationResponser {
+public interface CoordinationRequestGateway {
 
 	/**
-	 * Called when receiving a request from the client.
+	 * Send out a request to a specified coordinator and return the response.
 	 *
-	 * @param request the request received
-	 * @return the response from the coordinator for this request
+	 * @param operatorId specifies which coordinator to receive the request
+	 * @param request the request to send
+	 * @return the response from the coordinator
 	 */
-	CoordinationResponse handleCoordinationRequest(CoordinationRequest request);
+	CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
@@ -18,22 +18,17 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
-import org.apache.flink.runtime.jobgraph.OperatorID;
-
-import java.util.concurrent.CompletableFuture;
-
 /**
- * Client interface which sends out a {@link CoordinationRequest} and
- * expects for a {@link CoordinationResponse} from a {@link OperatorCoordinator}.
+ * Coordinator interface which can handle {@link CoordinationRequest}s
+ * and response with {@link CoordinationResponse}s to the client.
  */
-public interface CoordinationRequester {
+public interface CoordinationRequestHandler {
 
 	/**
-	 * Send out a request to a specified coordinator and return the response.
+	 * Called when receiving a request from the client.
 	 *
-	 * @param operatorId specifies which coordinator to receive the request
-	 * @param request the request to send
-	 * @return the response from the coordinator
+	 * @param request the request received
+	 * @return the response from the coordinator for this request
 	 */
-	CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request);
+	CoordinationResponse handleCoordinationRequest(CoordinationRequest request);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequestHandler.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * Coordinator interface which can handle {@link CoordinationRequest}s
  * and response with {@link CoordinationResponse}s to the client.
@@ -28,7 +30,7 @@ public interface CoordinationRequestHandler {
 	 * Called when receiving a request from the client.
 	 *
 	 * @param request the request received
-	 * @return the response from the coordinator for this request
+	 * @return a future containing the response from the coordinator for this request
 	 */
-	CoordinationResponse handleCoordinationRequest(CoordinationRequest request);
+	CompletableFuture<CoordinationResponse> handleCoordinationRequest(CoordinationRequest request);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequester.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationRequester.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Client interface which sends out a {@link CoordinationRequest} and
+ * expects for a {@link CoordinationResponse} from a {@link OperatorCoordinator}.
+ */
+public interface CoordinationRequester {
+
+	/**
+	 * Send out a request to a specified coordinator and return the response.
+	 *
+	 * @param operatorId specifies which coordinator to receive the request
+	 * @param request the request to send
+	 * @return the response from the coordinator
+	 */
+	CompletableFuture<CoordinationResponse> sendCoordinationRequest(OperatorID operatorId, CoordinationRequest request);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import java.io.Serializable;
+
+/**
+ * Root interface for all responses from a {@link OperatorCoordinator} to the client
+ * which is the response for a {@link CoordinationRequest}.
+ */
+public interface CoordinationResponse extends Serializable {}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationResponser.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/CoordinationResponser.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+/**
+ * Coordinator interface which can handle {@link CoordinationRequest}s
+ * and response with {@link CoordinationResponse}s to the client.
+ */
+public interface CoordinationResponser {
+
+	/**
+	 * Called when receiving a request from the client.
+	 *
+	 * @param request the request received
+	 * @return the response from the coordinator for this request
+	 */
+	CoordinationResponse handleCoordinationRequest(CoordinationRequest request);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job.coordination;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.rest.handler.AbstractRestHandler;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.RestHandlerException;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.OperatorIDPathParameter;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationRequestBody;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationResponseBody;
+import org.apache.flink.runtime.webmonitor.RestfulGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+import org.apache.flink.util.SerializedValue;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Handler that receives the coordination requests from the client and returns the response from the coordinator.
+ */
+public class ClientCoordinationHandler extends AbstractRestHandler<RestfulGateway, ClientCoordinationRequestBody, ClientCoordinationResponseBody, ClientCoordinationMessageParameters> {
+
+	public ClientCoordinationHandler(
+			GatewayRetriever<? extends RestfulGateway> leaderRetriever,
+			Time timeout,
+			Map<String, String> responseHeaders,
+			MessageHeaders<ClientCoordinationRequestBody, ClientCoordinationResponseBody, ClientCoordinationMessageParameters> messageHeaders) {
+		super(leaderRetriever, timeout, responseHeaders, messageHeaders);
+	}
+
+	@Override
+	protected CompletableFuture<ClientCoordinationResponseBody> handleRequest(
+			@Nonnull HandlerRequest<ClientCoordinationRequestBody, ClientCoordinationMessageParameters> request,
+			@Nonnull RestfulGateway gateway) throws RestHandlerException {
+		JobID jobId = request.getPathParameter(JobIDPathParameter.class);
+		OperatorID operatorId = request.getPathParameter(OperatorIDPathParameter.class);
+		SerializedValue<CoordinationRequest> serializedRequest =
+			request.getRequestBody().getSerializedCoordinationRequest();
+		CompletableFuture<CoordinationResponse> responseFuture =
+			gateway.deliverCoordinationRequestToCoordinator(jobId, operatorId, serializedRequest, timeout);
+		return responseFuture.thenApply(
+			coordinationResponse -> {
+				try {
+					return new ClientCoordinationResponseBody(new SerializedValue<>(coordinationResponse));
+				} catch (IOException e) {
+					throw new RuntimeException("Failed to construct response body", e);
+				}
+			});
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/coordination/ClientCoordinationHandler.java
@@ -36,11 +36,14 @@ import org.apache.flink.runtime.webmonitor.RestfulGateway;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
 import org.apache.flink.util.SerializedValue;
 
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
 import javax.annotation.Nonnull;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 /**
  * Handler that receives the coordination requests from the client and returns the response from the coordinator.
@@ -70,7 +73,11 @@ public class ClientCoordinationHandler extends AbstractRestHandler<RestfulGatewa
 				try {
 					return new ClientCoordinationResponseBody(new SerializedValue<>(coordinationResponse));
 				} catch (IOException e) {
-					throw new RuntimeException("Failed to construct response body", e);
+					throw new CompletionException(
+						new RestHandlerException(
+							"Failed to serialize coordination response",
+							HttpResponseStatus.INTERNAL_SERVER_ERROR,
+							e));
 				}
 			});
 	}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/OperatorIDPathParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/OperatorIDPathParameter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.util.StringUtils;
+
+/**
+ * Path parameter identifying operators.
+ */
+public class OperatorIDPathParameter extends MessagePathParameter<OperatorID> {
+
+	public static final String KEY = "operatorid";
+
+	public OperatorIDPathParameter() {
+		super(KEY);
+	}
+
+	@Override
+	protected OperatorID convertFromString(String value) throws ConversionException {
+		return new OperatorID(StringUtils.hexStringToByte(value));
+	}
+
+	@Override
+	protected String convertToString(OperatorID value) {
+		return value.toString();
+	}
+
+	@Override
+	public String getDescription() {
+		return "string value that identifies an operator.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationHeaders.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.rest.messages.job.coordination;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.job.coordination.ClientCoordinationHandler;
 import org.apache.flink.runtime.rest.messages.MessageHeaders;
@@ -27,6 +28,8 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseSt
 /**
  * Message headers for the {@link ClientCoordinationHandler}.
  */
+@Documentation.ExcludeFromDocumentation(
+	"This API is not exposed to the users, as coordinators are used only internally.")
 public class ClientCoordinationHeaders implements MessageHeaders<ClientCoordinationRequestBody, ClientCoordinationResponseBody, ClientCoordinationMessageParameters> {
 
 	public static final String URL = "/jobs/:jobid/coordinators/:operatorid";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationHeaders.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.coordination;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.handler.job.coordination.ClientCoordinationHandler;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Message headers for the {@link ClientCoordinationHandler}.
+ */
+public class ClientCoordinationHeaders implements MessageHeaders<ClientCoordinationRequestBody, ClientCoordinationResponseBody, ClientCoordinationMessageParameters> {
+
+	public static final String URL = "/jobs/:jobid/coordinators/:operatorid";
+
+	private static final ClientCoordinationHeaders INSTANCE = new ClientCoordinationHeaders();
+
+	private ClientCoordinationHeaders() {}
+
+	@Override
+	public Class<ClientCoordinationRequestBody> getRequestClass() {
+		return ClientCoordinationRequestBody.class;
+	}
+
+	@Override
+	public Class<ClientCoordinationResponseBody> getResponseClass() {
+		return ClientCoordinationResponseBody.class;
+	}
+
+	@Override
+	public HttpResponseStatus getResponseStatusCode() {
+		return HttpResponseStatus.OK;
+	}
+
+	@Override
+	public ClientCoordinationMessageParameters getUnresolvedMessageParameters() {
+		return new ClientCoordinationMessageParameters();
+	}
+
+	@Override
+	public HttpMethodWrapper getHttpMethod() {
+		return HttpMethodWrapper.POST;
+	}
+
+	@Override
+	public String getTargetRestEndpointURL() {
+		return URL;
+	}
+
+	public static ClientCoordinationHeaders getInstance() {
+		return INSTANCE;
+	}
+
+	@Override
+	public String getDescription() {
+		return "Send a request to a specified coordinator of the specified job and get the response. " +
+			"This API is for internal use only.";
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationMessageParameters.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationMessageParameters.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.coordination;
+
+import org.apache.flink.runtime.rest.handler.job.coordination.ClientCoordinationHandler;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.MessagePathParameter;
+import org.apache.flink.runtime.rest.messages.MessageQueryParameter;
+import org.apache.flink.runtime.rest.messages.OperatorIDPathParameter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * {@link MessageParameters} for {@link ClientCoordinationHandler}.
+ */
+public class ClientCoordinationMessageParameters extends MessageParameters {
+
+	public final JobIDPathParameter jobPathParameter = new JobIDPathParameter();
+	public final OperatorIDPathParameter operatorPathParameter = new OperatorIDPathParameter();
+
+	@Override
+	public Collection<MessagePathParameter<?>> getPathParameters() {
+		return Arrays.asList(jobPathParameter, operatorPathParameter);
+	}
+
+	@Override
+	public Collection<MessageQueryParameter<?>> getQueryParameters() {
+		return Collections.emptyList();
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationRequestBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationRequestBody.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.coordination;
+
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.json.SerializedValueDeserializer;
+import org.apache.flink.runtime.rest.messages.json.SerializedValueSerializer;
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Request that carries a serialized {@link CoordinationRequest} to a specified coordinator.
+ */
+public class ClientCoordinationRequestBody implements RequestBody {
+
+	public static final String FIELD_NAME_SERIALIZED_COORDINATION_REQUEST = "serializedCoordinationRequest";
+
+	@JsonProperty(FIELD_NAME_SERIALIZED_COORDINATION_REQUEST)
+	@JsonSerialize(using = SerializedValueSerializer.class)
+	@JsonDeserialize(using = SerializedValueDeserializer.class)
+	private final SerializedValue<CoordinationRequest> serializedCoordinationRequest;
+
+	@JsonCreator
+	public ClientCoordinationRequestBody(
+		@JsonProperty(FIELD_NAME_SERIALIZED_COORDINATION_REQUEST)
+			SerializedValue<CoordinationRequest> serializedCoordinationRequest) {
+		this.serializedCoordinationRequest = serializedCoordinationRequest;
+	}
+
+	@JsonIgnore
+	public SerializedValue<CoordinationRequest> getSerializedCoordinationRequest() {
+		return serializedCoordinationRequest;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationResponseBody.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/coordination/ClientCoordinationResponseBody.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job.coordination;
+
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.json.SerializedValueDeserializer;
+import org.apache.flink.runtime.rest.messages.json.SerializedValueSerializer;
+import org.apache.flink.util.SerializedValue;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Response that carries a serialized {@link CoordinationResponse} to the client.
+ */
+public class ClientCoordinationResponseBody implements ResponseBody {
+
+	public static final String FIELD_NAME_SERIALIZED_COORDINATION_RESULT = "serializedCoordinationResult";
+
+	@JsonProperty(FIELD_NAME_SERIALIZED_COORDINATION_RESULT)
+	@JsonSerialize(using = SerializedValueSerializer.class)
+	@JsonDeserialize(using = SerializedValueDeserializer.class)
+	private final SerializedValue<CoordinationResponse> serializedCoordinationResponse;
+
+	@JsonCreator
+	public ClientCoordinationResponseBody(
+		@JsonProperty(FIELD_NAME_SERIALIZED_COORDINATION_RESULT)
+			SerializedValue<CoordinationResponse> serializedCoordinationResponse) {
+		this.serializedCoordinationResponse = serializedCoordinationResponse;
+	}
+
+	@JsonIgnore
+	public SerializedValue<CoordinationResponse> getSerializedCoordinationResponse() {
+		return serializedCoordinationResponse;
+	}
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -76,6 +76,9 @@ import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponser;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
@@ -107,6 +110,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -163,6 +167,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 	private final boolean legacyScheduling;
 
 	protected final ExecutionVertexVersioner executionVertexVersioner;
+
+	private final Map<OperatorID, OperatorCoordinator> coordinatorMap;
 
 	private ComponentMainThreadExecutor mainThreadExecutor = new ComponentMainThreadExecutor.DummyComponentMainThreadExecutor(
 		"SchedulerBase is not initialized with proper main thread executor. " +
@@ -222,6 +228,8 @@ public abstract class SchedulerBase implements SchedulerNG {
 		this.schedulingTopology = executionGraph.getSchedulingTopology();
 
 		this.inputsLocationsRetriever = new ExecutionGraphToInputsLocationsRetrieverAdapter(executionGraph);
+
+		this.coordinatorMap = createCoordinatorMap();
 	}
 
 	private ExecutionGraph createAndRestoreExecutionGraph(
@@ -932,6 +940,22 @@ public abstract class SchedulerBase implements SchedulerNG {
 		}
 	}
 
+	@Override
+	public CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+			OperatorID operator,
+			CoordinationRequest request) throws FlinkException {
+		OperatorCoordinator coordinator = coordinatorMap.get(operator);
+		if (coordinator instanceof CoordinationResponser) {
+			return CompletableFuture.completedFuture(
+				((CoordinationResponser) coordinator).handleCoordinationRequest(request));
+		} else if (coordinator != null) {
+			return FutureUtils.completedExceptionally(
+				new IllegalArgumentException("Coordinator of operator " + operator + " cannot handle client event"));
+		} else {
+			throw new FlinkException("Coordinator of operator " + operator + " does not exist");
+		}
+	}
+
 	private void startAllOperatorCoordinators() {
 		final Collection<OperatorCoordinator> coordinators = getAllCoordinators();
 		try {
@@ -951,8 +975,16 @@ public abstract class SchedulerBase implements SchedulerNG {
 	}
 
 	private Collection<OperatorCoordinator> getAllCoordinators() {
-		return getExecutionGraph().getAllVertices().values().stream()
-			.flatMap((vertex) -> vertex.getOperatorCoordinators().stream())
-			.collect(Collectors.toList());
+		return coordinatorMap.values();
+	}
+
+	private Map<OperatorID, OperatorCoordinator> createCoordinatorMap() {
+		Map<OperatorID, OperatorCoordinator> coordinatorMap = new HashMap<>();
+		for (ExecutionJobVertex vertex : getExecutionGraph().getAllVertices().values()) {
+			for (Map.Entry<OperatorID, OperatorCoordinator> entry : vertex.getOperatorCoordinatorMap().entrySet()) {
+				coordinatorMap.put(entry.getKey(), entry.getValue());
+			}
+		}
+		return coordinatorMap;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -946,8 +946,7 @@ public abstract class SchedulerBase implements SchedulerNG {
 			CoordinationRequest request) throws FlinkException {
 		OperatorCoordinator coordinator = coordinatorMap.get(operator);
 		if (coordinator instanceof CoordinationRequestHandler) {
-			return CompletableFuture.completedFuture(
-				((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request));
+			return ((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request);
 		} else if (coordinator != null) {
 			throw new FlinkException("Coordinator of operator " + operator + " cannot handle client event");
 		} else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -77,8 +77,8 @@ import org.apache.flink.runtime.messages.webmonitor.JobDetails;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
-import org.apache.flink.runtime.operators.coordination.CoordinationResponser;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.TaskNotRunningException;
@@ -945,12 +945,11 @@ public abstract class SchedulerBase implements SchedulerNG {
 			OperatorID operator,
 			CoordinationRequest request) throws FlinkException {
 		OperatorCoordinator coordinator = coordinatorMap.get(operator);
-		if (coordinator instanceof CoordinationResponser) {
+		if (coordinator instanceof CoordinationRequestHandler) {
 			return CompletableFuture.completedFuture(
-				((CoordinationResponser) coordinator).handleCoordinationRequest(request));
+				((CoordinationRequestHandler) coordinator).handleCoordinationRequest(request));
 		} else if (coordinator != null) {
-			return FutureUtils.completedExceptionally(
-				new IllegalArgumentException("Coordinator of operator " + operator + " cannot handle client event"));
+			throw new FlinkException("Coordinator of operator " + operator + " cannot handle client event");
 		} else {
 			throw new FlinkException("Coordinator of operator " + operator + " does not exist");
 		}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -40,6 +40,8 @@ import org.apache.flink.runtime.jobmaster.SerializedInputSplit;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.checkpoint.DeclineCheckpoint;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.query.KvStateLocation;
@@ -138,4 +140,15 @@ public interface SchedulerNG {
 	 *                        for the given ID.
 	 */
 	void deliverOperatorEventToCoordinator(ExecutionAttemptID taskExecution, OperatorID operator, OperatorEvent evt) throws FlinkException;
+
+	/**
+	 * Delivers a coordination request to the {@link OperatorCoordinator} with the given {@link OperatorID}
+	 * and returns the coordinator's response.
+	 *
+	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
+	 *         if the coordinator cannot handle client events.
+	 * @throws FlinkException Thrown, if the task is not running or no operator/coordinator exists
+	 *                        for the given ID.
+	 */
+	CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(OperatorID operator, CoordinationRequest request) throws FlinkException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerNG.java
@@ -145,10 +145,9 @@ public interface SchedulerNG {
 	 * Delivers a coordination request to the {@link OperatorCoordinator} with the given {@link OperatorID}
 	 * and returns the coordinator's response.
 	 *
-	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
-	 *         if the coordinator cannot handle client events.
-	 * @throws FlinkException Thrown, if the task is not running or no operator/coordinator exists
-	 *                        for the given ID.
+	 * @return A future containing the response.
+	 * @throws FlinkException Thrown, if the task is not running, or no operator/coordinator exists
+	 *                        for the given ID, or the coordinator cannot handle client events.
 	 */
 	CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(OperatorID operator, CoordinationRequest request) throws FlinkException;
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -26,15 +26,19 @@ import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.metrics.dump.MetricQueryService;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.RpcGateway;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.util.SerializedValue;
 
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -184,6 +188,24 @@ public interface RestfulGateway extends RpcGateway {
 	}
 
 	default CompletableFuture<Acknowledge> shutDownCluster() {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Deliver a coordination request to a specified coordinator and return the response.
+	 *
+	 * @param jobId identifying the job which the coordinator belongs to
+	 * @param operatorId identifying the coordinator to receive the request
+	 * @param serializedRequest serialized request to deliver
+	 * @param timeout RPC timeout
+	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
+	 *         if the coordinator cannot handle client events.
+	 */
+	default CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
+			JobID jobId,
+			OperatorID operatorId,
+			SerializedValue<CoordinationRequest> serializedRequest,
+			@RpcTimeout Time timeout) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/RestfulGateway.java
@@ -198,8 +198,10 @@ public interface RestfulGateway extends RpcGateway {
 	 * @param operatorId identifying the coordinator to receive the request
 	 * @param serializedRequest serialized request to deliver
 	 * @param timeout RPC timeout
-	 * @return A future containing the response. The response will fail with an {@link IllegalArgumentException}
-	 *         if the coordinator cannot handle client events.
+	 * @return A future containing the response.
+	 *         The response will fail with a {@link org.apache.flink.util.FlinkException}
+	 *         if the task is not running, or no operator/coordinator exists for the given ID,
+	 *         or the coordinator cannot handle client events.
 	 */
 	default CompletableFuture<CoordinationResponse> deliverCoordinationRequestToCoordinator(
 			JobID jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatistic
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointStatsCache;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.CheckpointingStatisticsHandler;
 import org.apache.flink.runtime.rest.handler.job.checkpoints.TaskCheckpointStatisticDetailsHandler;
+import org.apache.flink.runtime.rest.handler.job.coordination.ClientCoordinationHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.AggregatingJobsMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.AggregatingSubtasksMetricsHandler;
 import org.apache.flink.runtime.rest.handler.job.metrics.AggregatingTaskManagersMetricsHandler;
@@ -119,6 +120,7 @@ import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskCurrentAttemptDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptAccumulatorsHeaders;
 import org.apache.flink.runtime.rest.messages.job.SubtaskExecutionAttemptDetailsHeaders;
+import org.apache.flink.runtime.rest.messages.job.coordination.ClientCoordinationHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerCustomLogHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerDetailsHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerLogFileHeaders;
@@ -559,6 +561,12 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		final ClusterDataSetDeleteHandlers.ClusterDataSetDeleteStatusHandler clusterDataSetDeleteStatusHandler =
 			clusterDataSetDeleteHandlers.new ClusterDataSetDeleteStatusHandler(leaderRetriever, timeout, responseHeaders);
 
+		final ClientCoordinationHandler clientCoordinationHandler = new ClientCoordinationHandler(
+			leaderRetriever,
+			timeout,
+			responseHeaders,
+			ClientCoordinationHeaders.getInstance());
+
 		final ShutdownHandler shutdownHandler = new ShutdownHandler(
 			leaderRetriever,
 			timeout,
@@ -625,6 +633,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
 		handlers.add(Tuple2.of(clusterDataSetListHandler.getMessageHeaders(), clusterDataSetListHandler));
 		handlers.add(Tuple2.of(clusterDataSetDeleteTriggerHandler.getMessageHeaders(), clusterDataSetDeleteTriggerHandler));
 		handlers.add(Tuple2.of(clusterDataSetDeleteStatusHandler.getMessageHeaders(), clusterDataSetDeleteStatusHandler));
+		handlers.add(Tuple2.of(clientCoordinationHandler.getMessageHeaders(), clientCoordinationHandler));
 
 		// TODO: Remove once the Yarn proxy can forward all REST verbs
 		handlers.add(Tuple2.of(YarnCancelJobTerminationHeaders.getInstance(), yarnJobCancelTerminationHandler));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorSchedulerTest.java
@@ -163,6 +163,36 @@ public class OperatorCoordinatorSchedulerTest extends TestLogger {
 		assertThat(result, futureFailedWith(TestException.class));
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testDeliveringClientRequestToResponser() throws Exception {
+		final OperatorCoordinator.Provider provider = new TestingCoordinationResponser.Provider(testOperatorId);
+		final DefaultScheduler scheduler = createScheduler(provider);
+
+		final String payload = "testing payload";
+		final TestingCoordinationResponser.Request<String> request =
+			new TestingCoordinationResponser.Request<>(payload);
+		final TestingCoordinationResponser.Response<String> response =
+			(TestingCoordinationResponser.Response<String>)
+				scheduler.deliverCoordinationRequestToCoordinator(testOperatorId, request).get();
+
+		assertEquals(payload, response.getPayload());
+	}
+
+	@Test
+	public void testDeliveringClientRequestToNonResponser() throws Exception {
+		final OperatorCoordinator.Provider provider = new TestingOperatorCoordinator.Provider(testOperatorId);
+		final DefaultScheduler scheduler = createScheduler(provider);
+
+		final String payload = "testing payload";
+		final TestingCoordinationResponser.Request<String> request =
+			new TestingCoordinationResponser.Request<>(payload);
+		final CompletableFuture<CoordinationResponse> future =
+			scheduler.deliverCoordinationRequestToCoordinator(testOperatorId, request);
+
+		assertThat(future, futureFailedWith(IllegalArgumentException.class));
+	}
+
 	// ------------------------------------------------------------------------
 	//  test setups
 	// ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationRequestHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationRequestHandler.java
@@ -21,11 +21,11 @@ package org.apache.flink.runtime.operators.coordination;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
 /**
- * A simple testing implementation of the {@link CoordinationResponser}.
+ * A simple testing implementation of the {@link CoordinationRequestHandler}.
  */
-public class TestingCoordinationResponser extends TestingOperatorCoordinator implements CoordinationResponser {
+public class TestingCoordinationRequestHandler extends TestingOperatorCoordinator implements CoordinationRequestHandler {
 
-	public TestingCoordinationResponser(Context context) {
+	public TestingCoordinationRequestHandler(Context context) {
 		super(context);
 	}
 
@@ -37,7 +37,7 @@ public class TestingCoordinationResponser extends TestingOperatorCoordinator imp
 
 	/**
 	 * A testing stub for an {@link OperatorCoordinator.Provider} that creates a
-	 * {@link TestingCoordinationResponser}.
+	 * {@link TestingCoordinationRequestHandler}.
 	 */
 	public static final class Provider implements OperatorCoordinator.Provider {
 
@@ -56,12 +56,12 @@ public class TestingCoordinationResponser extends TestingOperatorCoordinator imp
 
 		@Override
 		public OperatorCoordinator create(Context context) {
-			return new TestingCoordinationResponser(context);
+			return new TestingCoordinationRequestHandler(context);
 		}
 	}
 
 	/**
-	 * A {@link CoordinationRequest} that a {@link TestingCoordinationResponser} receives.
+	 * A {@link CoordinationRequest} that a {@link TestingCoordinationRequestHandler} receives.
 	 *
 	 * @param <T> payload type
 	 */
@@ -81,7 +81,7 @@ public class TestingCoordinationResponser extends TestingOperatorCoordinator imp
 	}
 
 	/**
-	 * A {@link CoordinationResponse} that a {@link TestingCoordinationResponser} gives.
+	 * A {@link CoordinationResponse} that a {@link TestingCoordinationRequestHandler} gives.
 	 *
 	 * @param <T> payload type
 	 */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationRequestHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationRequestHandler.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
+import java.util.concurrent.CompletableFuture;
+
 /**
  * A simple testing implementation of the {@link CoordinationRequestHandler}.
  */
@@ -30,9 +32,9 @@ public class TestingCoordinationRequestHandler extends TestingOperatorCoordinato
 	}
 
 	@Override
-	public CoordinationResponse handleCoordinationRequest(CoordinationRequest request) {
+	public CompletableFuture<CoordinationResponse> handleCoordinationRequest(CoordinationRequest request) {
 		Request req = (Request) request;
-		return new Response<>(req.getPayload());
+		return CompletableFuture.completedFuture(new Response<>(req.getPayload()));
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationResponser.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingCoordinationResponser.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.operators.coordination;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+
+/**
+ * A simple testing implementation of the {@link CoordinationResponser}.
+ */
+public class TestingCoordinationResponser extends TestingOperatorCoordinator implements CoordinationResponser {
+
+	public TestingCoordinationResponser(Context context) {
+		super(context);
+	}
+
+	@Override
+	public CoordinationResponse handleCoordinationRequest(CoordinationRequest request) {
+		Request req = (Request) request;
+		return new Response<>(req.getPayload());
+	}
+
+	/**
+	 * A testing stub for an {@link OperatorCoordinator.Provider} that creates a
+	 * {@link TestingCoordinationResponser}.
+	 */
+	public static final class Provider implements OperatorCoordinator.Provider {
+
+		private static final long serialVersionUID = 1L;
+
+		private final OperatorID operatorId;
+
+		public Provider(OperatorID operatorId) {
+			this.operatorId = operatorId;
+		}
+
+		@Override
+		public OperatorID getOperatorId() {
+			return operatorId;
+		}
+
+		@Override
+		public OperatorCoordinator create(Context context) {
+			return new TestingCoordinationResponser(context);
+		}
+	}
+
+	/**
+	 * A {@link CoordinationRequest} that a {@link TestingCoordinationResponser} receives.
+	 *
+	 * @param <T> payload type
+	 */
+	public static class Request<T> implements CoordinationRequest {
+
+		private static final long serialVersionUID = 1L;
+
+		private final T payload;
+
+		public Request(T payload) {
+			this.payload = payload;
+		}
+
+		public T getPayload() {
+			return payload;
+		}
+	}
+
+	/**
+	 * A {@link CoordinationResponse} that a {@link TestingCoordinationResponser} gives.
+	 *
+	 * @param <T> payload type
+	 */
+	public static class Response<T> implements CoordinationResponse {
+
+		private static final long serialVersionUID = 1L;
+
+		private final T payload;
+
+		public Response(T payload) {
+			this.payload = payload;
+		}
+
+		public T getPayload() {
+			return payload;
+		}
+	}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/TestingDispatcherGateway.java
@@ -29,12 +29,17 @@ import org.apache.flink.runtime.dispatcher.DispatcherId;
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.ClusterOverview;
 import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.rest.handler.legacy.backpressure.OperatorBackPressureStatsResponse;
 import org.apache.flink.runtime.rpc.RpcTimeout;
+import org.apache.flink.util.SerializedValue;
+import org.apache.flink.util.function.TriFunction;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -92,7 +97,8 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway implem
 			DispatcherId fencingToken,
 			Function<JobID, CompletableFuture<ArchivedExecutionGraph>> requestArchivedJobFunction,
 			Supplier<CompletableFuture<Acknowledge>> clusterShutdownSupplier,
-			Function<ApplicationStatus, CompletableFuture<Acknowledge>> clusterShutdownWithStatusFunction) {
+			Function<ApplicationStatus, CompletableFuture<Acknowledge>> clusterShutdownWithStatusFunction,
+			TriFunction<JobID, OperatorID, SerializedValue<CoordinationRequest>, CompletableFuture<CoordinationResponse>> deliverCoordinationRequestToCoordinatorFunction) {
 		super(
 			address,
 			hostname,
@@ -107,7 +113,8 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway implem
 			requestOperatorBackPressureStatsFunction,
 			triggerSavepointFunction,
 			stopWithSavepointFunction,
-			clusterShutdownSupplier);
+			clusterShutdownSupplier,
+			deliverCoordinationRequestToCoordinatorFunction);
 		this.submitFunction = submitFunction;
 		this.listFunction = listFunction;
 		this.blobServerPort = blobServerPort;
@@ -219,7 +226,8 @@ public final class TestingDispatcherGateway extends TestingRestfulGateway implem
 				fencingToken,
 				requestArchivedJobFunction,
 				clusterShutdownSupplier,
-				clusterShutdownWithStatusFunction);
+				clusterShutdownWithStatusFunction,
+				deliverCoordinationRequestToCoordinatorFunction);
 		}
 	}
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/api/environment/RemoteStreamEnvironmentTest.java
@@ -31,10 +31,13 @@ import org.apache.flink.core.execution.PipelineExecutorServiceLoader;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.jobmaster.JobResult.Builder;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.streaming.api.environment.RemoteStreamEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -272,6 +275,14 @@ public class RemoteStreamEnvironmentTest extends TestLogger {
 		public CompletableFuture<String> triggerSavepoint(
 				JobID jobId,
 				@Nullable String savepointDirectory) {
+			return null;
+		}
+
+		@Override
+		public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
+				JobID jobId,
+				OperatorID operatorId,
+				CoordinationRequest request) {
 			return null;
 		}
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR is part of the [FLINK-14807](https://issues.apache.org/jira/browse/FLINK-14807) which is going to introduce a collecting method for tables. See [here](https://docs.google.com/document/d/13Ata18-e89_hAdfukzEJYreOg2FBZO_Y0RohLDAme6Y/edit) for the whole design document.

To allow the clients to receive results from the coordinator, which acts as a proxy between the clients and the sinks, a communication protocol should be introduced between the clients and the coordinators. This PR introduce this new communication protocol through the REST API.

Note that as coordinators are internally used only, we're not going to expose this REST API to the user, thus no user document is provided.

## Brief change log

 - Introduce a REST API to allow the communication between clients and coordinators.

## Verifying this change

The changes can be verified by running the added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes (JobManager)
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented