### PR TITLE
[hotfix][hive] Should clear StreamTestSink in HiveTableSourceTest

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -499,7 +499,6 @@ public class HiveTableSourceTest {
 		out.print(); // add print to see streaming reading
 		out.addSink(sink);
 
-		StreamTestSink.clear();
 		JobClient job = env.executeAsync("job");
 
 		Runnable runnable = () -> {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
 import org.apache.flink.table.planner.runtime.utils.TestingAppendRowDataSink;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
@@ -497,6 +498,8 @@ public class HiveTableSourceTest {
 		DataStream<RowData> out = tEnv.toAppendStream(src, RowData.class);
 		out.print(); // add print to see streaming reading
 		out.addSink(sink);
+
+		StreamTestSink.clear();
 		JobClient job = env.executeAsync("job");
 
 		Runnable runnable = () -> {
@@ -529,6 +532,7 @@ public class HiveTableSourceTest {
 		results.sort(String::compareTo);
 		assertEquals(expected, results);
 		job.cancel();
+		StreamTestSink.clear();
 	}
 
 	private void testSourceConfig(boolean fallbackMR, boolean inferParallelism) throws Exception {


### PR DESCRIPTION

## What is the purpose of the change

For future testing, we should clear StreamTestSink in HiveTableSourceTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no