### PR TITLE
[FLINK-17502] [flink-connector-rabbitmq] RMQSource refactor

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -50,12 +50,15 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	/**
 	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to the
 	 * collector.
-	 * NOTICE: The implementation of this method MUST call {@link RMQCollector#setMessageIdentifiers(String, long)} with
-	 * the correlation ID of the message if checkpointing and UseCorrelationID (in the RMQSource constructor) were enabled
+	 *
+	 * <p><b>NOTICE:</b> The implementation of this method can call {@link RMQCollector#setMessageIdentifiers} with
+	 * a custom correlation ID and delivery tag if checkpointing and UseCorrelationID (in the RMQSource constructor) were
+	 * enabled
 	 * the {@link RMQSource}.
-	 * @param envelope
-	 * @param properties
-	 * @param body
+	 * @param envelope an AMQP {@link Envelope}.
+	 * @param properties the {@link AMQP.BasicProperties} of the message.
+	 * @param body the message itself as a byte array.
+	 * @param collector the {@link RMQCollector} that will collect the data.
 	 * @throws IOException
 	 */
 	public abstract void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException;

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -26,7 +26,6 @@ import com.rabbitmq.client.Envelope;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * Interface for the set of methods required to parse an RMQ delivery.
@@ -81,8 +80,6 @@ interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<
 	 * the message correlationId and deliveryTag.
 	 */
 	interface RMQCollector<T> extends Collector<T> {
-		void collect(List<T> records);
-
 		void setMessageIdentifiers(String correlationId, long deliveryTag);
 	}
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -32,7 +32,7 @@ import java.util.List;
  * Interface for the set of methods required to parse an RMQ delivery.
  * @param <T> The output type of the {@link RMQSource}
  */
