### PR TITLE
[FLINK-17587][filesystem] Filesystem streaming sink support commit success file

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSinkHelper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSinkHelper.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeCallback;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper for {@link StreamingFileSink}.
+ * This helper can be used by {@link RichSinkFunction} or {@link StreamOperator}.
+ */
+@Internal
+public class StreamingFileSinkHelper<IN> implements ProcessingTimeCallback {
+
+	// -------------------------- state descriptors ---------------------------
+
+	private static final ListStateDescriptor<byte[]> BUCKET_STATE_DESC =
+			new ListStateDescriptor<>("bucket-states", BytePrimitiveArraySerializer.INSTANCE);
+
+	private static final ListStateDescriptor<Long> MAX_PART_COUNTER_STATE_DESC =
+			new ListStateDescriptor<>("max-part-counter", LongSerializer.INSTANCE);
+
+	// --------------------------- fields -----------------------------
+
+	private final long bucketCheckInterval;
+
+	private final ProcessingTimeService procTimeService;
+
+	private final Buckets<IN, ?> buckets;
+
+	private final ListState<byte[]> bucketStates;
+
+	private final ListState<Long> maxPartCountersState;
+
+	public StreamingFileSinkHelper(
+			Buckets<IN, ?> buckets,
+			boolean isRestored,
+			OperatorStateStore stateStore,
+			ProcessingTimeService procTimeService,
+			long bucketCheckInterval) throws Exception {
+		this.bucketCheckInterval = bucketCheckInterval;
+		this.buckets = buckets;
+		this.bucketStates = stateStore.getListState(BUCKET_STATE_DESC);
+		this.maxPartCountersState = stateStore.getUnionListState(MAX_PART_COUNTER_STATE_DESC);
+		this.procTimeService = procTimeService;
+
+		if (isRestored) {
+			buckets.initializeState(bucketStates, maxPartCountersState);
+		}
+
+		long currentProcessingTime = procTimeService.getCurrentProcessingTime();
+		procTimeService.registerTimer(currentProcessingTime + bucketCheckInterval, this);
+	}
+
+	public void commitUpToCheckpoint(long checkpointId) throws Exception {
+		buckets.commitUpToCheckpoint(checkpointId);
+	}
+
+	public void snapshotState(long checkpointId) throws Exception {
+		buckets.snapshotState(
+				checkpointId,
+				bucketStates,
+				maxPartCountersState);
+	}
+
+	@Override
+	public void onProcessingTime(long timestamp) throws Exception {
+		final long currentTime = procTimeService.getCurrentProcessingTime();
+		buckets.onProcessingTime(currentTime);
+		procTimeService.registerTimer(currentTime + bucketCheckInterval, this);
+	}
+
+	public void onElement(
+			IN value,
+			long currentProcessingTime,
+			@Nullable Long elementTimestamp,
+			long currentWatermark) throws Exception {
+		buckets.onElement(value, currentProcessingTime, elementTimestamp, currentWatermark);
+	}
+
+	public void close() {
+		this.buckets.close();
+	}
+}

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/FsStreamingSinkITCaseBase.scala
@@ -20,10 +20,14 @@ package org.apache.flink.table.planner.runtime.stream
 
 import org.apache.flink.api.common.typeinfo.Types
 import org.apache.flink.api.java.typeutils.RowTypeInfo
+import org.apache.flink.runtime.state.CheckpointListener
+import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.scala.DataStream
-import org.apache.flink.streaming.util.FiniteTestSource
+import org.apache.flink.streaming.api.watermark.Watermark
 import org.apache.flink.table.api.Expressions.$
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
+import org.apache.flink.table.filesystem.DefaultPartTimeExtractor.{toLocalDateTime, toMills}
+import org.apache.flink.table.filesystem.FileSystemOptions._
 import org.apache.flink.table.planner.runtime.utils.{StreamingTestBase, TestSinkUtil}
 import org.apache.flink.types.Row
 
@@ -31,11 +35,13 @@ import org.apache.flink.shaded.guava18.com.google.common.collect.Lists
 
 import org.junit.Assert.assertEquals
 import org.junit.rules.Timeout
-import org.junit.{Before, Rule, Test}
+import org.junit.{Assert, Before, Rule, Test}
 
-import scala.collection.Seq
+import java.io.File
+import java.net.URI
 
 import scala.collection.JavaConversions._
