### PR TITLE
[FLINK-16367] [table] Introduce TableEnvironment#createStatementSet api

### DIFF
--- a/flink-python/pyflink/table/__init__.py
+++ b/flink-python/pyflink/table/__init__.py
@@ -55,6 +55,8 @@ Important classes of Flink Table API:
       user-defined function is executed, such as the metric group, and global job parameters, etc.
     - :class:`pyflink.table.ScalarFunction`
       Base interface for user-defined scalar function.
+    - :class:`pyflink.table.StatementSet`
+      Base interface accepts DML statements or Tables.
 """
 from __future__ import absolute_import
 
@@ -71,6 +73,7 @@ from pyflink.table.types import DataTypes, UserDefinedType, Row
 from pyflink.table.table_schema import TableSchema
 from pyflink.table.udf import FunctionContext, ScalarFunction
 from pyflink.table.explain_detail import ExplainDetail
+from pyflink.table.statement_set import StatementSet
 
 __all__ = [
     'TableEnvironment',
@@ -95,5 +98,6 @@ __all__ = [
     'FunctionContext',
     'ScalarFunction',
     'SqlDialect',
-    'ExplainDetail'
+    'ExplainDetail',
+    'StatementSet'
 ]

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -1,0 +1,93 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from abc import ABCMeta
+
+from pyflink.util.utils import to_j_explain_detail_arr
+
+__all__ = ['StatementSet']
+
+
+class StatementSet(object):
+    """
+    A StatementSet accepts DML statements or Tables,
+    the planner can optimize all added statements and Tables together
+    and then submit as one job.
+
+    .. note::
+    The added statements and Tables will be cleared
+    when calling the `execute` method.
+    """
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, _j_statement_set):
+        self._j_statement_set = _j_statement_set
+
+    def add_insert_sql(self, stmt):
+        """
+        add insert statement to the set.
+
+        :param stmt: The statement to be added.
+        :type stmt: str
+        :return: current StatementSet instance.
+        :rtype: pyflink.table.StatementSet
+        """
+        self._j_statement_set.addInsertSql(stmt)
+        return self
+
+    def add_insert(self, target_path, table, overwrite=False):
+        """
+        add Table with the given sink table name to the set.
+
+        :param target_path: The path of the registered :class:`~pyflink.table.TableSink` to which
+                            the :class:`~pyflink.table.Table` is written.
+        :type target_path: str
+        :param table: The Table to add.
+        :type table: pyflink.table.Table
+        :param overwrite The flag that indicates whether the insert
+                         should overwrite existing data or not.
+        :type overwrite: bool
+        :return: current StatementSet instance.
+        :rtype: pyflink.table.StatementSet
+        """
+        self._j_statement_set.addInsert(target_path, table._j_table, overwrite)
+        return self
+
+    def explain(self, *extra_details):
+        """
+        returns the AST and the execution plan of all statements and Tables.
+
+        :param extra_details: The extra explain details which the explain result should include,
+                              e.g. estimated cost, changelog mode for streaming
+        :type extra_details: tuple[ExplainDetail] (variable-length arguments of ExplainDetail)
+        :return: All statements and Tables for which the AST and execution plan will be returned.
+        :rtype: str
+        """
+        j_extra_details = to_j_explain_detail_arr(extra_details)
+        return self._j_statement_set.explain(j_extra_details)
+
+    def execute(self):
+        """
+        execute all statements and Tables as a batch.
+
+        .. note::
+        The added statements and Tables will be cleared when executing this method.
+        :return: execution result.
+        """
+        return self._j_statement_set.execute()

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -28,8 +28,10 @@ class StatementSet(object):
     and then submit as one job.
 
     .. note::
-    The added statements and Tables will be cleared
-    when calling the `execute` method.
+
+        The added statements and Tables will be cleared
+        when calling the `execute` method.
+
     """
 
     def __init__(self, _j_statement_set):
@@ -56,8 +58,8 @@ class StatementSet(object):
         :type target_path: str
         :param table: The Table to add.
         :type table: pyflink.table.Table
-        :param overwrite The flag that indicates whether the insert
-                         should overwrite existing data or not.
+        :param overwrite: The flag that indicates whether the insert
+                          should overwrite existing data or not.
         :type overwrite: bool
         :return: current StatementSet instance.
         :rtype: pyflink.table.StatementSet
@@ -83,7 +85,8 @@ class StatementSet(object):
         execute all statements and Tables as a batch.
 
         .. note::
-        The added statements and Tables will be cleared when executing this method.
+            The added statements and Tables will be cleared when executing this method.
+
         :return: execution result.
         """
         # TODO convert java TableResult to python TableResult once FLINK-17303 is finished

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -16,8 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-from abc import ABCMeta
-
 from pyflink.util.utils import to_j_explain_detail_arr
 
 __all__ = ['StatementSet']
@@ -33,8 +31,6 @@ class StatementSet(object):
     The added statements and Tables will be cleared
     when calling the `execute` method.
     """
-
-    __metaclass__ = ABCMeta
 
     def __init__(self, _j_statement_set):
         self._j_statement_set = _j_statement_set

