### PR TITLE
[FLINK-17603][table][core] Prepare Hive partitioned streaming source

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedOrcSplitReader.java
@@ -90,6 +90,11 @@ public class HiveVectorizedOrcSplitReader implements SplitReader {
 	}
 
 	@Override
+	public void seekToRow(long rowCount, RowData reuse) throws IOException {
+		this.reader.seekToRow(rowCount);
+	}
+
+	@Override
 	public boolean reachedEnd() throws IOException {
 		return this.reader.reachedEnd();
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveVectorizedParquetSplitReader.java
@@ -75,6 +75,11 @@ public class HiveVectorizedParquetSplitReader implements SplitReader {
 	}
 
 	@Override
+	public void seekToRow(long rowCount, RowData reuse) throws IOException {
+		this.reader.seekToRow(rowCount);
+	}
+
+	@Override
 	public boolean reachedEnd() throws IOException {
 		return this.reader.reachedEnd();
 	}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/SplitReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/SplitReader.java
@@ -46,4 +46,17 @@ public interface SplitReader extends Closeable {
 	 * @throws IOException Thrown, if an I/O error occurred.
 	 */
 	RowData nextRecord(RowData reuse) throws IOException;
+
+	/**
+	 * Seek to a particular row number.
+	 */
+	default void seekToRow(long rowCount, RowData reuse) throws IOException {
+		for (int i = 0; i < rowCount; i++) {
+			boolean end = reachedEnd();
+			if (end) {
+				throw new RuntimeException("Seek too many rows.");
+			}
+			nextRecord(reuse);
+		}
+	}
 }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcSplitReader.java
@@ -79,6 +79,13 @@ public abstract class OrcSplitReader<T, BATCH> implements Closeable {
 		nextRow = 0;
 	}
 
+	/**
+	 * Seek to a particular row number.
+	 */
+	public void seekToRow(long rowCount) throws IOException {
+		orcRowsReader.seekToRow(rowCount);
+	}
+
 	@VisibleForTesting
 	public RecordReader getRecordReader() {
 		return orcRowsReader;

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/vector/ParquetColumnarRowSplitReaderTest.java
@@ -168,14 +168,20 @@ public class ParquetColumnarRowSplitReaderTest {
 
 		// test reading and splitting
 		long fileLen = testPath.getFileSystem().getFileStatus(testPath).getLen();
-		int len1 = readSplitAndCheck(0, testPath, 0, fileLen / 3, values);
-		int len2 = readSplitAndCheck(len1, testPath, fileLen / 3, fileLen * 2 / 3, values);
-		int len3 = readSplitAndCheck(len1 + len2, testPath, fileLen * 2 / 3, Long.MAX_VALUE, values);
+		int len1 = readSplitAndCheck(0, 0, testPath, 0, fileLen / 3, values);
+		int len2 = readSplitAndCheck(len1, 0, testPath, fileLen / 3, fileLen * 2 / 3, values);
+		int len3 = readSplitAndCheck(len1 + len2, 0, testPath, fileLen * 2 / 3, Long.MAX_VALUE, values);
 		assertEquals(number, len1 + len2 + len3);
+
+		// test seek
+		assertEquals(
+				number - number / 2,
+				readSplitAndCheck(number / 2, number / 2, testPath, 0, fileLen, values));
 	}
 
 	private int readSplitAndCheck(
 			int start,
+			long seekToRow,
 			Path testPath,
 			long splitStart,
 			long splitLength,
@@ -209,6 +215,7 @@ public class ParquetColumnarRowSplitReaderTest {
 				new org.apache.hadoop.fs.Path(testPath.getPath()),
 				splitStart,
 				splitLength);
+		reader.seekToRow(seekToRow);
 
 		int i = start;
 		while (!reader.reachedEnd()) {

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
@@ -416,7 +416,7 @@ public class ContinuousFileProcessingMigrationTest {
 	private OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, FileInputSplit> createHarness(BlockingFileInputFormat format) throws Exception {
 		ExecutionConfig config = new ExecutionConfig();
 		return new OneInputStreamOperatorTestHarness<>(
-			new ContinuousFileReaderOperatorFactory<>(format, TypeExtractor.getInputFormatTypes(format), config),
+			new ContinuousFileReaderOperatorFactory(format, TypeExtractor.getInputFormatTypes(format), config),
 			TypeExtractor.getForClass(TimestampedFileInputSplit.class).createSerializer(config));
 	}
 

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileMonitoringFunction;
+import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperator;
 import org.apache.flink.streaming.api.functions.source.ContinuousFileReaderOperatorFactory;
 import org.apache.flink.streaming.api.functions.source.FileProcessingMode;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
@@ -312,7 +313,7 @@ public class ContinuousFileProcessingTest {
 	private <T> OneInputStreamOperatorTestHarness<TimestampedFileInputSplit, T> createHarness(FileInputFormat<T> format) throws Exception {
 		ExecutionConfig config = new ExecutionConfig();
 		return new OneInputStreamOperatorTestHarness<>(
-			new ContinuousFileReaderOperatorFactory<>(format, TypeExtractor.getInputFormatTypes(format), config),
+			new ContinuousFileReaderOperatorFactory(format, TypeExtractor.getInputFormatTypes(format), config),
 			TypeExtractor.getForClass(TimestampedFileInputSplit.class).createSerializer(config));
 	}
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -78,6 +78,7 @@ import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SocketTextStreamFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
+import org.apache.flink.streaming.api.functions.source.TimestampedFileInputSplit;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.streaming.api.graph.StreamGraphGenerator;
 import org.apache.flink.streaming.api.operators.StreamSource;
@@ -1507,7 +1508,8 @@ public class StreamExecutionEnvironment {
 		ContinuousFileMonitoringFunction<OUT> monitoringFunction =
 			new ContinuousFileMonitoringFunction<>(inputFormat, monitoringMode, getParallelism(), interval);
 
-		ContinuousFileReaderOperatorFactory<OUT> factory = new ContinuousFileReaderOperatorFactory<>(inputFormat);
+		ContinuousFileReaderOperatorFactory<OUT, TimestampedFileInputSplit> factory =
+				new ContinuousFileReaderOperatorFactory<>(inputFormat);
 
 		SingleOutputStreamOperator<OUT> source = addSource(monitoringFunction, sourceName)
 				.transform("Split Reader: " + sourceName, typeInfo, factory);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperatorFactory.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -31,19 +31,20 @@ import org.apache.flink.streaming.api.operators.YieldingOperatorFactory;
 /**
  * {@link ContinuousFileReaderOperator} factory.
  */
-public class ContinuousFileReaderOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OUT>
-	implements YieldingOperatorFactory<OUT>, OneInputStreamOperatorFactory<TimestampedFileInputSplit, OUT> {
+public class ContinuousFileReaderOperatorFactory<OUT, T extends TimestampedInputSplit>
+	extends AbstractStreamOperatorFactory<OUT>
+	implements YieldingOperatorFactory<OUT>, OneInputStreamOperatorFactory<T, OUT> {
 
-	private final FileInputFormat<OUT> inputFormat;
+	private final InputFormat<OUT, ? super T> inputFormat;
 	private TypeInformation<OUT> type;
 	private ExecutionConfig executionConfig;
 	private transient MailboxExecutor mailboxExecutor;
 
-	public ContinuousFileReaderOperatorFactory(FileInputFormat<OUT> inputFormat) {
+	public ContinuousFileReaderOperatorFactory(InputFormat<OUT, ? super T> inputFormat) {
 		this(inputFormat, null, null);
 	}
 
-	public ContinuousFileReaderOperatorFactory(FileInputFormat<OUT> inputFormat, TypeInformation<OUT> type, ExecutionConfig executionConfig) {
+	public ContinuousFileReaderOperatorFactory(InputFormat<OUT, ? super T> inputFormat, TypeInformation<OUT> type, ExecutionConfig executionConfig) {
 		this.inputFormat = inputFormat;
 		this.type = type;
 		this.executionConfig = executionConfig;
@@ -56,11 +57,11 @@ public class ContinuousFileReaderOperatorFactory<OUT> extends AbstractStreamOper
 	}
 
 	@Override
-	public <T extends StreamOperator<OUT>> T createStreamOperator(StreamOperatorParameters<OUT> parameters) {
-		ContinuousFileReaderOperator<OUT> operator = new ContinuousFileReaderOperator<>(inputFormat, processingTimeService, mailboxExecutor);
+	public <O extends StreamOperator<OUT>> O createStreamOperator(StreamOperatorParameters<OUT> parameters) {
+		ContinuousFileReaderOperator<OUT, T> operator = new ContinuousFileReaderOperator<>(inputFormat, processingTimeService, mailboxExecutor);
 		operator.setup(parameters.getContainingTask(), parameters.getStreamConfig(), parameters.getOutput());
 		operator.setOutputType(type, executionConfig);
-		return (T) operator;
+		return (O) operator;
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedFileInputSplit.java
@@ -24,15 +24,11 @@ import org.apache.flink.util.Preconditions;
 import java.io.Serializable;
 
 /**
- * An extended {@link FileInputSplit} that also includes information about:
- * <ul>
- *     <li>The modification time of the file this split belongs to.</li>
- *     <li>When checkpointing, the state of the split at the moment of the checkpoint.</li>
- * </ul>
- * This class is used by the {@link ContinuousFileMonitoringFunction} and the
- * {@link ContinuousFileReaderOperator} to perform continuous file processing.
- * */
-public class TimestampedFileInputSplit extends FileInputSplit implements Comparable<TimestampedFileInputSplit>{
+ * A {@link FileInputSplit} with {@link TimestampedInputSplit}.
+ */
+public class TimestampedFileInputSplit extends FileInputSplit implements TimestampedInputSplit {
+
+	private static final long serialVersionUID = -8153252402661556005L;
 
 	/** The modification time of the file this split belongs to. */
 	private final long modificationTime;
@@ -77,13 +73,6 @@ public class TimestampedFileInputSplit extends FileInputSplit implements Compara
 		this.splitState = state;
 	}
 
-	/**
-	 * Sets the state of the split to {@code null}.
-	 */
-	public void resetSplitState() {
-		this.setSplitState(null);
-	}
-
 	/** @return the state of the split. */
 	public Serializable getSplitState() {
 		return this.splitState;
@@ -95,24 +84,25 @@ public class TimestampedFileInputSplit extends FileInputSplit implements Compara
 	}
 
 	@Override
-	public int compareTo(TimestampedFileInputSplit o) {
-		int modTimeComp = Long.compare(this.modificationTime, o.modificationTime);
+	public int compareTo(TimestampedInputSplit o) {
+		TimestampedFileInputSplit other = (TimestampedFileInputSplit) o;
+		int modTimeComp = Long.compare(this.modificationTime, other.modificationTime);
 		if (modTimeComp != 0L) {
 			return modTimeComp;
 		}
 
 		// the file input split does not prevent null paths.
-		if (this.getPath() == null && o.getPath() != null) {
+		if (this.getPath() == null && other.getPath() != null) {
 			return 1;
-		} else if (this.getPath() != null && o.getPath() == null) {
+		} else if (this.getPath() != null && other.getPath() == null) {
 			return -1;
 		}
 
-		int pathComp = this.getPath() == o.getPath() ? 0 :
-			this.getPath().compareTo(o.getPath());
+		int pathComp = this.getPath() == other.getPath() ? 0 :
+			this.getPath().compareTo(other.getPath());
 
 		return pathComp != 0 ? pathComp :
-			this.getSplitNumber() - o.getSplitNumber();
+			this.getSplitNumber() - other.getSplitNumber();
 	}
 
 	@Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedInputSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/TimestampedInputSplit.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.source;
+
+import org.apache.flink.core.io.InputSplit;
+
+import java.io.Serializable;
+
+/**
+ * An extended {@link InputSplit} that also includes information about:
+ * <ul>
+ *     <li>The modification time of the file this split belongs to.</li>
+ *     <li>When checkpointing, the state of the split at the moment of the checkpoint.</li>
+ * </ul>
+ * This class is used by the {@link ContinuousFileMonitoringFunction} and the
+ * {@link ContinuousFileReaderOperator} to perform continuous file processing.
+ * */
+public interface TimestampedInputSplit extends InputSplit, Comparable<TimestampedInputSplit> {
+
+	/**
+	 * Sets the state of the split. This information is used when restoring from a checkpoint and
+	 * allows to resume reading the underlying file from the point we left off.
+	 *
+	 * <p>* This is applicable to
+	 * {@link org.apache.flink.api.common.io.FileInputFormat FileInputFormats} that implement the
+	 * {@link org.apache.flink.api.common.io.CheckpointableInputFormat} interface.
+	 */
+	void setSplitState(Serializable state);
+
+	/**
+	 * @return the state of the split.
+	 */
+	Serializable getSplitState();
+
+	/**
+	 * Sets the state of the split to {@code null}.
+	 */
+	default void resetSplitState() {
+		this.setSplitState(null);
+	}
+
+	/**
+	 * @return The modification time of the file this split belongs to.
+	 */
+	long getModificationTime();
+}


### PR DESCRIPTION

## What is the purpose of the change

Prepare Hive partitioned streaming source, refactor codes.

## Brief change log

- Refactor ContinuousFileReaderOperator to read generic split
- HiveTableInputFormat implements CheckpointableInputFormat

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented?JavaDocs