+import scala.collection.Seq
 
 /**
   * Streaming sink ITCase base, test checkpoint.
@@ -48,9 +54,11 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   protected var resultPath: String = _
 
   private val data = Seq(
-    Row.of(Integer.valueOf(1), "a", "b", "c", "12345"),
-    Row.of(Integer.valueOf(2), "p", "q", "r", "12345"),
-    Row.of(Integer.valueOf(3), "x", "y", "z", "12345"))
+    Row.of(Integer.valueOf(1), "a", "b", "2020-05-03", "7"),
+    Row.of(Integer.valueOf(2), "p", "q", "2020-05-03", "8"),
+    Row.of(Integer.valueOf(3), "x", "y", "2020-05-03", "9"),
+    Row.of(Integer.valueOf(4), "x", "y", "2020-05-03", "10"),
+    Row.of(Integer.valueOf(5), "x", "y", "2020-05-03", "11"))
 
   @Before
   override def before(): Unit = {
@@ -61,7 +69,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
     env.enableCheckpointing(100)
 
     val stream = new DataStream(env.getJavaEnv.addSource(
-      new FiniteTestSource[Row](data: _*),
+      new FiniteTestSource(data),
       new RowTypeInfo(Types.INT, Types.STRING, Types.STRING, Types.STRING, Types.STRING)))
 
     tEnv.createTemporaryView("my_table", stream, $("a"), $("b"), $("c"), $("d"), $("e"))
@@ -77,9 +85,17 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
   @Test
   def testPart(): Unit = {
     test(true)
+    val basePath = new File(new URI(resultPath).getPath, "d=2020-05-03")
+    Assert.assertEquals(5, basePath.list().length)
+    Assert.assertTrue(new File(new File(basePath, "e=7"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=8"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=9"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=10"), "_MY_SUCCESS").exists())
+    Assert.assertTrue(new File(new File(basePath, "e=11"), "_MY_SUCCESS").exists())
   }
 
   private def test(partition: Boolean): Unit = {
+    val dollar = '$'
     val ddl = s"""
                  |create table sink_table (
                  |  a int,
@@ -92,6 +108,11 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
                  |with (
                  |  'connector' = 'filesystem',
                  |  'path' = '$resultPath',
+                 |  '${PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key()}' =
+                 |      '${dollar}d ${dollar}e:00:00',
+                 |  '${SINK_PARTITION_COMMIT_DELAY.key()}' = '1h',
+                 |  '${SINK_PARTITION_COMMIT_POLICY_KIND.key()}' = 'success-file',
+                 |  '${SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key()}' = '_MY_SUCCESS',
                  |  ${additionalProperties().mkString(",\n")}
                  |)
        """.stripMargin
@@ -105,7 +126,7 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
     check(
       ddl,
       "select * from sink_table",
-      data ++ data)
+      data)
   }
 
   def check(ddl: String, sqlQuery: String, expectedResult: Seq[Row]): Unit = {
@@ -118,5 +139,41 @@ abstract class FsStreamingSinkITCaseBase extends StreamingTestBase {
     assertEquals(
       expectedResult.map(TestSinkUtil.rowToString(_)).sorted,
       result.map(TestSinkUtil.rowToString(_)).sorted)
+  }
+}
+
+class FiniteTestSource(elements: Iterable[Row]) extends SourceFunction[Row] with CheckpointListener{
+
+  private var running: Boolean = true
+
+  private var numCheckpointsComplete: Int = 0
+
+  @throws[Exception]
+  override def run(ctx: SourceFunction.SourceContext[Row]): Unit = {
+    val lock = ctx.getCheckpointLock
+    lock.synchronized {
+      for (t <- elements) {
+        ctx.collect(t)
+        ctx.emitWatermark(new Watermark(
+          toMills(toLocalDateTime(s"${t.getField(3)} ${t.getField(4)}:00:00"))))
+      }
+    }
+
+    ctx.emitWatermark(new Watermark(Long.MaxValue))
+
+    lock.synchronized {
+      while (running && numCheckpointsComplete < 2) {
+        lock.wait(1);
+      }
+    }
+  }
+
+  override def cancel(): Unit = {
+    running = false
+  }
+
+  @throws[Exception]
+  override def notifyCheckpointComplete(checkpointId: Long): Unit = {
+    numCheckpointsComplete += 1
   }
 }

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/StreamFileSystemTestCsvITCase.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql
+
+import org.apache.flink.table.planner.utils.TestCsvFileSystemFormatFactory.USE_BULK_WRITER
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import scala.collection.Seq
+
+/**
+  * Test csv [[StreamFileSystemITCaseBase]].
+  */
+@RunWith(classOf[Parameterized])
+class StreamFileSystemTestCsvITCase(useBulkWriter: Boolean) extends StreamFileSystemITCaseBase {
+
+  override def formatProperties(): Array[String] = {
+    super.formatProperties() ++ Seq(
+      "'format' = 'testcsv'",
+      s"'$USE_BULK_WRITER' = '$useBulkWriter'")
+  }
+}
+
+object StreamFileSystemTestCsvITCase {
+  @Parameterized.Parameters(name = "useBulkWriter-{0}")
+  def parameters(): java.util.Collection[Boolean] = {
+    java.util.Arrays.asList(true, false)
+  }
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemOptions.java
@@ -99,4 +99,50 @@ public class FileSystemOptions {
 					.defaultValue(Duration.ofMinutes(60))
 					.withDescription("The cache TTL (e.g. 10min) for the build table in lookup join. " +
 							"By default the TTL is 60 minutes.");
+
+	public static final ConfigOption<String> SINK_PARTITION_COMMIT_TRIGGER =
+			key("sink.partition-commit.trigger")
+					.stringType()
+					.defaultValue("partition-time")
+					.withDescription("Trigger type for partition commit:" +
+							" 'partition-time': extract time from partition," +
+							" if 'watermark' > 'partition-time' + 'delay', will commit the partition." +
+							" 'process-time': use processing time, if 'current processing time' > " +
+							"'partition directory creation time' + 'delay', will commit the partition.");
+
+	public static final ConfigOption<Duration> SINK_PARTITION_COMMIT_DELAY =
+			key("sink.partition-commit.delay")
+					.durationType()
+					.defaultValue(Duration.ofMillis(0))
+					.withDescription("The partition will not commit until the delay time." +
+							" if it is a day partition, should be '1 d'," +
+							" if it is a hour partition, should be '1 h'");
+
+	public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_KIND =
+			key("sink.partition-commit.policy.kind")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("Policy to commit a partition is to notify the downstream" +
+							" application that the partition has finished writing, the partition" +
+							" is ready to be read." +
+							" metastore: add partition to metastore. Only work with hive table," +
+							" it is empty implementation for file system table." +
+							" success-file: add '_success' file to directory." +
+							" Both can be configured at the same time: 'metastore,success-file'." +
+							" custom: use policy class to create a commit policy." +
+							" Support to configure multiple policies: 'metastore,success-file'.");
+
+	public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_CLASS =
+			key("sink.partition-commit.policy.class")
+					.stringType()
+					.noDefaultValue()
+					.withDescription("The partition commit policy class for implement" +
+							" PartitionCommitPolicy interface. Only work in custom commit policy");
+
+	public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
+			key("sink.partition-commit.success-file.name")
+					.stringType()
+					.defaultValue("_SUCCESS")
+					.withDescription("The file name for success-file partition commit policy," +
+							" default is '_SUCCESS'.");
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableFactory.java
@@ -39,6 +39,13 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR;
 import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
 import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_DELAY;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_TRIGGER;
 
 /**
  * File system {@link TableFactory}.
@@ -116,6 +123,13 @@ public class FileSystemTableFactory implements
 		properties.add(SINK_ROLLING_POLICY_FILE_SIZE.key());
 		properties.add(SINK_ROLLING_POLICY_TIME_INTERVAL.key());
 		properties.add(SINK_SHUFFLE_BY_PARTITION.key());
+		properties.add(PARTITION_TIME_EXTRACTOR_KIND.key());
+		properties.add(PARTITION_TIME_EXTRACTOR_CLASS.key());
+		properties.add(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN.key());
+		properties.add(SINK_PARTITION_COMMIT_TRIGGER.key());
+		properties.add(SINK_PARTITION_COMMIT_DELAY.key());
+		properties.add(SINK_PARTITION_COMMIT_POLICY_KIND.key());
+		properties.add(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.key());
 
 		// format
 		properties.add(FORMAT);
@@ -134,7 +148,7 @@ public class FileSystemTableFactory implements
 				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
-				getFormatProperties(context.getTable().getProperties()));
+				context.getTable().getProperties());
 	}
 
 	@Override
@@ -143,20 +157,13 @@ public class FileSystemTableFactory implements
 		properties.putProperties(context.getTable().getProperties());
 
 		return new FileSystemTableSink(
+				context.getObjectIdentifier(),
 				context.isBounded(),
 				context.getTable().getSchema(),
 				new Path(properties.getString(PATH)),
 				context.getTable().getPartitionKeys(),
 				getPartitionDefaultName(properties),
-				properties.getOptionalLong(SINK_ROLLING_POLICY_FILE_SIZE.key())
-						.orElse(SINK_ROLLING_POLICY_FILE_SIZE.defaultValue()),
-				properties.getOptionalLong(SINK_ROLLING_POLICY_TIME_INTERVAL.key())
-						.orElse(SINK_ROLLING_POLICY_TIME_INTERVAL.defaultValue()),
-				getFormatProperties(context.getTable().getProperties()));
-	}
-
-	private static Map<String, String> getFormatProperties(Map<String, String> tableProperties) {
-		return tableProperties;
+				context.getTable().getOptions());
 	}
 
 	private static String getPartitionDefaultName(DescriptorProperties properties) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/FileSystemTableSink.java
@@ -22,6 +22,8 @@ import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.serialization.BulkWriter;
 import org.apache.flink.api.common.serialization.Encoder;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FSDataOutputStream;
 import org.apache.flink.core.fs.FileSystem;
@@ -29,16 +31,23 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.PartFileInfo;
 import org.apache.flink.streaming.api.functions.sink.filesystem.RollingPolicy;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink.BucketsBuilder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.SimpleVersionedStringSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.FileSystemFormatFactory;
+import org.apache.flink.table.filesystem.stream.InactiveBucketListener;
+import org.apache.flink.table.filesystem.stream.StreamingFileCommitter;
+import org.apache.flink.table.filesystem.stream.StreamingFileCommitter.CommitMessage;
+import org.apache.flink.table.filesystem.stream.StreamingFileWriter;
 import org.apache.flink.table.sinks.AppendStreamTableSink;
 import org.apache.flink.table.sinks.OverwritableTableSink;
 import org.apache.flink.table.sinks.PartitionableTableSink;
@@ -54,6 +63,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.table.filesystem.FileSystemTableFactory.SINK_ROLLING_POLICY_FILE_SIZE;
+import static org.apache.flink.table.filesystem.FileSystemTableFactory.SINK_ROLLING_POLICY_TIME_INTERVAL;
 import static org.apache.flink.table.filesystem.FileSystemTableFactory.createFormatFactory;
 
 /**
@@ -64,14 +76,13 @@ public class FileSystemTableSink implements
 		PartitionableTableSink,
 		OverwritableTableSink {
 
+	private final ObjectIdentifier tableIdentifier;
 	private final boolean isBounded;
 	private final TableSchema schema;
 	private final List<String> partitionKeys;
 	private final Path path;
 	private final String defaultPartName;
-	private final long rollingFileSize;
-	private final long rollingTimeInterval;
-	private final Map<String, String> formatProperties;
+	private final Map<String, String> properties;
 
 	private boolean overwrite = false;
 	private boolean dynamicGrouping = false;
@@ -86,27 +97,23 @@ public class FileSystemTableSink implements
 	 * @param partitionKeys partition keys of the table.
 	 * @param defaultPartName The default partition name in case the dynamic partition column value
 	 *                        is null/empty string.
-	 * @param rollingFileSize the maximum part file size before rolling.
-	 * @param rollingTimeInterval the maximum time duration a part file can stay open before rolling.
-	 * @param formatProperties format properties.
+	 * @param properties properties.
 	 */
 	public FileSystemTableSink(
+			ObjectIdentifier tableIdentifier,
 			boolean isBounded,
 			TableSchema schema,
 			Path path,
 			List<String> partitionKeys,
 			String defaultPartName,
-			long rollingFileSize,
-			long rollingTimeInterval,
-			Map<String, String> formatProperties) {
+			Map<String, String> properties) {
+		this.tableIdentifier = tableIdentifier;
 		this.isBounded = isBounded;
 		this.schema = schema;
 		this.path = path;
 		this.defaultPartName = defaultPartName;
-		this.rollingFileSize = rollingFileSize;
-		this.rollingTimeInterval = rollingTimeInterval;
-		this.formatProperties = formatProperties;
 		this.partitionKeys = partitionKeys;
+		this.properties = properties;
 	}
 
 	@Override
@@ -117,48 +124,94 @@ public class FileSystemTableSink implements
 				schema.getFieldDataTypes(),
 				partitionKeys.toArray(new String[0]));
 
+		TableMetaStoreFactory metaStoreFactory = createTableMetaStoreFactory(path);
+
 		if (isBounded) {
 			FileSystemOutputFormat.Builder<RowData> builder = new FileSystemOutputFormat.Builder<>();
 			builder.setPartitionComputer(computer);
 			builder.setDynamicGrouped(dynamicGrouping);
 			builder.setPartitionColumns(partitionKeys.toArray(new String[0]));
 			builder.setFormatFactory(createOutputFormatFactory());
-			builder.setMetaStoreFactory(createTableMetaStoreFactory(path));
+			builder.setMetaStoreFactory(metaStoreFactory);
 			builder.setOverwrite(overwrite);
 			builder.setStaticPartitions(staticPartitions);
 			builder.setTempPath(toStagingPath());
 			return dataStream.writeUsingOutputFormat(builder.build())
 					.setParallelism(dataStream.getParallelism());
 		} else {
-			if (overwrite) {
-				throw new IllegalStateException("Streaming mode not support overwrite.");
-			}
-
+			Configuration conf = new Configuration();
+			properties.forEach(conf::setString);
 			Object writer = createWriter();
-
 			TableBucketAssigner assigner = new TableBucketAssigner(computer);
 			TableRollingPolicy rollingPolicy = new TableRollingPolicy(
 					!(writer instanceof Encoder),
-					rollingFileSize,
-					rollingTimeInterval);
+					conf.get(SINK_ROLLING_POLICY_FILE_SIZE),
+					conf.get(SINK_ROLLING_POLICY_TIME_INTERVAL));
 
-			StreamingFileSink<RowData> sink;
+			BucketsBuilder<RowData, ?, ? extends BucketsBuilder<RowData, ?, ?>> bucketsBuilder;
+			InactiveBucketListener listener = new InactiveBucketListener();
 			if (writer instanceof Encoder) {
 				//noinspection unchecked
-				sink = StreamingFileSink.forRowFormat(
+				bucketsBuilder = StreamingFileSink.forRowFormat(
 						path, new ProjectionEncoder((Encoder<RowData>) writer, computer))
 						.withBucketAssigner(assigner)
-						.withRollingPolicy(rollingPolicy).build();
+						.withBucketLifeCycleListener(listener)
+						.withRollingPolicy(rollingPolicy);
 			} else {
 				//noinspection unchecked
-				sink = StreamingFileSink.forBulkFormat(
+				bucketsBuilder = StreamingFileSink.forBulkFormat(
 						path, new ProjectionBulkFactory((BulkWriter.Factory<RowData>) writer, computer))
 						.withBucketAssigner(assigner)
-						.withRollingPolicy(rollingPolicy).build();
+						.withBucketLifeCycleListener(listener)
+						.withRollingPolicy(rollingPolicy);
 			}
-
-			return dataStream.addSink(sink).setParallelism(dataStream.getParallelism());
+			return createStreamingSink(
+					conf,
+					path,
+					partitionKeys,
+					tableIdentifier,
+					overwrite,
+					dataStream,
+					bucketsBuilder,
+					listener,
+					metaStoreFactory);
 		}
+	}
+
+	public static DataStreamSink<RowData> createStreamingSink(
+			Configuration conf,
+			Path path,
+			List<String> partitionKeys,
+			ObjectIdentifier tableIdentifier,
+			boolean overwrite,
+			DataStream<RowData> inputStream,
+			BucketsBuilder<RowData, ?, ? extends BucketsBuilder<RowData, ?, ?>> bucketsBuilder,
+			InactiveBucketListener listener,
+			TableMetaStoreFactory msFactory) {
+		if (overwrite) {
+			throw new IllegalStateException("Streaming mode not support overwrite.");
+		}
+
+		StreamingFileWriter fileWriter = new StreamingFileWriter(
+				BucketsBuilder.DEFAULT_BUCKET_CHECK_INTERVAL, bucketsBuilder, listener);
+		DataStream<CommitMessage> writerStream = inputStream.transform(
+				StreamingFileWriter.class.getSimpleName(),
+				TypeExtractor.createTypeInfo(CommitMessage.class),
+				fileWriter).setParallelism(inputStream.getParallelism());
+
+		DataStream<?> returnStream = writerStream;
+
+		// save committer when we don't need it.
+		if (partitionKeys.size() > 0 && conf.contains(SINK_PARTITION_COMMIT_POLICY_KIND)) {
+			StreamingFileCommitter committer = new StreamingFileCommitter(
+					path, tableIdentifier, partitionKeys, msFactory, conf);
+			returnStream = writerStream
+					.transform(StreamingFileCommitter.class.getSimpleName(), Types.VOID, committer)
+					.setParallelism(1)
+					.setMaxParallelism(1);
+		}
+		//noinspection unchecked
+		return returnStream.addSink(new DiscardingSink()).setParallelism(1);
 	}
 
 	private Path toStagingPath() {
@@ -183,7 +236,7 @@ public class FileSystemTableSink implements
 	}
 
 	private Object createWriter() {
-		FileSystemFormatFactory formatFactory = createFormatFactory(formatProperties);
+		FileSystemFormatFactory formatFactory = createFormatFactory(properties);
 		FileSystemFormatFactory.WriterContext context = new FileSystemFormatFactory.WriterContext() {
 
 			@Override
@@ -193,7 +246,7 @@ public class FileSystemTableSink implements
 
 			@Override
 			public Map<String, String> getFormatProperties() {
-				return formatProperties;
+				return properties;
 			}
 
 			@Override

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/MetastoreCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/MetastoreCommitPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.table.filesystem.TableMetaStoreFactory.TableMetaStore;
+
+import java.util.LinkedHashMap;
+
+/**
+ * Partition commit policy to update metastore.
+ *
+ * <p>If this is for file system table, the metastore is a empty implemantation.
+ * If this is for hive table, the metastore is for connecting to hive metastore.
+ */
+public class MetastoreCommitPolicy implements PartitionCommitPolicy {
+
+	private TableMetaStore metaStore;
+
+	public void setMetastore(TableMetaStore metaStore) {
+		this.metaStore = metaStore;
+	}
+
+	@Override
+	public void commit(Context context) throws Exception {
+		LinkedHashMap<String, String> partitionSpec = new LinkedHashMap<>();
+		for (int i = 0; i < context.partitionKeys().size(); i++) {
+			partitionSpec.put(context.partitionKeys().get(i), context.partitionValues().get(i));
+		}
+		metaStore.createOrAlterPartition(partitionSpec, context.partitionPath());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/PartitionCommitPolicy.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Policy for commit a partition.
+ *
+ * <p>The implemented commit method needs to be idempotent because the same partition may be
+ * committed multiple times.
+ *
+ * <p>Default implementations:
+ * See {@link MetastoreCommitPolicy}.
+ * See {@link SuccessFileCommitPolicy}.
+ *
+ * <p>Further more, you can implement your own policy, like:
+ * - RPC to notify downstream applications.
+ * - Trigger hive to analysis partition for generating statistics.
+ * ...
+ */
+@Experimental
+public interface PartitionCommitPolicy {
+
+	String METASTORE = "metastore";
+	String SUCCESS_FILE = "success-file";
+	String CUSTOM = "custom";
+
+	/**
+	 * Commit a partition.
+	 */
+	void commit(Context context) throws Exception;
+
+	/**
+	 * Context of policy, including table information and partition information.
+	 */
+	interface Context {
+
+		/**
+		 * Catalog name of this table.
+		 */
+		String catalogName();
+
+		/**
+		 * Database name of this table.
+		 */
+		String databaseName();
+
+		/**
+		 * Table name.
+		 */
+		String tableName();
+
+		/**
+		 * Table partition keys.
+		 */
+		List<String> partitionKeys();
+
+		/**
+		 * Values of this partition.
+		 */
+		List<String> partitionValues();
+
+		/**
+		 * Path of this partition.
+		 */
+		Path partitionPath();
+	}
+
+	/**
+	 * Create a policy chain from config.
+	 */
+	static List<PartitionCommitPolicy> createPolicyChain(
+			ClassLoader cl,
+			String policyKind,
+			String customClass,
+			String successFileName,
+			FileSystem fileSystem) {
+		if (policyKind == null) {
+			return Collections.emptyList();
+		}
+		String[] policyStrings = policyKind.split(",");
+		return Arrays.stream(policyStrings).map(name -> {
+			switch (name) {
+				case METASTORE:
+					return new MetastoreCommitPolicy();
+				case SUCCESS_FILE:
+					return new SuccessFileCommitPolicy(successFileName, fileSystem);
+				case CUSTOM:
+					try {
+						return (PartitionCommitPolicy) cl.loadClass(customClass).newInstance();
+					} catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+						throw new RuntimeException(
+								"Can not new instance for custom class from " + customClass, e);
+					}
+				default:
+					throw new UnsupportedOperationException("Unsupported policy: " + name);
+			}
+		}).collect(Collectors.toList());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SuccessFileCommitPolicy.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/SuccessFileCommitPolicy.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem;
+
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+/**
+ * Partition commit policy to add success file to directory. Success file is configurable and
+ * empty file.
+ */
+public class SuccessFileCommitPolicy implements PartitionCommitPolicy {
+
+	private final String fileName;
+	private final FileSystem fileSystem;
+
+	public SuccessFileCommitPolicy(String fileName, FileSystem fileSystem) {
+		this.fileName = fileName;
+		this.fileSystem = fileSystem;
+	}
+
+	@Override
+	public void commit(Context context) throws Exception {
+		fileSystem.create(
+				new Path(context.partitionPath(), fileName),
+				FileSystem.WriteMode.OVERWRITE).close();
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/InactiveBucketListener.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/InactiveBucketListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.streaming.api.functions.sink.filesystem.Bucket;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketLifeCycleListener;
+import org.apache.flink.table.data.RowData;
+
+import java.util.function.Consumer;
+
+/**
+ * Inactive {@link BucketLifeCycleListener} to obtain inactive buckets to consumer.
+ */
+public class InactiveBucketListener implements BucketLifeCycleListener<RowData, String> {
+
+	private transient Consumer<String> inactiveConsumer;
+
+	public void setInactiveConsumer(Consumer<String> inactiveConsumer) {
+		this.inactiveConsumer = inactiveConsumer;
+	}
+
+	@Override
+	public void bucketCreated(Bucket<RowData, String> bucket) {
+	}
+
+	@Override
+	public void bucketInactive(Bucket<RowData, String> bucket) {
+		inactiveConsumer.accept(bucket.getBucketId());
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitTrigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionCommitTrigger.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.base.ListSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.util.StringUtils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_TRIGGER;
+
+/**
+ * Abstract commit trigger, store partitions in state and provide {@link #committablePartitions}
+ * for trigger.
+ * See {@link PartitionTimeCommitTigger}.
+ * See {@link ProcTimeCommitTigger}.
+ */
+public abstract class PartitionCommitTrigger {
+
+	public static final String PARTITION_TIME = "partition-time";
+	public static final String PROCESS_TIME = "process-time";
+
+	private static final ListStateDescriptor<List<String>> PENDING_PARTITIONS_STATE_DESC =
+			new ListStateDescriptor<>(
+					"pending-partitions",
+					new ListSerializer<>(StringSerializer.INSTANCE));
+
+	protected final ListState<List<String>> pendingPartitionsState;
+	protected final Set<String> pendingPartitions;
+
+	protected PartitionCommitTrigger(
+			boolean isRestored, OperatorStateStore stateStore) throws Exception {
+		this.pendingPartitionsState = stateStore.getListState(PENDING_PARTITIONS_STATE_DESC);
+		this.pendingPartitions = new HashSet<>();
+		if (isRestored) {
+			pendingPartitions.addAll(pendingPartitionsState.get().iterator().next());
+		}
+	}
+
+	/**
+	 * Add a pending partition.
+	 */
+	public void addPartition(String partition) {
+		if (!StringUtils.isNullOrWhitespaceOnly(partition)) {
+			this.pendingPartitions.add(partition);
+		}
+	}
+
+	/**
+	 * Get committable partitions, and cleanup useless watermarks and partitions.
+	 */
+	public abstract List<String> committablePartitions(long checkpointId) throws IOException;
+
+	/**
+	 * End input, return committable partitions and clear.
+	 */
+	public List<String> endInput() {
+		ArrayList<String> partitions = new ArrayList<>(pendingPartitions);
+		pendingPartitions.clear();
+		return partitions;
+	}
+
+	/**
+	 * Snapshot state.
+	 */
+	public void snapshotState(long checkpointId, long watermark) throws Exception {
+		pendingPartitionsState.clear();
+		pendingPartitionsState.add(new ArrayList<>(pendingPartitions));
+	}
+
+	public static PartitionCommitTrigger create(
+			boolean isRestored,
+			OperatorStateStore stateStore,
+			Configuration conf,
+			ClassLoader cl,
+			List<String> partitionKeys,
+			ProcessingTimeService procTimeService,
+			FileSystem fileSystem,
+			Path locationPath) throws Exception {
+		String trigger = conf.get(SINK_PARTITION_COMMIT_TRIGGER);
+		switch (trigger) {
+			case PARTITION_TIME:
+				return new PartitionTimeCommitTigger(
+						isRestored, stateStore, conf, cl, partitionKeys);
+			case PROCESS_TIME:
+				return new ProcTimeCommitTigger(
+						isRestored, stateStore, conf, procTimeService, fileSystem, locationPath);
+			default:
+				throw new UnsupportedOperationException(
+						"Unsupported partition commit trigger: " + trigger);
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionTimeCommitTigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/PartitionTimeCommitTigger.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.MapSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.filesystem.PartitionTimeExtractor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.apache.flink.table.filesystem.DefaultPartTimeExtractor.toMills;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_CLASS;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_DELAY;
+import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionValues;
+
+/**
+ * Partition commit trigger by partition time and watermark,
+ * if 'watermark' > 'partition-time' + 'delay', will commit the partition.
+ *
+ * <p>Compares watermark, and watermark is related to records and checkpoint, so we need store
+ * watermark information for checkpoint.
+ */
+public class PartitionTimeCommitTigger extends PartitionCommitTrigger {
+
+	private static final ListStateDescriptor<Map<Long, Long>> WATERMARKS_STATE_DESC =
+			new ListStateDescriptor<>(
+					"checkpoint-id-to-watermark",
+					new MapSerializer<>(LongSerializer.INSTANCE, LongSerializer.INSTANCE));
+
+	private final ListState<Map<Long, Long>> watermarksState;
+	private final TreeMap<Long, Long> watermarks;
+	private final PartitionTimeExtractor extractor;
+	private final long commitDelay;
+	private final List<String> partitionKeys;
+
+	public PartitionTimeCommitTigger(
+			boolean isRestored,
+			OperatorStateStore stateStore,
+			Configuration conf,
+			ClassLoader cl,
+			List<String> partitionKeys) throws Exception {
+		super(isRestored, stateStore);
+		this.partitionKeys = partitionKeys;
+		this.commitDelay = conf.get(SINK_PARTITION_COMMIT_DELAY).toMillis();
+		this.extractor = PartitionTimeExtractor.create(
+				cl,
+				conf.get(PARTITION_TIME_EXTRACTOR_KIND),
+				conf.get(PARTITION_TIME_EXTRACTOR_CLASS),
+				conf.get(PARTITION_TIME_EXTRACTOR_TIMESTAMP_PATTERN));
+
+		this.watermarksState = stateStore.getListState(WATERMARKS_STATE_DESC);
+		this.watermarks = new TreeMap<>();
+		if (isRestored) {
+			watermarks.putAll(watermarksState.get().iterator().next());
+		}
+	}
+
+	@Override
+	public List<String> committablePartitions(long checkpointId) {
+		if (!watermarks.containsKey(checkpointId)) {
+			throw new IllegalArgumentException(String.format(
+					"Checkpoint(%d) has not been snapshot. The watermark information is: %s.",
+					checkpointId, watermarks));
+		}
+
+		long watermark = watermarks.get(checkpointId);
+		watermarks.headMap(checkpointId, true).clear();
+
+		List<String> needCommit = new ArrayList<>();
+		Iterator<String> iter = pendingPartitions.iterator();
+		while (iter.hasNext()) {
+			String partition = iter.next();
+			LocalDateTime partTime = extractor.extract(
+					partitionKeys, extractPartitionValues(new Path(partition)));
+			if (watermark > toMills(partTime) + commitDelay) {
+				needCommit.add(partition);
+				iter.remove();
+			}
+		}
+		return needCommit;
+	}
+
+	@Override
+	public void snapshotState(long checkpointId, long watermark) throws Exception {
+		super.snapshotState(checkpointId, watermark);
+		watermarks.put(checkpointId, watermark);
+		watermarksState.clear();
+		watermarksState.add(new HashMap<>(watermarks));
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/ProcTimeCommitTigger.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/ProcTimeCommitTigger.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_DELAY;
+
+/**
+ * Partition commit trigger by path creation time and processing time service,
+ * if 'current processing time' > 'partition directory creation time' + 'delay', will commit the partition.
+ *
+ * <p>It is hard to get partition start time from writer, so just get creation time from file system.
+ */
+public class ProcTimeCommitTigger extends PartitionCommitTrigger {
+
+	private final long commitDelay;
+	private final ProcessingTimeService procTimeService;
+	private final FileSystem fileSystem;
+	private final Path locationPath;
+
+	public ProcTimeCommitTigger(
+			boolean isRestored,
+			OperatorStateStore stateStore,
+			Configuration conf,
+			ProcessingTimeService procTimeService,
+			FileSystem fileSystem,
+			Path locationPath) throws Exception {
+		super(isRestored, stateStore);
+		this.procTimeService = procTimeService;
+		this.fileSystem = fileSystem;
+		this.locationPath = locationPath;
+		this.commitDelay = conf.get(SINK_PARTITION_COMMIT_DELAY).toMillis();
+	}
+
+	@Override
+	public List<String> committablePartitions(long checkpointId) throws IOException {
+		List<String> needCommit = new ArrayList<>();
+		long currentProcTime = procTimeService.getCurrentProcessingTime();
+		Iterator<String> iter = pendingPartitions.iterator();
+		while (iter.hasNext()) {
+			String partition = iter.next();
+			long creationTime = fileSystem.getFileStatus(new Path(locationPath, partition))
+					.getModificationTime();
+			if (currentProcTime > creationTime + commitDelay) {
+				needCommit.add(partition);
+				iter.remove();
+			}
+		}
+		return needCommit;
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileCommitter.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.filesystem.MetastoreCommitPolicy;
+import org.apache.flink.table.filesystem.PartitionCommitPolicy;
+import org.apache.flink.table.filesystem.TableMetaStoreFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeMap;
+
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_CLASS;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.table.filesystem.FileSystemOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
+import static org.apache.flink.table.utils.PartitionPathUtils.extractPartitionSpecFromPath;
+import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionPath;
+
+/**
+ * Committer for {@link StreamingFileWriter}. This is the single (non-parallel) task.
+ * It collects all the partition information sent from upstream, and triggers the partition
+ * submission decision when it judges to collect the partitions from all tasks of a checkpoint.
+ *
+ * <p>Processing steps:
+ * 1.Partitions are sent from upstream. Add partition to trigger.
+ * 2.{@link TaskTracker} say it have already received partition data from all tasks in a checkpoint.
+ * 3.Extracting committable partitions from {@link PartitionCommitTrigger}.
+ * 4.Using {@link PartitionCommitPolicy} chain to commit partitions.
+ *
+ * <p>See {@link StreamingFileWriter#notifyCheckpointComplete}.
+ */
+public class StreamingFileCommitter extends AbstractStreamOperator<Void>
+		implements OneInputStreamOperator<StreamingFileCommitter.CommitMessage, Void> {
+
+	private static final long serialVersionUID = 1L;
+
+	private final Configuration conf;
+
+	private final Path locationPath;
+
+	private final ObjectIdentifier tableIdentifier;
+
+	private final List<String> partitionKeys;
+
+	private final TableMetaStoreFactory metaStoreFactory;
+
+	private transient PartitionCommitTrigger trigger;
+
+	private transient TaskTracker taskTracker;
+
+	private transient long currentWatermark = Long.MIN_VALUE;
+
+	private transient List<PartitionCommitPolicy> policies;
+
+	public StreamingFileCommitter(
+			Path locationPath,
+			ObjectIdentifier tableIdentifier,
+			List<String> partitionKeys,
+			TableMetaStoreFactory metaStoreFactory,
+			Configuration conf) {
+		this.locationPath = locationPath;
+		this.tableIdentifier = tableIdentifier;
+		this.partitionKeys = partitionKeys;
+		this.metaStoreFactory = metaStoreFactory;
+		this.conf = conf;
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+		FileSystem fileSystem = locationPath.getFileSystem();
+		this.trigger = PartitionCommitTrigger.create(
+				context.isRestored(),
+				context.getOperatorStateStore(),
+				conf,
+				getUserCodeClassloader(),
+				partitionKeys,
+				getProcessingTimeService(),
+				fileSystem,
+				locationPath);
+		this.policies = PartitionCommitPolicy.createPolicyChain(
+				getUserCodeClassloader(),
+				conf.get(SINK_PARTITION_COMMIT_POLICY_KIND),
+				conf.get(SINK_PARTITION_COMMIT_POLICY_CLASS),
+				conf.get(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+				fileSystem);
+	}
+
+	@Override
+	public void processElement(StreamRecord<CommitMessage> element) throws Exception {
+		CommitMessage message = element.getValue();
+		for (String partition : message.partitions) {
+			trigger.addPartition(partition);
+		}
+
+		if (taskTracker == null) {
+			taskTracker = new TaskTracker(message.numberOfTasks);
+		}
+		boolean needCommit = taskTracker.add(message.checkpointId, message.taskId);
+		if (needCommit) {
+			commitPartitions(message.checkpointId);
+		}
+	}
+
+	private void commitPartitions(long checkpointId) throws Exception {
+		List<String> partitions = checkpointId == Long.MAX_VALUE ?
+				trigger.endInput() :
+				trigger.committablePartitions(checkpointId);
+		if (partitions.isEmpty()) {
+			return;
+		}
+
+		try (TableMetaStoreFactory.TableMetaStore metaStore = metaStoreFactory.createTableMetaStore()) {
+			for (String partition : partitions) {
+				LinkedHashMap<String, String> partSpec = extractPartitionSpecFromPath(new Path(partition));
+				Path path = new Path(metaStore.getLocationPath(), generatePartitionPath(partSpec));
+				PartitionCommitPolicy.Context context = new PolicyContext(
+						new ArrayList<>(partSpec.values()), path);
+				for (PartitionCommitPolicy policy : policies) {
+					if (policy instanceof MetastoreCommitPolicy) {
+						((MetastoreCommitPolicy) policy).setMetastore(metaStore);
+					}
+					policy.commit(context);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		super.processWatermark(mark);
+		this.currentWatermark = mark.getTimestamp();
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+		trigger.snapshotState(context.getCheckpointId(), currentWatermark);
+	}
+
+	/**
+	 * The message sent upstream.
+	 *
+	 * <p>Need to ensure that the partitions are ready to commit. That is to say, the files in
+	 * the partition have become readable rather than temporary.
+	 */
+	public static class CommitMessage implements Serializable {
+
+		public long checkpointId;
+		public int taskId;
+		public int numberOfTasks;
+		public List<String> partitions;
+
+		/**
+		 * Pojo need this constructor.
+		 */
+		public CommitMessage() {}
+
+		public CommitMessage(
+				long checkpointId, int taskId, int numberOfTasks, List<String> partitions) {
+			this.checkpointId = checkpointId;
+			this.taskId = taskId;
+			this.numberOfTasks = numberOfTasks;
+			this.partitions = partitions;
+		}
+	}
+
+	/**
+	 * Track the upstream tasks to determine whether all the upstream data of a checkpoint
+	 * has been received.
+	 */
+	private static class TaskTracker {
+
+		private final int numberOfTasks;
+
+		/**
+		 * Checkpoint id to notified tasks.
+		 */
+		private TreeMap<Long, Set<Integer>> notifiedTasks = new TreeMap<>();
+
+		private TaskTracker(int numberOfTasks) {
+			this.numberOfTasks = numberOfTasks;
+		}
+
+		/**
+		 * @return true, if this checkpoint id need be committed.
+		 */
+		private boolean add(long checkpointId, int task) {
+			Set<Integer> tasks = notifiedTasks.computeIfAbsent(checkpointId, (k) -> new HashSet<>());
+			tasks.add(task);
+			if (tasks.size() == numberOfTasks) {
+				notifiedTasks.headMap(checkpointId, true).clear();
+				return true;
+			}
+			return false;
+		}
+	}
+
+	private class PolicyContext implements PartitionCommitPolicy.Context {
+
+		private final List<String> partitionValues;
+		private final Path partitionPath;
+
+		private PolicyContext(List<String> partitionValues, Path partitionPath) {
+			this.partitionValues = partitionValues;
+			this.partitionPath = partitionPath;
+		}
+
+		@Override
+		public String catalogName() {
+			return tableIdentifier.getCatalogName();
+		}
+
+		@Override
+		public String databaseName() {
+			return tableIdentifier.getDatabaseName();
+		}
+
+		@Override
+		public String tableName() {
+			return tableIdentifier.getObjectName();
+		}
+
+		@Override
+		public List<String> partitionKeys() {
+			return partitionKeys;
+		}
+
+		@Override
+		public List<String> partitionValues() {
+			return partitionValues;
+		}
+
+		@Override
+		public Path partitionPath() {
+			return partitionPath;
+		}
+	}
+}

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/filesystem/stream/StreamingFileWriter.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.filesystem.stream;
+
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.functions.sink.filesystem.Buckets;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
+import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSinkHelper;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.filesystem.stream.StreamingFileCommitter.CommitMessage;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Operator for file system sink. It is a operator version of {@link StreamingFileSink}.
+ * It sends partition commit message to downstream for committing.
+ *
+ * <p>See {@link StreamingFileCommitter}.
+ */
+public class StreamingFileWriter extends AbstractStreamOperator<CommitMessage>
+		implements OneInputStreamOperator<RowData, CommitMessage>, BoundedOneInput{
+
+	private static final long serialVersionUID = 1L;
+
+	// ------------------------ configuration fields --------------------------
+
+	private final long bucketCheckInterval;
+
+	private final StreamingFileSink.BucketsBuilder<RowData, ?, ? extends
+			StreamingFileSink.BucketsBuilder<RowData, ?, ?>> bucketsBuilder;
+
+	private final InactiveBucketListener listener;
+
+	// --------------------------- runtime fields -----------------------------
+
+	private transient Buckets<RowData, ?> buckets;
+
+	private transient StreamingFileSinkHelper<RowData> helper;
+
+	private transient long currentWatermark = Long.MIN_VALUE;
+
+	private transient Set<String> inactivePartitions;
+
+	public StreamingFileWriter(
+			long bucketCheckInterval,
+			StreamingFileSink.BucketsBuilder<RowData, ?, ? extends
+					StreamingFileSink.BucketsBuilder<RowData, ?, ?>> bucketsBuilder,
+			InactiveBucketListener listener) {
+		this.bucketCheckInterval = bucketCheckInterval;
+		this.bucketsBuilder = bucketsBuilder;
+		this.listener = listener;
+	}
+
+	@Override
+	public void initializeState(StateInitializationContext context) throws Exception {
+		super.initializeState(context);
+		buckets = bucketsBuilder.createBuckets(getRuntimeContext().getIndexOfThisSubtask());
+		helper = new StreamingFileSinkHelper<>(
+				buckets,
+				context.isRestored(),
+				context.getOperatorStateStore(),
+				getRuntimeContext().getProcessingTimeService(),
+				bucketCheckInterval);
+
+		inactivePartitions = new HashSet<>();
+		listener.setInactiveConsumer(b -> inactivePartitions.add(b));
+	}
+
+	@Override
+	public void snapshotState(StateSnapshotContext context) throws Exception {
+		super.snapshotState(context);
+		helper.snapshotState(context.getCheckpointId());
+	}
+
+	@Override
+	public void processWatermark(Watermark mark) throws Exception {
+		super.processWatermark(mark);
+		currentWatermark = mark.getTimestamp();
+	}
+
+	@Override
+	public void processElement(StreamRecord<RowData> element) throws Exception {
+		helper.onElement(
+				element.getValue(),
+				getProcessingTimeService().getCurrentProcessingTime(),
+				element.hasTimestamp() ? element.getTimestamp() : null,
+				currentWatermark);
+	}
+
+	/**
+	 * Commit up to this checkpoint id, also send inactive partitions to downstream for committing.
+	 */
+	@Override
+	public void notifyCheckpointComplete(long checkpointId) throws Exception {
+		super.notifyCheckpointComplete(checkpointId);
+		commitUpToCheckpoint(checkpointId);
+	}
+
+	private void commitUpToCheckpoint(long checkpointId) throws Exception {
+		helper.commitUpToCheckpoint(checkpointId);
+		CommitMessage message = new CommitMessage(
+				checkpointId,
+				getRuntimeContext().getIndexOfThisSubtask(),
+				getRuntimeContext().getNumberOfParallelSubtasks(),
+				new ArrayList<>(inactivePartitions));
+		output.collect(new StreamRecord<>(message));
+		inactivePartitions.clear();
+	}
+
+	@Override
+	public void endInput() throws Exception {
+		buckets.onProcessingTime(Long.MAX_VALUE);
+		helper.snapshotState(Long.MAX_VALUE);
+		output.emitWatermark(new Watermark(Long.MAX_VALUE));
+		commitUpToCheckpoint(Long.MAX_VALUE);
+	}
+
+	@Override
+	public void dispose() throws Exception {
+		super.dispose();
+		if (helper != null) {
+			helper.close();
+		}
+	}
+}


### PR DESCRIPTION

## What is the purpose of the change

Committing a partition is to notify the downstream application that the partition has finished writing, the partition is ready to be read.
Add “.succes” file to directory (success file name is configurable too)

## Brief change log

- This PR is based on https://github.com/apache/flink/pull/12053
- StreamingFileWriter(parallelism) -> StreamingFileCommitter(Single task to commit partition)

## Verifying this change

`StreamFileSystemTestCsvITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? JavaDocs
