### PR TITLE
[FLINK-17579] Allow user to set the prefix of TaskManager's ResourceID in standalone mode

### DIFF
--- a/docs/_includes/generated/all_taskmanager_section.html
+++ b/docs/_includes/generated/all_taskmanager_section.html
@@ -88,6 +88,12 @@
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.resource-id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The TaskManager's ResourceID. If not configured, the ResourceID will be generated with the "RpcAddress:RpcPort" and a 6-character random string. Notice that this option is not valid in Yarn / Mesos and Native Kubernetes mode.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">"0"</td>
             <td>String</td>

--- a/docs/_includes/generated/task_manager_configuration.html
+++ b/docs/_includes/generated/task_manager_configuration.html
@@ -76,6 +76,12 @@
             <td>Defines the timeout for the TaskManager registration. If the duration is exceeded without a successful registration, then the TaskManager terminates.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.resource-id</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The TaskManager's ResourceID. If not configured, the ResourceID will be generated with the "RpcAddress:RpcPort" and a 6-character random string. Notice that this option is not valid in Yarn / Mesos and Native Kubernetes mode.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.rpc.bind-port</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -257,6 +257,18 @@ public class TaskManagerOptions {
 					text("\"ip\" - uses host's ip address as binding address"))
 				.build());
 
+	/**
+	 * The TaskManager's ResourceID. If not configured, the ResourceID will be generated with the RpcAddress:RpcPort and a 6-character
+	 * random string. Notice that this option is not valid in Yarn / Mesos and Native Kubernetes mode.
+	 */
+	@Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER)
+	public static final ConfigOption<String> TASK_MANAGER_RESOURCE_ID =
+		key("taskmanager.resource-id")
+			.stringType()
+			.noDefaultValue()
+			.withDescription("The TaskManager's ResourceID. If not configured, the ResourceID will be generated with the "
+				+ "\"RpcAddress:RpcPort\" and a 6-character random string. Notice that this option is not valid in Yarn / Mesos and Native Kubernetes mode.");
+
 	// ------------------------------------------------------------------------
 	//  Resource Options
 	// ------------------------------------------------------------------------

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesResourceManagerConfiguration;
 import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
@@ -308,8 +309,11 @@ public class KubernetesResourceManager extends ActiveResourceManager<KubernetesW
 		final ContaineredTaskManagerParameters taskManagerParameters =
 			ContaineredTaskManagerParameters.create(flinkConfig, taskExecutorProcessSpec);
 
+		final Configuration taskManagerConfig = new Configuration(flinkConfig);
+		taskManagerConfig.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, podName);
+
 		final String dynamicProperties =
-			BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, flinkConfig);
+			BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, taskManagerConfig);
 
 		return new KubernetesTaskManagerParameters(
 			flinkConfig,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -35,7 +35,6 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.kubernetes.utils.Constants.ENV_FLINK_POD_NAME;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -92,10 +91,6 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
 					.withContainerPort(kubernetesTaskManagerParameters.getRPCPort())
 					.build())
 				.withEnv(getCustomizedEnvs())
-				.addNewEnv()
-					.withName(ENV_FLINK_POD_NAME)
-					.withValue(kubernetesTaskManagerParameters.getPodName())
-					.endEnv()
 				.build();
 	}
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/taskmanager/KubernetesTaskExecutorRunner.java
@@ -18,13 +18,10 @@
 
 package org.apache.flink.kubernetes.taskmanager;
 
