### PR TITLE
[FLINK-17634][rest] Reject multiple registration for the same endpoint

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestServerEndpointITCase.java
@@ -595,12 +595,31 @@ public class RestServerEndpointITCase extends TestLogger {
 	}
 
 	@Test
+	public void testEndpointsMustBeUnique() throws Exception {
+		final RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
+
+		final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
+			Tuple2.of(new TestHeaders(), testHandler),
+			Tuple2.of(new TestHeaders(), testUploadHandler)
+		);
+
+		assertThrows("REST handler registration",
+			FlinkRuntimeException.class,
+			() -> {
+				try (TestRestServerEndpoint restServerEndpoint =  new TestRestServerEndpoint(serverConfig, handlers)) {
+					restServerEndpoint.start();
+					return null;
+				}
+			});
+	}
+
+	@Test
 	public void testDuplicateHandlerRegistrationIsForbidden() throws Exception {
 		final RestServerEndpointConfiguration serverConfig = RestServerEndpointConfiguration.fromConfiguration(config);
 
 		final List<Tuple2<RestHandlerSpecification, ChannelInboundHandler>> handlers = Arrays.asList(
 			Tuple2.of(new TestHeaders(), testHandler),
-			Tuple2.of(new TestHeaders(), testHandler)
+			Tuple2.of(TestUploadHeaders.INSTANCE, testHandler)
 		);
 
 		assertThrows("Duplicate REST handler",


### PR DESCRIPTION
Adds a new check to the `RestServerEndpoint` to ensure that there aren't multiple registration for the same (version, method, url), which happened in FLINK-17562.

So far we only checked that a handler isn't being re-used for multiple registrations.