-public abstract class RMQDeserializationSchema<T> implements  Serializable, ResultTypeQueryable<T> {
+interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
 	/**
 	 * Initialization method for the schema. It is called before the actual working methods
@@ -44,9 +44,7 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 *
 	 * @param context Contextual information that can be used during initialization.
 	 */
-	void open(DeserializationSchema.InitializationContext context) throws Exception {
-
-	}
+	default void open(DeserializationSchema.InitializationContext context) throws Exception { }
 
 	/**
 	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to
@@ -62,7 +60,7 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * @param collector the {@link RMQCollector} that will collect the data.
 	 * @throws IOException When the body of the message can't be parsed
 	 */
-	abstract void deserialize(Envelope envelope,
+	void deserialize(Envelope envelope,
 								AMQP.BasicProperties properties,
 								byte[] body,
 								RMQCollector<T> collector) throws IOException;
@@ -74,7 +72,7 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * @param nextElement The element to test for the end-of-stream signal.
 	 * @return True, if the element signals end of stream, false otherwise.
 	 */
-	abstract boolean isEndOfStream(T nextElement);
+	boolean isEndOfStream(T nextElement);
 
 	/**
 	 * Special collector for RMQ messages.
@@ -82,7 +80,7 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * <p>It extends the {@link Collector} to give the ability to collect more than 1 message and the ability to set
 	 * the message correlationId and deliveryTag.
 	 */
-	public interface RMQCollector<T> extends Collector<T> {
+	interface RMQCollector<T> extends Collector<T> {
 		void collect(List<T> records);
 
 		void setMessageIdentifiers(String correlationId, long deliveryTag);

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.rabbitmq;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
+
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Envelope;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Interface for the set of methods required to parse an RMQ delivery.
+ * @param <T> The output type of the {@link RMQSource}
+ */
+public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+	/**
+	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to the
+	 * collector.
+	 * NOTICE: The implementation of this method MUST call {@link RMQCollector#setMessageIdentifiers(String, long)} with
+	 * the correlation ID of the message if checkpointing and UseCorrelationID (in the RMQSource constructor) were enabled
+	 * the {@link RMQSource}.
+	 * @param envelope
+	 * @param properties
+	 * @param body
+	 * @throws IOException
+	 */
+	public  void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException;
+
+	/**
+	 * Method to decide whether the element signals the end of the stream. If
+	 * true is returned the element won't be emitted.
+	 *
+	 * @param nextElement The element to test for the end-of-stream signal.
+	 * @return True, if the element signals end of stream, false otherwise.
+	 */
+	boolean isEndOfStream(T nextElement);
+
+	/**
+	 * The {@link TypeInformation} for the deserialized T.
+	 * As an example the proper implementation of this method if T is a String is:
+	 * {@code return TypeExtractor.getForClass(String.class)}
+	 * @return TypeInformation
+	 */
+	public TypeInformation<T> getProducedType();
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	public void open(DeserializationSchema.InitializationContext context) throws Exception;
+
+
+	/**
+	 * Special collector for RMQ messages.
+	 * Captures the correlation ID and delivery tag also does the filtering logic for weather a message has been
+	 * processed or not.
+	 * @param <T>
+	 */
+	public interface RMQCollector<T> extends Collector<T> {
+		public void collect(List<T> records);
+
+		public void setMessageIdentifiers(String correlationId, long deliveryTag);
+	}
+}

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -38,22 +38,23 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * Initialization method for the schema. It is called before the actual working methods
 	 * {@link #deserialize} and thus suitable for one time setup work.
 	 *
-	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features
+	 * such as e.g.
 	 * registering user metrics.
 	 *
 	 * @param context Contextual information that can be used during initialization.
 	 */
-	public void open(DeserializationSchema.InitializationContext context) throws Exception {
+	void open(DeserializationSchema.InitializationContext context) throws Exception {
 
 	}
 
 	/**
-	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to the
-	 * collector.
+	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to
+	 * the collector.
 	 *
 	 * <p><b>NOTICE:</b> The implementation of this method can call {@link RMQCollector#setMessageIdentifiers} with
-	 * a custom correlation ID and delivery tag if checkpointing and UseCorrelationID (in the RMQSource constructor) were
-	 * enabled
+	 * a custom correlation ID and delivery tag if checkpointing and UseCorrelationID (in the RMQSource constructor)
+	 * were enabled
 	 * the {@link RMQSource}.
 	 * @param envelope an AMQP {@link Envelope}.
 	 * @param properties the {@link AMQP.BasicProperties} of the message.
@@ -61,7 +62,10 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * @param collector the {@link RMQCollector} that will collect the data.
 	 * @throws IOException
 	 */
-	public abstract void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException;
+	abstract void deserialize(Envelope envelope,
+								AMQP.BasicProperties properties,
+								byte[] body,
+								RMQCollector<T> collector) throws IOException;
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If
@@ -74,13 +78,13 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 
 	/**
 	 * Special collector for RMQ messages.
-	 * Captures the correlation ID and delivery tag also does the filtering logic for weather a message has been
-	 * processed or not.
-	 * @param <T>
+	 *
+	 * <p>It extends the {@link Collector} to give the ability to collect more than 1 message and the ability to set
+	 * the message correlationId and deliveryTag.
 	 */
 	public interface RMQCollector<T> extends Collector<T> {
-		public void collect(List<T> records);
+		void collect(List<T> records);
 
-		public void setMessageIdentifiers(String correlationId, long deliveryTag);
+		void setMessageIdentifiers(String correlationId, long deliveryTag);
 	}
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -34,6 +34,19 @@ import java.util.List;
  * @param <T> The output type of the {@link RMQSource}
  */
 public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+	/**
+	 * Initialization method for the schema. It is called before the actual working methods
+	 * {@link #deserialize} and thus suitable for one time setup work.
+	 *
+	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
+	 * registering user metrics.
+	 *
+	 * @param context Contextual information that can be used during initialization.
+	 */
+	public void open(DeserializationSchema.InitializationContext context) throws Exception;
+
+
 	/**
 	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to the
 	 * collector.
@@ -63,18 +76,6 @@ public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQue
 	 * @return TypeInformation
 	 */
 	public TypeInformation<T> getProducedType();
-
-	/**
-	 * Initialization method for the schema. It is called before the actual working methods
-	 * {@link #deserialize} and thus suitable for one time setup work.
-	 *
-	 * <p>The provided {@link DeserializationSchema.InitializationContext} can be used to access additional features such as e.g.
-	 * registering user metrics.
-	 *
-	 * @param context Contextual information that can be used during initialization.
-	 */
-	public void open(DeserializationSchema.InitializationContext context) throws Exception;
-
 
 	/**
 	 * Special collector for RMQ messages.

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -18,7 +18,6 @@
 package org.apache.flink.streaming.connectors.rabbitmq;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.util.Collector;
 
@@ -33,7 +32,7 @@ import java.util.List;
  * Interface for the set of methods required to parse an RMQ delivery.
  * @param <T> The output type of the {@link RMQSource}
  */
-public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+public abstract class RMQDeserializationSchema<T> implements  Serializable, ResultTypeQueryable<T> {
 
 	/**
 	 * Initialization method for the schema. It is called before the actual working methods
@@ -44,8 +43,9 @@ public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQue
 	 *
 	 * @param context Contextual information that can be used during initialization.
 	 */
-	public void open(DeserializationSchema.InitializationContext context) throws Exception;
+	public void open(DeserializationSchema.InitializationContext context) throws Exception {
 
+	}
 
 	/**
 	 * This method takes all the RabbitMQ delivery information supplied by the client extract the data and pass it to the
@@ -58,7 +58,7 @@ public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQue
 	 * @param body
 	 * @throws IOException
 	 */
-	public  void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException;
+	public abstract void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException;
 
 	/**
 	 * Method to decide whether the element signals the end of the stream. If
@@ -67,15 +67,7 @@ public interface RMQDeserializationSchema<T> extends Serializable, ResultTypeQue
 	 * @param nextElement The element to test for the end-of-stream signal.
 	 * @return True, if the element signals end of stream, false otherwise.
 	 */
-	boolean isEndOfStream(T nextElement);
-
-	/**
-	 * The {@link TypeInformation} for the deserialized T.
-	 * As an example the proper implementation of this method if T is a String is:
-	 * {@code return TypeExtractor.getForClass(String.class)}
-	 * @return TypeInformation
-	 */
-	public TypeInformation<T> getProducedType();
+	abstract boolean isEndOfStream(T nextElement);
 
 	/**
 	 * Special collector for RMQ messages.

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQDeserializationSchema.java
@@ -60,7 +60,7 @@ public abstract class RMQDeserializationSchema<T> implements  Serializable, Resu
 	 * @param properties the {@link AMQP.BasicProperties} of the message.
 	 * @param body the message itself as a byte array.
 	 * @param collector the {@link RMQCollector} that will collect the data.
-	 * @throws IOException
+	 * @throws IOException When the body of the message can't be parsed
 	 */
 	abstract void deserialize(Envelope envelope,
 								AMQP.BasicProperties properties,

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -412,7 +412,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	 * A default {@link RMQDeserializationSchema} implementation that uses the provided {@link DeserializationSchema} to
 	 * parse the message body.
 	 */
-	private static class RMQDeserializationSchemaWrapper<OUT> extends RMQDeserializationSchema<OUT>{
+	private static class RMQDeserializationSchemaWrapper<OUT> implements RMQDeserializationSchema<OUT>{
 		DeserializationSchema<OUT> schema;
 
 		private RMQDeserializationSchemaWrapper(DeserializationSchema<OUT> deserializationSchema) {

--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSource.java
@@ -27,13 +27,14 @@ import org.apache.flink.streaming.api.functions.source.MessageAcknowledgingSourc
 import org.apache.flink.streaming.api.functions.source.MultipleIdsMessageAcknowledgingSourceBase;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.connectors.rabbitmq.common.RMQConnectionConfig;
-import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
+import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.Delivery;
+import com.rabbitmq.client.Envelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 	private final RMQConnectionConfig rmqConnectionConfig;
 	protected final String queueName;
 	private final boolean usesCorrelationId;
-	protected DeserializationSchema<OUT> schema;
+	protected RMQDeserializationSchema<OUT> deliveryDeserializer;
 
 	protected transient Connection connection;
 	protected transient Channel channel;
@@ -123,7 +124,74 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 		this.rmqConnectionConfig = rmqConnectionConfig;
 		this.queueName = queueName;
 		this.usesCorrelationId = usesCorrelationId;
-		this.schema = deserializationSchema;
+		this.deliveryDeserializer = wrapDeserializationSchema(deserializationSchema);
+	}
+
+	/**
+	 * Creates a new RabbitMQ source with at-least-once message processing guarantee when
+	 * checkpointing is enabled. No strong delivery guarantees when checkpointing is disabled.
+	 *
+	 * <p>For exactly-once, please use the constructor
+	 * {@link RMQSource#RMQSource(RMQConnectionConfig, String, boolean, RMQDeserializationSchema)}.
+	 *
+	 * <p>It also uses the provided {@link RMQDeserializationSchema} to parse both the correlationID and the message.
+	 * @param rmqConnectionConfig The RabbiMQ connection configuration {@link RMQConnectionConfig}.
+	 * @param queueName  The queue to receive messages from.
+	 * @param deliveryDeserializer A {@link RMQDeserializationSchema} for parsing the RMQDelivery.
+	 */
+	public RMQSource(RMQConnectionConfig rmqConnectionConfig, String queueName,
+					RMQDeserializationSchema<OUT> deliveryDeserializer) {
+		this(rmqConnectionConfig, queueName, false, deliveryDeserializer);
+	}
+
+	/**
+	 * Creates a new RabbitMQ source. For exactly-once, you must set the correlation ids of messages
+	 * at the producer. The correlation id must be unique. Otherwise the behavior of the source is
+	 * undefined. If in doubt, set usesCorrelationId to false. When correlation ids are not
+	 * used, this source has at-least-once processing semantics when checkpointing is enabled.
+	 *
+	 * <p>It also uses the provided {@link RMQDeserializationSchema} to parse both the correlationID and the message.
+	 * @param rmqConnectionConfig The RabbiMQ connection configuration {@link RMQConnectionConfig}.
+	 * @param queueName The queue to receive messages from.
+	 * @param usesCorrelationId Whether the messages received are supplied with a <b>unique</b>
+	 *                          id to deduplicate messages (in case of failed acknowledgments).
+	 *                          Only used when checkpointing is enabled.
+	 * @param deliveryDeserializer A {@link RMQDeserializationSchema} for parsing the RMQDelivery.
+	 */
+	public RMQSource(RMQConnectionConfig rmqConnectionConfig,
+					String queueName, boolean usesCorrelationId, RMQDeserializationSchema<OUT> deliveryDeserializer) {
+		super(String.class);
+		this.rmqConnectionConfig = rmqConnectionConfig;
+		this.queueName = queueName;
+		this.usesCorrelationId = usesCorrelationId;
+		this.deliveryDeserializer = deliveryDeserializer;
+	}
+
+	static <T> RMQDeserializationSchema<T> wrapDeserializationSchema(DeserializationSchema<T> schema) {
+		return new RMQDeserializationSchema<T>() {
+			@Override
+			public void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException {
+				final long deliveryTag = envelope.getDeliveryTag();
+				final String correlationId = properties.getCorrelationId();
+				collector.setMessageIdentifiers(correlationId, deliveryTag);
+				collector.collect(schema.deserialize(body));
+			}
+
+			@Override
+			public TypeInformation<T> getProducedType() {
+				return schema.getProducedType();
+			}
+
+			@Override
+			public void open(DeserializationSchema.InitializationContext context) throws Exception {
+				schema.open(context);
+			}
+
+			@Override
+			public boolean isEndOfStream(T nextElement) {
+				return schema.isEndOfStream(nextElement);
+			}
+		};
 	}
 
 	/**
@@ -201,7 +269,7 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 			throw new RuntimeException("Cannot create RMQ connection with " + queueName + " at "
 					+ rmqConnectionConfig.getHost(), e);
 		}
-		this.schema.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
+		this.deliveryDeserializer.open(() -> getRuntimeContext().getMetricGroup().addGroup("user"));
 		running = true;
 	}
 
@@ -237,29 +305,36 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 		}
 	}
 
+	/**
+	 * Parse and collects the body of the an AMQP message.
+	 *
+	 * <p>If any of the constructors with the {@link DeserializationSchema} class was used to construct the source
+	 * it uses the {@link DeserializationSchema#deserialize(byte[])} to parse the body of the AMQP message.
+	 *
+	 * <p>If any of the constructors with the {@link RMQDeserializationSchema } class was used to construct the source it uses the
+	 * {@link RMQDeserializationSchema#deserialize(Envelope, AMQP.BasicProperties, byte[], RMQDeserializationSchema.RMQCollector collector)}
+	 * method of that provided instance.
+	 *
+	 * @param delivery the AMQP {@link Delivery}
+	 * @param collector a {@link RMQCollectorImpl} to collect the data
+	 * @throws IOException
+	 */
+	protected void processMessage(Delivery delivery, RMQDeserializationSchema.RMQCollector collector) throws IOException {
+		AMQP.BasicProperties properties = delivery.getProperties();
+		byte[] body = delivery.getBody();
+		Envelope envelope = delivery.getEnvelope();
+		deliveryDeserializer.deserialize(envelope, properties, body, collector);
+	}
+
 	@Override
 	public void run(SourceContext<OUT> ctx) throws Exception {
-		final RMQCollector collector = new RMQCollector(ctx);
+		final RMQCollectorImpl collector = new RMQCollectorImpl(ctx);
 		while (running) {
 			Delivery delivery = consumer.nextDelivery();
 
 			synchronized (ctx.getCheckpointLock()) {
-				if (!autoAck) {
-					final long deliveryTag = delivery.getEnvelope().getDeliveryTag();
-					if (usesCorrelationId) {
-						final String correlationId = delivery.getProperties().getCorrelationId();
-						Preconditions.checkNotNull(correlationId, "RabbitMQ source was instantiated " +
-							"with usesCorrelationId set to true but a message was received with " +
-							"correlation id set to null!");
-						if (!addId(correlationId)) {
-							// we have already processed this message
-							continue;
-						}
-					}
-					sessionIds.add(deliveryTag);
-				}
-
-				schema.deserialize(delivery.getBody(), collector);
+				collector.reset();
+				processMessage(delivery, collector);
 				if (collector.isEndOfStreamSignalled()) {
 					this.running = false;
 					return;
@@ -268,27 +343,78 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 		}
 	}
 
-	private class RMQCollector implements Collector<OUT> {
-
+	/**
+	 * Special collector for RMQ messages.
+	 * Captures the correlation ID and delivery tag also does the filtering logic for weather a message has been
+	 * processed or not.
+	 */
+	private class RMQCollectorImpl implements RMQDeserializationSchema.RMQCollector<OUT> {
 		private final SourceContext<OUT> ctx;
 		private boolean endOfStreamSignalled = false;
+		private Boolean messageValidated;
 
-		private RMQCollector(SourceContext<OUT> ctx) {
+		private RMQCollectorImpl(SourceContext<OUT> ctx) {
 			this.ctx = ctx;
 		}
 
 		@Override
 		public void collect(OUT record) {
-			if (endOfStreamSignalled || schema.isEndOfStream(record)) {
-				this.endOfStreamSignalled = true;
+			Preconditions.checkNotNull(messageValidated, "setMessageIdentifiers must be called at least once before" +
+				"calling this method !");
+
+			if (!messageValidated) {
 				return;
 			}
 
+			if (isEndOfStream(record)) {
+				this.endOfStreamSignalled = true;
+				return;
+			}
 			ctx.collect(record);
+		}
+
+		public void collect(List<OUT> records) {
+			Preconditions.checkNotNull(messageValidated, "setMessageIdentifiers must be called at least once before" +
+				"calling this method !");
+
+			if (!messageValidated) {
+				return;
+			}
+
+			for (OUT record : records){
+				if (isEndOfStream(record)) {
+					this.endOfStreamSignalled = true;
+					return;
+				}
+				ctx.collect(record);
+			}
+		}
+
+		public void setMessageIdentifiers(String correlationId, long deliveryTag){
+			messageValidated = true;
+			if (!autoAck) {
+				if (usesCorrelationId) {
+					Preconditions.checkNotNull(correlationId, "RabbitMQ source was instantiated " +
+						"with usesCorrelationId set to true yet we couldn't extract the correlation id from it !");
+					if (!addId(correlationId)) {
+						// we have already processed this message
+						messageValidated = false;
+					}
+				}
+				sessionIds.add(deliveryTag);
+			}
+		}
+
+		boolean isEndOfStream(OUT record) {
+			return endOfStreamSignalled || deliveryDeserializer.isEndOfStream(record);
 		}
 
 		public boolean isEndOfStreamSignalled() {
 			return endOfStreamSignalled;
+		}
+
+		public void reset() {
+			messageValidated = null;
 		}
 
 		@Override
@@ -316,6 +442,6 @@ public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OU
 
 	@Override
 	public TypeInformation<OUT> getProducedType() {
-		return schema.getProducedType();
+		return deliveryDeserializer.getProducedType();
 	}
 }

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -337,7 +337,7 @@ public class RMQSourceTest {
 		RMQDeserializationSchema.RMQCollector collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
 		source.processMessage(source.mockedDelivery, collector);
 		Mockito.verify(collector, Mockito.times(1)).collect("test");
-		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("1", messageId);
+		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("0", messageId);
 
 		source = new RMQTestSource(new CustomDeserializationSchema());
 		source.open(config);
@@ -347,7 +347,8 @@ public class RMQSourceTest {
 		collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
 		source.processMessage(source.mockedDelivery, collector);
 		Mockito.verify(collector, Mockito.times(1)).collect(Mockito.eq(expectedOutput));
-		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("1-MESSAGE_ID", messageId);
+		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("1", messageId - 1);
+		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("2-MESSAGE_ID", messageId);
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -490,7 +490,7 @@ public class RMQSourceTest {
 		}
 	}
 
-	private class CustomDeserializationSchema extends RMQDeserializationSchema<String> {
+	private class CustomDeserializationSchema implements RMQDeserializationSchema<String> {
 		@Override
 		public TypeInformation<String> getProducedType() {
 			return TypeExtractor.getForClass(String.class);

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -486,15 +486,10 @@ public class RMQSourceTest {
 		}
 	}
 
-	private class CustomDeserializationSchema implements RMQDeserializationSchema<String> {
+	private class CustomDeserializationSchema extends RMQDeserializationSchema<String> {
 		@Override
 		public TypeInformation<String> getProducedType() {
 			return TypeExtractor.getForClass(String.class);
-		}
-
-		@Override
-		public void open(DeserializationSchema.InitializationContext context) throws Exception {
-
 		}
 
 		@Override

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -334,7 +334,9 @@ public class RMQSourceTest {
 	public void testProcessMessage() throws Exception {
 		RMQTestSource source = new RMQTestSource();
 		source.open(config);
-		RMQDeserializationSchema.RMQCollector collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
+
+		RMQDeserializationSchema.RMQCollector<String> collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
+
 		source.processMessage(source.mockedDelivery, collector);
 		Mockito.verify(collector, Mockito.times(1)).collect("test");
 		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("0", messageId);
@@ -344,6 +346,7 @@ public class RMQSourceTest {
 		List<String> expectedOutput = new ArrayList<>(1);
 		expectedOutput.add("I Love Turtles");
 		expectedOutput.add("Brush your teeth");
+
 		collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
 		source.processMessage(source.mockedDelivery, collector);
 		Mockito.verify(collector, Mockito.times(1)).collect(Mockito.eq(expectedOutput));
@@ -494,8 +497,8 @@ public class RMQSourceTest {
 		}
 
 		@Override
-		public void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector collector) throws IOException {
-			List<String> messages = new ArrayList();
+		public void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector<String> collector){
+			List<String> messages = new ArrayList<>();
 			messages.add("I Love Turtles");
 			messages.add("Brush your teeth");
 			collector.setMessageIdentifiers(properties.getMessageId(), envelope.getDeliveryTag());
@@ -570,7 +573,7 @@ public class RMQSourceTest {
 			super(deserializationSchema);
 		}
 
-		public RMQTestSource(RMQDeserializationSchema deliveryParser) {
+		public RMQTestSource(RMQDeserializationSchema<String> deliveryParser) {
 			super(deliveryParser);
 		}
 

--- a/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/test/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSourceTest.java
@@ -53,8 +53,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
@@ -343,13 +341,11 @@ public class RMQSourceTest {
 
 		source = new RMQTestSource(new CustomDeserializationSchema());
 		source.open(config);
-		List<String> expectedOutput = new ArrayList<>(1);
-		expectedOutput.add("I Love Turtles");
-		expectedOutput.add("Brush your teeth");
 
 		collector = Mockito.mock(RMQDeserializationSchema.RMQCollector.class);
 		source.processMessage(source.mockedDelivery, collector);
-		Mockito.verify(collector, Mockito.times(1)).collect(Mockito.eq(expectedOutput));
+		Mockito.verify(collector, Mockito.times(1)).collect(Mockito.eq("I Love Turtles"));
+		Mockito.verify(collector, Mockito.times(1)).collect(Mockito.eq("Brush your teeth"));
 		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("1", messageId - 1);
 		Mockito.verify(collector, Mockito.times(1)).setMessageIdentifiers("2-MESSAGE_ID", messageId);
 	}
@@ -498,11 +494,9 @@ public class RMQSourceTest {
 
 		@Override
 		public void deserialize(Envelope envelope, AMQP.BasicProperties properties, byte[] body, RMQCollector<String> collector){
-			List<String> messages = new ArrayList<>();
-			messages.add("I Love Turtles");
-			messages.add("Brush your teeth");
 			collector.setMessageIdentifiers(properties.getMessageId(), envelope.getDeliveryTag());
-			collector.collect(messages);
+			collector.collect("I Love Turtles");
+			collector.collect("Brush your teeth");
 		}
 
 		@Override


### PR DESCRIPTION
better message and correlationID parsing

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*More flexibility in retrieving the message out of an AMQP delivery.*
*The ability to designate the ID upon which the messages are deduplicated.*

## Brief change log

- *Created a new interface `RMQDeliveryParser` that contains 2 methods one for parsing a body out of the `Envelope`, `AMQP.BasicProperties` and the body `byte[]` and another method with the same inputs to extract the correlationID*
- *Created 2 new constructors that take a instance of the new `RMQDeliveryParser` instead of a `DeserializationSchema` while keeping all the other constructor fields the same.*
- *Created 2 methods in the `RMQSource` class that decides which instance to use to parse / extract the body or correlation ID and by instance i mean the instance of `DeserializationSchema` or the instance of `RMQDeliveryParser` passed during the construction of the class*
- *Replaced the body parsing and correlationID extraction with the above methods.*
- *Changed the method `getProducedType` in the `RMQSource` so it deliveres the type based on which class instance was passed during the construction of the `RMQSource` and again by instance i mean an instance of `DeserializationSchema` or an instance of `RMQDeliveryParser`.*

## Verifying this change

This change added tests and can be verified as follows:

- *Modified the `RMQTestSource` class to give external access to the mocked AMQP `Envelope` and `BasicProperties`.*
- *Added a constructor to the `RMQTestSource` that accepts an instance of `RMQDeliveryParser`.* 
- *Added an implementation of `RMQDeliveryParser` named `CustomDeliveryParser` that returns the `BasicProperties#getMessageID()` when the method `parse` is called and `BasicProperties#getMessageID()` when the `getCorrelationID` method is called.*
- *Moved the AMQP `Delivery`, `Envelope` and `BasicProperties` mock from the `open` method of the `RMQTestSource` to their own method `initAMQPMocks` to facilitate the tests and called the new function in the `open` method. I also added a mock for the `BasicProperties#getMessageID()` method call.*
- *Created a test that creates an instance of the `RMQTestSource` once with an instance of `DeserializationSchema` and with a `RMQDeliveryParser` instance then calling the `parseBody` and asserting the correct response.*
- *Created a test that creates an instnace of the `RMQTestSource` once with an instance of `DeserializationSchema` and once with a `RMQDeliveryParser` insance then calling `extractCorrelationID` and asserting the correct response.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
