### PR TITLE
 [FLINK-17307] Add collector to deserialize method of DeserializationSchema

### DIFF
--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapper.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.connectors.gcp.pubsub;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubDeserializationSchema;
+import org.apache.flink.util.Collector;
 
 import com.google.pubsub.v1.PubsubMessage;
 
@@ -46,7 +47,12 @@ class DeserializationSchemaWrapper<T> implements PubSubDeserializationSchema<T> 
 
 	@Override
 	public T deserialize(PubsubMessage pubsubMessage) throws Exception {
-		return deserializationSchema.deserialize(pubsubMessage.getData().toByteArray());
+		throw new UnsupportedOperationException("Should never be called");
+	}
+
+	@Override
+	public void deserialize(PubsubMessage message, Collector<T> out) throws Exception {
+		deserializationSchema.deserialize(message.getData().toByteArray(), out);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSource.java
@@ -35,6 +35,7 @@ import org.apache.flink.streaming.connectors.gcp.pubsub.common.Acknowledger;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubDeserializationSchema;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriberFactory;
+import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 
 import com.google.auth.Credentials;
@@ -108,10 +109,10 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 
 	@Override
 	public void run(SourceContext<OUT> sourceContext) throws Exception {
+		PubSubCollector collector = new PubSubCollector(sourceContext);
 		while (isRunning) {
 			try {
-
-				processMessage(sourceContext, subscriber.pull());
+				processMessage(sourceContext, subscriber.pull(), collector);
 			} catch (InterruptedException | CancellationException e) {
 				isRunning = false;
 			}
@@ -119,7 +120,10 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 		subscriber.close();
 	}
 
-	void processMessage(SourceContext<OUT> sourceContext, List<ReceivedMessage> messages) throws Exception {
+	private void processMessage(
+			SourceContext<OUT> sourceContext,
+			List<ReceivedMessage> messages,
+			PubSubCollector collector) throws Exception {
 		rateLimiter.acquire(messages.size());
 
 		synchronized (sourceContext.getCheckpointLock()) {
@@ -128,14 +132,40 @@ public class PubSubSource<OUT> extends RichSourceFunction<OUT>
 
 				PubsubMessage pubsubMessage = message.getMessage();
 
-				OUT deserializedMessage = deserializationSchema.deserialize(pubsubMessage);
-				if (deserializationSchema.isEndOfStream(deserializedMessage)) {
+				deserializationSchema.deserialize(pubsubMessage, collector);
+				if (collector.isEndOfStreamSignalled()) {
 					cancel();
 					return;
 				}
-
-				sourceContext.collect(deserializedMessage);
 			}
+
+		}
+	}
+
+	private class PubSubCollector implements Collector<OUT> {
+		private final SourceContext<OUT> ctx;
+		private boolean endOfStreamSignalled = false;
+
+		private PubSubCollector(SourceContext<OUT> ctx) {
+			this.ctx = ctx;
+		}
+
+		@Override
+		public void collect(OUT record) {
+			if (endOfStreamSignalled || deserializationSchema.isEndOfStream(record)) {
+				this.endOfStreamSignalled = true;
+				return;
+			}
+
+			ctx.collect(record);
+		}
+
+		public boolean isEndOfStreamSignalled() {
+			return endOfStreamSignalled;
+		}
+
+		@Override
+		public void close() {
 
 		}
 	}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/PubSubDeserializationSchema.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/main/java/org/apache/flink/streaming/connectors/gcp/pubsub/common/PubSubDeserializationSchema.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.connectors.gcp.pubsub.common;
 
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
 
 import com.google.pubsub.v1.PubsubMessage;
 
@@ -62,4 +63,21 @@ public interface PubSubDeserializationSchema<T> extends Serializable, ResultType
 	 * @return The deserialized message as an object (null if the message cannot be deserialized).
 	 */
 	T deserialize(PubsubMessage message) throws Exception;
+
+	/**
+	 * Deserializes the PubSub record.
+	 *
+	 * <p>Can output multiple records through the {@link Collector}. Note that number and size of the
+	 * produced records should be relatively small. Depending on the source implementation records
+	 * can be buffered in memory or collecting records might delay emitting checkpoint barrier.
+	 *
+	 * @param message PubsubMessage to be deserialized.
+	 * @param out The collector to put the resulting messages.
+	 */
+	default void deserialize(PubsubMessage message, Collector<T> out) throws Exception {
+		T deserialized = deserialize(message);
+		if (deserialized != null) {
+			out.collect(deserialized);
+		}
+	}
 }

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/DeserializationSchemaWrapperTest.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.PubsubMessage;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -44,6 +46,10 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class DeserializationSchemaWrapperTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
 	@Mock
 	private DeserializationSchema<String> deserializationSchema;
 
@@ -71,12 +77,9 @@ public class DeserializationSchemaWrapperTest {
 	@Test
 	public void testDeserialize() throws Exception {
 		String inputAsString = "some-input";
-		byte[] inputAsBytes = inputAsString.getBytes();
 
-		when(deserializationSchema.deserialize(any())).thenReturn(inputAsString);
-
-		assertThat(deserializationSchemaWrapper.deserialize(pubSubMessage(inputAsString)), is(inputAsString));
-		verify(deserializationSchema, times(1)).deserialize(inputAsBytes);
+		thrown.expect(UnsupportedOperationException.class);
+		deserializationSchemaWrapper.deserialize(pubSubMessage(inputAsString));
 	}
 
 	@Test

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubConsumingTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.gcp.pubsub;
+
+import org.apache.flink.api.common.serialization.SimpleStringSchema;
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
+import org.apache.flink.streaming.util.CollectingSourceContext;
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.util.Collector;
+
+import com.google.auth.Credentials;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.ReceivedMessage;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for consuming records with {@link PubSubSource}.
+ */
+public class PubSubConsumingTest {
+
+	@Test
+	public void testProcessMessage() throws Exception {
+		TestPubSubSubscriber testPubSubSubscriber = new TestPubSubSubscriber(
+			receivedMessage("1", pubSubMessage("A")),
+			receivedMessage("2", pubSubMessage("B"))
+		);
+		PubSubSource<String> pubSubSource = PubSubSource.newBuilder()
+			.withDeserializationSchema(new SimpleStringSchema())
+			.withProjectName("fakeProject")
+			.withSubscriptionName("fakeSubscription")
+			.withPubSubSubscriberFactory(
+			credentials -> testPubSubSubscriber)
+			.withCredentials(mock(Credentials.class))
+			.build();
+
+		Object lock = new Object();
+		ConcurrentLinkedQueue<String> results = new ConcurrentLinkedQueue<>();
+		Thread thread = createSourceThread(pubSubSource, lock, results);
+		try {
+			thread.start();
+			awaitRecordCount(results, 2);
+
+			assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+			pubSubSource.snapshotState(0, 0);
+			pubSubSource.notifyCheckpointComplete(0);
+			assertThat(testPubSubSubscriber.getAcknowledgedIds(), equalTo(Arrays.asList("1", "2")));
+		} finally {
+			pubSubSource.cancel();
+			thread.join();
+		}
+	}
+
+	@Test
+	public void testStoppingConnectorWhenDeserializationSchemaIndicatesEndOfStream() throws Exception {
+		TestPubSubSubscriber testPubSubSubscriber = new TestPubSubSubscriber(
+			receivedMessage("1", pubSubMessage("A")),
+			receivedMessage("2", pubSubMessage("B")),
+			receivedMessage("3", pubSubMessage("C")),
+			receivedMessage("4", pubSubMessage("D"))
+		);
+		PubSubSource<String> pubSubSource = PubSubSource.newBuilder()
+			.withDeserializationSchema(new SimpleStringSchema() {
+				@Override
+				public boolean isEndOfStream(String nextElement) {
+					return nextElement.equals("C");
+				}
+			})
+			.withProjectName("fakeProject")
+			.withSubscriptionName("fakeSubscription")
+			.withPubSubSubscriberFactory(
+				credentials -> testPubSubSubscriber)
+			.withCredentials(mock(Credentials.class))
+			.build();
+
+		Object lock = new Object();
+		ConcurrentLinkedQueue<String> results = new ConcurrentLinkedQueue<>();
+		Thread thread = createSourceThread(pubSubSource, lock, results);
+		try {
+			thread.start();
+			awaitRecordCount(results, 2);
+
+			// we do not emit the end of stream record
+			assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+			pubSubSource.snapshotState(0, 0);
+			pubSubSource.notifyCheckpointComplete(0);
+			// we acknowledge also the end of the stream record
+			assertThat(testPubSubSubscriber.getAcknowledgedIds(), equalTo(Arrays.asList("1", "2", "3")));
+		} finally {
+			pubSubSource.cancel();
+			thread.join();
+		}
+	}
+
+	@Test
+	public void testProducingMultipleResults() throws Exception {
+		TestPubSubSubscriber testPubSubSubscriber = new TestPubSubSubscriber(
+			receivedMessage("1", pubSubMessage("A")),
+			receivedMessage("2", pubSubMessage("B,C,D")),
+			receivedMessage("3", pubSubMessage("E"))
+		);
+		PubSubSource<String> pubSubSource = PubSubSource.newBuilder()
+			.withDeserializationSchema(new SimpleStringSchema() {
+				@Override
+				public void deserialize(byte[] message, Collector<String> out) throws IOException {
+					String[] records = super.deserialize(message).split(",");
+					for (String record : records) {
+						out.collect(record);
+					}
+				}
+
+				@Override
+				public boolean isEndOfStream(String nextElement) {
+					return nextElement.equals("C");
+				}
+			})
+			.withProjectName("fakeProject")
+			.withSubscriptionName("fakeSubscription")
+			.withPubSubSubscriberFactory(
+				credentials -> testPubSubSubscriber)
+			.withCredentials(mock(Credentials.class))
+			.build();
+
+		Object lock = new Object();
+		ConcurrentLinkedQueue<String> results = new ConcurrentLinkedQueue<>();
+		Thread thread = createSourceThread(pubSubSource, lock, results);
+		try {
+			thread.start();
+			awaitRecordCount(results, 2);
+
+			// we emit only the records prior to the end of the stream
+			assertThat(new ArrayList<>(results), equalTo(Arrays.asList("A", "B")));
+			pubSubSource.snapshotState(0, 0);
+			pubSubSource.notifyCheckpointComplete(0);
+			// we acknowledge also the end of the stream record
+			assertThat(testPubSubSubscriber.getAcknowledgedIds(), equalTo(Arrays.asList("1", "2")));
+		} finally {
+			pubSubSource.cancel();
+			thread.join();
+		}
+	}
+
+	private Thread createSourceThread(
+		PubSubSource<String> pubSubSource,
+		Object lock,
+		ConcurrentLinkedQueue<String> results) {
+		return new Thread(
+				() -> {
+					try {
+						pubSubSource.setRuntimeContext(new MockStreamingRuntimeContext(true, 1, 0));
+						pubSubSource.open(new Configuration());
+						pubSubSource.run(new CollectingSourceContext<>(lock, results));
+					} catch (InterruptedException e) {
+						// expected on cancel
+					} catch (Exception e) {
+						throw new RuntimeException(e);
+					}
+				});
+	}
+
+	private static <T> void awaitRecordCount(ConcurrentLinkedQueue<T> queue, int count) throws Exception {
+		Deadline deadline  = Deadline.fromNow(Duration.ofSeconds(10));
+		while (deadline.hasTimeLeft() && queue.size() < count) {
+			Thread.sleep(10);
+		}
+	}
+
+	private ReceivedMessage receivedMessage(String ackId, PubsubMessage pubsubMessage) {
+		return ReceivedMessage.newBuilder()
+			.setAckId(ackId)
+			.setMessage(pubsubMessage)
+			.build();
+	}
+
+	private PubsubMessage pubSubMessage(String message) {
+		return PubsubMessage.newBuilder()
+			.setMessageId("some id")
+			.setData(ByteString.copyFrom(message.getBytes()))
+			.build();
+	}
+
+	private static class TestPubSubSubscriber implements PubSubSubscriber {
+
+		private final Queue<ReceivedMessage> queue;
+		private final List<String> acknowledgedIds = new ArrayList<>();
+
+		private TestPubSubSubscriber(ReceivedMessage... messages) {
+			this.queue = new ArrayBlockingQueue<>(
+				messages.length,
+				true,
+				Arrays.asList(messages));
+		}
+
+		@Override
+		public List<ReceivedMessage> pull() {
+			ReceivedMessage message = queue.poll();
+			if (message != null) {
+				return Collections.singletonList(message);
+			} else {
+				return Collections.emptyList();
+			}
+		}
+
+		@Override
+		public void close() throws Exception {
+
+		}
+
+		public List<String> getAcknowledgedIds() {
+			return acknowledgedIds;
+		}
+
+		@Override
+		public void acknowledge(List<String> ids) {
+			acknowledgedIds.addAll(ids);
+		}
+	}
+}

--- a/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
+++ b/flink-connectors/flink-connector-gcp-pubsub/src/test/java/org/apache/flink/streaming/connectors/gcp/pubsub/PubSubSourceTest.java
@@ -30,9 +30,6 @@ import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriber;
 import org.apache.flink.streaming.connectors.gcp.pubsub.common.PubSubSubscriberFactory;
 
 import com.google.auth.Credentials;
-import com.google.protobuf.ByteString;
-import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.ReceivedMessage;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,8 +41,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,7 +48,6 @@ import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
@@ -62,11 +56,6 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PubSubSourceTest {
-	private static final String FIRST_MESSAGE = "FirstMessage";
-	private static final String SECOND_MESSAGE = "SecondMessage";
-
-	@Mock
-	private SourceFunction.SourceContext<String> sourceContext;
 	@Mock
 	private PubSubDeserializationSchema<String> deserializationSchema;
 	@Mock
@@ -122,35 +111,6 @@ public class PubSubSourceTest {
 	}
 
 	@Test
-	public void testProcessMessage() throws Exception {
-		when(deserializationSchema.isEndOfStream(any())).thenReturn(false).thenReturn(false);
-		when(deserializationSchema.deserialize(pubSubMessage(FIRST_MESSAGE))).thenReturn(FIRST_MESSAGE);
-		when(deserializationSchema.deserialize(pubSubMessage(SECOND_MESSAGE))).thenReturn(SECOND_MESSAGE);
-		when(sourceContext.getCheckpointLock()).thenReturn("some object to lock on");
-
-		pubSubSource.open(null);
-		List<ReceivedMessage> receivedMessages = asList(
-			receivedMessage("firstAckId", pubSubMessage(FIRST_MESSAGE)),
-			receivedMessage("secondAckId", pubSubMessage(SECOND_MESSAGE))
-		);
-		pubSubSource.processMessage(sourceContext, receivedMessages);
-
-		//verify handling messages
-		verify(rateLimiter, times(1)).acquire(2);
-
-		verify(sourceContext, times(1)).getCheckpointLock();
-		verify(deserializationSchema, times(1)).isEndOfStream(FIRST_MESSAGE);
-		verify(deserializationSchema, times(1)).deserialize(pubSubMessage(FIRST_MESSAGE));
-		verify(sourceContext, times(1)).collect(FIRST_MESSAGE);
-		verify(acknowledgeOnCheckpoint, times(1)).addAcknowledgeId("firstAckId");
-
-		verify(deserializationSchema, times(1)).isEndOfStream(SECOND_MESSAGE);
-		verify(deserializationSchema, times(1)).deserialize(pubSubMessage(SECOND_MESSAGE));
-		verify(sourceContext, times(1)).collect(SECOND_MESSAGE);
-		verify(acknowledgeOnCheckpoint, times(1)).addAcknowledgeId("secondAckId");
-	}
-
-	@Test
 	public void testTypeInformationFromDeserializationSchema() {
 		TypeInformation<String> schemaTypeInformation = TypeInformation.of(String.class);
 		when(deserializationSchema.getProducedType()).thenReturn(schemaTypeInformation);
@@ -159,23 +119,6 @@ public class PubSubSourceTest {
 
 		assertThat(actualTypeInformation, is(schemaTypeInformation));
 		verify(deserializationSchema, times(1)).getProducedType();
-	}
-
-	@Test
-	public void testStoppingConnectorWhenDeserializationSchemaIndicatesEndOfStream() throws Exception {
-		when(deserializationSchema.deserialize(pubSubMessage(FIRST_MESSAGE))).thenReturn(FIRST_MESSAGE);
-		when(sourceContext.getCheckpointLock()).thenReturn("some object to lock on");
-		pubSubSource.open(null);
-
-		when(deserializationSchema.isEndOfStream(FIRST_MESSAGE)).thenReturn(true);
-
-		ReceivedMessage message = receivedMessage("ackId", pubSubMessage(FIRST_MESSAGE));
-
-		//Process message
-		pubSubSource.processMessage(sourceContext, singletonList(message));
-		verify(deserializationSchema, times(1)).isEndOfStream(FIRST_MESSAGE);
-		verify(sourceContext, times(1)).getCheckpointLock();
-		verifyNoMoreInteractions(sourceContext);
 	}
 
 	@Test
@@ -214,19 +157,5 @@ public class PubSubSourceTest {
 		pubSubSource.open(null);
 
 		verify(deserializationSchema, times(1)).open(any(DeserializationSchema.InitializationContext.class));
-	}
-
-	private ReceivedMessage receivedMessage(String ackId, PubsubMessage pubsubMessage) {
-		return ReceivedMessage.newBuilder()
-								.setAckId(ackId)
-								.setMessage(pubsubMessage)
-								.build();
-	}
-
-	private PubsubMessage pubSubMessage(String message) {
-		return PubsubMessage.newBuilder()
-			.setMessageId("some id")
-			.setData(ByteString.copyFrom(message.getBytes()))
-			.build();
 	}
 }

--- a/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kafka-base/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaDeserializationSchemaWrapper.java
@@ -53,10 +53,7 @@ public class KafkaDeserializationSchemaWrapper<T> implements KafkaDeserializatio
 
 	@Override
 	public void deserialize(ConsumerRecord<byte[], byte[]> message, Collector<T> out) throws Exception {
-		T record = deserializationSchema.deserialize(message.value());
-		if (record != null) {
-			out.collect(record);
-		}
+		deserializationSchema.deserialize(message.value(), out);
 	}
 
 	@Override

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/serialization/KinesisDeserializationSchemaWrapper.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kinesis.serialization;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
 
 import java.io.IOException;
 
@@ -35,6 +36,17 @@ public class KinesisDeserializationSchemaWrapper<T> implements KinesisDeserializ
 	private final DeserializationSchema<T> deserializationSchema;
 
 	public KinesisDeserializationSchemaWrapper(DeserializationSchema<T> deserializationSchema) {
+		try {
+			Class<? extends DeserializationSchema> deserilizationClass = deserializationSchema.getClass();
+			if (!deserilizationClass.getMethod("deserialize", byte[].class, Collector.class).isDefault()) {
+				throw new IllegalArgumentException(
+					"Kinesis consumer does not support DeserializationSchema that implements " +
+						"deserialization with a Collector. Unsupported DeserializationSchema: " +
+						deserilizationClass.getName());
+			}
+		} catch (NoSuchMethodException e) {
+			// swallow the exception
+		}
 		this.deserializationSchema = deserializationSchema;
 	}
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -67,9 +67,7 @@ import com.amazonaws.services.kinesis.model.HashKeyRange;
 import com.amazonaws.services.kinesis.model.SequenceNumberRange;
 import com.amazonaws.services.kinesis.model.Shard;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
@@ -110,9 +108,6 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({FlinkKinesisConsumer.class, KinesisConfigUtil.class})
 public class FlinkKinesisConsumerTest extends TestLogger {
-
-	@Rule
-	private ExpectedException exception = ExpectedException.none();
 
 	// ----------------------------------------------------------------------
 	// Tests related to state initialization

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/KinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/KinesisConsumerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.Collector;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Tests for {@link FlinkKinesisConsumer}. In contrast to tests in {@link FlinkKinesisConsumerTest} it does not
+ * use power mock, which makes it possible to use e.g. the {@link ExpectedException}.
+ */
+public class KinesisConsumerTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testKinesisConsumerThrowsExceptionIfSchemaImplementsCollector() {
+		DeserializationSchema<Object> schemaWithCollector = new DeserializationSchema<Object>() {
+			@Override
+			public Object deserialize(byte[] message) throws IOException {
+				return null;
+			}
+
+			@Override
+			public void deserialize(byte[] message, Collector<Object> out) throws IOException {
+				// we do not care about the implementation. we should just check if this method is declared
+			}
+
+			@Override
+			public boolean isEndOfStream(Object nextElement) {
+				return false;
+			}
+
+			@Override
+			public TypeInformation<Object> getProducedType() {
+				return null;
+			}
+		};
+
+		thrown.expect(IllegalArgumentException.class);
+		thrown.expectMessage(
+			"Kinesis consumer does not support DeserializationSchema that implements deserialization with a" +
+				" Collector. Unsupported DeserializationSchema: " +
+				"org.apache.flink.streaming.connectors.kinesis.KinesisConsumerTest");
+		new FlinkKinesisConsumer<>("fakeStream", schemaWithCollector, new Properties());
+	}
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR adds collector to `DeserializationSchema#deserializer`. It also implements support for this method in PubSub, Kinesis, Kafka (in #12018). Kinesis consumer because of complex threading model does not support it for now. There I check if the used schema implements the deserialize with a collector and eagerly throw an exception if that's the case

## Verifying this change

Added tests in corresponding modules.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (**yes** / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
