### PR TITLE
[FLINK-17588][scala-shell] Throw exception when hadoop jar is missing in flink scala's yarn mode

### DIFF
--- a/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
+++ b/flink-scala-shell/src/main/scala/org/apache/flink/api/scala/FlinkShell.scala
@@ -157,7 +157,7 @@ object FlinkShell {
 
     val flinkConfig = getGlobalConfig(config)
 
-    val (repl, clusterClient) = try {
+    val (repl, clusterClient) = {
       val (effectiveConfig, clusterClient) = fetchConnectionInfo(config, flinkConfig)
 
       val host = effectiveConfig.getString(JobManagerOptions.ADDRESS)
@@ -173,10 +173,6 @@ object FlinkShell {
       }
 
       (repl, clusterClient)
-    } catch {
-      case e: IllegalArgumentException =>
-        println(s"Error: ${e.getMessage}")
-        sys.exit()
     }
 
     val settings = new Settings()
@@ -245,6 +241,13 @@ object FlinkShell {
     val commandLine = CliFrontendParser.parse(commandLineOptions, args, true)
 
     val customCLI = frontend.getActiveCustomCommandLine(commandLine)
+    if (customCLI.getClass.getName != "org.apache.flink.yarn.cli.FlinkYarnSessionCli") {
+      throw new Exception("Fail to load FlinkYarnSessionCli, " +
+        "please make sure hadoop jar is under your classpath, " +
+        "refer this link for how to integrate with hadoop: " +
+        "https://ci.apache.org/projects/flink/flink-docs-master/ops/deployment/hadoop.html")
+    }
+
     val executorConfig = customCLI.applyCommandLineOptionsToConfiguration(commandLine)
 
     val serviceLoader = new DefaultClusterClientServiceLoader


### PR DESCRIPTION
## What is the purpose of the change

This PR is to throw meaningful exception when hadoop jar is missing in flink scala's yarn mode. Currently the error message is useless and confusing for users. see screenshot below.

## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework without any test coverage. See the following screenshot for comparison w/o this PR.

* Before
![image](https://user-images.githubusercontent.com/164491/81466691-21a2d500-9206-11ea-9c01-af831c9cfe81.png)

* After
![image](https://user-images.githubusercontent.com/164491/81466370-ba842100-9203-11ea-9b43-81c9e0b16fe2.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