-import org.apache.flink.kubernetes.utils.Constants;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,10 +38,6 @@ public class KubernetesTaskExecutorRunner {
 		SignalHandler.register(LOG);
 		JvmShutdownSafeguard.installAsShutdownHook(LOG);
 
-		final String resourceID = System.getenv().get(Constants.ENV_FLINK_POD_NAME);
-		Preconditions.checkArgument(resourceID != null,
-			"Pod name variable %s not set", Constants.ENV_FLINK_POD_NAME);
-
-		TaskManagerRunner.runTaskManagerSecurely(args, new ResourceID(resourceID));
+		TaskManagerRunner.runTaskManagerSecurely(args);
 	}
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -69,8 +69,6 @@ public class Constants {
 
 	public static final String ENV_FLINK_CLASSPATH = "FLINK_CLASSPATH";
 
-	public static final String ENV_FLINK_POD_NAME = "_FLINK_POD_NAME";
-
 	public static final String ENV_FLINK_POD_IP_ADDRESS = "_POD_IP_ADDRESS";
 
 	public static final String POD_IP_FIELD_PATH = "status.podIP";

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerTest.java
@@ -73,7 +73,6 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableList;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStateBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
-import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -208,10 +207,6 @@ public class KubernetesResourceManagerTest extends KubernetesTestBase {
 
 				final String podName = CLUSTER_ID + "-taskmanager-1-1";
 				assertEquals(podName, pod.getMetadata().getName());
-
-				// Check environments
-				assertThat(tmContainer.getEnv(), Matchers.contains(
-					new EnvVarBuilder().withName(Constants.ENV_FLINK_POD_NAME).withValue(podName).build()));
 
 				// Check task manager main class args.
 				assertEquals(3, tmContainer.getArgs().size());

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -159,7 +159,6 @@ public class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase 
 	@Test
 	public void testMainContainerEnv() {
 		final Map<String, String> expectedEnvVars = new HashMap<>(customizedEnvs);
-		expectedEnvVars.put(Constants.ENV_FLINK_POD_NAME, POD_NAME);
 
 		final Map<String, String> resultEnvVars = this.resultMainContainer.getEnv()
 			.stream()

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -71,7 +71,7 @@ public class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestB
 		assertEquals(CONTAINER_IMAGE, resultMainContainer.getImage());
 		assertEquals(CONTAINER_IMAGE_PULL_POLICY.name(), resultMainContainer.getImagePullPolicy());
 
-		assertEquals(4, resultMainContainer.getEnv().size());
+		assertEquals(3, resultMainContainer.getEnv().size());
 		assertTrue(resultMainContainer.getEnv()
 			.stream()
 			.anyMatch(envVar -> envVar.getName().equals("key1")));

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/entrypoint/MesosTaskExecutorRunner.java
@@ -23,10 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
-import org.apache.flink.mesos.runtime.clusterframework.MesosConfigKeys;
 import org.apache.flink.mesos.util.MesosUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
@@ -34,7 +32,6 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -95,18 +92,13 @@ public class MesosTaskExecutorRunner {
 		// tell akka to die in case of an error
 		configuration.setBoolean(AkkaOptions.JVM_EXIT_ON_FATAL_ERROR, true);
 
-		// Infer the resource identifier from the environment variable
-		String containerID = Preconditions.checkNotNull(envs.get(MesosConfigKeys.ENV_FLINK_CONTAINER_ID));
-		final ResourceID resourceId = new ResourceID(containerID);
-		LOG.info("ResourceID assigned for this container: {}", resourceId);
-
 		// Run the TM in the security context
 		SecurityConfiguration sc = new SecurityConfiguration(configuration);
 		SecurityUtils.install(sc);
 
 		try {
 			SecurityUtils.getInstalledContext().runSecured(() -> {
-				TaskManagerRunner.runTaskManager(configuration, resourceId, pluginManager);
+				TaskManagerRunner.runTaskManager(configuration, pluginManager);
 
 				return 0;
 			});

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/LaunchableMesosWorker.java
@@ -273,8 +273,8 @@ public class LaunchableMesosWorker implements LaunchableTask {
 			env.addVariables(variable(entry.getKey(), entry.getValue()));
 		}
 
-		// propagate the Mesos task ID to the TM
-		env.addVariables(variable(MesosConfigKeys.ENV_FLINK_CONTAINER_ID, taskInfo.getTaskId().getValue()));
+		// set the ResourceID of TM to the Mesos task
+		dynamicProperties.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, taskInfo.getTaskId().getValue());
 
 		// finalize the memory parameters
 		jvmArgs.append(" ").append(ProcessMemoryUtils.generateJvmParametersStr(tmParams.getTaskExecutorProcessSpec()));

--- a/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
+++ b/flink-mesos/src/main/java/org/apache/flink/mesos/runtime/clusterframework/MesosConfigKeys.java
@@ -27,11 +27,6 @@ public class MesosConfigKeys {
 	// ------------------------------------------------------------------------
 
 	/**
-	 * The Mesos task ID, used by the TM for informational purposes.
-	 */
-	public static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
-
-	/**
 	 * Reserved for future enhancement.
 	 */
 	public static final String ENV_FLINK_TMP_DIR = "_FLINK_TMP_DIR";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ActiveResourceManagerFactory.java
@@ -69,7 +69,10 @@ public abstract class ActiveResourceManagerFactory<T extends ResourceIDRetrievab
 	}
 
 	private Configuration createActiveResourceManagerConfiguration(Configuration originalConfiguration) {
+		final Configuration copiedConfig = new Configuration(originalConfiguration);
+		// In active mode, it's depend on the ResourceManager to set the ResourceID of TaskManagers.
+		copiedConfig.removeConfig(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID);
 		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
-			originalConfiguration, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
+			copiedConfig, TaskManagerOptions.TOTAL_PROCESS_MEMORY);
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -268,9 +268,7 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 			FutureUtils.orTimeout(terminationFuture, FATAL_ERROR_SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
 			terminationFuture.whenComplete(
-				(Void ignored, Throwable throwable) -> {
-					terminateJVM();
-				});
+				(Void ignored, Throwable throwable) -> terminateJVM());
 		}
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.taskexecutor;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
@@ -92,7 +93,8 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 
 	private static final int STARTUP_FAILURE_RETURN_CODE = 1;
 
-	public static final int RUNTIME_FAILURE_RETURN_CODE = 2;
+	@VisibleForTesting
+	static final int RUNTIME_FAILURE_RETURN_CODE = 2;
 
 	private final Object lock = new Object();
 
@@ -414,9 +416,10 @@ public class TaskManagerRunner implements FatalErrorHandler, AutoCloseableAsync 
 	 * @param configuration The configuration for the TaskManager.
 	 * @param haServices to use for the task manager hostname retrieval
 	 */
-	public static RpcService createRpcService(
-			final Configuration configuration,
-			final HighAvailabilityServices haServices) throws Exception {
+	@VisibleForTesting
+	static RpcService createRpcService(
+		final Configuration configuration,
+		final HighAvailabilityServices haServices) throws Exception {
 
 		checkNotNull(configuration);
 		checkNotNull(haServices);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
@@ -34,8 +33,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.net.InetAddress;
+
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -86,6 +89,38 @@ public class TaskManagerRunnerTest extends TestLogger {
 		assertThat(statusCode, is(equalTo(TaskManagerRunner.RUNTIME_FAILURE_RETURN_CODE)));
 	}
 
+	@Test
+	public void testGenerateTaskManagerResourceIDWithConfig() throws Exception {
+		final Configuration configuration = createConfiguration();
+		final String resourceID = "test";
+		configuration.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, resourceID);
+		final String taskManagerResourceID = TaskManagerRunner.getTaskManagerResourceID(configuration, "", -1);
+
+		assertThat(taskManagerResourceID, equalTo(resourceID));
+	}
+
+	@Test
+	public void testGenerateTaskManagerResourceIDWithRemoteRpcService() throws Exception {
+		final Configuration configuration = createConfiguration();
+		final String rpcAddress = "flink";
+		final int rpcPort = 9090;
+		final String taskManagerResourceID = TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort);
+
+		assertThat(taskManagerResourceID, notNullValue());
+		assertThat(taskManagerResourceID, containsString(rpcAddress + ":" + rpcPort));
+	}
+
+	@Test
+	public void testGenerateTaskManagerResourceIDWithLocalRpcService() throws Exception {
+		final Configuration configuration = createConfiguration();
+		final String rpcAddress = "";
+		final int rpcPort = -1;
+		final String taskManagerResourceID = TaskManagerRunner.getTaskManagerResourceID(configuration, rpcAddress, rpcPort);
+
+		assertThat(taskManagerResourceID, notNullValue());
+		assertThat(taskManagerResourceID, containsString(InetAddress.getLocalHost().getHostName()));
+	}
+
 	private static Configuration createConfiguration() {
 		final Configuration configuration = new Configuration();
 		configuration.setString(JobManagerOptions.ADDRESS, "localhost");
@@ -95,7 +130,7 @@ public class TaskManagerRunnerTest extends TestLogger {
 
 	private static TaskManagerRunner createTaskManagerRunner(final Configuration configuration) throws Exception {
 		final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
-		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, ResourceID.generate(), pluginManager);
+		TaskManagerRunner taskManagerRunner = new TaskManagerRunner(configuration, pluginManager);
 		taskManagerRunner.start();
 		return taskManagerRunner;
 	}

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/AbstractTaskManagerProcessFailureRecoveryTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.StandaloneSessionClusterEntrypoint;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.util.BlobServerResource;
@@ -325,7 +324,7 @@ public abstract class AbstractTaskManagerProcessFailureRecoveryTest extends Test
 				Configuration cfg = parameterTool.getConfiguration();
 				final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(cfg);
 
-				TaskManagerRunner.runTaskManager(cfg, ResourceID.generate(), pluginManager);
+				TaskManagerRunner.runTaskManager(cfg, pluginManager);
 			}
 			catch (Throwable t) {
 				LOG.error("Failed to start TaskManager process", t);

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/JobManagerHAProcessFailureRecoveryITCase.java
@@ -34,7 +34,6 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.concurrent.FutureUtils;
 import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.runtime.dispatcher.DispatcherGateway;
@@ -274,7 +273,7 @@ public class JobManagerHAProcessFailureRecoveryITCase extends TestLogger {
 			final PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(config);
 			// Start the task manager process
 			for (int i = 0; i < numberOfTaskManagers; i++) {
-				taskManagerRunners[i] = new TaskManagerRunner(config, ResourceID.generate(), pluginManager);
+				taskManagerRunners[i] = new TaskManagerRunner(config, pluginManager);
 				taskManagerRunners[i].start();
 			}
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
 import org.apache.flink.runtime.clusterframework.ContaineredTaskManagerParameters;
@@ -92,9 +93,6 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 
 	/** YARN container map. Package private for unit test purposes. */
 	private final ConcurrentMap<ResourceID, YarnWorkerNode> workerNodeMap;
-	/** Environment variable name of the final container id used by the YarnResourceManager.
-	 * Container ID generation may vary across Hadoop versions. */
-	static final String ENV_FLINK_CONTAINER_ID = "_FLINK_CONTAINER_ID";
 
 	/** Environment variable name of the hostname given by the YARN.
 	 * In task executor we use the hostnames given by YARN consistently throughout akka */
@@ -667,6 +665,7 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			taskExecutorProcessSpec);
 
 		final Configuration taskManagerConfig = BootstrapTools.cloneConfiguration(flinkConfig);
+		taskManagerConfig.set(TaskManagerOptions.TASK_MANAGER_RESOURCE_ID, containerId);
 
 		final String taskManagerDynamicProperties =
 			BootstrapTools.getDynamicPropertiesAsString(flinkClientConfig, taskManagerConfig);
@@ -683,9 +682,6 @@ public class YarnResourceManager extends ActiveResourceManager<YarnWorkerNode>
 			YarnTaskExecutorRunner.class,
 			log);
 
-		// set a special environment variable to uniquely identify this container
-		taskExecutorLaunchContext.getEnvironment()
-				.put(ENV_FLINK_CONTAINER_ID, containerId);
 		taskExecutorLaunchContext.getEnvironment()
 				.put(ENV_FLINK_NODE_ID, host);
 		return taskExecutorLaunchContext;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnTaskExecutorRunner.java
@@ -27,7 +27,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.runtime.clusterframework.BootstrapTools;
-import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
@@ -35,7 +34,6 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
@@ -79,7 +77,7 @@ public class YarnTaskExecutorRunner {
 
 	/**
 	 * The instance entry point for the YARN task executor. Obtains user group information and calls
-	 * the main work method {@link TaskManagerRunner#runTaskManager(Configuration, ResourceID)} as a
+	 * the main work method {@link TaskManagerRunner#runTaskManager(Configuration, PluginManager)} as a
 	 * privileged action.
 	 *
 	 * @param args The command line arguments.
@@ -99,12 +97,8 @@ public class YarnTaskExecutorRunner {
 
 			setupConfigurationAndInstallSecurityContext(configuration, currDir, ENV);
 
-			final String containerId = ENV.get(YarnResourceManager.ENV_FLINK_CONTAINER_ID);
-			Preconditions.checkArgument(containerId != null,
-				"ContainerId variable %s not set", YarnResourceManager.ENV_FLINK_CONTAINER_ID);
-
 			SecurityUtils.getInstalledContext().runSecured((Callable<Void>) () -> {
-				TaskManagerRunner.runTaskManager(configuration, new ResourceID(containerId), pluginManager);
+				TaskManagerRunner.runTaskManager(configuration, pluginManager);
 				return null;
 			});
 		}


### PR DESCRIPTION

## What is the purpose of the change

Set the resource id of taskexecutor according to environment variable if exist in standalone mode.

## Brief change log

Allow user to set the resource id of taskexecutor according to environment variable if exist in standalone mode.
The relevant env variable is "FLINK_STANDALONE_TASK_EXECUTOR_ID".

## Verifying this change

It could be verified manually.
- `bin/jobmanager.sh start`
- `FLINK_STANDALONE_TASK_EXECUTOR_ID=taskManager-1 bin/taskmanager.sh`

`2020-05-09 18:00:09,856 INFO  org.apache.flink.runtime.taskexecutor.TaskManagerRunner      [] - Starting TaskManager with ResourceID: taskManager-1` occurred in the log file of task executor.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
