### PR TITLE
[FLINK-17665][network] Serialize DataType of Buffer into BufferResponse

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/Buffer.java
@@ -238,6 +238,10 @@ public interface Buffer {
 	/**
 	 * Used to identify the type of data contained in the {@link Buffer} so that we can get
 	 * the information without deserializing the serialized data.
+	 *
+	 * <p>Notes: Currently, one byte is used to serialize the ordinal of {@link DataType} in
+	 * {@link org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse}, so the
+	 * maximum number of supported data types is 128.
 	 */
 	enum DataType {
 		/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NetworkBufferAllocator.java
@@ -66,12 +66,13 @@ class NetworkBufferAllocator {
 	 * Allocates an un-pooled network buffer with the specific size.
 	 *
 	 * @param size The requested buffer size.
+	 * @param dataType The data type this buffer represents.
 	 * @return The un-pooled network buffer.
 	 */
-	Buffer allocateUnPooledNetworkBuffer(int size) {
+	Buffer allocateUnPooledNetworkBuffer(int size, Buffer.DataType dataType) {
 		byte[] byteArray = new byte[size];
 		MemorySegment memSeg = MemorySegmentFactory.wrap(byteArray);
 
-		return new NetworkBuffer(memSeg, FreeingBufferRecycler.INSTANCE, Buffer.DataType.EVENT_BUFFER);
+		return new NetworkBuffer(memSeg, FreeingBufferRecycler.INSTANCE, dataType);
 	}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestQueueTest.java
@@ -395,8 +395,10 @@ public class PartitionRequestQueueTest {
 	@Test
 	public void testEnqueueReaderByResumingConsumption() throws Exception {
 		PipelinedSubpartition subpartition = PipelinedSubpartitionTest.createPipelinedSubpartition();
-		subpartition.add(createEventBufferConsumer(4096, Buffer.DataType.ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER));
-		subpartition.add(createEventBufferConsumer(4096, Buffer.DataType.DATA_BUFFER));
+		Buffer.DataType dataType1 = Buffer.DataType.ALIGNED_EXACTLY_ONCE_CHECKPOINT_BARRIER;
+		Buffer.DataType dataType2 = Buffer.DataType.DATA_BUFFER;
+		subpartition.add(createEventBufferConsumer(4096, dataType1));
+		subpartition.add(createEventBufferConsumer(4096, dataType2));
 
 		BufferAvailabilityListener bufferAvailabilityListener = new NoOpBufferAvailablityListener();
 		PipelinedSubpartitionView view = subpartition.createReadView(bufferAvailabilityListener);
@@ -423,9 +425,9 @@ public class PartitionRequestQueueTest {
 		assertEquals(0, subpartition.unsynchronizedGetNumberOfQueuedBuffers());
 
 		Object data1 = channel.readOutbound();
-		assertFalse(((NettyMessage.BufferResponse) data1).isBuffer);
+		assertEquals(dataType1, ((NettyMessage.BufferResponse) data1).buffer.getDataType());
 		Object data2 = channel.readOutbound();
-		assertTrue(((NettyMessage.BufferResponse) data2).isBuffer);
+		assertEquals(dataType2, ((NettyMessage.BufferResponse) data2).buffer.getDataType());
 	}
 
 	@Test


### PR DESCRIPTION
## What is the purpose of the change

After serializing DataType of Buffer into BufferResponse, we can get the DataType at downstream without deserializing the Buffer, which is more performance friendly.


## Brief change log

  - Serialize DataType of Buffer into BufferResponse


## Verifying this change

Existing test is modified to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
