### PR TITLE
[FLINK-17590][connector/filesystem] Support bucket lifecycle listener in streaming file sink buckets

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/Bucket.java
@@ -162,15 +162,15 @@ public class Bucket<IN, BucketID> {
 		}
 	}
 
-	BucketID getBucketId() {
+	public BucketID getBucketId() {
 		return bucketId;
 	}
 
-	Path getBucketPath() {
+	public Path getBucketPath() {
 		return bucketPath;
 	}
 
-	long getPartCounter() {
+	public long getPartCounter() {
 		return partCounter;
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketLifeCycleListener.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketLifeCycleListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+/**
+ * Listener about the status of {@link Bucket}.
+ */
+@Internal
+public interface BucketLifeCycleListener<IN, BucketID> extends Serializable {
+
+	/**
+	 * Notifies a new bucket has been created.
+	 *
+	 * @param bucket The newly created bucket.
+	 */
+	void bucketCreated(Bucket<IN, BucketID> bucket);
+
+	/**
+	 * Notifies a bucket become inactive. A bucket becomes inactive after all
+	 * the records received so far have been committed.
+	 *
+	 * @param bucket The bucket getting inactive.
+	 */
+	void bucketInactive(Bucket<IN, BucketID> bucket);
+
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -222,6 +222,8 @@ public class StreamingFileSink<IN>
 
 		private OutputFileConfig outputFileConfig;
 
+		private BucketLifeCycleListener<IN, BucketID> bucketLifeCycleListener;
+
 		protected RowFormatBuilder(Path basePath, Encoder<IN> encoder, BucketAssigner<IN, BucketID> bucketAssigner) {
 			this(basePath, encoder, bucketAssigner, DefaultRollingPolicy.builder().build(), DEFAULT_BUCKET_CHECK_INTERVAL, new DefaultBucketFactoryImpl<>(), OutputFileConfig.builder().build());
 		}
@@ -262,6 +264,11 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		public T withBucketLifeCycleListener(final BucketLifeCycleListener<IN, BucketID> listener) {
+			this.bucketLifeCycleListener = Preconditions.checkNotNull(listener);
+			return self();
+		}
+
 		public T withOutputFileConfig(final OutputFileConfig outputFileConfig) {
 			this.outputFileConfig = outputFileConfig;
 			return self();
@@ -291,7 +298,7 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new RowWisePartWriter.Factory<>(encoder),
 					rollingPolicy,
-					null,
+					bucketLifeCycleListener,
 					subtaskIndex,
 					outputFileConfig);
 		}
@@ -326,6 +333,8 @@ public class StreamingFileSink<IN>
 		private BucketAssigner<IN, BucketID> bucketAssigner;
 
 		private CheckpointRollingPolicy<IN, BucketID> rollingPolicy;
+
+		private BucketLifeCycleListener<IN, BucketID> bucketLifeCycleListener;
 
 		private BucketFactory<IN, BucketID> bucketFactory;
 
@@ -372,6 +381,11 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		public T withBucketLifeCycleListener(final BucketLifeCycleListener<IN, BucketID> listener) {
+			this.bucketLifeCycleListener = Preconditions.checkNotNull(listener);
+			return self();
+		}
+
 		@VisibleForTesting
 		T withBucketFactory(final BucketFactory<IN, BucketID> factory) {
 			this.bucketFactory = Preconditions.checkNotNull(factory);
@@ -402,7 +416,7 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new BulkPartWriter.Factory<>(writerFactory),
 					rollingPolicy,
-					null,
+					bucketLifeCycleListener,
 					subtaskIndex,
 					outputFileConfig);
 		}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.serialization.BulkWriter;
@@ -264,6 +265,7 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		@Internal
 		public T withBucketLifeCycleListener(final BucketLifeCycleListener<IN, BucketID> listener) {
 			this.bucketLifeCycleListener = Preconditions.checkNotNull(listener);
 			return self();
@@ -381,6 +383,7 @@ public class StreamingFileSink<IN>
 			return self();
 		}
 
+		@Internal
 		public T withBucketLifeCycleListener(final BucketLifeCycleListener<IN, BucketID> listener) {
 			this.bucketLifeCycleListener = Preconditions.checkNotNull(listener);
 			return self();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -291,6 +291,7 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new RowWisePartWriter.Factory<>(encoder),
 					rollingPolicy,
+					null,
 					subtaskIndex,
 					outputFileConfig);
 		}
@@ -401,6 +402,7 @@ public class StreamingFileSink<IN>
 					bucketFactory,
 					new BulkPartWriter.Factory<>(writerFactory),
 					rollingPolicy,
+					null,
 					subtaskIndex,
 					outputFileConfig);
 		}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketAssignerITCases.java
@@ -56,6 +56,7 @@ public class BucketAssignerITCases {
 			new DefaultBucketFactoryImpl<>(),
 			new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 			rollingPolicy,
+			null,
 			0,
 			OutputFileConfig.builder().build()
 		);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.TestUtils.MockListState;
@@ -34,8 +35,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -317,6 +323,7 @@ public class BucketsTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				DefaultRollingPolicy.builder().build(),
+				null,
 				2,
 				OutputFileConfig.builder().build()
 		);
@@ -367,6 +374,66 @@ public class BucketsTest {
 		}
 	}
 
