### PR TITLE
[FLINK-16074][docs-zh] Translate the Overview page for State & Fault Tolerance into Chinese

### DIFF
--- a/docs/dev/stream/state/index.zh.md
+++ b/docs/dev/stream/state/index.zh.md
@@ -25,21 +25,17 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-In this section you will learn about the APIs that Flink provides for writing
-stateful programs. Please take a look at [Stateful Stream
-Processing]({% link concepts/stateful-stream-processing.zh.md %})
-to learn about the concepts behind stateful stream processing.
-
+你将在本节中了解到 Flink 提供的用于编写有状态程序的 API，想了解更多有状态流处理的概念，请查看[有状态的流处理]({% link concepts/stateful-stream-processing.zh.md %})
 {% top %}
 
-Where to go next?
+接下来看什么?
 -----------------
 
-* [Working with State](state.html): Shows how to use state in a Flink application and explains the different kinds of state.
-* [The Broadcast State Pattern](broadcast_state.html): Explains how to connect a broadcast stream with a non-broadcast stream and use state to exchange information between them. 
-* [Checkpointing](checkpointing.html): Describes how to enable and configure checkpointing for fault tolerance.
-* [Queryable State](queryable_state.html): Explains how to access state from outside of Flink during runtime.
-* [State Schema Evolution](schema_evolution.html): Shows how schema of state types can be evolved.
-* [Custom Serialization for Managed State](custom_serialization.html): Discusses how to implement custom serializers, especially for schema evolution.
+* [Working with State](state.html): 描述了如何在 Flink 应用程序中使用状态，以及不同类型的状态。
+* [The Broadcast State 模式](broadcast_state.html): 描述了如何将广播流和非广播流进行连接从而交换数据。
+* [Checkpointing](checkpointing.html): 介绍了如何开启和配置 checkpoint，以实现状态容错。
+* [可查询状态](queryable_state.html): 介绍了如何从外围访问 Flink 的状态。
+* [状态数据结构升级](schema_evolution.html): 介绍了状态数据结构升级相关的内容。
+* [Managed State 的自定义序列化器](custom_serialization.html): 介绍了如何实现自定义的序列化器，尤其是如何支持状态数据结构升级。
 
 {% top %}

--- a/docs/dev/stream/state/index.zh.md
+++ b/docs/dev/stream/state/index.zh.md
@@ -34,7 +34,7 @@ under the License.
 * [Working with State](state.html): 描述了如何在 Flink 应用程序中使用状态，以及不同类型的状态。
 * [The Broadcast State 模式](broadcast_state.html): 描述了如何将广播流和非广播流进行连接从而交换数据。
 * [Checkpointing](checkpointing.html): 介绍了如何开启和配置 checkpoint，以实现状态容错。
-* [可查询状态](queryable_state.html): 介绍了如何从外围访问 Flink 的状态。
+* [Queryable State](queryable_state.html): 介绍了如何从外围访问 Flink 的状态。
 * [状态数据结构升级](schema_evolution.html): 介绍了状态数据结构升级相关的内容。
 * [Managed State 的自定义序列化器](custom_serialization.html): 介绍了如何实现自定义的序列化器，尤其是如何支持状态数据结构升级。
 


### PR DESCRIPTION

## What is the purpose of the change

Translate the Overview page for State & Fault Tolerance into Chinese

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)

CC  @carp84 @wuchong 