### PR TITLE
[FLINK-17336][CI] Update watchdog to properly kill watched process

### DIFF
--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -222,7 +222,8 @@ watchdog () {
 
 			print_stacktraces | tee $TRACE_OUT
 
-			kill $(<$CMD_PID)
+			# Kill $CMD and all descendants
+			pkill -P $(<$CMD_PID)
 
 			exit 1
 		fi

--- a/tools/travis_watchdog.sh
+++ b/tools/travis_watchdog.sh
@@ -39,7 +39,7 @@ echo "Build for commit ${TRAVIS_COMMIT} of ${TRAVIS_REPO_SLUG} [build ID: ${TRAV
 # =============================================================================
 
 # Number of seconds w/o output before printing a stack trace and killing $MVN
-MAX_NO_OUTPUT=${1:-300}
+MAX_NO_OUTPUT=${1:-600}
 
 # Number of seconds to sleep before checking the output again
 SLEEP_TIME=20


### PR DESCRIPTION
## What is the purpose of the change

As part of FLINK-16411, we introduced a `run_mvn` bash function. A side
effect of this is that the watchdog was killing the run_mvn function
call, but not the child process of that function (in this case)
Maven.
With this change, we are killing the function and all children
of that function.

Reference: https://stackoverflow.com/questions/2618403/how-to-kill-all-subprocesses-of-shell


## Verifying this change

I set up a job where maven intentionally stalls: https://dev.azure.com/georgeryan1322/Flink/_build/results?buildId=324&view=logs&j=66592496-52df-56bb-d03e-37509e1d9d0f&t=0e66df09-1dda-54b0-cbd9-bcded749d3c0


