### PR TITLE
[FLINK-17622][connectors / jdbc] Remove useless switch for decimal in PostgresCatalog

### DIFF
--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
@@ -258,6 +258,11 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
 	public static final String PG_CHARACTER_VARYING = "varchar";
 	public static final String PG_CHARACTER_VARYING_ARRAY = "_varchar";
 
+	/**
+	 * Converts Postgres type to Flink {@link DataType}.
+	 *
+	 * @see org.postgresql.jdbc.TypeInfoCache
+	 */
 	private DataType fromJDBCType(ResultSetMetaData metadata, int colIndex) throws SQLException {
 		String pgType = metadata.getColumnTypeName(colIndex);
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalog.java
@@ -217,6 +217,14 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
 		}
 	}
 
+	// Postgres jdbc driver maps several alias to real type, we use real type rather than alias:
+	// smallint <=> int2
+	// integer <=> int4
+	// int <=> int4
+	// bigint <=> int8
+	// float <=> float8
+	// boolean <=> bool
+	// decimal <=> numeric
 	public static final String PG_BYTEA = "bytea";
 	public static final String PG_BYTEA_ARRAY = "_bytea";
 	public static final String PG_SMALLINT = "int2";
@@ -227,8 +235,6 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
 	public static final String PG_BIGINT_ARRAY = "_int8";
 	public static final String PG_REAL = "float4";
 	public static final String PG_REAL_ARRAY = "_float4";
-	public static final String PG_DECIMAL = "decimal";
-	public static final String PG_DECIMAL_ARRAY = "_decimal";
 	public static final String PG_DOUBLE_PRECISION = "float8";
 	public static final String PG_DOUBLE_PRECISION_ARRAY = "_float8";
 	public static final String PG_NUMERIC = "numeric";
@@ -258,6 +264,8 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
 		int precision = metadata.getPrecision(colIndex);
 		int scale = metadata.getScale(colIndex);
 
+		// pg types that gets replaced by jdbc driver:
+	    // - decimal => numeric
 		switch (pgType) {
 			case PG_BOOLEAN:
 				return DataTypes.BOOLEAN();
@@ -287,14 +295,12 @@ public class PostgresCatalog extends AbstractJdbcCatalog {
 				return DataTypes.DOUBLE();
 			case PG_DOUBLE_PRECISION_ARRAY:
 				return DataTypes.ARRAY(DataTypes.DOUBLE());
-			case PG_DECIMAL:
 			case PG_NUMERIC:
 				// see SPARK-26538: handle numeric without explicit precision and scale.
 				if (precision > 0) {
 					return DataTypes.DECIMAL(precision, metadata.getScale(colIndex));
 				}
 				return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
-			case PG_DECIMAL_ARRAY:
 			case PG_NUMERIC_ARRAY:
 				// see SPARK-26538: handle numeric without explicit precision and scale.
 				if (precision > 0) {

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogITCase.java
@@ -88,7 +88,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 		List<Row> results = Lists.newArrayList(
 			tEnv.sqlQuery(String.format("select * from %s", TABLE_PRIMITIVE_TYPE)).execute().collect());
 
-		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03,500.000000000000000000]", results.toString());
+		assertEquals("[1,[50],3,4,5.5,6.6,7.70000,8.8,true,a,b,c  ,d,2016-06-22T19:10:25,2015-01-01,00:51:03,500.000000000000000000]", results.toString());
 	}
 
 	@Test
@@ -107,6 +107,7 @@ public class PostgresCatalogITCase extends PostgresCatalogTestBase {
 				"[6.6, 7.7, 8.8]," +
 				"[7.70000, 8.80000, 9.90000]," +
 				"[8.800000000000000000, 9.900000000000000000, 10.100000000000000000]," +
+				"[9.90, 10.10, 11.11]," +
 				"[true, false, true]," +
 				"[a, b, c]," +
 				"[b, c, d]," +

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/catalog/PostgresCatalogTestBase.java
@@ -164,6 +164,7 @@ public class PostgresCatalogTestBase {
 				.field("real", DataTypes.FLOAT())
 				.field("double_precision", DataTypes.DOUBLE())
 				.field("numeric", DataTypes.DECIMAL(10, 5))
+				.field("decimal", DataTypes.DECIMAL(10, 1))
 				.field("boolean", DataTypes.BOOLEAN())
 				.field("text", DataTypes.STRING())
 				.field("char", DataTypes.CHAR(1))
@@ -182,6 +183,7 @@ public class PostgresCatalogTestBase {
 				"real real, " +
 				"double_precision double precision, " +
 				"numeric numeric(10, 5), " +
+				"decimal decimal(10, 1), " +
 				"boolean boolean, " +
 				"text text, " +
 				"char char, " +
@@ -199,6 +201,7 @@ public class PostgresCatalogTestBase {
 				"5.5," +
 				"6.6," +
 				"7.7," +
+				"8.8," +
 				"true," +
 				"'a'," +
 				"'b'," +
@@ -224,6 +227,7 @@ public class PostgresCatalogTestBase {
 				.field("double_precision_arr", DataTypes.ARRAY(DataTypes.DOUBLE()))
 				.field("numeric_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 5)))
 				.field("numeric_arr_default", DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18)))
+				.field("decimal_arr", DataTypes.ARRAY(DataTypes.DECIMAL(10, 2)))
 				.field("boolean_arr", DataTypes.ARRAY(DataTypes.BOOLEAN()))
 				.field("text_arr", DataTypes.ARRAY(DataTypes.STRING()))
 				.field("char_arr", DataTypes.ARRAY(DataTypes.CHAR(1)))
@@ -243,6 +247,7 @@ public class PostgresCatalogTestBase {
 				"double_precision_arr double precision[], " +
 				"numeric_arr numeric(10, 5)[], " +
 				"numeric_arr_default numeric[], " +
+				"decimal_arr decimal(10,2)[], " +
 				"boolean_arr boolean[], " +
 				"text_arr text[], " +
 				"char_arr char[], " +
@@ -261,6 +266,7 @@ public class PostgresCatalogTestBase {
 					"'{6.6,7.7,8.8}'," +
 					"'{7.7,8.8,9.9}'," +
 					"'{8.8,9.9,10.10}'," +
+					"'{9.9,10.10,11.11}'," +
 					"'{true,false,true}'," +
 					"'{a,b,c}'," +
 					"'{b,c,d}'," +


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request remove 2 useless constants and switch clauses in the PostgresCatalog class.

## Brief change log

The decimal fields are returned as numeric by the Postgres JDBC driver. The code to verify this fact are introduced in the pull request #11900.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
However serial type is auto-incremented: you can write a value into it but if you try to autogenerate a value you get duplicate values until you find a value that is not already in use. However Flink does not keep track of the original field type so there's no way to warn the user that is not using this field correctly (he/she should use DEFAULT or not specify any value for such columns).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not documented**
