### PR TITLE
[FLINK-17577] SinkFormat#createSinkFormat should use DynamicTableSink…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/SinkFormat.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/format/SinkFormat.java
@@ -20,7 +20,6 @@ package org.apache.flink.table.connector.format;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.types.DataType;
 
 /**
@@ -34,5 +33,5 @@ public interface SinkFormat<I> extends Format {
 	/**
 	 * Creates runtime implementation that is configured to consume data of the given data type.
 	 */
-	I createSinkFormat(ScanTableSource.Context context, DataType consumedDataType);
+	I createSinkFormat(DynamicTableSink.Context context, DataType consumedDataType);
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestFormatFactory.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.format.ScanFormat;
 import org.apache.flink.table.connector.format.SinkFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
@@ -150,7 +151,7 @@ public class TestFormatFactory implements DeserializationFormatFactory, Serializ
 
 		@Override
 		public SerializationSchema<RowData> createSinkFormat(
-				ScanTableSource.Context context,
+				DynamicTableSink.Context context,
 				DataType consumeDataType) {
 			return null;
 		}


### PR DESCRIPTION
….Context as the first parameter

This interface was introduced in FLINK-16997, it uses the ScanTableSource.Context as the first param, which is not correct.