### PR TITLE
[hotfix][runtime][javadoc] Fix typo

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -85,7 +85,7 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 	/**
 	 * Tests that older checkpoints are not cleaned up right away when recovering. Only after
-	 * another checkpointed has been completed the old checkpoints exceeding the number of
+	 * another checkpoint has been completed the old checkpoints exceeding the number of
 	 * checkpoints to retain will be removed.
 	 */
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

Fix javadoc typo for `ZooKeeperCompletedCheckpointStoreITCase#testRecover`.

## Verifying this change

This change is a trivial code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