--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -86,4 +86,5 @@ class StatementSet(object):
         The added statements and Tables will be cleared when executing this method.
         :return: execution result.
         """
+        # TODO convert java TableResult to python TableResult once FLINK-17303 is finished
         return self._j_statement_set.execute()

--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -28,6 +28,7 @@ from pyflink.common import JobExecutionResult
 from pyflink.serializers import BatchedSerializer, PickleSerializer
 from pyflink.table.catalog import Catalog
 from pyflink.table.serializers import ArrowSerializer
+from pyflink.table.statement_set import StatementSet
 from pyflink.table.table_config import TableConfig
 from pyflink.table.descriptors import StreamTableDescriptor, BatchTableDescriptor
 
@@ -523,6 +524,18 @@ class TableEnvironment(object):
                 or a string message ("OK") for other statements.
         """
         return self._j_tenv.executeSql(stmt)
+
+    def create_statement_set(self):
+        """
+        Create a StatementSet instance which accepts DML statements or Tables,
+        the planner can optimize all added statements and Tables together
+        and then submit as one job.
+
+        :return statement_set instance
+        :rtype: pyflink.table.StatementSet
+        """
+        _j_statement_set = self._j_tenv.createStatementSet()
+        return StatementSet(_j_statement_set)
 
     def sql_update(self, stmt):
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/StatementSet.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A {@link StatementSet} accepts DML statements or {@link Table}s,
+ * the planner can optimize all added statements and Tables together
+ * and then submit as one job.
+ *
+ * <p>The added statements and Tables will be cleared
+ * when calling the `execute` method.
+ */
+@PublicEvolving
+public interface StatementSet {
+
+	/**
+	 * add insert statement to the set.
+	 */
+	StatementSet addInsertSql(String statement);
+
+	/**
+	 * add Table with the given sink table name to the set.
+	 */
+	StatementSet addInsert(String targetPath, Table table);
+
+	/**
+	 * add {@link Table} with the given sink table name to the set.
+	 */
+	StatementSet addInsert(String targetPath, Table table, boolean overwrite);
+
+	/**
+	 * returns the AST and the execution plan to compute the result of the
+	 * all statements and Tables.
+	 *
+	 * @param extraDetails The extra explain details which the explain result should include,
+	 *                     e.g. estimated cost, changelog mode for streaming
+	 * @return AST and the execution plan.
+	 */
+	String explain(ExplainDetail... extraDetails);
+
+	/**
+	 * execute all statements and Tables as a batch.
+	 *
+	 * <p>The added statements and Tables will be cleared when executing this method.
+	 */
+	TableResult execute();
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -1132,4 +1132,11 @@ public interface TableEnvironment {
 	 * @throws Exception which occurs during job execution.
 	 */
 	JobExecutionResult execute(String jobName) throws Exception;
+
+	/**
+	 * Create a {@link StatementSet} instance which accepts DML statements or Tables,
+	 * the planner can optimize all added statements and Tables together
+	 * and then submit as one job.
+	 */
+	StatementSet createStatementSet();
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -40,8 +40,8 @@ import java.util.stream.Collectors;
  */
 @Internal
 class StatementSetImpl implements StatementSet {
-	private List<ModifyOperation> operations = new ArrayList<>();
 	private final TableEnvironmentInternal tableEnvironment;
+	private List<ModifyOperation> operations = new ArrayList<>();
 
 	protected StatementSetImpl(TableEnvironmentInternal tableEnvironment) {
 		this.tableEnvironment = tableEnvironment;
@@ -52,14 +52,14 @@ class StatementSetImpl implements StatementSet {
 		List<Operation> operations = tableEnvironment.getParser().parse(statement);
 
 		if (operations.size() != 1) {
-			throw new TableException("only single insert statement is supported");
+			throw new TableException("Only single statement is supported.");
 		}
 
 		Operation operation = operations.get(0);
 		if (operation instanceof ModifyOperation) {
 			this.operations.add((ModifyOperation) operation);
 		} else {
-			throw new TableException("only insert statement is supported");
+			throw new TableException("Only insert statement is supported now.");
 		}
 		return this;
 	}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StatementSetImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.operations.CatalogSinkModifyOperation;
+import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.Operation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation for {@link StatementSet}.
+ */
+@Internal
+class StatementSetImpl implements StatementSet {
+	private List<ModifyOperation> operations = new ArrayList<>();
+	private final TableEnvironmentInternal tableEnvironment;
+
+	protected StatementSetImpl(TableEnvironmentInternal tableEnvironment) {
+		this.tableEnvironment = tableEnvironment;
+	}
+
+	@Override
+	public StatementSet addInsertSql(String statement) {
+		List<Operation> operations = tableEnvironment.getParser().parse(statement);
+
+		if (operations.size() != 1) {
+			throw new TableException("only single insert statement is supported");
+		}
+
+		Operation operation = operations.get(0);
+		if (operation instanceof ModifyOperation) {
+			this.operations.add((ModifyOperation) operation);
+		} else {
+			throw new TableException("only insert statement is supported");
+		}
+		return this;
+	}
+
+	@Override
+	public StatementSet addInsert(String targetPath, Table table) {
+		return addInsert(targetPath, table, false);
+	}
+
+	@Override
+	public StatementSet addInsert(String targetPath, Table table, boolean overwrite) {
+		UnresolvedIdentifier unresolvedIdentifier = tableEnvironment.getParser().parseIdentifier(targetPath);
+		ObjectIdentifier objectIdentifier = tableEnvironment.getCatalogManager()
+				.qualifyIdentifier(unresolvedIdentifier);
+
+		operations.add(new CatalogSinkModifyOperation(
+				objectIdentifier,
+				table.getQueryOperation(),
+				Collections.emptyMap(),
+				overwrite,
+				Collections.emptyMap()));
+
+		return this;
+	}
+
+	@Override
+	public String explain(ExplainDetail... extraDetails) {
+		List<Operation> operationList = operations.stream().map(o -> (Operation) o).collect(Collectors.toList());
+		return tableEnvironment.explainInternal(operationList, extraDetails);
+	}
+
+	@Override
+	public TableResult execute() {
+		try {
+			return tableEnvironment.executeInternal(operations);
+		} finally {
+			operations.clear();
+		}
+	}
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.ExplainDetail;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.SqlParserException;
+import org.apache.flink.table.api.StatementSet;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
@@ -655,12 +656,38 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 	}
 
 	@Override
-	public TableResult executeInternal(List<ModifyOperation> operations) {
-		if (operations.size() != 1) {
-			throw new TableException("Only one ModifyOperation is supported now.");
-		}
+	public StatementSet createStatementSet() {
+		return new StatementSetImpl(this);
+	}
 
-		return executeOperation(operations.get(0));
+	@Override
+	public TableResult executeInternal(List<ModifyOperation> operations) {
+		List<Transformation<?>> transformations = translate(operations);
+		String jobName = extractJobName(operations);
+		Pipeline pipeline = execEnv.createPipeline(transformations, tableConfig, jobName);
+		try {
+			JobClient jobClient = execEnv.executeAsync(pipeline);
+			TableSchema.Builder builder = TableSchema.builder();
+			Object[] affectedRowCounts = new Long[operations.size()];
+			for (int i = 0; i < operations.size(); ++i) {
+				// if only one operation, field name is 'affected_rowcount', else is 'affected_rowcount_$i'
+				String fieldName = "affected_rowcount";
+				if (operations.size() > 1) {
+					fieldName = fieldName + "_" + i;
+				}
+				builder.field(fieldName, DataTypes.BIGINT());
+				affectedRowCounts[i] = -1L;
+			}
+
+			return TableResultImpl.builder()
+					.jobClient(jobClient)
+					.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+					.tableSchema(builder.build())
+					.data(Collections.singletonList(Row.of(affectedRowCounts)))
+					.build();
+		} catch (Exception e) {
+			throw new TableException("Failed to execute sql", e);
+		}
 	}
 
 	@Override
@@ -698,20 +725,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
 	private TableResult executeOperation(Operation operation) {
 		if (operation instanceof ModifyOperation) {
-			List<Transformation<?>> transformations = translate(Collections.singletonList((ModifyOperation) operation));
-			String jobName = extractJobName(operation);
-			Pipeline pipeline = execEnv.createPipeline(transformations, tableConfig, jobName);
-			try {
-				JobClient jobClient = execEnv.executeAsync(pipeline);
-				return TableResultImpl.builder()
-						.jobClient(jobClient)
-						.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-						.tableSchema(TableSchema.builder().field("affected_rowcount", DataTypes.BIGINT()).build())
-						.data(Collections.singletonList(Row.of(-1L)))
-						.build();
-			} catch (Exception e) {
-				throw new TableException("Failed to execute sql", e);
-			}
+			return executeInternal(Collections.singletonList((ModifyOperation) operation));
 		} else if (operation instanceof CreateTableOperation) {
 			CreateTableOperation createTableOperation = (CreateTableOperation) operation;
 			if (createTableOperation.isTemporary()) {
@@ -894,14 +908,17 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 				.build();
 	}
 
-	private String extractJobName(Operation operation) {
-		String tableName;
-		if (operation instanceof CatalogSinkModifyOperation) {
-			tableName = ((CatalogSinkModifyOperation) operation).getTableIdentifier().toString();
-		} else {
-			throw new UnsupportedOperationException("Unsupported operation: " + operation);
+	private String extractJobName(List<ModifyOperation> operations) {
+		List<String> tableNames = new ArrayList<>();
+		for (ModifyOperation operation : operations) {
+			if (operation instanceof CatalogSinkModifyOperation) {
+				String tableName = ((CatalogSinkModifyOperation) operation).getTableIdentifier().toString();
+				tableNames.add(tableName);
+			} else {
+				throw new UnsupportedOperationException("Unsupported operation: " + operation);
+			}
 		}
-		return "insert_into_" + tableName;
+		return "insert_into_" + String.join(",", tableNames);
 	}
 
 	/** Get catalog from catalogName or throw a ValidationException if the catalog not exists. */

--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testStatementSet.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testStatementSet.out
@@ -1,0 +1,63 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink1`], fields=[first])
++- LogicalProject(first=[$0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
+
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[last])
++- LogicalProject(last=[$3])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first, id, score, last)]]])
+
+== Optimized Logical Plan ==
+Sink(name=[`default_catalog`.`default_database`.`MySink1`], fields=[first])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
+
+Sink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[last])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : Source: Custom File source
+
+	 : Operator
+		content : CsvTableSource(read fields: first)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: first)]], fields=[first])
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : SinkConversionToRow
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Map
+					ship_strategy : REBALANCE
+
+ : Data Source
+	content : Source: Custom File source
+
+	 : Operator
+		content : CsvTableSource(read fields: last)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : SourceConversion(table=[default_catalog.default_database.MyTable, source: [CsvTableSource(read fields: last)]], fields=[last])
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : SinkConversionToRow
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Map
+					ship_strategy : REBALANCE
+
+					 : Data Sink
+						content : Sink: CsvTableSink(first)
+						ship_strategy : FORWARD
+
+						 : Data Sink
+							content : Sink: CsvTableSink(last)
+							ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTa
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory
 import org.apache.flink.table.planner.runtime.utils.TestingAppendSink
 import org.apache.flink.table.planner.utils.TableTestUtil.{readFromResource, replaceStageId}
-import org.apache.flink.table.planner.utils.TestTableSourceSinks
+import org.apache.flink.table.planner.utils.{TableTestUtil, TestTableSourceSinks}
 import org.apache.flink.types.Row
 import org.apache.flink.util.{FileUtils, TestLogger}
 
@@ -268,7 +268,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
       tEnv, new TableSchema(Array("first"), Array(STRING)), "MySink1")
     checkEmptyFile(sinkPath)
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -297,7 +297,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     )
 
     val tableResult1 = tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult1)
+    checkInsertTableResult(tableResult1, -1L)
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -305,7 +305,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertFirstValues(sinkPath)
 
     val tableResult2 =  tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult2)
+    checkInsertTableResult(tableResult2, -1L)
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -323,7 +323,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     checkEmptyFile(sink2Path)
 
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -361,7 +361,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     resultSet.addSink(sink)
 
     val tableResult = streamTableEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -386,7 +386,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     checkEmptyFile(sinkPath)
     val table = tEnv.sqlQuery("select first from MyTable")
     val tableResult = table.executeInsert("MySink")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -401,7 +401,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
       return
     }
     val sinkPath = _tempFolder.newFolder().toString
-    tEnv.sqlUpdate(
+    tEnv.executeSql(
       s"""
          |create table MySink (
          |  first string
@@ -413,7 +413,7 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
        """.stripMargin
     )
     val tableResult1 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult1)
+    checkInsertTableResult(tableResult1, -1L)
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -421,12 +421,100 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertFirstValues(sinkPath)
 
     val tableResult2 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult2)
+    checkInsertTableResult(tableResult2, -1L)
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
       .get()
     assertFirstValues(sinkPath)
+  }
+
+  @Test
+  def testStatementSet(): Unit = {
+    val sink1Path = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("first"), Array(STRING)), "MySink1")
+
+    val sink2Path = TestTableSourceSinks.createCsvTemporarySinkTable(
+      tEnv, new TableSchema(Array("last"), Array(STRING)), "MySink2")
+
+    val stmtSet = tEnv.createStatementSet()
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"))
+      .addInsertSql("insert into MySink2 select last from MyTable")
+
+    val actual = stmtSet.explain()
+    val expected = TableTestUtil.readFromResource("/explain/testStatementSet.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+
+    val tableResult = stmtSet.execute()
+    checkInsertTableResult(tableResult, -1L, -1L)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
+  }
+
+  @Test
+  def testStatementSetWithOverwrite(): Unit = {
+    if(isStreaming) {
+      // Streaming mode not support overwrite for FileSystemTableSink.
+      return
+    }
+    val sink1Path = _tempFolder.newFolder().toString
+    tEnv.executeSql(
+      s"""
+         |create table MySink1 (
+         |  first string
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$sink1Path',
+         |  'format' = 'testcsv'
+         |)
+       """.stripMargin
+    )
+
+    val sink2Path = _tempFolder.newFolder().toString
+    tEnv.executeSql(
+      s"""
+         |create table MySink2 (
+         |  last string
+         |) with (
+         |  'connector' = 'filesystem',
+         |  'path' = '$sink2Path',
+         |  'format' = 'testcsv'
+         |)
+       """.stripMargin
+    )
+
+    val stmtSet = tEnv.createStatementSet()
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"), true)
+    stmtSet.addInsertSql("insert overwrite MySink2 select last from MyTable")
+
+    val tableResult1 = stmtSet.execute()
+    checkInsertTableResult(tableResult1, -1L, -1L)
+    // wait job finished
+    tableResult1.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
+
+    // execute again using same StatementSet instance
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"), true)
+      .addInsertSql("insert overwrite MySink2 select last from MyTable")
+
+    val tableResult2 = stmtSet.execute()
+    checkInsertTableResult(tableResult2, -1L, -1L)
+    // wait job finished
+    tableResult2.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
   }
 
   @Test
@@ -492,12 +580,12 @@ class TableEnvironmentITCase(tableEnvName: String, isStreaming: Boolean) extends
     assertFalse(new File(path).exists())
   }
 
-  private def checkInsertTableResult(tableResult: TableResult): Unit = {
+  private def checkInsertTableResult(tableResult: TableResult, affectedRowCounts: JLong*): Unit = {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     assertTrue(it.hasNext)
-    assertEquals(Row.of(JLong.valueOf(-1L)), it.next())
+    assertEquals(Row.of(affectedRowCounts: _*), it.next())
     assertFalse(it.hasNext)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/api/internal/TableEnvImpl.scala
@@ -50,7 +50,7 @@ import org.apache.calcite.tools.FrameworkConfig
 
 import _root_.java.lang.{Iterable => JIterable, Long => JLong}
 import _root_.java.util.function.{Function => JFunction, Supplier => JSupplier}
-import _root_.java.util.{Optional, ArrayList => JArrayList, Collections => JCollections, HashMap => JHashMap, HashSet => JHashSet, List => JList, Map => JMap}
+import _root_.java.util.{Optional, Collections => JCollections, HashMap => JHashMap, List => JList, Map => JMap}
 
 import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.JavaConverters._
@@ -827,45 +827,14 @@ abstract class TableEnvImpl(
 
   /**
     * extract sink identifier names from [[ModifyOperation]]s.
-    *
-    * <p>This method will keep the shortest form of an identifier,
-    * which should be unique between all identifiers. e.g.
-    * cat.db.tbl1, cat.db.tbl2, cat.db1.tbl3, cat.db2.tbl3, cat1.db.tbl4, cat2.db.tbl4
-    * the result is
-    * tbl1, tbl2, db1.tbl3, db2.tbl3, cat1.db.tbl4, cat2.db.tbl4
     */
   private def extractSinkIdentifierNames(operations: JList[ModifyOperation]): JList[String] = {
-    val identifiers = new JArrayList[ObjectIdentifier](operations.size)
-    val tableName2DatabaseNames = new JHashMap[String, JArrayList[String]]
     operations.map {
       case catalogSinkModifyOperation: CatalogSinkModifyOperation =>
-        val identifier = catalogSinkModifyOperation.getTableIdentifier
-        identifiers.add(identifier)
-        val tableName = identifier.getObjectName
-        if (!tableName2DatabaseNames.containsKey(tableName)) {
-          tableName2DatabaseNames.put(tableName, new JArrayList[String]())
-        }
-        tableName2DatabaseNames.get(tableName).add(identifier.getDatabaseName)
+        catalogSinkModifyOperation.getTableIdentifier.asSummaryString()
       case o =>
         throw new UnsupportedOperationException("Unsupported operation: " + o)
     }
-
-    val tableNames = new JArrayList[String](identifiers.size)
-    identifiers.foreach { i =>
-      val databaseNames = tableName2DatabaseNames.get(i.getObjectName)
-      if (databaseNames.size == 1) {
-        // current table name is unique
-        tableNames.add(i.getObjectName)
-      } else if (databaseNames.size == new JHashSet[String](databaseNames).size) {
-        // current table name is not unique
-        // while database names associated with current table name are unique
-        tableNames.add(String.join(".", i.getDatabaseName, i.getObjectName))
-      } else {
-        // use full name
-        tableNames.add(String.join(".", i.getCatalogName, i.getDatabaseName, i.getObjectName))
-      }
-    }
-    tableNames
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -254,7 +254,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
     checkEmptyFile(sinkPath)
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -272,7 +272,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
 
     checkEmptyFile(sinkPath)
     val tableResult1 = tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult1)
+    checkInsertTableResult(tableResult1, -1L)
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -280,7 +280,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFirstValues(sinkPath)
 
     val tableResult2 = tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult2)
+    checkInsertTableResult(tableResult2, -1L)
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -296,7 +296,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     checkEmptyFile(sink2Path)
 
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -332,7 +332,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     resultSet.addSink(new StreamITCase.StringSink[Row])
 
     val tableResult = streamTableEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -356,7 +356,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     checkEmptyFile(sinkPath)
     val table = tEnv.sqlQuery("select first from MyTable")
     val tableResult = table.executeInsert("MySink")
-    checkInsertTableResult(tableResult)
+    checkInsertTableResult(tableResult, -1L)
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -374,7 +374,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
 
     checkEmptyFile(sinkPath)
     val tableResult1 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult1)
+    checkInsertTableResult(tableResult1, -1L)
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -382,12 +382,79 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFirstValues(sinkPath)
 
     val tableResult2 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult2)
+    checkInsertTableResult(tableResult2, -1L)
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
       .get()
     assertFirstValues(sinkPath)
+  }
+
+  @Test
+  def testStatementSet(): Unit = {
+    val sink1Path = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
+    val sink2Path = registerCsvTableSink(tEnv, Array("last"), Array(STRING), "MySink2")
+
+    val stmtSet = tEnv.createStatementSet()
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"))
+    stmtSet.addInsertSql("insert into MySink2 select last from MyTable")
+
+    val actual = stmtSet.explain()
+    val expected = readFromResource("testStatementSet0.out")
+    assertEquals(replaceStageId(expected), replaceStageId(actual))
+
+    val tableResult = stmtSet.execute()
+    checkInsertTableResult(tableResult, -1L, -1L)
+    // wait job finished
+    tableResult.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
+  }
+
+  @Test
+  def testStatementSetWithOverwrite(): Unit = {
+    val sink1Path = _tempFolder.newFile().getAbsolutePath
+    val configuredSink1 = new TestingOverwritableTableSink(sink1Path)
+      .configure(Array("first"), Array(STRING))
+    tEnv.registerTableSink("MySink1", configuredSink1)
+    checkEmptyFile(sink1Path)
+
+    val sink2Path = _tempFolder.newFile().getAbsolutePath
+    val configuredSink2 = new TestingOverwritableTableSink(sink2Path)
+      .configure(Array("last"), Array(STRING))
+    tEnv.registerTableSink("MySink2", configuredSink2)
+    checkEmptyFile(sink2Path)
+
+    val stmtSet = tEnv.createStatementSet()
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"), true)
+      .addInsertSql("insert overwrite MySink2 select last from MyTable")
+
+    val tableResult1 = stmtSet.execute()
+    checkInsertTableResult(tableResult1, -1L, -1L)
+    // wait job finished
+    tableResult1.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
+
+    // execute again using same StatementSet instance
+    stmtSet.addInsert("MySink1", tEnv.sqlQuery("select first from MyTable"), true)
+      .addInsertSql("insert overwrite MySink2 select last from MyTable")
+
+    val tableResult2 = stmtSet.execute()
+    checkInsertTableResult(tableResult2, -1L, -1L)
+    // wait job finished
+    tableResult2.getJobClient.get()
+      .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
+      .get()
+
+    assertFirstValues(sink1Path)
+    assertLastValues(sink2Path)
   }
 
   private def registerCsvTableSink(
@@ -433,12 +500,12 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFalse(new File(path).exists())
   }
 
-  private def checkInsertTableResult(tableResult: TableResult): Unit = {
+  private def checkInsertTableResult(tableResult: TableResult, affectedRowCounts: JLong*): Unit = {
     assertTrue(tableResult.getJobClient.isPresent)
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     assertTrue(it.hasNext)
-    assertEquals(Row.of(JLong.valueOf(-1L)), it.next())
+    assertEquals(Row.of(affectedRowCounts: _*), it.next())
     assertFalse(it.hasNext)
   }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentITCase.scala
@@ -24,11 +24,10 @@ import org.apache.flink.api.scala._
 import org.apache.flink.core.fs.FileSystem.WriteMode
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment => ScalaStreamExecutionEnvironment}
-import org.apache.flink.table.api.TableEnvironmentITCase.{getPersonCsvTableSource, getPersonData}
+import org.apache.flink.table.api.TableEnvironmentITCase.getPersonCsvTableSource
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
 import org.apache.flink.table.api.java.StreamTableEnvironment
-import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment, _}
-import org.apache.flink.table.catalog.GenericInMemoryCatalog
+import org.apache.flink.table.api.scala.{StreamTableEnvironment => ScalaStreamTableEnvironment}
 import org.apache.flink.table.runtime.utils.StreamITCase
 import org.apache.flink.table.sinks.CsvTableSink
 import org.apache.flink.table.sources.CsvTableSource
@@ -255,7 +254,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     val sinkPath = registerCsvTableSink(tEnv, Array("first"), Array(STRING), "MySink1")
     checkEmptyFile(sinkPath)
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult, "MySink1")
+    checkInsertTableResult(tableResult, "default_catalog.default_database.MySink1")
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -273,7 +272,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
 
     checkEmptyFile(sinkPath)
     val tableResult1 = tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult1, "MySink")
+    checkInsertTableResult(tableResult1, "default_catalog.default_database.MySink")
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -281,7 +280,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFirstValues(sinkPath)
 
     val tableResult2 = tEnv.executeSql("insert overwrite MySink select first from MyTable")
-    checkInsertTableResult(tableResult2, "MySink")
+    checkInsertTableResult(tableResult2, "default_catalog.default_database.MySink")
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -297,7 +296,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     checkEmptyFile(sink2Path)
 
     val tableResult = tEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult, "MySink1")
+    checkInsertTableResult(tableResult, "default_catalog.default_database.MySink1")
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -333,7 +332,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     resultSet.addSink(new StreamITCase.StringSink[Row])
 
     val tableResult = streamTableEnv.executeSql("insert into MySink1 select first from MyTable")
-    checkInsertTableResult(tableResult, "MySink1")
+    checkInsertTableResult(tableResult, "default_catalog.default_database.MySink1")
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -357,7 +356,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     checkEmptyFile(sinkPath)
     val table = tEnv.sqlQuery("select first from MyTable")
     val tableResult = table.executeInsert("MySink")
-    checkInsertTableResult(tableResult, "MySink")
+    checkInsertTableResult(tableResult, "default_catalog.default_database.MySink")
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -375,7 +374,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
 
     checkEmptyFile(sinkPath)
     val tableResult1 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult1, "MySink")
+    checkInsertTableResult(tableResult1, "default_catalog.default_database.MySink")
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -383,7 +382,7 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertFirstValues(sinkPath)
 
     val tableResult2 = tEnv.sqlQuery("select first from MyTable").executeInsert("MySink", true)
-    checkInsertTableResult(tableResult2, "MySink")
+    checkInsertTableResult(tableResult2, "default_catalog.default_database.MySink")
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -405,7 +404,10 @@ class TableEnvironmentITCase(tableEnvName: String) {
     assertEquals(replaceStageId(expected), replaceStageId(actual))
 
     val tableResult = stmtSet.execute()
-    checkInsertTableResult(tableResult, "MySink1", "MySink2")
+    checkInsertTableResult(
+      tableResult,
+      "default_catalog.default_database.MySink1",
+      "default_catalog.default_database.MySink2")
     // wait job finished
     tableResult.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -434,7 +436,10 @@ class TableEnvironmentITCase(tableEnvName: String) {
       .addInsertSql("insert overwrite MySink2 select last from MyTable")
 
     val tableResult1 = stmtSet.execute()
-    checkInsertTableResult(tableResult1, "MySink1", "MySink2")
+    checkInsertTableResult(
+      tableResult1,
+      "default_catalog.default_database.MySink1",
+      "default_catalog.default_database.MySink2")
     // wait job finished
     tableResult1.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -448,7 +453,10 @@ class TableEnvironmentITCase(tableEnvName: String) {
       .addInsertSql("insert overwrite MySink2 select last from MyTable")
 
     val tableResult2 = stmtSet.execute()
-    checkInsertTableResult(tableResult2, "MySink1", "MySink2")
+    checkInsertTableResult(
+      tableResult2,
+      "default_catalog.default_database.MySink1",
+      "default_catalog.default_database.MySink2")
     // wait job finished
     tableResult2.getJobClient.get()
       .getJobExecutionResult(Thread.currentThread().getContextClassLoader)
@@ -456,45 +464,6 @@ class TableEnvironmentITCase(tableEnvName: String) {
 
     assertFirstValues(sink1Path)
     assertLastValues(sink2Path)
-  }
-
-  @Test
-  def testStatementSetWithMultipleSinkNames(): Unit = {
-    tEnv.registerCatalog("cat1", new GenericInMemoryCatalog("cat1", "db"))
-    tEnv.registerCatalog("cat2", new GenericInMemoryCatalog("cat2", "db"))
-    tEnv.registerCatalog("cat3", new GenericInMemoryCatalog("cat3", "db"))
-    tEnv.executeSql("CREATE DATABASE cat1.db1")
-    tEnv.executeSql("CREATE DATABASE cat1.db2")
-    createTable("cat1.db.tbl1")
-    createTable("cat1.db.tbl2")
-    createTable("cat1.db1.tbl3")
-    createTable("cat1.db2.tbl3")
-    createTable("cat2.db.tbl4")
-    createTable("cat3.db.tbl4")
-
-    val stmtSet = tEnv.createStatementSet()
-    stmtSet.addInsertSql("insert into cat1.db.tbl1 select first from MyTable where id = 1")
-    stmtSet.addInsertSql("insert into cat1.db1.tbl3 select first from MyTable where id = 3")
-    stmtSet.addInsertSql("insert into cat1.db.tbl2 select first from MyTable where id = 2")
-    stmtSet.addInsertSql("insert into cat2.db.tbl4 select first from MyTable where id = 5")
-    stmtSet.addInsertSql("insert into cat1.db2.tbl3 select first from MyTable where id = 4")
-    stmtSet.addInsertSql("insert into cat3.db.tbl4 select first from MyTable where id = 6")
-    val tableResult = stmtSet.execute()
-    checkInsertTableResult(
-      tableResult, "tbl1", "db1.tbl3", "tbl2", "cat2.db.tbl4", "db2.tbl3", "cat3.db.tbl4")
-  }
-
-  private def createTable(fullName: String): Unit = {
-    tEnv.executeSql(
-      s"""
-         |create table $fullName (
-         |  first string
-         |) with (
-         |  'connector' = 'COLLECTION',
-         |  'is-bounded' = 'true'
-         |)
-       """.stripMargin
-    )
   }
 
   private def registerCsvTableSink(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/utils/MockTableEnvironment.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.utils
 
 import org.apache.flink.api.common.JobExecutionResult
 import org.apache.flink.api.common.typeinfo.TypeInformation
-import org.apache.flink.table.api.{ExplainDetail, Table, TableConfig, TableEnvironment, TableResult}
+import org.apache.flink.table.api.{ExplainDetail, StatementSet, Table, TableConfig, TableEnvironment, TableResult}
 import org.apache.flink.table.catalog.Catalog
 import org.apache.flink.table.descriptors.{ConnectTableDescriptor, ConnectorDescriptor}
 import org.apache.flink.table.expressions.Expression
@@ -81,6 +81,8 @@ class MockTableEnvironment extends TableEnvironment {
   override def sqlQuery(query: String): Table = ???
 
   override def executeSql(statement: String): TableResult = ???
+
+  override def createStatementSet(): StatementSet = ???
 
   override def sqlUpdate(stmt: String): Unit = ???
 

--- a/flink-table/flink-table-planner/src/test/scala/resources/testStatementSet0.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testStatementSet0.out
@@ -1,0 +1,63 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  LogicalProject(first=[$0])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+LogicalSink(name=[default_catalog.default_database.MySink2], fields=[last])
+  LogicalProject(last=[$3])
+    LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+
+== Optimized Logical Plan ==
+DataStreamSink(name=[default_catalog.default_database.MySink1], fields=[first])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[first], source=[CsvTableSource(read fields: first)])
+
+DataStreamSink(name=[default_catalog.default_database.MySink2], fields=[last])
+  StreamTableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[last], source=[CsvTableSource(read fields: last)])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : CsvTableSource(read fields: first)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : Map
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Map
+					ship_strategy : REBALANCE
+
+ : Data Source
+	content : collect elements with CollectionInputFormat
+
+	 : Operator
+		content : CsvTableSource(read fields: last)
+		ship_strategy : REBALANCE
+
+		 : Operator
+			content : Map
+			ship_strategy : FORWARD
+
+			 : Operator
+				content : to: Row
+				ship_strategy : FORWARD
+
+				 : Operator
+					content : Map
+					ship_strategy : REBALANCE
+
+					 : Data Sink
+						content : Sink: CsvTableSink(first)
+						ship_strategy : FORWARD
+
+						 : Data Sink
+							content : Sink: CsvTableSink(last)
+							ship_strategy : FORWARD
+

--- a/flink-table/flink-table-planner/src/test/scala/resources/testStatementSet1.out
+++ b/flink-table/flink-table-planner/src/test/scala/resources/testStatementSet1.out
@@ -1,0 +1,81 @@
+== Abstract Syntax Tree ==
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink1`], fields=[d, e, f])
+  LogicalProject(a=[$0], b=[$1], c=[$2])
+    LogicalFilter(condition=[>($0, 2)])
+      LogicalProject(a=[AS($0, _UTF-16LE'a')], b=[AS($1, _UTF-16LE'b')], c=[AS($2, _UTF-16LE'c')])
+        FlinkLogicalDataSetScan(ref=[], fields=[_1, _2, _3])
+
+LogicalSink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[i, j, k])
+  LogicalProject(a=[$0], b=[$1], c=[$2])
+    LogicalFilter(condition=[<=($0, 2)])
+      LogicalProject(a=[AS($0, _UTF-16LE'a')], b=[AS($1, _UTF-16LE'b')], c=[AS($2, _UTF-16LE'c')])
+        FlinkLogicalDataSetScan(ref=[], fields=[_1, _2, _3])
+
+== Optimized Logical Plan ==
+DataSetSink(name=[`default_catalog`.`default_database`.`MySink1`], fields=[d, e, f])
+  DataSetCalc(select=[_1 AS a, _2 AS b, _3 AS c], where=[>(_1, 2)])
+    DataSetScan(ref=[], fields=[_1, _2, _3])
+
+DataSetSink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[i, j, k])
+  DataSetCalc(select=[_1 AS a, _2 AS b, _3 AS c], where=[<=(_1, 2)])
+    DataSetScan(ref=[], fields=[_1, _2, _3])
+
+== Physical Execution Plan ==
+ : Data Source
+	content : collect elements with CollectionInputFormat
+	Partitioning : RANDOM_PARTITIONED
+
+	 : Map
+		content : from: (_1, _2, _3)
+		ship_strategy : Forward
+		exchange_mode : PIPELINED
+		driver_strategy : Map
+		Partitioning : RANDOM_PARTITIONED
+
+		 : FlatMap
+			content : where: (>(_1, 2)), select: (_1 AS a, _2 AS b, _3 AS c)
+			ship_strategy : Forward
+			exchange_mode : PIPELINED
+			driver_strategy : FlatMap
+			Partitioning : RANDOM_PARTITIONED
+
+			 : Map
+				content : to: Row
+				ship_strategy : Forward
+				exchange_mode : PIPELINED
+				driver_strategy : Map
+				Partitioning : RANDOM_PARTITIONED
+
+				 : Data Sink
+					content : TextOutputFormat () - UTF-8
+					ship_strategy : Forward
+					exchange_mode : PIPELINED
+					Partitioning : RANDOM_PARTITIONED
+
+					 : Map
+						content : from: (_1, _2, _3)
+						ship_strategy : Forward
+						exchange_mode : PIPELINED
+						driver_strategy : Map
+						Partitioning : RANDOM_PARTITIONED
+
+						 : FlatMap
+							content : where: (<=(_1, 2)), select: (_1 AS a, _2 AS b, _3 AS c)
+							ship_strategy : Forward
+							exchange_mode : PIPELINED
+							driver_strategy : FlatMap
+							Partitioning : RANDOM_PARTITIONED
+
+							 : Map
+								content : to: Row
+								ship_strategy : Forward
+								exchange_mode : PIPELINED
+								driver_strategy : Map
+								Partitioning : RANDOM_PARTITIONED
+
+								 : Data Sink
+									content : TextOutputFormat () - UTF-8
+									ship_strategy : Forward
+									exchange_mode : PIPELINED
+									Partitioning : RANDOM_PARTITIONED
+


### PR DESCRIPTION

## What is the purpose of the change

*Introduce TableEnvironment#createStatementSet api to support accept DML statements and Tables. The planner can optimize all added statements and Tables in StatementSet together and then submit as one job.*


## Brief change log

  - *add TableEnvironment#createStatementSet method*
  - *add StatementSet interface*
  - *add related classes and methods in flink-python*

## Verifying this change

This change added tests and can be verified as follows:
  - *Extended TableEnvironmentITCase to verify StatementSet*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
