### PR TITLE
[FLINK-17643][tests] Fix LaunchCoordinatorTest instability by completing stubbing

### DIFF
--- a/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
+++ b/flink-mesos/src/test/scala/org/apache/flink/mesos/scheduler/LaunchCoordinatorTest.scala
@@ -403,6 +403,9 @@ class LaunchCoordinatorTest
       }
       "ResourceOffers" which {
         "stays in GatheringOffers with offer queue updated" in new Context {
+          private val result: SchedulingResult = schedulingResult(successes = Nil)
+          when(optimizer.scheduleOnce(MM.any(), MM.any())).thenReturn(result)
+
           fsm.setState(GatheringOffers,
             GatherData(tasks = Seq(task1._2), newLeases = Seq(lease(slave1._3))))
           fsm ! new ResourceOffers(Seq(slave1._4, slave2._3).asJava)


### PR DESCRIPTION
## What is the purpose of the change

The LaunchCoordinatorTest was susceptible to test failures because a test did not fully
define a mock. The test scheduled a scheduled action which, if executed long enough, would
be triggered and then call into an incomplete mock causing a NPE.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
