### PR TITLE
[FLINK-17631][core] Supports char type for ConfigOption

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -142,6 +142,13 @@ public class ConfigOptions {
 		}
 
 		/**
+		 * Defines that the value of the option should be of {@link Character} type.
+		 */
+		public TypedConfigOptionBuilder<Character> charType() {
+			return new TypedConfigOptionBuilder<>(key, Character.class);
+		}
+
+		/**
 		 * Defines that the value of the option should be of {@link Duration} type.
 		 */
 		public TypedConfigOptionBuilder<Duration> durationType() {

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -51,6 +51,7 @@ public class ConfigurationTest extends TestLogger {
 	public void testConfigurationSerializationAndGetters() {
 		try {
 			final Configuration orig = new Configuration();
+			orig.setCharacter("myChar", 'c');
 			orig.setString("mykey", "myvalue");
 			orig.setInteger("mynumber", 100);
 			orig.setLong("longvalue", 478236947162389746L);
@@ -61,6 +62,7 @@ public class ConfigurationTest extends TestLogger {
 			orig.setClass("myclass", this.getClass());
 
 			final Configuration copy = InstantiationUtil.createCopyWritable(orig);
+			assertEquals('c', copy.getCharacter("myChar", 'b'));
 			assertEquals("myvalue", copy.getString("mykey", "null"));
 			assertEquals(100, copy.getInteger("mynumber", 0));
 			assertEquals(478236947162389746L, copy.getLong("longvalue", 0L));


### PR DESCRIPTION
## What is the purpose of the change

This PR enables to configure option as CHARACTER type.

## Verifying this change

Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no
