### PR TITLE
[FLINK-17660][table-common] Check default constructor for structured types

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -53,6 +53,7 @@ import static org.apache.flink.table.types.extraction.ExtractionUtils.collectTyp
 import static org.apache.flink.table.types.extraction.ExtractionUtils.createRawType;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.extractAssigningConstructor;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.extractionError;
+import static org.apache.flink.table.types.extraction.ExtractionUtils.hasInvokableConstructor;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.isStructuredFieldMutable;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.resolveVariable;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.toClass;
@@ -474,6 +475,12 @@ public final class DataTypeExtractor {
 					"accessible and assigns all fields: %s",
 				clazz.getName(),
 				fields.stream().map(Field::getName).collect(Collectors.joining(", ")));
+		}
+		// check for a default constructor otherwise
+		else if (constructor == null && !hasInvokableConstructor(clazz)) {
+			throw extractionError(
+				"Class '%s' has neither a constructor that assigns all fields nor a default constructor.",
+				clazz.getName());
 		}
 
 		final Map<String, DataType> fieldDataTypes = extractStructuredTypeFields(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -20,17 +20,16 @@ package org.apache.flink.table.types.extraction;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.DataTypeFactory;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.StructuredType;
-
 import org.apache.flink.shaded.asm7.org.objectweb.asm.ClassReader;
 import org.apache.flink.shaded.asm7.org.objectweb.asm.ClassVisitor;
 import org.apache.flink.shaded.asm7.org.objectweb.asm.Label;
 import org.apache.flink.shaded.asm7.org.objectweb.asm.MethodVisitor;
 import org.apache.flink.shaded.asm7.org.objectweb.asm.Opcodes;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.StructuredType;
 
 import javax.annotation.Nullable;
 
@@ -53,6 +52,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -66,6 +66,10 @@ import static org.apache.flink.shaded.asm7.org.objectweb.asm.Type.getMethodDescr
 @Internal
 public final class ExtractionUtils {
 
+	// --------------------------------------------------------------------------------------------
+	// Methods shared across packages
+	// --------------------------------------------------------------------------------------------
+
 	/**
 	 * Collects methods of the given name.
 	 */
@@ -77,29 +81,33 @@ public final class ExtractionUtils {
 	}
 
 	/**
-	 * Checks whether a method can be called with the given argument classes. This includes type
+	 * Checks whether a method/constructor can be called with the given argument classes. This includes type
 	 * widening and vararg. {@code null} is a wildcard.
 	 *
 	 * <p>E.g., {@code (int.class, int.class)} matches {@code f(Object...), f(int, int), f(Integer, Object)}
 	 * and so forth.
 	 */
-	public static boolean isMethodInvokable(Method method, Class<?>... classes) {
-		final int paramCount = method.getParameterCount();
+	public static boolean isInvokable(Executable executable, Class<?>... classes) {
+		final int m = executable.getModifiers();
+		if (!Modifier.isPublic(m)) {
+			return false;
+		}
+		final int paramCount = executable.getParameterCount();
 		final int classCount = classes.length;
 		// check for enough classes for each parameter
-		if (classCount < paramCount || (method.isVarArgs() && classCount < paramCount - 1)) {
+		if (classCount < paramCount || (executable.isVarArgs() && classCount < paramCount - 1)) {
 			return false;
 		}
 		int currentClass = 0;
 		for (int currentParam = 0; currentParam < paramCount; currentParam++) {
-			final Class<?> param = method.getParameterTypes()[currentParam];
+			final Class<?> param = executable.getParameterTypes()[currentParam];
 			// entire parameter matches
 			if (classes[currentClass] == null || ExtractionUtils.isAssignable(classes[currentClass], param, true)) {
 				currentClass++;
 			}
 			// last parameter is a vararg that consumes remaining classes
-			else if (currentParam == paramCount - 1 && method.isVarArgs()) {
-				final Class<?> paramComponent = method.getParameterTypes()[currentParam].getComponentType();
+			else if (currentParam == paramCount - 1 && executable.isVarArgs()) {
+				final Class<?> paramComponent = executable.getParameterTypes()[currentParam].getComponentType();
 				while (currentClass < classCount && ExtractionUtils.isAssignable(classes[currentClass], paramComponent, true)) {
 					currentClass++;
 				}
@@ -135,6 +143,125 @@ public final class ExtractionUtils {
 					.collect(Collectors.joining(", ", "(", ")")));
 		return builder.toString();
 	}
+
+	/**
+	 * Checks for a field getter of a structured type. The logic is as broad as possible to support
+	 * both Java and Scala in different flavors.
+	 */
+	public static Optional<Method> getStructuredFieldGetter(Class<?> clazz, Field field) {
+		final String normalizedFieldName = field.getName().toUpperCase();
+
+		final List<Method> methods = collectStructuredMethods(clazz);
+		for (Method method : methods) {
+			// check name:
+			// get<Name>()
+			// is<Name>()
+			// <Name>() for Scala
+			final String normalizedMethodName = method.getName().toUpperCase();
+			final boolean hasName = normalizedMethodName.equals("GET" + normalizedFieldName) ||
+				normalizedMethodName.equals("IS" + normalizedFieldName) ||
+				normalizedMethodName.equals(normalizedFieldName);
+			if (!hasName) {
+				continue;
+			}
+
+			// check return type:
+			// equal to field type
+			final Type returnType = method.getGenericReturnType();
+			final boolean hasReturnType = returnType.equals(field.getGenericType());
+			if (!hasReturnType) {
+				continue;
+			}
+
+			// check parameters:
+			// no parameters
+			final boolean hasNoParameters = method.getParameterCount() == 0;
+			if (!hasNoParameters) {
+				continue;
+			}
+
+			// matching getter found
+			return Optional.of(method);
+		}
+
+		// no getter found
+		return Optional.empty();
+	}
+
+	/**
+	 * Checks for a field setters of a structured type. The logic is as broad as possible to support
+	 * both Java and Scala in different flavors.
+	 */
+	public static Optional<Method> getStructuredFieldSetter(Class<?> clazz, Field field) {
+		final String normalizedFieldName = field.getName().toUpperCase();
+
+		final List<Method> methods = collectStructuredMethods(clazz);
+		for (Method method : methods) {
+
+			// check name:
+			// set<Name>(type)
+			// <Name>(type)
+			// <Name>_$eq(type) for Scala
+			final String normalizedMethodName = method.getName().toUpperCase();
+			final boolean hasName = normalizedMethodName.equals("SET" + normalizedFieldName) ||
+				normalizedMethodName.equals(normalizedFieldName) ||
+				normalizedMethodName.equals(normalizedFieldName + "_$EQ");
+			if (!hasName) {
+				continue;
+			}
+
+			// check return type:
+			// void or the declaring class
+			final Class<?> returnType = method.getReturnType();
+			final boolean hasReturnType = returnType == Void.TYPE || returnType == clazz;
+			if (!hasReturnType) {
+				continue;
+			}
+
+			// check parameters:
+			// one parameter that has the same (or primitive) type of the field
+			final boolean hasParameter = method.getParameterCount() == 1 &&
+				(method.getGenericParameterTypes()[0].equals(field.getGenericType()) ||
+					primitiveToWrapper(method.getGenericParameterTypes()[0]).equals(field.getGenericType()));
+			if (!hasParameter) {
+				continue;
+			}
+
+			// matching setter found
+			return Optional.of(method);
+		}
+
+		// no setter found
+		return Optional.empty();
+	}
+
+	/**
+	 * Checks for an invokable constructor matching the given arguments.
+	 *
+	 * @see #isInvokable(Executable, Class[])
+	 */
+	public static boolean hasInvokableConstructor(Class<?> clazz, Class<?>... classes) {
+		for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
+			if (isInvokable(constructor, classes)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks whether a field is directly readable without a getter.
+	 */
+	public static boolean isStructuredFieldDirectlyReadable(Field field) {
+		final int m = field.getModifiers();
+
+		// field is directly readable
+		return Modifier.isPublic(m);
+	}
+
+	// --------------------------------------------------------------------------------------------
+	// Methods intended for this package
+	// --------------------------------------------------------------------------------------------
 
 	/**
 	 * Helper method for creating consistent exceptions during extraction.
@@ -310,15 +437,13 @@ public final class ExtractionUtils {
 	 * Validates if a field is properly readable either directly or through a getter.
 	 */
 	static void validateStructuredFieldReadability(Class<?> clazz, Field field) {
-		final int m = field.getModifiers();
-
 		// field is accessible
-		if (Modifier.isPublic(m)) {
+		if (isStructuredFieldDirectlyReadable(field)) {
 			return;
 		}
 
 		// field needs a getter
-		if (!hasStructuredFieldGetter(clazz, field)) {
+		if (!getStructuredFieldGetter(clazz, field).isPresent()) {
 			throw extractionError(
 				"Field '%s' of class '%s' is neither publicly accessible nor does it have " +
 					"a corresponding getter method.",
@@ -342,8 +467,9 @@ public final class ExtractionUtils {
 		if (Modifier.isPublic(m)) {
 			return true;
 		}
+
 		// field has setters by which it is mutable
-		if (hasFieldSetter(clazz, field)) {
+		if (getStructuredFieldSetter(clazz, field).isPresent()) {
 			return true;
 		}
 
@@ -355,53 +481,6 @@ public final class ExtractionUtils {
 	}
 
 	/**
-	 * Checks for a field setters. The logic is as broad as possible to support both Java and Scala
-	 * in different flavors.
-	 */
-	static boolean hasFieldSetter(Class<?> clazz, Field field) {
-		final String normalizedFieldName = field.getName().toUpperCase();
-
-		final List<Method> methods = collectStructuredMethods(clazz);
-		for (Method method : methods) {
-
-			// check name:
-			// set<Name>(type)
-			// <Name>(type)
-			// <Name>_$eq(type) for Scala
-			final String normalizedMethodName = method.getName().toUpperCase();
-			final boolean hasName = normalizedMethodName.equals("SET" + normalizedFieldName) ||
-				normalizedMethodName.equals(normalizedFieldName) ||
-				normalizedMethodName.equals(normalizedFieldName + "_$EQ");
-			if (!hasName) {
-				continue;
-			}
-
-			// check return type:
-			// void or the declaring class
-			final Class<?> returnType = method.getReturnType();
-			final boolean hasReturnType = returnType == Void.TYPE || returnType == clazz;
-			if (!hasReturnType) {
-				continue;
-			}
-
-			// check parameters:
-			// one parameter that has the same (or primitive) type of the field
-			final boolean hasParameter = method.getParameterCount() == 1 &&
-				(method.getGenericParameterTypes()[0].equals(field.getGenericType()) ||
-					primitiveToWrapper(method.getGenericParameterTypes()[0]).equals(field.getGenericType()));
-			if (!hasParameter) {
-				continue;
-			}
-
-			// matching setter found
-			return true;
-		}
-
-		// no setter found
-		return false;
-	}
-
-	/**
 	 * Returns the boxed type of a primitive type.
 	 */
 	static Type primitiveToWrapper(Type type) {
@@ -409,50 +488,6 @@ public final class ExtractionUtils {
 			return primitiveToWrapper((Class<?>) type);
 		}
 		return type;
-	}
-
-	/**
-	 * Checks for a field getter. The logic is as broad as possible to support both Java and Scala
-	 * in different flavors.
-	 */
-	static boolean hasStructuredFieldGetter(Class<?> clazz, Field field) {
-		final String normalizedFieldName = field.getName().toUpperCase();
-
-		final List<Method> methods = collectStructuredMethods(clazz);
-		for (Method method : methods) {
-			// check name:
-			// get<Name>()
-			// is<Name>()
-			// <Name>() for Scala
-			final String normalizedMethodName = method.getName().toUpperCase();
-			final boolean hasName = normalizedMethodName.equals("GET" + normalizedFieldName) ||
-				normalizedMethodName.equals("IS" + normalizedFieldName) ||
-				normalizedMethodName.equals(normalizedFieldName);
-			if (!hasName) {
-				continue;
-			}
-
-			// check return type:
-			// equal to field type
-			final Type returnType = method.getGenericReturnType();
-			final boolean hasReturnType = returnType.equals(field.getGenericType());
-			if (!hasReturnType) {
-				continue;
-			}
-
-			// check parameters:
-			// no parameters
-			final boolean hasNoParameters = method.getParameterCount() == 0;
-			if (!hasNoParameters) {
-				continue;
-			}
-
-			// matching getter found
-			return true;
-		}
-
-		// no getter found
-		return false;
 	}
 
 	/**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/FunctionMappingExtractor.java
@@ -47,7 +47,7 @@ import static org.apache.flink.table.types.extraction.ExtractionUtils.collectMet
 import static org.apache.flink.table.types.extraction.ExtractionUtils.createMethodSignatureString;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.extractionError;
 import static org.apache.flink.table.types.extraction.ExtractionUtils.isAssignable;
-import static org.apache.flink.table.types.extraction.ExtractionUtils.isMethodInvokable;
+import static org.apache.flink.table.types.extraction.ExtractionUtils.isInvokable;
 import static org.apache.flink.table.types.extraction.TemplateUtils.extractGlobalFunctionTemplates;
 import static org.apache.flink.table.types.extraction.TemplateUtils.extractLocalFunctionTemplates;
 import static org.apache.flink.table.types.extraction.TemplateUtils.findInputOnlyTemplates;
@@ -419,7 +419,7 @@ final class FunctionMappingExtractor {
 		return (method, signature, result) -> {
 			final Class<?>[] parameters = signature.toArray(new Class[0]);
 			final Class<?> returnType = method.getReturnType();
-			final boolean isValid = isMethodInvokable(method, parameters) &&
+			final boolean isValid = isInvokable(method, parameters) &&
 				isAssignable(result, returnType, true);
 			if (!isValid) {
 				throw createMethodNotFoundError(method.getName(), parameters, result);
@@ -449,7 +449,7 @@ final class FunctionMappingExtractor {
 		return (method, signature, result) -> {
 			final Class<?>[] parameters = Stream.concat(Stream.of(argumentClass), signature.stream())
 				.toArray(Class<?>[]::new);
-			if (!isMethodInvokable(method, parameters)) {
+			if (!isInvokable(method, parameters)) {
 				throw createMethodNotFoundError(method.getName(), parameters, null);
 			}
 		};
@@ -461,7 +461,7 @@ final class FunctionMappingExtractor {
 	static MethodVerification createParameterVerification() {
 		return (method, signature, result) -> {
 			final Class<?>[] parameters = signature.toArray(new Class[0]);
-			if (!isMethodInvokable(method, parameters)) {
+			if (!isInvokable(method, parameters)) {
 				throw createMethodNotFoundError(method.getName(), parameters, null);
 			}
 		};

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/extraction/DataTypeExtractorTest.java
@@ -396,7 +396,14 @@ public class DataTypeExtractorTest {
 			// method with generic return type
 			TestSpec
 				.forMethodOutput(IntegerVarArg.class)
-				.expectDataType(DataTypes.INT())
+				.expectDataType(DataTypes.INT()),
+
+			// structured type with invalid constructor
+			TestSpec
+				.forType(SimplePojoWithInvalidConstructor.class)
+				.expectErrorMessage(
+					"Class '" + SimplePojoWithInvalidConstructor.class.getName() + "' has neither a " +
+						"constructor that assigns all fields nor a default constructor.")
 		);
 	}
 
@@ -941,5 +948,18 @@ public class DataTypeExtractorTest {
 
 	private static class RawTypeSpecific extends RawTypeGeneric {
 		// nothing to do
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	public static class SimplePojoWithInvalidConstructor {
+		public Integer intField;
+		public boolean primitiveBooleanField;
+		public int primitiveIntField;
+		public String stringField;
+
+		public SimplePojoWithInvalidConstructor(Integer intField) {
+			this.intField = intField;
+		}
 	}
 }

--- a/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
+++ b/flink-table/flink-table-planner-blink/src/main/scala/org/apache/flink/table/planner/codegen/calls/BridgingSqlFunctionCallGen.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.planner.functions.inference.OperatorBindingCallCon
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.runtime.collector.WrappingCollector
 import org.apache.flink.table.types.DataType
-import org.apache.flink.table.types.extraction.ExtractionUtils.{createMethodSignatureString, isAssignable, isMethodInvokable, primitiveToWrapper}
+import org.apache.flink.table.types.extraction.ExtractionUtils.{createMethodSignatureString, isAssignable, isInvokable, primitiveToWrapper}
 import org.apache.flink.table.types.inference.TypeInferenceUtil
 import org.apache.flink.table.types.logical.utils.LogicalTypeCasts.supportsAvoidingCast
 import org.apache.flink.table.types.logical.utils.LogicalTypeChecks.{hasRoot, isCompositeType}
@@ -332,7 +332,7 @@ class BridgingSqlFunctionCallGen(call: RexCall) extends CallGenerator {
     val outputClass = outputDataType.map(_.getConversionClass).getOrElse(classOf[Unit])
     // verifies regular JVM calling semantics
     def methodMatches(method: Method): Boolean = {
-      isMethodInvokable(method, argumentClasses: _*) &&
+      isInvokable(method, argumentClasses: _*) &&
         isAssignable(outputClass, method.getReturnType, true)
     }
     if (!methods.exists(methodMatches)) {


### PR DESCRIPTION
## What is the purpose of the change

If a field assigning constructor does not exist, we need to check for a default constructor.

## Brief change log

- Check for default constructor
- Refactor utilities a bit

## Verifying this change

This change is already covered by existing tests, such as `DataTypeExtractorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
