### PR TITLE
[FLINK-17652][config] Legacy JM heap options should fallback to new JVM_HEAP_MEMORY in standalone

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/AbstractContainerizedClusterClientFactory.java
@@ -37,7 +37,7 @@ public abstract class AbstractContainerizedClusterClientFactory<ClusterID> imple
 	public ClusterSpecification getClusterSpecification(Configuration configuration) {
 		checkNotNull(configuration);
 
-		final int jobManagerMemoryMB = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
+		final int jobManagerMemoryMB = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 				configuration,
 				JobManagerOptions.TOTAL_PROCESS_MEMORY)
 			.getTotalProcessMemorySize()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/JavaCmdJobManagerDecorator.java
@@ -48,7 +48,7 @@ public class JavaCmdJobManagerDecorator extends AbstractKubernetesStepDecorator 
 
 	@Override
 	public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
-		final JobManagerProcessSpec processSpec = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
+		final JobManagerProcessSpec processSpec = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			kubernetesJobManagerParameters.getFlinkConfiguration(),
 			JobManagerOptions.TOTAL_PROCESS_MEMORY);
 		final String startCommand = getJobManagerStartCommand(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmanager/JobManagerProcessUtils.java
@@ -65,11 +65,11 @@ public class JobManagerProcessUtils {
 	private JobManagerProcessUtils() {
 	}
 
-	public static JobManagerProcessSpec processSpecFromConfigWithFallbackForLegacyHeap(
+	public static JobManagerProcessSpec processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			Configuration config,
-			ConfigOption<MemorySize> newFallbackOptionForLegacyHeap) {
+			ConfigOption<MemorySize> newOptionToInterpretLegacyHeap) {
 		return processSpecFromConfig(
-			getConfigurationWithLegacyHeapSizeMappedToNewConfigOption(config, newFallbackOptionForLegacyHeap));
+			getConfigurationWithLegacyHeapSizeMappedToNewConfigOption(config, newOptionToInterpretLegacyHeap));
 	}
 
 	static JobManagerProcessSpec processSpecFromConfig(Configuration config) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -78,7 +78,7 @@ public class BashJavaUtils {
 	private static void getJmResourceParams(String[] args) throws Exception {
 		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
 			FlinkConfigLoader.loadConfiguration(args),
-			JobManagerOptions.TOTAL_FLINK_MEMORY);
+			JobManagerOptions.JVM_HEAP_MEMORY);
 		System.out.println(EXECUTION_PREFIX + ProcessMemoryUtils.generateJvmParametersStr(jobManagerProcessSpec));
 	}
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -51,15 +51,14 @@ public class BashJavaUtils {
 
 		Command command = Command.valueOf(args[0]);
 		String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
-		Configuration configuration = FlinkConfigLoader.loadConfiguration(commandArgs);
-		List<String> output = runCommand(command, configuration);
+		List<String> output = runCommand(command, commandArgs);
 		for (String outputLine : output) {
 			System.out.println(EXECUTION_PREFIX + outputLine);
 		}
 	}
 
