### PR TITLE
[FLINK-17614][table] Add project it case for partition table in file system

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -112,7 +112,7 @@ public class ParquetSplitReaderUtil {
 				LogicalType type = fullFieldTypes[selectedFields[i]].getLogicalType();
 				vectors[i] = partitionSpec.containsKey(name) ?
 						createVectorFromConstant(type, partitionSpec.get(name), batchSize) :
-						readVectors[i];
+						readVectors[selNonPartNames.indexOf(name)];
 			}
 			return new VectorizedColumnBatch(vectors);
 		};

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/FileSystemITCaseBase.scala
@@ -226,6 +226,20 @@ trait FileSystemITCaseBase {
       "select x, y from nonPartitionedTable where a=10086",
       Seq())
   }
+
+  @Test
+  def testProjectPushDown(): Unit = {
+    tableEnv.sqlUpdate("insert into partitionedTable select x, y, a, b from originalT")
+    tableEnv.execute("test")
+
+    check(
+      "select y, b, x from partitionedTable where a=3",
+      Seq(
+        row(17, 1, "x17"),
+        row(18, 2, "x18"),
+        row(19, 3, "x19")
+      ))
+  }
 }
 
 object FileSystemITCaseBase {


### PR DESCRIPTION

## What is the purpose of the change

Add case:
```
check(
  "select y, b, x from partitionedTable where a=3",
  Seq(
    row(17, 1, "x17"),
    row(18, 2, "x18"),
   row(19, 3, "x19")
))
```

## Brief change log

- Add case
- Fix parquet bug

## Verifying this change

`FileSystemITCaseBase.testProjectPushDown`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no