### PR TITLE
[FLINK-17601][table-planner-blink] Correct the table scan node name in the explain result of TableEnvironmentITCase#testStatementSet

### DIFF
--- a/flink-table/flink-table-planner-blink/src/test/resources/explain/testStatementSet.out
+++ b/flink-table/flink-table-planner-blink/src/test/resources/explain/testStatementSet.out
@@ -9,10 +9,10 @@ LogicalSink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[last]
 
 == Optimized Logical Plan ==
 Sink(name=[`default_catalog`.`default_database`.`MySink1`], fields=[first])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: first)]]], fields=[first])
 
 Sink(name=[`default_catalog`.`default_database`.`MySink2`], fields=[last])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [CsvTableSource(read fields: last)]]], fields=[last])
 
 == Physical Execution Plan ==
  : Data Source


### PR DESCRIPTION

## What is the purpose of the change

*This is a hotfix for https://github.com/apache/flink/pull/12042:  the table scan node name in the explain result of TableEnvironmentITCase#testStatementSet should be LegacyTableSourceScan not TableSourceScan. This change is introduced by FLINK-16989*


## Brief change log

*(for example:)*
  - *rename TableSourceScan to LegacyTableSourceScan in testStatementSet.out*


## Verifying this change

This change is a hotfix without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