-	@VisibleForTesting
-	static List<String> runCommand(Command command, Configuration configuration) {
+	private static List<String> runCommand(Command command, String[] commandArgs) throws FlinkException {
+		Configuration configuration = FlinkConfigLoader.loadConfiguration(commandArgs);
 		switch (command) {
 			case GET_TM_RESOURCE_PARAMS:
 				return getTmResourceParams(configuration);
@@ -85,7 +84,11 @@ public class BashJavaUtils {
 			TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
 	}
 
-	private static List<String> getJmResourceParams(Configuration configuration) {
+	/**
+	 * Generate and print JVM parameters of Flink Master resources as one line.
+	 */
+	@VisibleForTesting
+	static List<String> getJmResourceParams(Configuration configuration) {
 		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			configuration,
 			JobManagerOptions.JVM_HEAP_MEMORY);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -27,8 +27,11 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessSpec;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessUtils;
 import org.apache.flink.runtime.util.config.memory.ProcessMemoryUtils;
+import org.apache.flink.util.FlinkException;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -40,18 +43,28 @@ public class BashJavaUtils {
 	@VisibleForTesting
 	public static final String EXECUTION_PREFIX = "BASH_JAVA_UTILS_EXEC_RESULT:";
 
-	public static void main(String[] args) throws Exception {
+	private BashJavaUtils() {
+	}
+
+	public static void main(String[] args) throws FlinkException {
 		checkArgument(args.length > 0, "Command not specified.");
 
+		Command command = Command.valueOf(args[0]);
 		String[] commandArgs = Arrays.copyOfRange(args, 1, args.length);
+		Configuration configuration = FlinkConfigLoader.loadConfiguration(commandArgs);
+		List<String> output = runCommand(command, configuration);
+		for (String outputLine : output) {
+			System.out.println(EXECUTION_PREFIX + outputLine);
+		}
+	}
 
-		switch (Command.valueOf(args[0])) {
+	@VisibleForTesting
+	static List<String> runCommand(Command command, Configuration configuration) {
+		switch (command) {
 			case GET_TM_RESOURCE_PARAMS:
-				getTmResourceParams(commandArgs);
-				break;
+				return getTmResourceParams(configuration);
 			case GET_JM_RESOURCE_PARAMS:
-				getJmResourceParams(commandArgs);
-				break;
+				return getJmResourceParams(configuration);
 			default:
 				// unexpected, Command#valueOf should fail if a unknown command is passed in
 				throw new RuntimeException("Unexpected, something is wrong.");
@@ -62,24 +75,21 @@ public class BashJavaUtils {
 	 * Generate and print JVM parameters and dynamic configs of task executor resources. The last two lines of
 	 * the output should be JVM parameters and dynamic configs respectively.
 	 */
-	private static void getTmResourceParams(String[] args) throws Exception {
-		Configuration configuration = getConfigurationForStandaloneTaskManagers(args);
-		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configuration);
-		System.out.println(EXECUTION_PREFIX + ProcessMemoryUtils.generateJvmParametersStr(taskExecutorProcessSpec));
-		System.out.println(EXECUTION_PREFIX + TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
+	private static List<String> getTmResourceParams(Configuration configuration) {
+		Configuration configurationWithFallback = TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
+			configuration,
+			TaskManagerOptions.TOTAL_FLINK_MEMORY);
+		TaskExecutorProcessSpec taskExecutorProcessSpec = TaskExecutorProcessUtils.processSpecFromConfig(configurationWithFallback);
+		return Arrays.asList(
+			ProcessMemoryUtils.generateJvmParametersStr(taskExecutorProcessSpec),
+			TaskExecutorProcessUtils.generateDynamicConfigsStr(taskExecutorProcessSpec));
 	}
 
-	private static Configuration getConfigurationForStandaloneTaskManagers(String[] args) throws Exception {
-		Configuration configuration = FlinkConfigLoader.loadConfiguration(args);
-		return TaskExecutorProcessUtils.getConfigurationMapLegacyTaskManagerHeapSizeToConfigOption(
-			configuration, TaskManagerOptions.TOTAL_FLINK_MEMORY);
-	}
-
-	private static void getJmResourceParams(String[] args) throws Exception {
+	private static List<String> getJmResourceParams(Configuration configuration) {
 		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
-			FlinkConfigLoader.loadConfiguration(args),
+			configuration,
 			JobManagerOptions.JVM_HEAP_MEMORY);
-		System.out.println(EXECUTION_PREFIX + ProcessMemoryUtils.generateJvmParametersStr(jobManagerProcessSpec));
+		return Collections.singletonList(ProcessMemoryUtils.generateJvmParametersStr(jobManagerProcessSpec));
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/bash/BashJavaUtils.java
@@ -86,7 +86,7 @@ public class BashJavaUtils {
 	}
 
 	private static List<String> getJmResourceParams(Configuration configuration) {
-		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
+		JobManagerProcessSpec jobManagerProcessSpec = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			configuration,
 			JobManagerOptions.JVM_HEAP_MEMORY);
 		return Collections.singletonList(ProcessMemoryUtils.generateJvmParametersStr(jobManagerProcessSpec));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/BashJavaUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/BashJavaUtilsTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.runtime.util.bash.BashJavaUtils.Command;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class BashJavaUtilsTest extends TestLogger {
 		Configuration configuration = new Configuration();
 		MemorySize heapSize = MemorySize.ofMebiBytes(10);
 		configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, heapSize);
-		String jvmArgsLine = BashJavaUtils.runCommand(Command.GET_JM_RESOURCE_PARAMS, configuration).get(0);
+		String jvmArgsLine = BashJavaUtils.getJmResourceParams(configuration).get(0);
 		Map<String, String> jvmArgs = ConfigurationUtils.parseJvmArgString(jvmArgsLine);
 		String heapSizeStr = Long.toString(heapSize.getBytes());
 		assertThat(jvmArgs.get("-Xmx"), is(heapSizeStr));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/BashJavaUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/bash/BashJavaUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.util.bash;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.util.bash.BashJavaUtils.Command;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link BashJavaUtils}
+ */
+public class BashJavaUtilsTest extends TestLogger {
+	@Test
+	public void testJmLegacyHeapOptionSetsNewJvmHeap() {
+		Configuration configuration = new Configuration();
+		MemorySize heapSize = MemorySize.ofMebiBytes(10);
+		configuration.set(JobManagerOptions.JOB_MANAGER_HEAP_MEMORY, heapSize);
+		String jvmArgsLine = BashJavaUtils.runCommand(Command.GET_JM_RESOURCE_PARAMS, configuration).get(0);
+		Map<String, String> jvmArgs = ConfigurationUtils.parseJvmArgString(jvmArgsLine);
+		String heapSizeStr = Long.toString(heapSize.getBytes());
+		assertThat(jvmArgs.get("-Xmx"), is(heapSizeStr));
+		assertThat(jvmArgs.get("-Xms"), is(heapSizeStr));
+	}
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -934,7 +934,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
 			}
 		}
 
-		final JobManagerProcessSpec processSpec = JobManagerProcessUtils.processSpecFromConfigWithFallbackForLegacyHeap(
+		final JobManagerProcessSpec processSpec = JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
 			flinkConfiguration,
 			JobManagerOptions.TOTAL_PROCESS_MEMORY);
 		final ContainerLaunchContext amContainer = setupApplicationMasterContainer(


### PR DESCRIPTION
FLINK-16742 states that the legacy JM heap options should fallback to JobManagerOptions.JVM_HEAP_MEMORY in standalone scripts. BashJavaUtils#getJmResourceParams has been implemented to fallback to JobManagerOptions.TOTAL_FLINK_MEMORY in #11545. This PR fixes this.