### PR TITLE
[FLINK-17636][network][tests] Fix the unstable unit tests in SingleInputGateTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.checkpoint.channel.InputChannelInfo;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.deployment.InputGateDeploymentDescriptor;
 import org.apache.flink.runtime.event.TaskEvent;
-import org.apache.flink.runtime.execution.CancelTaskException;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
@@ -226,7 +225,10 @@ public class SingleInputGateTest extends InputGateTestBase {
 						if (!getNextBufferAndVerify(inputGate, states)) {
 							Thread.sleep(1);
 						}
-					} catch (CancelTaskException expected) {
+					} catch (Throwable t) {
+						if (!inputGate.getCloseFuture().isDone()) {
+							throw new AssertionError("Exceptions are expected here only if the gate was closed", t);
+						}
 						return null;
 					}
 				}


### PR DESCRIPTION
## What is the purpose of the change

Fix the unstable unit test in SingleInputGateTest#testConcurrentReadStateAndProcessAndClose.
It not only throws `CancelTaskException` after gate closed during `getNextBuffer`, so we extend it to a general `Throwable` to avoid fragile.

## Brief change log

  - *Ignores any kind of exceptions after single gate closed inside `SingleInputGateTest#testConcurrentReadStateAndProcessAndClose`*

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
