### PR TITLE
[hotfix][javadocs]java doc error fix

### DIFF
--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -214,7 +214,7 @@ class ExecutionEnvironment(javaEnv: JavaEnv) {
    *
    * @param filePath The path of the file, as a URI (e.g., "file:///some/local/file" or
    *                 "hdfs://host:port/file/path").
-   * @param charsetName The name of the character set used to read the file. Default is UTF-0
+   * @param charsetName The name of the character set used to read the file. Default is UTF-8
    */
   def readTextFile(filePath: String, charsetName: String = "UTF-8"): DataSet[String] = {
     require(filePath != null, "The file path may not be null.")


### PR DESCRIPTION

## What is the purpose of the change
java doc in ExecutionEnvironment.readTextFile is error

## Brief change log
change Default is UTF-0 to UTF-8

## Verifying this change


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
