### PR TITLE
[FLINK-17562][document]Monitoring REST API page has duplicate items

### DIFF
--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -613,8 +613,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     </tr>
     <tr>
       <td colspan="2">
-        <button data-toggle="collapse" data-target="#1311035100">Response</button>
-        <div id="1311035100" class="collapse">
+        <button data-toggle="collapse" data-target="#1313426502">Response</button>
+        <div id="1313426502" class="collapse">
           <pre>
             <code>
 {
@@ -4081,6 +4081,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "dataPort" : {
             "type" : "integer"
           },
+          "freeResource" : {
+            "type" : "object",
+            "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
+          },
           "freeSlots" : {
             "type" : "integer"
           },
@@ -4113,6 +4117,33 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           },
           "timeSinceLastHeartbeat" : {
             "type" : "integer"
+          },
+          "totalResource" : {
+            "type" : "object",
+            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo",
+            "properties" : {
+              "cpuCores" : {
+                "type" : "number"
+              },
+              "extendedResources" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "number"
+                }
+              },
+              "managedMemory" : {
+                "type" : "integer"
+              },
+              "networkMemory" : {
+                "type" : "integer"
+              },
+              "taskHeapMemory" : {
+                "type" : "integer"
+              },
+              "taskOffHeapMemory" : {
+                "type" : "integer"
+              }
+            }
           }
         }
       }
@@ -4221,6 +4252,10 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     "dataPort" : {
       "type" : "integer"
     },
+    "freeResource" : {
+      "type" : "object",
+      "$ref" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo"
+    },
     "freeSlots" : {
       "type" : "integer"
     },
@@ -4319,6 +4354,33 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "timeSinceLastHeartbeat" : {
       "type" : "integer"
+    },
+    "totalResource" : {
+      "type" : "object",
+      "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:ResourceProfileInfo",
+      "properties" : {
+        "cpuCores" : {
+          "type" : "number"
+        },
+        "extendedResources" : {
+          "type" : "object",
+          "additionalProperties" : {
+            "type" : "number"
+          }
+        },
+        "managedMemory" : {
+          "type" : "integer"
+        },
+        "networkMemory" : {
+          "type" : "integer"
+        },
+        "taskHeapMemory" : {
+          "type" : "integer"
+        },
+        "taskOffHeapMemory" : {
+          "type" : "integer"
+        }
+      }
     }
   }
 }            </code>
@@ -4445,6 +4507,72 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             <code>
 {
   "type" : "any"
+}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<table class="table table-bordered">
+  <tbody>
+    <tr>
+      <td class="text-left" colspan="2"><h5><strong>/taskmanagers/:taskmanagerid/thread-dump</strong></h5></td>
+    </tr>
+    <tr>
+      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left">Response code: <code>200 OK</code></td>
+    </tr>
+    <tr>
+      <td colspan="2">Returns the thread dump of the requested TaskManager.</td>
+    </tr>
+    <tr>
+      <td colspan="2">Path parameters</td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <ul>
+<li><code>taskmanagerid</code> - 32-character hexadecimal string that identifies a task manager.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#451701794">Request</button>
+        <div id="451701794" class="collapse">
+          <pre>
+            <code>
+{}            </code>
+          </pre>
+         </div>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2">
+        <button data-toggle="collapse" data-target="#1465230704">Response</button>
+        <div id="1465230704" class="collapse">
+          <pre>
+            <code>
+{
+  "type" : "object",
+  "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:ThreadDumpInfo",
+  "properties" : {
+    "threadInfos" : {
+      "type" : "array",
+      "items" : {
+        "type" : "object",
+        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:taskmanager:ThreadDumpInfo:ThreadInfo",
+        "properties" : {
+          "stringifiedThreadInfo" : {
+            "type" : "string"
+          },
+          "threadName" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
 }            </code>
           </pre>
          </div>

--- a/docs/_includes/generated/rest_v1_dispatcher.html
+++ b/docs/_includes/generated/rest_v1_dispatcher.html
@@ -548,7 +548,7 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       <td class="text-left" colspan="2"><h5><strong>/jars/:jarid/plan</strong></h5></td>
     </tr>
     <tr>
-      <td class="text-left" style="width: 20%">Verb: <code>GET</code></td>
+      <td class="text-left" style="width: 20%">Verb: <code>POST</code></td>
       <td class="text-left">Response code: <code>200 OK</code></td>
     </tr>
     <tr>
@@ -579,8 +579,8 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     </tr>
     <tr>
       <td colspan="2">
-        <button data-toggle="collapse" data-target="#550027726">Request</button>
-        <div id="550027726" class="collapse">
+        <button data-toggle="collapse" data-target="#552419128">Request</button>
+        <div id="552419128" class="collapse">
           <pre>
             <code>
 {

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/WebSubmissionExtension.java
@@ -125,7 +125,7 @@ public class WebSubmissionExtension implements WebMonitorExtension {
 		webSubmissionHandlers.add(Tuple2.of(JarRunHeaders.getInstance(), jarRunHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarDeleteHeaders.getInstance(), jarDeleteHandler));
 		webSubmissionHandlers.add(Tuple2.of(JarPlanGetHeaders.getInstance(), jarPlanHandler));
-		webSubmissionHandlers.add(Tuple2.of(JarPlanGetHeaders.getInstance(), postJarPlanHandler));
+		webSubmissionHandlers.add(Tuple2.of(JarPlanPostHeaders.getInstance(), postJarPlanHandler));
 	}
 
 	@Override

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -318,7 +318,7 @@
     }
   }, {
     "url" : "/jars/:jarid/plan",
-    "method" : "GET",
+    "method" : "POST",
     "status-code" : "200 OK",
     "file-upload" : false,
     "path-parameters" : {


### PR DESCRIPTION
## What is the purpose of the change

*Monitoring REST API has two `/jars/:jarid/plan` column and there descriptions are same, which of  them should be removed. Because in `WebSubmissionExtension`, `PostJarPlanHandler` specifies the wrong `AbstractJarPlanHeaders` instance to `JarPlanGetHeaders`, which should be `JarPlanPostHeaders`.*

## Brief change log

  - *Modify `WebSubmissionExtension` constructor method to specify `AbstractJarPlanHeaders` instance to `JarPlanPostHeaders`.*

## Verifying this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
