### PR TITLE
[hotfix][runtime] Remove useless class ZooKeeperCompletedCheckpointStoreITCase#HeapStateStorageHelper

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/ZooKeeperCompletedCheckpointStoreITCase.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.concurrent.Executors;
 import org.apache.flink.runtime.state.RetrievableStateHandle;
 import org.apache.flink.runtime.state.SharedStateRegistry;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
-import org.apache.flink.runtime.zookeeper.RetrievableStateStorageHelper;
 import org.apache.flink.runtime.zookeeper.ZooKeeperStateHandleStore;
 import org.apache.flink.runtime.zookeeper.ZooKeeperTestEnvironment;
 
@@ -282,14 +281,6 @@ public class ZooKeeperCompletedCheckpointStoreITCase extends CompletedCheckpoint
 
 		// the checkpoint should be discarded eventually because there is no lock on it anymore
 		recoveredTestCheckpoint.awaitDiscard();
-	}
-
-
-	static class HeapStateStorageHelper implements RetrievableStateStorageHelper<CompletedCheckpoint> {
-		@Override
-		public RetrievableStateHandle<CompletedCheckpoint> store(CompletedCheckpoint state) throws Exception {
-			return new HeapRetrievableStateHandle<>(state);
-		}
 	}
 
 	static class HeapRetrievableStateHandle<T extends Serializable> implements RetrievableStateHandle<T> {


### PR DESCRIPTION
## What is the purpose of the change

Minor cleanups.


## Brief change log

Remove class of `ZooKeeperCompletedCheckpointStoreITCase#HeapStateStorageHelper`.


## Verifying this change

This change is a trivial code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
