### PR TITLE
[FLINK-17315][tests/checkpointing] Reenabling UnalignedCheckpointITCase.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/serialization/SpillingAdaptiveSpanningRecordDeserializer.java
@@ -638,6 +638,8 @@ public class SpillingAdaptiveSpanningRecordDeserializer<T extends IOReadableWrit
 			this.recordLength = -1;
 			this.lengthBuffer.clear();
 			this.leftOverData = null;
+			this.leftOverStart = 0;
+			this.leftOverLimit = 0;
 			this.accumulatedRecordBytes = 0;
 
 			if (spillingChannel != null) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -127,10 +127,7 @@ public class PipelinedSubpartition extends ResultSubpartition {
 	@Override
 	public boolean add(BufferConsumer bufferConsumer, boolean isPriorityEvent) throws IOException {
 		if (isPriorityEvent) {
-			if (readView != null && readView.notifyPriorityEvent(bufferConsumer)) {
-				bufferConsumer.close();
-				return true;
-			}
+			// TODO: use readView.notifyPriorityEvent for local channels
 			return add(bufferConsumer, false, true);
 		}
 		return add(bufferConsumer, false, false);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -174,7 +174,9 @@ public class PipelinedSubpartition extends ResultSubpartition {
 			// Meanwhile prepare the collection of in-flight buffers which would be fetched in the next step later.
 			for (BufferConsumer buffer : buffers) {
 				try (BufferConsumer bc = buffer.copy()) {
-					inflightBufferSnapshot.add(bc.build());
+					if (bc.isBuffer()) {
+						inflightBufferSnapshot.add(bc.build());
+					}
 				}
 			}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannel.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
 import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.io.network.TaskEventPublisher;
@@ -65,6 +66,12 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	private volatile ResultSubpartitionView subpartitionView;
 
 	private volatile boolean isReleased;
+
+	/** The latest already triggered checkpoint id which would be updated during {@link #spillInflightBuffers(long, ChannelStateWriter)}.*/
+	private long lastRequestedCheckpointId = -1;
+
+	/** The current received checkpoint id from the network. */
+	private long receivedCheckpointId = -1;
 
 	public LocalInputChannel(
 		SingleInputGate inputGate,
@@ -167,6 +174,11 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 	}
 
 	@Override
+	public void spillInflightBuffers(long checkpointId, ChannelStateWriter channelStateWriter) {
+		this.lastRequestedCheckpointId = checkpointId;
+	}
+
+	@Override
 	Optional<BufferAndAvailability> getNextBuffer() throws IOException, InterruptedException {
 		checkError();
 
@@ -198,9 +210,17 @@ public class LocalInputChannel extends InputChannel implements BufferAvailabilit
 			}
 		}
 
-		numBytesIn.inc(next.buffer().getSize());
+		Buffer buffer = next.buffer();
+		CheckpointBarrier notifyReceivedBarrier = parseCheckpointBarrierOrNull(buffer);
+		if (notifyReceivedBarrier != null) {
+			receivedCheckpointId = notifyReceivedBarrier.getId();
+		} else if (receivedCheckpointId < lastRequestedCheckpointId && buffer.isBuffer()) {
+			inputGate.getBufferReceivedListener().notifyBufferReceived(buffer.retainBuffer(), channelInfo);
+		}
+
+		numBytesIn.inc(buffer.getSize());
 		numBuffersIn.inc();
-		return Optional.of(new BufferAndAvailability(next.buffer(), next.isDataAvailable(), next.buffersInBacklog()));
+		return Optional.of(new BufferAndAvailability(buffer, next.isDataAvailable(), next.buffersInBacklog()));
 	}
 
 	@Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/AbstractInvokable.java
@@ -248,7 +248,8 @@ public abstract class AbstractInvokable {
 			ThrowingRunnable<E> runnable,
 			String descriptionFormat,
 			Object... descriptionArgs) throws E {
-		throw new UnsupportedOperationException(String.format("runInTaskThread not supported by %s", this.getClass().getName()));
+		throw new UnsupportedOperationException(
+			String.format("executeInTaskThread not supported by %s", getClass().getName()));
 	}
 
 	/**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/serialization/SpanningRecordSerializationTest.java
@@ -233,6 +233,15 @@ public class SpanningRecordSerializationTest extends TestLogger {
 			Util.randomRecord(SerializationTestTypeFactory.BYTE_ARRAY),
 			1,
 			new byte[] {42, 43, 44});
+
+		deserializer.clear();
+
+		testUnconsumedBuffer(
+			serializer,
+			deserializer,
+			Util.randomRecord(SerializationTestTypeFactory.BYTE_ARRAY),
+			1,
+			new byte[] {42, 43, 44});
 	}
 
 	public void testUnconsumedBuffer(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -331,46 +331,13 @@ public class PipelinedSubpartitionWithReadViewTest {
 		BufferConsumer barrierBuffer = EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options));
 		subpartition.add(barrierBuffer, true);
 		assertEquals(2, availablityListener.getNumNotifications());
-		assertEquals(1, availablityListener.getNumPriorityEvents());
+		assertEquals(0, availablityListener.getNumPriorityEvents());
 
 		List<Buffer> inflight = subpartition.requestInflightBufferSnapshot();
 		assertEquals(Arrays.asList(1, 2, 3), inflight.stream().map(Buffer::getSize).collect(Collectors.toList()));
 		inflight.forEach(Buffer::recycleBuffer);
 
 		assertNextEvent(readView, barrierBuffer.getWrittenBytes(), CheckpointBarrier.class, true, 2, false, true);
-		assertNextBuffer(readView, 1, true, 1, false, true);
-		assertNextBuffer(readView, 2, false, 0, false, true);
-		assertNextBuffer(readView, 3, false, 0, false, true);
-		assertNoNextBuffer(readView);
-	}
-
-	@Test
-	public void testBarrierConsumedByAvailabilityListener() throws Exception {
-		availablityListener.consumePriorityEvents();
-
-		subpartition.add(createFilledFinishedBufferConsumer(1));
-		assertEquals(0, availablityListener.getNumNotifications());
-		assertEquals(0, availablityListener.getNumPriorityEvents());
-
-		subpartition.add(createFilledFinishedBufferConsumer(2));
-		assertEquals(1, availablityListener.getNumNotifications());
-		assertEquals(0, availablityListener.getNumPriorityEvents());
-
-		subpartition.add(createFilledFinishedBufferConsumer(3));
-		assertEquals(1, availablityListener.getNumNotifications());
-		assertEquals(0, availablityListener.getNumPriorityEvents());
-
-		CheckpointOptions options = new CheckpointOptions(
-			CheckpointType.CHECKPOINT,
-			new CheckpointStorageLocationReference(new byte[]{0, 1, 2}));
-		BufferConsumer barrierBuffer = EventSerializer.toBufferConsumer(new CheckpointBarrier(0, 0, options));
-		subpartition.add(barrierBuffer, true);
-		assertEquals(1, availablityListener.getNumNotifications());
-		assertEquals(1, availablityListener.getNumPriorityEvents());
-
-		List<Buffer> inflight = subpartition.requestInflightBufferSnapshot();
-		assertEquals(Arrays.asList(), inflight.stream().map(Buffer::getSize).collect(Collectors.toList()));
-
 		assertNextBuffer(readView, 1, true, 1, false, true);
 		assertNextBuffer(readView, 2, false, 0, false, true);
 		assertNextBuffer(readView, 3, false, 0, false, true);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartitionWithReadViewTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.checkpoint.CheckpointType;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.EndOfSuperstepEvent;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
@@ -319,7 +320,12 @@ public class PipelinedSubpartitionWithReadViewTest {
 		assertEquals(1, availablityListener.getNumNotifications());
 		assertEquals(0, availablityListener.getNumPriorityEvents());
 
-		subpartition.add(createFilledFinishedBufferConsumer(3));
+		BufferConsumer eventBuffer = EventSerializer.toBufferConsumer(EndOfSuperstepEvent.INSTANCE);
+		subpartition.add(eventBuffer);
+		assertEquals(1, availablityListener.getNumNotifications());
+		assertEquals(0, availablityListener.getNumPriorityEvents());
+
+		subpartition.add(createFilledFinishedBufferConsumer(4));
 		assertEquals(1, availablityListener.getNumNotifications());
 		assertEquals(0, availablityListener.getNumPriorityEvents());
 
@@ -334,13 +340,14 @@ public class PipelinedSubpartitionWithReadViewTest {
 		assertEquals(0, availablityListener.getNumPriorityEvents());
 
 		List<Buffer> inflight = subpartition.requestInflightBufferSnapshot();
-		assertEquals(Arrays.asList(1, 2, 3), inflight.stream().map(Buffer::getSize).collect(Collectors.toList()));
+		assertEquals(Arrays.asList(1, 2, 4), inflight.stream().map(Buffer::getSize).collect(Collectors.toList()));
 		inflight.forEach(Buffer::recycleBuffer);
 
 		assertNextEvent(readView, barrierBuffer.getWrittenBytes(), CheckpointBarrier.class, true, 2, false, true);
 		assertNextBuffer(readView, 1, true, 1, false, true);
-		assertNextBuffer(readView, 2, false, 0, false, true);
-		assertNextBuffer(readView, 3, false, 0, false, true);
+		assertNextBuffer(readView, 2, true, 0, true, true);
+		assertNextEvent(readView, eventBuffer.getWrittenBytes(), EndOfSuperstepEvent.class, false, 0, false, true);
+		assertNextBuffer(readView, 4, false, 0, false, true);
 		assertNoNextBuffer(readView);
 	}
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyInvokable.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/testutils/DummyInvokable.java
@@ -20,11 +20,8 @@ package org.apache.flink.runtime.operators.testutils;
 
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
-import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
-
-import javax.annotation.Nullable;
+import org.apache.flink.util.function.ThrowingRunnable;
 
 /**
  * An invokable that does nothing.
@@ -56,5 +53,13 @@ public class DummyInvokable extends AbstractInvokable {
 	@Override
 	public ExecutionConfig getExecutionConfig() {
 		return new ExecutionConfig();
+	}
+
+	@Override
+	public <E extends Exception> void executeInTaskThread(
+			ThrowingRunnable<E> runnable,
+			String descriptionFormat,
+			Object... descriptionArgs) throws E {
+		runnable.run();
 	}
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -210,12 +210,15 @@ public final class StreamTaskNetworkInput<T> implements StreamTaskInput<T> {
 			final InputChannel channel = checkpointedInputGate.getChannel(channelIndex);
 
 			// Assumption for retrieving buffers = one concurrent checkpoint
-			recordDeserializers[channelIndex].getUnconsumedBuffer().ifPresent(buffer ->
-				channelStateWriter.addInputData(
-					checkpointId,
-					channel.getChannelInfo(),
-					ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
-					buffer));
+			RecordDeserializer<?> deserializer = recordDeserializers[channelIndex];
+			if (deserializer != null) {
+				deserializer.getUnconsumedBuffer().ifPresent(buffer ->
+					channelStateWriter.addInputData(
+						checkpointId,
+						channel.getChannelInfo(),
+						ChannelStateWriter.SEQUENCE_NUMBER_UNKNOWN,
+						buffer));
+			}
 
 			checkpointedInputGate.spillInflightBuffers(checkpointId, channelIndex, channelStateWriter);
 		}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixes all known checkpointing bugs in unaligned checkpoint to reenable `UnalignedCheckpointITCase`.

## Brief change log

- Fixes NPE in unaligned checkpoint after EndOfPartition events.
- Disables priority event listener.
- Fixes SpillingAdaptiveSpanningRecordDeserializer#getUnconsumedBuffer.
- LocalInputChannel also checkpoints in-flight data.
- Reenables `UnalignedCheckpointITCase`.

## Verifying this change

- Added unit test in `StreamTaskNetworkInputTest#testSnapshotAfterEndOfPartition`
- Expanded unit test `SpanningRecordSerializationTest#testLargeSpanningRecordUnconsumedBufferWithLeftOverBytes`
- Added unit test `LocalInputChannelTest#testCheckpointingInflightData`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
