### PR TITLE
[FLINK-15138][e2e][python] Add PyFlink e2e tests.

### DIFF
--- a/flink-end-to-end-tests/flink-python-test/pom.xml
+++ b/flink-end-to-end-tests/flink-python-test/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+    -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.11-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-python-test_${scala.binary.version}</artifactId>
+	<name>flink-python-test</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-java</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-uber_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-python_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>PythonUdfSqlJobExample</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<finalName>PythonUdfSqlJobExample</finalName>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>org.apache.flink.python.tests.BlinkStreamPythonUdfSqlJob</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-end-to-end-tests/flink-python-test/python/add_one.py
+++ b/flink-end-to-end-tests/flink-python-test/python/add_one.py
@@ -1,0 +1,25 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.table import DataTypes
+from pyflink.table.udf import udf
+
+
+@udf(input_types=[DataTypes.BIGINT()], result_type=DataTypes.BIGINT())
+def add_one(i):
+    from scipy.special import jv
+    return i + int(jv([0], [0])[0])

--- a/flink-end-to-end-tests/flink-python-test/python/python_job.py
+++ b/flink-end-to-end-tests/flink-python-test/python/python_job.py
@@ -1,0 +1,82 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+import logging
+import os
+import shutil
+import sys
+import tempfile
+
+from pyflink.dataset import ExecutionEnvironment
+from pyflink.table import BatchTableEnvironment, TableConfig
+
+
+def word_count():
+    content = "line Licensed to the Apache Software Foundation ASF under one " \
+              "line or more contributor license agreements See the NOTICE file " \
+              "line distributed with this work for additional information " \
+              "line regarding copyright ownership The ASF licenses this file " \
+              "to you under the Apache License Version the " \
+              "License you may not use this file except in compliance " \
+              "with the License"
+
+    t_config = TableConfig()
+    env = ExecutionEnvironment.get_execution_environment()
+    t_env = BatchTableEnvironment.create(env, t_config)
+
+    # register Results table in table environment
+    tmp_dir = tempfile.gettempdir()
+    result_path = tmp_dir + '/result'
+    if os.path.exists(result_path):
+        try:
+            if os.path.isfile(result_path):
+                os.remove(result_path)
+            else:
+                shutil.rmtree(result_path)
+        except OSError as e:
+            logging.error("Error removing directory: %s - %s.", e.filename, e.strerror)
+
+    logging.info("Results directory: %s", result_path)
+
+    sink_ddl = """
+        create table Results(
+            word VARCHAR,
+            `count` BIGINT
+        ) with (
+            'connector.type' = 'filesystem',
+            'format.type' = 'csv',
+            'connector.path' = '{}'
+        )
+        """.format(result_path)
+    t_env.sql_update(sink_ddl)
+
+    t_env.sql_update("create temporary system function add_one as 'add_one.add_one' language python")
+
+    elements = [(word, 0) for word in content.split(" ")]
+    t_env.from_elements(elements, ["word", "count"]) \
+        .select("word, add_one(count) as count") \
+        .group_by("word") \
+        .select("word, count(count) as count") \
+        .insert_into("Results")
+
+    t_env.execute("word_count")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
+
+    word_count()

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkBatchPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkBatchPythonUdfSqlJob.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.tests;
+
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A simple job used to test submitting the Python UDF job in blink batch mode.
+ */
+public class BlinkBatchPythonUdfSqlJob {
+
+	public static void main(String[] args) {
+		TableEnvironment tEnv = TableEnvironment.create(
+			EnvironmentSettings.newInstance().useBlinkPlanner().inBatchMode().build());
+		tEnv.getConfig().getConfiguration().set(CoreOptions.DEFAULT_PARALLELISM, 1);
+		tEnv.executeSql("create temporary system function add_one as 'add_one.add_one' language python");
+
+		tEnv.createTemporaryView("source", tEnv.fromValues(1L, 2L, 3L).as("a"));
+
+		Iterator<Row> result = tEnv.executeSql("select add_one(a) as a from source").collect();
+
+		List<Long> actual = new ArrayList<>();
+		while (result.hasNext()) {
+			Row r = result.next();
+			actual.add((Long) r.getField(0));
+		}
+
+		List<Long> expected = Arrays.asList(2L, 3L, 4L);
+		if (!actual.equals(expected)) {
+			throw new AssertionError(String.format("The output result: %s is not as expected: %s!", actual, expected));
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkStreamPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/BlinkStreamPythonUdfSqlJob.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.tests;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A simple job used to test submitting the Python UDF job in blink stream mode.
+ */
+public class BlinkStreamPythonUdfSqlJob {
+
+	public static void main(String[] args) {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(
+			env,
+			EnvironmentSettings.newInstance().useBlinkPlanner().inStreamingMode().build());
+		tEnv.executeSql("create temporary system function add_one as 'add_one.add_one' language python");
+
+		tEnv.createTemporaryView("source", tEnv.fromValues(1L, 2L, 3L).as("a"));
+
+		Iterator<Row> result = tEnv.executeSql("select add_one(a) as a from source").collect();
+
+		List<Long> actual = new ArrayList<>();
+		while (result.hasNext()) {
+			Row r = result.next();
+			actual.add((Long) r.getField(0));
+		}
+
+		List<Long> expected = Arrays.asList(2L, 3L, 4L);
+		if (!actual.equals(expected)) {
+			throw new AssertionError(String.format("The output result: %s is not as expected: %s!", actual, expected));
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/FlinkBatchPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/FlinkBatchPythonUdfSqlJob.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.tests;
+
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.table.api.java.BatchTableEnvironment;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A simple job used to test submitting the Python UDF job in flink batch mode.
+ */
+public class FlinkBatchPythonUdfSqlJob {
+
+	public static void main(String[] args) {
+		ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		BatchTableEnvironment tEnv = BatchTableEnvironment.create(env);
+		tEnv.executeSql("create temporary system function add_one as 'add_one.add_one' language python");
+
+		tEnv.createTemporaryView("source", tEnv.fromDataSet(env.fromElements(1L, 2L, 3L)).as("a"));
+
+		Iterator<Row> result = tEnv.executeSql("select add_one(a) as a from source").collect();
+
+		List<Long> actual = new ArrayList<>();
+		while (result.hasNext()) {
+			Row r = result.next();
+			actual.add((Long) r.getField(0));
+		}
+
+		List<Long> expected = Arrays.asList(2L, 3L, 4L);
+		if (!actual.equals(expected)) {
+			throw new AssertionError(String.format("The output result: %s is not as expected: %s!", actual, expected));
+		}
+	}
+}

--- a/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/FlinkStreamPythonUdfSqlJob.java
+++ b/flink-end-to-end-tests/flink-python-test/src/main/java/org/apache/flink/python/tests/FlinkStreamPythonUdfSqlJob.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.python.tests;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A simple job used to test submitting the Python UDF job in flink stream mode.
+ */
+public class FlinkStreamPythonUdfSqlJob {
+
+	public static void main(String[] args) throws Exception {
+		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+		env.setParallelism(1);
+		StreamTableEnvironment tEnv = StreamTableEnvironment.create(
+			env,
+			EnvironmentSettings.newInstance().useOldPlanner().inStreamingMode().build());
+		tEnv.executeSql("create temporary system function add_one as 'add_one.add_one' language python");
+
+		tEnv.createTemporaryView("source", tEnv.fromValues(1L, 2L, 3L).as("a"));
+
+		Iterator<Row> result = tEnv.executeSql("select add_one(a) as a from source").collect();
+
+		List<Long> actual = new ArrayList<>();
+		while (result.hasNext()) {
+			Row r = result.next();
+			actual.add((Long) r.getField(0));
+		}
+
+		List<Long> expected = Arrays.asList(2L, 3L, 4L);
+		if (!actual.equals(expected)) {
+			throw new AssertionError(String.format("The output result: %s is not as expected: %s!", actual, expected));
+		}
+	}
+}

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -88,6 +88,7 @@ under the License.
 		<module>flink-end-to-end-tests-common-kafka</module>
 		<module>flink-tpcds-test</module>
 		<module>flink-netty-shuffle-memory-control-test</module>
+		<module>flink-python-test</module>
 	</modules>
 
 	<dependencies>

--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -214,6 +214,8 @@ run_test "Dependency shading of table modules test" "$END_TO_END_DIR/test-script
 
 run_test "Shaded Hadoop S3A with credentials provider end-to-end test" "$END_TO_END_DIR/test-scripts/test_batch_wordcount.sh hadoop_with_provider"
 
+run_test "PyFlink end-to-end test" "$END_TO_END_DIR/test-scripts/test_pyflink.sh" "skip_check_exceptions"
+
 ################################################################################
 # Sticky Scheduling
 ################################################################################

--- a/flink-end-to-end-tests/test-scripts/test_pyflink.sh
+++ b/flink-end-to-end-tests/test-scripts/test_pyflink.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+set -Eeuo pipefail
+CURRENT_DIR=`cd "$(dirname "$0")" && pwd -P`
+source "${CURRENT_DIR}"/common.sh
+
+FLINK_PYTHON_DIR=`cd "${CURRENT_DIR}/../../flink-python" && pwd -P`
+
+CONDA_HOME="${FLINK_PYTHON_DIR}/dev/.conda"
+
+"${FLINK_PYTHON_DIR}/dev/lint-python.sh" -s miniconda
+
+PYTHON_EXEC="${CONDA_HOME}/bin/python"
+
+source "${CONDA_HOME}/bin/activate"
+
+cd "${FLINK_PYTHON_DIR}"
+
+rm -rf dist
+
+python setup.py sdist
+
+pip install dist/*
+
+cd dev
+
+conda install -y -q zip=3.0
+
+rm -rf .conda/pkgs
+
+zip -q -r "${TEST_DATA_DIR}/venv.zip" .conda
+
+deactivate
+
+cd "${CURRENT_DIR}"
+
+start_cluster
+on_exit stop_cluster
+
+FLINK_PYTHON_TEST_DIR=`cd "${CURRENT_DIR}/../flink-python-test" && pwd -P`
+REQUIREMENTS_PATH="${TEST_DATA_DIR}/requirements.txt"
+
+echo "scipy==1.4.1" > "${REQUIREMENTS_PATH}"
+
+echo "Test submitting python job:\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    -py "${FLINK_PYTHON_TEST_DIR}/python/python_job.py"
+
+echo "Test blink stream python udf sql job:\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
+
+echo "Test blink batch python udf sql job:\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    -c org.apache.flink.python.tests.BlinkBatchPythonUdfSqlJob \
+    "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
+
+echo "Test flink stream python udf sql job:\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    -c org.apache.flink.python.tests.FlinkStreamPythonUdfSqlJob \
+    "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
+
+echo "Test flink batch python udf sql job:\n"
+PYFLINK_CLIENT_EXECUTABLE=${PYTHON_EXEC} "${FLINK_DIR}/bin/flink" run \
+    -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+    -pyreq "${REQUIREMENTS_PATH}" \
+    -pyarch "${TEST_DATA_DIR}/venv.zip" \
+    -pyexec "venv.zip/.conda/bin/python" \
+    -c org.apache.flink.python.tests.FlinkBatchPythonUdfSqlJob \
+    "${FLINK_PYTHON_TEST_DIR}/target/PythonUdfSqlJobExample.jar"
+
+echo "Test using python udf in sql client:\n"
+SQL_CONF=$TEST_DATA_DIR/sql-client-session.conf
+
+cat >> $SQL_CONF << EOF
+tables:
+- name: sink
+  type: sink-table
+  update-mode: append
+  schema:
+  - name: a
+    type: BIGINT
+  connector:
+    type: filesystem
+    path: "$TEST_DATA_DIR/sql-client-test.csv"
+  format:
+    type: csv
+    fields:
+    - name: a
+      type: BIGINT
+
+functions:
+- name: add_one
+  from: python
+  fully-qualified-name: add_one.add_one
+
+configuration:
+  python.client.executable: "$PYTHON_EXEC"
+EOF
+
+SQL_STATEMENT="insert into sink select add_one(a) from (VALUES (1), (2), (3)) as source (a)"
+
+JOB_ID=$($FLINK_DIR/bin/sql-client.sh embedded \
+  --environment $SQL_CONF \
+  -pyfs "${FLINK_PYTHON_TEST_DIR}/python/add_one.py" \
+  -pyreq "${REQUIREMENTS_PATH}" \
+  -pyarch "${TEST_DATA_DIR}/venv.zip" \
+  -pyexec "venv.zip/.conda/bin/python" \
+  --update "$SQL_STATEMENT" | grep "Job ID:" | sed 's/.* //g')
+
+wait_job_terminal_state "$JOB_ID" "FINISHED"
+
+stop_cluster


### PR DESCRIPTION
## What is the purpose of the change

*This pull request adds the PyFlink e2e tests, which includes 1 python job, 4 python udf sql job and 1 python udf sql-client job.*


## Brief change log

  - *Add a new project `flink-python-test` in the `flink-end-to-end-tests`.*
  - *Add a new script `test_pyflink.sh` in the `flink-end-to-end-tests/test-scripts` folder.*
  - *Add the python e2e test call to the `flink-end-to-end-tests/run-nightly-tests.sh* script.


## Verifying this change

This change is already covered by existing tests, such as *flink-end-to-end-tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
