### PR TITLE
[FLINK-17609][python] Execute the script directly when user specified…

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriver.java
@@ -106,8 +106,12 @@ public final class PythonDriver {
 	 */
 	static List<String> constructPythonCommands(final PythonDriverOptions pythonDriverOptions) {
 		final List<String> commands = new ArrayList<>();
-		commands.add("-m");
-		commands.add(pythonDriverOptions.getEntryPointModule());
+		if (pythonDriverOptions.getEntryPointScript().isPresent()) {
+			commands.add(pythonDriverOptions.getEntryPointScript().get());
+		} else {
+			commands.add("-m");
+			commands.add(pythonDriverOptions.getEntryPointModule());
+		}
 		commands.addAll(pythonDriverOptions.getProgramArgs());
 		return commands;
 	}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptions.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
  */
 final class PythonDriverOptions {
 
-	@Nonnull
+	@Nullable
 	private String entryPointModule;
 
 	@Nullable
@@ -40,7 +40,7 @@ final class PythonDriverOptions {
 	@Nonnull
 	private List<String> programArgs;
 
-	@Nonnull
+	@Nullable
 	String getEntryPointModule() {
 		return entryPointModule;
 	}
@@ -55,10 +55,10 @@ final class PythonDriverOptions {
 	}
 
 	PythonDriverOptions(
-		String entryPointModule,
+		@Nullable String entryPointModule,
 		@Nullable String entryPointScript,
 		List<String> programArgs) {
-		this.entryPointModule = requireNonNull(entryPointModule, "entryPointModule");
+		this.entryPointModule = entryPointModule;
 		this.entryPointScript = entryPointScript;
 		this.programArgs = requireNonNull(programArgs, "programArgs");
 	}

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonDriverOptionsParserFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.client.python;
 
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.entrypoint.FlinkParseException;
 import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
 
@@ -46,20 +45,13 @@ final class PythonDriverOptionsParserFactory implements ParserResultFactory<Pyth
 
 	@Override
 	public PythonDriverOptions createResult(@Nonnull CommandLine commandLine) throws FlinkParseException {
-		String entryPointModule;
+		String entryPointModule = null;
 		String entryPointScript = null;
 
 		if (commandLine.hasOption(PY_OPTION.getOpt()) && commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
 			throw new FlinkParseException("Cannot use options -py and -pym simultaneously.");
 		} else if (commandLine.hasOption(PY_OPTION.getOpt())) {
 			entryPointScript = commandLine.getOptionValue(PY_OPTION.getOpt());
-			Path file = new Path(entryPointScript);
-			String fileName = file.getName();
-			if (fileName.endsWith(".py")) {
-				entryPointModule = fileName.substring(0, fileName.length() - 3);
-			} else {
-				throw new FlinkParseException("The entry point script does not end with \".py\".");
-			}
 		} else if (commandLine.hasOption(PYMODULE_OPTION.getOpt())) {
 			entryPointModule = commandLine.getOptionValue(PYMODULE_OPTION.getOpt());
 		} else {

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverOptionsParserFactoryTest.java
@@ -69,8 +69,11 @@ public class PythonDriverOptionsParserFactoryTest {
 	private void verifyPythonDriverOptionsParsing(final String[] args) throws FlinkParseException {
 		final PythonDriverOptions pythonCommandOptions = commandLineParser.parse(args);
 
-		// verify the parsed python entrypoint module
-		assertEquals("xxx", pythonCommandOptions.getEntryPointModule());
+		if (pythonCommandOptions.getEntryPointScript().isPresent()){
+			assertEquals("xxx.py", pythonCommandOptions.getEntryPointScript().get());
+		} else {
+			assertEquals("xxx", pythonCommandOptions.getEntryPointModule());
+		}
 
 		// verify the python program arguments
 		final List<String> programArgs = pythonCommandOptions.getProgramArgs();

--- a/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
+++ b/flink-python/src/test/java/org/apache/flink/client/python/PythonDriverTest.java
@@ -46,7 +46,7 @@ public class PythonDriverTest {
 	}
 
 	@Test
-	public void testConstructCommands() {
+	public void testConstructCommandsWithEntryPointModule() {
 		List<String> args = new ArrayList<>();
 		args.add("--input");
 		args.add("in.txt");
@@ -62,5 +62,22 @@ public class PythonDriverTest {
 		Assert.assertEquals(commands.get(1), "xxx");
 		Assert.assertEquals(commands.get(2), "--input");
 		Assert.assertEquals(commands.get(3), "in.txt");
+	}
+
+	@Test
+	public void testConstructCommandsWithEntryPointScript() {
+		List<String> args = new ArrayList<>();
+		args.add("--input");
+		args.add("in.txt");
+
+		PythonDriverOptions pythonDriverOptions = new PythonDriverOptions(
+			null,
+			"xxx",
+			args);
+		List<String> commands = PythonDriver.constructPythonCommands(pythonDriverOptions);
+		Assert.assertEquals(3, commands.size());
+		Assert.assertEquals(commands.get(0), "xxx");
+		Assert.assertEquals(commands.get(1), "--input");
+		Assert.assertEquals(commands.get(2), "in.txt");
 	}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request change the constructPythonCommands in PythonDriver to directly construct the execution command with the user specified script when user applies the "-py" option and specifies the entry point script file path, rather than run as a module.

## Brief change log

- change the entryPointModule to be nullable in PythonDriverOptions.
- delete the code section which will get the module name of entry point script when it is specified in PythonDriverOptionsParserFactory.
- no need to add -m option when entry point script is specified in constructPythonCommand()

## Verifying this change

This change is already covered by existing tests, such as test cases in PythonDriverTest:
- testConstructCommandsWithEntryPointModule
- testConstructCommandsWithEntryPointScript

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
