### PR TITLE
[FLINK-17586][python] Use the real StreamExecutionEnvironment contained in DummyStreamExecutionEnvironment when translating the Python UDF physical nodes to operators.

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/plan/nodes/common/CommonPythonBase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo}
 import org.apache.flink.table.planner.functions.utils.{ScalarSqlFunction, TableSqlFunction}
+import org.apache.flink.table.planner.utils.DummyStreamExecutionEnvironment
 
 import scala.collection.mutable
 import scala.collection.JavaConversions._
@@ -90,9 +91,11 @@ trait CommonPythonBase {
       env: StreamExecutionEnvironment,
       tableConfig: TableConfig): Configuration = {
     val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
+    val realEnv = getRealEnvironment(env)
     val method = clazz.getDeclaredMethod(
       "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(null, env.getCachedFiles, getMergedConfiguration(env, tableConfig))
+    val config = method.invoke(
+      null, realEnv.getCachedFiles, getMergedConfiguration(realEnv, tableConfig))
       .asInstanceOf[Configuration]
     config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
     config
@@ -110,6 +113,16 @@ trait CommonPythonBase {
     val config = new Configuration(method.invoke(env).asInstanceOf[Configuration])
     config.addAll(tableConfig.getConfiguration)
     config
+  }
+
+  private def getRealEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment = {
+    val realExecEnvField = classOf[DummyStreamExecutionEnvironment].getDeclaredField("realExecEnv")
+    realExecEnvField.setAccessible(true)
+    var realEnv = env
+    while (realEnv.isInstanceOf[DummyStreamExecutionEnvironment]) {
+      realEnv = realExecEnvField.get(realEnv).asInstanceOf[StreamExecutionEnvironment]
+    }
+    realEnv
   }
 }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/plan/nodes/CommonPythonBase.scala
@@ -26,6 +26,7 @@ import org.apache.flink.table.api.{TableConfig, TableException}
 import org.apache.flink.table.functions.UserDefinedFunction
 import org.apache.flink.table.functions.python.{PythonFunction, PythonFunctionInfo}
 import org.apache.flink.table.functions.utils.{ScalarSqlFunction, TableSqlFunction}
+import org.apache.flink.table.util.DummyStreamExecutionEnvironment
 
 import scala.collection.mutable
 import scala.collection.JavaConversions._
@@ -93,7 +94,8 @@ trait CommonPythonBase {
     val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
     val method = clazz.getDeclaredMethod(
       "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(null, field.get(env), getMergedConfiguration(env, tableConfig))
+    val config = method.invoke(
+      null, field.get(env), getMergedConfiguration(env, tableConfig))
       .asInstanceOf[Configuration]
     config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
     config
@@ -103,9 +105,11 @@ trait CommonPythonBase {
       env: StreamExecutionEnvironment,
       tableConfig: TableConfig): Configuration = {
     val clazz = loadClass(CommonPythonBase.PYTHON_DEPENDENCY_UTILS_CLASS)
+    val realEnv = getRealEnvironment(env)
     val method = clazz.getDeclaredMethod(
       "configurePythonDependencies", classOf[java.util.List[_]], classOf[Configuration])
-    val config = method.invoke(null, env.getCachedFiles, getMergedConfiguration(env, tableConfig))
+    val config = method.invoke(
+      null, realEnv.getCachedFiles, getMergedConfiguration(realEnv, tableConfig))
       .asInstanceOf[Configuration]
     config.setString("table.exec.timezone", tableConfig.getLocalTimeZone.getId)
     config
@@ -135,6 +139,16 @@ trait CommonPythonBase {
     val config = new Configuration(env.getConfiguration)
     config.addAll(tableConfig.getConfiguration)
     config
+  }
+
+  private def getRealEnvironment(env: StreamExecutionEnvironment): StreamExecutionEnvironment = {
+    val realExecEnvField = classOf[DummyStreamExecutionEnvironment].getDeclaredField("realExecEnv")
+    realExecEnvField.setAccessible(true)
+    var realEnv = env
+    while (realEnv.isInstanceOf[DummyStreamExecutionEnvironment]) {
+      realEnv = realExecEnvField.get(realEnv).asInstanceOf[StreamExecutionEnvironment]
+    }
+    realEnv
   }
 }
 


### PR DESCRIPTION
## What is the purpose of the change

*This pull request gets the real Configuration object from DummyStreamExecutionEnvironment when translating the Python UDF physical nodes to operators.*

## Brief change log

  - *Get the real environment object from the DummyStreamExecutionEnvironment before getting the configuration.*

## Verifying this change

This change can be verified as follows:

  - *Prepare a sql job with python udfs.*
  - *Submit the sql job with python dependency management command line options.*

**NOTE:** This change can be verify automatically after adding the PyFlink e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
