### PR TITLE
[FLINK-17668][table] Fix shortcomings in new data structures

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ValuesOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ValuesOperationFactory.java
@@ -38,7 +38,6 @@ import org.apache.flink.table.types.FieldsDataType;
 import org.apache.flink.table.types.KeyValueDataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
-import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeGeneralization;
 import org.apache.flink.table.types.utils.TypeConversions;
 
@@ -202,13 +201,10 @@ class ValuesOperationFactory {
 			ResolvedExpression sourceExpression,
 			FieldsDataType targetDataType,
 			ExpressionResolver.PostResolverFactory postResolverFactory) {
-		DataType[] targetDataTypes = ((RowType) targetDataType.getLogicalType()).getFieldNames()
-			.stream()
-			.map(name -> targetDataType.getFieldDataTypes().get(name))
-			.toArray(DataType[]::new);
+		List<DataType> targetDataTypes = targetDataType.getChildren();
 		List<ResolvedExpression> resolvedChildren = sourceExpression.getResolvedChildren();
 
-		if (resolvedChildren.size() != targetDataTypes.length) {
+		if (resolvedChildren.size() != targetDataTypes.size()) {
 			return Optional.empty();
 		}
 
@@ -217,13 +213,13 @@ class ValuesOperationFactory {
 			boolean typesMatch = resolvedChildren.get(i)
 				.getOutputDataType()
 				.getLogicalType()
-				.equals(targetDataTypes[i].getLogicalType());
+				.equals(targetDataTypes.get(i).getLogicalType());
 			if (typesMatch) {
 				castedChildren[i] = resolvedChildren.get(i);
 			}
 
 			ResolvedExpression child = resolvedChildren.get(i);
-			DataType targetChildDataType = targetDataTypes[i];
+			DataType targetChildDataType = targetDataTypes.get(i);
 
 			Optional<ResolvedExpression> castedChild = convertToExpectedType(
 				child,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -661,8 +661,9 @@ public final class DataTypes {
 			.map(f -> Preconditions.checkNotNull(f, "Field definition must not be null."))
 			.map(f -> new RowField(f.name, f.dataType.getLogicalType(), f.description))
 			.collect(Collectors.toList());
-		final Map<String, DataType> fieldDataTypes = Stream.of(fields)
-			.collect(Collectors.toMap(f -> f.name, f -> f.dataType));
+		final List<DataType> fieldDataTypes = Stream.of(fields)
+			.map(f -> f.dataType)
+			.collect(Collectors.toList());
 		return new FieldsDataType(new RowType(logicalFields), fieldDataTypes);
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -21,10 +21,19 @@ package org.apache.flink.table.data;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.TimestampType;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldCount;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
 
 /**
  * Base interface of an internal data structure representing data of {@link ArrayType}.
@@ -163,7 +172,9 @@ public interface ArrayData {
 	 * @param pos position of the element to return
 	 * @param elementType the element type of the array
 	 * @return the element object at the specified position in this array data
+	 * @deprecated Use {@link #createElementGetter(LogicalType)} for a more efficient hot path.
 	 */
+	@Deprecated
 	static Object get(ArrayData array, int pos, LogicalType elementType) {
 		if (array.isNullAt(pos)) {
 			return null;
@@ -214,5 +225,104 @@ public interface ArrayData {
 			default:
 				throw new UnsupportedOperationException("Unsupported type: " + elementType);
 		}
+	}
+
+	/**
+	 * Creates an accessor for getting elements in an internal array data structure at the
+	 * given position.
+	 *
+	 * @param elementType the element type of the array
+	 */
+	static ElementGetter createElementGetter(LogicalType elementType) {
+		final ElementGetter elementGetter;
+		// ordered by type root definition
+		switch (elementType.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+				elementGetter = ArrayData::getString;
+				break;
+			case BOOLEAN:
+				elementGetter = ArrayData::getBoolean;
+				break;
+			case BINARY:
+			case VARBINARY:
+				elementGetter = ArrayData::getBinary;
+				break;
+			case DECIMAL:
+				final int decimalPrecision = getPrecision(elementType);
+				final int decimalScale = getScale(elementType);
+				elementGetter = (array, pos) -> array.getDecimal(pos, decimalPrecision, decimalScale);
+				break;
+			case TINYINT:
+				elementGetter = ArrayData::getByte;
+				break;
+			case SMALLINT:
+				elementGetter = ArrayData::getShort;
+				break;
+			case INTEGER:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+				elementGetter = ArrayData::getInt;
+				break;
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				elementGetter = ArrayData::getLong;
+				break;
+			case FLOAT:
+				elementGetter = ArrayData::getFloat;
+				break;
+			case DOUBLE:
+				elementGetter = ArrayData::getDouble;
+				break;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				final int timestampPrecision = getPrecision(elementType);
+				elementGetter = (array, pos) -> array.getTimestamp(pos, timestampPrecision);
+				break;
+			case TIMESTAMP_WITH_TIME_ZONE:
+				throw new UnsupportedOperationException();
+			case ARRAY:
+				elementGetter = ArrayData::getArray;
+				break;
+			case MULTISET:
+			case MAP:
+				elementGetter = ArrayData::getMap;
+				break;
+			case ROW:
+			case STRUCTURED_TYPE:
+				final int rowFieldCount = getFieldCount(elementType);
+				elementGetter = (array, pos) -> array.getRow(pos, rowFieldCount);
+				break;
+			case DISTINCT_TYPE:
+				elementGetter = createElementGetter(((DistinctType) elementType).getSourceType());
+				break;
+			case RAW:
+				elementGetter = ArrayData::getRawValue;
+				break;
+			case NULL:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				throw new IllegalArgumentException();
+		}
+		if (!elementType.isNullable()) {
+			return elementGetter;
+		}
+		return (array, pos) -> {
+			if (array.isNullAt(pos)) {
+				return null;
+			}
+			return elementGetter.getElementOrNull(array, pos);
+		};
+	}
+
+	/**
+	 * Accessor for getting the elements of an array during runtime.
+	 *
+	 * @see #createElementGetter(LogicalType)
+	 */
+	interface ElementGetter extends Serializable {
+		@Nullable Object getElementOrNull(ArrayData array, int pos);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/ArrayData.java
@@ -172,7 +172,7 @@ public interface ArrayData {
 	 * @param pos position of the element to return
 	 * @param elementType the element type of the array
 	 * @return the element object at the specified position in this array data
-	 * @deprecated Use {@link #createElementGetter(LogicalType)} for a more efficient hot path.
+	 * @deprecated Use {@link #createElementGetter(LogicalType)} for avoiding logical types during runtime.
 	 */
 	@Deprecated
 	static Object get(ArrayData array, int pos, LogicalType elementType) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
@@ -23,6 +23,9 @@ import org.apache.flink.table.types.logical.ArrayType;
 
 import org.apache.commons.lang3.ArrayUtils;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * An internal data structure representing data of {@link ArrayType}.
  *
@@ -130,6 +133,25 @@ public final class GenericArrayData implements ArrayData {
 	@Override
 	public boolean isNullAt(int pos) {
 		return !isPrimitiveArray && ((Object[]) array)[pos] == null;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GenericArrayData that = (GenericArrayData) o;
+		return size == that.size &&
+			isPrimitiveArray == that.isPrimitiveArray &&
+			Arrays.deepEquals(new Object[] {array}, new Object[]{that.array});
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(array, size, isPrimitiveArray);
 	}
 
 	// ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericArrayData.java
@@ -146,12 +146,14 @@ public final class GenericArrayData implements ArrayData {
 		GenericArrayData that = (GenericArrayData) o;
 		return size == that.size &&
 			isPrimitiveArray == that.isPrimitiveArray &&
-			Arrays.deepEquals(new Object[] {array}, new Object[]{that.array});
+			Objects.deepEquals(array, that.array);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(array, size, isPrimitiveArray);
+		int result = Objects.hash(size, isPrimitiveArray);
+		result = 31 * result + Arrays.deepHashCode(new Object[]{array});
+		return result;
 	}
 
 	// ------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An internal data structure representing data of {@link MapType} or {@link MultisetType}.
@@ -73,6 +74,23 @@ public final class GenericMapData implements MapData {
 	public ArrayData valueArray() {
 		Object[] values = map.values().toArray();
 		return new GenericArrayData(values);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GenericMapData that = (GenericMapData) o;
+		return Objects.equals(map, that.map);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(map);
 	}
 }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 
+import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 
 /**
  * An internal data structure representing data of {@link MapType} or {@link MultisetType}.
@@ -85,12 +85,15 @@ public final class GenericMapData implements MapData {
 			return false;
 		}
 		GenericMapData that = (GenericMapData) o;
-		return Objects.equals(map, that.map);
+		return Arrays.deepEquals(map.keySet().toArray(), that.map.keySet().toArray()) &&
+			Arrays.deepEquals(map.values().toArray(), that.map.values().toArray());
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(map);
+		int result = Arrays.deepHashCode(map.keySet().toArray());
+		result = 31 * result + Arrays.deepHashCode(map.values().toArray());
+		return result;
 	}
 }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericMapData.java
@@ -22,8 +22,8 @@ import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 
-import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An internal data structure representing data of {@link MapType} or {@link MultisetType}.
@@ -78,21 +78,48 @@ public final class GenericMapData implements MapData {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
+		if (o == this) {
 			return true;
 		}
-		if (o == null || getClass() != o.getClass()) {
+		if (!(o instanceof GenericMapData)) {
 			return false;
 		}
-		GenericMapData that = (GenericMapData) o;
-		return Arrays.deepEquals(map.keySet().toArray(), that.map.keySet().toArray()) &&
-			Arrays.deepEquals(map.values().toArray(), that.map.values().toArray());
+		// deepEquals for values of byte[]
+		return deepEquals(map, ((GenericMapData) o).map);
+	}
+
+	private static <K, V> boolean deepEquals(Map<K, V> m1, Map<?, ?> m2) {
+		// copied from HashMap.equals but with deepEquals comparision
+		if (m1.size() != m2.size()) {
+			return false;
+		}
+		try {
+			for (Map.Entry<K, V> e : m1.entrySet()) {
+				K key = e.getKey();
+				V value = e.getValue();
+				if (value == null) {
+					if (!(m2.get(key) == null && m2.containsKey(key))) {
+						return false;
+					}
+				} else {
+					if (!Objects.deepEquals(value, m2.get(key))) {
+						return false;
+					}
+				}
+			}
+		} catch (ClassCastException | NullPointerException unused) {
+			return false;
+		}
+		return true;
 	}
 
 	@Override
 	public int hashCode() {
-		int result = Arrays.deepHashCode(map.keySet().toArray());
-		result = 31 * result + Arrays.deepHashCode(map.values().toArray());
+		int result = 0;
+		for (Object key : map.keySet()) {
+			// only include key because values can contain byte[]
+			result += 31 * key.hashCode();
+		}
 		return result;
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/GenericRowData.java
@@ -25,6 +25,7 @@ import org.apache.flink.types.RowKind;
 import org.apache.flink.util.StringUtils;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -191,17 +192,22 @@ public final class GenericRowData implements RowData {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof GenericRowData) {
-			GenericRowData other = (GenericRowData) o;
-			return kind == other.kind && Arrays.equals(fields, other.fields);
-		} else {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof GenericRowData)) {
 			return false;
 		}
+		GenericRowData that = (GenericRowData) o;
+		return kind == that.kind &&
+			Arrays.deepEquals(fields, that.fields);
 	}
 
 	@Override
 	public int hashCode() {
-		return 31 * kind.hashCode() + Arrays.hashCode(fields);
+		int result = Objects.hash(kind);
+		result = 31 * result + Arrays.deepHashCode(fields);
+		return result;
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RawValueData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RawValueData.java
@@ -61,7 +61,14 @@ public interface RawValueData<T> {
 	 * Creates an instance of {@link RawValueData} from a Java object.
 	 */
 	static <T> RawValueData<T> fromObject(T javaObject) {
-		return new BinaryRawValueData<>(javaObject);
+		return BinaryRawValueData.fromObject(javaObject);
+	}
+
+	/**
+	 * Creates an instance of {@link RawValueData} from the given byte array.
+	 */
+	static <T> RawValueData<T> fromBytes(byte[] bytes) {
+		return BinaryRawValueData.fromBytes(bytes);
 	}
 
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -21,12 +21,21 @@ package org.apache.flink.table.data;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.StructuredType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getFieldCount;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
 
 /**
  * Base interface for an internal data structure representing data of {@link RowType} and other
@@ -228,6 +237,7 @@ public interface RowData {
 	 * @param pos position of the field to return
 	 * @param fieldType the field type
 	 * @return the field object at the specified position in this row data.
+	 * @deprecated Use {@link #createFieldGetter(LogicalType, int)} for a more efficient hot path.
 	 */
 	static Object get(RowData row, int pos, LogicalType fieldType) {
 		if (row.isNullAt(pos)) {
@@ -279,5 +289,105 @@ public interface RowData {
 			default:
 				throw new UnsupportedOperationException("Unsupported type: " + fieldType);
 		}
+	}
+
+	/**
+	 * Creates an accessor for getting elements in an internal row data structure at the
+	 * given position.
+	 *
+	 * @param fieldType the element type of the row
+	 * @param fieldPos the element type of the row
+	 */
+	static FieldGetter createFieldGetter(LogicalType fieldType, int fieldPos) {
+		final FieldGetter fieldGetter;
+		// ordered by type root definition
+		switch (fieldType.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+				fieldGetter = row -> row.getString(fieldPos);
+				break;
+			case BOOLEAN:
+				fieldGetter = row -> row.getBoolean(fieldPos);
+				break;
+			case BINARY:
+			case VARBINARY:
+				fieldGetter = row -> row.getBinary(fieldPos);
+				break;
+			case DECIMAL:
+				final int decimalPrecision = getPrecision(fieldType);
+				final int decimalScale = getScale(fieldType);
+				fieldGetter = row -> row.getDecimal(fieldPos, decimalPrecision, decimalScale);
+				break;
+			case TINYINT:
+				fieldGetter = row -> row.getByte(fieldPos);
+				break;
+			case SMALLINT:
+				fieldGetter = row -> row.getShort(fieldPos);
+				break;
+			case INTEGER:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+				fieldGetter = row -> row.getInt(fieldPos);
+				break;
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				fieldGetter = row -> row.getLong(fieldPos);
+				break;
+			case FLOAT:
+				fieldGetter = row -> row.getFloat(fieldPos);
+				break;
+			case DOUBLE:
+				fieldGetter = row -> row.getDouble(fieldPos);
+				break;
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				final int timestampPrecision = getPrecision(fieldType);
+				fieldGetter = row -> row.getTimestamp(fieldPos, timestampPrecision);
+				break;
+			case TIMESTAMP_WITH_TIME_ZONE:
+				throw new UnsupportedOperationException();
+			case ARRAY:
+				fieldGetter = row -> row.getArray(fieldPos);
+				break;
+			case MULTISET:
+			case MAP:
+				fieldGetter = row -> row.getMap(fieldPos);
+				break;
+			case ROW:
+			case STRUCTURED_TYPE:
+				final int rowFieldCount = getFieldCount(fieldType);
+				fieldGetter = row -> row.getRow(fieldPos, rowFieldCount);
+				break;
+			case DISTINCT_TYPE:
+				fieldGetter = createFieldGetter(((DistinctType) fieldType).getSourceType(), fieldPos);
+				break;
+			case RAW:
+				fieldGetter = row -> row.getRawValue(fieldPos);
+				break;
+			case NULL:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				throw new IllegalArgumentException();
+		}
+		if (!fieldType.isNullable()) {
+			return fieldGetter;
+		}
+		return row -> {
+			if (row.isNullAt(fieldPos)) {
+				return null;
+			}
+			return fieldGetter.getFieldOrNull(row);
+		};
+	}
+
+	/**
+	 * Accessor for getting the field of a row during runtime.
+	 *
+	 * @see #createFieldGetter(LogicalType, int)
+	 */
+	interface FieldGetter extends Serializable {
+		@Nullable Object getFieldOrNull(RowData row);
 	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/RowData.java
@@ -237,7 +237,7 @@ public interface RowData {
 	 * @param pos position of the field to return
 	 * @param fieldType the field type
 	 * @return the field object at the specified position in this row data.
-	 * @deprecated Use {@link #createFieldGetter(LogicalType, int)} for a more efficient hot path.
+	 * @deprecated Use {@link #createFieldGetter(LogicalType, int)} for avoiding logical types during runtime.
 	 */
 	static Object get(RowData row, int pos, LogicalType fieldType) {
 		if (row.isNullAt(pos)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
 
@@ -70,10 +71,32 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
 	 * It store the length and offset of variable-length part when type is string, map, etc.
 	 */
 	public static int calculateFixLengthPartSize(LogicalType type) {
+		// ordered by type root definition
 		switch (type.getTypeRoot()) {
 			case BOOLEAN:
 			case TINYINT:
 				return 1;
+			case CHAR:
+			case VARCHAR:
+			case BINARY:
+			case VARBINARY:
+			case DECIMAL:
+			case BIGINT:
+			case DOUBLE:
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+			case INTERVAL_DAY_TIME:
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case STRUCTURED_TYPE:
+			case RAW:
+				// long, double is 8 bytes.
+				// It store the length and offset of variable-length part when type is string, map, etc.
+				return 8;
+			case TIMESTAMP_WITH_TIME_ZONE:
+				throw new UnsupportedOperationException();
 			case SMALLINT:
 				return 2;
 			case INTEGER:
@@ -82,10 +105,13 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
 			case TIME_WITHOUT_TIME_ZONE:
 			case INTERVAL_YEAR_MONTH:
 				return 4;
+			case DISTINCT_TYPE:
+				return calculateFixLengthPartSize(((DistinctType) type).getSourceType());
+			case NULL:
+			case SYMBOL:
+			case UNRESOLVED:
 			default:
-				// long, double is 8 bytes.
-				// It store the length and offset of variable-length part when type is string, map, etc.
-				return 8;
+				throw new IllegalStateException();
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryArrayData.java
@@ -92,8 +92,9 @@ public final class BinaryArrayData extends BinarySection implements ArrayData, T
 			case ROW:
 			case STRUCTURED_TYPE:
 			case RAW:
-				// long, double is 8 bytes.
-				// It store the length and offset of variable-length part when type is string, map, etc.
+				// long and double are 8 bytes;
+				// otherwise it stores the length and offset of the variable-length part for types
+				// such as is string, map, etc.
 				return 8;
 			case TIMESTAMP_WITH_TIME_ZONE:
 				throw new UnsupportedOperationException();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRawValueData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryRawValueData.java
@@ -104,4 +104,35 @@ public final class BinaryRawValueData<T> extends LazyBinaryFormat<T> implements 
 			throw new RuntimeException(e);
 		}
 	}
+
+	// ------------------------------------------------------------------------------------------
+	// Construction Utilities
+	// ------------------------------------------------------------------------------------------
+
+	/**
+	 * Creates a {@link BinaryRawValueData} instance from the given Java object.
+	 */
+	public static <T> BinaryRawValueData<T> fromObject(T javaObject) {
+		if (javaObject == null) {
+			return null;
+		}
+		return new BinaryRawValueData<>(javaObject);
+	}
+
+	/**
+	 * Creates a {@link BinaryStringData} instance from the given bytes.
+	 */
+	public static <T> BinaryRawValueData<T> fromBytes(byte[] bytes) {
+		return fromBytes(bytes, 0, bytes.length);
+	}
+
+	/**
+	 * Creates a {@link BinaryStringData} instance from the given bytes with offset and number of bytes.
+	 */
+	public static <T> BinaryRawValueData<T> fromBytes(byte[] bytes, int offset, int numBytes) {
+		return new BinaryRawValueData<>(
+			new MemorySegment[] {MemorySegmentFactory.wrap(bytes)},
+			offset,
+			numBytes);
+	}
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/data/binary/BinaryStringData.java
@@ -63,7 +63,7 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
 	// ------------------------------------------------------------------------------------------
 
 	/**
-	 * Creates an BinaryStringData from given address (base and offset) and length.
+	 * Creates a {@link BinaryStringData} instance from the given address (base and offset) and length.
 	 */
 	public static BinaryStringData fromAddress(
 			MemorySegment[] segments,
@@ -73,7 +73,7 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
 	}
 
 	/**
-	 * Creates an BinaryStringData from given java String.
+	 * Creates a {@link BinaryStringData} instance from the given Java string.
 	 */
 	public static BinaryStringData fromString(String str) {
 		if (str == null) {
@@ -84,14 +84,14 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
 	}
 
 	/**
-	 * Creates an BinaryStringData from given UTF-8 bytes.
+	 * Creates a {@link BinaryStringData} instance from the given UTF-8 bytes.
 	 */
 	public static BinaryStringData fromBytes(byte[] bytes) {
 		return fromBytes(bytes, 0, bytes.length);
 	}
 
 	/**
-	 * Creates an BinaryStringData from given UTF-8 bytes with offset and number of bytes.
+	 * Creates a {@link BinaryStringData} instance from the given UTF-8 bytes with offset and number of bytes.
 	 */
 	public static BinaryStringData fromBytes(byte[] bytes, int offset, int numBytes) {
 		return new BinaryStringData(
@@ -101,7 +101,7 @@ public final class BinaryStringData extends LazyBinaryFormat<String> implements 
 	}
 
 	/**
-	 * Creates an BinaryStringData that contains `length` spaces.
+	 * Creates a {@link BinaryStringData} instance that contains `length` spaces.
 	 */
 	public static BinaryStringData blankString(int length) {
 		byte[] spaces = new byte[length];

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/AtomicDataType.java
@@ -25,6 +25,9 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * A data type that does not contain further data types (e.g. {@code INT} or {@code BOOLEAN}).
  *
@@ -60,6 +63,11 @@ public final class AtomicDataType extends DataType {
 		return new AtomicDataType(
 			logicalType,
 			Preconditions.checkNotNull(newConversionClass, "New conversion class must not be null."));
+	}
+
+	@Override
+	public List<DataType> getChildren() {
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/CollectionDataType.java
@@ -27,6 +27,8 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.lang.reflect.Array;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -79,6 +81,11 @@ public final class CollectionDataType extends DataType {
 			logicalType,
 			Preconditions.checkNotNull(newConversionClass, "New conversion class must not be null."),
 			elementDataType);
+	}
+
+	@Override
+	public List<DataType> getChildren() {
+		return Collections.singletonList(elementDataType);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/DataType.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -83,6 +84,8 @@ public abstract class DataType implements AbstractDataType<DataType>, Serializab
 	public Class<?> getConversionClass() {
 		return conversionClass;
 	}
+
+	public abstract List<DataType> getChildren();
 
 	public abstract <R> R accept(DataTypeVisitor<R> visitor);
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/KeyValueDataType.java
@@ -25,6 +25,8 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -89,6 +91,11 @@ public final class KeyValueDataType extends DataType {
 			Preconditions.checkNotNull(newConversionClass, "New conversion class must not be null."),
 			keyDataType,
 			valueDataType);
+	}
+
+	@Override
+	public List<DataType> getChildren() {
+		return Arrays.asList(keyDataType, valueDataType);
 	}
 
 	@Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/DataTypeExtractor.java
@@ -482,11 +482,20 @@ public final class DataTypeExtractor {
 			type,
 			fields);
 
+		final List<StructuredAttribute> attributes = createStructuredTypeAttributes(
+			constructor,
+			fieldDataTypes);
+
 		final StructuredType.Builder builder = StructuredType.newBuilder(clazz);
-		builder.attributes(createStructuredTypeAttributes(constructor, fieldDataTypes));
+		builder.attributes(attributes);
 		builder.setFinal(true); // anonymous structured types should not allow inheritance
 		builder.setInstantiable(true);
-		return new FieldsDataType(builder.build(), clazz, fieldDataTypes);
+		return new FieldsDataType(
+			builder.build(),
+			clazz,
+			attributes.stream()
+				.map(a -> fieldDataTypes.get(a.getName()))
+				.collect(Collectors.toList()));
 	}
 
 	private Map<String, DataType> extractStructuredTypeFields(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecks.java
@@ -30,7 +30,10 @@ import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampKind;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -40,6 +43,8 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -64,6 +69,10 @@ public final class LogicalTypeChecks {
 	private static final FractionalPrecisionExtractor FRACTIONAL_PRECISION_EXTRACTOR = new FractionalPrecisionExtractor();
 
 	private static final SingleFieldIntervalExtractor SINGLE_FIELD_INTERVAL_EXTRACTOR = new SingleFieldIntervalExtractor();
+
+	private static final FieldCountExtractor FIELD_COUNT_EXTRACTOR = new FieldCountExtractor();
+
+	private static final FieldNamesExtractor FIELD_NAMES_EXTRACTOR = new FieldNamesExtractor();
 
 	public static boolean hasRoot(LogicalType logicalType, LogicalTypeRoot typeRoot) {
 		return logicalType.getTypeRoot() == typeRoot;
@@ -170,6 +179,20 @@ public final class LogicalTypeChecks {
 
 	public static boolean isSingleFieldInterval(LogicalType logicalType) {
 		return logicalType.accept(SINGLE_FIELD_INTERVAL_EXTRACTOR);
+	}
+
+	/**
+	 * Returns the field count of row and structured types.
+	 */
+	public static int getFieldCount(LogicalType logicalType) {
+		return logicalType.accept(FIELD_COUNT_EXTRACTOR);
+	}
+
+	/**
+	 * Returns the field names of row and structured types.
+	 */
+	public static List<String> getFieldNames(LogicalType logicalType) {
+		return logicalType.accept(FIELD_NAMES_EXTRACTOR);
 	}
 
 	private LogicalTypeChecks() {
@@ -357,6 +380,57 @@ public final class LogicalTypeChecks {
 				default:
 					return false;
 			}
+		}
+	}
+
+	private static class FieldCountExtractor extends Extractor<Integer> {
+
+		@Override
+		public Integer visit(RowType rowType) {
+			return rowType.getFieldCount();
+		}
+
+		@Override
+		public Integer visit(StructuredType structuredType) {
+			int fieldCount = 0;
+			StructuredType currentType = structuredType;
+			while (currentType != null) {
+				fieldCount += currentType.getAttributes().size();
+				currentType = currentType.getSuperType().orElse(null);
+			}
+			return fieldCount;
+		}
+
+		@Override
+		public Integer visit(DistinctType distinctType) {
+			return distinctType.getSourceType().accept(this);
+		}
+	}
+
+	private static class FieldNamesExtractor extends Extractor<List<String>> {
+
+		@Override
+		public List<String> visit(RowType rowType) {
+			return rowType.getFieldNames();
+		}
+
+		@Override
+		public List<String> visit(StructuredType structuredType) {
+			final List<String> fieldNames = new ArrayList<>();
+			// add super fields first
+			structuredType.getSuperType()
+				.map(superType -> superType.accept(this))
+				.ifPresent(fieldNames::addAll);
+			// then specific fields
+			structuredType.getAttributes().stream()
+				.map(StructuredAttribute::getName)
+				.forEach(fieldNames::add);
+			return fieldNames;
+		}
+
+		@Override
+		public List<String> visit(DistinctType distinctType) {
+			return distinctType.getSourceType().accept(this);
 		}
 	}
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/utils/LogicalTypeDataTypeConverter.java
@@ -45,7 +45,6 @@ import org.apache.flink.table.types.logical.RawType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.StructuredType;
-import org.apache.flink.table.types.logical.StructuredType.StructuredAttribute;
 import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
@@ -55,7 +54,8 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -202,9 +202,10 @@ public final class LogicalTypeDataTypeConverter {
 
 		@Override
 		public DataType visit(RowType rowType) {
-			final Map<String, DataType> fieldDataTypes = rowType.getFields()
+			final List<DataType> fieldDataTypes = rowType.getFields()
 				.stream()
-				.collect(Collectors.toMap(RowType.RowField::getName, f -> f.getType().accept(this)));
+				.map(f -> f.getType().accept(this))
+				.collect(Collectors.toList());
 			return new FieldsDataType(
 				rowType,
 				fieldDataTypes);
@@ -212,14 +213,17 @@ public final class LogicalTypeDataTypeConverter {
 
 		@Override
 		public DataType visit(DistinctType distinctType) {
-			return distinctType.getSourceType().accept(this);
+			return new FieldsDataType(
+				distinctType,
+				Collections.singletonList(distinctType.getSourceType().accept(this)));
 		}
 
 		@Override
 		public DataType visit(StructuredType structuredType) {
-			final Map<String, DataType> attributeDataTypes = structuredType.getAttributes()
+			final List<DataType> attributeDataTypes = structuredType.getAttributes()
 				.stream()
-				.collect(Collectors.toMap(StructuredAttribute::getName, a -> a.getType().accept(this)));
+				.map(a -> a.getType().accept(this))
+				.collect(Collectors.toList());
 			return new FieldsDataType(
 				structuredType,
 				attributeDataTypes);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/logical/utils/LogicalTypeChecksTest.java
@@ -32,8 +32,7 @@ import org.apache.flink.table.types.utils.TypeConversions;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
@@ -99,10 +98,8 @@ public class LogicalTypeChecksTest {
 			))
 			.build();
 
-		Map<String, DataType> dataTypes = new HashMap<>();
-		dataTypes.put("f0", DataTypes.INT());
-		dataTypes.put("f1", DataTypes.STRING());
-		FieldsDataType dataType = new FieldsDataType(logicalType, dataTypes);
+		List<DataType> fieldDataTypes = Arrays.asList(DataTypes.INT(), DataTypes.STRING());
+		FieldsDataType dataType = new FieldsDataType(logicalType, fieldDataTypes);
 		boolean isCompositeType = LogicalTypeChecks.isCompositeType(dataType.getLogicalType());
 
 		assertThat(isCompositeType, is(true));
@@ -122,5 +119,17 @@ public class LogicalTypeChecksTest {
 		boolean isCompositeType = LogicalTypeChecks.isCompositeType(dataType.getLogicalType());
 
 		assertThat(isCompositeType, is(false));
+	}
+
+	@Test
+	public void testFieldNameExtraction() {
+		DataType dataType = ROW(FIELD("f0", INT()), FIELD("f1", STRING()));
+		assertThat(LogicalTypeChecks.getFieldNames(dataType.getLogicalType()), is(Arrays.asList("f0", "f1")));
+	}
+
+	@Test
+	public void testFieldCountExtraction() {
+		DataType dataType = ROW(FIELD("f0", INT()), FIELD("f1", STRING()));
+		assertThat(LogicalTypeChecks.getFieldCount(dataType.getLogicalType()), is(2));
 	}
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/utils/DataTypeUtilsTest.java
@@ -34,8 +34,7 @@ import org.junit.Test;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
 
 import static org.apache.flink.table.api.DataTypes.FIELD;
 import static org.apache.flink.table.api.DataTypes.INT;
@@ -98,11 +97,11 @@ public class DataTypeUtilsTest {
 			))
 			.build();
 
-		Map<String, DataType> dataTypes = new HashMap<>();
-		dataTypes.put("f0", DataTypes.INT());
-		dataTypes.put("f1", DataTypes.STRING());
-		dataTypes.put("f2", DataTypes.TIMESTAMP(5).bridgedTo(Timestamp.class));
-		dataTypes.put("f3", DataTypes.TIMESTAMP(3));
+		List<DataType> dataTypes = Arrays.asList(
+			DataTypes.INT(),
+			DataTypes.STRING(),
+			DataTypes.TIMESTAMP(5).bridgedTo(Timestamp.class),
+			DataTypes.TIMESTAMP(3));
 		FieldsDataType dataType = new FieldsDataType(logicalType, dataTypes);
 
 		TableSchema schema = DataTypeUtils.expandCompositeTypeToSchema(dataType);
@@ -131,7 +130,7 @@ public class DataTypeUtilsTest {
 			ObjectIdentifier.of("catalog", "database", "type"),
 			originalLogicalType)
 			.build();
-		DataType distinctDataType = new FieldsDataType(distinctLogicalType, dataType.getFieldDataTypes());
+		DataType distinctDataType = new FieldsDataType(distinctLogicalType, dataType.getChildren());
 
 		TableSchema schema = DataTypeUtils.expandCompositeTypeToSchema(distinctDataType);
 

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
@@ -21,7 +21,10 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.table.data.binary.BinaryArrayData;
 import org.apache.flink.table.data.binary.BinarySegmentUtils;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LogicalType;
+
+import java.io.Serializable;
 
 /**
  * Writer for binary array. See {@link BinaryArrayData}.
@@ -110,6 +113,10 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 		setNullLong(ordinal);
 	}
 
+	/**
+	 * @deprecated Use {@link #createNullSetter(LogicalType)} for a more efficient hot path.
+	 */
+	@Deprecated
 	public void setNullAt(int pos, LogicalType type) {
 		switch (type.getTypeRoot()) {
 			case BOOLEAN:
@@ -215,5 +222,67 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 
 	public int getNumElements() {
 		return numElements;
+	}
+
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * Creates an for accessor setting the elements of an array writer to {@code null} during runtime.
+	 *
+	 * @param elementType the element type of the array
+	 */
+	public static NullSetter createNullSetter(LogicalType elementType) {
+		// ordered by type root definition
+		switch (elementType.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+			case BINARY:
+			case VARBINARY:
+			case DECIMAL:
+			case BIGINT:
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+			case INTERVAL_DAY_TIME:
+			case ARRAY:
+			case MULTISET:
+			case MAP:
+			case ROW:
+			case STRUCTURED_TYPE:
+			case RAW:
+				return BinaryArrayWriter::setNullLong;
+			case BOOLEAN:
+				return BinaryArrayWriter::setNullBoolean;
+			case TINYINT:
+				return BinaryArrayWriter::setNullByte;
+			case SMALLINT:
+				return BinaryArrayWriter::setNullShort;
+			case INTEGER:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+				return BinaryArrayWriter::setNullInt;
+			case FLOAT:
+				return BinaryArrayWriter::setNullFloat;
+			case DOUBLE:
+				return BinaryArrayWriter::setNullDouble;
+			case TIMESTAMP_WITH_TIME_ZONE:
+				throw new UnsupportedOperationException();
+			case DISTINCT_TYPE:
+				return createNullSetter(((DistinctType) elementType).getSourceType());
+			case NULL:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Accessor for setting the elements of an array writer to {@code null} during runtime.
+	 *
+	 * @see #createNullSetter(LogicalType)
+	 */
+	public interface NullSetter extends Serializable {
+		void setNull(BinaryArrayWriter writer, int pos);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryArrayWriter.java
@@ -114,7 +114,7 @@ public final class BinaryArrayWriter extends AbstractBinaryWriter {
 	}
 
 	/**
-	 * @deprecated Use {@link #createNullSetter(LogicalType)} for a more efficient hot path.
+	 * @deprecated Use {@link #createNullSetter(LogicalType)} for avoiding logical types during runtime.
 	 */
 	@Deprecated
 	public void setNullAt(int pos, LogicalType type) {

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
@@ -26,14 +26,20 @@ import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.runtime.types.InternalSerializers;
 import org.apache.flink.table.runtime.typeutils.ArrayDataSerializer;
 import org.apache.flink.table.runtime.typeutils.MapDataSerializer;
 import org.apache.flink.table.runtime.typeutils.RawValueDataSerializer;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DistinctType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimestampType;
+
+import java.io.Serializable;
+
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
 
 /**
  * Writer to write a composite data format, like row, array.
@@ -89,6 +95,12 @@ public interface BinaryWriter {
 	 */
 	void complete();
 
+	// --------------------------------------------------------------------------------------------
+
+	/**
+	 * @deprecated Use {@link #createValueSetter(LogicalType)} for a more efficient hot path.
+	 */
+	@Deprecated
 	static void write(
 			BinaryWriter writer, int pos, Object o, LogicalType type, TypeSerializer<?> serializer) {
 		switch (type.getTypeRoot()) {
@@ -153,5 +165,77 @@ public interface BinaryWriter {
 			default:
 				throw new UnsupportedOperationException("Not support type: " + type);
 		}
+	}
+
+	/**
+	 * Creates an accessor for setting the elements of an array writer during runtime.
+	 *
+	 * @param elementType the element type of the array
+	 */
+	static ValueSetter createValueSetter(LogicalType elementType) {
+		// ordered by type root definition
+		switch (elementType.getTypeRoot()) {
+			case CHAR:
+			case VARCHAR:
+				return (writer, pos, value) -> writer.writeString(pos, (StringData) value);
+			case BOOLEAN:
+				return (writer, pos, value) -> writer.writeBoolean(pos, (boolean) value);
+			case BINARY:
+			case VARBINARY:
+				return (writer, pos, value) -> writer.writeBinary(pos, (byte[]) value);
+			case DECIMAL:
+				final int decimalPrecision = getPrecision(elementType);
+				return (writer, pos, value) -> writer.writeDecimal(pos, (DecimalData) value, decimalPrecision);
+			case TINYINT:
+				return (writer, pos, value) -> writer.writeByte(pos, (byte) value);
+			case SMALLINT:
+				return (writer, pos, value) -> writer.writeShort(pos, (short) value);
+			case INTEGER:
+			case DATE:
+			case TIME_WITHOUT_TIME_ZONE:
+			case INTERVAL_YEAR_MONTH:
+				return (writer, pos, value) -> writer.writeInt(pos, (int) value);
+			case BIGINT:
+			case INTERVAL_DAY_TIME:
+				return (writer, pos, value) -> writer.writeLong(pos, (long) value);
+			case FLOAT:
+				return (writer, pos, value) -> writer.writeFloat(pos, (float) value);
+			case DOUBLE:
+				return (writer, pos, value) -> writer.writeDouble(pos, (double) value);
+			case TIMESTAMP_WITHOUT_TIME_ZONE:
+			case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+				final int timestampPrecision = getPrecision(elementType);
+				return (writer, pos, value) -> writer.writeTimestamp(pos, (TimestampData) value, timestampPrecision);
+			case TIMESTAMP_WITH_TIME_ZONE:
+				throw new UnsupportedOperationException();
+			case ARRAY:
+				final ArrayDataSerializer arraySerializer = (ArrayDataSerializer) InternalSerializers.create(elementType);
+				return (writer, pos, value) -> writer.writeArray(pos, (ArrayData) value, arraySerializer);
+			case MULTISET:
+			case MAP:
+				final MapDataSerializer mapSerializer = (MapDataSerializer) InternalSerializers.create(elementType);
+				return (writer, pos, value) -> writer.writeMap(pos, (MapData) value, mapSerializer);
+			case ROW:
+			case STRUCTURED_TYPE:
+				final RowDataSerializer rowSerializer = (RowDataSerializer) InternalSerializers.create(elementType);
+				return (writer, pos, value) -> writer.writeRow(pos, (RowData) value, rowSerializer);
+			case DISTINCT_TYPE:
+				return createValueSetter(((DistinctType) elementType).getSourceType());
+			case RAW:
+				final RawValueDataSerializer<?> rawSerializer = (RawValueDataSerializer<?>) InternalSerializers.create(elementType);
+				return (writer, pos, value) -> writer.writeRawValue(pos, (RawValueData<?>) value, rawSerializer);
+			case NULL:
+			case SYMBOL:
+			case UNRESOLVED:
+			default:
+				throw new IllegalStateException();
+		}
+	}
+
+	/**
+	 * Accessor for setting the elements of an array writer during runtime.
+	 */
+	interface ValueSetter extends Serializable {
+		void setValue(BinaryArrayWriter writer, int pos, Object value);
 	}
 }

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/data/writer/BinaryWriter.java
@@ -98,7 +98,7 @@ public interface BinaryWriter {
 	// --------------------------------------------------------------------------------------------
 
 	/**
-	 * @deprecated Use {@link #createValueSetter(LogicalType)} for a more efficient hot path.
+	 * @deprecated Use {@link #createValueSetter(LogicalType)} for avoiding logical types during runtime.
 	 */
 	@Deprecated
 	static void write(

--- a/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
+++ b/flink-table/flink-table-runtime-blink/src/main/java/org/apache/flink/table/runtime/types/InternalSerializers.java
@@ -53,7 +53,14 @@ import org.apache.flink.table.types.logical.TypeInformationRawType;
 public class InternalSerializers {
 
 	/**
-	 * Get {@link TypeSerializer} for internal data structure from the given {@link LogicalType}.
+	 * Creates a {@link TypeSerializer} for internal data structures of the given {@link LogicalType}.
+	 */
+	public static TypeSerializer<?> create(LogicalType type) {
+		return create(type, new ExecutionConfig());
+	}
+
+	/**
+	 * Creates a {@link TypeSerializer} for internal data structures of the given {@link LogicalType}.
 	 */
 	public static TypeSerializer create(LogicalType type, ExecutionConfig config) {
 		switch (type.getTypeRoot()) {


### PR DESCRIPTION
## What is the purpose of the change

This fixes the following shortcomings in the new data structures:

- The some data structures do not provide a hashCode/equals for testing.
- `RawValueData` cannot be created from bytes.
- Accessing elements requires dealing with logical types during runtime.
- Null checks are performed multiple times during runtime even for types that are declared as NOT NULL.

So far these changes are not used. This will change in FLINK-16999.

## Brief change log

Adds `hashCode/equals` and specialized runtime instances by type for getting and setting values.

## Verifying this change

Tests are following in FLINK-16999.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
