### PR TITLE
[FLINK-17646][python] Reduce the package size of PyFlink.

### DIFF
--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -263,7 +263,7 @@ run sdist.
         'pyflink.plugins': ['*', '*/*'],
         'pyflink.bin': ['*']}
 
-    if exist_licenses:
+    if exist_licenses and platform.system() != "Windows":
         PACKAGES.append('pyflink.licenses')
         PACKAGE_DIR['pyflink.licenses'] = TEMP_PATH + '/licenses'
         PACKAGE_DATA['pyflink.licenses'] = ['*']

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -120,7 +120,6 @@ in_flink_source = os.path.isfile("../flink-java/src/main/java/org/apache/flink/a
 # Due to changes in FLINK-14008, the licenses directory and NOTICE file may not exist in
 # build-target folder. Just ignore them in this case.
 exist_licenses = None
-exist_notice = None
 try:
     if in_flink_source:
 
@@ -217,7 +216,6 @@ run sdist.
                   "directory.")
             sys.exit(-1)
         exist_licenses = os.path.exists(LICENSES_TEMP_PATH)
-        exist_notice = os.path.exists(NOTICE_FILE_TEMP_PATH)
 
     script_names = ["pyflink-shell.sh", "find-flink-home.sh"]
     scripts = [os.path.join(SCRIPTS_TEMP_PATH, script) for script in script_names]

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -50,7 +50,9 @@ def find_file_path(pattern):
         exit(-1)
     if len(files) > 1:
         print("The file pattern %s is ambiguous: %s" % (pattern, files))
+        exit(-1)
     return files[0]
+
 
 # Currently Cython optimizing doesn't support Windows.
 if platform.system() == 'Windows':


### PR DESCRIPTION
## What is the purpose of the change

*This pull request reduces the the python package size of PyFlink.*


## Brief change log

  - *Remove the jars in the `deps/opt` folder of the PyFlink python package file except `flink-python.jar` and `flink-sql-client.jar`.*
  - *Regenerate the licenses directory and NOTICE file of the PyFlink python package file.*


## Verifying this change

This change added tests and can be verified as follows:

- *run `mvn clean install -DskipTests` on the flink source root directory.*
- *run `cd flink-python;python setup.py sdist` to pack a python package.*
- *check the package size in `flink-python/dist`, make sure it is less than 300MB.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
