### PR TITLE
[FLINK-16624][k8s] Support user-specified annotations for the rest Service

### DIFF
--- a/docs/_includes/generated/kubernetes_config_configuration.html
+++ b/docs/_includes/generated/kubernetes_config_configuration.html
@@ -117,6 +117,12 @@
             <td>The namespace that will be used for running the jobmanager and taskmanager pods.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.rest-service.annotations</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>The user-specified annotations that are set to the rest Service. The value should be in the form of a1:v1,a2:v2</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.rest-service.exposed.type</h5></td>
             <td style="word-wrap: break-word;">LoadBalancer</td>
             <td><p>Enum</p>Possible values: [ClusterIP, NodePort, LoadBalancer]</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -204,6 +204,13 @@ public class KubernetesConfigOptions {
 				"in the form of key:key1,operator:Equal,value:value1,effect:NoSchedule;" +
 				"key:key2,operator:Exists,effect:NoExecute,tolerationSeconds:6000");
 
+	public static final ConfigOption<Map<String, String>> REST_SERVICE_ANNOTATIONS =
+		key("kubernetes.rest-service.annotations")
+			.mapType()
+			.noDefaultValue()
+			.withDescription("The user-specified annotations that are set to the rest Service. The value should be " +
+				"in the form of a1:v1,a2:v2");
+
 	/**
 	 * The flink rest service exposed type.
 	 */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecorator.java
@@ -53,6 +53,7 @@ public class ExternalServiceDecorator extends AbstractKubernetesStepDecorator {
 			.withNewMetadata()
 				.withName(serviceName)
 				.withLabels(kubernetesJobManagerParameters.getCommonLabels())
+				.withAnnotations(kubernetesJobManagerParameters.getRestServiceAnnotations())
 				.endMetadata()
 			.withNewSpec()
 				.withType(kubernetesJobManagerParameters.getRestServiceExposedType().name())

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -85,6 +85,10 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
 		return flinkConfig.getOptional(KubernetesConfigOptions.JOB_MANAGER_TOLERATIONS).orElse(Collections.emptyList());
 	}
 
+	public Map<String, String> getRestServiceAnnotations() {
+		return flinkConfig.getOptional(KubernetesConfigOptions.REST_SERVICE_ANNOTATIONS).orElse(Collections.emptyMap());
+	}
+
 	public String getJobManagerMainContainerName() {
 		return JOB_MANAGER_MAIN_CONTAINER_NAME;
 	}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExternalServiceDecoratorTest.java
@@ -32,10 +32,14 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 /**
  * General tests for the {@link ExternalServiceDecorator}.
@@ -44,9 +48,18 @@ public class ExternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
 
 	private ExternalServiceDecorator externalServiceDecorator;
 
+	private Map<String, String> customizedAnnotations = new HashMap<String, String>() {
+		{
+			put("annotation1", "annotation-value1");
+			put("annotation2", "annotation-value2");
+		}
+	};
+
 	@Before
 	public void setup() throws Exception {
 		super.setup();
+
+		this.flinkConfig.set(KubernetesConfigOptions.REST_SERVICE_ANNOTATIONS, customizedAnnotations);
 		this.externalServiceDecorator = new ExternalServiceDecorator(this.kubernetesJobManagerParameters);
 	}
 
@@ -77,6 +90,9 @@ public class ExternalServiceDecoratorTest extends KubernetesJobManagerTestBase {
 		expectedLabels.put(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER);
 		expectedLabels.putAll(userLabels);
 		assertEquals(expectedLabels, restService.getSpec().getSelector());
+
+		final Map<String, String> resultAnnotations = restService.getMetadata().getAnnotations();
+		assertThat(resultAnnotations, is(equalTo(customizedAnnotations)));
 	}
 
 	@Test

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
@@ -78,7 +78,7 @@ public class KubernetesJobManagerParametersTest extends KubernetesTestBase {
 	}
 
 	@Test
-	public void testGetAnnotations() {
+	public void testGetJobManagerAnnotations() {
 		final Map<String, String> expectedAnnotations = new HashMap<>();
 		expectedAnnotations.put("a1", "v1");
 		expectedAnnotations.put("a2", "v2");
@@ -86,6 +86,19 @@ public class KubernetesJobManagerParametersTest extends KubernetesTestBase {
 		flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, expectedAnnotations);
 
 		final Map<String, String> resultAnnotations = kubernetesJobManagerParameters.getAnnotations();
+
+		assertThat(resultAnnotations, is(equalTo(expectedAnnotations)));
+	}
+
+	@Test
+	public void testGetServiceAnnotations() {
+		final Map<String, String> expectedAnnotations = new HashMap<>();
+		expectedAnnotations.put("a1", "v1");
+		expectedAnnotations.put("a2", "v2");
+
+		flinkConfig.set(KubernetesConfigOptions.REST_SERVICE_ANNOTATIONS, expectedAnnotations);
+
+		final Map<String, String> resultAnnotations = kubernetesJobManagerParameters.getRestServiceAnnotations();
 
 		assertThat(resultAnnotations, is(equalTo(expectedAnnotations)));
 	}


### PR DESCRIPTION
## What is the purpose of the change

This PR allows users to customize annotations for their rest Services, for example:
1. Specify the LB type to decide whether it should have an external IP.
2. Specify the Security Policy for the LB.

It's a general need, especially for the Cloud platform users. 

## Brief change log

  - Introduce a new config option of `kubernetes.rest-service.annotations` with Map type.
  - Add a new method `KubernetesJobManagerParameters#getRestServiceAnnotations`.
  - Set annotations for the metadata of the rest service in `ExternalServiceDecorator.java`


## Verifying this change

This change added tests and can be verified as follows:

  - The unit tests should pass.
  - Test in a real K8s cluster to make sure the annotations take effect.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
