### PR TITLE
[FLINK-17585][python] PythonProgramOptions should not change the entr…

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/client/cli/PythonProgramOptions.java
@@ -49,7 +49,7 @@ public class PythonProgramOptions extends ProgramOptions {
 		pythonConfiguration = PythonDependencyUtils.parsePythonDependencyConfiguration(line);
 		// If the job is Python Shell job, the entry point class name is PythonGateWayServer.
 		// Otherwise, the entry point class of python job is PythonDriver
-		if (entryPointClass == null) {
+		if (isPythonEntryPoint && entryPointClass == null) {
 			entryPointClass = "org.apache.flink.client.python.PythonDriver";
 		}
 	}


### PR DESCRIPTION
…ypoint when user submit a Java sql job which contains Python UDF.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the bug that "PythonProgramOptions" changes the entry point class when user submit a Java sql job which contains Python UDF.

## Brief change log

Add a judgement whether the job has a python entrypoint in PythonProgramOptions.

## Verifying this change

This change can be verified as follows:

- prepare a java sql job that contains python udfs.
- packaged the java program as a jar and submit the job via `flink run` wiht "-pyfs" option and without "-c" option
**NOTE:** This change can be verify automatically after adding the PyFlink e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
 