### PR TITLE
[FLINK-17649][table-planner-blink] Generated hash aggregate code may …

### DIFF
--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenHelper.scala
@@ -465,8 +465,12 @@ object HashAggCodeGenHelper {
              |""".stripMargin.trim
 
         if (filterArg >= 0) {
+          var filterTerm = s"$inputTerm.getBoolean($filterArg)"
+          if (ctx.nullCheck) {
+            filterTerm = s"!$inputTerm.isNullAt($filterArg) && " + filterTerm
+          }
           s"""
-             |if ($inputTerm.getBoolean($filterArg)) {
+             |if ($filterTerm) {
              | $innerCode
              |}
           """.stripMargin

--- a/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
+++ b/flink-table/flink-table-planner-blink/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/agg/AggregateITCaseBase.scala
@@ -27,7 +27,6 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.types.Row
-
 import org.junit.{Before, Test}
 
 import scala.collection.Seq
@@ -118,6 +117,28 @@ abstract class AggregateITCaseBase(testName: String) extends BatchTestBase {
         row(1),
         row(2),
         row(3)
+      )
+    )
+  }
+
+  @Test
+  def testSimpleAndDistinctAggWithCommonFilter(): Unit = {
+    val sql =
+      """
+        |SELECT
+        |   h,
+        |   COUNT(1) FILTER(WHERE d > 1),
+        |   COUNT(1) FILTER(WHERE d < 2),
+        |   COUNT(DISTINCT e) FILTER(WHERE d > 1)
+        |FROM Table5
+        |GROUP BY h
+        |""".stripMargin
+    checkResult(
+      sql,
+      Seq(
+        row(1,0,1,4),
+        row(2,0,0,7),
+        row(3,0,0,3)
       )
     )
   }


### PR DESCRIPTION
…produce NPE in some cases existing aggregate call with Filter.

## What is the purpose of the change

When generating code for Filter predicate of aggregate call in `HashAggCodeGenHelper`, we should check the nullability of the boolean field firstly rather than `getBoolean` directly, otherwise, NPE may be produced.

## Brief change log
* This PR fix bugs in `HashAggCodeGenHelper`.

## Verifying this change
This change added tests:
* Add integration test in `AggregateITCaseBase` for end-to-end test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
