### PR TITLE
[FLINK-17633][table-common] Improve FactoryUtil to align with new format options keys

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -71,11 +71,9 @@ public final class FactoryUtil {
 			"Uniquely identifies the connector of a dynamic table that is used for accessing data in " +
 			"an external system. Its value is used during table source and table sink discovery.");
 
-	public static final String FORMAT_PREFIX = "format.";
+	public static final String FORMAT_KEY = "format";
 
-	public static final String KEY_FORMAT_PREFIX = "key.format.";
-
-	public static final String VALUE_FORMAT_PREFIX = "value.format.";
+	public static final String FORMAT_SUFFIX = ".format";
 
 	/**
 	 * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
@@ -162,8 +160,8 @@ public final class FactoryUtil {
 	 * <pre>{@code
 	 * // in createDynamicTableSource()
 	 * helper = FactoryUtil.createTableFactoryHelper(this, context);
-	 * keyFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, KEY_OPTION, "prefix");
-	 * valueFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, VALUE_OPTION, "prefix");
+	 * keyFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, KEY_OPTION);
+	 * valueFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, VALUE_OPTION);
 	 * helper.validate();
 	 * ... // construct connector with discovered formats
 	 * }</pre>
@@ -378,13 +376,17 @@ public final class FactoryUtil {
 		/**
 		 * Discovers a {@link ScanFormat} of the given type using the given option as factory identifier.
 		 *
-		 * <p>A prefix, e.g. {@link #KEY_FORMAT_PREFIX}, projects the options for the format factory.
+		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
+		 * will replace 'format' with the factory identifier value as the format prefix.
+		 * For example, assuming the identifier is 'json', if format option key is 'format',
+		 * then format prefix is 'json.'. If format option key is 'value.format', then format
+		 * prefix is 'value.json'. The format prefix is used to project the options for the
+		 * format factory.
 		 */
 		public <I, F extends ScanFormatFactory<I>> ScanFormat<I> discoverScanFormat(
 				Class<F> formatFactoryClass,
-				ConfigOption<String> formatOption,
-				String formatPrefix) {
-			return discoverOptionalScanFormat(formatFactoryClass, formatOption, formatPrefix)
+				ConfigOption<String> formatOption) {
+			return discoverOptionalScanFormat(formatFactoryClass, formatOption)
 				.orElseThrow(() ->
 					new ValidationException(
 						String.format("Could not find required scan format '%s'.", formatOption.key())));
@@ -394,14 +396,19 @@ public final class FactoryUtil {
 		 * Discovers a {@link ScanFormat} of the given type using the given option (if present) as factory
 		 * identifier.
 		 *
-		 * <p>A prefix, e.g. {@link #KEY_FORMAT_PREFIX}, projects the options for the format factory.
+		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
+		 * will replace 'format' with the factory identifier value as the format prefix.
+		 * For example, assuming the identifier is 'json', if format option key is 'format',
+		 * then format prefix is 'json.'. If format option key is 'value.format', then format
+		 * prefix is 'value.json'. The format prefix is used to project the options for the
+		 * format factory.
 		 */
 		public <I, F extends ScanFormatFactory<I>> Optional<ScanFormat<I>> discoverOptionalScanFormat(
 				Class<F> formatFactoryClass,
-				ConfigOption<String> formatOption,
-				String formatPrefix) {
-			return discoverOptionalFormatFactory(formatFactoryClass, formatOption, formatPrefix)
+				ConfigOption<String> formatOption) {
+			return discoverOptionalFormatFactory(formatFactoryClass, formatOption)
 				.map(formatFactory -> {
+					String formatPrefix = formatPrefix(formatFactory, formatOption);
 					try {
 						return formatFactory.createScanFormat(context, projectOptions(formatPrefix));
 					} catch (Throwable t) {
@@ -418,13 +425,17 @@ public final class FactoryUtil {
 		/**
 		 * Discovers a {@link SinkFormat} of the given type using the given option as factory identifier.
 		 *
-		 * <p>A prefix, e.g. {@link #KEY_FORMAT_PREFIX}, projects the options for the format factory.
+		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
+		 * will replace 'format' with the factory identifier value as the format prefix.
+		 * For example, assuming the identifier is 'json', if format option key is 'format',
+		 * then format prefix is 'json.'. If format option key is 'value.format', then format
+		 * prefix is 'value.json'. The format prefix is used to project the options for the
+		 * format factory.
 		 */
 		public <I, F extends SinkFormatFactory<I>> SinkFormat<I> discoverSinkFormat(
 				Class<F> formatFactoryClass,
-				ConfigOption<String> formatOption,
-				String formatPrefix) {
-			return discoverOptionalSinkFormat(formatFactoryClass, formatOption, formatPrefix)
+				ConfigOption<String> formatOption) {
+			return discoverOptionalSinkFormat(formatFactoryClass, formatOption)
 				.orElseThrow(() ->
 					new ValidationException(
 						String.format("Could not find required sink format '%s'.", formatOption.key())));
@@ -434,14 +445,19 @@ public final class FactoryUtil {
 		 * Discovers a {@link SinkFormat} of the given type using the given option (if present) as factory
 		 * identifier.
 		 *
-		 * <p>A prefix, e.g. {@link #KEY_FORMAT_PREFIX}, projects the options for the format factory.
+		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
+		 * will replace 'format' with the factory identifier value as the format prefix.
+		 * For example, assuming the identifier is 'json', if format option key is 'format',
+		 * then format prefix is 'json.'. If format option key is 'value.format', then format
+		 * prefix is 'value.json'. The format prefix is used to project the options for the
+		 * format factory.
 		 */
 		public <I, F extends SinkFormatFactory<I>> Optional<SinkFormat<I>> discoverOptionalSinkFormat(
 				Class<F> formatFactoryClass,
-				ConfigOption<String> formatOption,
-				String formatPrefix) {
-			return discoverOptionalFormatFactory(formatFactoryClass, formatOption, formatPrefix)
+				ConfigOption<String> formatOption) {
+			return discoverOptionalFormatFactory(formatFactoryClass, formatOption)
 				.map(formatFactory -> {
+					String formatPrefix = formatPrefix(formatFactory, formatOption);
 					try {
 						return formatFactory.createSinkFormat(context, projectOptions(formatPrefix));
 					} catch (Throwable t) {
@@ -492,8 +508,7 @@ public final class FactoryUtil {
 
 		private <F extends Factory> Optional<F> discoverOptionalFormatFactory(
 				Class<F> formatFactoryClass,
-				ConfigOption<String> formatOption,
-				String formatPrefix) {
+				ConfigOption<String> formatOption) {
 			final String identifier = allOptions.get(formatOption);
 			if (identifier == null) {
 				return Optional.empty();
@@ -502,6 +517,7 @@ public final class FactoryUtil {
 				context.getClassLoader(),
 				formatFactoryClass,
 				identifier);
+			String formatPrefix = formatPrefix(factory, formatOption);
 			// log all used options of other factories
 			consumedOptionKeys.addAll(
 				factory.requiredOptions().stream()
@@ -514,6 +530,21 @@ public final class FactoryUtil {
 					.map(k -> formatPrefix + k)
 					.collect(Collectors.toSet()));
 			return Optional.of(factory);
+		}
+
+		private String formatPrefix(Factory formatFactory, ConfigOption<String> formatOption) {
+			String identifier = formatFactory.factoryIdentifier();
+			if (formatOption.key().equals(FORMAT_KEY)) {
+				return identifier + ".";
+			} else if (formatOption.key().endsWith(FORMAT_SUFFIX)) {
+				// extract the key prefix, e.g. extract 'key' from 'key.format'
+				String keyPrefix = formatOption.key().substring(0, formatOption.key().length() - FORMAT_SUFFIX.length());
+				return keyPrefix + "." + identifier + ".";
+			} else {
+				throw new ValidationException(
+					"Format identifier key should be 'format' or suffix with '.format', " +
+						"don't support format identifier key '" + formatOption.key() + "'.");
+			}
 		}
 
 		private ReadableConfig projectOptions(String formatPrefix) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -74,17 +74,23 @@ public final class FactoryUtil {
 	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
 		.key("key.format")
 		.stringType()
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Defines the format identifier for encoding key data. " +
+			"The identifier is used to discover a suitable format factory.");
 
 	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
 		.key("value.format")
 		.stringType()
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Defines the format identifier for encoding value data. " +
+			"The identifier is used to discover a suitable format factory.");
 
 	public static final ConfigOption<String> FORMAT = ConfigOptions
 		.key("format")
 		.stringType()
-		.noDefaultValue();
+		.noDefaultValue()
+		.withDescription("Defines the format identifier for encoding data. " +
+			"The identifier is used to discover a suitable format factory.");
 
 	private static final String FORMAT_KEY = "format";
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java
@@ -71,9 +71,24 @@ public final class FactoryUtil {
 			"Uniquely identifies the connector of a dynamic table that is used for accessing data in " +
 			"an external system. Its value is used during table source and table sink discovery.");
 
-	public static final String FORMAT_KEY = "format";
+	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
+		.key("key.format")
+		.stringType()
+		.noDefaultValue();
 
-	public static final String FORMAT_SUFFIX = ".format";
+	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
+		.key("value.format")
+		.stringType()
+		.noDefaultValue();
+
+	public static final ConfigOption<String> FORMAT = ConfigOptions
+		.key("format")
+		.stringType()
+		.noDefaultValue();
+
+	private static final String FORMAT_KEY = "format";
+
+	private static final String FORMAT_SUFFIX = ".format";
 
 	/**
 	 * Creates a {@link DynamicTableSource} from a {@link CatalogTable}.
@@ -160,11 +175,19 @@ public final class FactoryUtil {
 	 * <pre>{@code
 	 * // in createDynamicTableSource()
 	 * helper = FactoryUtil.createTableFactoryHelper(this, context);
-	 * keyFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, KEY_OPTION);
-	 * valueFormat = helper.discoverScanFormat(classloader, MyFormatFactory.class, VALUE_OPTION);
+	 * keyFormat = helper.discoverScanFormat(DeserializationFormatFactory.class, KEY_FORMAT);
+	 * valueFormat = helper.discoverScanFormat(DeserializationFormatFactory.class, VALUE_FORMAT);
 	 * helper.validate();
 	 * ... // construct connector with discovered formats
 	 * }</pre>
+	 *
+	 * <p>Note: The format option parameter of {@code helper.discoverScanFormat(formatFactoryClass, formatOption)}
+	 * and {@code helper.discoverSinkFormat(formatFactoryClass, formatOption)} must be 'format' or
+	 * with '.format' suffix (e.g. {@link #FORMAT}, {@link #KEY_FORMAT} and {@link #VALUE_FORMAT}).
+	 * The discovery logic will replace 'format' with the factory identifier value as the format
+	 * prefix. For example, assuming the identifier is 'json', if format option key is 'format',
+	 * then format prefix is 'json.'. If format option key is 'value.format', then format prefix
+	 * is 'value.json'. The format prefix is used to project the options for the format factory.
 	 *
 	 * <p>Note: This utility checks for left-over options in the final step.
 	 */
@@ -375,13 +398,6 @@ public final class FactoryUtil {
 
 		/**
 		 * Discovers a {@link ScanFormat} of the given type using the given option as factory identifier.
-		 *
-		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
-		 * will replace 'format' with the factory identifier value as the format prefix.
-		 * For example, assuming the identifier is 'json', if format option key is 'format',
-		 * then format prefix is 'json.'. If format option key is 'value.format', then format
-		 * prefix is 'value.json'. The format prefix is used to project the options for the
-		 * format factory.
 		 */
 		public <I, F extends ScanFormatFactory<I>> ScanFormat<I> discoverScanFormat(
 				Class<F> formatFactoryClass,
@@ -395,13 +411,6 @@ public final class FactoryUtil {
 		/**
 		 * Discovers a {@link ScanFormat} of the given type using the given option (if present) as factory
 		 * identifier.
-		 *
-		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
-		 * will replace 'format' with the factory identifier value as the format prefix.
-		 * For example, assuming the identifier is 'json', if format option key is 'format',
-		 * then format prefix is 'json.'. If format option key is 'value.format', then format
-		 * prefix is 'value.json'. The format prefix is used to project the options for the
-		 * format factory.
 		 */
 		public <I, F extends ScanFormatFactory<I>> Optional<ScanFormat<I>> discoverOptionalScanFormat(
 				Class<F> formatFactoryClass,
@@ -424,13 +433,6 @@ public final class FactoryUtil {
 
 		/**
 		 * Discovers a {@link SinkFormat} of the given type using the given option as factory identifier.
-		 *
-		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
-		 * will replace 'format' with the factory identifier value as the format prefix.
-		 * For example, assuming the identifier is 'json', if format option key is 'format',
-		 * then format prefix is 'json.'. If format option key is 'value.format', then format
-		 * prefix is 'value.json'. The format prefix is used to project the options for the
-		 * format factory.
 		 */
 		public <I, F extends SinkFormatFactory<I>> SinkFormat<I> discoverSinkFormat(
 				Class<F> formatFactoryClass,
@@ -444,13 +446,6 @@ public final class FactoryUtil {
 		/**
 		 * Discovers a {@link SinkFormat} of the given type using the given option (if present) as factory
 		 * identifier.
-		 *
-		 * <p>The format option key must be 'format' or with '.format' suffix. The discovery logic
-		 * will replace 'format' with the factory identifier value as the format prefix.
-		 * For example, assuming the identifier is 'json', if format option key is 'format',
-		 * then format prefix is 'json.'. If format option key is 'value.format', then format
-		 * prefix is 'value.json'. The format prefix is used to project the options for the
-		 * format factory.
 		 */
 		public <I, F extends SinkFormatFactory<I>> Optional<SinkFormat<I>> discoverOptionalSinkFormat(
 				Class<F> formatFactoryClass,

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/FactoryUtilTest.java
@@ -85,8 +85,8 @@ public class FactoryUtilTest {
 
 	@Test
 	public void testMissingFormat() {
-		expectError("Could not find required scan format 'value.format.kind'.");
-		testError(options -> options.remove("value.format.kind"));
+		expectError("Could not find required scan format 'value.format'.");
+		testError(options -> options.remove("value.format"));
 	}
 
 	@Test
@@ -96,24 +96,24 @@ public class FactoryUtilTest {
 				DeserializationFormatFactory.class.getName() + "' in the classpath.\n\n" +
 			"Available factory identifiers are:\n\n" +
 			"test-format");
-		testError(options -> options.put("value.format.kind", "FAIL"));
+		testError(options -> options.put("value.format", "FAIL"));
 	}
 
 	@Test
 	public void testMissingFormatOption() {
 		expectError(
-			"Error creating scan format 'test-format' in option space 'key.format.'.");
+			"Error creating scan format 'test-format' in option space 'key.test-format.'.");
 		expectError(
 			"One or more required options are missing.\n\n" +
 			"Missing required options are:\n\n" +
 			"delimiter");
-		testError(options -> options.remove("key.format.delimiter"));
+		testError(options -> options.remove("key.test-format.delimiter"));
 	}
 
 	@Test
 	public void testInvalidFormatOption() {
 		expectError("Invalid value for option 'fail-on-missing'.");
-		testError(options -> options.put("key.format.fail-on-missing", "FAIL"));
+		testError(options -> options.put("key.test-format.fail-on-missing", "FAIL"));
 	}
 
 	@Test
@@ -126,14 +126,15 @@ public class FactoryUtilTest {
 			"Supported options:\n\n" +
 			"buffer-size\n" +
 			"connector\n" +
-			"key.format.delimiter\n" +
-			"key.format.fail-on-missing\n" +
-			"key.format.kind\n" +
+			"format\n" +
+			"key.format\n" +
+			"key.test-format.delimiter\n" +
+			"key.test-format.fail-on-missing\n" +
 			"property-version\n" +
 			"target\n" +
-			"value.format.delimiter\n" +
-			"value.format.fail-on-missing\n" +
-			"value.format.kind");
+			"value.format\n" +
+			"value.test-format.delimiter\n" +
+			"value.test-format.fail-on-missing");
 		testError(options -> {
 			options.put("this-is-not-consumed", "42");
 			options.put("this-is-also-not-consumed", "true");
@@ -161,8 +162,8 @@ public class FactoryUtilTest {
 	@Test
 	public void testOptionalFormat() {
 		final Map<String, String> options = createAllOptions();
-		options.remove("key.format.kind");
-		options.remove("key.format.delimiter");
+		options.remove("key.format");
+		options.remove("key.test-format.delimiter");
 		final DynamicTableSource actualSource = createTableSource(options);
 		final DynamicTableSource expectedSource = new DynamicTableSourceMock(
 			"MyTarget",
@@ -175,6 +176,30 @@ public class FactoryUtilTest {
 			1000L,
 			null,
 			new SinkFormatMock("|"));
+		assertEquals(expectedSink, actualSink);
+	}
+
+	@Test
+	public void testAlternativeValueFormat() {
+		final Map<String, String> options = createAllOptions();
+		options.remove("value.format");
+		options.remove("value.test-format.delimiter");
+		options.remove("value.test-format.fail-on-missing");
+		options.put("format", "test-format");
+		options.put("test-format.delimiter", ";");
+		options.put("test-format.fail-on-missing", "true");
+		final DynamicTableSource actualSource = createTableSource(options);
+		final DynamicTableSource expectedSource = new DynamicTableSourceMock(
+			"MyTarget",
+			new ScanFormatMock(",", false),
+			new ScanFormatMock(";", true));
+		assertEquals(expectedSource, actualSource);
+		final DynamicTableSink actualSink = createTableSink(options);
+		final DynamicTableSink expectedSink = new DynamicTableSinkMock(
+			"MyTarget",
+			1000L,
+			new SinkFormatMock(","),
+			new SinkFormatMock(";"));
 		assertEquals(expectedSink, actualSink);
 	}
 
@@ -198,11 +223,11 @@ public class FactoryUtilTest {
 		options.put("connector", TestDynamicTableFactory.IDENTIFIER);
 		options.put("target", "MyTarget");
 		options.put("buffer-size", "1000");
-		options.put("key.format.kind", TestFormatFactory.IDENTIFIER);
-		options.put("key.format.delimiter", ",");
-		options.put("value.format.kind", TestFormatFactory.IDENTIFIER);
-		options.put("value.format.delimiter", "|");
-		options.put("value.format.fail-on-missing", "true");
+		options.put("key.format", "test-format");
+		options.put("key.test-format.delimiter", ",");
+		options.put("value.format", "test-format");
+		options.put("value.test-format.delimiter", "|");
+		options.put("value.test-format.fail-on-missing", "true");
 		return options;
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -56,12 +56,17 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 		.defaultValue(100L);
 
 	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
-		.key("key.format.kind")
+		.key("key.format")
 		.stringType()
 		.noDefaultValue();
 
 	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
-		.key("value.format.kind")
+		.key("value.format")
+		.stringType()
+		.noDefaultValue();
+
+	public static final ConfigOption<String> FORMAT = ConfigOptions
+		.key("format")
 		.stringType()
 		.noDefaultValue();
 
@@ -71,12 +76,13 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 
 		final Optional<ScanFormat<DeserializationSchema<RowData>>> keyFormat = helper.discoverOptionalScanFormat(
 			DeserializationFormatFactory.class,
-			KEY_FORMAT,
-			FactoryUtil.KEY_FORMAT_PREFIX);
-		final ScanFormat<DeserializationSchema<RowData>> valueFormat = helper.discoverScanFormat(
+			KEY_FORMAT);
+		final ScanFormat<DeserializationSchema<RowData>> valueFormat = helper.discoverOptionalScanFormat(
 			DeserializationFormatFactory.class,
-			VALUE_FORMAT,
-			FactoryUtil.VALUE_FORMAT_PREFIX);
+			FORMAT).orElseGet(
+				() -> helper.discoverScanFormat(
+					DeserializationFormatFactory.class,
+					VALUE_FORMAT));
 		helper.validate();
 
 		return new DynamicTableSourceMock(
@@ -91,12 +97,13 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 
 		final Optional<SinkFormat<SerializationSchema<RowData>>> keyFormat = helper.discoverOptionalSinkFormat(
 			SerializationFormatFactory.class,
-			KEY_FORMAT,
-			FactoryUtil.KEY_FORMAT_PREFIX);
-		final SinkFormat<SerializationSchema<RowData>> valueFormat = helper.discoverSinkFormat(
+			KEY_FORMAT);
+		final SinkFormat<SerializationSchema<RowData>> valueFormat = helper.discoverOptionalSinkFormat(
 			SerializationFormatFactory.class,
-			VALUE_FORMAT,
-			FactoryUtil.VALUE_FORMAT_PREFIX);
+			FORMAT).orElseGet(
+				() -> helper.discoverSinkFormat(
+					SerializationFormatFactory.class,
+					VALUE_FORMAT));
 		helper.validate();
 
 		return new DynamicTableSinkMock(
@@ -115,7 +122,6 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 	public Set<ConfigOption<?>> requiredOptions() {
 		final Set<ConfigOption<?>> options = new HashSet<>();
 		options.add(TARGET);
-		options.add(VALUE_FORMAT);
 		return options;
 	}
 
@@ -124,6 +130,8 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 		final Set<ConfigOption<?>> options = new HashSet<>();
 		options.add(BUFFER_SIZE);
 		options.add(KEY_FORMAT);
+		options.add(FORMAT);
+		options.add(VALUE_FORMAT);
 		return options;
 	}
 

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestDynamicTableFactory.java
@@ -38,6 +38,10 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
+import static org.apache.flink.table.factories.FactoryUtil.KEY_FORMAT;
+import static org.apache.flink.table.factories.FactoryUtil.VALUE_FORMAT;
+
 /**
  * Test implementations for {@link DynamicTableSourceFactory} and {@link DynamicTableSinkFactory}.
  */
@@ -54,21 +58,6 @@ public final class TestDynamicTableFactory implements DynamicTableSourceFactory,
 		.key("buffer-size")
 		.longType()
 		.defaultValue(100L);
-
-	public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
-		.key("key.format")
-		.stringType()
-		.noDefaultValue();
-
-	public static final ConfigOption<String> VALUE_FORMAT = ConfigOptions
-		.key("value.format")
-		.stringType()
-		.noDefaultValue();
-
-	public static final ConfigOption<String> FORMAT = ConfigOptions
-		.key("format")
-		.stringType()
-		.noDefaultValue();
 
 	@Override
 	public DynamicTableSource createDynamicTableSource(Context context) {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](https://flink.apache.org/contributing/contribute-code.html#open-a-pull-request).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The current `discoverScan/SinkFormat` implementation in `FactoryUtil` uses `value.format.fail-on-missing-field` as the format options. However, as discussed in [mailing list](http://apache-flink-mailing-list-archive.1008284.n3.nabble.com/DISCUSS-Hierarchies-in-ConfigOption-td40920.html),  the following format options are proposed to use:

```
format = json
json.fail-on-missing-field = true
json.ignore-parse-error = true

value.format = json
value.json.fail-on-missing-field = true
value.json.ignore-parse-error = true
```

So that we should update the format discovery in `FactoryUtil` to make it more easy to use in connectors. 

## Brief change log

- remove `formatPrefix` parameter from `discoverScanFormat` and `discoverSinkFormat`.
- derive the `formatPrefix` according to the `identifier` and `formatOption` in `TableFactoryHelper`.

## Verifying this change

- Update `TestDynamicTableFactory` to use the new format options.
- Update `TestDynamicTableFactory` to support discover alternative value format which uses `format` key.
- Update `FactoryUtilTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