+	@Test
+	public void testBucketLifeCycleListenerOnCreatingAndInactive() throws Exception {
+		File outDir = TEMP_FOLDER.newFolder();
+		Path path = new Path(outDir.toURI());
+		OnProcessingTimePolicy<String, String> rollOnProcessingTimeCountingPolicy =
+			new OnProcessingTimePolicy<>(2L);
+		RecordBucketLifeCycleListener bucketLifeCycleListener = new RecordBucketLifeCycleListener();
+		Buckets<String, String> buckets = createBuckets(
+			path,
+			rollOnProcessingTimeCountingPolicy,
+			bucketLifeCycleListener,
+			0,
+			OutputFileConfig.builder().build());
+		ListState<byte[]> bucketStateContainer = new MockListState<>();
+		ListState<Long> partCounterContainer = new MockListState<>();
+
+		buckets.onElement("test1", new TestUtils.MockSinkContext(null, 1L, 2L));
+		buckets.onElement("test2", new TestUtils.MockSinkContext(null, 1L, 3L));
+
+		// Will close the part file writer of the bucket "test1".
+		buckets.onProcessingTime(4);
+		buckets.snapshotState(0, bucketStateContainer, partCounterContainer);
+		buckets.commitUpToCheckpoint(0);
+
+		// Will close the part file writer of the bucket "test2".
+		buckets.onProcessingTime(6);
+		buckets.snapshotState(1, bucketStateContainer, partCounterContainer);
+		buckets.commitUpToCheckpoint(1);
+
+		List<Tuple2<RecordBucketLifeCycleListener.EventType, String>> expectedEvents = Arrays.asList(
+			new Tuple2<>(RecordBucketLifeCycleListener.EventType.CREATED, "test1"),
+			new Tuple2<>(RecordBucketLifeCycleListener.EventType.CREATED, "test2"),
+			new Tuple2<>(RecordBucketLifeCycleListener.EventType.INACTIVE, "test1"),
+			new Tuple2<>(RecordBucketLifeCycleListener.EventType.INACTIVE, "test2"));
+		Assert.assertEquals(expectedEvents, bucketLifeCycleListener.getEvents());
+	}
+
+	private static class RecordBucketLifeCycleListener implements BucketLifeCycleListener<String, String> {
+		public enum EventType {
+			CREATED,
+			INACTIVE
+		}
+
+		private List<Tuple2<EventType, String>> events = new ArrayList<>();
+
+		@Override
+		public void bucketCreated(Bucket<String, String> bucket) {
+			events.add(new Tuple2<>(EventType.CREATED, bucket.getBucketId()));
+		}
+
+		@Override
+		public void bucketInactive(Bucket<String, String> bucket) {
+			events.add(new Tuple2<>(EventType.INACTIVE, bucket.getBucketId()));
+		}
+
+		public List<Tuple2<EventType, String>> getEvents() {
+			return events;
+		}
+	}
+
 	// ------------------------------- Utility Methods --------------------------------
 
 	private static Buckets<String, String> createBuckets(
@@ -376,6 +443,7 @@ public class BucketsTest {
 		return createBuckets(
 				basePath,
 				rollingPolicy,
+				null,
 				subtaskIdx,
 				OutputFileConfig.builder().build());
 	}
@@ -383,6 +451,7 @@ public class BucketsTest {
 	private static Buckets<String, String> createBuckets(
 			final Path basePath,
 			final RollingPolicy<String, String> rollingPolicy,
+			@Nullable final BucketLifeCycleListener<String, String> bucketLifeCycleListener,
 			final int subtaskIdx,
 			final OutputFileConfig outputFileConfig) throws IOException {
 		return new Buckets<>(
@@ -391,6 +460,7 @@ public class BucketsTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicy,
+				bucketLifeCycleListener,
 				subtaskIdx,
 				outputFileConfig
 		);
@@ -418,7 +488,12 @@ public class BucketsTest {
 			final ListState<byte[]> bucketState,
 			final ListState<Long> partCounterState,
 			final OutputFileConfig outputFileConfig) throws Exception {
-		final Buckets<String, String> restoredBuckets = createBuckets(basePath, rollingPolicy, subtaskIdx, outputFileConfig);
+		final Buckets<String, String> restoredBuckets = createBuckets(
+			basePath,
+			rollingPolicy,
+			null,
+			subtaskIdx,
+			outputFileConfig);
 		restoredBuckets.initializeState(bucketState, partCounterState);
 		return restoredBuckets;
 	}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/sink/filesystem/RollingPolicyTest.java
@@ -203,6 +203,7 @@ public class RollingPolicyTest {
 				new DefaultBucketFactoryImpl<>(),
 				new RowWisePartWriter.Factory<>(new SimpleStringEncoder<>()),
 				rollingPolicyToTest,
+				null,
 				0,
 				OutputFileConfig.builder().build()
 		);


### PR DESCRIPTION
## What is the purpose of the change

This PR adds listener into `Buckets` to support acquiring the events of state migration of `Bucket`. This is used to support writing meta-info in Hive Sink.


## Brief change log

  - 1e1d15d10c7026928824e1fbc99099cc52821de4 Adds the bucket lifecycle listener.

## Verifying this change

This PR is verified by 
  - Added Unit test to verify the listener is called at suitable time if the listener is set.
  - The existing tests verify the Buckets works well when the listener is not set.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector:  **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
