### PR TITLE
[hotfix][runtime] Remove useless local variable in CompletedCheckpointStoreTest3testAddCheckpointMoreThanMaxRetained

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStoreTest.java
@@ -105,8 +105,6 @@ public abstract class CompletedCheckpointStoreTest extends TestLogger {
 		assertEquals(1, checkpoints.getNumberOfRetainedCheckpoints());
 
 		for (int i = 1; i < expected.length; i++) {
-			Collection<OperatorState> taskStates = expected[i - 1].getOperatorStates().values();
-
 			checkpoints.addCheckpoint(expected[i]);
 
 			// The ZooKeeper implementation discards asynchronously


### PR DESCRIPTION
Remove useless local variable `taskStates` in `CompletedCheckpointStoreTest3testAddCheckpointMoreThanMaxRetained`